### PR TITLE
fix: resolve CI type check and test failures

### DIFF
--- a/assistant/src/__tests__/integrations-cli.test.ts
+++ b/assistant/src/__tests__/integrations-cli.test.ts
@@ -163,28 +163,6 @@ describe("vellum integrations CLI", () => {
     );
   });
 
-  test("passes filters for ingress members (now calls /v1/contacts)", async () => {
-    const result = await runCli(
-      ["--json", "ingress", "members", "--role", "contact", "--limit", "20"],
-      { ok: true, contacts: [] },
-    );
-    expect(result.exitCode).toBe(0);
-    expect(result.fetchCalls[0]?.url).toBe(
-      "http://gateway.test/v1/contacts?role=contact&limit=20",
-    );
-  });
-
-  test("ingress members defaults role to contact", async () => {
-    const result = await runCli(["--json", "ingress", "members"], {
-      ok: true,
-      contacts: [],
-    });
-    expect(result.exitCode).toBe(0);
-    expect(result.fetchCalls[0]?.url).toBe(
-      "http://gateway.test/v1/contacts?role=contact",
-    );
-  });
-
   test("reads ingress config without gateway fetch", async () => {
     rawConfig = {
       ingress: {

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -91,6 +91,27 @@ export async function handleMergeContacts(
   }
 }
 
+const VALID_CHANNEL_STATUSES: readonly ChannelStatus[] = [
+  "active",
+  "pending",
+  "revoked",
+  "blocked",
+  "unverified",
+];
+const VALID_CHANNEL_POLICIES: readonly ChannelPolicy[] = [
+  "allow",
+  "deny",
+  "escalate",
+];
+
+function isChannelStatus(value: string): value is ChannelStatus {
+  return (VALID_CHANNEL_STATUSES as readonly string[]).includes(value);
+}
+
+function isChannelPolicy(value: string): value is ChannelPolicy {
+  return (VALID_CHANNEL_POLICIES as readonly string[]).includes(value);
+}
+
 /**
  * POST /v1/contacts { displayName, id?, relationship?, importance?, ... }
  */
@@ -143,6 +164,26 @@ export async function handleUpsertContact(
     );
   }
 
+  // Validate channel status/policy values before passing to the store
+  if (body.channels) {
+    for (const ch of body.channels) {
+      if (ch.status !== undefined && !isChannelStatus(ch.status)) {
+        return httpError(
+          "BAD_REQUEST",
+          `Invalid channel status "${ch.status}". Must be one of: ${VALID_CHANNEL_STATUSES.join(", ")}`,
+          400,
+        );
+      }
+      if (ch.policy !== undefined && !isChannelPolicy(ch.policy)) {
+        return httpError(
+          "BAD_REQUEST",
+          `Invalid channel policy "${ch.policy}". Must be one of: ${VALID_CHANNEL_POLICIES.join(", ")}`,
+          400,
+        );
+      }
+    }
+  }
+
   try {
     const contact = upsertContact({
       id: body.id,
@@ -153,7 +194,17 @@ export async function handleUpsertContact(
       preferredTone: body.preferredTone,
       role: body.role as ContactRole | undefined,
       assistantId,
-      channels: body.channels,
+      channels: body.channels as
+        | Array<{
+            type: string;
+            address: string;
+            isPrimary?: boolean;
+            status?: ChannelStatus;
+            policy?: ChannelPolicy;
+            externalUserId?: string;
+            externalChatId?: string;
+          }>
+        | undefined,
     });
     return Response.json(
       { ok: true, contact },
@@ -163,27 +214,6 @@ export async function handleUpsertContact(
     const message = err instanceof Error ? err.message : String(err);
     return httpError("BAD_REQUEST", message, 400);
   }
-}
-
-const VALID_CHANNEL_STATUSES: readonly ChannelStatus[] = [
-  "active",
-  "pending",
-  "revoked",
-  "blocked",
-  "unverified",
-];
-const VALID_CHANNEL_POLICIES: readonly ChannelPolicy[] = [
-  "allow",
-  "deny",
-  "escalate",
-];
-
-function isChannelStatus(value: string): value is ChannelStatus {
-  return (VALID_CHANNEL_STATUSES as readonly string[]).includes(value);
-}
-
-function isChannelPolicy(value: string): value is ChannelPolicy {
-  return (VALID_CHANNEL_POLICIES as readonly string[]).includes(value);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix type check error in `contact-routes.ts` by validating and casting channel `status`/`policy` fields before passing to `upsertContact`, and moving validation helpers above the handler
- Remove two dead `ingress members` tests in `integrations-cli.test.ts` that referenced the command removed in PR #12337

## Original prompt
fix the CI errors in https://github.com/vellum-ai/vellum-assistant/actions/runs/22676622325

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
