### PR TITLE
M9: Enable proactive Slack outbound notifications

### DIFF
--- a/assistant/src/channels/config.ts
+++ b/assistant/src/channels/config.ts
@@ -47,7 +47,7 @@ const CHANNEL_POLICIES = {
   },
   slack: {
     notification: {
-      deliveryEnabled: false,
+      deliveryEnabled: true,
       conversationStrategy: "continue_existing_conversation",
     },
   },

--- a/assistant/src/config/bundled-skills/notifications/TOOLS.json
+++ b/assistant/src/config/bundled-skills/notifications/TOOLS.json
@@ -19,11 +19,7 @@
           },
           "urgency": {
             "type": "string",
-            "enum": [
-              "low",
-              "medium",
-              "high"
-            ],
+            "enum": ["low", "medium", "high"],
             "description": "Urgency hint (default: \"medium\")"
           },
           "requires_action": {
@@ -46,10 +42,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "vellum",
-                "telegram"
-              ]
+              "enum": ["vellum", "telegram", "slack"]
             },
             "description": "Optional routing hints for preferred channels (not deterministic)"
           },
@@ -74,10 +67,7 @@
             "description": "Confidence score (0-1) for this action"
           }
         },
-        "required": [
-          "message",
-          "confidence"
-        ]
+        "required": ["message", "confidence"]
       },
       "executor": "tools/send-notification.ts",
       "execution_target": "host"

--- a/assistant/src/notifications/adapters/slack.ts
+++ b/assistant/src/notifications/adapters/slack.ts
@@ -1,0 +1,90 @@
+/**
+ * Slack channel adapter — delivers notifications to Slack DMs
+ * via the gateway's channel-reply endpoint.
+ *
+ * Follows the same delivery pattern as the Telegram adapter: POST to
+ * the gateway's `/deliver/slack` endpoint with a chat ID (the guardian's
+ * Slack DM channel ID) and text payload. The gateway forwards the
+ * message to the Slack Web API.
+ */
+
+import { getGatewayInternalBaseUrl } from "../../config/env.js";
+import { mintDaemonDeliveryToken } from "../../runtime/auth/token-service.js";
+import { deliverChannelReply } from "../../runtime/gateway-client.js";
+import { getLogger } from "../../util/logger.js";
+import { nonEmpty } from "../copy-composer.js";
+import { isThreadSeedSane } from "../thread-seed-composer.js";
+import type {
+  ChannelAdapter,
+  ChannelDeliveryPayload,
+  ChannelDestination,
+  DeliveryResult,
+  NotificationChannel,
+} from "../types.js";
+
+const log = getLogger("notif-adapter-slack");
+
+function resolveSlackMessageText(payload: ChannelDeliveryPayload): string {
+  const deliveryText = nonEmpty(payload.copy.deliveryText);
+  if (deliveryText) return deliveryText;
+
+  if (isThreadSeedSane(payload.copy.threadSeedMessage)) {
+    return payload.copy.threadSeedMessage.trim();
+  }
+
+  const body = nonEmpty(payload.copy.body);
+  if (body) return body;
+
+  const title = nonEmpty(payload.copy.title);
+  if (title) return title;
+
+  return payload.sourceEventName.replace(/[._]/g, " ");
+}
+
+export class SlackAdapter implements ChannelAdapter {
+  readonly channel: NotificationChannel = "slack";
+
+  async send(
+    payload: ChannelDeliveryPayload,
+    destination: ChannelDestination,
+  ): Promise<DeliveryResult> {
+    const chatId = destination.endpoint;
+    if (!chatId) {
+      log.warn(
+        { sourceEventName: payload.sourceEventName },
+        "Slack destination has no chat ID — skipping",
+      );
+      return {
+        success: false,
+        error: "No chat ID configured for Slack destination",
+      };
+    }
+
+    const gatewayBase = getGatewayInternalBaseUrl();
+    const deliverUrl = `${gatewayBase}/deliver/slack`;
+
+    const messageText = resolveSlackMessageText(payload);
+
+    try {
+      await deliverChannelReply(
+        deliverUrl,
+        { chatId, text: messageText },
+        mintDaemonDeliveryToken(),
+      );
+
+      log.info(
+        { sourceEventName: payload.sourceEventName, chatId },
+        "Slack notification delivered",
+      );
+
+      return { success: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error(
+        { err, sourceEventName: payload.sourceEventName, chatId },
+        "Failed to deliver Slack notification",
+      );
+      return { success: false, error: message };
+    }
+  }
+}

--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -64,7 +64,8 @@ export function resolveDestinations(
         break;
       }
       case "telegram":
-      case "sms": {
+      case "sms":
+      case "slack": {
         const guardianResult = findGuardianForChannel(channel, assistantId);
         if (guardianResult && guardianResult.channel.externalChatId) {
           result.set(channel as NotificationChannel, {

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -16,6 +16,7 @@ import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import { type BroadcastFn, VellumAdapter } from "./adapters/macos.js";
+import { SlackAdapter } from "./adapters/slack.js";
 import { SmsAdapter } from "./adapters/sms.js";
 import { TelegramAdapter } from "./adapters/telegram.js";
 import {
@@ -61,7 +62,11 @@ export function registerBroadcastFn(fn: BroadcastFn): void {
 
 function getBroadcaster(): NotificationBroadcaster {
   if (!broadcasterInstance) {
-    const adapters = [new TelegramAdapter(), new SmsAdapter()];
+    const adapters = [
+      new TelegramAdapter(),
+      new SmsAdapter(),
+      new SlackAdapter(),
+    ];
     if (registeredBroadcastFn) {
       adapters.unshift(new VellumAdapter(registeredBroadcastFn));
     }
@@ -109,7 +114,8 @@ function getConnectedChannels(assistantId: string): NotificationChannel[] {
         channels.push(channel);
         break;
       case "telegram":
-      case "sms": {
+      case "sms":
+      case "slack": {
         // A binding-based channel is connected when the guardian has an
         // active channel entry with a valid delivery endpoint. The
         // externalChatId check ensures we don't report a channel as


### PR DESCRIPTION
Flip deliveryEnabled to true for Slack, wire notification router to deliver to Slack DMs via gateway. Part of #12344.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
