### PR TITLE
fix: initialize accessRequestWaitStartedAt before TTS delay timer

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1557,6 +1557,11 @@ export class RelayConnection {
     // Delay the first heartbeat by the estimated TTS playback duration so
     // the initial hold message finishes before any heartbeat fires.
     this.heartbeatSequence = 0;
+    // Set the wait start time now so scheduleNextHeartbeat() always has a
+    // valid reference point — even if the TTS delay timer is cancelled early
+    // (e.g. by handleWaitStatePrompt when the caller speaks during playback).
+    // The callback below re-stamps it to exclude the TTS delay if it fires.
+    this.accessRequestWaitStartedAt = Date.now();
     this.accessRequestHeartbeatTimer = setTimeout(() => {
       this.accessRequestWaitStartedAt = Date.now();
       this.scheduleNextHeartbeat();


### PR DESCRIPTION
Both Codex and Devin identified that accessRequestWaitStartedAt was only set inside the delayed timeout callback in startAccessRequestWait(). If a caller speaks during the TTS delay, the timer gets cancelled and scheduleNextHeartbeat() runs with the timestamp still at 0, causing it to permanently skip the initial heartbeat window. Fix: set the timestamp before the setTimeout so it's always initialized.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
