### PR TITLE
fix: add assistantId scoping to listContacts, searchContacts, getContact, mergeContacts, and upsertContact

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -208,6 +208,7 @@ const noopProcessMessage = mock(async () => ({ messageId: "msg-1" }));
 function ensureTestContact(): void {
   upsertContact({
     displayName: "Test User",
+    assistantId: "self",
     channels: [
       {
         type: "telegram",
@@ -1599,6 +1600,7 @@ describe("assistant-scoped guardian verification via handleChannelInbound", () =
   test("inbound with explicit assistantId does not mutate existing external bindings", async () => {
     upsertContact({
       displayName: "Incoming User",
+      assistantId: "self",
       channels: [
         {
           type: "telegram",
@@ -2348,6 +2350,7 @@ describe("requester cancel of guardian-gated pending request", () => {
     });
     upsertContact({
       displayName: "Requester Cancel User",
+      assistantId: "self",
       channels: [
         {
           type: "telegram",
@@ -3298,6 +3301,7 @@ describe("trusted-contact self-approval blocked before guardian approval row exi
     });
     upsertContact({
       displayName: "TC Self-Approval User",
+      assistantId: "self",
       channels: [
         {
           type: "telegram",

--- a/assistant/src/__tests__/conversation-attention-telegram.test.ts
+++ b/assistant/src/__tests__/conversation-attention-telegram.test.ts
@@ -92,6 +92,7 @@ function resetTables(): void {
 function ensureTestContact(): void {
   upsertContact({
     displayName: "Test User",
+    assistantId: "self",
     channels: [
       {
         type: "telegram",

--- a/assistant/src/__tests__/guardian-routing-state.test.ts
+++ b/assistant/src/__tests__/guardian-routing-state.test.ts
@@ -185,6 +185,7 @@ describe("inbound-message-handler trusted-contact interactivity", () => {
     // Insert a test contact so the contacts-based ACL lookup passes
     upsertContact({
       displayName: "Test User",
+      assistantId: "self",
       channels: [
         {
           type: "telegram",

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
@@ -2,6 +2,7 @@ import {
   getContact,
   mergeContacts,
 } from "../../../../contacts/contact-store.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../../runtime/assistant-scope.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -22,8 +23,8 @@ export async function executeContactMerge(
   }
 
   // Show what will be merged for clarity
-  const keepContact = getContact(keepId);
-  const mergeContact = getContact(mergeId);
+  const keepContact = getContact(keepId, DAEMON_INTERNAL_ASSISTANT_ID);
+  const mergeContact = getContact(mergeId, DAEMON_INTERNAL_ASSISTANT_ID);
 
   if (!keepContact) {
     return { content: `Error: Contact "${keepId}" not found`, isError: true };
@@ -33,7 +34,7 @@ export async function executeContactMerge(
   }
 
   try {
-    const merged = mergeContacts(keepId, mergeId);
+    const merged = mergeContacts(keepId, mergeId, DAEMON_INTERNAL_ASSISTANT_ID);
 
     const channelList = merged.channels
       .map(

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-search.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-search.ts
@@ -1,5 +1,6 @@
 import { searchContacts } from "../../../../contacts/contact-store.js";
 import type { ContactWithChannels } from "../../../../contacts/types.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../../runtime/assistant-scope.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -42,6 +43,7 @@ export async function executeContactSearch(
 
   try {
     const results = searchContacts({
+      assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
       query,
       channelAddress,
       channelType,

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-upsert.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-upsert.ts
@@ -1,4 +1,5 @@
 import { upsertContact } from "../../../../contacts/contact-store.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../../runtime/assistant-scope.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -67,6 +68,7 @@ export async function executeContactUpsert(
       importance,
       responseExpectation: input.response_expectation as string | undefined,
       preferredTone: input.preferred_tone as string | undefined,
+      assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
       channels,
     });
 

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -99,9 +99,25 @@ interface SyncChannelData {
 
 // ── CRUD ─────────────────────────────────────────────────────────────
 
-export function getContact(id: string): ContactWithChannels | null {
+/** Internal helper: retrieve a contact by ID without assistantId scoping.
+ * Used by functions that have already resolved identity through channel lookups. */
+function getContactInternal(id: string): ContactWithChannels | null {
   const db = getDb();
   const row = db.select().from(contacts).where(eq(contacts.id, id)).get();
+  if (!row) return null;
+  return withChannels(parseContact(row));
+}
+
+export function getContact(
+  id: string,
+  assistantId: string,
+): ContactWithChannels | null {
+  const db = getDb();
+  const row = db
+    .select()
+    .from(contacts)
+    .where(and(eq(contacts.id, id), eq(contacts.assistantId, assistantId)))
+    .get();
   if (!row) return null;
   return withChannels(parseContact(row));
 }
@@ -129,7 +145,7 @@ export function upsertContact(params: {
   preferredTone?: string | null;
   role?: ContactRole;
   principalId?: string | null;
-  assistantId?: string | null;
+  assistantId: string;
   channels?: SyncChannelData[];
 }): ContactWithChannels & { created: boolean } {
   const db = getDb();
@@ -180,7 +196,7 @@ export function upsertContact(params: {
         syncChannels(contactId, params.channels, now);
       }
 
-      return { ...getContact(contactId)!, created: false };
+      return { ...getContactInternal(contactId)!, created: false };
     }
   }
 
@@ -246,7 +262,7 @@ export function upsertContact(params: {
           .run();
 
         syncChannels(contactId, params.channels, now);
-        return { ...getContact(contactId)!, created: false };
+        return { ...getContactInternal(contactId)!, created: false };
       }
     }
   }
@@ -265,7 +281,7 @@ export function upsertContact(params: {
       interactionCount: 0,
       role: params.role ?? "contact",
       principalId: params.principalId ?? null,
-      assistantId: params.assistantId ?? null,
+      assistantId: params.assistantId,
       createdAt: now,
       updatedAt: now,
     })
@@ -275,7 +291,7 @@ export function upsertContact(params: {
     syncChannels(contactId, params.channels, now);
   }
 
-  return { ...getContact(contactId)!, created: true };
+  return { ...getContactInternal(contactId)!, created: true };
 }
 
 /**
@@ -396,6 +412,7 @@ function syncChannels(
 }
 
 export function searchContacts(params: {
+  assistantId: string;
   query?: string;
   channelAddress?: string;
   channelType?: string;
@@ -411,15 +428,20 @@ export function searchContacts(params: {
     const normalizedAddress = escapeLike(params.channelAddress.toLowerCase());
     if (!normalizedAddress) return [];
     const channelRows = db
-      .select()
+      .select({ contactId: contactChannels.contactId })
       .from(contactChannels)
+      .innerJoin(contacts, eq(contactChannels.contactId, contacts.id))
       .where(
         params.channelType
           ? and(
+              eq(contacts.assistantId, params.assistantId),
               eq(contactChannels.type, params.channelType),
               like(contactChannels.address, `%${normalizedAddress}%`),
             )
-          : like(contactChannels.address, `%${normalizedAddress}%`),
+          : and(
+              eq(contacts.assistantId, params.assistantId),
+              like(contactChannels.address, `%${normalizedAddress}%`),
+            ),
       )
       .all();
 
@@ -429,7 +451,7 @@ export function searchContacts(params: {
     const results: ContactWithChannels[] = [];
     for (const id of contactIds) {
       if (results.length >= limit) break;
-      const contact = getContact(id);
+      const contact = getContactInternal(id);
       if (contact && (!params.role || contact.role === params.role)) {
         results.push(contact);
       }
@@ -438,7 +460,7 @@ export function searchContacts(params: {
   }
 
   // Search by display name and/or relationship
-  const conditions = [];
+  const conditions = [eq(contacts.assistantId, params.assistantId)];
   if (params.query) {
     const sanitized = escapeLike(params.query);
     if (!sanitized && !params.relationship && !params.role) return [];
@@ -454,11 +476,7 @@ export function searchContacts(params: {
   }
 
   const whereClause =
-    conditions.length > 0
-      ? conditions.length === 1
-        ? conditions[0]
-        : and(...conditions)
-      : undefined;
+    conditions.length > 1 ? and(...conditions) : conditions[0];
 
   const rows = db
     .select()
@@ -472,16 +490,19 @@ export function searchContacts(params: {
 }
 
 export function listContacts(
+  assistantId: string,
   limit = 50,
   role?: ContactRole,
   opts?: { uncapped?: boolean },
 ): ContactWithChannels[] {
   const db = getDb();
   const effectiveLimit = opts?.uncapped ? limit : Math.min(limit, 200);
+  const conditions = [eq(contacts.assistantId, assistantId)];
+  if (role) conditions.push(eq(contacts.role, role));
   const rows = db
     .select()
     .from(contacts)
-    .where(role ? eq(contacts.role, role) : undefined)
+    .where(conditions.length === 1 ? conditions[0] : and(...conditions))
     .orderBy(
       sql`${contacts.role} = 'guardian' DESC`,
       desc(contacts.importance),
@@ -500,6 +521,7 @@ export function listContacts(
 export function mergeContacts(
   keepId: string,
   mergeId: string,
+  assistantId: string,
 ): ContactWithChannels {
   const db = getDb();
 
@@ -511,14 +533,18 @@ export function mergeContacts(
     const keep = tx
       .select()
       .from(contacts)
-      .where(eq(contacts.id, keepId))
+      .where(
+        and(eq(contacts.id, keepId), eq(contacts.assistantId, assistantId)),
+      )
       .get();
     if (!keep) throw new Error(`Contact "${keepId}" not found`);
 
     const merge = tx
       .select()
       .from(contacts)
-      .where(eq(contacts.id, mergeId))
+      .where(
+        and(eq(contacts.id, mergeId), eq(contacts.assistantId, assistantId)),
+      )
       .get();
     if (!merge) throw new Error(`Contact "${mergeId}" not found`);
 
@@ -576,7 +602,7 @@ export function mergeContacts(
     tx.delete(contacts).where(eq(contacts.id, mergeId)).run();
   });
 
-  return getContact(keepId)!;
+  return getContactInternal(keepId)!;
 }
 
 /**
@@ -599,7 +625,7 @@ export function findContactByAddress(
     .get();
 
   if (!channel) return null;
-  return getContact(channel.contactId);
+  return getContactInternal(channel.contactId);
 }
 
 /**
@@ -623,7 +649,7 @@ export function findContactByChannelExternalId(
     .get();
 
   if (!channel) return null;
-  return getContact(channel.contactId);
+  return getContactInternal(channel.contactId);
 }
 
 /**
@@ -646,7 +672,7 @@ export function findContactByChannelExternalChatId(
     )
     .get();
   if (!channel) return null;
-  return getContact(channel.contactId);
+  return getContactInternal(channel.contactId);
 }
 
 /**

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -8,6 +8,7 @@
 
 import type { ChannelId } from "../channels/types.js";
 import type { GuardianBinding } from "../memory/channel-guardian-store.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { getLogger } from "../util/logger.js";
 import { emitContactChange } from "./contact-events.js";
@@ -177,6 +178,7 @@ export function upsertMember(params: {
 
   upsertContact({
     displayName,
+    assistantId: params.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
     channels: [
       {
         type: params.sourceChannel,
@@ -232,7 +234,10 @@ export function revokeMember(
     revokedReason: reason ?? null,
   });
 
-  const contact = getContact(channelRow.contactId);
+  const contact = getContact(
+    channelRow.contactId,
+    DAEMON_INTERNAL_ASSISTANT_ID,
+  );
   if (!contact) return null;
   const updatedChannel = contact.channels.find((ch) => ch.id === channelId);
   if (!updatedChannel) return null;
@@ -261,7 +266,10 @@ export function blockMember(
     blockedReason: reason ?? null,
   });
 
-  const contact = getContact(channelRow.contactId);
+  const contact = getContact(
+    channelRow.contactId,
+    DAEMON_INTERNAL_ASSISTANT_ID,
+  );
   if (!contact) return null;
   const updatedChannel = contact.channels.find((ch) => ch.id === channelId);
   if (!updatedChannel) return null;

--- a/assistant/src/daemon/handlers/contacts.ts
+++ b/assistant/src/daemon/handlers/contacts.ts
@@ -6,6 +6,7 @@ import {
   updateChannelStatus,
 } from "../../contacts/contact-store.js";
 import type { ContactWithChannels } from "../../contacts/types.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
 import type {
   ContactChannelPayload,
   ContactPayload,
@@ -53,7 +54,11 @@ export function handleContacts(
   try {
     switch (msg.action) {
       case "list": {
-        const results = listContacts(msg.limit ?? 50, msg.role);
+        const results = listContacts(
+          DAEMON_INTERNAL_ASSISTANT_ID,
+          msg.limit ?? 50,
+          msg.role,
+        );
         ctx.send(socket, {
           type: "contacts_response",
           success: true,
@@ -71,7 +76,7 @@ export function handleContacts(
           });
           return;
         }
-        const contact = getContact(msg.contactId);
+        const contact = getContact(msg.contactId, DAEMON_INTERNAL_ASSISTANT_ID);
         if (!contact) {
           ctx.send(socket, {
             type: "contacts_response",
@@ -122,7 +127,10 @@ export function handleContacts(
           return;
         }
         // Return the parent contact with all channels so the client has the full picture
-        const parentContact = getContact(updated.contactId);
+        const parentContact = getContact(
+          updated.contactId,
+          DAEMON_INTERNAL_ASSISTANT_ID,
+        );
         ctx.send(socket, {
           type: "contacts_response",
           success: true,

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -1109,25 +1109,28 @@ export class RuntimeHttpServer {
       {
         endpoint: "contacts",
         method: "GET",
-        handler: ({ url }) => handleListContacts(url),
+        handler: ({ url, authContext }) =>
+          handleListContacts(url, authContext.assistantId),
       },
       {
         endpoint: "contacts/merge",
         method: "POST",
-        handler: async ({ req }) => handleMergeContacts(req),
+        handler: async ({ req, authContext }) =>
+          handleMergeContacts(req, authContext.assistantId),
       },
       {
         endpoint: "contacts/channels/:id",
         method: "PATCH",
         policyKey: "contacts/channels",
-        handler: async ({ req, params }) =>
-          handleUpdateContactChannel(req, params.id),
+        handler: async ({ req, params, authContext }) =>
+          handleUpdateContactChannel(req, params.id, authContext.assistantId),
       },
       {
         endpoint: "contacts/:id",
         method: "GET",
         policyKey: "contacts",
-        handler: ({ params }) => handleGetContact(params.id),
+        handler: ({ params, authContext }) =>
+          handleGetContact(params.id, authContext.assistantId),
       },
 
       // ------------------------------------------------------------------

--- a/assistant/src/runtime/ingress-service.ts
+++ b/assistant/src/runtime/ingress-service.ts
@@ -29,6 +29,7 @@ import {
 } from "../memory/ingress-invite-store.js";
 import { isValidE164 } from "../util/phone.js";
 import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 import { getTransport } from "./channel-invite-transport.js";
 import {
   type InviteRedemptionOutcome,
@@ -358,9 +359,12 @@ export function listIngressContacts(params: {
   policy?: string;
 }): IngressResult<MemberResponseData[]> {
   // Use uncapped: true since this internal path needs the full dataset
-  const allContacts = listContacts(Number.MAX_SAFE_INTEGER, "contact", {
-    uncapped: true,
-  });
+  const allContacts = listContacts(
+    params.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+    Number.MAX_SAFE_INTEGER,
+    "contact",
+    { uncapped: true },
+  );
   const members = allContacts.flatMap((c) => contactToMemberResponse(c));
 
   const filtered = members.filter((m) => {

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -23,18 +23,21 @@ import { httpError } from "../http-errors.js";
 /**
  * GET /v1/contacts?limit=50&role=guardian
  */
-export function handleListContacts(url: URL): Response {
+export function handleListContacts(url: URL, assistantId: string): Response {
   const limit = Number(url.searchParams.get("limit") ?? 50);
   const role = url.searchParams.get("role") as ContactRole | null;
-  const contacts = listContacts(limit, role ?? undefined);
+  const contacts = listContacts(assistantId, limit, role ?? undefined);
   return Response.json({ ok: true, contacts });
 }
 
 /**
  * GET /v1/contacts/:id
  */
-export function handleGetContact(contactId: string): Response {
-  const contact = getContact(contactId);
+export function handleGetContact(
+  contactId: string,
+  assistantId: string,
+): Response {
+  const contact = getContact(contactId, assistantId);
   if (!contact) {
     return httpError("NOT_FOUND", `Contact "${contactId}" not found`, 404);
   }
@@ -44,7 +47,10 @@ export function handleGetContact(contactId: string): Response {
 /**
  * POST /v1/contacts/merge { keepId, mergeId }
  */
-export async function handleMergeContacts(req: Request): Promise<Response> {
+export async function handleMergeContacts(
+  req: Request,
+  assistantId: string,
+): Promise<Response> {
   const body = (await req.json()) as { keepId?: string; mergeId?: string };
 
   if (!body.keepId || !body.mergeId) {
@@ -52,7 +58,7 @@ export async function handleMergeContacts(req: Request): Promise<Response> {
   }
 
   try {
-    const contact = mergeContacts(body.keepId, body.mergeId);
+    const contact = mergeContacts(body.keepId, body.mergeId, assistantId);
     return Response.json({ ok: true, contact });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -87,6 +93,7 @@ function isChannelPolicy(value: string): value is ChannelPolicy {
 export async function handleUpdateContactChannel(
   req: Request,
   channelId: string,
+  assistantId: string,
 ): Promise<Response> {
   const body = (await req.json()) as {
     status?: string;
@@ -135,6 +142,6 @@ export async function handleUpdateContactChannel(
     return httpError("NOT_FOUND", `Channel "${channelId}" not found`, 404);
   }
 
-  const parentContact = getContact(updated.contactId);
+  const parentContact = getContact(updated.contactId, assistantId);
   return Response.json({ ok: true, contact: parentContact ?? undefined });
 }

--- a/assistant/src/runtime/routes/global-search-routes.ts
+++ b/assistant/src/runtime/routes/global-search-routes.ts
@@ -19,6 +19,7 @@ import { rawAll } from "../../memory/raw-query.js";
 import { semanticSearch } from "../../memory/search/semantic.js";
 import { listSchedules } from "../../schedule/schedule-store.js";
 import { getLogger } from "../../util/logger.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { httpError } from "../http-errors.js";
 
 const log = getLogger("global-search");
@@ -247,7 +248,11 @@ export async function handleGlobalSearch(url: URL): Promise<Response> {
   }
 
   if (categories.has("contacts")) {
-    const contactResults = searchContacts({ query, limit });
+    const contactResults = searchContacts({
+      assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+      query,
+      limit,
+    });
     results.contacts = contactResults.map((c) => ({
       id: c.id,
       displayName: c.displayName,

--- a/assistant/src/tools/followups/followup_create.ts
+++ b/assistant/src/tools/followups/followup_create.ts
@@ -1,6 +1,7 @@
 import { getContact } from "../../contacts/contact-store.js";
 import { createFollowUp } from "../../followups/followup-store.js";
 import type { FollowUp } from "../../followups/types.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 function formatFollowUp(f: FollowUp): string {
@@ -56,7 +57,7 @@ export async function executeFollowupCreate(
 
   // Validate contact exists if provided
   if (contactId) {
-    const contact = getContact(contactId);
+    const contact = getContact(contactId, DAEMON_INTERNAL_ASSISTANT_ID);
     if (!contact) {
       return {
         content: `Error: Contact "${contactId}" not found`,


### PR DESCRIPTION
## Summary
- Add assistantId as required param to listContacts, searchContacts, getContact, mergeContacts
- Make assistantId required on upsertContact
- Thread authContext.assistantId through all contact route handlers
- Update all callers across the codebase (daemon handlers, ingress service, global search, skill tools, followup_create, contacts-write, test files)
- Add getContactInternal helper for internal channel-based lookups that have already resolved identity

Part of plan: contacts-skill-cli-consolidation.md (PR 1 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
