### PR TITLE
fix: sync outbound-proxy-sidecar flag to bundled registry copies

### DIFF
--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -88,6 +88,14 @@
       "label": "Contacts Tab",
       "description": "Show the Contacts tab in Settings for viewing and managing contacts",
       "defaultEnabled": false
+    },
+    {
+      "id": "outbound-proxy-sidecar",
+      "scope": "assistant",
+      "key": "feature_flags.outbound-proxy-sidecar.enabled",
+      "label": "Outbound Proxy Sidecar",
+      "description": "Route proxy session management through the sidecar process instead of running in-process",
+      "defaultEnabled": false
     }
   ]
 }

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -88,6 +88,14 @@
       "label": "Contacts Tab",
       "description": "Show the Contacts tab in Settings for viewing and managing contacts",
       "defaultEnabled": false
+    },
+    {
+      "id": "outbound-proxy-sidecar",
+      "scope": "assistant",
+      "key": "feature_flags.outbound-proxy-sidecar.enabled",
+      "label": "Outbound Proxy Sidecar",
+      "description": "Route proxy session management through the sidecar process instead of running in-process",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds the `outbound-proxy-sidecar` flag entry to the bundled registry copies in `assistant/src/config/` and `gateway/src/`
- Without this, packaged builds would resolve the flag as undeclared (default `true`) instead of the intended `defaultEnabled: false`
- Fixes the guard tests that assert bundled copies match the canonical registry

## Test plan
- [ ] `assistant/src/__tests__/assistant-feature-flag-guard.test.ts` passes (bundled copy matches canonical)
- [ ] `gateway/src/__tests__/feature-flag-defaults-sync.test.ts` passes (bundled copy matches canonical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
