### PR TITLE
fix: set all feature flag defaults to false

### DIFF
--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -7,7 +7,7 @@
       "key": "feature_flags.sms.enabled",
       "label": "SMS",
       "description": "Show SMS setup in Settings > Connect and enable the SMS setup skill",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "hatch-new-assistant",
@@ -15,7 +15,7 @@
       "key": "feature_flags.hatch-new-assistant.enabled",
       "label": "Hatch New Assistant",
       "description": "Show Hatch New Assistant action in Settings > Account",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "guardian-verify-setup",
@@ -23,7 +23,7 @@
       "key": "feature_flags.guardian-verify-setup.enabled",
       "label": "Guardian Verification Setup",
       "description": "Enable guardian verification routing in the system prompt",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "browser",
@@ -31,7 +31,7 @@
       "key": "feature_flags.browser.enabled",
       "label": "Browser",
       "description": "Enable browser skill prerequisites section in the system prompt",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "twitter",
@@ -39,7 +39,7 @@
       "key": "feature_flags.twitter.enabled",
       "label": "Twitter",
       "description": "Enable X (Twitter) skill section in the system prompt",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "messaging",
@@ -47,7 +47,7 @@
       "key": "feature_flags.messaging.enabled",
       "label": "Messaging",
       "description": "Enable messaging skill section in the system prompt",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "collect-usage-data",
@@ -55,7 +55,7 @@
       "key": "feature_flags.collect-usage-data.enabled",
       "label": "Collect usage data",
       "description": "Send crash reports and error diagnostics to help improve the app",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "user-hosted-enabled",
@@ -79,7 +79,7 @@
       "key": "feature_flags.command-palette.enabled",
       "label": "Command Palette",
       "description": "Enable the CMD+K command palette for unified search across conversations, memories, schedules, and contacts",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "contacts-tab",

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -7,7 +7,7 @@
       "key": "feature_flags.sms.enabled",
       "label": "SMS",
       "description": "Show SMS setup in Settings > Connect and enable the SMS setup skill",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "hatch-new-assistant",
@@ -15,7 +15,7 @@
       "key": "feature_flags.hatch-new-assistant.enabled",
       "label": "Hatch New Assistant",
       "description": "Show Hatch New Assistant action in Settings > Account",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "guardian-verify-setup",
@@ -23,7 +23,7 @@
       "key": "feature_flags.guardian-verify-setup.enabled",
       "label": "Guardian Verification Setup",
       "description": "Enable guardian verification routing in the system prompt",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "browser",
@@ -31,7 +31,7 @@
       "key": "feature_flags.browser.enabled",
       "label": "Browser",
       "description": "Enable browser skill prerequisites section in the system prompt",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "twitter",
@@ -39,7 +39,7 @@
       "key": "feature_flags.twitter.enabled",
       "label": "Twitter",
       "description": "Enable X (Twitter) skill section in the system prompt",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "messaging",
@@ -47,7 +47,7 @@
       "key": "feature_flags.messaging.enabled",
       "label": "Messaging",
       "description": "Enable messaging skill section in the system prompt",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "collect-usage-data",
@@ -55,7 +55,7 @@
       "key": "feature_flags.collect-usage-data.enabled",
       "label": "Collect usage data",
       "description": "Send crash reports and error diagnostics to help improve the app",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "user-hosted-enabled",
@@ -79,7 +79,7 @@
       "key": "feature_flags.command-palette.enabled",
       "label": "Command Palette",
       "description": "Enable the CMD+K command palette for unified search across conversations, memories, schedules, and contacts",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "contacts-tab",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -7,7 +7,7 @@
       "key": "feature_flags.sms.enabled",
       "label": "SMS",
       "description": "Show SMS setup in Settings > Connect and enable the SMS setup skill",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "hatch-new-assistant",
@@ -15,7 +15,7 @@
       "key": "feature_flags.hatch-new-assistant.enabled",
       "label": "Hatch New Assistant",
       "description": "Show Hatch New Assistant action in Settings > Account",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "guardian-verify-setup",
@@ -23,7 +23,7 @@
       "key": "feature_flags.guardian-verify-setup.enabled",
       "label": "Guardian Verification Setup",
       "description": "Enable guardian verification routing in the system prompt",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "browser",
@@ -31,7 +31,7 @@
       "key": "feature_flags.browser.enabled",
       "label": "Browser",
       "description": "Enable browser skill prerequisites section in the system prompt",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "twitter",
@@ -39,7 +39,7 @@
       "key": "feature_flags.twitter.enabled",
       "label": "Twitter",
       "description": "Enable X (Twitter) skill section in the system prompt",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "messaging",
@@ -47,7 +47,7 @@
       "key": "feature_flags.messaging.enabled",
       "label": "Messaging",
       "description": "Enable messaging skill section in the system prompt",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "collect-usage-data",
@@ -55,7 +55,7 @@
       "key": "feature_flags.collect-usage-data.enabled",
       "label": "Collect usage data",
       "description": "Send crash reports and error diagnostics to help improve the app",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "user-hosted-enabled",
@@ -79,7 +79,7 @@
       "key": "feature_flags.command-palette.enabled",
       "label": "Command Palette",
       "description": "Enable the CMD+K command palette for unified search across conversations, memories, schedules, and contacts",
-      "defaultEnabled": true
+      "defaultEnabled": false
     },
     {
       "id": "contacts-tab",


### PR DESCRIPTION
## Summary
- Audited all 12 feature flags across the registry
- Changed 8 flags from `defaultEnabled: true` to `defaultEnabled: false` (sms, hatch-new-assistant, guardian-verify-setup, browser, twitter, messaging, collect-usage-data, command-palette)
- Updated all 3 copies of the registry: `meta/feature-flags/`, `assistant/src/config/`, `gateway/src/`
- 4 flags were already `false` (user-hosted-enabled, local-http-enabled, contacts-tab, outbound-proxy-sidecar)

## Original prompt
Can you audit all of our feature flags and ensure that they all use default values of false. No feature flag should be on by default at this stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)