### PR TITLE
M2: PTT auto-submission and audio feedback

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -2282,7 +2282,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             if NSApp.isActive,
                let mainWindow = self?.mainWindow, mainWindow.isVisible,
                let viewModel = mainWindow.activeViewModel {
+                viewModel.pendingVoiceMessage = true
                 viewModel.inputText = text
+                viewModel.sendMessage()
                 return
             }
 

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -698,6 +698,7 @@ final class VoiceInputManager {
         case .dictation:
             guard let context = currentDictationContext else {
                 // No context captured (e.g. continuous recording path) — fall back to conversation
+                VoiceFeedback.playDeactivationChime()
                 onTranscription?(text)
                 return
             }
@@ -726,6 +727,7 @@ final class VoiceInputManager {
             } catch {
                 log.error("Failed to send dictation_request: \(error.localizedDescription)")
                 overlayWindow.dismiss()
+                VoiceFeedback.playDeactivationChime()
                 onTranscription?(text)
             }
         }

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -529,6 +529,7 @@ final class VoiceInputManager {
 
         isRecording = true
         onRecordingStateChanged?(true)
+        VoiceFeedback.playActivationChime()
         if currentMode == .dictation {
             overlayWindow.show(state: .recording)
         }
@@ -692,6 +693,7 @@ final class VoiceInputManager {
     func handleFinalTranscription(_ text: String) {
         switch currentMode {
         case .conversation:
+            VoiceFeedback.playDeactivationChime()
             onTranscription?(text)
         case .dictation:
             guard let context = currentDictationContext else {
@@ -735,6 +737,7 @@ final class VoiceInputManager {
         if mode == "dictation" || mode == "command" {
             DictationTextInserter.insertText(text)
             overlayWindow.showDoneAndDismiss()
+            VoiceFeedback.playDeactivationChime()
         } else if mode == "action" {
             overlayWindow.dismiss()
             log.info("Action mode detected — routing transcription to task submission: \(text, privacy: .public)")

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/VoiceFeedback.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/VoiceFeedback.swift
@@ -1,11 +1,11 @@
 import AppKit
 import os
 
-private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "WakeWordFeedback")
+private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "VoiceFeedback")
 
-/// Provides audio feedback for wake word detection events.
+/// Provides audio feedback for voice activation events (wake word and PTT).
 /// Uses system sounds to keep the feedback subtle and respectful of user preferences.
-enum WakeWordFeedback {
+enum VoiceFeedback {
 
     /// Play a short chime when the wake word is detected and voice mode activates.
     static func playActivationChime() {

--- a/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/WakeWord/WakeWordCoordinator.swift
@@ -114,7 +114,7 @@ final class WakeWordCoordinator: ObservableObject {
         lastActivationTime = Date()
 
         // 1. Play activation chime and show visual indicator
-        WakeWordFeedback.playActivationChime()
+        VoiceFeedback.playActivationChime()
         activationWindow.show(state: .activated)
 
         // 2. Capture the ChatViewModel NOW (before any async delay) so it matches
@@ -225,7 +225,7 @@ final class WakeWordCoordinator: ObservableObject {
                     if UserDefaults.standard.bool(forKey: "wakeWordEnabled") {
                         log.info("Voice mode deactivated — resuming wake word listening after delay")
                         if self.activatedViaWakeWord {
-                            WakeWordFeedback.playDeactivationChime()
+                            VoiceFeedback.playDeactivationChime()
                             self.activationWindow.show(state: .listening)
                         }
                         // Cancel any pending restart before scheduling a new one — rapid


### PR DESCRIPTION
Adds auto-submission when PTT routes to chat (matching wake word behavior) and activation/deactivation audio chimes for PTT. Renames WakeWordFeedback to VoiceFeedback since it's now shared. Addresses Gap 2 and Gap 4 from #11260. Part of #12271.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
