### PR TITLE
Fix feedback on PR #12369: prefix apr: in button values

### DIFF
--- a/gateway/src/slack/block-kit-builder.test.ts
+++ b/gateway/src/slack/block-kit-builder.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect } from "bun:test";
+import {
+  BlockKitBuilder,
+  button,
+  approvalPrompt,
+  permissionRequest,
+  progressIndicator,
+  errorMessage,
+  type SectionBlock,
+  type ActionsBlock,
+  type ContextBlock,
+  type DividerBlock,
+  type HeaderBlock,
+  type ButtonElement,
+} from "./block-kit-builder.js";
+
+// ---------------------------------------------------------------------------
+// button()
+// ---------------------------------------------------------------------------
+
+describe("button", () => {
+  it("creates a minimal button element", () => {
+    const btn = button({ actionId: "click_me", text: "Click" });
+    expect(btn).toEqual({
+      type: "button",
+      text: { type: "plain_text", text: "Click", emoji: true },
+      action_id: "click_me",
+    });
+  });
+
+  it("includes value when provided", () => {
+    const btn = button({ actionId: "a1", text: "Go", value: "v1" });
+    expect(btn.value).toBe("v1");
+  });
+
+  it("includes style when provided", () => {
+    const primary = button({
+      actionId: "a1",
+      text: "OK",
+      style: "primary",
+    });
+    expect(primary.style).toBe("primary");
+
+    const danger = button({
+      actionId: "a2",
+      text: "Delete",
+      style: "danger",
+    });
+    expect(danger.style).toBe("danger");
+  });
+
+  it("omits value and style when not provided", () => {
+    const btn = button({ actionId: "a1", text: "Hi" });
+    expect("value" in btn).toBe(false);
+    expect("style" in btn).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BlockKitBuilder — individual block types
+// ---------------------------------------------------------------------------
+
+describe("BlockKitBuilder", () => {
+  it("builds a section block with mrkdwn text", () => {
+    const blocks = new BlockKitBuilder().section("Hello *world*").toBlocks();
+    expect(blocks).toHaveLength(1);
+
+    const section = blocks[0] as SectionBlock;
+    expect(section.type).toBe("section");
+    expect(section.text).toEqual({ type: "mrkdwn", text: "Hello *world*" });
+  });
+
+  it("builds a divider block", () => {
+    const blocks = new BlockKitBuilder().divider().toBlocks();
+    expect(blocks).toHaveLength(1);
+    expect((blocks[0] as DividerBlock).type).toBe("divider");
+  });
+
+  it("builds an actions block with buttons", () => {
+    const btn = button({ actionId: "act_1", text: "Press" });
+    const blocks = new BlockKitBuilder().actions([btn]).toBlocks();
+    expect(blocks).toHaveLength(1);
+
+    const actions = blocks[0] as ActionsBlock;
+    expect(actions.type).toBe("actions");
+    expect(actions.elements).toHaveLength(1);
+    expect(actions.elements[0].action_id).toBe("act_1");
+  });
+
+  it("builds a context block with text elements", () => {
+    const blocks = new BlockKitBuilder()
+      .context([{ type: "mrkdwn", text: "hint" }])
+      .toBlocks();
+    expect(blocks).toHaveLength(1);
+
+    const ctx = blocks[0] as ContextBlock;
+    expect(ctx.type).toBe("context");
+    expect(ctx.elements).toHaveLength(1);
+    expect(ctx.elements[0]).toEqual({ type: "mrkdwn", text: "hint" });
+  });
+
+  it("builds a context block via contextMrkdwn shorthand", () => {
+    const blocks = new BlockKitBuilder().contextMrkdwn("note").toBlocks();
+    const ctx = blocks[0] as ContextBlock;
+    expect(ctx.elements).toEqual([{ type: "mrkdwn", text: "note" }]);
+  });
+
+  it("builds a header block with plain text", () => {
+    const blocks = new BlockKitBuilder().header("Title").toBlocks();
+    expect(blocks).toHaveLength(1);
+
+    const header = blocks[0] as HeaderBlock;
+    expect(header.type).toBe("header");
+    expect(header.text).toEqual({
+      type: "plain_text",
+      text: "Title",
+      emoji: true,
+    });
+  });
+
+  it("chains multiple block types", () => {
+    const blocks = BlockKitBuilder.header("Status Update")
+      .section("Things are going well.")
+      .divider()
+      .actions([button({ actionId: "ack", text: "Acknowledge" })])
+      .contextMrkdwn("Sent by Vellum")
+      .toBlocks();
+
+    expect(blocks).toHaveLength(5);
+    expect(blocks.map((b) => b.type)).toEqual([
+      "header",
+      "section",
+      "divider",
+      "actions",
+      "context",
+    ]);
+  });
+
+  it("static section() starts a new builder", () => {
+    const blocks = BlockKitBuilder.section("hi").toBlocks();
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("section");
+  });
+
+  it("static divider() starts a new builder", () => {
+    const blocks = BlockKitBuilder.divider().toBlocks();
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("divider");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: approvalPrompt
+// ---------------------------------------------------------------------------
+
+describe("approvalPrompt", () => {
+  it("produces section + actions blocks", () => {
+    const blocks = approvalPrompt({
+      message: "Allow file access?",
+      requestId: "req-1",
+      actions: [
+        { id: "approve_once", label: "Approve" },
+        { id: "reject", label: "Reject" },
+      ],
+    });
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe("section");
+    expect((blocks[0] as SectionBlock).text.text).toBe("Allow file access?");
+
+    const actions = blocks[1] as ActionsBlock;
+    expect(actions.type).toBe("actions");
+    expect(actions.elements).toHaveLength(2);
+  });
+
+  it("encodes requestId and actionId into action_id", () => {
+    const blocks = approvalPrompt({
+      message: "ok?",
+      requestId: "r42",
+      actions: [{ id: "go", label: "Go" }],
+    });
+
+    const btn = (blocks[1] as ActionsBlock).elements[0] as ButtonElement;
+    expect(btn.action_id).toBe("apr:r42:go");
+    expect(btn.value).toBe("r42:go");
+  });
+
+  it("applies style to buttons", () => {
+    const blocks = approvalPrompt({
+      message: "ok?",
+      requestId: "r1",
+      actions: [
+        { id: "yes", label: "Yes", style: "primary" },
+        { id: "no", label: "No", style: "danger" },
+      ],
+    });
+
+    const elements = (blocks[1] as ActionsBlock).elements;
+    expect(elements[0].style).toBe("primary");
+    expect(elements[1].style).toBe("danger");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: permissionRequest
+// ---------------------------------------------------------------------------
+
+describe("permissionRequest", () => {
+  it("produces approve (primary) and reject (danger) buttons", () => {
+    const blocks = permissionRequest({
+      message: "Run shell command?",
+      requestId: "req-99",
+    });
+
+    expect(blocks).toHaveLength(2);
+    const actions = blocks[1] as ActionsBlock;
+    expect(actions.elements).toHaveLength(2);
+
+    expect(actions.elements[0].action_id).toBe("apr:req-99:approve_once");
+    expect(actions.elements[0].style).toBe("primary");
+
+    expect(actions.elements[1].action_id).toBe("apr:req-99:reject");
+    expect(actions.elements[1].style).toBe("danger");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: progressIndicator
+// ---------------------------------------------------------------------------
+
+describe("progressIndicator", () => {
+  it("produces section + context blocks", () => {
+    const blocks = progressIndicator({
+      title: "Deploying...",
+      status: "Step 2 of 5",
+    });
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe("section");
+    expect((blocks[0] as SectionBlock).text.text).toBe("Deploying...");
+
+    const ctx = blocks[1] as ContextBlock;
+    expect(ctx.type).toBe("context");
+    expect(ctx.elements[0]).toEqual({ type: "mrkdwn", text: "Step 2 of 5" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: errorMessage
+// ---------------------------------------------------------------------------
+
+describe("errorMessage", () => {
+  it("produces a section with warning prefix", () => {
+    const blocks = errorMessage({ message: "Something broke" });
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("section");
+    expect((blocks[0] as SectionBlock).text.text).toBe(
+      ":warning: Something broke",
+    );
+  });
+
+  it("appends context when detail is provided", () => {
+    const blocks = errorMessage({
+      message: "Timeout",
+      detail: "Request took >30s",
+    });
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[1].type).toBe("context");
+    expect((blocks[1] as ContextBlock).elements[0]).toEqual({
+      type: "mrkdwn",
+      text: "Request took >30s",
+    });
+  });
+
+  it("omits context when detail is not provided", () => {
+    const blocks = errorMessage({ message: "Oops" });
+    expect(blocks).toHaveLength(1);
+  });
+});

--- a/gateway/src/slack/block-kit-builder.test.ts
+++ b/gateway/src/slack/block-kit-builder.test.ts
@@ -182,7 +182,7 @@ describe("approvalPrompt", () => {
 
     const btn = (blocks[1] as ActionsBlock).elements[0] as ButtonElement;
     expect(btn.action_id).toBe("apr:r42:go");
-    expect(btn.value).toBe("r42:go");
+    expect(btn.value).toBe("apr:r42:go");
   });
 
   it("applies style to buttons", () => {

--- a/gateway/src/slack/block-kit-builder.ts
+++ b/gateway/src/slack/block-kit-builder.ts
@@ -1,0 +1,229 @@
+/**
+ * Composable builder for Slack Block Kit elements.
+ *
+ * Analogous to Telegram's `buildInlineKeyboard()` and WhatsApp's
+ * `selectWhatsAppButtons()` — provides a fluent API for constructing
+ * Slack Block Kit payloads.
+ */
+
+// ---------------------------------------------------------------------------
+// Block Kit element types
+// ---------------------------------------------------------------------------
+
+export type MrkdwnText = {
+  type: "mrkdwn";
+  text: string;
+};
+
+export type PlainText = {
+  type: "plain_text";
+  text: string;
+  emoji?: boolean;
+};
+
+export type TextObject = MrkdwnText | PlainText;
+
+export type ButtonElement = {
+  type: "button";
+  text: PlainText;
+  action_id: string;
+  value?: string;
+  style?: "primary" | "danger";
+};
+
+export type SectionBlock = {
+  type: "section";
+  text: MrkdwnText;
+};
+
+export type ActionsBlock = {
+  type: "actions";
+  elements: ButtonElement[];
+};
+
+export type ContextBlock = {
+  type: "context";
+  elements: TextObject[];
+};
+
+export type DividerBlock = {
+  type: "divider";
+};
+
+export type HeaderBlock = {
+  type: "header";
+  text: PlainText;
+};
+
+export type Block =
+  | SectionBlock
+  | ActionsBlock
+  | ContextBlock
+  | DividerBlock
+  | HeaderBlock;
+
+// ---------------------------------------------------------------------------
+// Button builder
+// ---------------------------------------------------------------------------
+
+export type ButtonOptions = {
+  actionId: string;
+  text: string;
+  value?: string;
+  style?: "primary" | "danger";
+};
+
+export function button(opts: ButtonOptions): ButtonElement {
+  const btn: ButtonElement = {
+    type: "button",
+    text: { type: "plain_text", text: opts.text, emoji: true },
+    action_id: opts.actionId,
+  };
+  if (opts.value !== undefined) btn.value = opts.value;
+  if (opts.style !== undefined) btn.style = opts.style;
+  return btn;
+}
+
+// ---------------------------------------------------------------------------
+// Block Kit builder (fluent / chainable)
+// ---------------------------------------------------------------------------
+
+export class BlockKitBuilder {
+  private blocks: Block[] = [];
+
+  /** Add a section block with mrkdwn text. */
+  section(text: string): this {
+    this.blocks.push({ type: "section", text: { type: "mrkdwn", text } });
+    return this;
+  }
+
+  /** Add a divider block. */
+  divider(): this {
+    this.blocks.push({ type: "divider" });
+    return this;
+  }
+
+  /** Add an actions block containing one or more buttons. */
+  actions(buttons: ButtonElement[]): this {
+    this.blocks.push({ type: "actions", elements: buttons });
+    return this;
+  }
+
+  /** Add a context block with one or more text elements. */
+  context(elements: TextObject[]): this {
+    this.blocks.push({ type: "context", elements });
+    return this;
+  }
+
+  /** Shorthand: add a context block with a single mrkdwn string. */
+  contextMrkdwn(text: string): this {
+    return this.context([{ type: "mrkdwn", text }]);
+  }
+
+  /** Add a header block with plain text. */
+  header(text: string): this {
+    this.blocks.push({
+      type: "header",
+      text: { type: "plain_text", text, emoji: true },
+    });
+    return this;
+  }
+
+  /** Return the accumulated blocks array. */
+  toBlocks(): Block[] {
+    return this.blocks;
+  }
+
+  // -------------------------------------------------------------------------
+  // Static entry points for one-liner starts
+  // -------------------------------------------------------------------------
+
+  static section(text: string): BlockKitBuilder {
+    return new BlockKitBuilder().section(text);
+  }
+
+  static header(text: string): BlockKitBuilder {
+    return new BlockKitBuilder().header(text);
+  }
+
+  static divider(): BlockKitBuilder {
+    return new BlockKitBuilder().divider();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Common pattern helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an approval prompt with a message, action buttons, and a context hint.
+ *
+ * Mirrors the approval payloads used by Telegram's `buildInlineKeyboard()`
+ * and WhatsApp's interactive buttons.
+ */
+export function approvalPrompt(opts: {
+  message: string;
+  requestId: string;
+  actions: Array<{ id: string; label: string; style?: "primary" | "danger" }>;
+}): Block[] {
+  const buttons = opts.actions.map((action) =>
+    button({
+      actionId: `apr:${opts.requestId}:${action.id}`,
+      text: action.label,
+      value: `${opts.requestId}:${action.id}`,
+      style: action.style,
+    }),
+  );
+
+  return new BlockKitBuilder()
+    .section(opts.message)
+    .actions(buttons)
+    .toBlocks();
+}
+
+/**
+ * Build a permission request prompt — a specialised approval prompt with
+ * consistent styling for approve/reject actions.
+ */
+export function permissionRequest(opts: {
+  message: string;
+  requestId: string;
+}): Block[] {
+  return approvalPrompt({
+    message: opts.message,
+    requestId: opts.requestId,
+    actions: [
+      { id: "approve_once", label: "Approve", style: "primary" },
+      { id: "reject", label: "Reject", style: "danger" },
+    ],
+  });
+}
+
+/**
+ * Build a progress indicator block set — a section with a status emoji and
+ * a context line showing the current step.
+ */
+export function progressIndicator(opts: {
+  title: string;
+  status: string;
+}): Block[] {
+  return new BlockKitBuilder()
+    .section(opts.title)
+    .contextMrkdwn(opts.status)
+    .toBlocks();
+}
+
+/**
+ * Build an error message block set — a header-less section with danger
+ * styling context.
+ */
+export function errorMessage(opts: {
+  message: string;
+  detail?: string;
+}): Block[] {
+  const builder = new BlockKitBuilder().section(`:warning: ${opts.message}`);
+  if (opts.detail) {
+    builder.contextMrkdwn(opts.detail);
+  }
+  return builder.toBlocks();
+}

--- a/gateway/src/slack/block-kit-builder.ts
+++ b/gateway/src/slack/block-kit-builder.ts
@@ -170,7 +170,7 @@ export function approvalPrompt(opts: {
     button({
       actionId: `apr:${opts.requestId}:${action.id}`,
       text: action.label,
-      value: `${opts.requestId}:${action.id}`,
+      value: `apr:${opts.requestId}:${action.id}`,
       style: action.style,
     }),
   );


### PR DESCRIPTION
Address Codex review: approvalPrompt() now uses apr:requestId:actionId format matching the shared callback parser.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
