### PR TITLE
Fix panel top-edge jump in DictationOverlayWindow

### DIFF
--- a/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/DictationOverlayWindow.swift
@@ -40,7 +40,9 @@ final class DictationOverlayWindow {
             if let screen = NSScreen.main {
                 let screenFrame = screen.visibleFrame
                 let x = screenFrame.midX - width / 2
-                let newFrame = NSRect(x: x, y: panel.frame.origin.y, width: width, height: height)
+                // Pin the top edge so the panel doesn't jump when contracting from expanded height
+                let topY = panel.frame.origin.y + panel.frame.height
+                let newFrame = NSRect(x: x, y: topY - height, width: width, height: height)
                 panel.setFrame(newFrame, display: true, animate: false)
             }
 


### PR DESCRIPTION
Pins the top edge of the DictationOverlayWindow when transitioning between states, preventing a visual jump when the panel contracts from expanded (58pt with transcription) to base (40pt) height. Addresses feedback from #12275.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
