### PR TITLE
fix: regenerate IPC Swift code after ingress member→contact rename

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2434,6 +2434,90 @@ public struct IPCIngressConfigResponse: Codable, Sendable {
     }
 }
 
+public struct IPCIngressContactRequest: Codable, Sendable {
+    public let type: String
+    public let action: String
+    /// Assistant ID for scoping member operations (defaults to 'self').
+    public let assistantId: String?
+    /// Source channel (required for upsert, optional filter for list).
+    public let sourceChannel: String?
+    /// External user ID (upsert only).
+    public let externalUserId: String?
+    /// External chat ID (upsert only).
+    public let externalChatId: String?
+    /// Display name (upsert only).
+    public let displayName: String?
+    /// Username (upsert only).
+    public let username: String?
+    /// Access policy (upsert only).
+    public let policy: String?
+    /// Member status (upsert only for setting, list only for filtering).
+    public let status: String?
+    /// Member ID (revoke and block only).
+    public let memberId: String?
+    /// Reason for revoke or block (revoke and block only).
+    public let reason: String?
+
+    public init(type: String, action: String, assistantId: String? = nil, sourceChannel: String? = nil, externalUserId: String? = nil, externalChatId: String? = nil, displayName: String? = nil, username: String? = nil, policy: String? = nil, status: String? = nil, memberId: String? = nil, reason: String? = nil) {
+        self.type = type
+        self.action = action
+        self.assistantId = assistantId
+        self.sourceChannel = sourceChannel
+        self.externalUserId = externalUserId
+        self.externalChatId = externalChatId
+        self.displayName = displayName
+        self.username = username
+        self.policy = policy
+        self.status = status
+        self.memberId = memberId
+        self.reason = reason
+    }
+}
+
+public struct IPCIngressContactResponse: Codable, Sendable {
+    public let type: String
+    public let success: Bool
+    public let error: String?
+    /// Single member (returned on upsert/revoke/block).
+    public let member: IPCIngressContactResponseMember?
+    /// List of members (returned on list).
+    public let members: [IPCIngressContactResponseMember]?
+
+    public init(type: String, success: Bool, error: String? = nil, member: IPCIngressContactResponseMember? = nil, members: [IPCIngressContactResponseMember]? = nil) {
+        self.type = type
+        self.success = success
+        self.error = error
+        self.member = member
+        self.members = members
+    }
+}
+
+public struct IPCIngressContactResponseMember: Codable, Sendable {
+    public let id: String
+    public let sourceChannel: String
+    public let externalUserId: String?
+    public let externalChatId: String?
+    public let displayName: String?
+    public let username: String?
+    public let status: String
+    public let policy: String
+    public let lastSeenAt: Int?
+    public let createdAt: Int
+
+    public init(id: String, sourceChannel: String, externalUserId: String? = nil, externalChatId: String? = nil, displayName: String? = nil, username: String? = nil, status: String, policy: String, lastSeenAt: Int? = nil, createdAt: Int) {
+        self.id = id
+        self.sourceChannel = sourceChannel
+        self.externalUserId = externalUserId
+        self.externalChatId = externalChatId
+        self.displayName = displayName
+        self.username = username
+        self.status = status
+        self.policy = policy
+        self.lastSeenAt = lastSeenAt
+        self.createdAt = createdAt
+    }
+}
+
 public struct IPCIngressInviteRequest: Codable, Sendable {
     public let type: String
     public let action: String
@@ -2517,90 +2601,6 @@ public struct IPCIngressInviteResponseInvite: Codable, Sendable {
         self.expiresAt = expiresAt
         self.status = status
         self.note = note
-        self.createdAt = createdAt
-    }
-}
-
-public struct IPCIngressMemberRequest: Codable, Sendable {
-    public let type: String
-    public let action: String
-    /// Assistant ID for scoping member operations (defaults to 'self').
-    public let assistantId: String?
-    /// Source channel (required for upsert, optional filter for list).
-    public let sourceChannel: String?
-    /// External user ID (upsert only).
-    public let externalUserId: String?
-    /// External chat ID (upsert only).
-    public let externalChatId: String?
-    /// Display name (upsert only).
-    public let displayName: String?
-    /// Username (upsert only).
-    public let username: String?
-    /// Access policy (upsert only).
-    public let policy: String?
-    /// Member status (upsert only for setting, list only for filtering).
-    public let status: String?
-    /// Member ID (revoke and block only).
-    public let memberId: String?
-    /// Reason for revoke or block (revoke and block only).
-    public let reason: String?
-
-    public init(type: String, action: String, assistantId: String? = nil, sourceChannel: String? = nil, externalUserId: String? = nil, externalChatId: String? = nil, displayName: String? = nil, username: String? = nil, policy: String? = nil, status: String? = nil, memberId: String? = nil, reason: String? = nil) {
-        self.type = type
-        self.action = action
-        self.assistantId = assistantId
-        self.sourceChannel = sourceChannel
-        self.externalUserId = externalUserId
-        self.externalChatId = externalChatId
-        self.displayName = displayName
-        self.username = username
-        self.policy = policy
-        self.status = status
-        self.memberId = memberId
-        self.reason = reason
-    }
-}
-
-public struct IPCIngressMemberResponse: Codable, Sendable {
-    public let type: String
-    public let success: Bool
-    public let error: String?
-    /// Single member (returned on upsert/revoke/block).
-    public let member: IPCIngressMemberResponseMember?
-    /// List of members (returned on list).
-    public let members: [IPCIngressMemberResponseMember]?
-
-    public init(type: String, success: Bool, error: String? = nil, member: IPCIngressMemberResponseMember? = nil, members: [IPCIngressMemberResponseMember]? = nil) {
-        self.type = type
-        self.success = success
-        self.error = error
-        self.member = member
-        self.members = members
-    }
-}
-
-public struct IPCIngressMemberResponseMember: Codable, Sendable {
-    public let id: String
-    public let sourceChannel: String
-    public let externalUserId: String?
-    public let externalChatId: String?
-    public let displayName: String?
-    public let username: String?
-    public let status: String
-    public let policy: String
-    public let lastSeenAt: Int?
-    public let createdAt: Int
-
-    public init(id: String, sourceChannel: String, externalUserId: String? = nil, externalChatId: String? = nil, displayName: String? = nil, username: String? = nil, status: String, policy: String, lastSeenAt: Int? = nil, createdAt: Int) {
-        self.id = id
-        self.sourceChannel = sourceChannel
-        self.externalUserId = externalUserId
-        self.externalChatId = externalChatId
-        self.displayName = displayName
-        self.username = username
-        self.status = status
-        self.policy = policy
-        self.lastSeenAt = lastSeenAt
         self.createdAt = createdAt
     }
 }


### PR DESCRIPTION
## Summary
- Regenerated `IPCContractGenerated.swift` to reflect the `IngressMember` → `IngressContact` rename from recent PRs
- Fixes CI `check:ipc-generated` failure

## Original prompt
fix all build errors in this CI run: https://github.com/vellum-ai/vellum-assistant/actions/runs/22671004991

🤖 Generated with [Claude Code](https://claude.com/claude-code)