### PR TITLE
feat: accept status, policy, externalUserId, and externalChatId in POST /v1/contacts channel objects

### DIFF
--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -106,7 +106,15 @@ export async function handleUpsertContact(
     responseExpectation?: string;
     preferredTone?: string;
     role?: string;
-    channels?: Array<{ type: string; address: string; isPrimary?: boolean }>;
+    channels?: Array<{
+      type: string;
+      address: string;
+      isPrimary?: boolean;
+      status?: string;
+      policy?: string;
+      externalUserId?: string;
+      externalChatId?: string;
+    }>;
   };
 
   if (


### PR DESCRIPTION
## Summary
- Extend the channel type in handleUpsertContact to accept status, policy, externalUserId, and externalChatId fields
- These fields already flow through to the underlying upsertContact() via SyncChannelData interface
- Enables migration of consumers from /v1/ingress/members to /v1/contacts

Part of plan: rm-ingress-members.md (PR 1 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
