### PR TITLE
fix: add guardian binding creation to voice verification path in relay-server

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -17,7 +17,11 @@ import {
   findGuardianForChannel,
   listGuardianChannels,
 } from "../contacts/contact-store.js";
-import { upsertMember } from "../contacts/contacts-write.js";
+import {
+  createGuardianBinding,
+  revokeGuardianBinding,
+  upsertMember,
+} from "../contacts/contacts-write.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { getCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
 import * as conversationStore from "../memory/conversation-store.js";
@@ -1256,19 +1260,58 @@ export class RelayConnection {
           fromNumber: this.guardianVerificationFromNumber,
         });
       } else {
-        // Inbound guardian verification: proceed to normal call flow
+        // Inbound guardian verification: create/update binding, then proceed
+        // to normal call flow. Mirrors the binding creation logic in
+        // verification-intercept.ts for the inbound channel path.
+        const guardianAssistantId = this.guardianChallengeAssistantId;
+        const callerNumber = this.guardianVerificationFromNumber;
+
+        const existingBinding = getGuardianBinding(
+          guardianAssistantId,
+          "voice",
+        );
+        if (
+          existingBinding &&
+          existingBinding.guardianExternalUserId !== callerNumber
+        ) {
+          log.warn(
+            {
+              sourceChannel: "voice",
+              existingGuardian: existingBinding.guardianExternalUserId,
+            },
+            "Guardian binding conflict: another user already holds the voice channel binding",
+          );
+        } else {
+          revokeGuardianBinding(guardianAssistantId, "voice");
+
+          // Resolve canonical principal from the vellum channel binding
+          // so all channel bindings share a single principal identity.
+          const vellumBinding = getGuardianBinding(
+            guardianAssistantId,
+            "vellum",
+          );
+          const canonicalPrincipal =
+            vellumBinding?.guardianPrincipalId ?? callerNumber;
+
+          createGuardianBinding({
+            assistantId: guardianAssistantId,
+            channel: "voice",
+            guardianExternalUserId: callerNumber,
+            guardianDeliveryChatId: callerNumber,
+            guardianPrincipalId: canonicalPrincipal,
+            verifiedVia: "challenge",
+          });
+        }
+
         if (this.controller) {
           const verifiedActorTrust = resolveActorTrust({
-            assistantId: this.guardianChallengeAssistantId,
+            assistantId: guardianAssistantId,
             sourceChannel: "voice",
-            conversationExternalId: this.guardianVerificationFromNumber,
-            actorExternalId: this.guardianVerificationFromNumber,
+            conversationExternalId: callerNumber,
+            actorExternalId: callerNumber,
           });
           this.controller.setTrustContext(
-            toTrustContext(
-              verifiedActorTrust,
-              this.guardianVerificationFromNumber,
-            ),
+            toTrustContext(verifiedActorTrust, callerNumber),
           );
           this.startNormalCallFlow(this.controller, true);
         }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for verify-consolidation.md.

**Gap:** Voice verification path regression — missing guardian binding creation
**What was expected:** Voice guardian verification should create binding after validateAndConsumeChallenge succeeds
**What was found:** Binding creation was moved to verification-intercept.ts but relay-server.ts voice path was not updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
