### PR TITLE
refactor: simplify ingress-service to work directly with contacts types

### DIFF
--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -15,19 +15,19 @@ import { getBindingByConversation } from "../../memory/external-conversation-sto
 import { mintDaemonDeliveryToken } from "../../runtime/auth/token-service.js";
 import { deliverChannelReply } from "../../runtime/gateway-client.js";
 import {
-  blockIngressMember,
+  blockIngressContact,
   createIngressInvite,
+  listIngressContacts,
   listIngressInvites,
-  listIngressMembers,
   redeemIngressInvite,
+  revokeIngressContact,
   revokeIngressInvite,
-  revokeIngressMember,
-  upsertIngressMember,
+  upsertIngressContact,
 } from "../../runtime/ingress-service.js";
 import type {
   AssistantInboxEscalationRequest,
+  IngressContactRequest,
   IngressInviteRequest,
-  IngressMemberRequest,
 } from "../ipc-protocol.js";
 import {
   defineHandlers,
@@ -149,15 +149,15 @@ export function handleIngressInvite(
   }
 }
 
-export function handleIngressMember(
-  msg: IngressMemberRequest,
+export function handleIngressContact(
+  msg: IngressContactRequest,
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   try {
     switch (msg.action) {
       case "list": {
-        const result = listIngressMembers({
+        const result = listIngressContacts({
           assistantId: msg.assistantId,
           sourceChannel: msg.sourceChannel,
           status: msg.status,
@@ -180,7 +180,7 @@ export function handleIngressMember(
       }
 
       case "upsert": {
-        const result = upsertIngressMember({
+        const result = upsertIngressContact({
           assistantId: msg.assistantId,
           sourceChannel: msg.sourceChannel,
           externalUserId: msg.externalUserId,
@@ -207,7 +207,7 @@ export function handleIngressMember(
       }
 
       case "revoke": {
-        const result = revokeIngressMember(msg.memberId, msg.reason);
+        const result = revokeIngressContact(msg.memberId, msg.reason);
         if (!result.ok) {
           ctx.send(socket, {
             type: "ingress_member_response",
@@ -225,7 +225,7 @@ export function handleIngressMember(
       }
 
       case "block": {
-        const result = blockIngressMember(msg.memberId, msg.reason);
+        const result = blockIngressContact(msg.memberId, msg.reason);
         if (!result.ok) {
           ctx.send(socket, {
             type: "ingress_member_response",
@@ -569,6 +569,6 @@ async function executeDeny(
 
 export const inboxInviteHandlers = defineHandlers({
   ingress_invite: handleIngressInvite,
-  ingress_member: handleIngressMember,
+  ingress_member: handleIngressContact,
   assistant_inbox_escalation: handleInboxEscalation,
 });

--- a/assistant/src/daemon/ipc-contract/inbox.ts
+++ b/assistant/src/daemon/ipc-contract/inbox.ts
@@ -29,7 +29,7 @@ export interface IngressInviteRequest {
   guardianName?: string;
 }
 
-export interface IngressMemberRequest {
+export interface IngressContactRequest {
   type: "ingress_member";
   action: "list" | "upsert" | "revoke" | "block";
   /** Assistant ID for scoping member operations (defaults to 'self'). */
@@ -102,7 +102,7 @@ export interface IngressInviteResponse {
   }>;
 }
 
-export interface IngressMemberResponse {
+export interface IngressContactResponse {
   type: "ingress_member_response";
   success: boolean;
   error?: string;
@@ -162,10 +162,10 @@ export interface AssistantInboxEscalationResponse {
 
 export type _InboxClientMessages =
   | IngressInviteRequest
-  | IngressMemberRequest
+  | IngressContactRequest
   | AssistantInboxEscalationRequest;
 
 export type _InboxServerMessages =
   | IngressInviteResponse
-  | IngressMemberResponse
+  | IngressContactResponse
   | AssistantInboxEscalationResponse;

--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -1,5 +1,5 @@
 /**
- * Shared business logic for ingress member and invite management.
+ * Shared business logic for ingress contact and invite management.
  *
  * Extracted from the IPC handlers in daemon/handlers/config-inbox.ts so that
  * both the HTTP routes and the IPC handlers call the same logic.
@@ -348,10 +348,10 @@ export function redeemVoiceInviteCode(params: {
 }
 
 // ---------------------------------------------------------------------------
-// Member operations
+// Contact operations
 // ---------------------------------------------------------------------------
 
-export function listIngressMembers(params: {
+export function listIngressContacts(params: {
   assistantId?: string;
   sourceChannel?: string;
   status?: string;
@@ -374,7 +374,7 @@ export function listIngressMembers(params: {
   return { ok: true, data: filtered };
 }
 
-export function upsertIngressMember(params: {
+export function upsertIngressContact(params: {
   sourceChannel?: string;
   externalUserId?: string;
   externalChatId?: string;
@@ -410,7 +410,7 @@ export function upsertIngressMember(params: {
   return { ok: true, data: writeResultToResponse(result) };
 }
 
-export function revokeIngressMember(
+export function revokeIngressContact(
   memberId?: string,
   reason?: string,
 ): IngressResult<MemberResponseData> {
@@ -424,7 +424,7 @@ export function revokeIngressMember(
   return { ok: true, data: writeResultToResponse(result) };
 }
 
-export function blockIngressMember(
+export function blockIngressContact(
   memberId?: string,
   reason?: string,
 ): IngressResult<MemberResponseData> {

--- a/assistant/src/runtime/routes/ingress-routes.ts
+++ b/assistant/src/runtime/routes/ingress-routes.ts
@@ -15,15 +15,15 @@
  */
 
 import {
-  blockIngressMember,
+  blockIngressContact,
   createIngressInvite,
+  listIngressContacts,
   listIngressInvites,
-  listIngressMembers,
   redeemIngressInvite,
   redeemVoiceInviteCode,
+  revokeIngressContact,
   revokeIngressInvite,
-  revokeIngressMember,
-  upsertIngressMember,
+  upsertIngressContact,
 } from "../ingress-service.js";
 
 // ---------------------------------------------------------------------------
@@ -34,7 +34,7 @@ import {
  * GET /v1/ingress/members?assistantId=&sourceChannel=&status=&policy=
  */
 export function handleListMembers(url: URL): Response {
-  const result = listIngressMembers({
+  const result = listIngressContacts({
     assistantId: url.searchParams.get("assistantId") ?? undefined,
     sourceChannel: url.searchParams.get("sourceChannel") ?? undefined,
     status: url.searchParams.get("status") ?? undefined,
@@ -53,7 +53,7 @@ export function handleListMembers(url: URL): Response {
 export async function handleUpsertMember(req: Request): Promise<Response> {
   const body = (await req.json()) as Record<string, unknown>;
 
-  const result = upsertIngressMember({
+  const result = upsertIngressContact({
     sourceChannel: body.sourceChannel as string | undefined,
     externalUserId: body.externalUserId as string | undefined,
     externalChatId: body.externalChatId as string | undefined,
@@ -85,7 +85,7 @@ export async function handleRevokeMember(
     // DELETE may have no body
   }
 
-  const result = revokeIngressMember(memberId, reason);
+  const result = revokeIngressContact(memberId, reason);
 
   if (!result.ok) {
     return Response.json({ ok: false, error: result.error }, { status: 404 });
@@ -108,7 +108,7 @@ export async function handleBlockMember(
     // Body is optional — callers may omit it entirely
   }
 
-  const result = blockIngressMember(memberId, reason);
+  const result = blockIngressContact(memberId, reason);
 
   if (!result.ok) {
     return Response.json({ ok: false, error: result.error }, { status: 404 });


### PR DESCRIPTION
## Summary
- Rename IngressMember-prefixed functions and types to IngressContact throughout ingress-service, IPC contract, and route handlers
- Keep wire protocol values (type: "ingress_member") unchanged for backward compatibility
- The contactToMemberResponse function remains the sole formatting path from native contact types
- Historical migration code left untouched (frozen database migration operations)

Part of plan: contacts-post-migration-cleanup.md (PR 12 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
