### PR TITLE
fix: enforce write scope on contacts upsert and add NaN validation

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -165,6 +165,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "brain-graph-ui", scopes: ["settings.read"] },
   { endpoint: "home-base-ui", scopes: ["settings.read"] },
   { endpoint: "contacts", scopes: ["settings.read"] },
+  { endpoint: "contacts:POST", scopes: ["settings.write"] },
   { endpoint: "contacts/merge", scopes: ["settings.write"] },
   { endpoint: "contacts:GET", scopes: ["settings.read"] },
   { endpoint: "contacts/channels", scopes: ["settings.write"] },

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -124,6 +124,7 @@ export async function handleUpsertContact(
   if (
     body.importance !== undefined &&
     (typeof body.importance !== "number" ||
+      Number.isNaN(body.importance) ||
       body.importance < 0 ||
       body.importance > 1)
   ) {


### PR DESCRIPTION
Addresses feedback from PR #12297:

1. Add write-specific policyKey to POST /v1/contacts route to prevent read-only principals from creating/updating contacts
2. Add Number.isNaN check to importance validation to prevent NaN from bypassing the range check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
