### PR TITLE
fix: add guardian binding conflict check to voice verification in relay-server

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -1213,15 +1213,43 @@ export class RelayConnection {
 
       // Create the guardian binding now that verification succeeded.
       if (result.verificationType === "guardian") {
-        revokeGuardianBinding(this.guardianChallengeAssistantId, "voice");
-        createGuardianBinding({
-          assistantId: this.guardianChallengeAssistantId,
-          channel: "voice",
-          guardianExternalUserId: this.guardianVerificationFromNumber,
-          guardianDeliveryChatId: this.guardianVerificationFromNumber,
-          guardianPrincipalId: this.guardianVerificationFromNumber,
-          verifiedVia: "challenge",
-        });
+        const existingBinding = getGuardianBinding(
+          this.guardianChallengeAssistantId,
+          "voice",
+        );
+        if (
+          existingBinding &&
+          existingBinding.guardianExternalUserId !==
+            this.guardianVerificationFromNumber
+        ) {
+          log.warn(
+            {
+              callSessionId: this.callSessionId,
+              existingGuardian: existingBinding.guardianExternalUserId,
+            },
+            "Guardian binding conflict: another user already holds the voice binding",
+          );
+        } else {
+          revokeGuardianBinding(this.guardianChallengeAssistantId, "voice");
+
+          // Unify all channel bindings onto the canonical (vellum) principal
+          const vellumBinding = getGuardianBinding(
+            this.guardianChallengeAssistantId,
+            "vellum",
+          );
+          const canonicalPrincipal =
+            vellumBinding?.guardianPrincipalId ??
+            this.guardianVerificationFromNumber;
+
+          createGuardianBinding({
+            assistantId: this.guardianChallengeAssistantId,
+            channel: "voice",
+            guardianExternalUserId: this.guardianVerificationFromNumber,
+            guardianDeliveryChatId: this.guardianVerificationFromNumber,
+            guardianPrincipalId: canonicalPrincipal,
+            verifiedVia: "challenge",
+          });
+        }
       }
 
       if (isOutbound) {


### PR DESCRIPTION
Adds the same guardian binding conflict check that verification-intercept.ts has to the voice verification path in relay-server.ts. When a different user already holds the voice guardian binding, logs a warning and skips binding creation instead of unconditionally overwriting. Also resolves the canonical principal from the vellum binding (as verification-intercept does) instead of using the raw phone number, preventing cross-channel guardian action identity mismatches.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
