### PR TITLE
fix: remove stale guardian-bindings.ts reference from contact-store comment

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -89,7 +89,7 @@ All HTTP API requests use a single `Authorization: Bearer <jwt>` header for auth
 | `src/runtime/routes/guardian-refresh-routes.ts`   | `POST /v1/integrations/guardian/vellum/refresh` (token rotation)                              |
 | `src/runtime/routes/pairing-routes.ts`            | JWT credential issuance in pairing flow                                                       |
 | `src/runtime/local-actor-identity.ts`             | `resolveLocalIpcGuardianContext` — deterministic IPC identity                                 |
-| `src/memory/channel-guardian-store.ts`            | Guardian binding types and re-exports (types moved here from deleted guardian-bindings.ts)    |
+| `src/memory/channel-guardian-store.ts`            | Guardian binding types and re-exports                                                         |
 
 ### Channel-Agnostic Scoped Approval Grants
 

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -727,9 +727,8 @@ export function findGuardianForChannel(
 
 /**
  * Revoke the guardian's active channel of the given type by setting its
- * status to 'revoked'. This is the contacts-side counterpart to
- * revokeBinding() in guardian-bindings.ts — it ensures findGuardianForChannel()
- * no longer returns stale data after a binding is revoked.
+ * status to 'revoked'. This ensures findGuardianForChannel() no longer
+ * returns stale data after a binding is revoked.
  *
  * Returns true if a channel was found and revoked, false otherwise.
  */

--- a/assistant/src/memory/channel-guardian-store.ts
+++ b/assistant/src/memory/channel-guardian-store.ts
@@ -7,13 +7,13 @@
  * - guardian-rate-limits.ts — verification rate limiting
  *
  * Guardian binding types (GuardianBinding, BindingStatus) are defined locally
- * here after the deletion of the legacy guardian-bindings.ts store.
+ * here.
  *
  * This file re-exports everything for backward compatibility.
  */
 
 // ---------------------------------------------------------------------------
-// Guardian binding types (formerly in guardian-bindings.ts)
+// Guardian binding types
 // ---------------------------------------------------------------------------
 
 export type BindingStatus = "active" | "revoked";


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contacts-post-migration-cleanup.md.

**Gap:** Stale comment referencing deleted guardian-bindings.ts file
**What was expected:** No comments referencing deleted files
**What was found:** Line 731 of contact-store.ts references revokeBinding() in guardian-bindings.ts

Also cleaned up 3 additional references to guardian-bindings.ts found in:
- assistant/src/memory/channel-guardian-store.ts (2 references in comments)
- assistant/ARCHITECTURE.md (1 reference in architecture table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
