### PR TITLE
refactor: remove deprecated vellum integrations ingress members CLI command

### DIFF
--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -301,32 +301,6 @@ export function registerIntegrationsCommand(program: Command): void {
     });
 
   ingress
-    .command("members")
-    .description(
-      "[Deprecated: use 'vellum contacts list'] List trusted contacts",
-    )
-    .option("--limit <limit>", "Maximum number of contacts to return")
-    .option("--role <role>", "Filter by role (default: contact)")
-    .action(
-      async (
-        opts: {
-          limit?: string;
-          role?: string;
-        },
-        cmd: Command,
-      ) => {
-        process.stderr.write(
-          "⚠️  'vellum integrations ingress members' is deprecated. Use 'vellum contacts list' instead.\n",
-        );
-        const query = toQueryString({
-          role: opts.role ?? "contact",
-          limit: opts.limit,
-        });
-        await runRead(cmd, async () => gatewayGet(`/v1/contacts${query}`));
-      },
-    );
-
-  ingress
     .command("invites")
     .description(
       "[Deprecated: use 'vellum contacts invites'] List trusted ingress invites",


### PR DESCRIPTION
## Summary
- Remove the deprecated `vellum integrations ingress members` CLI command
- The `vellum contacts list` command already provides this functionality
- The `ingress invites` subcommand is preserved

Part of plan: rm-ingress-members.md (PR 5 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)