### PR TITLE
feat(macos): add status indicators and pin button to popover thread rows [LUM-9]

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1617,13 +1617,64 @@ struct MainWindowView: View {
                                 ForEach(regularThreads) { thread in
                                     let isActive = thread.id == threadManager.activeThreadId
                                     let isHovered = sidebar.isHoveredThread == thread.id
+                                    let interactionState = threadManager.interactionState(for: thread.id)
                                     HStack(spacing: VSpacing.xs) {
-                                        VThreadIcon(
-                                            title: thread.title,
-                                            size: .small,
-                                            isActive: isActive,
-                                            dotColor: interactionDotColor(for: thread)
-                                        )
+                                        // Leading status indicator / pin button slot
+                                        if isHovered {
+                                            Button {
+                                                withAnimation(VAnimation.standard) {
+                                                    if thread.isPinned {
+                                                        threadManager.unpinThread(id: thread.id)
+                                                    } else {
+                                                        threadManager.pinThread(id: thread.id)
+                                                    }
+                                                }
+                                            } label: {
+                                                Image(systemName: thread.isPinned ? "pin.fill" : "pin")
+                                                    .font(.system(size: 13, weight: .medium))
+                                                    .foregroundColor(thread.isPinned ? VColor.textMuted : VColor.textSecondary)
+                                                    .rotationEffect(.degrees(-45))
+                                                    .frame(width: 20, height: 20)
+                                                    .contentShape(Rectangle())
+                                            }
+                                            .buttonStyle(.plain)
+                                            .transition(.opacity)
+                                        } else {
+                                            switch interactionState {
+                                            case .processing:
+                                                VBusyIndicator()
+                                                    .frame(width: 20, height: 20)
+                                            case .waitingForInput:
+                                                Image(systemName: "exclamationmark.circle.fill")
+                                                    .font(.system(size: 12))
+                                                    .foregroundColor(VColor.warning)
+                                                    .frame(width: 20, height: 20)
+                                            case .error:
+                                                Image(systemName: "exclamationmark.circle.fill")
+                                                    .font(.system(size: 12))
+                                                    .foregroundColor(VColor.error)
+                                                    .frame(width: 20, height: 20)
+                                                    .transition(.opacity)
+                                            case .idle:
+                                                if thread.hasUnseenLatestAssistantMessage {
+                                                    Circle()
+                                                        .fill(Color(hex: 0xE86B40))
+                                                        .frame(width: 6, height: 6)
+                                                        .frame(width: 20, height: 20)
+                                                        .transition(.opacity)
+                                                } else if thread.isPinned {
+                                                    Image(systemName: "pin.fill")
+                                                        .font(.system(size: 13, weight: .medium))
+                                                        .foregroundColor(VColor.textMuted)
+                                                        .rotationEffect(.degrees(-45))
+                                                        .frame(width: 20, height: 20)
+                                                        .transition(.opacity)
+                                                } else {
+                                                    Color.clear
+                                                        .frame(width: 20, height: 20)
+                                                }
+                                            }
+                                        }
 
                                         Text(thread.title)
                                             .font(VFont.body)
@@ -1632,13 +1683,6 @@ struct MainWindowView: View {
                                             .truncationMode(.tail)
 
                                         Spacer()
-
-                                        // Unseen indicator
-                                        if thread.hasUnseenLatestAssistantMessage {
-                                            Circle()
-                                                .fill(Color(hex: 0xE86B40))
-                                                .frame(width: 6, height: 6)
-                                        }
                                     }
                                     .padding(.horizontal, VSpacing.sm)
                                     .padding(.vertical, VSpacing.xs)


### PR DESCRIPTION
## Summary
- Replace `VThreadIcon` in collapsed sidebar popover with 20×20 leading status indicator slot matching expanded sidebar's `threadItem()`
- Show pin toggle button on hover, status indicators (processing/warning/error/unseen/pinned) when not hovered
- Remove separate trailing unseen indicator (now integrated into leading slot)

Part of plan: lum9-popover-thread-parity.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
