### PR TITLE
feat: add outbound-proxy-sidecar feature flag

### DIFF
--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -88,6 +88,14 @@
       "label": "Contacts Tab",
       "description": "Show the Contacts tab in Settings for viewing and managing contacts",
       "defaultEnabled": false
+    },
+    {
+      "id": "outbound-proxy-sidecar",
+      "scope": "assistant",
+      "key": "feature_flags.outbound-proxy-sidecar.enabled",
+      "label": "Outbound Proxy Sidecar",
+      "description": "Route proxy session management through the sidecar process instead of running in-process",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Registers a new `outbound-proxy-sidecar` feature flag (assistant scope, default: false)
- When enabled, this will gate proxy session management to use the sidecar process instead of running in-process
- No behavioral change — this is just the flag registration

Accessed via: `isAssistantFeatureFlagEnabled("feature_flags.outbound-proxy-sidecar.enabled", config)`

## Test plan
- [ ] `bun run tsc --noEmit` passes in assistant
- [ ] `bun run lint` passes in assistant
- [ ] Flag defaults to false — no behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
