### PR TITLE
fix: add self-heal and idempotency guards for legacy guardian binding migration

### DIFF
--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -114,7 +114,14 @@ async function dispatchGuardianQuestionInner(
         { callSessionId, assistantId },
         "No guardian principal from contacts — self-healing for voice dispatch",
       );
-      guardianPrincipalId = ensureVellumGuardianBinding(assistantId);
+      try {
+        guardianPrincipalId = ensureVellumGuardianBinding(assistantId);
+      } catch (err) {
+        log.warn(
+          { err, callSessionId, assistantId },
+          "ensureVellumGuardianBinding failed during voice dispatch self-heal",
+        );
+      }
     }
 
     if (!guardianPrincipalId) {

--- a/assistant/src/runtime/guardian-vellum-migration.ts
+++ b/assistant/src/runtime/guardian-vellum-migration.ts
@@ -40,15 +40,29 @@ export function ensureVellumGuardianBinding(
 
   const guardianPrincipalId = `vellum-principal-${uuid()}`;
 
-  createGuardianBinding({
-    assistantId,
-    channel: "vellum",
-    guardianExternalUserId: guardianPrincipalId,
-    guardianDeliveryChatId: "local",
-    guardianPrincipalId,
-    verifiedVia: "startup-migration",
-    metadataJson: JSON.stringify({ migratedAt: Date.now() }),
-  });
+  try {
+    createGuardianBinding({
+      assistantId,
+      channel: "vellum",
+      guardianExternalUserId: guardianPrincipalId,
+      guardianDeliveryChatId: "local",
+      guardianPrincipalId,
+      verifiedVia: "startup-migration",
+      metadataJson: JSON.stringify({ migratedAt: Date.now() }),
+    });
+  } catch (err) {
+    // A concurrent call or legacy binding may already occupy this slot.
+    // Re-check contacts; if a binding now exists, return it instead of throwing.
+    const existing = findGuardianForChannel("vellum", assistantId);
+    if (existing?.contact.principalId) {
+      log.debug(
+        { assistantId, guardianPrincipalId: existing.contact.principalId },
+        "Vellum guardian binding creation conflicted — returning existing principal",
+      );
+      return existing.contact.principalId;
+    }
+    throw err;
+  }
 
   log.info(
     { assistantId, guardianPrincipalId },

--- a/assistant/src/runtime/local-actor-identity.ts
+++ b/assistant/src/runtime/local-actor-identity.ts
@@ -56,14 +56,28 @@ export function resolveLocalIpcTrustContext(
   // No guardian contact with a principalId — bootstrap via ensureVellumGuardianBinding
   // to self-heal (creates the binding + contact if missing).
   log.debug("No vellum guardian contact found; bootstrapping binding for IPC");
-  const principalId = ensureVellumGuardianBinding(assistantId);
-  const trustCtx = resolveTrustContext({
-    assistantId,
-    sourceChannel: "vellum",
-    conversationExternalId: "local",
-    actorExternalId: principalId,
-  });
-  return { ...trustCtx, sourceChannel };
+  try {
+    const principalId = ensureVellumGuardianBinding(assistantId);
+    const trustCtx = resolveTrustContext({
+      assistantId,
+      sourceChannel: "vellum",
+      conversationExternalId: "local",
+      actorExternalId: principalId,
+    });
+    return { ...trustCtx, sourceChannel };
+  } catch (err) {
+    log.warn(
+      { err },
+      "Self-heal ensureVellumGuardianBinding failed — falling back to minimal trust context",
+    );
+    const trustCtx = resolveTrustContext({
+      assistantId,
+      sourceChannel: "vellum",
+      conversationExternalId: "local",
+      actorExternalId: "local",
+    });
+    return { ...trustCtx, sourceChannel };
+  }
 }
 
 /**
@@ -88,6 +102,21 @@ export function resolveLocalIpcAuthContext(sessionId: string): AuthContext {
       ...authContext,
       actorPrincipalId: guardianResult.contact.principalId,
     };
+  }
+
+  // Self-heal: no guardian contact with principalId — bootstrap via
+  // ensureVellumGuardianBinding (mirrors resolveLocalIpcTrustContext).
+  try {
+    log.debug(
+      "No vellum guardian contact found; bootstrapping binding for IPC auth",
+    );
+    const principalId = ensureVellumGuardianBinding(authContext.assistantId);
+    return { ...authContext, actorPrincipalId: principalId };
+  } catch (err) {
+    log.warn(
+      { err },
+      "Self-heal ensureVellumGuardianBinding failed in auth context — returning without actorPrincipalId",
+    );
   }
 
   return authContext;


### PR DESCRIPTION
Addresses review feedback on PR #12092. Codex flagged that ensureVellumGuardianBinding can hit uniqueness constraint when legacy binding exists without contacts record. Devin flagged missing self-heal in resolveLocalIpcAuthContext. Fixes: (1) add self-heal to resolveLocalIpcAuthContext, (2) add try/catch or idempotency to guardian-dispatch, (3) ensure ensureVellumGuardianBinding handles existing bindings.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
