### PR TITLE
Fix feedback on PR #12374: no thread tracking for ephemeral

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -334,6 +334,36 @@ describe("channel-reply-delivery", () => {
     expect(deliveryCalls).toHaveLength(0);
   });
 
+  it("passes ephemeral and user through to each delivery call", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/slack",
+      chatId: "C123",
+      textSegments: ["Part 1.", "Part 2."],
+      interSegmentDelayMs: 0,
+      ephemeral: true,
+      user: "U456",
+    });
+
+    expect(deliveryCalls).toHaveLength(2);
+    expect(deliveryCalls[0].payload.ephemeral).toBe(true);
+    expect(deliveryCalls[0].payload.user).toBe("U456");
+    expect(deliveryCalls[1].payload.ephemeral).toBe(true);
+    expect(deliveryCalls[1].payload.user).toBe("U456");
+  });
+
+  it("does not include ephemeral fields when not set", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/slack",
+      chatId: "C123",
+      textSegments: ["Normal message."],
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0].payload.ephemeral).toBeUndefined();
+    expect(deliveryCalls[0].payload.user).toBeUndefined();
+  });
+
   it("passes startFromSegment through deliverReplyViaCallback options", async () => {
     conversationMessages.push(
       { id: "msg-u", role: "user", content: "hi" },

--- a/assistant/src/messaging/providers/slack/client.ts
+++ b/assistant/src/messaging/providers/slack/client.ts
@@ -17,6 +17,7 @@ import type {
   SlackConversationRepliesResponse,
   SlackConversationsListResponse,
   SlackConversationsOpenResponse,
+  SlackPostEphemeralResponse,
   SlackPostMessageResponse,
   SlackReactionAddResponse,
   SlackSearchMessagesResponse,
@@ -207,6 +208,29 @@ export async function postMessage(
   return request<SlackPostMessageResponse>(
     token,
     "chat.postMessage",
+    undefined,
+    body,
+  );
+}
+
+/**
+ * Post an ephemeral message visible only to the specified user.
+ *
+ * Ephemeral messages are fire-and-forget: they cannot be edited or deleted
+ * after posting, and they disappear when the user reloads the Slack client.
+ */
+export async function postEphemeral(
+  token: string,
+  channel: string,
+  user: string,
+  text: string,
+  threadTs?: string,
+): Promise<SlackPostEphemeralResponse> {
+  const body: Record<string, unknown> = { channel, user, text };
+  if (threadTs) body.thread_ts = threadTs;
+  return request<SlackPostEphemeralResponse>(
+    token,
+    "chat.postEphemeral",
     undefined,
     body,
   );

--- a/assistant/src/messaging/providers/slack/types.ts
+++ b/assistant/src/messaging/providers/slack/types.ts
@@ -133,3 +133,7 @@ export interface SlackChatUpdateResponse extends SlackApiResponse {
 }
 
 export type SlackConversationMarkResponse = SlackApiResponse;
+
+export interface SlackPostEphemeralResponse extends SlackApiResponse {
+  message_ts: string;
+}

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -20,6 +20,14 @@ type DeliverRenderedReplyParams = {
   /** Called after each segment is successfully delivered, with the
    *  1-based count of segments delivered so far (including prior attempts). */
   onSegmentDelivered?: (deliveredCount: number) => void;
+  /**
+   * When true, deliver via ephemeral messaging so only the target `user`
+   * sees the content. Ephemeral messages are fire-and-forget: they cannot
+   * be edited or deleted after posting.
+   */
+  ephemeral?: boolean;
+  /** Channel-specific user ID — required when `ephemeral` is true. */
+  user?: string;
 };
 
 function sleep(ms: number): Promise<void> {
@@ -54,6 +62,8 @@ export async function deliverRenderedReplyViaCallback(
     interSegmentDelayMs = INTER_SEGMENT_DELAY_MS,
     startFromSegment = 0,
     onSegmentDelivered,
+    ephemeral,
+    user,
   } = params;
 
   const deliverableSegments = toDeliverableTextSegments(
@@ -71,6 +81,8 @@ export async function deliverRenderedReplyViaCallback(
           chatId,
           attachments: replyAttachments,
           assistantId,
+          ephemeral,
+          user,
         },
         bearerToken,
       );
@@ -87,6 +99,8 @@ export async function deliverRenderedReplyViaCallback(
         text: deliverableSegments[i],
         attachments: isLastSegment ? replyAttachments : undefined,
         assistantId,
+        ephemeral,
+        user,
       },
       bearerToken,
     );
@@ -104,6 +118,10 @@ export async function deliverRenderedReplyViaCallback(
 export type DeliverReplyOptions = {
   startFromSegment?: number;
   onSegmentDelivered?: (deliveredCount: number) => void;
+  /** Deliver as ephemeral (visible only to `user`). Fire-and-forget. */
+  ephemeral?: boolean;
+  /** Channel-specific user ID — required when `ephemeral` is true. */
+  user?: string;
 };
 
 export async function deliverReplyViaCallback(
@@ -145,6 +163,8 @@ export async function deliverReplyViaCallback(
       bearerToken,
       startFromSegment: options?.startFromSegment,
       onSegmentDelivered: options?.onSegmentDelivered,
+      ephemeral: options?.ephemeral,
+      user: options?.user,
     });
     break;
   }

--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -23,6 +23,14 @@ export interface ChannelReplyPayload {
   attachments?: RuntimeAttachmentMetadata[];
   approval?: ApprovalUIMetadata;
   chatAction?: "typing";
+  /**
+   * When true, deliver via `chat.postEphemeral` so only the target `user`
+   * sees the message. Ephemeral messages are fire-and-forget: they cannot
+   * be edited or deleted after posting.
+   */
+  ephemeral?: boolean;
+  /** Slack user ID — required when `ephemeral` is true. */
+  user?: string;
 }
 
 interface ManagedOutboundCallbackContext {

--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -352,4 +352,35 @@ describe("slack-deliver endpoint", () => {
     expect((slackCall!.body as any).thread_ts).toBe("1700000000.000100");
     expect((slackCall!.body as any).user).toBe("U789");
   });
+
+  test("does not call onThreadReply for ephemeral messages in a thread", async () => {
+    const onThreadReply = mock(() => {});
+    const handler = createSlackDeliverHandler(makeConfig(), onThreadReply);
+    const req = makeRequest(
+      {
+        chatId: "C123",
+        text: "ephemeral thread msg",
+        ephemeral: true,
+        user: "U456",
+      },
+      undefined,
+      "?threadTs=1700000000.000200",
+    );
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    expect(onThreadReply).not.toHaveBeenCalled();
+  });
+
+  test("calls onThreadReply for non-ephemeral messages in a thread", async () => {
+    const onThreadReply = mock(() => {});
+    const handler = createSlackDeliverHandler(makeConfig(), onThreadReply);
+    const req = makeRequest(
+      { chatId: "C123", text: "normal thread msg" },
+      undefined,
+      "?threadTs=1700000000.000300",
+    );
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    expect(onThreadReply).toHaveBeenCalledWith("1700000000.000300");
+  });
 });

--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -108,8 +108,11 @@ beforeEach(() => {
       }
       fetchCalls.push({ url, body, headers });
 
-      // Slack API response
-      if (url.includes("slack.com/api/chat.postMessage")) {
+      // Slack API responses
+      if (
+        url.includes("slack.com/api/chat.postMessage") ||
+        url.includes("slack.com/api/chat.postEphemeral")
+      ) {
         return new Response(JSON.stringify({ ok: true }), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -286,5 +289,67 @@ describe("slack-deliver endpoint", () => {
     );
     expect(slackCall).toBeDefined();
     expect((slackCall!.body as any).thread_ts).toBeUndefined();
+  });
+
+  test("uses chat.postEphemeral when ephemeral flag is set", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({
+      chatId: "C123",
+      text: "secret info",
+      ephemeral: true,
+      user: "U456",
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const slackCall = fetchCalls.find((c) =>
+      c.url.includes("chat.postEphemeral"),
+    );
+    expect(slackCall).toBeDefined();
+    expect((slackCall!.body as any).channel).toBe("C123");
+    expect((slackCall!.body as any).text).toBe("secret info");
+    expect((slackCall!.body as any).user).toBe("U456");
+
+    // Should NOT call chat.postMessage
+    const postMessageCall = fetchCalls.find((c) =>
+      c.url.includes("chat.postMessage"),
+    );
+    expect(postMessageCall).toBeUndefined();
+  });
+
+  test("returns 400 when ephemeral is set but user is missing", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({
+      chatId: "C123",
+      text: "secret info",
+      ephemeral: true,
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("user is required");
+  });
+
+  test("ephemeral message includes thread_ts when threadTs query param is set", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest(
+      {
+        chatId: "C123",
+        text: "ephemeral in thread",
+        ephemeral: true,
+        user: "U789",
+      },
+      undefined,
+      "?threadTs=1700000000.000100",
+    );
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const slackCall = fetchCalls.find((c) =>
+      c.url.includes("chat.postEphemeral"),
+    );
+    expect(slackCall).toBeDefined();
+    expect((slackCall!.body as any).thread_ts).toBe("1700000000.000100");
+    expect((slackCall!.body as any).user).toBe("U789");
   });
 });

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -38,6 +38,8 @@ export function createSlackDeliverHandler(
       text?: string;
       assistantId?: string;
       attachments?: unknown[];
+      ephemeral?: boolean;
+      user?: string;
     };
     try {
       body = (await req.json()) as typeof body;
@@ -73,6 +75,14 @@ export function createSlackDeliverHandler(
       return Response.json({ error: "text is required" }, { status: 400 });
     }
 
+    const isEphemeral = body.ephemeral === true;
+    if (isEphemeral && (!body.user || typeof body.user !== "string")) {
+      return Response.json(
+        { error: "user is required for ephemeral messages" },
+        { status: 400 },
+      );
+    }
+
     // Support threading via query param
     const threadTs = new URL(req.url).searchParams.get("threadTs") ?? undefined;
 
@@ -85,17 +95,24 @@ export function createSlackDeliverHandler(
         slackBody.thread_ts = threadTs;
       }
 
-      const response = await fetchImpl(
-        "https://slack.com/api/chat.postMessage",
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${config.slackChannelBotToken}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(slackBody),
+      // Ephemeral messages are only visible to the target user and cannot be
+      // edited or deleted after posting — they are fire-and-forget.
+      if (isEphemeral) {
+        slackBody.user = body.user!;
+      }
+
+      const slackMethod = isEphemeral
+        ? "chat.postEphemeral"
+        : "chat.postMessage";
+
+      const response = await fetchImpl(`https://slack.com/api/${slackMethod}`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.slackChannelBotToken}`,
+          "Content-Type": "application/json",
         },
-      );
+        body: JSON.stringify(slackBody),
+      });
 
       const data = (await response.json()) as { ok?: boolean; error?: string };
 
@@ -111,7 +128,10 @@ export function createSlackDeliverHandler(
       return Response.json({ error: "Delivery failed" }, { status: 502 });
     }
 
-    tlog.info({ chatId, hasThreadTs: !!threadTs }, "Slack message sent");
+    tlog.info(
+      { chatId, hasThreadTs: !!threadTs, ephemeral: isEphemeral },
+      "Slack message sent",
+    );
 
     // Track the thread so future replies without @mention are forwarded
     if (threadTs && onThreadReply) {

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -133,8 +133,10 @@ export function createSlackDeliverHandler(
       "Slack message sent",
     );
 
-    // Track the thread so future replies without @mention are forwarded
-    if (threadTs && onThreadReply) {
+    // Track the thread so future replies without @mention are forwarded.
+    // Skip for ephemeral sends — they are user-specific and should not
+    // activate global thread tracking for all participants.
+    if (threadTs && onThreadReply && !isEphemeral) {
       onThreadReply(threadTs);
     }
 


### PR DESCRIPTION
## Summary
- Ephemeral Slack messages no longer activate global thread tracking via `onThreadReply()`
- Fixes behavior regression where ephemeral sends would let other users trigger bot replies without @mention in the thread
- Adds two tests: one verifying ephemeral skips tracking, one verifying non-ephemeral still tracks

Addresses Codex review feedback on #12374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
