### PR TITLE
fix: revert contact_id tip in contacts SKILL.md to match followup tool parameter

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -439,7 +439,7 @@ Each channel has:
 ## Tips
 
 - Use contact search with `channelAddress` to find contacts by their email, phone, or handle.
-- When creating follow-ups, provide a `contactId` to link the follow-up to a specific contact for grace period calculations.
+- When creating follow-ups, provide a `contact_id` to link the follow-up to a specific contact for grace period calculations.
 - Contacts with higher importance scores get shorter default response deadlines.
 - When merging contacts, the surviving contact keeps the higher importance score and gains all channels from the donor.
 


### PR DESCRIPTION
Codex correctly identified that PR #12307 changed the follow-up tip from `contact_id` to `contactId`, but the followup_create tool reads `input.contact_id` (snake_case). This reverts that specific change to prevent the model from using the wrong key, which would silently break contact-follow-up linkage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
