### PR TITLE
chore: update stale ingress member comments to contact terminology

### DIFF
--- a/assistant/README.md
+++ b/assistant/README.md
@@ -323,10 +323,10 @@ When a member's policy is `escalate`:
 
 ### How the Systems Connect
 
-Guardian verification and ingress membership are complementary but independent systems:
+Guardian verification and ingress contact management are complementary but independent systems:
 
 - **Guardian verification** establishes _who controls the assistant_ on a given channel. The guardian can approve sensitive actions, approve escalated messages, and is the trust anchor.
-- **Ingress membership** controls _who can interact with the assistant_ on a given channel. Members are created via invite redemption, not via guardian verification.
+- **Ingress contacts** control _who can interact with the assistant_ on a given channel. Contacts are created via invite redemption, not via guardian verification.
 - **Dependency**: Escalation requires a guardian binding — if no guardian has been verified for the channel, `escalate` policy messages are denied. This means guardian verification must precede any escalation-based access control.
 
 ### Key Modules

--- a/assistant/src/__tests__/conversation-attention-telegram.test.ts
+++ b/assistant/src/__tests__/conversation-attention-telegram.test.ts
@@ -387,7 +387,7 @@ describe("duplicate event deduplication", () => {
 
 describe("non-Telegram channel filtering", () => {
   test("SMS inbound message does not record a Telegram seen signal", async () => {
-    // Override ingress member store for SMS channel
+    // Override contact store for SMS channel
     const req = makeInboundRequest({
       sourceChannel: "sms",
       interface: "sms",

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1892,7 +1892,7 @@ export class RelayConnection {
 
   /**
    * Validate an entered invite code against active voice invites for the
-   * caller. On success, create/activate the ingress member and transition
+   * caller. On success, create/activate the contact and transition
    * to the normal call flow. On failure, allow retries up to max attempts.
    */
   private attemptInviteCodeRedemption(enteredCode: string): void {

--- a/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: "Guardian Verify Setup"
 description: "Set up guardian verification for voice or Telegram channels via outbound verification flow"
 user-invocable: true
-metadata: {"vellum": {"emoji": "\ud83d\udd10"}}
+metadata: { "vellum": { "emoji": "\ud83d\udd10" } }
 ---
 
 You are helping your user set up guardian verification for a messaging channel (voice or Telegram). This links their identity as the trusted guardian for the chosen channel. Use gateway control-plane APIs for outbound actions, and use `vellum integrations guardian status` for status reads.
@@ -60,14 +60,14 @@ After reporting the bootstrap URL for Telegram handle flows, wait for the user t
 
 Handle each error code:
 
-| Error code | Action |
-|---|---|
-| `missing_destination` | Ask the user to provide their phone number or Telegram destination. |
-| `invalid_destination` | Tell the user the format is invalid. For phone: suggest E.164 format (+15551234567). For Telegram: explain that group chat IDs (negative numbers) are not supported. |
-| `already_bound` | Tell the user a guardian is already bound for this channel. Ask if they want to replace it. If yes, re-run the start request with `"rebind": true` added to the JSON body. |
-| `rate_limited` | Tell the user they have sent too many verification attempts to this destination. Ask them to wait and try again later. |
-| `unsupported_channel` | Tell the user the channel is not supported. Only voice and telegram are valid. |
-| `no_bot_username` | Telegram bot is not configured. Load and run the `telegram-setup` skill first. |
+| Error code            | Action                                                                                                                                                                     |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `missing_destination` | Ask the user to provide their phone number or Telegram destination.                                                                                                        |
+| `invalid_destination` | Tell the user the format is invalid. For phone: suggest E.164 format (+15551234567). For Telegram: explain that group chat IDs (negative numbers) are not supported.       |
+| `already_bound`       | Tell the user a guardian is already bound for this channel. Ask if they want to replace it. If yes, re-run the start request with `"rebind": true` added to the JSON body. |
+| `rate_limited`        | Tell the user they have sent too many verification attempts to this destination. Ask them to wait and try again later.                                                     |
+| `unsupported_channel` | Tell the user the channel is not supported. Only voice and telegram are valid.                                                                                             |
+| `no_bot_username`     | Telegram bot is not configured. Load and run the `telegram-setup` skill first.                                                                                             |
 
 ## Step 4: Handle Resend
 
@@ -89,13 +89,13 @@ On success, report the next action based on the channel:
 
 Handle each error code from the resend endpoint:
 
-| Error code | Action |
-|---|---|
-| `rate_limited` | Tell the user to wait before trying again (the cooldown is 15 seconds between resends). |
+| Error code           | Action                                                                                                                                                                                            |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rate_limited`       | Tell the user to wait before trying again (the cooldown is 15 seconds between resends).                                                                                                           |
 | `max_sends_exceeded` | Tell the user they have reached the maximum number of resends for this session (5 sends per session). Suggest canceling the current session (Step 5) and starting a new verification from Step 3. |
-| `no_destination` | This should not normally occur during resend. Tell the user to cancel (Step 5) and restart verification from scratch at Step 3. |
-| `pending_bootstrap` | Remind the user to click the Telegram deep-link first before a code can be sent. |
-| `no_active_session` | No session is active. Start a new one from Step 3. |
+| `no_destination`     | This should not normally occur during resend. Tell the user to cancel (Step 5) and restart verification from scratch at Step 3.                                                                   |
+| `pending_bootstrap`  | Remind the user to click the Telegram deep-link first before a code can be sent.                                                                                                                  |
+| `no_active_session`  | No session is active. Start a new one from Step 3.                                                                                                                                                |
 
 ## Step 5: Handle Cancel
 
@@ -130,12 +130,14 @@ vellum integrations guardian status --channel voice --json
 
 **Rebind guard:**
 When in a **rebind flow** (i.e., the `start_outbound` request included `"rebind": true` because a binding already existed), do NOT treat the first `bound: true` poll result as success. The pre-existing binding will already show `bound: true` before the user has entered the new code, which would be a false positive. To guard against this:
+
 - Note the `bound_at` timestamp from the **first** poll response as a baseline.
 - Only report success when a subsequent poll shows `bound: true` with a `bound_at` timestamp **strictly newer** than the baseline. This proves the new outbound session was consumed.
 - If the status endpoint does not include `bound_at`, fall back to skipping the first poll result entirely and only start evaluating `bound: true` from the **second poll onward** (giving the user time to enter the new code).
 - Non-rebind flows (fresh verification with no prior binding) are unaffected — the first `bound: true` is trustworthy.
 
 **Important polling rules:**
+
 - This polling loop is voice-only. Do NOT poll for Telegram channels (Telegram has its own bot-driven flow).
 - Do NOT require the user to ask "did it work?" — the whole point is proactive confirmation.
 - If the user sends a message while polling is in progress, handle their message normally. If their message is about verification status, the next poll iteration will provide the answer.
@@ -180,4 +182,4 @@ The response includes `bound: false` after the operation completes. Check the pr
 - Per-destination rate limiting allows up to 10 sends within a 1-hour rolling window.
 - Guardian verification is identity-bound: the code can only be consumed by the identity matching the destination provided at start time.
 - **Missing `secret` guardrail**: For voice and Telegram chat-ID flows, the API response MUST include a `secret` field. If `secret` is unexpectedly absent from a start or resend response that otherwise indicates success, treat this as a control-plane error. Do NOT fabricate a code or tell the user to proceed without one. Instead, tell the user something went wrong and ask them to retry the start (Step 3) or resend (Step 4).
-- **Revoking a guardian**: To remove the current guardian from a channel, use the revoke API (Step 7). This revokes the binding AND revokes the guardian's ingress member record, so they lose access to the channel. A new guardian can then be verified for that channel.
+- **Revoking a guardian**: To remove the current guardian from a channel, use the revoke API (Step 7). This revokes the binding AND revokes the guardian's contact record, so they lose access to the channel. A new guardian can then be verified for that channel.

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -197,7 +197,7 @@ export function revokeGuardianForChannel(
   revokePendingChallenges(assistantId, resolvedChannel);
 
   // Capture binding before revoking so we can revoke the guardian's
-  // ingress member record — without this, the guardian would still pass
+  // contact record — without this, the guardian would still pass
   // the ACL check after unbinding.
   const bindingBeforeRevoke = getGuardianBinding(assistantId, resolvedChannel);
   if (!bindingBeforeRevoke) {
@@ -226,10 +226,7 @@ export function revokeGuardianForChannel(
       channelStatus === "pending" ||
       channelStatus === "unverified"
     ) {
-      revokeMember(
-        contactResult.channel.id,
-        "guardian_binding_revoked",
-      );
+      revokeMember(contactResult.channel.id, "guardian_binding_revoked");
     }
   }
 

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -569,6 +569,6 @@ async function executeDeny(
 
 export const inboxInviteHandlers = defineHandlers({
   ingress_invite: handleIngressInvite,
-  ingress_member: handleIngressContact,
+  ingress_member: handleIngressContact, // Legacy discriminator name
   assistant_inbox_escalation: handleInboxEscalation,
 });

--- a/assistant/src/daemon/ipc-contract/inbox.ts
+++ b/assistant/src/daemon/ipc-contract/inbox.ts
@@ -30,7 +30,7 @@ export interface IngressInviteRequest {
 }
 
 export interface IngressContactRequest {
-  type: "ingress_member";
+  type: "ingress_member"; // Legacy discriminator — kept for client compatibility
   action: "list" | "upsert" | "revoke" | "block";
   /** Assistant ID for scoping member operations (defaults to 'self'). */
   assistantId?: string;
@@ -103,7 +103,7 @@ export interface IngressInviteResponse {
 }
 
 export interface IngressContactResponse {
-  type: "ingress_member_response";
+  type: "ingress_member_response"; // Legacy discriminator — kept for client compatibility
   success: boolean;
   error?: string;
   /** Single member (returned on upsert/revoke/block). */

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -205,7 +205,7 @@ export async function runDaemon(): Promise<void> {
     }
 
     // Catch-up migration: populate contacts table from legacy guardian
-    // bindings and ingress member rows. Ensures upgrades from pre-contacts
+    // bindings and contact rows. Ensures upgrades from pre-contacts
     // versions have a populated contacts table on first boot.
     try {
       migrateContactsFromLegacyTables("self");

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -75,7 +75,7 @@ export interface TrustContext {
   requesterDisplayName?: string;
   /** Raw sender display name as provided by the channel transport. */
   requesterSenderDisplayName?: string;
-  /** Guardian-managed member display name from ingress membership. */
+  /** Guardian-managed display name from the contact record. */
   requesterMemberDisplayName?: string;
   /** Canonical external user ID of the requester (the current actor). */
   requesterExternalUserId?: string;
@@ -103,15 +103,15 @@ export interface InboundActorContext {
   actorDisplayName?: string;
   /** Raw sender display name as provided by the channel transport. */
   actorSenderDisplayName?: string;
-  /** Guardian-managed member display name from ingress membership. */
+  /** Guardian-managed display name from the contact record. */
   actorMemberDisplayName?: string;
   /** Trust classification: guardian, trusted_contact, or unknown. */
   trustClass: "guardian" | "trusted_contact" | "unknown";
   /** Guardian identity for this (assistant, channel) binding. */
   guardianIdentity?: string;
-  /** Member status when the actor has an ingress member record. */
+  /** Member status when the actor has a contact record. */
   memberStatus?: string;
-  /** Member policy when the actor has an ingress member record. */
+  /** Member policy when the actor has a contact record. */
   memberPolicy?: string;
   /** Denial reason when access is blocked. */
   denialReason?: string;

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -35,11 +35,11 @@ export type { TrustContext } from "../daemon/session-runtime-assembly.js";
  * - `'guardian'`: The sender matches the active guardian binding for this
  *   (assistant, channel). Guardians have full control-plane access and
  *   self-approve tool invocations.
- * - `'trusted_contact'`: The sender is an active ingress member (not the
- *   guardian). Trusted contacts can invoke tools but require guardian
- *   approval for sensitive operations.
- * - `'unknown'`: The sender has no member record, no identity could be
- *   established, or the sender is an inactive/revoked member. Unknown
+ * - `'trusted_contact'`: The sender is an active contact with a channel
+ *   (not the guardian). Trusted contacts can invoke tools but require
+ *   guardian approval for sensitive operations.
+ * - `'unknown'`: The sender has no contact record, no identity could be
+ *   established, or the sender is an inactive/revoked contact. Unknown
  *   actors are fail-closed with no escalation path.
  */
 export type TrustClass = "guardian" | "trusted_contact" | "unknown";
@@ -118,7 +118,7 @@ export interface ResolveActorTrustInput {
  * 1. Canonicalize the sender identity (E.164 for phone channels, trimmed ID otherwise).
  * 2. Look up the guardian binding for (assistantId, channel).
  * 3. Compare canonical sender identity to the guardian binding.
- * 4. Look up the ingress member record using the canonical identity.
+ * 4. Look up the contact record using the canonical identity.
  * 5. Classify: guardian > trusted_contact (active member) > unknown.
  */
 export function resolveActorTrust(

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -1141,7 +1141,7 @@ export class RuntimeHttpServer {
       },
 
       // ------------------------------------------------------------------
-      // Ingress members
+      // Ingress contacts
       // ------------------------------------------------------------------
       {
         endpoint: "ingress/members",

--- a/assistant/src/runtime/routes/ingress-routes.ts
+++ b/assistant/src/runtime/routes/ingress-routes.ts
@@ -1,5 +1,5 @@
 /**
- * Route handlers for ingress member and invite management.
+ * Route handlers for ingress contact and invite management.
  *
  * Members:
  *   GET    /v1/ingress/members           — list members

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -166,7 +166,7 @@ public final class SettingsStore: ObservableObject {
     @Published var voiceOutboundSendCount: Int = 0
     @Published var voiceOutboundCode: String?
 
-    // MARK: - Approved Ingress Members (Telegram)
+    // MARK: - Approved Ingress Contacts (Telegram)
 
     struct ApprovedMember: Identifiable, Equatable {
         let id: String
@@ -1586,7 +1586,7 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    // MARK: - Approved Ingress Members Actions
+    // MARK: - Approved Ingress Contacts Actions
 
     func refreshTelegramApprovedMembers() {
         guard let http = resolveRuntimeHTTP() else { return }

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -514,7 +514,7 @@ The channel inbound handler (`inbound-message-handler.ts`) enforces an access co
 
 **Invite-based onboarding:** Invite tokens are created via the `ingress_invite` IPC contract. Each token is SHA-256 hashed before storage -- the raw token is returned exactly once at creation time. External users redeem invites by sending the token as a channel message, which atomically creates a member record with `active` status and `allow` policy.
 
-**Relationship to guardian verification:** Guardian verification and ingress membership are independent systems. Guardian verification establishes who controls the assistant on a channel (the trust anchor for approvals and escalations). Ingress membership controls who can interact with the assistant. Escalation (`policy=escalate`) depends on a guardian binding existing for the channel -- without one, escalated messages are denied (fail-closed).
+**Relationship to guardian verification:** Guardian verification and ingress contact management are independent systems. Guardian verification establishes who controls the assistant on a channel (the trust anchor for approvals and escalations). Ingress contacts control who can interact with the assistant. Escalation (`policy=escalate`) depends on a guardian binding existing for the channel -- without one, escalated messages are denied (fail-closed).
 
 #### Escalation Data Flow
 

--- a/gateway/src/http/routes/ingress-control-plane-proxy.ts
+++ b/gateway/src/http/routes/ingress-control-plane-proxy.ts
@@ -1,5 +1,5 @@
 /**
- * Gateway proxy endpoints for ingress members/invites control-plane routes.
+ * Gateway proxy endpoints for ingress contacts/invites control-plane routes.
  *
  * These routes remain available even when the broad runtime proxy is
  * disabled, so skills and clients can use gateway URLs exclusively.


### PR DESCRIPTION
## Summary
- Update comments in actor-trust-resolver.ts from 'ingress member' to 'contact'
- Document legacy IPC discriminator naming in inbox.ts for backward compatibility
- Document legacy handler map key in config-inbox.ts
- Update remaining 'ingress member' references in comments across 15 files to use 'contact' terminology
- Excluded: migration files (historical), ingress-service.ts (ingress concept still valid), CLI deprecation warnings (intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
