### PR TITLE
fix: remove box shadow from app cards

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -207,7 +207,7 @@ struct AppsGridView: View {
                     .allowsHitTesting(isHovered)
                     .animation(VAnimation.fast, value: isHovered)
                 }
-                .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
+
 
                 // Name + date below the image
                 VStack(alignment: .leading, spacing: 2) {


### PR DESCRIPTION
## Summary
- Remove the subtle box shadow (`.shadow(color: .black.opacity(0.06), radius: 4, y: 2)`) from app card thumbnails in the Things grid

## Test plan
- [ ] App cards in Things panel have no drop shadow beneath the image area

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
