### PR TITLE
fix: correct verification dispatch comments to acknowledge dual-caller architecture

### DIFF
--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -153,8 +153,9 @@ export function createVerificationChallenge(
  * validates the secret against pending challenges, verifies identity
  * binding, and consumes the challenge. It returns the verification type
  * (guardian or trusted_contact) but does NOT create bindings or apply
- * role-specific side effects — those are handled by the caller
- * (verification-intercept.ts) in a symmetric dispatch pattern.
+ * role-specific side effects — those are handled by callers:
+ * verification-intercept.ts (channel verification) and
+ * relay-server.ts (voice verification).
  *
  * On failure the invalid-attempt counter is incremented; after
  * exceeding the threshold the actor is locked out for a cooldown
@@ -320,8 +321,9 @@ export function validateAndConsumeChallenge(
   // Reset the rate-limit counter on success
   resetRateLimit(assistantId, channel, actorExternalUserId, actorChatId);
 
-  // Return the verification type — all role-specific side effects are
-  // handled by the caller (verification-intercept) symmetrically.
+  // Return the verification type — role-specific side effects are
+  // handled by callers: verification-intercept (channel) and
+  // relay-server (voice).
   return {
     success: true,
     verificationType:

--- a/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
@@ -4,7 +4,8 @@
  * trusted-contact activation signals), upserts member records, and delivers
  * deterministic template-driven replies.
  *
- * This is the single dispatch point for all post-verification side effects.
+ * This is the dispatch point for channel-based post-verification side
+ * effects. Voice verification has its own dispatch in relay-server.ts.
  * Both guardian and trusted-contact flows converge here after
  * validateAndConsumeChallenge() returns success.
  *


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for verify-consolidation.md.

**Gap:** Documentation claims false invariant about single dispatch point
**What was expected:** Comments should accurately reflect the architecture
**What was found:** Comments claimed verification-intercept.ts was the single dispatch point, but relay-server.ts also handles voice verification side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
