### PR TITLE
chore: deprecate vellum integrations ingress CLI in favor of vellum contacts

### DIFF
--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -302,7 +302,9 @@ export function registerIntegrationsCommand(program: Command): void {
 
   ingress
     .command("members")
-    .description("List trusted contacts (calls /v1/contacts with role=contact)")
+    .description(
+      "[Deprecated: use 'vellum contacts list'] List trusted contacts",
+    )
     .option("--limit <limit>", "Maximum number of contacts to return")
     .option("--role <role>", "Filter by role (default: contact)")
     .action(
@@ -313,6 +315,9 @@ export function registerIntegrationsCommand(program: Command): void {
         },
         cmd: Command,
       ) => {
+        process.stderr.write(
+          "⚠️  'vellum integrations ingress members' is deprecated. Use 'vellum contacts list' instead.\n",
+        );
         const query = toQueryString({
           role: opts.role ?? "contact",
           limit: opts.limit,
@@ -323,7 +328,9 @@ export function registerIntegrationsCommand(program: Command): void {
 
   ingress
     .command("invites")
-    .description("List trusted ingress invites")
+    .description(
+      "[Deprecated: use 'vellum contacts invites'] List trusted ingress invites",
+    )
     .option("--source-channel <sourceChannel>", "Filter by source channel")
     .option("--status <status>", "Filter by invite status")
     .action(
@@ -331,6 +338,9 @@ export function registerIntegrationsCommand(program: Command): void {
         opts: { sourceChannel?: IngressChannel; status?: string },
         cmd: Command,
       ) => {
+        process.stderr.write(
+          "⚠️  'vellum integrations ingress invites' is deprecated. Use 'vellum contacts invites' instead.\n",
+        );
         const query = toQueryString({
           sourceChannel: opts.sourceChannel,
           status: opts.status,

--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -105,18 +105,19 @@ Trusted contacts control who is allowed to send messages to the assistant throug
 Use this to show the user who currently has access, or to look up a specific contact.
 
 ```bash
-vellum integrations ingress members --json
+vellum contacts list --json
 ```
 
 Optional query parameters for filtering:
 
 - `--role <role>` -- filter by role (default: `contact`; use `guardian` to list guardians)
 - `--limit <limit>` -- maximum number of contacts to return
+- `--query <query>` -- search query to filter contacts
 
 Example:
 
 ```bash
-vellum integrations ingress members --role contact --json
+vellum contacts list --role contact --json
 ```
 
 The response contains `{ ok: true, contacts: [...] }` where each contact has:
@@ -343,13 +344,13 @@ If the user provides a phone number without the `+` country code prefix, ask the
 Use this to show the guardian their active (and optionally all) invite links.
 
 ```bash
-vellum integrations ingress invites --source-channel telegram --json
+vellum contacts invites --source-channel telegram --json
 ```
 
 For voice invites:
 
 ```bash
-vellum integrations ingress invites --source-channel voice --json
+vellum contacts invites --source-channel voice --json
 ```
 
 Optional query parameters:


### PR DESCRIPTION
## Summary
- Add deprecation warnings to vellum integrations ingress members/invites commands
- Update contacts/SKILL.md to reference vellum contacts list/invites
- Update all documentation references from old to new CLI commands

Part of plan: contacts-skill-cli-consolidation.md (PR 7 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)