### PR TITLE
chore: replace user-facing 'daemon' with 'assistant' terminology

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -18,7 +18,7 @@ Re-run `setup` after pulling updates to the claude-skills repo.
 
 These commands are specific to vellum-assistant and live in `.claude/skills/<name>/` as local skill directories (NOT symlinks):
 
-- **`/update`** — Pull latest from main, use `vellum ps/sleep/wake` to manage daemon/gateway lifecycle, rebuild/launch the macOS app (`.claude/skills/update/SKILL.md`)
+- **`/update`** — Pull latest from main, use `vellum ps/sleep/wake` to manage assistant/gateway lifecycle, rebuild/launch the macOS app (`.claude/skills/update/SKILL.md`)
 - **`/release`** — Cut a new release by triggering the GitHub Actions release workflow (`.claude/skills/release/SKILL.md`)
 
 The shared-vs-local model:
@@ -39,7 +39,7 @@ Creates and removes isolated git worktrees for parallel development. Used by `/s
 
 ### `scripts/vellum-runtime-tunnel.sh` — SSH tunnel for remote runtime access
 
-Forwards a local TCP port to a remote Vellum runtime HTTP server via SSH. Use this when running the web app in local mode against a remote assistant daemon.
+Forwards a local TCP port to a remote Vellum runtime HTTP server via SSH. Use this when running the web app in local mode against a remote assistant.
 
 ```bash
 # Start a tunnel to a remote host

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: update
 description: >
-  Pull latest from main (or a specified branch), use vellum ps/sleep/wake to manage daemon and gateway lifecycle, rebuild/launch the macOS app, and print a startup summary.
+  Pull latest from main (or a specified branch), use vellum ps/sleep/wake to manage assistant and gateway lifecycle, rebuild/launch the macOS app, and print a startup summary.
 ---
 
 # Update — Pull Latest and Restart Vellum
@@ -28,7 +28,7 @@ The user may pass `$ARGUMENTS` as the branch name (e.g., `/update feature/phone-
    pkill -f "build\.sh run" || true
    ```
 
-3. Quiesce with `vellum sleep` — stop daemon and gateway processes. This is directory-agnostic and stops processes globally regardless of CWD:
+3. Quiesce with `vellum sleep` — stop assistant and gateway processes. This is directory-agnostic and stops processes globally regardless of CWD:
    ```bash
    vellum sleep || true
    ```
@@ -62,7 +62,7 @@ The user may pass `$ARGUMENTS` as the branch name (e.g., `/update feature/phone-
    cd gateway && bun install && cd ..
    ```
 
-7. Restart with `vellum wake` — start daemon and gateway from the current checkout. `vellum wake` must be run from the checkout directory that should supply the new daemon code:
+7. Restart with `vellum wake` — start assistant and gateway from the current checkout. `vellum wake` must be run from the checkout directory that should supply the new assistant code:
    ```bash
    vellum wake
    ```
@@ -85,5 +85,5 @@ The user may pass `$ARGUMENTS` as the branch name (e.g., `/update feature/phone-
 Report:
 
 1. What was pulled (new commits).
-2. The startup summary block output (daemon health, gateway health).
-3. Note: the macOS app manages its own daemon and gateway. On first launch, the app will hatch and start them automatically.
+2. The startup summary block output (assistant health, gateway health).
+3. Note: the macOS app manages its own assistant and gateway. On first launch, the app will hatch and start them automatically.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ When your PR establishes a new mandatory pattern, convention, or architectural c
 
 ## Slash Commands
 
-Most commands are shared from [`claude-skills`](https://github.com/vellum-ai/claude-skills) via symlinks. Repo-local commands (`/update`, `/release`) live in `.claude/skills/<name>/`. See `.claude/README.md` for the full list. The `/update` command uses `vellum ps`, `vellum sleep`, and `vellum wake` to manage daemon and gateway lifecycle.
+Most commands are shared from [`claude-skills`](https://github.com/vellum-ai/claude-skills) via symlinks. Repo-local commands (`/update`, `/release`) live in `.claude/skills/<name>/`. See `.claude/README.md` for the full list. The `/update` command uses `vellum ps`, `vellum sleep`, and `vellum wake` to manage assistant and gateway lifecycle.
 
 ## Linear Ticket Hygiene
 
@@ -142,6 +142,10 @@ Skills must be self-contained and portable — no coupling to daemon tools, inte
 ## Assistant-Driven Judgement
 
 Judgement calls affecting user experience should be made by the assistant through the daemon — not hardcoded heuristics. Reserve deterministic logic for mechanical operations (parsing, validation, access control). If you're writing string matches or scoring functions to approximate what the model would decide, route it through the daemon instead.
+
+## User-Facing Terminology: "daemon" vs "assistant"
+
+"Daemon" is an internal implementation detail. In all user-facing text — CLI output, error messages, help strings, SKILL.md instructions that would be relayed to users, README documentation, and UI strings — use **"assistant"** instead of "daemon". Internal code (variable names, class names, file paths, log messages, comments explaining architecture) may continue using "daemon" since users don't see those. When in doubt, ask: "Would a user ever read this?" If yes, say "assistant".
 
 ## Release Update Hygiene
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ AI-powered assistant platform by Vellum.
 
 The platform has three main domains:
 
-- **Assistant runtime** (`assistant/`): Bun + TypeScript daemon that owns conversation history, attachment storage, and channel delivery state in a local SQLite database. Exposes a Unix domain socket (macOS) and optional TCP listener (iOS) for native clients, plus an HTTP API consumed by the gateway.
-- **Native clients** (`clients/`): Swift Package with macOS and iOS apps sharing ~45-50% of code via `VellumAssistantShared`. The macOS app is a menu bar assistant with computer-use (accessibility + CGEvent). The iOS app is a chat client supporting standalone mode (direct Anthropic API) and connected-to-Mac mode (TCP proxy through the daemon).
+- **Assistant runtime** (`assistant/`): Bun + TypeScript assistant runtime that owns conversation history, attachment storage, and channel delivery state in a local SQLite database. Exposes a Unix domain socket (macOS) and optional TCP listener (iOS) for native clients, plus an HTTP API consumed by the gateway.
+- **Native clients** (`clients/`): Swift Package with macOS and iOS apps sharing ~45-50% of code via `VellumAssistantShared`. The macOS app is a menu bar assistant with computer-use (accessibility + CGEvent). The iOS app is a chat client supporting standalone mode (direct Anthropic API) and connected-to-Mac mode (TCP proxy through the assistant).
 - **Gateway** (`gateway/`): Standalone Bun + TypeScript service that serves as the public ingress boundary for all external webhooks and callbacks. Owns Telegram integration end-to-end (receives webhooks, routes to assistants, delivers replies). Routes Twilio voice and SMS webhooks, handles OAuth callbacks, and optionally acts as an authenticated reverse proxy for the assistant runtime API (client → gateway → runtime).
 
 Architecture docs are split by ownership domain: [`ARCHITECTURE.md`](ARCHITECTURE.md), [`assistant/ARCHITECTURE.md`](assistant/ARCHITECTURE.md), [`gateway/ARCHITECTURE.md`](gateway/ARCHITECTURE.md), and [`clients/ARCHITECTURE.md`](clients/ARCHITECTURE.md).
@@ -55,7 +55,7 @@ Architecture docs are split by ownership domain: [`ARCHITECTURE.md`](ARCHITECTUR
 
 ```
 /
-├── assistant/         # Bun-based assistant runtime (daemon, CLI, HTTP API)
+├── assistant/         # Bun-based assistant runtime (runtime, CLI, HTTP API)
 ├── clients/           # Native clients (macOS menu bar app + iOS chat app)
 ├── gateway/           # Telegram gateway service
 ├── benchmarking/      # Load testing scripts (gateway webhook/proxy benchmarks)
@@ -71,7 +71,7 @@ Architecture docs are split by ownership domain: [`ARCHITECTURE.md`](ARCHITECTUR
 <details>
 <summary><b>Prerequisites</b></summary>
 
-- **Docker** is required. The sandbox uses Docker as its default backend for container-level isolation. Install [Docker Desktop](https://docs.docker.com/get-docker/) (macOS/Windows) or Docker Engine (Linux) and ensure the daemon is running before starting the assistant.
+- **Docker** is required. The sandbox uses Docker as its default backend for container-level isolation. Install [Docker Desktop](https://docs.docker.com/get-docker/) (macOS/Windows) or Docker Engine (Linux) and ensure Docker is running before starting the assistant.
 
 </details>
 
@@ -95,17 +95,17 @@ See [.githooks/README.md](./.githooks/README.md) for more details about availabl
 The assistant runtime lives in `/assistant`. The recommended way to start it is via the `vellum` CLI:
 
 ```bash
-vellum wake    # starts daemon + gateway from current checkout
+vellum wake    # starts assistant + gateway from current checkout
 vellum ps      # check process status
-vellum sleep   # stop daemon + gateway
+vellum sleep   # stop assistant + gateway
 ```
 
-> **Note:** `vellum wake` requires a hatched assistant. Run `vellum hatch` first, or launch the macOS app which handles hatching automatically. Alternatively, the macOS app supports **managed sign-in** during onboarding — authenticating via the platform and connecting to a platform-hosted assistant without running a local daemon.
+> **Note:** `vellum wake` requires a hatched assistant. Run `vellum hatch` first, or launch the macOS app which handles hatching automatically. Alternatively, the macOS app supports **managed sign-in** during onboarding — authenticating via the platform and connecting to a platform-hosted assistant without running a local assistant.
 
 <details>
 <summary>Development: raw bun commands</summary>
 
-For low-level development (e.g., working on the daemon itself):
+For low-level development (e.g., working on the assistant runtime itself):
 
 ```bash
 cd assistant
@@ -321,7 +321,7 @@ Twitter integration supports two operation paths: **OAuth** (X API v2) and **Bro
 
 - **Strategy selection**: `vellum x strategy set <oauth|browser|auto>` controls which path is used. Default is `auto`, which prefers OAuth when credentials are available and the operation is supported, then falls back to browser. The strategy is persisted in config as `twitterOperationStrategy`.
 
-**OAuth2 PKCE setup** (`local_byo` mode): The user provides their own Twitter OAuth2 Client ID (and optional Client Secret). The daemon runs a standard OAuth2 PKCE flow against `twitter.com/i/oauth2/authorize` and `api.x.com/2/oauth2/token`. The flow verifies the user's identity (`GET /2/users/me`) and stores tokens in the vault for use by both identity verification and the OAuth operation path. Connect via the Settings UI or `twitter_auth_start` IPC message.
+**OAuth2 PKCE setup** (`local_byo` mode): The user provides their own Twitter OAuth2 Client ID (and optional Client Secret). The assistant runs a standard OAuth2 PKCE flow against `twitter.com/i/oauth2/authorize` and `api.x.com/2/oauth2/token`. The flow verifies the user's identity (`GET /2/users/me`) and stores tokens in the vault for use by both identity verification and the OAuth operation path. Connect via the Settings UI or `twitter_auth_start` IPC message.
 
 **Available tools**: `twitter_post` — posts a tweet via the strategy router (OAuth or CDP depending on configuration). Read operations (timeline, search, etc.) use the browser path.
 
@@ -500,7 +500,7 @@ The runtime HTTP server exposes a Server-Sent Events (SSE) endpoint that streams
 GET /v1/events?conversationKey=<key>
 ```
 
-**Auth**: JWT bearer token (same rules as other runtime HTTP endpoints). The SSE endpoint requires a valid JWT with the `chat.read` scope, passed as `Authorization: Bearer <jwt>`. JWTs are issued by the daemon's auth system (see Vellum Guardian Identity for the bootstrap flow). The route policy in `route-policy.ts` enforces scope requirements per endpoint.
+**Auth**: JWT bearer token (same rules as other runtime HTTP endpoints). The SSE endpoint requires a valid JWT with the `chat.read` scope, passed as `Authorization: Bearer <jwt>`. JWTs are issued by the assistant's auth system (see Vellum Guardian Identity for the bootstrap flow). The route policy in `route-policy.ts` enforces scope requirements per endpoint.
 
 **Query params**:
 
@@ -568,7 +568,7 @@ The `message` field is the unchanged IPC `ServerMessage` payload — the same ty
 The standard browser `EventSource` API does not support custom request headers, so authenticated connections require `fetch()` with manual SSE stream parsing:
 
 ```js
-const TOKEN = '<jwt>'; // JWT obtained via the guardian bootstrap flow or daemon auth system
+const TOKEN = '<jwt>'; // JWT obtained via the guardian bootstrap flow or assistant auth system
 const res = await fetch(
   'http://localhost:3001/v1/events?conversationKey=my-conversation',
   { headers: { Authorization: `Bearer ${TOKEN}` } },
@@ -601,7 +601,7 @@ while (true) {
 <details>
 <summary><b>Remote Access</b></summary>
 
-Access a remote assistant daemon from your local machine via SSH.
+Access a remote assistant from your local machine via SSH.
 
 ### CLI (socket forwarding)
 
@@ -625,7 +625,7 @@ VELLUM_DAEMON_SOCKET=~/.vellum/remote.sock open -a Vellum
 
 ### Blob Transport Behavior
 
-When the macOS client connects to a local daemon, large CU observation payloads (screenshots, AX trees) are offloaded to file-based blobs at `~/.vellum/workspace/data/ipc-blobs/` instead of being embedded inline in IPC JSON. On connect, the client probes whether client and daemon share the same blob directory. If the probe succeeds, large payloads are written as blob files and only lightweight references travel over the socket.
+When the macOS client connects to a local assistant, large CU observation payloads (screenshots, AX trees) are offloaded to file-based blobs at `~/.vellum/workspace/data/ipc-blobs/` instead of being embedded inline in IPC JSON. On connect, the client probes whether client and assistant share the same blob directory. If the probe succeeds, large payloads are written as blob files and only lightweight references travel over the socket.
 
 Over SSH-forwarded sockets, the probe fails automatically (the filesystems don't overlap), so the client falls back to inline base64/text payloads transparently. On iOS (TCP connections), the probe is skipped entirely and inline payloads are always used. No configuration is needed.
 
@@ -633,10 +633,10 @@ Over SSH-forwarded sockets, the probe fails automatically (the filesystems don't
 
 | Symptom | Check |
 |---|---|
-| CLI: "could not connect to daemon socket" | Is the SSH socket tunnel active? Check `VELLUM_DAEMON_SOCKET` path |
-| CLI: daemon starts locally despite socket override | Check that `VELLUM_DAEMON_AUTOSTART` is not set to `1` |
+| CLI: "could not connect to assistant socket" | Is the SSH socket tunnel active? Check `VELLUM_DAEMON_SOCKET` path |
+| CLI: assistant starts locally despite socket override | Check that `VELLUM_DAEMON_AUTOSTART` is not set to `1` |
 | macOS: not connecting | Verify socket path in `VELLUM_DAEMON_SOCKET` exists and is writable |
-| Any: "connection refused" | Is the remote daemon running? (`vellum ps` on remote) |
+| Any: "connection refused" | Is the remote assistant running? (`vellum ps` on remote) |
 
 Run `vellum doctor` for a full diagnostic check including socket path and autostart policy.
 
@@ -697,7 +697,7 @@ Multiple plans can run in parallel — just specify the plan name to disambiguat
 |---------|---------|
 | `/plan-html <topic\|plan-name>` | Create or refresh a rollout plan in `.private/plans/` with both markdown and a polished, review-friendly HTML view (including per-PR file lists). |
 | `/release [version]` | Cut a release: pull main, determine/create version tag, generate release notes, publish GitHub Release, and verify CI trigger. |
-| `/update` | Pull latest from `main`, kill stale processes, rebuild and launch the macOS app. The app manages its own daemon and gateway lifecycle (hatching on first launch). Prints a startup summary. |
+| `/update` | Pull latest from `main`, kill stale processes, rebuild and launch the macOS app. The app manages its own assistant and gateway lifecycle (hatching on first launch). Prints a startup summary. |
 
 
 ### Review
@@ -741,7 +741,7 @@ Run `/release [version]` in Claude Code. If no version is provided, the patch ve
 
 Creating the GitHub Release triggers three workflows in parallel:
 
-- **Build and Release macOS App** (`build-and-release-macos.yml`): Builds the macOS `.app` from source, compiles the Bun daemon binary, code-signs it with a Developer ID certificate, notarizes it with Apple, creates a DMG installer, and publishes both the DMG and a Sparkle-compatible ZIP + `appcast.xml` to the public updates repo ([vellum-ai/velly](https://github.com/vellum-ai/velly)). This takes ~15-20 minutes.
+- **Build and Release macOS App** (`build-and-release-macos.yml`): Builds the macOS `.app` from source, compiles the Bun assistant binary, code-signs it with a Developer ID certificate, notarizes it with Apple, creates a DMG installer, and publishes both the DMG and a Sparkle-compatible ZIP + `appcast.xml` to the public updates repo ([vellum-ai/velly](https://github.com/vellum-ai/velly)). This takes ~15-20 minutes.
 - **Publish velly to npm** (`publish-velly.yml`): Publishes the `velly` CLI package to npm with provenance.
 - **Slack Release Notification** (`slack-release-notification.yml`): Posts a summary message to the releases Slack channel with a threaded changelog.
 

--- a/assistant/.env.example
+++ b/assistant/.env.example
@@ -9,11 +9,11 @@ OLLAMA_BASE_URL=
 
 # --- Remote Access ---
 
-# Override the daemon socket path (default: ~/.vellum/vellum.sock).
+# Override the assistant socket path (default: ~/.vellum/vellum.sock).
 # Use this to target a forwarded or remote socket.
 # VELLUM_DAEMON_SOCKET=/path/to/remote/vellum.sock
 
-# Control daemon autostart behavior.
+# Control assistant autostart behavior.
 # When VELLUM_DAEMON_SOCKET is set, autostart is disabled by default.
 # Set to 1 to force autostart even with a custom socket path.
 # VELLUM_DAEMON_AUTOSTART=1

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -1,6 +1,6 @@
 # Vellum Assistant Runtime
 
-Bun + TypeScript daemon that owns conversation history, attachment storage, and channel delivery state in a local SQLite database. Exposes a Unix domain socket (macOS) and optional TCP listener (iOS) for native clients, plus an HTTP API consumed by the gateway.
+Bun + TypeScript assistant runtime that owns conversation history, attachment storage, and channel delivery state in a local SQLite database. Exposes a Unix domain socket (macOS) and optional TCP listener (iOS) for native clients, plus an HTTP API consumed by the gateway.
 
 ## Architecture
 
@@ -47,11 +47,11 @@ cp .env.example .env
 | `OLLAMA_API_KEY`       | No       | —                           | API key for authenticated Ollama deployments      |
 | `OLLAMA_BASE_URL`      | No       | `http://127.0.0.1:11434/v1` | Ollama base URL                                   |
 | `RUNTIME_HTTP_PORT`    | No       | —                           | Enable the HTTP server (required for gateway/web) |
-| `VELLUM_DAEMON_SOCKET` | No       | `~/.vellum/vellum.sock`     | Override the daemon socket path                   |
+| `VELLUM_DAEMON_SOCKET` | No       | `~/.vellum/vellum.sock`     | Override the assistant socket path                |
 
 ## Update Bulletin
 
-When a release includes relevant updates, the daemon materializes release notes from the bundled `src/config/templates/UPDATES.md` into `~/.vellum/workspace/UPDATES.md` on startup. The assistant uses judgment to surface updates to the user when relevant, and deletes the file when done.
+When a release includes relevant updates, the assistant materializes release notes from the bundled `src/config/templates/UPDATES.md` into `~/.vellum/workspace/UPDATES.md` on startup. The assistant uses judgment to surface updates to the user when relevant, and deletes the file when done.
 
 **For release maintainers:** Update `assistant/src/config/templates/UPDATES.md` with release notes before each relevant release. Leave the template empty (or comment-only) for releases with no user/assistant-facing changes.
 
@@ -59,19 +59,19 @@ When a release includes relevant updates, the daemon materializes release notes 
 
 ### Lifecycle management (recommended)
 
-Use the `vellum` CLI to manage daemon and gateway processes:
+Use the `vellum` CLI to manage assistant and gateway processes:
 
 ```bash
-vellum wake    # start daemon + gateway from current checkout
+vellum wake    # start assistant + gateway from current checkout
 vellum ps      # list assistants and per-assistant process status
-vellum sleep   # stop daemon + gateway (directory-agnostic)
+vellum sleep   # stop assistant + gateway (directory-agnostic)
 ```
 
 > **Note:** `vellum wake` requires a hatched assistant. Run `vellum hatch` first, or launch the macOS app which handles hatching automatically.
 
 ### Development: raw bun commands
 
-For low-level development (e.g., working on the daemon itself):
+For low-level development (e.g., working on the assistant runtime itself):
 
 ```bash
 bun run src/index.ts daemon start   # start daemon only
@@ -83,11 +83,11 @@ bun run src/index.ts dev            # dev mode (auto-restart on file changes)
 
 | Command                                    | Description                                      |
 | ------------------------------------------ | ------------------------------------------------ |
-| `vellum wake`                              | Start daemon + gateway from current checkout     |
-| `vellum sleep`                             | Stop daemon + gateway processes                  |
+| `vellum wake`                              | Start assistant + gateway from current checkout  |
+| `vellum sleep`                             | Stop assistant + gateway processes               |
 | `vellum ps`                                | List assistants and per-assistant process status |
 | `vellum`                                   | Launch interactive CLI session                   |
-| `vellum dev`                               | Run daemon with auto-restart on file changes     |
+| `vellum dev`                               | Run assistant with auto-restart on file changes  |
 | `vellum sessions list\|new\|export\|clear` | Manage conversation sessions                     |
 | `vellum config set\|get\|list`             | Manage configuration                             |
 | `vellum keys set\|list\|delete`            | Manage API keys in secure storage                |
@@ -230,7 +230,7 @@ All endpoints are JWT-authenticated (require a valid JWT with appropriate scopes
 
 ### Ingress Webhook Reconciliation
 
-When the public ingress URL is changed via the Settings UI (`ingress_config` set action), the daemon automatically reconciles Twilio webhooks in addition to triggering a Telegram webhook reconcile on the gateway. If all of the following conditions are met, the daemon pushes updated webhook URLs (voice, status callback, SMS) to Twilio:
+When the public ingress URL is changed via the Settings UI (`ingress_config` set action), the assistant automatically reconciles Twilio webhooks in addition to triggering a Telegram webhook reconcile on the gateway. If all of the following conditions are met, the assistant pushes updated webhook URLs (voice, status callback, SMS) to Twilio:
 
 1. Ingress is being **enabled** (not disabled)
 2. Twilio **credentials** are configured (Account SID + Auth Token in secure storage)
@@ -271,7 +271,7 @@ The channel guardian service generates verification challenge instructions with 
 ### Operator Notes
 
 - **Verification input format:** Channel verification accepts a bare code reply only (6-digit numeric for identity-bound sessions; 64-char hex for unbound inbound/bootstrap compatibility).
-- **Rebind requirement:** Creating a new guardian challenge when a binding already exists requires `rebind: true` in the IPC request. Without it, the daemon returns `already_bound`. This prevents accidental guardian replacement.
+- **Rebind requirement:** Creating a new guardian challenge when a binding already exists requires `rebind: true` in the IPC request. Without it, the assistant returns `already_bound`. This prevents accidental guardian replacement.
 - **Takeover prevention:** Verification is rejected when an active binding exists for a different external user. Same-user re-verification is allowed.
 
 ### Vellum Guardian Identity (Actor Tokens)
@@ -282,7 +282,7 @@ The vellum channel (macOS, iOS, CLI) uses JWTs to bind guardian identity to HTTP
 - **iOS pairing**: The pairing response includes `accessToken` and `refreshToken` credentials automatically when a vellum guardian binding exists.
 - **IPC fallback**: Local IPC (Unix socket) connections resolve identity server-side via `resolveLocalIpcGuardianContext()` without requiring a JWT.
 - **HTTP enforcement**: All vellum HTTP routes require a valid JWT via the `Authorization: Bearer <jwt>` header. The JWT carries identity claims (`sub` with principal type and ID) and scope permissions. Route-level enforcement in `route-policy.ts` checks scopes and principal types.
-- **Startup migration**: On daemon start, `ensureVellumGuardianBinding()` backfills a vellum guardian binding for existing installations so the identity system works without requiring a manual bootstrap step.
+- **Startup migration**: On assistant start, `ensureVellumGuardianBinding()` backfills a vellum guardian binding for existing installations so the identity system works without requiring a manual bootstrap step.
 
 ## Guardian Verification and Ingress ACL
 
@@ -292,7 +292,7 @@ This section documents the end-to-end flow from guardian verification through in
 
 Guardian verification establishes a cryptographic trust binding between a human identity and an `(assistantId, channel)` pair. The flow is:
 
-1. **Challenge creation** — The owner initiates verification from the desktop UI, which sends a guardian-verification IPC message (`create_challenge` action) to the daemon. The daemon generates a random secret (32-byte hex for unbound inbound/bootstrap sessions, 6-digit numeric for identity-bound sessions), hashes it with SHA-256, stores the hash with a 10-minute TTL, and returns the raw secret to the desktop.
+1. **Challenge creation** — The owner initiates verification from the desktop UI, which sends a guardian-verification IPC message (`create_challenge` action) to the assistant. The assistant generates a random secret (32-byte hex for unbound inbound/bootstrap sessions, 6-digit numeric for identity-bound sessions), hashes it with SHA-256, stores the hash with a 10-minute TTL, and returns the raw secret to the desktop.
 2. **Code sharing** — The desktop displays the code and instructs the owner to reply with that code in the target channel conversation (e.g., Telegram or SMS).
 3. **Verification** — When the message arrives at `/channels/inbound`, the handler intercepts valid verification-code replies before normal message processing. It hashes the provided code, looks up a matching pending challenge, validates expiry, and consumes the challenge (preventing replay).
 4. **Binding** — On success, any existing active binding for the `(assistantId, channel)` pair is revoked, and a new guardian binding is created with the verifier's `actorExternalId` and `chatId` (DB columns: `externalUserId`, `chatId`). The verifier receives a confirmation message.

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -914,7 +914,9 @@ export async function startCli(): Promise<void> {
             resolve();
             return;
           }
-          reject(new Error("Session token not found — is the daemon running?"));
+          reject(
+            new Error("Session token not found — is the assistant running?"),
+          );
           newSocket.destroy();
           return;
         }

--- a/assistant/src/cli/amazon.ts
+++ b/assistant/src/cli/amazon.ts
@@ -845,7 +845,7 @@ async function startLearnSession(
     socket.on("error", (err) => {
       reject(
         new Error(
-          `Cannot connect to daemon: ${err.message}. Is the daemon running?`,
+          `Cannot connect to assistant: ${err.message}. Is the assistant running?`,
         ),
       );
     });
@@ -887,7 +887,7 @@ async function startLearnSession(
           } else {
             clearTimeout(timeoutHandle);
             socket.destroy();
-            reject(new Error("Daemon authentication failed"));
+            reject(new Error("Authentication failed"));
           }
           continue;
         }

--- a/assistant/src/cli/ipc-client.ts
+++ b/assistant/src/cli/ipc-client.ts
@@ -23,7 +23,7 @@ export function sendOneMessage(msg: ClientMessage): Promise<ServerMessage> {
       if (!token) {
         resolved = true;
         reject(
-          new IpcError("Session token not found — is the daemon running?"),
+          new IpcError("Session token not found — is the assistant running?"),
         );
         socket.destroy();
         return;

--- a/assistant/src/cli/map.ts
+++ b/assistant/src/cli/map.ts
@@ -217,7 +217,7 @@ async function startLearnSession(
     socket.on("error", (err) => {
       reject(
         new Error(
-          `Cannot connect to daemon: ${err.message}. Is the daemon running?`,
+          `Cannot connect to assistant: ${err.message}. Is the assistant running?`,
         ),
       );
     });
@@ -261,7 +261,7 @@ async function startLearnSession(
           } else {
             clearTimeout(timeoutHandle);
             socket.destroy();
-            reject(new Error("Daemon authentication failed"));
+            reject(new Error("Authentication failed"));
           }
           continue;
         }

--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -533,7 +533,7 @@ function sendDaemonMessage(
 
     const timeoutHandle = setTimeout(() => {
       socket.destroy();
-      reject(new Error("Daemon request timed out after 10s"));
+      reject(new Error("Request timed out after 10s"));
     }, 10_000);
     timeoutHandle.unref();
 
@@ -550,7 +550,7 @@ function sendDaemonMessage(
       clearTimeout(timeoutHandle);
       reject(
         new Error(
-          `Cannot connect to daemon: ${err.message}. Is the daemon running?`,
+          `Cannot connect to assistant: ${err.message}. Is the assistant running?`,
         ),
       );
     });
@@ -567,7 +567,7 @@ function sendDaemonMessage(
           } else {
             clearTimeout(timeoutHandle);
             socket.destroy();
-            reject(new Error("Daemon authentication failed"));
+            reject(new Error("Authentication failed"));
           }
           continue;
         }
@@ -579,7 +579,8 @@ function sendDaemonMessage(
           socket.destroy();
           reject(
             new Error(
-              (m as { message?: string }).message ?? "Daemon returned an error",
+              (m as { message?: string }).message ??
+                "Assistant returned an error",
             ),
           );
           return;
@@ -761,7 +762,7 @@ async function startLearnSession(
     socket.on("error", (err) => {
       reject(
         new Error(
-          `Cannot connect to daemon: ${err.message}. Is the daemon running?`,
+          `Cannot connect to assistant: ${err.message}. Is the assistant running?`,
         ),
       );
     });
@@ -803,7 +804,7 @@ async function startLearnSession(
           } else {
             clearTimeout(timeoutHandle);
             socket.destroy();
-            reject(new Error("Daemon authentication failed"));
+            reject(new Error("Authentication failed"));
           }
           continue;
         }

--- a/assistant/src/config/bundled-skills/computer-use/SKILL.md
+++ b/assistant/src/config/bundled-skills/computer-use/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: false
 disable-model-invocation: true
 ---
 
-This skill provides the 12 computer_use_* action tools for controlling
+This skill provides the 12 computer*use*\* action tools for controlling
 the macOS desktop (used by CU sessions).
 
 The `computer_use_request_control` escalation tool is registered in the core
@@ -14,4 +14,4 @@ registry (not this skill) so text_qa sessions can execute it directly.
 The skill is internally preactivated for computer-use sessions.
 
 Tools in this skill are proxy tools — execution is forwarded to the connected
-macOS client, never handled locally by the daemon.
+macOS client, never handled locally by the assistant.

--- a/assistant/src/config/bundled-skills/configure-settings/SKILL.md
+++ b/assistant/src/config/bundled-skills/configure-settings/SKILL.md
@@ -2,7 +2,7 @@
 name: "Configure Settings"
 description: "Read, update, or reset assistant configuration values using the vellum config CLI"
 user-invocable: true
-metadata: {"vellum": {"emoji": "⚙️"}}
+metadata: { "vellum": { "emoji": "⚙️" } }
 ---
 
 You are helping the user view or change assistant configuration through the `vellum` CLI. Treat CLI commands as the canonical interface. Do **not** read or edit config files directly.
@@ -27,6 +27,7 @@ vellum config get <key>
 ```
 
 Examples:
+
 ```bash
 vellum config get platform.baseUrl
 vellum config get memory.qdrant.url
@@ -42,6 +43,7 @@ vellum config set <key> <value>
 ```
 
 Examples:
+
 ```bash
 vellum config set platform.baseUrl "https://platform.vellum.ai"
 vellum config set provider "openai"
@@ -65,20 +67,20 @@ vellum config list
 
 ## Common configuration keys
 
-| Key | Description |
-|-----|-------------|
-| `platform.baseUrl` | Vellum platform URL for auth and API calls |
-| `provider` | Default LLM provider (anthropic, openai, etc.) |
-| `model` | Default model name |
-| `memory.enabled` | Enable/disable memory system |
-| `memory.qdrant.url` | Qdrant vector store URL |
-| `calls.enabled` | Enable/disable phone call support |
-| `sandbox.enabled` | Enable/disable sandbox for tool execution |
-| `ingress.publicBaseUrl` | Public ingress URL for webhooks |
+| Key                     | Description                                    |
+| ----------------------- | ---------------------------------------------- |
+| `platform.baseUrl`      | Vellum platform URL for auth and API calls     |
+| `provider`              | Default LLM provider (anthropic, openai, etc.) |
+| `model`                 | Default model name                             |
+| `memory.enabled`        | Enable/disable memory system                   |
+| `memory.qdrant.url`     | Qdrant vector store URL                        |
+| `calls.enabled`         | Enable/disable phone call support              |
+| `sandbox.enabled`       | Enable/disable sandbox for tool execution      |
+| `ingress.publicBaseUrl` | Public ingress URL for webhooks                |
 
 ## Notes
 
-- Changes to most settings take effect after the daemon restarts or reconnects
+- Changes to most settings take effect after the assistant restarts or reconnects
 - Platform URL changes take effect after the macOS app reconnects (Settings > Connect)
 - Boolean values should be `true` or `false`; numeric values are bare numbers
 - The full config schema is defined in `assistant/src/config/core-schema.ts`

--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -10,7 +10,7 @@ Manage the user's contacts, relationship graph, access control (trusted contacts
 ## Prerequisites
 
 - Use the injected `INTERNAL_GATEWAY_BASE_URL` for gateway API calls.
-- Use gateway control-plane routes only: this skill calls `/v1/contacts`, `/v1/ingress/*`, and `/v1/integrations/telegram/config` on the gateway, never the daemon runtime port directly.
+- Use gateway control-plane routes only: this skill calls `/v1/contacts`, `/v1/ingress/*`, and `/v1/integrations/telegram/config` on the gateway, never the assistant runtime port directly.
 - The bearer token is available as the `$GATEWAY_AUTH_TOKEN` environment variable for control-plane `curl` requests.
 
 ## Contact Management

--- a/assistant/src/config/bundled-skills/doordash/doordash-cli.ts
+++ b/assistant/src/config/bundled-skills/doordash/doordash-cli.ts
@@ -1120,7 +1120,7 @@ async function startLearnSession(
     socket.on("error", (err) => {
       reject(
         new Error(
-          `Cannot connect to daemon: ${err.message}. Is the daemon running?`,
+          `Cannot connect to assistant: ${err.message}. Is the assistant running?`,
         ),
       );
     });
@@ -1164,7 +1164,7 @@ async function startLearnSession(
           } else {
             clearTimeout(timeoutHandle);
             socket.destroy();
-            reject(new Error("Daemon authentication failed"));
+            reject(new Error("Authentication failed"));
           }
           continue;
         }

--- a/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
@@ -10,7 +10,7 @@ You are helping your user set up guardian verification for a messaging channel (
 ## Prerequisites
 
 - Use the injected `INTERNAL_GATEWAY_BASE_URL` for gateway API calls.
-- Never call the daemon runtime port directly; always call the gateway URL.
+- Never call the assistant runtime port directly; always call the gateway URL.
 - The bearer token is available as the `$GATEWAY_AUTH_TOKEN` environment variable for control-plane `curl` requests.
 - Run shell commands for this skill with `bash`.
 - Keep narration minimal: execute required calls first, then provide a concise status update. Do not narrate internal install/check/load chatter unless something fails.

--- a/assistant/src/config/bundled-skills/mcp-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/mcp-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: "MCP Setup"
 description: "Add, authenticate, list, and remove MCP (Model Context Protocol) servers"
 user-invocable: false
-metadata: {"vellum": {"emoji": "🔌"}}
+metadata: { "vellum": { "emoji": "🔌" } }
 ---
 
 Help users configure MCP servers so external tools (e.g. Linear, GitHub, Notion) become available in conversations.
@@ -32,6 +32,7 @@ vellum mcp add <name> -t <transport-type> -u <url> [-r <risk>] [--disabled]
 - `-r` — risk level: `low`, `medium`, or `high` (default: `high`)
 
 Examples:
+
 ```
 vellum mcp add linear -t streamable-http -u https://mcp.linear.app/mcp
 vellum mcp add context7 -t streamable-http -u https://mcp.context7.com/mcp -r low
@@ -47,6 +48,7 @@ vellum mcp auth <name>
 Opens the user's browser for OAuth authorization. Only works for `sse`/`streamable-http` servers that require authentication. After the user completes login in the browser, tokens are saved automatically.
 
 Use this when:
+
 - A server shows `! Needs authentication` in `vellum mcp list`
 - An MCP tool call fails with an auth/token error
 - Setting up a new OAuth-protected server for the first time
@@ -61,7 +63,7 @@ Removes the server config and cleans up any stored OAuth credentials.
 
 ## After Changes
 
-After adding, removing, or authenticating a server, the user must **quit and relaunch the Vellum app** for changes to take effect. The app runs its own daemon — `vellum daemon restart` only restarts the CLI daemon, which is a separate process.
+After adding, removing, or authenticating a server, the user must **quit and relaunch the Vellum app** for changes to take effect. The app runs its own assistant process — `vellum daemon restart` only restarts the CLI assistant, which is a separate process.
 
 Tell the user: "Please quit and relaunch the Vellum app, then start a new conversation."
 

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -102,28 +102,28 @@ Present these voices grouped by category:
 
 #### Female voices
 
-| Voice     | Style                          | Voice ID                       |
-| --------- | ------------------------------ | ------------------------------ |
-| Rachel    | Calm, warm, conversational     | `21m00Tcm4TlvDq8ikWAM`        |
-| Sarah     | Soft, young, approachable      | `EXAVITQu4vr4xnSDxMaL`        |
-| Charlotte | Warm, Swedish-accented         | `XB0fDUnXU5powFXDhCwa`        |
-| Alice     | Confident, British             | `Xb7hH8MSUJpSbSDYk0k2`        |
-| Matilda   | Warm, friendly, young          | `XrExE9yKIg1WjnnlVkGX`        |
-| Lily      | Warm, British                  | `pFZP5JQG7iQjIQuC4Bku`        |
+| Voice     | Style                      | Voice ID               |
+| --------- | -------------------------- | ---------------------- |
+| Rachel    | Calm, warm, conversational | `21m00Tcm4TlvDq8ikWAM` |
+| Sarah     | Soft, young, approachable  | `EXAVITQu4vr4xnSDxMaL` |
+| Charlotte | Warm, Swedish-accented     | `XB0fDUnXU5powFXDhCwa` |
+| Alice     | Confident, British         | `Xb7hH8MSUJpSbSDYk0k2` |
+| Matilda   | Warm, friendly, young      | `XrExE9yKIg1WjnnlVkGX` |
+| Lily      | Warm, British              | `pFZP5JQG7iQjIQuC4Bku` |
 
 #### Male voices
 
-| Voice   | Style                            | Voice ID                       |
-| ------- | -------------------------------- | ------------------------------ |
-| Antoni  | Warm, well-rounded               | `ErXwobaYiN019PkySvjV`        |
-| Josh    | Deep, young, clear               | `TxGEqnHWrfWFTfGW9XjX`       |
-| Arnold  | Crisp, narrative                  | `VR6AewLTigWG4xSOukaG`        |
-| Adam    | Deep, middle-aged, professional  | `pNInz6obpgDQGcFmaJgB`        |
-| Bill    | Trustworthy, American            | `pqHfZKP75CvOlQylNhV4`        |
-| George  | Warm, British, distinguished     | `JBFqnCBsd6RMkjVDRZzb`        |
-| Daniel  | Authoritative, British           | `onwK4e9ZLuTAKqWW03F9`        |
-| Charlie | Casual, Australian               | `IKne3meq5aSn9XLyUdCD`        |
-| Liam    | Young, articulate                | `TX3LPaxmHKxFdv7VOQHJ`        |
+| Voice   | Style                           | Voice ID               |
+| ------- | ------------------------------- | ---------------------- |
+| Antoni  | Warm, well-rounded              | `ErXwobaYiN019PkySvjV` |
+| Josh    | Deep, young, clear              | `TxGEqnHWrfWFTfGW9XjX` |
+| Arnold  | Crisp, narrative                | `VR6AewLTigWG4xSOukaG` |
+| Adam    | Deep, middle-aged, professional | `pNInz6obpgDQGcFmaJgB` |
+| Bill    | Trustworthy, American           | `pqHfZKP75CvOlQylNhV4` |
+| George  | Warm, British, distinguished    | `JBFqnCBsd6RMkjVDRZzb` |
+| Daniel  | Authoritative, British          | `onwK4e9ZLuTAKqWW03F9` |
+| Charlie | Casual, Australian              | `IKne3meq5aSn9XLyUdCD` |
+| Liam    | Young, articulate               | `TX3LPaxmHKxFdv7VOQHJ` |
 
 After the user picks a voice, use `voice_config_update` to set the shared voice ID. This writes to the config file (`elevenlabs.voiceId`) for phone calls **and** pushes to the macOS app via IPC (`ttsVoiceId`) for in-app TTS in one call:
 
@@ -478,13 +478,13 @@ sqlite3 ~/.vellum/workspace/data/db/assistant.db \
 
 ### Key paths
 
-| Resource                                   | Path                                       |
-| ------------------------------------------ | ------------------------------------------ |
-| Daemon logs (caller-side transcripts only) | `~/.vellum/workspace/data/logs/vellum.log` |
-| Full conversation database                 | `~/.vellum/workspace/data/db/assistant.db` |
-| Messages table                             | `messages` (keyed by `conversation_id`)    |
-| Call sessions table                        | `call_sessions`                            |
-| Call events table                          | `call_events`                              |
+| Resource                                      | Path                                       |
+| --------------------------------------------- | ------------------------------------------ |
+| Assistant logs (caller-side transcripts only) | `~/.vellum/workspace/data/logs/vellum.log` |
+| Full conversation database                    | `~/.vellum/workspace/data/db/assistant.db` |
+| Messages table                                | `messages` (keyed by `conversation_id`)    |
+| Call sessions table                           | `call_sessions`                            |
+| Call events table                             | `call_events`                              |
 
 ### Important
 
@@ -539,24 +539,24 @@ The `context` field is powerful — use it to give the agent background that hel
 
 All call-related settings can be managed via `vellum config`:
 
-| Setting                                     | Description                                                                                                | Default                                                                                                  |
-| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `calls.enabled`                             | Master switch for the calling feature                                                                      | `false`                                                                                                  |
-| `calls.provider`                            | Voice provider (currently only `twilio`)                                                                   | `twilio`                                                                                                 |
-| `calls.maxDurationSeconds`                  | Maximum call length in seconds                                                                             | `3600` (1 hour)                                                                                          |
-| `calls.userConsultTimeoutSeconds`           | How long to wait for user answers                                                                          | `120` (2 min)                                                                                            |
-| `calls.disclosure.enabled`                  | Whether the AI announces itself at call start                                                              | `true`                                                                                                   |
-| `calls.disclosure.text`                     | The disclosure message spoken at call start                                                                | `"At the very beginning of the call, introduce yourself as an assistant calling on behalf of my human."` |
-| `calls.model`                               | Override LLM model for call orchestration                                                                  | _(uses default model)_                                                                                   |
-| `calls.callerIdentity.allowPerCallOverride` | Allow per-call caller identity selection                                                                   | `true`                                                                                                   |
-| `calls.callerIdentity.userNumber`           | E.164 phone number for user-number mode                                                                    | _(empty)_                                                                                                |
-| `calls.voice.language`                      | Language code for TTS and transcription                                                                    | `en-US`                                                                                                  |
-| `calls.voice.transcriptionProvider`         | Speech-to-text provider (`Deepgram`, `Google`)                                                             | `Deepgram`                                                                                               |
-| `elevenlabs.voiceId`                        | ElevenLabs voice ID used by both in-app TTS and phone calls. Set during setup from the curated voice list. Defaults to Rachel  | `21m00Tcm4TlvDq8ikWAM`                                                                                  |
-| `elevenlabs.voiceModelId`                   | Optional Twilio ConversationRelay model suffix. Leave empty to send bare `voiceId`                         | _(empty)_                                                                                                |
-| `elevenlabs.speed`                          | Playback speed (`0.7` – `1.2`)                                                                             | `1.0`                                                                                                    |
-| `elevenlabs.stability`                      | Voice stability (`0.0` – `1.0`)                                                                            | `0.5`                                                                                                    |
-| `elevenlabs.similarityBoost`                | Voice similarity boost (`0.0` – `1.0`)                                                                     | `0.75`                                                                                                   |
+| Setting                                     | Description                                                                                                                   | Default                                                                                                  |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `calls.enabled`                             | Master switch for the calling feature                                                                                         | `false`                                                                                                  |
+| `calls.provider`                            | Voice provider (currently only `twilio`)                                                                                      | `twilio`                                                                                                 |
+| `calls.maxDurationSeconds`                  | Maximum call length in seconds                                                                                                | `3600` (1 hour)                                                                                          |
+| `calls.userConsultTimeoutSeconds`           | How long to wait for user answers                                                                                             | `120` (2 min)                                                                                            |
+| `calls.disclosure.enabled`                  | Whether the AI announces itself at call start                                                                                 | `true`                                                                                                   |
+| `calls.disclosure.text`                     | The disclosure message spoken at call start                                                                                   | `"At the very beginning of the call, introduce yourself as an assistant calling on behalf of my human."` |
+| `calls.model`                               | Override LLM model for call orchestration                                                                                     | _(uses default model)_                                                                                   |
+| `calls.callerIdentity.allowPerCallOverride` | Allow per-call caller identity selection                                                                                      | `true`                                                                                                   |
+| `calls.callerIdentity.userNumber`           | E.164 phone number for user-number mode                                                                                       | _(empty)_                                                                                                |
+| `calls.voice.language`                      | Language code for TTS and transcription                                                                                       | `en-US`                                                                                                  |
+| `calls.voice.transcriptionProvider`         | Speech-to-text provider (`Deepgram`, `Google`)                                                                                | `Deepgram`                                                                                               |
+| `elevenlabs.voiceId`                        | ElevenLabs voice ID used by both in-app TTS and phone calls. Set during setup from the curated voice list. Defaults to Rachel | `21m00Tcm4TlvDq8ikWAM`                                                                                   |
+| `elevenlabs.voiceModelId`                   | Optional Twilio ConversationRelay model suffix. Leave empty to send bare `voiceId`                                            | _(empty)_                                                                                                |
+| `elevenlabs.speed`                          | Playback speed (`0.7` – `1.2`)                                                                                                | `1.0`                                                                                                    |
+| `elevenlabs.stability`                      | Voice stability (`0.0` – `1.0`)                                                                                               | `0.5`                                                                                                    |
+| `elevenlabs.similarityBoost`                | Voice similarity boost (`0.0` – `1.0`)                                                                                        | `0.75`                                                                                                   |
 
 ### Adjusting settings
 

--- a/assistant/src/config/bundled-skills/public-ingress/SKILL.md
+++ b/assistant/src/config/bundled-skills/public-ingress/SKILL.md
@@ -2,7 +2,7 @@
 name: "Public Ingress"
 description: "Set up and manage ngrok-based public ingress for webhooks and OAuth callbacks via ingress.publicBaseUrl"
 user-invocable: true
-metadata: {"vellum": {"emoji": "🌍"}}
+metadata: { "vellum": { "emoji": "🌍" } }
 ---
 
 You are setting up and managing a public ingress tunnel so that external services (Telegram webhooks, OAuth callbacks, etc.) can reach the local Vellum gateway. This skill uses ngrok to create a secure tunnel and persists the public URL as `ingress.publicBaseUrl`.
@@ -10,6 +10,7 @@ You are setting up and managing a public ingress tunnel so that external service
 ## Overview
 
 The Vellum gateway listens locally and needs a publicly reachable URL for:
+
 - Telegram webhook delivery
 - Google/Slack OAuth redirect callbacks
 - Any other inbound webhook traffic
@@ -25,6 +26,7 @@ vellum integrations ingress config --json
 ```
 
 The response includes:
+
 - `publicBaseUrl` — currently configured public ingress URL (if any)
 - `enabled` — whether ingress is enabled
 - `localGatewayTarget` — local gateway URL ngrok should forward to
@@ -42,16 +44,19 @@ ngrok version
 If not installed, install it:
 
 **macOS (Homebrew):**
+
 ```bash
 brew install ngrok/ngrok/ngrok
 ```
 
 **Linux (snap):**
+
 ```bash
 sudo snap install ngrok
 ```
 
 **Linux (apt — alternative):**
+
 ```bash
 curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null
 echo "deb https://ngrok-agent.s3.amazonaws.com buster main" | sudo tee /etc/apt/sources.list.d/ngrok.list
@@ -182,16 +187,21 @@ Provide useful follow-up commands:
 ## Troubleshooting
 
 ### ngrok not installed
+
 Run the install commands in Step 2. On macOS, make sure Homebrew is installed first (`brew --version`).
 
 ### Auth token invalid or expired
+
 Sign in to https://dashboard.ngrok.com, copy a fresh token from the "Your Authtoken" page, and re-run Step 3.
 
 ### ngrok API (port 4040) not responding
+
 The ngrok process may not be running. Check with `ps aux | grep ngrok`. If not running, start it per Step 4. If running but 4040 is unresponsive, check `/tmp/ngrok.log` for errors.
 
 ### Gateway not reachable on local target
-Re-check local gateway target with `vellum integrations ingress config --json`, then run `curl -s "<localGatewayTarget>/healthz"`. If the gateway is not running, start the assistant daemon first.
+
+Re-check local gateway target with `vellum integrations ingress config --json`, then run `curl -s "<localGatewayTarget>/healthz"`. If the gateway is not running, start the assistant first.
 
 ### "Too many connections" or tunnel limit errors
+
 ngrok's free tier allows one tunnel at a time. Stop any other ngrok tunnels before starting a new one.

--- a/assistant/src/config/bundled-skills/screen-recording/SKILL.md
+++ b/assistant/src/config/bundled-skills/screen-recording/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "Screen Recording"
 description: "Record the user's screen as a video file"
-metadata: {"vellum": {"emoji": "🎬", "os": ["darwin"]}}
+metadata: { "vellum": { "emoji": "🎬", "os": ["darwin"] } }
 ---
 
 Capture screen recordings as video files attached to the conversation.
@@ -11,6 +11,7 @@ Capture screen recordings as video files attached to the conversation.
 This skill activates when the user asks to record their screen. Common phrases:
 
 **Start recording:**
+
 - "record my screen"
 - "start recording"
 - "begin recording"
@@ -21,12 +22,14 @@ This skill activates when the user asks to record their screen. Common phrases:
 - "hey Nova, start recording"
 
 **Stop recording:**
+
 - "stop recording"
 - "end recording"
 - "finish recording"
 - "halt recording"
 
 **Restart recording:**
+
 - "restart recording"
 - "redo the recording"
 - "stop recording and start a new one"
@@ -34,10 +37,12 @@ This skill activates when the user asks to record their screen. Common phrases:
 - "stop and restart the recording"
 
 **Pause recording:**
+
 - "pause recording"
 - "pause the recording"
 
 **Resume recording:**
+
 - "resume recording"
 - "unpause the recording"
 
@@ -76,11 +81,12 @@ Recording intent resolution follows a precedence chain:
 
 ### 1. `commandIntent` (structured IPC) — highest priority
 
-The macOS client can send structured intents with `domain: 'screen_recording'` and `action: 'start' | 'stop' | 'restart' | 'pause' | 'resume'`. These bypass text parsing entirely. The daemon checks for `commandIntent` before any text analysis.
+The macOS client can send structured intents with `domain: 'screen_recording'` and `action: 'start' | 'stop' | 'restart' | 'pause' | 'resume'`. These bypass text parsing entirely. The assistant checks for `commandIntent` before any text analysis.
 
 ### 2. Deterministic text resolver (`resolveRecordingIntent`)
 
 A regex-based pipeline that classifies the user's text. The pipeline:
+
 1. Strips dynamic assistant names (leading vocative like "Nova, ...")
 2. Strips leading polite wrappers ("please", "can you", etc.)
 3. Applies the interrogative guard — WH-questions return `none`
@@ -98,12 +104,14 @@ If no recording intent is detected (kind is `none`), the message flows to the cl
 Questions about recording are NOT treated as commands. The resolver filters out WH-questions to prevent side effects from informational queries.
 
 **Filtered (no recording action triggered):**
+
 - "how do I stop recording?"
 - "what does screen recording do?"
 - "why is the recording paused?"
 - "when should I stop recording?"
 
 **Preserved as commands (recording action IS triggered):**
+
 - "can you stop recording?" — polite imperative
 - "could you record my screen?" — polite imperative
 - "please stop recording" — direct command with filler
@@ -122,7 +130,7 @@ The remainder preserves the user's original phrasing (stripping is applied to th
 
 ## Behavior Rules
 
-1. **Do not invoke computer use** for recording-only requests. The daemon handles these directly.
+1. **Do not invoke computer use** for recording-only requests. The assistant handles these directly.
 2. **One recording at a time.** If a recording is already active, starting another returns an "already recording" message.
 3. **Conversation-linked.** Each recording is linked to the conversation that started it for attachment purposes. However, since only one recording can be active at a time, stop commands from any conversation will stop the active recording regardless of which conversation started it.
 4. **Permission required.** Screen recording requires macOS Screen Recording permission. If denied, the user sees actionable guidance to enable it in System Settings.

--- a/assistant/src/config/bundled-skills/self-upgrade/SKILL.md
+++ b/assistant/src/config/bundled-skills/self-upgrade/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: "Self Upgrade"
-description: "Upgrade vellum to the latest version, restart the daemon, and restart the gateway"
+description: "Upgrade vellum to the latest version, restart the assistant, and restart the gateway"
 user-invocable: true
-metadata: {"vellum": {"emoji": "⬆️"}}
+metadata: { "vellum": { "emoji": "⬆️" } }
 ---
 
 You are performing a self-upgrade of the Vellum assistant. Follow these steps **in order**. Use the `bash` tool to run each command. Confirm each step succeeds before moving to the next.
@@ -43,9 +43,9 @@ pkill -TERM -f 'vellum-gateway|gateway/src/index.ts'
 
 Then start the gateway again using whatever method the user's deployment uses (e.g. `bun run gateway/src/index.ts`, a systemd service, or a container orchestrator). If you are unsure how the gateway is deployed, ask the user.
 
-## Step 4: Restart the daemon
+## Step 4: Restart the assistant
 
-Use `vellum sleep` to stop the running daemon and gateway, then `vellum wake` to start them again from the updated binary:
+Use `vellum sleep` to stop the running assistant and gateway, then `vellum wake` to start them again from the updated binary:
 
 ```bash
 vellum sleep && vellum wake
@@ -57,12 +57,13 @@ Verify it is running:
 vellum ps
 ```
 
-**Important:** This is the last step because the current daemon process is the one executing this conversation. After the restart, the new daemon takes over and this session ends gracefully.
+**Important:** This is the last step because the current assistant process is the one executing this conversation. After the restart, the new assistant takes over and this session ends gracefully.
 
 ## After Upgrade
 
 Report back to the user with:
+
 - The previous and new vellum version
-- Daemon status (running, PID)
+- Assistant status (running, PID)
 - Gateway status (restarted or not found)
 - Any errors encountered during the process

--- a/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
@@ -12,9 +12,9 @@ You are helping your user connect a Telegram bot to the Vellum Assistant gateway
 
 Before beginning setup, verify these conditions are met:
 
-1. **Gateway API base URL is set and reachable:** Use the injected `INTERNAL_GATEWAY_BASE_URL`, then run `curl -sf "$INTERNAL_GATEWAY_BASE_URL/healthz"` — it should return gateway health JSON (for example `{"status":"ok"}`). If it fails, tell the user to start the daemon with `vellum wake` and wait for it to become healthy before continuing.
+1. **Gateway API base URL is set and reachable:** Use the injected `INTERNAL_GATEWAY_BASE_URL`, then run `curl -sf "$INTERNAL_GATEWAY_BASE_URL/healthz"` — it should return gateway health JSON (for example `{"status":"ok"}`). If it fails, tell the user to start the assistant with `vellum wake` and wait for it to become healthy before continuing.
 2. **Public ingress URL is configured.** The gateway webhook URL is derived from `${ingress.publicBaseUrl}/webhooks/telegram`. If the ingress URL is not configured, load and execute the **public-ingress** skill first (`skill_load` with `skill: "public-ingress"`) to set up an ngrok tunnel and persist the URL before continuing.
-3. **Use gateway control-plane routes only.** Telegram setup/config actions in this skill must call gateway endpoints under `/v1/integrations/telegram/*` — never call the daemon runtime port directly.
+3. **Use gateway control-plane routes only.** Telegram setup/config actions in this skill must call gateway endpoints under `/v1/integrations/telegram/*` — never call the assistant runtime port directly.
 
 ## What You Need
 
@@ -61,7 +61,7 @@ On success, check the `commandsRegistered` field in the response. Confirm to the
 
 Manual webhook registration is no longer required. The gateway automatically reconciles the Telegram webhook on startup and whenever credentials change. It compares the current webhook URL against `${INGRESS_PUBLIC_BASE_URL}/webhooks/telegram` and updates it if needed, including the webhook secret and allowed updates.
 
-If the webhook secret changes (e.g., secret rotation), the gateway's credential watcher detects the change and re-registers the webhook automatically. If the ingress URL changes (e.g., tunnel restart), the assistant daemon triggers an immediate internal reconcile so the webhook re-registers automatically without a gateway restart.
+If the webhook secret changes (e.g., secret rotation), the gateway's credential watcher detects the change and re-registers the webhook automatically. If the ingress URL changes (e.g., tunnel restart), the assistant triggers an immediate internal reconcile so the webhook re-registers automatically without a gateway restart.
 
 ### Step 4: Verify Guardian Identity
 
@@ -121,7 +121,7 @@ Summarize what was done:
 - Routing configuration validated
 - To re-check guardian status later, use: `vellum integrations guardian status --channel telegram --json`
 
-The gateway automatically detects credentials from the vault, reconciles the Telegram webhook registration, and begins accepting Telegram webhooks shortly. In single-assistant mode, routing is automatically configured — no manual environment variable configuration or webhook registration is needed. If the webhook secret changes later, the gateway's credential watcher will automatically re-register the webhook. If the ingress URL changes (e.g., tunnel restart), the assistant daemon triggers an immediate internal reconcile so the webhook re-registers automatically without a gateway restart.
+The gateway automatically detects credentials from the vault, reconciles the Telegram webhook registration, and begins accepting Telegram webhooks shortly. In single-assistant mode, routing is automatically configured — no manual environment variable configuration or webhook registration is needed. If the webhook secret changes later, the gateway's credential watcher will automatically re-register the webhook. If the ingress URL changes (e.g., tunnel restart), the assistant triggers an immediate internal reconcile so the webhook re-registers automatically without a gateway restart.
 
 ## Bot-Account Limitations
 

--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -38,7 +38,7 @@ Mutating operations use Twilio HTTP control-plane endpoints on the gateway. Stat
 
 ### Multi-Assistant Setups
 
-In a multi-assistant environment (multiple assistants sharing the same daemon), some actions are **assistant-scoped** while others are **global** (shared across all assistants):
+In a multi-assistant environment (multiple assistants sharing the same runtime), some actions are **assistant-scoped** while others are **global** (shared across all assistants):
 
 **Global actions** (ignore `assistantId` — credentials are shared across all assistants):
 

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -2,7 +2,7 @@
 name: "X"
 description: "Read and post on X (formerly Twitter) via OAuth or browser session"
 user-invocable: true
-metadata: {"vellum": {"emoji": "𝕏"}}
+metadata: { "vellum": { "emoji": "𝕏" } }
 ---
 
 You are an X (formerly Twitter) assistant. Use the `execute_bash` tool to run `vellum x` CLI commands.
@@ -39,9 +39,11 @@ When the strategy is `auto` (the default), the router tries OAuth first for supp
 When the user triggers a Twitter operation and no strategy has been configured yet, follow these steps:
 
 1. **Check current status:**
+
    ```bash
    vellum x status --json
    ```
+
    Look at `oauthConnected`, `browserSessionActive`, `preferredStrategy`, and `strategyConfigured` in the response. If `strategyConfigured` is `false`, the user has not yet chosen a strategy and should be guided through setup.
 
 2. **Present both options with trade-offs:**
@@ -84,7 +86,7 @@ When a Twitter operation fails, follow these steps:
    - `OAuth is not configured` — the user chose OAuth but credentials are not set up.
    - `Twitter API error (401)` — OAuth token may be expired or revoked.
    - `UnsupportedOAuthOperationError` — the requested write operation is not available via OAuth.
-   - `Cannot connect to daemon` — the Vellum daemon is not running.
+   - `Cannot connect to assistant` — the Vellum assistant is not running.
 
 2. **Explain the likely cause clearly** to the user.
 
@@ -94,6 +96,7 @@ When a Twitter operation fails, follow these steps:
    - If the operation is unsupported via OAuth: explain that this write operation is not yet supported via OAuth, and suggest using the browser path with `vellum x strategy set browser`.
 
 4. **Offer concrete steps to switch:**
+
    ```bash
    # Switch to the other strategy
    vellum x strategy set <oauth|browser|auto>
@@ -140,54 +143,68 @@ Like `post`, the `reply` command routes through the strategy router and returns 
 Read-only operations always use the browser path directly, regardless of the strategy setting. They work the same whether the strategy is `oauth`, `browser`, or `auto` — the strategy only affects `post` and `reply` commands.
 
 ### User timeline
+
 ```bash
 vellum x timeline <screenName> [--count N]
 ```
+
 Returns `user` and `tweets` array.
 
 ### Single tweet + replies
+
 ```bash
 vellum x tweet <tweetIdOrUrl>
 ```
+
 Returns the focal tweet and its reply thread.
 
 ### Search
+
 ```bash
 vellum x search "query" [--count N] [--product Top|Latest|People|Media]
 ```
 
 ### Home timeline
+
 ```bash
 vellum x home [--count N]
 ```
 
 ### Bookmarks
+
 ```bash
 vellum x bookmarks [--count N]
 ```
 
 ### Notifications
+
 ```bash
 vellum x notifications [--count N]
 ```
+
 Returns `notifications` array with `id`, `message`, `timestamp`, `url`.
 
 ### Likes
+
 ```bash
 vellum x likes <screenName> [--count N]
 ```
 
 ### Followers / Following
+
 ```bash
 vellum x followers <screenName> [--count N]
 vellum x following <screenName> [--count N]
 ```
+
 Returns `user` and `followers`/`following` array (userId, screenName, name).
 
 ### Media
+
 ```bash
 vellum x media <screenName> [--count N]
 ```
+
 Returns tweets that contain media from the user's profile.
 
 ## Workflows

--- a/assistant/src/daemon/main.ts
+++ b/assistant/src/daemon/main.ts
@@ -17,9 +17,9 @@ runDaemon().catch(async (err) => {
   } catch {
     // Logger may not be initialized yet
   }
-  console.error("Failed to start daemon:", err);
+  console.error("Failed to start assistant:", err);
   console.error(
-    "Troubleshooting: check if another daemon is already running, verify ~/.vellum/ permissions, and review logs at ~/.vellum/workspace/data/logs/",
+    "Troubleshooting: check if another assistant is already running, verify ~/.vellum/ permissions, and review logs at ~/.vellum/workspace/data/logs/",
   );
   process.exit(1);
 });

--- a/cli/README.md
+++ b/cli/README.md
@@ -16,13 +16,13 @@ bun run ./src/index.ts <command> [options]
 
 ### Lifecycle: `ps`, `sleep`, `wake`
 
-Day-to-day process management for the daemon and gateway.
+Day-to-day process management for the assistant and gateway.
 
-| Command | Description |
-|---------|-------------|
-| `vellum ps` | List assistants and per-assistant process status (daemon, gateway PIDs and health). |
-| `vellum sleep` | Stop daemon and gateway processes. Directory-agnostic — works from anywhere. |
-| `vellum wake` | Start the daemon and gateway from the current checkout. |
+| Command        | Description                                                                            |
+| -------------- | -------------------------------------------------------------------------------------- |
+| `vellum ps`    | List assistants and per-assistant process status (assistant, gateway PIDs and health). |
+| `vellum sleep` | Stop assistant and gateway processes. Directory-agnostic — works from anywhere.        |
+| `vellum wake`  | Start the assistant and gateway from the current checkout.                             |
 
 ```bash
 # Start everything
@@ -47,36 +47,36 @@ vellum hatch [species] [options]
 
 #### Species
 
-| Species    | Description                                 |
-| ---------- | ------------------------------------------- |
+| Species    | Description                                       |
+| ---------- | ------------------------------------------------- |
 | `vellum`   | Default. Provisions the Vellum assistant runtime. |
-| `openclaw` | Provisions the OpenClaw runtime with gateway. |
+| `openclaw` | Provisions the OpenClaw runtime with gateway.     |
 
 #### Options
 
-| Option              | Description |
-| ------------------- | ----------- |
-| `-d`                | Detached mode. Start the instance in the background without watching startup progress. |
-| `--name <name>`     | Use a specific instance name instead of an auto-generated one. |
+| Option              | Description                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------- |
+| `-d`                | Detached mode. Start the instance in the background without watching startup progress.         |
+| `--name <name>`     | Use a specific instance name instead of an auto-generated one.                                 |
 | `--remote <target>` | Where to provision the instance. One of: `local`, `gcp`, `aws`, `custom`. Defaults to `local`. |
 
 #### Remote Targets
 
-- **`local`** -- Starts the local daemon and local gateway. Gateway source resolution order is: `VELLUM_GATEWAY_DIR` override, repo source tree, then installed `@vellumai/vellum-gateway` package.
+- **`local`** -- Starts the local assistant and local gateway. Gateway source resolution order is: `VELLUM_GATEWAY_DIR` override, repo source tree, then installed `@vellumai/vellum-gateway` package.
 - **`gcp`** -- Creates a GCP Compute Engine VM (`e2-standard-4`: 4 vCPUs, 16 GB) with a startup script that bootstraps the assistant. Requires `gcloud` authentication and `GCP_PROJECT` / `GCP_DEFAULT_ZONE` environment variables.
 - **`aws`** -- Provisions an AWS instance.
 - **`custom`** -- Provisions on an arbitrary SSH host. Set `VELLUM_CUSTOM_HOST` (e.g. `user@hostname`) to specify the target.
 
 #### Environment Variables
 
-| Variable              | Required For | Description |
-| --------------------- | ------------ | ----------- |
-| `ANTHROPIC_API_KEY`   | All             | Anthropic API key passed to the assistant runtime. |
-| `GCP_PROJECT`         | `gcp`        | GCP project ID. Falls back to the active `gcloud` project. |
-| `GCP_DEFAULT_ZONE`    | `gcp`        | GCP zone for the compute instance. |
-| `VELLUM_CUSTOM_HOST`  | `custom`     | SSH host in `user@hostname` format. |
-| `VELLUM_GATEWAY_DIR`  | `local`      | Optional absolute path to a local gateway source directory to run instead of the packaged gateway. |
-| `INGRESS_PUBLIC_BASE_URL` | `local` | Optional fallback public ingress URL when `ingress.publicBaseUrl` is not set in workspace config. |
+| Variable                  | Required For | Description                                                                                        |
+| ------------------------- | ------------ | -------------------------------------------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY`       | All          | Anthropic API key passed to the assistant runtime.                                                 |
+| `GCP_PROJECT`             | `gcp`        | GCP project ID. Falls back to the active `gcloud` project.                                         |
+| `GCP_DEFAULT_ZONE`        | `gcp`        | GCP zone for the compute instance.                                                                 |
+| `VELLUM_CUSTOM_HOST`      | `custom`     | SSH host in `user@hostname` format.                                                                |
+| `VELLUM_GATEWAY_DIR`      | `local`      | Optional absolute path to a local gateway source directory to run instead of the packaged gateway. |
+| `INGRESS_PUBLIC_BASE_URL` | `local`      | Optional fallback public ingress URL when `ingress.publicBaseUrl` is not set in workspace config.  |
 
 #### Examples
 
@@ -111,8 +111,8 @@ The CLI looks up the instance by name in `~/.vellum.lock.json` and determines ho
 
 - **`gcp`** -- Deletes the GCP Compute Engine instance via `gcloud compute instances delete`.
 - **`aws`** -- Terminates the AWS EC2 instance by looking up the instance ID from its Name tag.
-- **`local`** -- Stops the local daemon (`vellum sleep`) and removes the `~/.vellum` directory.
-- **`custom`** -- SSHs to the remote host to stop the daemon/gateway and remove the `~/.vellum` directory.
+- **`local`** -- Stops the local assistant (`vellum sleep`) and removes the `~/.vellum` directory.
+- **`custom`** -- SSHs to the remote host to stop the assistant/gateway and remove the `~/.vellum` directory.
 
 #### Examples
 

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -201,13 +201,13 @@ function parseArgs(): HatchArgs {
         "  --remote <host>           Remote host (local, gcp, aws, custom)",
       );
       console.log(
-        "  --daemon-only             Start daemon only, skip gateway",
+        "  --daemon-only             Start assistant only, skip gateway",
       );
       console.log(
         "  --restart                 Restart processes without onboarding side effects",
       );
       console.log(
-        "  --watch                   Run daemon and gateway in watch mode (hot reload on source changes)",
+        "  --watch                   Run assistant and gateway in watch mode (hot reload on source changes)",
       );
       process.exit(0);
     } else if (arg === "-d") {
@@ -596,7 +596,7 @@ async function displayPairingQRCode(
     const daemonReady = await waitForDaemonReady(runtimeUrl, bearerToken);
     if (!daemonReady) {
       console.warn(
-        "⚠ Daemon health check did not pass within 15s. Run `vellum pair` to try again.\n",
+        "⚠ Assistant health check did not pass within 15s. Run `vellum pair` to try again.\n",
       );
       return;
     }
@@ -751,7 +751,7 @@ async function hatchLocal(
     // Gateway failed — stop the daemon we just started so we don't leave
     // orphaned processes with no lock file entry.
     console.error(
-      `\n❌ Gateway startup failed — stopping daemon to avoid orphaned processes.`,
+      `\n❌ Gateway startup failed — stopping assistant to avoid orphaned processes.`,
     );
     await stopLocalProcesses();
     throw error;

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -90,8 +90,8 @@ function classifyProcess(command: string): string {
   if (/qdrant/.test(command)) return "qdrant";
   if (/vellum-gateway/.test(command)) return "gateway";
   if (/openclaw/.test(command)) return "openclaw-adapter";
-  if (/vellum-daemon/.test(command)) return "daemon";
-  if (/daemon\s+(start|restart)/.test(command)) return "daemon";
+  if (/vellum-daemon/.test(command)) return "assistant";
+  if (/daemon\s+(start|restart)/.test(command)) return "assistant";
   // Exclude macOS desktop app processes — their path contains .app/Contents/MacOS/
   // but they are not background service processes.
   if (/\.app\/Contents\/MacOS\//.test(command)) return "unknown";
@@ -224,7 +224,7 @@ async function getLocalProcesses(entry: AssistantEntry): Promise<TableRow[]> {
 
   const specs: ProcessSpec[] = [
     {
-      name: "daemon",
+      name: "assistant",
       pgrepName: "vellum-daemon",
       port: RUNTIME_HTTP_PORT,
       pidFile: join(vellumDir, "vellum.pid"),
@@ -323,7 +323,7 @@ async function detectOrphanedProcesses(): Promise<OrphanedProcess[]> {
 
   // Strategy 1: PID file scan
   const pidFiles: Array<{ file: string; name: string }> = [
-    { file: join(vellumDir, "vellum.pid"), name: "daemon" },
+    { file: join(vellumDir, "vellum.pid"), name: "assistant" },
     { file: join(vellumDir, "gateway.pid"), name: "gateway" },
     { file: join(vellumDir, "qdrant.pid"), name: "qdrant" },
   ];

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -41,7 +41,7 @@ function extractHostFromUrl(url: string): string {
 }
 
 async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
-  console.log("\u{1F5D1}\ufe0f  Stopping local daemon...\n");
+  console.log("\u{1F5D1}\ufe0f  Stopping local assistant...\n");
 
   const vellumDir = join(homedir(), ".vellum");
 

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -8,7 +8,7 @@ export async function sleep(): Promise<void> {
   if (args.includes("--help") || args.includes("-h")) {
     console.log("Usage: vellum sleep");
     console.log("");
-    console.log("Stop the daemon, gateway, and outbound-proxy processes.");
+    console.log("Stop the assistant, gateway, and outbound-proxy processes.");
     process.exit(0);
   }
 
@@ -23,9 +23,9 @@ export async function sleep(): Promise<void> {
     socketFile,
   ]);
   if (!daemonStopped) {
-    console.log("Daemon is not running.");
+    console.log("Assistant is not running.");
   } else {
-    console.log("Daemon stopped.");
+    console.log("Assistant stopped.");
   }
 
   // Stop gateway

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -15,7 +15,7 @@ export async function wake(): Promise<void> {
   if (args.includes("--help") || args.includes("-h")) {
     console.log("Usage: vellum wake");
     console.log("");
-    console.log("Start the daemon and gateway processes.");
+    console.log("Start the assistant and gateway processes.");
     process.exit(0);
   }
 
@@ -40,7 +40,7 @@ export async function wake(): Promise<void> {
       try {
         process.kill(pid, 0);
         daemonRunning = true;
-        console.log(`Daemon already running (pid ${pid}).`);
+        console.log(`Assistant already running (pid ${pid}).`);
       } catch {
         // Process not alive, will start below
       }

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -3,7 +3,14 @@ import { createHash, randomBytes, randomUUID } from "crypto";
 import { hostname, platform, userInfo } from "os";
 import { basename } from "path";
 import qrcode from "qrcode-terminal";
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from "react";
 import { Box, render as inkRender, Text, useInput, useStdout } from "ink";
 
 import { removeAssistantEntry } from "../lib/assistant-config";
@@ -26,7 +33,16 @@ export const ANSI = {
   gray: "\x1b[90m",
 } as const;
 
-export const SLASH_COMMANDS = ["/clear", "/doctor", "/exit", "/help", "/pair", "/q", "/quit", "/retire"];
+export const SLASH_COMMANDS = [
+  "/clear",
+  "/doctor",
+  "/exit",
+  "/help",
+  "/pair",
+  "/q",
+  "/quit",
+  "/retire",
+];
 
 const POLL_INTERVAL_MS = 3000;
 const SEND_TIMEOUT_MS = 5000;
@@ -45,17 +61,24 @@ const LEFT_HEADER_LINES = 3; // spacer + heading + spacer
 const LEFT_FOOTER_LINES = 3; // spacer + runtimeUrl + dirName
 
 // Right panel structure
-const TIPS = ["Send a message to start chatting", "Use /help to see available commands"];
+const TIPS = [
+  "Send a message to start chatting",
+  "Use /help to see available commands",
+];
 const RIGHT_PANEL_INFO_SECTIONS = 3; // Assistant, Species, Status — each with heading + value
 const RIGHT_PANEL_SPACERS = 2; // top spacer + spacer between tips and info
 const RIGHT_PANEL_TIPS_HEADING = 1;
 const RIGHT_PANEL_LINE_COUNT =
-  RIGHT_PANEL_SPACERS + RIGHT_PANEL_TIPS_HEADING + TIPS.length + RIGHT_PANEL_INFO_SECTIONS * 2;
+  RIGHT_PANEL_SPACERS +
+  RIGHT_PANEL_TIPS_HEADING +
+  TIPS.length +
+  RIGHT_PANEL_INFO_SECTIONS * 2;
 
 // Header chrome (borders around panel content)
 const HEADER_TOP_BORDER_LINES = 1; // "── Vellum ───..." line
 const HEADER_BOTTOM_BORDER_LINES = 2; // bottom rule + blank line
-const HEADER_CHROME_LINES = HEADER_TOP_BORDER_LINES + HEADER_BOTTOM_BORDER_LINES;
+const HEADER_CHROME_LINES =
+  HEADER_TOP_BORDER_LINES + HEADER_BOTTOM_BORDER_LINES;
 
 // Selection / Secret windows
 const DIALOG_WINDOW_WIDTH = 60;
@@ -182,7 +205,10 @@ async function checkHealthRuntime(baseUrl: string): Promise<HealthResponse> {
   return response.json() as Promise<HealthResponse>;
 }
 
-async function bootstrapAccessToken(baseUrl: string, bearerToken?: string): Promise<string> {
+async function bootstrapAccessToken(
+  baseUrl: string,
+  bearerToken?: string,
+): Promise<string> {
   if (!bearerToken) {
     throw new Error("Missing bearer token; cannot bootstrap actor identity");
   }
@@ -249,7 +275,12 @@ async function sendMessage(
     "/messages",
     {
       method: "POST",
-      body: JSON.stringify({ conversationKey: assistantId, content, sourceChannel: "vellum", interface: "cli" }),
+      body: JSON.stringify({
+        conversationKey: assistantId,
+        content,
+        sourceChannel: "vellum",
+        interface: "cli",
+      }),
       signal,
     },
     bearerToken,
@@ -318,7 +349,10 @@ async function pollPendingInteractions(
   );
 }
 
-function formatConfirmationPreview(toolName: string, input: Record<string, unknown>): string {
+function formatConfirmationPreview(
+  toolName: string,
+  input: Record<string, unknown>,
+): string {
   switch (toolName) {
     case "bash":
       return String(input.command ?? "");
@@ -333,7 +367,9 @@ function formatConfirmationPreview(toolName: string, input: Record<string, unkno
     case "browser_navigate":
       return `navigate ${String(input.url ?? "").slice(0, 80)}`;
     case "browser_close":
-      return input.close_all_pages ? "close all browser pages" : "close browser page";
+      return input.close_all_pages
+        ? "close all browser pages"
+        : "close browser page";
     case "browser_click":
       return `click ${input.element_id ?? input.selector ?? ""}`;
     case "browser_type":
@@ -354,7 +390,10 @@ async function handleConfirmationPrompt(
   bearerToken?: string,
   accessToken?: string,
 ): Promise<void> {
-  const preview = formatConfirmationPreview(confirmation.toolName, confirmation.input);
+  const preview = formatConfirmationPreview(
+    confirmation.toolName,
+    confirmation.input,
+  );
   const allowlistOptions = confirmation.allowlistOptions ?? [];
 
   chatApp.addStatus(`\u250C ${confirmation.toolName}: ${preview}`);
@@ -365,14 +404,24 @@ async function handleConfirmationPrompt(
   chatApp.addStatus("\u2514");
 
   const options = ["Allow once", "Deny once"];
-  if (allowlistOptions.length > 0 && confirmation.persistentDecisionsAllowed !== false) {
+  if (
+    allowlistOptions.length > 0 &&
+    confirmation.persistentDecisionsAllowed !== false
+  ) {
     options.push("Allowlist...", "Denylist...");
   }
 
   const index = await chatApp.showSelection("Tool Approval", options);
 
   if (index === 0) {
-    await submitDecision(baseUrl, assistantId, requestId, "allow", bearerToken, accessToken);
+    await submitDecision(
+      baseUrl,
+      assistantId,
+      requestId,
+      "allow",
+      bearerToken,
+      accessToken,
+    );
     chatApp.addStatus("\u2714 Allowed", "green");
     return;
   }
@@ -403,7 +452,14 @@ async function handleConfirmationPrompt(
     return;
   }
 
-  await submitDecision(baseUrl, assistantId, requestId, "deny", bearerToken, accessToken);
+  await submitDecision(
+    baseUrl,
+    assistantId,
+    requestId,
+    "deny",
+    bearerToken,
+    accessToken,
+  );
   chatApp.addStatus("\u2718 Denied", "yellow");
 }
 
@@ -421,7 +477,10 @@ async function handlePatternSelection(
   const label = trustDecision === "always_deny" ? "Denylist" : "Allowlist";
   const options = allowlistOptions.map((o) => o.label);
 
-  const index = await chatApp.showSelection(`${label}: choose command pattern`, options);
+  const index = await chatApp.showSelection(
+    `${label}: choose command pattern`,
+    options,
+  );
 
   if (index >= 0 && index < allowlistOptions.length) {
     const selectedPattern = allowlistOptions[index].pattern;
@@ -439,7 +498,14 @@ async function handlePatternSelection(
     return;
   }
 
-  await submitDecision(baseUrl, assistantId, requestId, "deny", bearerToken, accessToken);
+  await submitDecision(
+    baseUrl,
+    assistantId,
+    requestId,
+    "deny",
+    bearerToken,
+    accessToken,
+  );
   chatApp.addStatus("\u2718 Denied", "yellow");
 }
 
@@ -480,7 +546,8 @@ async function handleScopeSelection(
       bearerToken,
       accessToken,
     );
-    const ruleLabel = trustDecision === "always_deny" ? "Denylisted" : "Allowlisted";
+    const ruleLabel =
+      trustDecision === "always_deny" ? "Denylisted" : "Allowlisted";
     const ruleColor = trustDecision === "always_deny" ? "yellow" : "green";
     chatApp.addStatus(
       `${trustDecision === "always_deny" ? "\u2718" : "\u2714"} ${ruleLabel}`,
@@ -489,7 +556,14 @@ async function handleScopeSelection(
     return;
   }
 
-  await submitDecision(baseUrl, assistantId, requestId, "deny", bearerToken, accessToken);
+  await submitDecision(
+    baseUrl,
+    assistantId,
+    requestId,
+    "deny",
+    bearerToken,
+    accessToken,
+  );
   chatApp.addStatus("\u2718 Denied", "yellow");
 }
 
@@ -582,7 +656,8 @@ function ToolCallDisplay({ tc }: ToolCallDisplayProps): ReactElement {
         : null}
       {tc.result !== undefined ? (
         <Text dimColor>
-          {"\u2502"} <Text color={statusColor}>{statusIcon}</Text> {truncateValue(tc.result, 70)}
+          {"\u2502"} <Text color={statusColor}>{statusIcon}</Text>{" "}
+          {truncateValue(tc.result, 70)}
         </Text>
       ) : null}
       <Text dimColor>{"\u2514"}</Text>
@@ -667,7 +742,9 @@ function SpinnerDisplay({ text }: { text: string }): ReactElement {
 
 export function renderErrorMainScreen(error: unknown): number {
   const msg = error instanceof Error ? error.message : String(error);
-  console.log(`${ANSI.red}${ANSI.bold}Failed to render MainWindow${ANSI.reset}`);
+  console.log(
+    `${ANSI.red}${ANSI.bold}Failed to render MainWindow${ANSI.reset}`,
+  );
   console.log(`${ANSI.dim}${msg}${ANSI.reset}`);
   console.log(`${ANSI.dim}Run /clear to retry${ANSI.reset}`);
   return 3;
@@ -733,7 +810,10 @@ function DefaultMainScreen({
 
   return (
     <Box flexDirection="column" width={totalWidth}>
-      <Text dimColor>{HEADER_PREFIX + "─".repeat(Math.max(0, totalWidth - HEADER_PREFIX.length))}</Text>
+      <Text dimColor>
+        {HEADER_PREFIX +
+          "─".repeat(Math.max(0, totalWidth - HEADER_PREFIX.length))}
+      </Text>
       <Box flexDirection="row">
         <Box flexDirection="column" width={LEFT_PANEL_WIDTH}>
           {Array.from({ length: maxLines }, (_, i) => {
@@ -790,7 +870,6 @@ function DefaultMainScreen({
   );
 }
 
-
 export interface SelectionRequest {
   title: string;
   options: string[];
@@ -817,7 +896,12 @@ interface ErrorLine {
   text: string;
 }
 
-type FeedItem = RuntimeMessage | StatusLine | SpinnerLine | HelpLine | ErrorLine;
+type FeedItem =
+  | RuntimeMessage
+  | StatusLine
+  | SpinnerLine
+  | HelpLine
+  | ErrorLine;
 
 function isRuntimeMessage(item: FeedItem): item is RuntimeMessage {
   return "role" in item;
@@ -833,8 +917,13 @@ function estimateItemHeight(item: FeedItem, terminalColumns: number): number {
     if (item.role === "assistant" && item.toolCalls) {
       for (const tc of item.toolCalls) {
         const paramCount =
-          typeof tc.input === "object" && tc.input ? Object.keys(tc.input).length : 0;
-        lines += TOOL_CALL_CHROME_LINES + paramCount + (tc.result !== undefined ? 1 : 0);
+          typeof tc.input === "object" && tc.input
+            ? Object.keys(tc.input).length
+            : 0;
+        lines +=
+          TOOL_CALL_CHROME_LINES +
+          paramCount +
+          (tc.result !== undefined ? 1 : 0);
       }
     }
     return lines + MESSAGE_SPACING;
@@ -863,7 +952,11 @@ function calculateHeaderHeight(species: Species): number {
 
 const SCROLL_STEP = 5;
 
-export function render(runtimeUrl: string, assistantId: string, species: Species): number {
+export function render(
+  runtimeUrl: string,
+  assistantId: string,
+  species: Species,
+): number {
   const config = SPECIES_CONFIG[species];
   const art = config.art;
 
@@ -871,7 +964,11 @@ export function render(runtimeUrl: string, assistantId: string, species: Species
   const maxLines = Math.max(leftLineCount, RIGHT_PANEL_LINE_COUNT);
 
   const { unmount } = inkRender(
-    <DefaultMainScreen runtimeUrl={runtimeUrl} assistantId={assistantId} species={species} />,
+    <DefaultMainScreen
+      runtimeUrl={runtimeUrl}
+      assistantId={assistantId}
+      species={species}
+    />,
     { exitOnCtrlC: false },
   );
   unmount();
@@ -883,7 +980,9 @@ export function render(runtimeUrl: string, assistantId: string, species: Species
       const statusText = health.detail
         ? `${withStatusEmoji(health.status)} (${health.detail})`
         : withStatusEmoji(health.status);
-      process.stdout.write(`\x1b7\x1b[${statusCanvasLine};${statusCol}H\x1b[K${statusText}\x1b8`);
+      process.stdout.write(
+        `\x1b7\x1b[${statusCanvasLine};${statusCol}H\x1b[K${statusText}\x1b8`,
+      );
     })
     .catch(() => {});
 
@@ -917,7 +1016,9 @@ function SelectionWindow({
       },
     ) => {
       if (key.upArrow) {
-        setSelectedIndex((prev: number) => (prev - 1 + options.length) % options.length);
+        setSelectedIndex(
+          (prev: number) => (prev - 1 + options.length) % options.length,
+        );
       } else if (key.downArrow) {
         setSelectedIndex((prev: number) => (prev + 1) % options.length);
       } else if (key.return) {
@@ -928,26 +1029,42 @@ function SelectionWindow({
     },
   );
 
-  const borderH = "\u2500".repeat(Math.max(0, DIALOG_WINDOW_WIDTH - title.length - DIALOG_TITLE_CHROME));
+  const borderH = "\u2500".repeat(
+    Math.max(0, DIALOG_WINDOW_WIDTH - title.length - DIALOG_TITLE_CHROME),
+  );
 
   return (
     <Box flexDirection="column" width={DIALOG_WINDOW_WIDTH}>
       <Text>{"\u250C\u2500 " + title + " " + borderH + "\u2510"}</Text>
       {options.map((option, i) => {
         const marker = i === selectedIndex ? "\u276F" : " ";
-        const padding = " ".repeat(Math.max(0, DIALOG_WINDOW_WIDTH - option.length - SELECTION_OPTION_CHROME));
+        const padding = " ".repeat(
+          Math.max(
+            0,
+            DIALOG_WINDOW_WIDTH - option.length - SELECTION_OPTION_CHROME,
+          ),
+        );
         return (
           <Text key={i}>
             {"\u2502 "}
-            <Text color={i === selectedIndex ? "cyan" : undefined}>{marker}</Text>{" "}
+            <Text color={i === selectedIndex ? "cyan" : undefined}>
+              {marker}
+            </Text>{" "}
             <Text bold={i === selectedIndex}>{option}</Text>
             {padding}
             {"\u2502"}
           </Text>
         );
       })}
-      <Text>{"\u2514" + "\u2500".repeat(DIALOG_WINDOW_WIDTH - DIALOG_BORDER_CORNERS) + "\u2518"}</Text>
-      <Tooltip text="\u2191/\u2193 navigate  Enter select  Esc cancel" delay={1000} />
+      <Text>
+        {"\u2514" +
+          "\u2500".repeat(DIALOG_WINDOW_WIDTH - DIALOG_BORDER_CORNERS) +
+          "\u2518"}
+      </Text>
+      <Tooltip
+        text="\u2191/\u2193 navigate  Enter select  Esc cancel"
+        delay={1000}
+      />
     </Box>
   );
 }
@@ -990,11 +1107,19 @@ function SecretInputWindow({
     },
   );
 
-  const borderH = "\u2500".repeat(Math.max(0, DIALOG_WINDOW_WIDTH - label.length - DIALOG_TITLE_CHROME));
+  const borderH = "\u2500".repeat(
+    Math.max(0, DIALOG_WINDOW_WIDTH - label.length - DIALOG_TITLE_CHROME),
+  );
   const masked = "\u2022".repeat(value.length);
-  const displayText = value.length > 0 ? masked : (placeholder ?? "Enter secret...");
+  const displayText =
+    value.length > 0 ? masked : (placeholder ?? "Enter secret...");
   const displayColor = value.length > 0 ? undefined : "gray";
-  const contentPad = " ".repeat(Math.max(0, DIALOG_WINDOW_WIDTH - displayText.length - SECRET_CONTENT_CHROME));
+  const contentPad = " ".repeat(
+    Math.max(
+      0,
+      DIALOG_WINDOW_WIDTH - displayText.length - SECRET_CONTENT_CHROME,
+    ),
+  );
 
   return (
     <Box flexDirection="column" width={DIALOG_WINDOW_WIDTH}>
@@ -1005,7 +1130,11 @@ function SecretInputWindow({
         {contentPad}
         {"\u2502"}
       </Text>
-      <Text>{"\u2514" + "\u2500".repeat(DIALOG_WINDOW_WIDTH - DIALOG_BORDER_CORNERS) + "\u2518"}</Text>
+      <Text>
+        {"\u2514" +
+          "\u2500".repeat(DIALOG_WINDOW_WIDTH - DIALOG_BORDER_CORNERS) +
+          "\u2518"}
+      </Text>
       <Tooltip text="Enter submit  Esc cancel" delay={1000} />
     </Box>
   );
@@ -1039,7 +1168,10 @@ export interface ChatAppHandle {
   showSecretInput: (label: string, placeholder?: string) => Promise<string>;
   handleSecretPrompt: (
     secret: PendingSecret,
-    onSubmit: (value: string, delivery?: "store" | "transient_send") => Promise<void>,
+    onSubmit: (
+      value: string,
+      delivery?: "store" | "transient_send",
+    ) => Promise<void>,
   ) => Promise<void>;
   clearFeed: () => void;
   setBusy: (busy: boolean) => void;
@@ -1071,10 +1203,14 @@ function ChatApp({
   const [feed, setFeed] = useState<FeedItem[]>([]);
   const [spinnerText, setSpinnerText] = useState<string | null>(null);
   const [selection, setSelection] = useState<SelectionRequest | null>(null);
-  const [secretInput, setSecretInput] = useState<SecretInputRequest | null>(null);
+  const [secretInput, setSecretInput] = useState<SecretInputRequest | null>(
+    null,
+  );
   const [inputFocused, setInputFocused] = useState(true);
   const [scrollIndex, setScrollIndex] = useState<number | null>(null);
-  const [healthStatus, setHealthStatus] = useState<string | undefined>(undefined);
+  const [healthStatus, setHealthStatus] = useState<string | undefined>(
+    undefined,
+  );
   const prevFeedLengthRef = useRef(0);
   const busyRef = useRef(false);
   const connectedRef = useRef(false);
@@ -1098,7 +1234,10 @@ function ChatApp({
       : spinnerText
         ? SPINNER_HEIGHT + INPUT_AREA_HEIGHT
         : INPUT_AREA_HEIGHT;
-  const availableRows = Math.max(MIN_FEED_ROWS, terminalRows - headerHeight - bottomHeight);
+  const availableRows = Math.max(
+    MIN_FEED_ROWS,
+    terminalRows - headerHeight - bottomHeight,
+  );
 
   const addMessage = useCallback((msg: RuntimeMessage) => {
     setFeed((prev) => [...prev, msg]);
@@ -1198,24 +1337,33 @@ function ChatApp({
     setFeed((prev) => [...prev, item]);
   }, []);
 
-  const showSelection = useCallback((title: string, options: string[]): Promise<number> => {
-    setInputFocused(false);
-    return new Promise<number>((resolve) => {
-      setSelection({ title, options, resolve });
-    });
-  }, []);
+  const showSelection = useCallback(
+    (title: string, options: string[]): Promise<number> => {
+      setInputFocused(false);
+      return new Promise<number>((resolve) => {
+        setSelection({ title, options, resolve });
+      });
+    },
+    [],
+  );
 
-  const showSecretInput = useCallback((label: string, placeholder?: string): Promise<string> => {
-    setInputFocused(false);
-    return new Promise<string>((resolve) => {
-      setSecretInput({ label, placeholder, resolve });
-    });
-  }, []);
+  const showSecretInput = useCallback(
+    (label: string, placeholder?: string): Promise<string> => {
+      setInputFocused(false);
+      return new Promise<string>((resolve) => {
+        setSecretInput({ label, placeholder, resolve });
+      });
+    },
+    [],
+  );
 
   const handleSecretPromptFn = useCallback(
     async (
       secret: PendingSecret,
-      onSubmit: (value: string, delivery?: "store" | "transient_send") => Promise<void>,
+      onSubmit: (
+        value: string,
+        delivery?: "store" | "transient_send",
+      ) => Promise<void>,
     ): Promise<void> => {
       addStatus(`\u250C Secret needed: ${secret.label}`);
       addStatus(`\u2502 Service: ${secret.service} / ${secret.field}`);
@@ -1311,12 +1459,18 @@ function ChatApp({
     try {
       const health = await checkHealthRuntime(runtimeUrl);
       if (!accessTokenRef.current) {
-        accessTokenRef.current = await bootstrapAccessToken(runtimeUrl, bearerToken);
+        accessTokenRef.current = await bootstrapAccessToken(
+          runtimeUrl,
+          bearerToken,
+        );
       }
       h.hideSpinner();
       h.updateHealthStatus(health.status);
       if (health.status === "healthy" || health.status === "ok") {
-        h.addStatus(`${statusEmoji(health.status)} Connected to assistant`, "green");
+        h.addStatus(
+          `${statusEmoji(health.status)} Connected to assistant`,
+          "green",
+        );
       } else {
         const statusMsg = health.message ? ` - ${health.message}` : "";
         h.addStatus(
@@ -1374,7 +1528,10 @@ function ChatApp({
       connectingRef.current = false;
       h.updateHealthStatus("unreachable");
       const msg = err instanceof Error ? err.message : String(err);
-      h.addStatus(`${statusEmoji("unreachable")} Failed to connect: ${msg}`, "red");
+      h.addStatus(
+        `${statusEmoji("unreachable")} Failed to connect: ${msg}`,
+        "red",
+      );
       return false;
     }
   }, [runtimeUrl, assistantId, bearerToken]);
@@ -1427,17 +1584,27 @@ function ChatApp({
             method: "POST",
             headers: {
               "Content-Type": "application/json",
-              ...(bearerToken ? { Authorization: `Bearer ${bearerToken}` } : {}),
+              ...(bearerToken
+                ? { Authorization: `Bearer ${bearerToken}` }
+                : {}),
             },
-            body: JSON.stringify({ pairingRequestId, pairingSecret, gatewayUrl }),
+            body: JSON.stringify({
+              pairingRequestId,
+              pairingSecret,
+              gatewayUrl,
+            }),
           });
 
           if (!registerRes.ok) {
             const body = await registerRes.text().catch(() => "");
-            throw new Error(`HTTP ${registerRes.status}: ${body || registerRes.statusText}`);
+            throw new Error(
+              `HTTP ${registerRes.status}: ${body || registerRes.statusText}`,
+            );
           }
 
-          const hostId = createHash("sha256").update(hostname() + userInfo().username).digest("hex");
+          const hostId = createHash("sha256")
+            .update(hostname() + userInfo().username)
+            .digest("hex");
           const payload = JSON.stringify({
             type: "vellum-daemon",
             v: 4,
@@ -1462,14 +1629,18 @@ function ChatApp({
           );
         } catch (err) {
           h.hideSpinner();
-          h.showError(`Pairing failed: ${err instanceof Error ? err.message : err}`);
+          h.showError(
+            `Pairing failed: ${err instanceof Error ? err.message : err}`,
+          );
         }
         return;
       }
 
       if (trimmed === "/retire") {
         if (!project || !zone) {
-          h.showError("No instance info available. Connect to a hatched instance first.");
+          h.showError(
+            "No instance info available. Connect to a hatched instance first.",
+          );
           return;
         }
 
@@ -1524,9 +1695,13 @@ function ChatApp({
           handleRef_.current?.hideSpinner();
           if (code === 0) {
             removeAssistantEntry(assistantId);
-            handleRef_.current?.addStatus(`Removed ${assistantId} from lockfile.json`);
+            handleRef_.current?.addStatus(
+              `Removed ${assistantId} from lockfile.json`,
+            );
           } else {
-            handleRef_.current?.showError(`Failed to delete instance (exit code ${code})`);
+            handleRef_.current?.showError(
+              `Failed to delete instance (exit code ${code})`,
+            );
           }
           cleanup();
           process.exit(code === 0 ? 0 : 1);
@@ -1534,14 +1709,18 @@ function ChatApp({
 
         child.on("error", (err) => {
           handleRef_.current?.hideSpinner();
-          handleRef_.current?.showError(`Failed to retire instance: ${err.message}`);
+          handleRef_.current?.showError(
+            `Failed to retire instance: ${err.message}`,
+          );
         });
         return;
       }
 
       if (trimmed === "/doctor" || trimmed.startsWith("/doctor ")) {
         if (!project || !zone) {
-          h.showError("No instance info available. Connect to a hatched instance first.");
+          h.showError(
+            "No instance info available. Connect to a hatched instance first.",
+          );
           return;
         }
         const userPrompt = trimmed.slice("/doctor".length).trim() || undefined;
@@ -1571,7 +1750,9 @@ function ChatApp({
             (event) => {
               switch (event.phase) {
                 case "invoking_prompt":
-                  handleRef_.current?.showSpinner(`Analyzing ${assistantId}...`);
+                  handleRef_.current?.showSpinner(
+                    `Analyzing ${assistantId}...`,
+                  );
                   break;
                 case "calling_tool":
                   handleRef_.current?.showSpinner(
@@ -1579,7 +1760,9 @@ function ChatApp({
                   );
                   break;
                 case "processing_tool_result":
-                  handleRef_.current?.showSpinner(`Reviewing diagnostics for ${assistantId}...`);
+                  handleRef_.current?.showSpinner(
+                    `Reviewing diagnostics for ${assistantId}...`,
+                  );
                   break;
               }
             },
@@ -1589,14 +1772,17 @@ function ChatApp({
           h.hideSpinner();
           if (result.recommendation) {
             h.addStatus(`Recommendation:\n${result.recommendation}`);
-            chatLogRef.current.push({ role: "assistant", content: result.recommendation });
+            chatLogRef.current.push({
+              role: "assistant",
+              content: result.recommendation,
+            });
           } else if (result.error) {
             h.showError(result.error);
             chatLogRef.current.push({ role: "error", content: result.error });
           }
         } catch (err) {
           h.hideSpinner();
-          const errorMsg = `Doctor daemon unreachable: ${err instanceof Error ? err.message : err}`;
+          const errorMsg = `Doctor assistant unreachable: ${err instanceof Error ? err.message : err}`;
           h.showError(errorMsg);
           chatLogRef.current.push({ role: "error", content: errorMsg });
         }
@@ -1657,7 +1843,9 @@ function ChatApp({
         h.showSpinner("Working...");
 
         while (true) {
-          await new Promise((resolve) => setTimeout(resolve, RESPONSE_POLL_INTERVAL_MS));
+          await new Promise((resolve) =>
+            setTimeout(resolve, RESPONSE_POLL_INTERVAL_MS),
+          );
 
           // Check for pending confirmations/secrets
           try {
@@ -1686,19 +1874,26 @@ function ChatApp({
             if (pending.pendingSecret) {
               const secretRequestId = pending.pendingSecret.requestId ?? "";
               h.hideSpinner();
-              await h.handleSecretPrompt(pending.pendingSecret, async (value, delivery) => {
-                await runtimeRequest(
-                  runtimeUrl,
-                  assistantId,
-                  "/secret",
-                  {
-                    method: "POST",
-                    body: JSON.stringify({ requestId: secretRequestId, value, delivery }),
-                  },
-                  bearerToken,
-                  accessTokenRef.current,
-                );
-              });
+              await h.handleSecretPrompt(
+                pending.pendingSecret,
+                async (value, delivery) => {
+                  await runtimeRequest(
+                    runtimeUrl,
+                    assistantId,
+                    "/secret",
+                    {
+                      method: "POST",
+                      body: JSON.stringify({
+                        requestId: secretRequestId,
+                        value,
+                        delivery,
+                      }),
+                    },
+                    bearerToken,
+                    accessTokenRef.current,
+                  );
+                },
+              );
               h.showSpinner("Working...");
               continue;
             }
@@ -1719,7 +1914,10 @@ function ChatApp({
                 seenMessageIdsRef.current.add(msg.id);
                 if (msg.role === "assistant") {
                   h.addMessage(msg);
-                  chatLogRef.current.push({ role: "assistant", content: msg.content });
+                  chatLogRef.current.push({
+                    role: "assistant",
+                    content: msg.content,
+                  });
                   h.setBusy(false);
                   h.hideSpinner();
                   return;
@@ -1730,7 +1928,6 @@ function ChatApp({
             // Poll failure; retry
           }
         }
-
       } catch (error) {
         h.setBusy(false);
         h.hideSpinner();
@@ -1746,7 +1943,15 @@ function ChatApp({
         }
       }
     },
-    [runtimeUrl, assistantId, bearerToken, project, zone, cleanup, ensureConnected],
+    [
+      runtimeUrl,
+      assistantId,
+      bearerToken,
+      project,
+      zone,
+      cleanup,
+      ensureConnected,
+    ],
   );
 
   const handleSubmit = useCallback(
@@ -1890,7 +2095,8 @@ function ChatApp({
       <Box flexDirection="column" flexGrow={1} overflow="hidden">
         {visibleWindow.hiddenAbove > 0 ? (
           <Text dimColor>
-            {"\u2191"} {visibleWindow.hiddenAbove} more above (Shift+\u2191/Cmd+\u2191)
+            {"\u2191"} {visibleWindow.hiddenAbove} more above
+            (Shift+\u2191/Cmd+\u2191)
           </Text>
         ) : null}
 
@@ -1905,7 +2111,10 @@ function ChatApp({
           }
           if (item.type === "status") {
             return (
-              <Text key={feedIndex} color={item.color as "green" | "yellow" | "red" | undefined}>
+              <Text
+                key={feedIndex}
+                color={item.color as "green" | "yellow" | "red" | undefined}
+              >
                 {item.text}
               </Text>
             );
@@ -1925,7 +2134,8 @@ function ChatApp({
 
         {visibleWindow.hiddenBelow > 0 ? (
           <Text dimColor>
-            {"\u2193"} {visibleWindow.hiddenBelow} more below (Shift+\u2193/Cmd+\u2193)
+            {"\u2193"} {visibleWindow.hiddenBelow} more below
+            (Shift+\u2193/Cmd+\u2193)
           </Text>
         ) : null}
       </Box>
@@ -1956,14 +2166,14 @@ function ChatApp({
           <Box paddingLeft={1}>
             <Text color="green" bold>
               you{">"}
-            {" "}
-          </Text>
-          <TextInput
-            value={inputValue}
-            onChange={setInputValue}
-            onSubmit={handleSubmit}
-            focus={inputFocused}
-          />
+              {" "}
+            </Text>
+            <TextInput
+              value={inputValue}
+              onChange={setInputValue}
+              onSubmit={handleSubmit}
+              focus={inputFocused}
+            />
           </Box>
           <Text dimColor>{"\u2500".repeat(terminalColumns)}</Text>
           <Text dimColor> ? for shortcuts</Text>

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -97,10 +97,10 @@ async function main() {
     );
     console.log("  recover  Restore a previously retired local assistant");
     console.log("  retire   Delete an assistant instance");
-    console.log("  sleep    Stop the daemon process");
+    console.log("  sleep    Stop the assistant process");
     console.log("  ssh      SSH into a remote assistant instance");
     console.log("  tunnel   Create a tunnel for a locally hosted assistant");
-    console.log("  wake     Start the daemon and gateway");
+    console.log("  wake     Start the assistant and gateway");
     console.log("  whoami   Show current logged-in user");
     process.exit(0);
   }

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -181,7 +181,7 @@ async function startDaemonFromSource(assistantIndex: string): Promise<void> {
       if (!isNaN(pid)) {
         try {
           process.kill(pid, 0);
-          console.log(`   Daemon already running (pid ${pid})\n`);
+          console.log(`   Assistant already running (pid ${pid})\n`);
           return;
         } catch {
           try {
@@ -197,10 +197,10 @@ async function startDaemonFromSource(assistantIndex: string): Promise<void> {
     if (ownerPid) {
       writeFileSync(pidFile, String(ownerPid), "utf-8");
       console.log(
-        `   Daemon socket is responsive (pid ${ownerPid}) — skipping restart\n`,
+        `   Assistant socket is responsive (pid ${ownerPid}) — skipping restart\n`,
       );
     } else {
-      console.log("   Daemon socket is responsive — skipping restart\n");
+      console.log("   Assistant socket is responsive — skipping restart\n");
     }
     return;
   }
@@ -262,7 +262,7 @@ async function startDaemonWatchFromSource(
       if (!isNaN(pid)) {
         try {
           process.kill(pid, 0); // Check if alive
-          console.log(`   Daemon already running (pid ${pid})\n`);
+          console.log(`   Assistant already running (pid ${pid})\n`);
           return;
         } catch {
           // Process doesn't exist, clean up stale PID file
@@ -281,10 +281,10 @@ async function startDaemonWatchFromSource(
     if (ownerPid) {
       writeFileSync(pidFile, String(ownerPid), "utf-8");
       console.log(
-        `   Daemon socket is responsive (pid ${ownerPid}) — skipping restart\n`,
+        `   Assistant socket is responsive (pid ${ownerPid}) — skipping restart\n`,
       );
     } else {
-      console.log("   Daemon socket is responsive — skipping restart\n");
+      console.log("   Assistant socket is responsive — skipping restart\n");
     }
     return;
   }
@@ -313,7 +313,7 @@ async function startDaemonWatchFromSource(
     writeFileSync(pidFile, String(daemonPid), "utf-8");
   }
 
-  console.log("   Daemon started in watch mode (bun --watch)");
+  console.log("   Assistant started in watch mode (bun --watch)");
 }
 
 function resolveGatewayDir(): string {
@@ -605,7 +605,7 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
           try {
             process.kill(pid, 0); // Check if alive
             daemonAlive = true;
-            console.log(`   Daemon already running (pid ${pid})\n`);
+            console.log(`   Assistant already running (pid ${pid})\n`);
           } catch {
             // Process doesn't exist, clean up stale PID file
             try {
@@ -627,10 +627,10 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
         if (ownerPid) {
           writeFileSync(pidFile, String(ownerPid), "utf-8");
           console.log(
-            `   Daemon socket is responsive (pid ${ownerPid}) — skipping restart\n`,
+            `   Assistant socket is responsive (pid ${ownerPid}) — skipping restart\n`,
           );
         } else {
-          console.log("   Daemon socket is responsive — skipping restart\n");
+          console.log("   Assistant socket is responsive — skipping restart\n");
         }
         return;
       }
@@ -640,7 +640,7 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
         unlinkSync(socketFile);
       } catch {}
 
-      console.log("🔨 Starting daemon...");
+      console.log("🔨 Starting assistant...");
 
       // Ensure ~/.vellum/ exists for PID/socket files
       mkdirSync(vellumDir, { recursive: true });
@@ -702,7 +702,7 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
       const assistantIndex = resolveAssistantIndexPath();
       if (assistantIndex) {
         console.log(
-          "   Bundled daemon socket not ready after 60s — falling back to source daemon...",
+          "   Bundled assistant socket not ready after 60s — falling back to source assistant...",
         );
         // Kill the bundled daemon to avoid two processes competing for the same socket/port
         await stopProcessByPidFile(pidFile, "bundled daemon", [socketFile]);
@@ -716,14 +716,14 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
     }
 
     if (socketReady) {
-      console.log("   Daemon socket ready\n");
+      console.log("   Assistant socket ready\n");
     } else {
       console.log(
-        "   ⚠️  Daemon socket did not appear within 60s — continuing anyway\n",
+        "   ⚠️  Assistant socket did not appear within 60s — continuing anyway\n",
       );
     }
   } else {
-    console.log("🔨 Starting local daemon...");
+    console.log("🔨 Starting local assistant...");
 
     const assistantIndex = resolveAssistantIndexPath();
     if (!assistantIndex) {
@@ -739,10 +739,10 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
       const socketFile = join(vellumDir, "vellum.sock");
       const socketReady = await waitForSocketFile(socketFile, 60000);
       if (socketReady) {
-        console.log("   Daemon socket ready\n");
+        console.log("   Assistant socket ready\n");
       } else {
         console.log(
-          "   ⚠️  Daemon socket did not appear within 60s — continuing anyway\n",
+          "   ⚠️  Assistant socket did not appear within 60s — continuing anyway\n",
         );
       }
     } else {
@@ -752,10 +752,10 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
       const socketFile = join(vellumDir, "vellum.sock");
       const socketReady = await waitForSocketFile(socketFile, 60000);
       if (socketReady) {
-        console.log("   Daemon socket ready\n");
+        console.log("   Assistant socket ready\n");
       } else {
         console.log(
-          "   ⚠️  Daemon socket did not appear within 60s — continuing anyway\n",
+          "   ⚠️  Assistant socket did not appear within 60s — continuing anyway\n",
         );
       }
     }

--- a/clients/README.md
+++ b/clients/README.md
@@ -36,7 +36,7 @@ clients/
 **Purpose**: Platform-agnostic code shared between macOS and iOS apps
 
 **Contains**:
-- **IPC layer** (`DaemonClient`, `IPCMessages`, `Generated/IPCContractGenerated`) - Network communication with daemon
+- **IPC layer** (`DaemonClient`, `IPCMessages`, `Generated/IPCContractGenerated`) - Network communication with the assistant
   - macOS: Unix domain socket (`~/.vellum/vellum.sock`)
   - iOS: TCP connection (configurable hostname:port)
   - Wire types are auto-generated from the TS IPC contract; `IPCMessages.swift` provides
@@ -108,7 +108,7 @@ See [clients/ios/README.md](ios/README.md) for full build, packaging, and config
 
 **Current features:**
 - ✅ Standalone mode — direct Anthropic API connection (no Mac required)
-- ✅ Connected to Mac mode — TCP proxy through the Vellum daemon
+- ✅ Connected to Mac mode — TCP proxy through the Vellum assistant
 - ✅ Chat interface with streaming, markdown, code blocks
 - ✅ Multiple threads with JSON persistence
 - ✅ Onboarding with adaptive steps per connection mode
@@ -128,7 +128,7 @@ Depends only on `VellumAssistantShared` (no macOS frameworks).
 
 **~45-50% code reuse** between macOS and iOS achieved through:
 
-1. **Shared IPC layer** - Both platforms communicate with daemon (different transport)
+1. **Shared IPC layer** - Both platforms communicate with the assistant (different transport)
 2. **Shared design system** - Tokens and components with conditional compilation
 3. **Shared ViewModels** - ChatViewModel, message models work on both platforms
 
@@ -160,17 +160,17 @@ Depends only on `VellumAssistantShared` (no macOS frameworks).
 ## Known Limitations
 
 ### iOS Signing Operations
-- iOS clients log errors when daemon sends signing requests (macOS-specific IPC)
+- iOS clients log errors when assistant sends signing requests (macOS-specific IPC)
 - Cannot send error responses (protocol limitation)
 
 ### iOS TCP — Real Device Networking
 - `localhost` only works in the simulator (simulator shares Mac's network stack)
-- For real device: enter Mac's local IP in Settings → Mac Daemon → Hostname
+- For real device: enter Mac's local IP in Settings → Mac Assistant → Hostname
 - For remote access: requires VPN, SSH tunnel, or port forwarding
 
 ### iOS Computer-Use
 - AXUIElement + CGEvent APIs are macOS-only (sandbox prevents on iOS)
-- Computer-use sessions initiated from iOS proxy through the Mac daemon
+- Computer-use sessions initiated from iOS proxy through the Mac assistant
 
 ## Documentation
 

--- a/clients/shared/Features/Chat/ChatErrorManager.swift
+++ b/clients/shared/Features/Chat/ChatErrorManager.swift
@@ -42,11 +42,11 @@ public final class ChatErrorManager: ObservableObject {
             case .posix(let code):
                 switch code {
                 case .ECONNREFUSED:
-                    return "Daemon is not accepting connections — it may still be starting."
+                    return "Assistant is not accepting connections — it may still be starting."
                 case .ENOENT:
-                    return "Daemon socket not found — the daemon may not be running."
+                    return "Assistant socket not found — the assistant may not be running."
                 case .ETIMEDOUT:
-                    return "Connection timed out — the daemon may be unresponsive or the socket path may be wrong."
+                    return "Connection timed out — the assistant may be unresponsive or the socket path may be wrong."
                 default:
                     return "POSIX error \(code.rawValue): \(nwErr.localizedDescription)"
                 }
@@ -57,11 +57,11 @@ public final class ChatErrorManager: ObservableObject {
         if let authErr = error as? DaemonClient.AuthError {
             switch authErr {
             case .missingToken:
-                return "Session token not found — try restarting the daemon."
+                return "Session token not found — try restarting the assistant."
             case .timeout:
-                return "Authentication timed out — daemon may be overloaded."
+                return "Authentication timed out — assistant may be overloaded."
             case .rejected:
-                return "Session token rejected — token may have changed; try restarting the daemon."
+                return "Session token rejected — token may have changed; try restarting the assistant."
             }
         }
         #endif
@@ -73,7 +73,7 @@ public final class ChatErrorManager: ObservableObject {
             case .timedOut:
                 return "Gateway request timed out — check your host and port."
             case .cannotConnectToHost:
-                return "Cannot connect to gateway host — verify the address and that the daemon is running."
+                return "Cannot connect to gateway host — verify the address and that the assistant is running."
             case .networkConnectionLost:
                 return "Network connection lost."
             default:


### PR DESCRIPTION
## Summary
- Replace all user-facing mentions of "daemon" with "assistant" across CLI output, error messages, Swift client strings, documentation (SKILL.md, READMEs), and config comments
- Internal identifiers (env vars, CLI flags, process names, import paths) left unchanged to avoid breaking changes
- Add "User-Facing Terminology" rule to AGENTS.md to prevent future regressions

## Original prompt
Look for all user-facing mentions of "daemon" and update them to reference "assistant" instead. "daemon" is an internnal facing concept and should not be revealed to our users. If we don't already, add a rule about this somewhere in AGENTS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
