### PR TITLE
Fix feedback on PR #12371: reaction gating + action dedup

### DIFF
--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from "bun:test";
+import {
+  normalizeSlackBlockActions,
+  normalizeSlackReactionAdded,
+  type SlackBlockActionsPayload,
+  type SlackReactionAddedEvent,
+} from "./normalize.js";
+import type { GatewayConfig } from "../config.js";
+
+function makeConfig(overrides?: Partial<GatewayConfig>): GatewayConfig {
+  return {
+    routingEntries: [],
+    unmappedPolicy: "default",
+    defaultAssistantId: "ast-1",
+    ...overrides,
+  } as GatewayConfig;
+}
+
+function makeBlockActionsPayload(
+  overrides?: Partial<{
+    actionId: string;
+    actionValue: string;
+    userId: string;
+    channelId: string;
+    messageTs: string;
+    triggerId: string;
+  }>,
+): SlackBlockActionsPayload {
+  return {
+    type: "block_actions",
+    trigger_id: overrides?.triggerId ?? "trigger-123",
+    user: { id: overrides?.userId ?? "U123", username: "alice", name: "Alice" },
+    channel: { id: overrides?.channelId ?? "C456", name: "general" },
+    message: {
+      ts: overrides?.messageTs ?? "1234567890.123456",
+      text: "Choose an option",
+    },
+    actions: [
+      {
+        action_id: overrides?.actionId ?? "approve_btn",
+        value: overrides?.actionValue ?? "apr:run1:approve",
+        type: "button",
+        block_id: "block-1",
+        action_ts: "1234567890.654321",
+      },
+    ],
+  };
+}
+
+function makeReactionAddedEvent(
+  overrides?: Partial<{
+    user: string;
+    reaction: string;
+    channelId: string;
+    messageTs: string;
+  }>,
+): SlackReactionAddedEvent {
+  return {
+    type: "reaction_added",
+    user: overrides?.user ?? "U123",
+    reaction: overrides?.reaction ?? "thumbsup",
+    item: {
+      type: "message",
+      channel: overrides?.channelId ?? "C456",
+      ts: overrides?.messageTs ?? "1234567890.123456",
+    },
+  };
+}
+
+describe("normalizeSlackBlockActions", () => {
+  it("normalizes a block_actions payload with callbackData", () => {
+    const config = makeConfig();
+    const payload = makeBlockActionsPayload();
+    const result = normalizeSlackBlockActions(payload, "env-1", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.sourceChannel).toBe("slack");
+    expect(result!.event.message.callbackData).toBe("apr:run1:approve");
+    expect(result!.event.message.callbackQueryId).toBe("trigger-123");
+    expect(result!.event.message.content).toBe("apr:run1:approve");
+    expect(result!.event.message.conversationExternalId).toBe("C456");
+    expect(result!.event.actor.actorExternalId).toBe("U123");
+    expect(result!.event.actor.username).toBe("alice");
+    expect(result!.event.actor.displayName).toBe("Alice");
+    expect(result!.event.source.messageId).toBe("1234567890.123456");
+    expect(result!.channel).toBe("C456");
+    expect(result!.threadTs).toBe("1234567890.123456");
+  });
+
+  it("falls back to action_id when value is undefined", () => {
+    const config = makeConfig();
+    const payload = makeBlockActionsPayload({
+      actionValue: undefined as unknown as string,
+    });
+    payload.actions[0].value = undefined;
+    const result = normalizeSlackBlockActions(payload, "env-2", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.callbackData).toBe("approve_btn");
+    expect(result!.event.message.content).toBe("approve_btn");
+  });
+
+  it("returns null when actions array is empty", () => {
+    const config = makeConfig();
+    const payload = makeBlockActionsPayload();
+    payload.actions = [];
+    const result = normalizeSlackBlockActions(payload, "env-3", config);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when user ID is missing", () => {
+    const config = makeConfig();
+    const payload = makeBlockActionsPayload();
+    payload.user = { id: "", username: "alice" };
+    const result = normalizeSlackBlockActions(payload, "env-4", config);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when channel is missing", () => {
+    const config = makeConfig();
+    const payload = makeBlockActionsPayload();
+    payload.channel = undefined;
+    const result = normalizeSlackBlockActions(payload, "env-5", config);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when routing rejects", () => {
+    const config = makeConfig({
+      unmappedPolicy: "reject",
+      defaultAssistantId: undefined,
+    });
+    const payload = makeBlockActionsPayload();
+    const result = normalizeSlackBlockActions(payload, "env-6", config);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("normalizeSlackReactionAdded", () => {
+  it("normalizes a reaction_added event with callbackData", () => {
+    const config = makeConfig();
+    const event = makeReactionAddedEvent();
+    const result = normalizeSlackReactionAdded(event, "evt-1", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.sourceChannel).toBe("slack");
+    expect(result!.event.message.callbackData).toBe("reaction:thumbsup");
+    expect(result!.event.message.content).toBe("reaction:thumbsup");
+    expect(result!.event.message.conversationExternalId).toBe("C456");
+    expect(result!.event.message.externalMessageId).toBe(
+      "C456:1234567890.123456:thumbsup",
+    );
+    expect(result!.event.actor.actorExternalId).toBe("U123");
+    expect(result!.event.source.messageId).toBe("1234567890.123456");
+    expect(result!.channel).toBe("C456");
+    expect(result!.threadTs).toBe("1234567890.123456");
+  });
+
+  it("returns null when user is missing", () => {
+    const config = makeConfig();
+    const event = makeReactionAddedEvent({ user: "" });
+    const result = normalizeSlackReactionAdded(event, "evt-2", config);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when item channel is missing", () => {
+    const config = makeConfig();
+    const event = makeReactionAddedEvent();
+    event.item.channel = "";
+    const result = normalizeSlackReactionAdded(event, "evt-3", config);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when item ts is missing", () => {
+    const config = makeConfig();
+    const event = makeReactionAddedEvent();
+    event.item.ts = "";
+    const result = normalizeSlackReactionAdded(event, "evt-4", config);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when routing rejects", () => {
+    const config = makeConfig({
+      unmappedPolicy: "reject",
+      defaultAssistantId: undefined,
+    });
+    const event = makeReactionAddedEvent();
+    const result = normalizeSlackReactionAdded(event, "evt-5", config);
+
+    expect(result).toBeNull();
+  });
+
+  it("uses the reaction name in callbackData", () => {
+    const config = makeConfig();
+    const event = makeReactionAddedEvent({ reaction: "white_check_mark" });
+    const result = normalizeSlackReactionAdded(event, "evt-6", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.callbackData).toBe(
+      "reaction:white_check_mark",
+    );
+  });
+});

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -82,9 +82,29 @@ describe("normalizeSlackBlockActions", () => {
     expect(result!.event.actor.actorExternalId).toBe("U123");
     expect(result!.event.actor.username).toBe("alice");
     expect(result!.event.actor.displayName).toBe("Alice");
+    expect(result!.event.message.externalMessageId).toBe(
+      "C456:1234567890.123456:1234567890.654321",
+    );
     expect(result!.event.source.messageId).toBe("1234567890.123456");
     expect(result!.channel).toBe("C456");
     expect(result!.threadTs).toBe("1234567890.123456");
+  });
+
+  it("generates unique externalMessageId per click via action_ts", () => {
+    const config = makeConfig();
+    const payload1 = makeBlockActionsPayload();
+    payload1.actions[0].action_ts = "1000000000.000001";
+    const payload2 = makeBlockActionsPayload();
+    payload2.actions[0].action_ts = "1000000000.000002";
+
+    const result1 = normalizeSlackBlockActions(payload1, "env-same", config);
+    const result2 = normalizeSlackBlockActions(payload2, "env-same", config);
+
+    expect(result1).not.toBeNull();
+    expect(result2).not.toBeNull();
+    expect(result1!.event.message.externalMessageId).not.toBe(
+      result2!.event.message.externalMessageId,
+    );
   });
 
   it("falls back to action_id when value is undefined", () => {

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -290,6 +290,10 @@ export function normalizeSlackBlockActions(
 
   const callbackData = action.value ?? action.action_id;
   const messageTs = payload.message?.ts;
+  // Use action_ts (unique per click) to prevent dedup collisions when
+  // multiple buttons on the same message are clicked or the same button
+  // is clicked again after a transient failure.
+  const actionTs = action.action_ts ?? envelopeId;
 
   return {
     event: {
@@ -299,7 +303,7 @@ export function normalizeSlackBlockActions(
       message: {
         content: callbackData,
         conversationExternalId: channelId,
-        externalMessageId: `${channelId}:${messageTs ?? envelopeId}`,
+        externalMessageId: `${channelId}:${messageTs ?? envelopeId}:${actionTs}`,
         callbackQueryId: payload.trigger_id,
         callbackData,
       },

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -225,3 +225,142 @@ export function normalizeSlackAppMention(
     channel: event.channel,
   };
 }
+
+/**
+ * Slack `block_actions` interactive payload shape (subset relevant to normalization).
+ * Sent when a user clicks a Block Kit interactive element (button, menu, etc.).
+ */
+export interface SlackBlockActionsPayload {
+  type: "block_actions";
+  trigger_id: string;
+  user: { id: string; username?: string; name?: string };
+  channel?: { id: string; name?: string };
+  message?: { ts: string; text?: string };
+  actions: Array<{
+    action_id: string;
+    value?: string;
+    type: string;
+    block_id?: string;
+    action_ts?: string;
+  }>;
+}
+
+/**
+ * Slack `reaction_added` event shape.
+ */
+export interface SlackReactionAddedEvent {
+  type: "reaction_added";
+  user: string;
+  reaction: string;
+  item: {
+    type: string;
+    channel: string;
+    ts: string;
+  };
+  item_user?: string;
+  event_ts?: string;
+}
+
+/**
+ * Normalize a Slack `block_actions` interactive payload into the gateway's
+ * canonical inbound event shape, matching Telegram's `callback_query` pattern.
+ *
+ * Uses the first action in the `actions` array. The `callbackData` field is
+ * set to match the Telegram `apr:{requestId}:{actionId}` convention when the
+ * action value follows that pattern, or falls back to the raw action value.
+ *
+ * Returns null if the payload is missing required fields or cannot be routed.
+ */
+export function normalizeSlackBlockActions(
+  payload: SlackBlockActionsPayload,
+  envelopeId: string,
+  config: GatewayConfig,
+): NormalizedSlackEvent | null {
+  const action = payload.actions?.[0];
+  if (!action) return null;
+
+  const userId = payload.user?.id;
+  if (!userId) return null;
+
+  const channelId = payload.channel?.id;
+  if (!channelId) return null;
+
+  const routing = resolveAssistant(config, channelId, userId);
+  if (isRejection(routing)) return null;
+
+  const callbackData = action.value ?? action.action_id;
+  const messageTs = payload.message?.ts;
+
+  return {
+    event: {
+      version: "v1",
+      sourceChannel: "slack",
+      receivedAt: new Date().toISOString(),
+      message: {
+        content: callbackData,
+        conversationExternalId: channelId,
+        externalMessageId: `${channelId}:${messageTs ?? envelopeId}`,
+        callbackQueryId: payload.trigger_id,
+        callbackData,
+      },
+      actor: {
+        actorExternalId: userId,
+        username: payload.user.username,
+        displayName: payload.user.name,
+      },
+      source: {
+        updateId: envelopeId,
+        messageId: messageTs,
+      },
+      raw: payload as unknown as Record<string, unknown>,
+    },
+    routing,
+    threadTs: messageTs ?? envelopeId,
+    channel: channelId,
+  };
+}
+
+/**
+ * Normalize a Slack `reaction_added` event into the gateway's canonical
+ * inbound event shape. The reaction emoji name is placed in `callbackData`
+ * so downstream handlers can process it like a callback action.
+ *
+ * Returns null if the event is missing required fields or cannot be routed.
+ */
+export function normalizeSlackReactionAdded(
+  event: SlackReactionAddedEvent,
+  eventId: string,
+  config: GatewayConfig,
+): NormalizedSlackEvent | null {
+  if (!event.user || !event.item?.channel || !event.item?.ts) return null;
+
+  const routing = resolveAssistant(config, event.item.channel, event.user);
+  if (isRejection(routing)) return null;
+
+  const callbackData = `reaction:${event.reaction}`;
+
+  return {
+    event: {
+      version: "v1",
+      sourceChannel: "slack",
+      receivedAt: new Date().toISOString(),
+      message: {
+        content: callbackData,
+        conversationExternalId: event.item.channel,
+        externalMessageId: `${event.item.channel}:${event.item.ts}:${event.reaction}`,
+        callbackData,
+      },
+      actor: {
+        actorExternalId: event.user,
+      },
+      source: {
+        updateId: eventId,
+        messageId: event.item.ts,
+      },
+      raw: event as unknown as Record<string, unknown>,
+    },
+    routing,
+    threadTs: event.item.ts,
+    channel: event.item.channel,
+  };
+}

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -277,7 +277,6 @@ export class SlackSocketModeClient {
 
     const isAppMention = event.type === "app_mention";
     const isDm = event.type === "message" && dmEvent.channel_type === "im";
-    const isReactionAdded = event.type === "reaction_added";
     const mentionsBot =
       this.config.botUserId &&
       channelEvent.text?.includes(`<@${this.config.botUserId}>`);
@@ -288,7 +287,14 @@ export class SlackSocketModeClient {
       !!channelEvent.thread_ts &&
       this.activeThreads.has(channelEvent.thread_ts);
 
-    // Process app_mention events, DMs, reaction_added, and replies in active bot threads
+    // Only forward reaction_added events on messages in tracked bot threads
+    const reactionEvent = event as SlackReactionAddedEvent;
+    const isReactionAdded =
+      event.type === "reaction_added" &&
+      !!reactionEvent.item?.ts &&
+      this.activeThreads.has(reactionEvent.item.ts);
+
+    // Process app_mention events, DMs, scoped reactions, and replies in active bot threads
     if (!isAppMention && !isDm && !isReactionAdded && !isActiveThreadReply) {
       return;
     }

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -5,9 +5,13 @@ import {
   normalizeSlackAppMention,
   normalizeSlackDirectMessage,
   normalizeSlackChannelMessage,
+  normalizeSlackBlockActions,
+  normalizeSlackReactionAdded,
   type SlackAppMentionEvent,
   type SlackDirectMessageEvent,
   type SlackChannelMessageEvent,
+  type SlackBlockActionsPayload,
+  type SlackReactionAddedEvent,
   type NormalizedSlackEvent,
 } from "./normalize.js";
 
@@ -191,7 +195,15 @@ export class SlackSocketModeClient {
         event?:
           | SlackAppMentionEvent
           | SlackDirectMessageEvent
-          | SlackChannelMessageEvent;
+          | SlackChannelMessageEvent
+          | SlackReactionAddedEvent;
+        // Interactive payloads are delivered directly as the payload
+        type?: string;
+        trigger_id?: string;
+        user?: { id: string; username?: string; name?: string };
+        channel?: { id: string; name?: string };
+        message?: { ts: string; text?: string };
+        actions?: SlackBlockActionsPayload["actions"];
       };
       reason?: string;
     };
@@ -232,6 +244,27 @@ export class SlackSocketModeClient {
       return;
     }
 
+    // Handle interactive envelopes (block_actions from Block Kit buttons, menus, etc.)
+    if (envelope.type === "interactive") {
+      const interactivePayload = envelope.payload;
+      if (interactivePayload?.type === "block_actions") {
+        const normalized = normalizeSlackBlockActions(
+          interactivePayload as unknown as SlackBlockActionsPayload,
+          envelope.envelope_id ?? "unknown",
+          this.config.gatewayConfig,
+        );
+        if (normalized) {
+          this.onEvent(normalized);
+        } else {
+          log.info(
+            { envelopeId: envelope.envelope_id },
+            "Slack block_actions dropped by normalization/routing",
+          );
+        }
+      }
+      return;
+    }
+
     // Only process events_api envelopes
     if (envelope.type !== "events_api") return;
 
@@ -244,6 +277,7 @@ export class SlackSocketModeClient {
 
     const isAppMention = event.type === "app_mention";
     const isDm = event.type === "message" && dmEvent.channel_type === "im";
+    const isReactionAdded = event.type === "reaction_added";
     const mentionsBot =
       this.config.botUserId &&
       channelEvent.text?.includes(`<@${this.config.botUserId}>`);
@@ -254,8 +288,8 @@ export class SlackSocketModeClient {
       !!channelEvent.thread_ts &&
       this.activeThreads.has(channelEvent.thread_ts);
 
-    // Process app_mention events, DMs, and replies in active bot threads
-    if (!isAppMention && !isDm && !isActiveThreadReply) {
+    // Process app_mention events, DMs, reaction_added, and replies in active bot threads
+    if (!isAppMention && !isDm && !isReactionAdded && !isActiveThreadReply) {
       return;
     }
 
@@ -268,7 +302,13 @@ export class SlackSocketModeClient {
     this.dedupMap.set(eventId, Date.now());
 
     let normalized: NormalizedSlackEvent | null;
-    if (isAppMention) {
+    if (isReactionAdded) {
+      normalized = normalizeSlackReactionAdded(
+        event as SlackReactionAddedEvent,
+        eventId,
+        this.config.gatewayConfig,
+      );
+    } else if (isAppMention) {
       normalized = normalizeSlackAppMention(
         event as SlackAppMentionEvent,
         eventId,
@@ -292,7 +332,11 @@ export class SlackSocketModeClient {
 
     if (!normalized) {
       log.info(
-        { eventId, channel: event.channel, type: event.type },
+        {
+          eventId,
+          channel: (event as { channel?: string }).channel,
+          type: event.type,
+        },
         "Slack event dropped by normalization/routing",
       );
       return;


### PR DESCRIPTION
Address Codex review: only forward reactions on tracked threads/bot messages, generate unique externalMessageId per block action click.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
