### PR TITLE
fix: rebind null-scoped contact to caller assistantId after merge

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -596,6 +596,8 @@ export function mergeContacts(
           keep.responseExpectation ?? merge.responseExpectation,
         preferredTone: keep.preferredTone ?? merge.preferredTone,
         updatedAt: now,
+        // Rebind legacy null-scoped contacts to prevent cross-assistant leakage
+        ...(keep.assistantId == null ? { assistantId } : {}),
       })
       .where(eq(contacts.id, keepId))
       .run();


### PR DESCRIPTION
Prevents cross-assistant data leakage when a legacy NULL-assistantId contact survives a merge. After merge, if the surviving contact has NULL assistantId, rebinds it to the caller's assistantId. Addresses feedback from PR #12302.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
