### PR TITLE
feat(macos): add archive and context menu to popover thread rows [LUM-9]

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1617,6 +1617,7 @@ struct MainWindowView: View {
                                 ForEach(regularThreads) { thread in
                                     let isActive = thread.id == threadManager.activeThreadId
                                     let isHovered = sidebar.isHoveredThread == thread.id
+                                    let hasTrailingIcon = isHovered || sidebar.threadPendingDeletion == thread.id
                                     HStack(spacing: VSpacing.xs) {
                                         VThreadIcon(
                                             title: thread.title,
@@ -1640,7 +1641,8 @@ struct MainWindowView: View {
                                                 .frame(width: 6, height: 6)
                                         }
                                     }
-                                    .padding(.horizontal, VSpacing.sm)
+                                    .padding(.leading, VSpacing.sm)
+                                    .padding(.trailing, hasTrailingIcon ? (VSpacing.xs + 20 + VSpacing.xs) : VSpacing.sm)
                                     .padding(.vertical, VSpacing.xs)
                                     .background {
                                         if isActive {
@@ -1652,11 +1654,50 @@ struct MainWindowView: View {
                                         }
                                     }
                                     .animation(VAnimation.fast, value: isHovered)
+                                    .overlay(alignment: .trailing) {
+                                        if sidebar.threadPendingDeletion == thread.id {
+                                            VButton(label: "Confirm", style: .danger, size: .small) {
+                                                threadManager.archiveThread(id: thread.id)
+                                                sidebar.threadPendingDeletion = nil
+                                            }
+                                            .padding(.trailing, VSpacing.xs)
+                                        } else if isHovered {
+                                            Button {
+                                                sidebar.threadPendingDeletion = thread.id
+                                            } label: {
+                                                Image(systemName: "archivebox")
+                                                    .font(.system(size: 13, weight: .medium))
+                                                    .foregroundColor(VColor.textSecondary)
+                                                    .frame(width: 20, height: 20)
+                                                    .contentShape(Rectangle())
+                                            }
+                                            .buttonStyle(.plain)
+                                            .padding(.trailing, VSpacing.xs)
+                                        }
+                                    }
                                     .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
                                     .contentShape(Rectangle())
                                     .onTapGesture {
                                         selectThread(thread)
                                         showThreadSwitcher = false
+                                    }
+                                    .contextMenu {
+                                        Button {
+                                            withAnimation(VAnimation.standard) {
+                                                if thread.isPinned {
+                                                    threadManager.unpinThread(id: thread.id)
+                                                } else {
+                                                    threadManager.pinThread(id: thread.id)
+                                                }
+                                            }
+                                        } label: {
+                                            Label(thread.isPinned ? "Unpin" : "Pin to Top", systemImage: thread.isPinned ? "pin.slash" : "pin")
+                                        }
+                                        Button {
+                                            threadManager.archiveThread(id: thread.id)
+                                        } label: {
+                                            Label("Archive", systemImage: "archivebox")
+                                        }
                                     }
                                     .onHover { hovering in
                                         withAnimation(VAnimation.fast) {


### PR DESCRIPTION
## Summary
- Add trailing archive button on hover with confirmation step to popover thread rows
- Add context menu with Pin/Unpin and Archive actions matching expanded sidebar
- Dynamic trailing padding to accommodate archive button without layout shift

Part of plan: lum9-popover-thread-parity.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
