### PR TITLE
fix: give scheduled sessions guardian trust class

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -313,7 +313,12 @@ export async function runDaemon(): Promise<void> {
 
     const scheduler = startScheduler(
       async (conversationId, message) => {
-        await server.processMessage(conversationId, message);
+        await server.processMessage(conversationId, message, undefined, {
+          trustContext: {
+            sourceChannel: "vellum",
+            trustClass: "guardian",
+          },
+        });
       },
       (reminder) => {
         void emitNotificationSignal({

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -312,13 +312,13 @@ export async function runDaemon(): Promise<void> {
     registerBroadcastFn((msg) => server.broadcast(msg));
 
     const scheduler = startScheduler(
-      async (conversationId, message) => {
-        await server.processMessage(conversationId, message, undefined, {
+      async (conversationId, message, options) => {
+        await server.processMessage(conversationId, message, undefined, options?.trustClass ? {
           trustContext: {
             sourceChannel: "vellum",
-            trustClass: "guardian",
+            trustClass: options.trustClass,
           },
-        });
+        } : undefined);
       },
       (reminder) => {
         void emitNotificationSignal({

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -23,9 +23,14 @@ import {
 
 const log = getLogger("scheduler");
 
+export interface ScheduleMessageOptions {
+  trustClass?: "guardian" | "trusted_contact" | "unknown";
+}
+
 export type ScheduleMessageProcessor = (
   conversationId: string,
   message: string,
+  options?: ScheduleMessageOptions,
 ) => Promise<unknown>;
 
 export type ReminderNotifier = (reminder: {
@@ -218,7 +223,7 @@ async function runScheduleOnce(
         },
         "Executing schedule",
       );
-      await processMessage(conversation.id, job.message);
+      await processMessage(conversation.id, job.message, { trustClass: "guardian" });
       completeScheduleRun(runId, { status: "ok" });
       notifySchedule({ id: job.id, name: job.name });
       processed += 1;
@@ -267,7 +272,7 @@ async function runScheduleOnce(
           },
           "Executing reminder",
         );
-        await processMessage(conversation.id, reminder.message);
+        await processMessage(conversation.id, reminder.message, { trustClass: "guardian" });
         completeReminder(reminder.id);
       } catch (err) {
         log.warn(


### PR DESCRIPTION
## Problem
Scheduled sessions dispatch via `server.processMessage()` with no `trustContext`, causing the tool approval handler to treat them as untrusted actors. This silently blocks side-effect tools like `messaging_send` from executing in scheduled jobs.

## Root Cause
In `lifecycle.ts`, `startScheduler` calls `server.processMessage(conversationId, message)` without passing `SessionCreateOptions`. This results in `setTrustContext(null)`, which downstream resolves to an untrusted trust class. The log shows:

```
[tool-approval-handler] Guardian approval gate blocked untrusted actor tool invocation (no matching grant)
```

## Fix
Explicitly pass `trustContext: { sourceChannel: 'vellum', trustClass: 'guardian' }` when the scheduler dispatches sessions. This is safe because only the guardian can create schedules.

## Testing
Verified manually that scheduled jobs were being blocked by the approval handler. After this fix, scheduled sessions will carry guardian trust and be able to use side-effect tools like `messaging_send`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
