### PR TITLE
refactor: merge guardian and trusted-contact success templates into a single parameterized template

### DIFF
--- a/assistant/src/runtime/guardian-verification-templates.ts
+++ b/assistant/src/runtime/guardian-verification-templates.ts
@@ -39,9 +39,6 @@ export const GUARDIAN_VERIFY_TEMPLATE_KEYS = {
   CHANNEL_VERIFY_FAILED: "guardian_verify.channel.failed",
   /** Deterministic reply for bootstrap deep-link success. */
   CHANNEL_BOOTSTRAP_BOUND: "guardian_verify.channel.bootstrap_bound",
-  /** Deterministic reply after successful trusted contact verification. */
-  CHANNEL_TRUSTED_CONTACT_VERIFY_SUCCESS:
-    "guardian_verify.channel.trusted_contact_success",
 } as const;
 
 export type GuardianVerifyTemplateKey =
@@ -61,8 +58,7 @@ type TextVerifyTemplateKey =
 export type ChannelVerifyReplyTemplateKey =
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_SUCCESS
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_FAILED
-  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_BOOTSTRAP_BOUND
-  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_TRUSTED_CONTACT_VERIFY_SUCCESS;
+  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_BOOTSTRAP_BOUND;
 
 // ---------------------------------------------------------------------------
 // Template Variables
@@ -82,6 +78,8 @@ export interface GuardianVerifyVoiceTemplateVars {
 export interface ChannelVerifyReplyVars {
   /** Failure reason (anti-oracle: generic message). Only used for failed template. */
   failureReason?: string;
+  /** Drives different success copy for guardian vs trusted contact verification. */
+  verificationType?: "guardian" | "trusted_contact";
 }
 
 // ---------------------------------------------------------------------------
@@ -204,17 +202,16 @@ const channelVerifyReplyTemplates: Record<
   ChannelVerifyReplyTemplateKey,
   (vars: ChannelVerifyReplyVars) => string
 > = {
-  [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_SUCCESS]: () =>
-    "Verification successful. You are now set as the guardian for this channel.",
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_SUCCESS]: (vars) =>
+    vars.verificationType === "trusted_contact"
+      ? "Verification successful! You can now message the assistant."
+      : "Verification successful. You are now set as the guardian for this channel.",
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_FAILED]: (vars) =>
     vars.failureReason ?? "The verification code is invalid or has expired.",
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_BOOTSTRAP_BOUND]: () =>
     "Welcome! Your identity has been linked. Please check for a verification code message.",
-
-  [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_TRUSTED_CONTACT_VERIFY_SUCCESS]: () =>
-    "Verification successful! You can now message the assistant.",
 };
 
 /**

--- a/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
@@ -196,17 +196,12 @@ export async function handleVerificationIntercept(
     if (!verifyResult.success) {
       replyText = composeChannelVerifyReply(
         GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_FAILED,
-        {
-          failureReason: stripVerificationFailurePrefix(verifyResult.reason),
-        },
-      );
-    } else if (verifyResult.verificationType === "trusted_contact") {
-      replyText = composeChannelVerifyReply(
-        GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_TRUSTED_CONTACT_VERIFY_SUCCESS,
+        { failureReason: stripVerificationFailurePrefix(verifyResult.reason) },
       );
     } else {
       replyText = composeChannelVerifyReply(
         GUARDIAN_VERIFY_TEMPLATE_KEYS.CHANNEL_VERIFY_SUCCESS,
+        { verificationType: verifyResult.verificationType },
       );
     }
     try {


### PR DESCRIPTION
## Summary
- Merge `CHANNEL_VERIFY_SUCCESS` and `CHANNEL_TRUSTED_CONTACT_VERIFY_SUCCESS` template keys into a single parameterized `CHANNEL_VERIFY_SUCCESS` template
- Add `verificationType` field to `ChannelVerifyReplyVars` to drive different success copy
- Collapse the three-way template branch in verification-intercept.ts to a two-way success/failure branch

Part of plan: verify-consolidation.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
