### PR TITLE
fix: expand menu button hit area to include padding

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -199,9 +199,10 @@ struct AppsGridView: View {
                         .menuIndicator(.hidden)
                     }
                     .fixedSize()
-                    .onTapGesture {} // absorb tap so it doesn't propagate to parent Button
                     .accessibilityLabel("App actions")
                     .padding(VSpacing.sm)
+                    .contentShape(Rectangle())
+                    .onTapGesture {} // absorb tap so it doesn't propagate to parent Button
                     .opacity(isHovered ? 1 : 0)
                     .allowsHitTesting(isHovered)
                     .animation(VAnimation.fast, value: isHovered)


### PR DESCRIPTION
## Summary
- Move `.padding()` before `.contentShape(Rectangle())` and `.onTapGesture {}` so the full padded area (icon + 8pt border) absorbs clicks and opens the menu, instead of falling through to the parent card button

## Test plan
- [ ] Hover an app card, click anywhere on/around the "..." button — menu opens, app does not launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
