### PR TITLE
feat(macos): add hover tracking and Moss background to popover thread rows [LUM-9]

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1616,6 +1616,7 @@ struct MainWindowView: View {
                             VStack(spacing: 0) {
                                 ForEach(regularThreads) { thread in
                                     let isActive = thread.id == threadManager.activeThreadId
+                                    let isHovered = sidebar.isHoveredThread == thread.id
                                     HStack(spacing: VSpacing.xs) {
                                         VThreadIcon(
                                             title: thread.title,
@@ -1641,12 +1642,31 @@ struct MainWindowView: View {
                                     }
                                     .padding(.horizontal, VSpacing.sm)
                                     .padding(.vertical, VSpacing.xs)
-                                    .background(isActive ? VColor.accent.opacity(0.12) : Color.clear)
+                                    .background {
+                                        if isActive {
+                                            adaptiveColor(light: Moss._100, dark: Moss._700)
+                                        } else if isHovered {
+                                            adaptiveColor(light: Moss._100, dark: Moss._700).opacity(0.5)
+                                        } else {
+                                            Color.clear
+                                        }
+                                    }
+                                    .animation(VAnimation.fast, value: isHovered)
                                     .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                                     .contentShape(Rectangle())
                                     .onTapGesture {
                                         selectThread(thread)
                                         showThreadSwitcher = false
+                                    }
+                                    .onHover { hovering in
+                                        withAnimation(VAnimation.fast) {
+                                            if hovering {
+                                                sidebar.isHoveredThread = thread.id
+                                            } else if sidebar.isHoveredThread == thread.id {
+                                                sidebar.isHoveredThread = nil
+                                            }
+                                        }
+                                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                                     }
                                 }
                             }
@@ -1654,7 +1674,7 @@ struct MainWindowView: View {
                         }
                         .frame(maxHeight: 300)
                     }
-                    .frame(width: 200)
+                    .frame(width: 240)
                     .padding(.bottom, VSpacing.sm)
                     .onHover { hovering in
                         if hovering {


### PR DESCRIPTION
## Summary
- Add per-row hover tracking to collapsed sidebar thread switcher popover using existing `sidebar.isHoveredThread` state
- Replace `VColor.accent.opacity(0.12)` active background with Moss._700 palette matching expanded sidebar
- Add hover highlight with Moss._700 at 50% opacity, cursor change, and `VAnimation.fast`
- Widen popover from 200pt to 240pt for upcoming trailing actions

Part of plan: lum9-popover-thread-parity.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
