### PR TITLE
fix: update tests for feature flag registry defaults and self-heal migration

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -449,14 +449,15 @@ describe("resolveLocalIpcAuthContext", () => {
     );
   });
 
-  test("actorPrincipalId is undefined when no vellum binding exists", () => {
+  test("actorPrincipalId is auto-created via self-heal when no vellum binding exists", () => {
     // Reset DB to ensure no binding
     resetDb();
     initializeDb();
 
     const ctx = resolveLocalIpcAuthContext("session-123");
-    // When no binding exists, actorPrincipalId is not set
-    expect(ctx.actorPrincipalId).toBeUndefined();
+    // Self-heal creates a vellum guardian binding automatically
+    expect(ctx.actorPrincipalId).toBeDefined();
+    expect(ctx.actorPrincipalId).toMatch(/^vellum-principal-/);
   });
 
   test("sessionId matches the provided argument", () => {

--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -146,16 +146,20 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     currentConfig = {
       sandbox: { enabled: false, backend: "native" },
-      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: false },
+      assistantFeatureFlagValues: {
+        [DECLARED_FLAG_KEY]: false,
+        "feature_flags.twitter.enabled": true,
+      },
     };
 
     const result = buildSystemPrompt();
 
+    // twitter is explicitly enabled, declared flagged skill is explicitly off
     expect(result).toContain('id="twitter"');
     expect(result).not.toContain(`id="${DECLARED_SKILL_ID}"`);
   });
 
-  test("all skills visible when no flag overrides set", () => {
+  test("declared skills hidden when no flag overrides set (registry defaults to false)", () => {
     createSkillOnDisk(
       DECLARED_SKILL_ID,
       "Hatch New Assistant",
@@ -169,8 +173,9 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     const result = buildSystemPrompt();
 
-    expect(result).toContain(`id="${DECLARED_SKILL_ID}"`);
-    expect(result).toContain('id="twitter"');
+    // Both skills are declared in the registry with defaultEnabled: false
+    expect(result).not.toContain(`id="${DECLARED_SKILL_ID}"`);
+    expect(result).not.toContain('id="twitter"');
   });
 
   test("flagged-off skills hidden when all flags are OFF", () => {
@@ -227,7 +232,7 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
     expect(result).not.toContain('id="browser"');
   });
 
-  test("undeclared flags with no persisted override default to enabled", () => {
+  test("declared flags with no persisted override use registry default", () => {
     createSkillOnDisk("browser", "Browser", "Web browsing automation");
 
     currentConfig = {
@@ -236,7 +241,8 @@ describe("buildSystemPrompt assistant feature flag filtering", () => {
 
     const result = buildSystemPrompt();
 
-    expect(result).toContain('id="browser"');
+    // browser is declared in the registry with defaultEnabled: false
+    expect(result).not.toContain('id="browser"');
   });
 });
 
@@ -265,10 +271,12 @@ describe("isAssistantFeatureFlagEnabled", () => {
 
   test("missing persisted value falls back to defaults registry defaultEnabled", () => {
     // No explicit config at all — should fall back to defaults registry
-    // which has defaultEnabled: true for hatch-new-assistant
+    // which has defaultEnabled: false for hatch-new-assistant
     const config = {} as any;
 
-    expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(true);
+    expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(
+      false,
+    );
   });
 
   test("unknown flag defaults to true when no persisted override", () => {
@@ -302,9 +310,9 @@ describe("legacy isSkillFeatureEnabled backward compat", () => {
     expect(isSkillFeatureEnabled(DECLARED_SKILL_ID, config)).toBe(false);
   });
 
-  test("enabled when no override set", () => {
+  test("disabled when no override set (registry default is false)", () => {
     const config = {} as any;
 
-    expect(isSkillFeatureEnabled(DECLARED_SKILL_ID, config)).toBe(true);
+    expect(isSkillFeatureEnabled(DECLARED_SKILL_ID, config)).toBe(false);
   });
 });

--- a/assistant/src/__tests__/browser-skill-endstate.test.ts
+++ b/assistant/src/__tests__/browser-skill-endstate.test.ts
@@ -4,7 +4,16 @@
  * Locks the final invariants from the BROWSER_SKILL plan so that future
  * changes cannot silently regress any of the migration guarantees.
  */
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    sandbox: { enabled: false, backend: "native" },
+    assistantFeatureFlagValues: {
+      "feature_flags.browser.enabled": true,
+    },
+  }),
+}));
 
 import {
   projectSkillTools,

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -394,7 +394,9 @@ describe("guardian service challenge validation", () => {
     );
 
     expect(result.success).toBe(true);
-    expect(result.verificationType).toBe("guardian");
+    if (result.success) {
+      expect(result.verificationType).toBe("guardian");
+    }
   });
 
   test("validateAndConsumeChallenge does not create a guardian binding (caller responsibility)", () => {
@@ -497,7 +499,9 @@ describe("guardian service challenge validation", () => {
     );
 
     expect(result.success).toBe(true);
-    expect(result.verificationType).toBe("guardian");
+    if (result.success) {
+      expect(result.verificationType).toBe("guardian");
+    }
 
     // validateAndConsumeChallenge no longer creates bindings — that is
     // now handled by the caller (verification-intercept / relay-server).
@@ -1757,7 +1761,9 @@ describe("voice guardian challenge validation", () => {
     );
 
     expect(result.success).toBe(true);
-    expect(result.verificationType).toBe("guardian");
+    if (result.success) {
+      expect(result.verificationType).toBe("guardian");
+    }
   });
 
   test("validateAndConsumeChallenge does not create a guardian binding for voice (caller responsibility)", () => {
@@ -2492,7 +2498,9 @@ describe("outbound verification sessions", () => {
     );
 
     expect(result.success).toBe(true);
-    expect(result.verificationType).toBe("guardian");
+    if (result.success) {
+      expect(result.verificationType).toBe("guardian");
+    }
   });
 
   // ── Session state transitions ──
@@ -3022,7 +3030,9 @@ describe("outbound SMS verification", () => {
     );
 
     expect(result.success).toBe(true);
-    expect(result.verificationType).toBe("guardian");
+    if (result.success) {
+      expect(result.verificationType).toBe("guardian");
+    }
   });
 
   test("inbound SMS from wrong identity + correct code is rejected", () => {

--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -46,6 +46,15 @@ mock.module("../util/logger.js", () => ({
   truncateForLog: (v: string) => v,
 }));
 
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    sandbox: { enabled: false, backend: "native" },
+    assistantFeatureFlagValues: {
+      "feature_flags.browser.enabled": true,
+    },
+  }),
+}));
+
 const { buildSystemPrompt } = await import("../config/system-prompt.js");
 
 describe("Dynamic Skill Authoring Workflow prompt section", () => {

--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -50,6 +50,9 @@ mock.module("../config/loader.js", () => ({
     ui: {},
 
     sandbox: { enabled: false, backend: "local" },
+    assistantFeatureFlagValues: {
+      "feature_flags.guardian-verify-setup.enabled": true,
+    },
   }),
 }));
 

--- a/assistant/src/__tests__/skill-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags-integration.test.ts
@@ -141,17 +141,20 @@ describe("buildSystemPrompt feature flag filtering", () => {
 
     currentConfig = {
       sandbox: { enabled: false, backend: "native" },
-      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: false },
+      assistantFeatureFlagValues: {
+        [DECLARED_FLAG_KEY]: false,
+        "feature_flags.twitter.enabled": true,
+      },
     };
 
     const result = buildSystemPrompt();
 
-    // twitter should be visible, declared flagged skill should not
+    // twitter is explicitly enabled, declared flagged skill is explicitly off
     expect(result).toContain('id="twitter"');
     expect(result).not.toContain(`id="${DECLARED_SKILL_ID}"`);
   });
 
-  test("all skills visible when featureFlags is empty", () => {
+  test("declared skills hidden when featureFlags is empty (registry defaults to false)", () => {
     createSkillOnDisk(
       DECLARED_SKILL_ID,
       "Hatch New Assistant",
@@ -166,8 +169,9 @@ describe("buildSystemPrompt feature flag filtering", () => {
 
     const result = buildSystemPrompt();
 
-    expect(result).toContain(`id="${DECLARED_SKILL_ID}"`);
-    expect(result).toContain('id="twitter"');
+    // Both skills are declared in the registry with defaultEnabled: false
+    expect(result).not.toContain(`id="${DECLARED_SKILL_ID}"`);
+    expect(result).not.toContain('id="twitter"');
   });
 
   test("flagged-off skills hidden even when all workspace skill flags are OFF", () => {

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -59,9 +59,9 @@ function makeSkill(
 // ---------------------------------------------------------------------------
 
 describe("isSkillFeatureEnabled", () => {
-  test("returns true when no flag overrides", () => {
+  test("returns false when no flag overrides (registry default is false)", () => {
     const config = makeConfig();
-    expect(isSkillFeatureEnabled(DECLARED_SKILL_ID, config)).toBe(true);
+    expect(isSkillFeatureEnabled(DECLARED_SKILL_ID, config)).toBe(false);
   });
 
   test("returns true when skill key is explicitly true", () => {
@@ -103,8 +103,10 @@ describe("isAssistantFeatureFlagEnabled", () => {
 
   test("falls back to registry default when no override", () => {
     const config = makeConfig();
-    // hatch-new-assistant defaults to true in the registry
-    expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(true);
+    // hatch-new-assistant defaults to false in the registry
+    expect(isAssistantFeatureFlagEnabled(DECLARED_FLAG_KEY, config)).toBe(
+      false,
+    );
   });
 
   test("respects persisted overrides for undeclared keys", () => {
@@ -116,11 +118,12 @@ describe("isAssistantFeatureFlagEnabled", () => {
     ).toBe(false);
   });
 
-  test("undeclared keys with no persisted override default to enabled", () => {
+  test("declared keys with no persisted override use registry default", () => {
     const config = makeConfig();
+    // browser is declared in the registry with defaultEnabled: false
     expect(
       isAssistantFeatureFlagEnabled("feature_flags.browser.enabled", config),
-    ).toBe(true);
+    ).toBe(false);
   });
 });
 
@@ -132,7 +135,10 @@ describe("resolveSkillStates with feature flags", () => {
   test("flag OFF skill does not appear in resolved list", () => {
     const catalog = [makeSkill(DECLARED_SKILL_ID), makeSkill("twitter")];
     const config = makeConfig({
-      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: false },
+      assistantFeatureFlagValues: {
+        [DECLARED_FLAG_KEY]: false,
+        "feature_flags.twitter.enabled": true,
+      },
     });
 
     const resolved = resolveSkillStates(catalog, config);
@@ -158,13 +164,13 @@ describe("resolveSkillStates with feature flags", () => {
     expect(ids).toContain("twitter");
   });
 
-  test("missing flag key defaults to enabled", () => {
+  test("declared flag key defaults to registry value (false)", () => {
     const catalog = [makeSkill(DECLARED_SKILL_ID)];
     const config = makeConfig();
 
     const resolved = resolveSkillStates(catalog, config);
-    expect(resolved.length).toBe(1);
-    expect(resolved[0].summary.id).toBe(DECLARED_SKILL_ID);
+    // hatch-new-assistant registry default is false, so it's filtered out
+    expect(resolved.length).toBe(0);
   });
 
   test("feature flag OFF takes precedence over user-enabled config entry", () => {
@@ -202,6 +208,7 @@ describe("resolveSkillStates with feature flags", () => {
     const config = makeConfig({
       assistantFeatureFlagValues: {
         [DECLARED_FLAG_KEY]: false,
+        "feature_flags.twitter.enabled": true,
         "feature_flags.deploy.enabled": false,
       },
     });
@@ -209,8 +216,7 @@ describe("resolveSkillStates with feature flags", () => {
     const resolved = resolveSkillStates(catalog, config);
     const ids = resolved.map((r) => r.summary.id);
 
-    // Both declared (hatch-new-assistant) and undeclared (deploy) skills with
-    // persisted false overrides are filtered out; only twitter remains.
+    // hatch-new-assistant and deploy explicitly false; twitter explicitly true
     expect(ids).toEqual(["twitter"]);
   });
 });

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -154,7 +154,7 @@ describe("skill_load feature flag enforcement", () => {
     expect(result.content).toContain("Skill: Hatch New Assistant");
   });
 
-  test("loads skill normally when flag key is absent (defaults to enabled)", async () => {
+  test("rejects skill when flag key is absent (registry defaults to disabled)", async () => {
     writeSkill(
       DECLARED_SKILL_ID,
       "Hatch New Assistant",
@@ -172,7 +172,8 @@ describe("skill_load feature flag enforcement", () => {
 
     const result = await executeSkillLoad({ skill: DECLARED_SKILL_ID });
 
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain("Skill: Hatch New Assistant");
+    // hatch-new-assistant is declared in the registry with defaultEnabled: false
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("disabled by feature flag");
   });
 });

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -449,7 +449,9 @@ describe("trusted contact verification → member activation", () => {
     );
 
     expect(result.success).toBe(true);
-    expect(result.verificationType).toBe("guardian");
+    if (result.success) {
+      expect(result.verificationType).toBe("guardian");
+    }
 
     const guardianResult = findGuardianForChannel("telegram", "self");
     expect(guardianResult).toBeNull();


### PR DESCRIPTION
## Summary
- Update tests to match `defaultEnabled: false` for all feature flags set in PR #12321
- Fix TypeScript narrowing errors on `ValidateChallengeResult` discriminated union by adding type guards
- Update actor-token-service test to expect self-heal behavior from PR #12328

## Original prompt
fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22675885830

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
