### PR TITLE
Fix activation chime timing and pendingVoiceMessage in PTT

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -2286,7 +2286,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             if NSApp.isActive,
                let mainWindow = self?.mainWindow, mainWindow.isVisible,
                let viewModel = mainWindow.activeViewModel {
-                viewModel.pendingVoiceMessage = true
                 viewModel.inputText = text
                 viewModel.sendMessage()
                 return

--- a/clients/macos/vellum-assistant/App/VoiceInputManager.swift
+++ b/clients/macos/vellum-assistant/App/VoiceInputManager.swift
@@ -529,7 +529,6 @@ final class VoiceInputManager {
 
         isRecording = true
         onRecordingStateChanged?(true)
-        VoiceFeedback.playActivationChime()
         if currentMode == .dictation {
             overlayWindow.show(state: .recording)
         }
@@ -591,6 +590,7 @@ final class VoiceInputManager {
         do {
             audioEngine.prepare()
             try audioEngine.start()
+            VoiceFeedback.playActivationChime()
         } catch {
             log.error("Audio engine failed to start: \(error.localizedDescription)")
             isRecording = false


### PR DESCRIPTION
Moves PTT activation chime to after audioEngine.start() succeeds so users don't hear a chime when recording fails. Removes incorrect pendingVoiceMessage flag from PTT path since PTT doesn't use TTS responses. Addresses feedback from #12283.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
