### PR TITLE
feat: add top-level vellum contacts CLI commands

### DIFF
--- a/assistant/src/cli/core-commands.ts
+++ b/assistant/src/cli/core-commands.ts
@@ -734,7 +734,7 @@ export function registerCompletionsCommand(program: Command): void {
         trust: ["list", "remove", "clear"],
         memory: ["status", "backfill", "cleanup", "query", "rebuild-index"],
         hooks: ["list", "enable", "disable", "install", "remove"],
-        contacts: ["list", "get", "merge"],
+        contacts: ["list", "invites", "get", "merge"],
         autonomy: ["get", "set"],
       };
       const topLevel = [

--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -160,6 +160,57 @@ async function runRead(
   }
 }
 
+export function registerContactsCommand(program: Command): void {
+  const contacts = program
+    .command("contacts")
+    .description("Manage and query the contact graph")
+    .option("--json", "Machine-readable compact JSON output");
+
+  contacts
+    .command("list")
+    .description("List contacts (calls /v1/contacts)")
+    .option("--role <role>", "Filter by role")
+    .option("--limit <limit>", "Maximum number of contacts to return")
+    .option("--query <query>", "Search query to filter contacts")
+    .action(
+      async (
+        opts: {
+          role?: string;
+          limit?: string;
+          query?: string;
+        },
+        cmd: Command,
+      ) => {
+        const query = toQueryString({
+          role: opts.role,
+          limit: opts.limit,
+          query: opts.query,
+        });
+        await runRead(cmd, async () => gatewayGet(`/v1/contacts${query}`));
+      },
+    );
+
+  contacts
+    .command("invites")
+    .description("List ingress invites (calls /v1/ingress/invites)")
+    .option("--source-channel <sourceChannel>", "Filter by source channel")
+    .option("--status <status>", "Filter by invite status")
+    .action(
+      async (
+        opts: { sourceChannel?: IngressChannel; status?: string },
+        cmd: Command,
+      ) => {
+        const query = toQueryString({
+          sourceChannel: opts.sourceChannel,
+          status: opts.status,
+        });
+        await runRead(cmd, async () =>
+          gatewayGet(`/v1/ingress/invites${query}`),
+        );
+      },
+    );
+}
+
 export function registerIntegrationsCommand(program: Command): void {
   const integrations = program
     .command("integrations")

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -24,7 +24,10 @@ import {
 } from "./cli/core-commands.js";
 import { registerEmailCommand } from "./cli/email.js";
 import { registerInfluencerCommand } from "./cli/influencer.js";
-import { registerIntegrationsCommand } from "./cli/integrations.js";
+import {
+  registerContactsCommand,
+  registerIntegrationsCommand,
+} from "./cli/integrations.js";
 import { registerMapCommand } from "./cli/map.js";
 import { registerMcpCommand } from "./cli/mcp.js";
 import { registerSequenceCommand } from "./cli/sequence.js";
@@ -48,6 +51,7 @@ registerHooksCommand(program);
 registerMcpCommand(program);
 registerEmailCommand(program);
 registerIntegrationsCommand(program);
+registerContactsCommand(program);
 registerAmazonCommand(program);
 registerCompletionsCommand(program);
 


### PR DESCRIPTION
## Summary
- Add vellum contacts list command (replaces vellum integrations ingress members)
- Add vellum contacts invites command (replaces vellum integrations ingress invites)
- Both support --json, filtering params

Part of plan: contacts-skill-cli-consolidation.md (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
