### PR TITLE
fix(macos): restore accessibility label on collapsed thread icon [LUM-8]

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1551,6 +1551,7 @@ struct MainWindowView: View {
                         .font(.system(size: 13, weight: .medium))
                         .foregroundColor(adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._400))
                         .frame(width: 28, height: 28)
+                        .accessibilityLabel("Thread: \(activeThread.title)")
 
                     // Unseen dot overlay (bottom-right) — shows when any thread has unseen messages
                     if regularThreads.contains(where: { $0.hasUnseenLatestAssistantMessage }) {


### PR DESCRIPTION
## Summary
- Restores the `.accessibilityLabel("Thread: \(activeThread.title)")` that was lost when `VThreadIcon` was replaced with an SF Symbol in #12342
- VoiceOver users can now identify which thread the collapsed sidebar icon represents

Addresses review feedback from Codex and Devin on #12342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
