### PR TITLE
Fix feedback on PR #12376: strip ref tags

### DIFF
--- a/assistant/src/__tests__/nl-approval-parser.test.ts
+++ b/assistant/src/__tests__/nl-approval-parser.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  type ApprovalIntent,
+  parseApprovalIntent,
+} from "../runtime/nl-approval-parser.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function expectApproval(
+  text: string,
+  decision: ApprovalIntent["decision"],
+): void {
+  const result = parseApprovalIntent(text);
+  expect(result).not.toBeNull();
+  expect(result!.decision).toBe(decision);
+  expect(result!.confidence).toBeGreaterThanOrEqual(0.9);
+}
+
+function expectNoIntent(text: string): void {
+  const result = parseApprovalIntent(text);
+  expect(result).toBeNull();
+}
+
+// ---------------------------------------------------------------------------
+// Approval patterns
+// ---------------------------------------------------------------------------
+
+describe("parseApprovalIntent", () => {
+  describe("approval phrases", () => {
+    test.each([
+      "yes",
+      "yep",
+      "yeah",
+      "yea",
+      "yup",
+      "approved",
+      "approve",
+      "go ahead",
+      "do it",
+      "sure",
+      "ok",
+      "okay",
+      "k",
+      "lgtm",
+      "sounds good",
+      "go for it",
+      "please",
+      "pls",
+      "y",
+    ])("recognizes '%s' as approval", (phrase) => {
+      expectApproval(phrase, "approve");
+    });
+
+    test("recognizes thumbs up emoji", () => {
+      expectApproval("\u{1F44D}", "approve");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rejection patterns
+  // ---------------------------------------------------------------------------
+
+  describe("rejection phrases", () => {
+    test.each([
+      "no",
+      "nope",
+      "nah",
+      "reject",
+      "rejected",
+      "denied",
+      "deny",
+      "don't",
+      "dont",
+      "cancel",
+      "stop",
+      "n",
+    ])("recognizes '%s' as rejection", (phrase) => {
+      expectApproval(phrase, "reject");
+    });
+
+    test("recognizes thumbs down emoji", () => {
+      expectApproval("\u{1F44E}", "reject");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Timed approval patterns
+  // ---------------------------------------------------------------------------
+
+  describe("timed approval", () => {
+    test.each([
+      "approve for 10 minutes",
+      "approve for 10 min",
+      "approve for 10m",
+      "yes for 10 minutes",
+      "yes for 10 min",
+      "ok for 10 minutes",
+      "sure for 10 minutes",
+      "go ahead for 10 minutes",
+      "yep for 10 minutes",
+      "yeah for 10 minutes",
+      "approve 10m",
+      "approve 10 min",
+      "approve 10 minutes",
+    ])("recognizes '%s' as timed approval", (phrase) => {
+      expectApproval(phrase, "approve_10m");
+    });
+
+    test.each(["yes for now", "approve for now", "ok for now"])(
+      "recognizes '%s' as timed approval",
+      (phrase) => {
+        expectApproval(phrase, "approve_10m");
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Case insensitivity
+  // ---------------------------------------------------------------------------
+
+  describe("case insensitivity", () => {
+    test.each(["YES", "Yes", "yEs", "APPROVE", "Approve", "LGTM", "Lgtm"])(
+      "handles mixed case '%s'",
+      (phrase) => {
+        expectApproval(phrase, "approve");
+      },
+    );
+
+    test.each(["NO", "No", "REJECT", "Reject", "CANCEL", "Cancel"])(
+      "handles mixed case rejection '%s'",
+      (phrase) => {
+        expectApproval(phrase, "reject");
+      },
+    );
+
+    test("handles mixed case timed approval", () => {
+      expectApproval("Approve For 10 Minutes", "approve_10m");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Whitespace and punctuation
+  // ---------------------------------------------------------------------------
+
+  describe("whitespace and punctuation", () => {
+    test("trims leading/trailing whitespace", () => {
+      expectApproval("  yes  ", "approve");
+    });
+
+    test("strips trailing period", () => {
+      expectApproval("yes.", "approve");
+    });
+
+    test("strips trailing exclamation", () => {
+      expectApproval("yes!", "approve");
+    });
+
+    test("strips trailing comma", () => {
+      expectApproval("ok,", "approve");
+    });
+
+    test("strips trailing question mark", () => {
+      expectApproval("ok?", "approve");
+    });
+
+    test("strips multiple trailing punctuation", () => {
+      expectApproval("yes!!!", "approve");
+    });
+
+    test("collapses internal whitespace", () => {
+      expectApproval("go   ahead", "approve");
+    });
+
+    test("handles trailing punctuation on rejection", () => {
+      expectApproval("no.", "reject");
+    });
+
+    test("handles trailing punctuation on timed approval", () => {
+      expectApproval("approve for 10 minutes.", "approve_10m");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Non-matching inputs (should return null)
+  // ---------------------------------------------------------------------------
+
+  describe("non-matching inputs", () => {
+    test("returns null for empty string", () => {
+      expectNoIntent("");
+    });
+
+    test("returns null for whitespace-only string", () => {
+      expectNoIntent("   ");
+    });
+
+    test("returns null for unrelated message", () => {
+      expectNoIntent("what is the weather today?");
+    });
+
+    test("does not match approval word inside a longer sentence", () => {
+      expectNoIntent("yes but also do X");
+    });
+
+    test("does not match 'yes and can you also...'", () => {
+      expectNoIntent("yes and can you also check the logs");
+    });
+
+    test("does not match approval word as substring of other words", () => {
+      expectNoIntent("yesterday was a good day");
+    });
+
+    test("does not match 'no I meant something else'", () => {
+      expectNoIntent("no I meant something else");
+    });
+
+    test("does not match a long message containing approval words", () => {
+      expectNoIntent(
+        "I think we should approve this after we review the changes",
+      );
+    });
+
+    test("does not match a question about approval", () => {
+      expectNoIntent("should I approve this?");
+    });
+
+    test("does not match multi-sentence messages", () => {
+      expectNoIntent("ok. But also check the database.");
+    });
+
+    test("returns null for random text", () => {
+      expectNoIntent("hello world");
+    });
+
+    test("returns null for numbers", () => {
+      expectNoIntent("12345");
+    });
+
+    test("returns null for URLs", () => {
+      expectNoIntent("https://example.com");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Ref tag stripping
+  // ---------------------------------------------------------------------------
+
+  describe("ref tag stripping", () => {
+    test("strips [ref:...] tag from approval", () => {
+      expectApproval("yes [ref:abc123]", "approve");
+    });
+
+    test("strips [ref:...] tag from rejection", () => {
+      expectApproval("no [ref:req-2]", "reject");
+    });
+
+    test("strips [ref:...] tag from emoji approval", () => {
+      expectApproval("\u{1F44D} [ref:req-2]", "approve");
+    });
+
+    test("strips [ref:...] tag from timed approval", () => {
+      expectApproval("approve for 10 minutes [ref:req-5]", "approve_10m");
+    });
+
+    test("strips [ref:...] tag with mixed case", () => {
+      expectApproval("Yes [ref:REQ-42]", "approve");
+    });
+
+    test("handles [ref:...] tag with no space before it", () => {
+      expectApproval("ok[ref:abc]", "approve");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edge cases
+  // ---------------------------------------------------------------------------
+
+  describe("edge cases", () => {
+    test("single character 'y' is approval", () => {
+      expectApproval("y", "approve");
+    });
+
+    test("single character 'n' is rejection", () => {
+      expectApproval("n", "reject");
+    });
+
+    test("does not match 'yes please do X' (has additional content)", () => {
+      expectNoIntent("yes please do something else too");
+    });
+
+    test("matches 'please' alone as approval", () => {
+      expectApproval("please", "approve");
+    });
+
+    test("does not match numeric-only strings as approval", () => {
+      expectNoIntent("10");
+    });
+
+    test("rejects very long strings even if they start with approval", () => {
+      expectNoIntent("yes ".repeat(20));
+    });
+  });
+});

--- a/assistant/src/runtime/nl-approval-parser.ts
+++ b/assistant/src/runtime/nl-approval-parser.ts
@@ -1,0 +1,138 @@
+/**
+ * Natural language approval intent parser.
+ *
+ * Parses short inbound messages (e.g. from Slack) to determine whether the
+ * entire message expresses an approval, rejection, or timed-approval intent.
+ * Only matches when the full message is an approval/rejection phrase -- does
+ * NOT match partial intent inside longer sentences like "yes but also do X".
+ *
+ * This parser complements the existing `channel-approval-parser.ts`
+ * (deterministic phrase-map) by covering a broader set of colloquial
+ * patterns, emoji, and timed-approval variants.
+ */
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type ApprovalDecision = "approve" | "reject" | "approve_10m";
+
+export interface ApprovalIntent {
+  decision: ApprovalDecision;
+  confidence: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pattern definitions
+// ---------------------------------------------------------------------------
+
+/** Exact-match phrases (after normalization) for approval. */
+const APPROVE_EXACT: ReadonlySet<string> = new Set([
+  "yes",
+  "yep",
+  "yeah",
+  "yea",
+  "yup",
+  "approved",
+  "approve",
+  "go ahead",
+  "do it",
+  "sure",
+  "ok",
+  "okay",
+  "k",
+  "lgtm",
+  "sounds good",
+  "go for it",
+  "please",
+  "pls",
+  "y",
+  "\u{1F44D}", // 👍
+]);
+
+/** Exact-match phrases for rejection. */
+const REJECT_EXACT: ReadonlySet<string> = new Set([
+  "no",
+  "nope",
+  "nah",
+  "reject",
+  "rejected",
+  "denied",
+  "deny",
+  "don't",
+  "dont",
+  "cancel",
+  "stop",
+  "n",
+  "\u{1F44E}", // 👎
+]);
+
+/**
+ * Patterns for timed approval (e.g. "approve for 10 minutes", "yes for now").
+ * Matched after normalization.
+ */
+const TIMED_PATTERNS: readonly RegExp[] = [
+  /^(?:approve|yes|ok|okay|sure|yep|yeah|go ahead)\s+for\s+10\s*(?:min(?:utes?)?|m)$/,
+  /^(?:approve|yes|ok|okay|sure|yep|yeah)\s+for\s+now$/,
+  /^approve\s+10\s*(?:min(?:utes?)?|m)$/,
+];
+
+// ---------------------------------------------------------------------------
+// Normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize input: lowercase, trim, strip `[ref:...]` disambiguation tags,
+ * strip trailing punctuation (except emoji), collapse internal whitespace.
+ */
+function normalize(text: string): string {
+  return text
+    .trim()
+    .toLowerCase()
+    .replace(/\[ref:[^\]]*\]/g, "")
+    .replace(/\s+/g, " ")
+    .replace(/[.!?,;:]+$/, "")
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a message for approval/rejection intent.
+ *
+ * Returns an `ApprovalIntent` when the entire message clearly expresses a
+ * single approval or rejection decision. Returns `null` when no intent is
+ * detected or when the message contains additional content beyond the
+ * decision phrase.
+ */
+export function parseApprovalIntent(text: string): ApprovalIntent | null {
+  const normalized = normalize(text);
+
+  if (normalized.length === 0) return null;
+
+  // Reject messages that are too long to be a simple decision phrase.
+  // This prevents matching approval words buried inside longer messages.
+  // The longest timed-approval phrase is ~30 chars; allow some padding.
+  if (normalized.length > 40) return null;
+
+  // Check timed approval patterns first (more specific).
+  for (const pattern of TIMED_PATTERNS) {
+    if (pattern.test(normalized)) {
+      return { decision: "approve_10m", confidence: 0.95 };
+    }
+  }
+
+  // Exact approval match.
+  if (APPROVE_EXACT.has(normalized)) {
+    return { decision: "approve", confidence: 0.95 };
+  }
+
+  // Exact rejection match.
+  if (REJECT_EXACT.has(normalized)) {
+    return { decision: "reject", confidence: 0.95 };
+  }
+
+  return null;
+}


### PR DESCRIPTION
Address Codex review: parseApprovalIntent now strips [ref:...] tags before matching.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
