### PR TITLE
M3: Routing consistency — document by-design difference

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -2272,6 +2272,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             self?.voiceTranscriptionWindow?.close()
             self?.voiceTranscriptionWindow = nil
 
+            // PTT uses priority-based routing because it's a one-shot dictation: the user
+            // speaks a single utterance and expects it to go to whatever surface is currently
+            // focused. This differs from wake word, which binds to a specific ChatViewModel at
+            // activation time for continuous conversational mode (see VoiceModeManager.handleSilenceDetected).
             // Priority 0: Route to quick input bar if visible
             if let quickInput = self?.quickInputWindow, quickInput.isVisible {
                 quickInput.setVoiceText(text)

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceModeManager.swift
@@ -281,6 +281,11 @@ final class VoiceModeManager: ObservableObject {
 
             partialTranscription = trimmed
 
+            // Wake word routes directly to the bound chatViewModel rather than using
+            // PTT's priority routing (quick input → main window → TextResponseWindow → new session).
+            // This is by design: wake word activates a continuous conversational mode tied to a
+            // specific chat thread. Re-routing mid-conversation to a different surface would break
+            // the back-and-forth voice dialogue flow.
             chatViewModel.pendingVoiceMessage = true
             chatViewModel.inputText = trimmed
             chatViewModel.sendMessage()


### PR DESCRIPTION
Documents the routing architecture difference between PTT and wake word as by-design. PTT uses priority routing (quick input → chat → text response → new session) because it's a one-shot dictation. Wake word binds to a chat thread at activation time for conversational continuity. Addresses Gap 5 from #11260. Part of #12271.