### PR TITLE
fix: debounce contacts_changed refresh to avoid racing channel update responses

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
@@ -17,6 +17,10 @@ final class ContactsViewModel: ObservableObject {
 
     private let daemonClient: DaemonClient?
 
+    /// Debounce task for contacts_changed events, avoiding races with
+    /// in-progress channel update response handling in ContactDetailView.
+    private var contactsChangedTask: Task<Void, Never>?
+
     // MARK: - Init
 
     init(daemonClient: DaemonClient?) {
@@ -70,7 +74,16 @@ final class ContactsViewModel: ObservableObject {
         }
 
         daemonClient.onContactsChanged = { [weak self] _ in
-            self?.loadContacts()
+            guard let self else { return }
+            // Debounce to let in-flight channel update responses
+            // (consumed by ContactDetailView.updateChannelStatus) settle
+            // before we fire a new list request.
+            self.contactsChangedTask?.cancel()
+            self.contactsChangedTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                guard !Task.isCancelled else { return }
+                self?.loadContacts()
+            }
         }
 
         do {


### PR DESCRIPTION
Addresses review feedback on PR #12073. Codex identified that onContactsChanged immediately calls loadContacts(), racing with ContactDetailView.updateChannelStatus response handling. Adds a debounce to prevent the list response from being consumed by the uncorrelated for-await loops.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
