### PR TITLE
refactor: remove /v1/ingress/members gateway routes and proxy handlers

### DIFF
--- a/gateway/src/http/routes/ingress-control-plane-proxy.ts
+++ b/gateway/src/http/routes/ingress-control-plane-proxy.ts
@@ -96,28 +96,6 @@ export function createIngressControlPlaneProxyHandler(config: GatewayConfig) {
   }
 
   return {
-    async handleListMembers(req: Request): Promise<Response> {
-      const url = new URL(req.url);
-      return proxyToRuntime(req, "/v1/ingress/members", url.search);
-    },
-
-    async handleUpsertMember(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/ingress/members", "");
-    },
-
-    async handleBlockMember(req: Request, memberId: string): Promise<Response> {
-      const encoded = encodeURIComponent(memberId);
-      return proxyToRuntime(req, `/v1/ingress/members/${encoded}/block`, "");
-    },
-
-    async handleRevokeMember(
-      req: Request,
-      memberId: string,
-    ): Promise<Response> {
-      const encoded = encodeURIComponent(memberId);
-      return proxyToRuntime(req, `/v1/ingress/members/${encoded}`, "");
-    },
-
     async handleListInvites(req: Request): Promise<Response> {
       const url = new URL(req.url);
       return proxyToRuntime(req, "/v1/ingress/invites", url.search);

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -349,32 +349,6 @@ function main() {
 
     // ── Ingress control plane ──
     {
-      path: "/v1/ingress/members",
-      method: "GET",
-      auth: "edge",
-      handler: (req) => ingressControlPlaneProxy.handleListMembers(req),
-    },
-    {
-      path: "/v1/ingress/members",
-      method: "POST",
-      auth: "edge",
-      handler: (req) => ingressControlPlaneProxy.handleUpsertMember(req),
-    },
-    {
-      path: /^\/v1\/ingress\/members\/([^/]+)\/block$/,
-      method: "POST",
-      auth: "edge",
-      handler: (req, params) =>
-        ingressControlPlaneProxy.handleBlockMember(req, params[0]),
-    },
-    {
-      path: /^\/v1\/ingress\/members\/([^/]+)$/,
-      method: "DELETE",
-      auth: "edge",
-      handler: (req, params) =>
-        ingressControlPlaneProxy.handleRevokeMember(req, params[0]),
-    },
-    {
       path: "/v1/ingress/invites",
       method: "GET",
       auth: "edge",


### PR DESCRIPTION
## Summary
- Remove 4 ingress/members route registrations from gateway index
- Remove handleListMembers, handleUpsertMember, handleBlockMember, handleRevokeMember proxy handlers
- All ingress/invites routes preserved

Part of plan: rm-ingress-members.md (PR 6 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
