### PR TITLE
refactor: convert contacts skill tools from direct store imports to gateway HTTP calls

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
@@ -1,12 +1,24 @@
-import {
-  getContact,
-  mergeContacts,
-} from "../../../../contacts/contact-store.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../../runtime/assistant-scope.js";
+import { getGatewayInternalBaseUrl } from "../../../../config/env.js";
+import { mintEdgeRelayToken } from "../../../../runtime/auth/token-service.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
+
+interface ContactChannel {
+  type: string;
+  address: string;
+  isPrimary: boolean;
+}
+
+interface ContactResponse {
+  id: string;
+  displayName: string;
+  relationship: string | null;
+  importance: number;
+  interactionCount: number;
+  channels: ContactChannel[];
+}
 
 export async function executeContactMerge(
   input: Record<string, unknown>,
@@ -22,19 +34,74 @@ export async function executeContactMerge(
     return { content: "Error: merge_id is required", isError: true };
   }
 
-  // Show what will be merged for clarity
-  const keepContact = getContact(keepId, DAEMON_INTERNAL_ASSISTANT_ID);
-  const mergeContact = getContact(mergeId, DAEMON_INTERNAL_ASSISTANT_ID);
-
-  if (!keepContact) {
-    return { content: `Error: Contact "${keepId}" not found`, isError: true };
-  }
-  if (!mergeContact) {
-    return { content: `Error: Contact "${mergeId}" not found`, isError: true };
-  }
-
   try {
-    const merged = mergeContacts(keepId, mergeId, DAEMON_INTERNAL_ASSISTANT_ID);
+    const gatewayBase = getGatewayInternalBaseUrl();
+    const token = mintEdgeRelayToken();
+    const headers = {
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`,
+    };
+
+    // Validate both contacts exist before merging
+    const [keepResp, mergeResp] = await Promise.all([
+      fetch(`${gatewayBase}/v1/contacts/${keepId}`, {
+        method: "GET",
+        headers,
+      }),
+      fetch(`${gatewayBase}/v1/contacts/${mergeId}`, {
+        method: "GET",
+        headers,
+      }),
+    ]);
+
+    if (!keepResp.ok) {
+      return { content: `Error: Contact "${keepId}" not found`, isError: true };
+    }
+    if (!mergeResp.ok) {
+      return {
+        content: `Error: Contact "${mergeId}" not found`,
+        isError: true,
+      };
+    }
+
+    const keepData = (await keepResp.json()) as {
+      ok: boolean;
+      contact: ContactResponse;
+    };
+    const mergeData = (await mergeResp.json()) as {
+      ok: boolean;
+      contact: ContactResponse;
+    };
+    const keepContact = keepData.contact;
+    const mergeContact = mergeData.contact;
+
+    // Execute the merge
+    const mergeResult = await fetch(`${gatewayBase}/v1/contacts/merge`, {
+      method: "POST",
+      headers: {
+        ...headers,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ keepId, mergeId }),
+    });
+
+    if (!mergeResult.ok) {
+      const body = await mergeResult.text();
+      let message = `Gateway request failed (${mergeResult.status})`;
+      try {
+        const parsed = JSON.parse(body) as { error?: string };
+        if (parsed.error) message = parsed.error;
+      } catch {
+        if (body) message = body;
+      }
+      return { content: `Error: ${message}`, isError: true };
+    }
+
+    const resultData = (await mergeResult.json()) as {
+      ok: boolean;
+      contact: ContactResponse;
+    };
+    const merged = resultData.contact;
 
     const channelList = merged.channels
       .map(

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-search.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-search.ts
@@ -1,12 +1,26 @@
-import { searchContacts } from "../../../../contacts/contact-store.js";
-import type { ContactWithChannels } from "../../../../contacts/types.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../../runtime/assistant-scope.js";
+import { getGatewayInternalBaseUrl } from "../../../../config/env.js";
+import { mintEdgeRelayToken } from "../../../../runtime/auth/token-service.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
 
-function formatContactSummary(c: ContactWithChannels): string {
+interface ContactChannel {
+  type: string;
+  address: string;
+  isPrimary: boolean;
+}
+
+interface ContactResponse {
+  id: string;
+  displayName: string;
+  relationship: string | null;
+  importance: number;
+  interactionCount: number;
+  channels: ContactChannel[];
+}
+
+function formatContactSummary(c: ContactResponse): string {
   const parts = [`- **${c.displayName}** (ID: ${c.id})`];
   if (c.relationship) parts.push(`  Relationship: ${c.relationship}`);
   parts.push(
@@ -42,14 +56,44 @@ export async function executeContactSearch(
   }
 
   try {
-    const results = searchContacts({
-      assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-      query,
-      channelAddress,
-      channelType,
-      relationship,
-      limit,
+    const gatewayBase = getGatewayInternalBaseUrl();
+    const token = mintEdgeRelayToken();
+
+    const params = new URLSearchParams();
+    if (query) params.set("query", query);
+    if (channelAddress) params.set("channelAddress", channelAddress);
+    if (channelType) params.set("channelType", channelType);
+    if (relationship) params.set("relationship", relationship);
+    if (limit !== undefined) params.set("limit", String(limit));
+
+    const qs = params.toString();
+    const url = `${gatewayBase}/v1/contacts${qs ? `?${qs}` : ""}`;
+
+    const resp = await fetch(url, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      },
     });
+
+    if (!resp.ok) {
+      const body = await resp.text();
+      let message = `Gateway request failed (${resp.status})`;
+      try {
+        const parsed = JSON.parse(body) as { error?: string };
+        if (parsed.error) message = parsed.error;
+      } catch {
+        if (body) message = body;
+      }
+      return { content: `Error: ${message}`, isError: true };
+    }
+
+    const data = (await resp.json()) as {
+      ok: boolean;
+      contacts: ContactResponse[];
+    };
+    const results = data.contacts;
 
     if (results.length === 0) {
       return {

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-upsert.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-upsert.ts
@@ -1,11 +1,28 @@
-import { upsertContact } from "../../../../contacts/contact-store.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../../runtime/assistant-scope.js";
+import { getGatewayInternalBaseUrl } from "../../../../config/env.js";
+import { mintEdgeRelayToken } from "../../../../runtime/auth/token-service.js";
 import type {
   ToolContext,
   ToolExecutionResult,
 } from "../../../../tools/types.js";
 
-function formatContact(c: ReturnType<typeof upsertContact>): string {
+interface ContactChannel {
+  type: string;
+  address: string;
+  isPrimary: boolean;
+}
+
+interface ContactResponse {
+  id: string;
+  displayName: string;
+  relationship: string | null;
+  importance: number;
+  responseExpectation: string | null;
+  preferredTone: string | null;
+  interactionCount: number;
+  channels: ContactChannel[];
+}
+
+function formatContact(c: ContactResponse): string {
   const lines = [`Contact ${c.id}`, `  Name: ${c.displayName}`];
   if (c.relationship) lines.push(`  Relationship: ${c.relationship}`);
   lines.push(`  Importance: ${c.importance.toFixed(2)}`);
@@ -61,21 +78,46 @@ export async function executeContactUpsert(
   }));
 
   try {
-    const contact = upsertContact({
-      id: input.id as string | undefined,
-      displayName: displayName.trim(),
-      relationship: input.relationship as string | undefined,
-      importance,
-      responseExpectation: input.response_expectation as string | undefined,
-      preferredTone: input.preferred_tone as string | undefined,
-      assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-      channels,
+    const gatewayBase = getGatewayInternalBaseUrl();
+    const token = mintEdgeRelayToken();
+
+    const resp = await fetch(`${gatewayBase}/v1/contacts`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        id: input.id as string | undefined,
+        displayName: displayName.trim(),
+        relationship: input.relationship as string | undefined,
+        importance,
+        responseExpectation: input.response_expectation as string | undefined,
+        preferredTone: input.preferred_tone as string | undefined,
+        channels,
+      }),
     });
 
+    if (!resp.ok) {
+      const body = await resp.text();
+      let message = `Gateway request failed (${resp.status})`;
+      try {
+        const parsed = JSON.parse(body) as { error?: string };
+        if (parsed.error) message = parsed.error;
+      } catch {
+        if (body) message = body;
+      }
+      return { content: `Error: ${message}`, isError: true };
+    }
+
+    const data = (await resp.json()) as {
+      ok: boolean;
+      contact: ContactResponse;
+    };
+    const created = resp.status === 201;
+
     return {
-      content: `${
-        contact.created ? "Created" : "Updated"
-      } contact:\n${formatContact(contact)}`,
+      content: `${created ? "Created" : "Updated"} contact:\n${formatContact(data.contact)}`,
       isError: false,
     };
   } catch (err) {


### PR DESCRIPTION
## Summary
- Replace direct upsertContact/searchContacts/getContact/mergeContacts store imports with gateway HTTP calls
- contact-upsert now uses POST /v1/contacts
- contact-search now uses GET /v1/contacts with query params
- contact-merge now uses GET /v1/contacts/:id + POST /v1/contacts/merge
- assistantId conveyed via gateway JWT, not in request bodies

Part of plan: contacts-skill-cli-consolidation.md (PR 4 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)