### PR TITLE
feat: add POST /v1/contacts upsert endpoint

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -139,6 +139,7 @@ import {
   handleListContacts,
   handleMergeContacts,
   handleUpdateContactChannel,
+  handleUpsertContact,
 } from "./routes/contact-routes.js";
 import { handleListConversationAttention } from "./routes/conversation-attention-routes.js";
 // Route handlers — grouped by domain
@@ -1111,6 +1112,12 @@ export class RuntimeHttpServer {
         method: "GET",
         handler: ({ url, authContext }) =>
           handleListContacts(url, authContext.assistantId),
+      },
+      {
+        endpoint: "contacts",
+        method: "POST",
+        handler: async ({ req, authContext }) =>
+          handleUpsertContact(req, authContext.assistantId),
       },
       {
         endpoint: "contacts/merge",

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -2,6 +2,7 @@
  * Route handlers for contact management endpoints.
  *
  * GET   /v1/contacts              — list contacts
+ * POST  /v1/contacts              — create or update a contact
  * GET   /v1/contacts/:id          — get a contact by ID
  * POST  /v1/contacts/merge        — merge two contacts
  * PATCH /v1/contacts/channels/:id — update a contact channel's status/policy
@@ -12,6 +13,7 @@ import {
   listContacts,
   mergeContacts,
   updateChannelStatus,
+  upsertContact,
 } from "../../contacts/contact-store.js";
 import type {
   ChannelPolicy,
@@ -60,6 +62,71 @@ export async function handleMergeContacts(
   try {
     const contact = mergeContacts(body.keepId, body.mergeId, assistantId);
     return Response.json({ ok: true, contact });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return httpError("BAD_REQUEST", message, 400);
+  }
+}
+
+/**
+ * POST /v1/contacts { displayName, id?, relationship?, importance?, ... }
+ */
+export async function handleUpsertContact(
+  req: Request,
+  assistantId: string,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    id?: string;
+    displayName?: string;
+    relationship?: string;
+    importance?: number;
+    responseExpectation?: string;
+    preferredTone?: string;
+    role?: string;
+    channels?: Array<{ type: string; address: string; isPrimary?: boolean }>;
+  };
+
+  if (
+    !body.displayName ||
+    typeof body.displayName !== "string" ||
+    body.displayName.trim().length === 0
+  ) {
+    return httpError(
+      "BAD_REQUEST",
+      "displayName is required and must be a non-empty string",
+      400,
+    );
+  }
+
+  if (
+    body.importance !== undefined &&
+    (typeof body.importance !== "number" ||
+      body.importance < 0 ||
+      body.importance > 1)
+  ) {
+    return httpError(
+      "BAD_REQUEST",
+      "importance must be a number between 0 and 1",
+      400,
+    );
+  }
+
+  try {
+    const contact = upsertContact({
+      id: body.id,
+      displayName: body.displayName.trim(),
+      relationship: body.relationship,
+      importance: body.importance,
+      responseExpectation: body.responseExpectation,
+      preferredTone: body.preferredTone,
+      role: body.role as ContactRole | undefined,
+      assistantId,
+      channels: body.channels,
+    });
+    return Response.json(
+      { ok: true, contact },
+      { status: contact.created ? 201 : 200 },
+    );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return httpError("BAD_REQUEST", message, 400);


### PR DESCRIPTION
## Summary
- Add handleUpsertContact handler in contact-routes.ts
- Register POST /v1/contacts route in http-server.ts
- Validates displayName (required) and importance range (0-1)
- Returns 201 for creation, 200 for update

Part of plan: contacts-skill-cli-consolidation.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
