### PR TITLE
fix(macos): replace VThreadIcon with SF Symbol in collapsed sidebar [LUM-8]

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1546,13 +1546,11 @@ struct MainWindowView: View {
             // MARK: Thread Section (collapsed)
             if let activeThread = threadManager.activeThread {
                 ZStack(alignment: .bottomTrailing) {
-                    // Active thread icon
-                    VThreadIcon(
-                        title: activeThread.title,
-                        size: .medium,
-                        isActive: true,
-                        dotColor: interactionDotColor(for: activeThread)
-                    )
+                    // Active thread icon — SF Symbol chat bubble matching SidebarNavRow style
+                    Image(systemName: "ellipsis.message")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._400))
+                        .frame(width: 28, height: 28)
 
                     // Unseen dot overlay (bottom-right) — shows when any thread has unseen messages
                     if regularThreads.contains(where: { $0.hasUnseenLatestAssistantMessage }) {


### PR DESCRIPTION
## Summary
- Replace `VThreadIcon` (colored square with thread initial) with `ellipsis.message` SF Symbol in collapsed sidebar thread section
- Style matches other `SidebarNavRow` items: 13pt medium weight, forest green color
- Preserves unseen-dot overlay, hover/popover thread switching behavior

Part of plan: lum8-collapsed-thread-icon.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
