### PR TITLE
Fix feedback on PR #12370: use configured data root

### DIFF
--- a/gateway/src/db/connection.ts
+++ b/gateway/src/db/connection.ts
@@ -1,0 +1,52 @@
+import { Database } from "bun:sqlite";
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { getRootDir } from "../credential-reader.js";
+
+let db: Database | null = null;
+
+function getDbPath(): string {
+  const dataDir = join(getRootDir(), "data");
+  if (!existsSync(dataDir)) {
+    mkdirSync(dataDir, { recursive: true });
+  }
+  return join(dataDir, "gateway.sqlite");
+}
+
+export function getGatewayDb(): Database {
+  if (!db) {
+    db = new Database(getDbPath());
+    db.exec("PRAGMA journal_mode=WAL");
+    db.exec("PRAGMA synchronous=FULL");
+    db.exec("PRAGMA busy_timeout=5000");
+    db.exec("PRAGMA foreign_keys=ON");
+    migrate(db);
+  }
+  return db;
+}
+
+function migrate(db: Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS slack_active_threads (
+      thread_ts TEXT PRIMARY KEY,
+      tracked_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL
+    )
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS slack_seen_events (
+      event_id TEXT PRIMARY KEY,
+      seen_at INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL
+    )
+  `);
+}
+
+/** Reset the singleton — used by tests. */
+export function resetGatewayDb(): void {
+  if (db) {
+    db.close();
+    db = null;
+  }
+}


### PR DESCRIPTION
Address Codex review: gateway DB now uses getRootDir() instead of hardcoded homedir().
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
