### PR TITLE
Fix feedback on PR #12372: restrict to DM destinations

### DIFF
--- a/assistant/src/channels/config.ts
+++ b/assistant/src/channels/config.ts
@@ -47,7 +47,7 @@ const CHANNEL_POLICIES = {
   },
   slack: {
     notification: {
-      deliveryEnabled: false,
+      deliveryEnabled: true,
       conversationStrategy: "continue_existing_conversation",
     },
   },

--- a/assistant/src/notifications/adapters/slack.ts
+++ b/assistant/src/notifications/adapters/slack.ts
@@ -1,0 +1,90 @@
+/**
+ * Slack channel adapter — delivers notifications to Slack DMs
+ * via the gateway's channel-reply endpoint.
+ *
+ * Follows the same delivery pattern as the Telegram adapter: POST to
+ * the gateway's `/deliver/slack` endpoint with a chat ID (the guardian's
+ * Slack DM channel ID) and text payload. The gateway forwards the
+ * message to the Slack Web API.
+ */
+
+import { getGatewayInternalBaseUrl } from "../../config/env.js";
+import { mintDaemonDeliveryToken } from "../../runtime/auth/token-service.js";
+import { deliverChannelReply } from "../../runtime/gateway-client.js";
+import { getLogger } from "../../util/logger.js";
+import { nonEmpty } from "../copy-composer.js";
+import { isThreadSeedSane } from "../thread-seed-composer.js";
+import type {
+  ChannelAdapter,
+  ChannelDeliveryPayload,
+  ChannelDestination,
+  DeliveryResult,
+  NotificationChannel,
+} from "../types.js";
+
+const log = getLogger("notif-adapter-slack");
+
+function resolveSlackMessageText(payload: ChannelDeliveryPayload): string {
+  const deliveryText = nonEmpty(payload.copy.deliveryText);
+  if (deliveryText) return deliveryText;
+
+  if (isThreadSeedSane(payload.copy.threadSeedMessage)) {
+    return payload.copy.threadSeedMessage.trim();
+  }
+
+  const body = nonEmpty(payload.copy.body);
+  if (body) return body;
+
+  const title = nonEmpty(payload.copy.title);
+  if (title) return title;
+
+  return payload.sourceEventName.replace(/[._]/g, " ");
+}
+
+export class SlackAdapter implements ChannelAdapter {
+  readonly channel: NotificationChannel = "slack";
+
+  async send(
+    payload: ChannelDeliveryPayload,
+    destination: ChannelDestination,
+  ): Promise<DeliveryResult> {
+    const chatId = destination.endpoint;
+    if (!chatId) {
+      log.warn(
+        { sourceEventName: payload.sourceEventName },
+        "Slack destination has no chat ID — skipping",
+      );
+      return {
+        success: false,
+        error: "No chat ID configured for Slack destination",
+      };
+    }
+
+    const gatewayBase = getGatewayInternalBaseUrl();
+    const deliverUrl = `${gatewayBase}/deliver/slack`;
+
+    const messageText = resolveSlackMessageText(payload);
+
+    try {
+      await deliverChannelReply(
+        deliverUrl,
+        { chatId, text: messageText },
+        mintDaemonDeliveryToken(),
+      );
+
+      log.info(
+        { sourceEventName: payload.sourceEventName, chatId },
+        "Slack notification delivered",
+      );
+
+      return { success: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error(
+        { err, sourceEventName: payload.sourceEventName, chatId },
+        "Failed to deliver Slack notification",
+      );
+      return { success: false, error: message };
+    }
+  }
+}

--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -85,6 +85,36 @@ export function resolveDestinations(
         );
         break;
       }
+      case "slack": {
+        const guardianResult = findGuardianForChannel("slack", assistantId);
+        const chatId = guardianResult?.channel.externalChatId;
+        // Slack bindings can originate from app_mention in shared channels.
+        // Only route notifications to DM channels (IDs starting with "D")
+        // to prevent leaking notifications into shared workspaces.
+        if (guardianResult && chatId && isSlackDmChannel(chatId)) {
+          result.set("slack", {
+            channel: "slack",
+            endpoint: chatId,
+            metadata: {
+              externalUserId: guardianResult.channel.externalUserId,
+            },
+          });
+        } else if (guardianResult && chatId) {
+          log.warn(
+            { channel: "slack", chatId },
+            "skipping non-DM Slack channel for notification delivery",
+          );
+        }
+        log.debug(
+          {
+            channel: "slack",
+            source: "contacts",
+            hasEndpoint: !!(chatId && isSlackDmChannel(chatId)),
+          },
+          "destination resolved",
+        );
+        break;
+      }
       default: {
         // Future deliverable channels without a resolver — skip silently.
         break;
@@ -93,4 +123,14 @@ export function resolveDestinations(
   }
 
   return result;
+}
+
+/**
+ * Slack DM channel IDs start with "D". Channels starting with "C" are
+ * public/shared channels, "G" are legacy group DMs. We restrict proactive
+ * notification delivery to "D"-prefixed IDs to avoid leaking into shared
+ * channels where app_mention bindings may have been created.
+ */
+function isSlackDmChannel(channelId: string): boolean {
+  return channelId.startsWith("D");
 }

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -16,6 +16,7 @@ import { findGuardianForChannel } from "../contacts/contact-store.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import { type BroadcastFn, VellumAdapter } from "./adapters/macos.js";
+import { SlackAdapter } from "./adapters/slack.js";
 import { SmsAdapter } from "./adapters/sms.js";
 import { TelegramAdapter } from "./adapters/telegram.js";
 import {
@@ -61,7 +62,11 @@ export function registerBroadcastFn(fn: BroadcastFn): void {
 
 function getBroadcaster(): NotificationBroadcaster {
   if (!broadcasterInstance) {
-    const adapters = [new TelegramAdapter(), new SmsAdapter()];
+    const adapters = [
+      new TelegramAdapter(),
+      new SmsAdapter(),
+      new SlackAdapter(),
+    ];
     if (registeredBroadcastFn) {
       adapters.unshift(new VellumAdapter(registeredBroadcastFn));
     }
@@ -117,6 +122,17 @@ function getConnectedChannels(assistantId: string): NotificationChannel[] {
         // delivery address the destination-resolver needs.
         const guardian = findGuardianForChannel(channel, assistantId);
         if (guardian && guardian.channel.externalChatId) {
+          channels.push(channel);
+        }
+        break;
+      }
+      case "slack": {
+        // Slack bindings can originate from shared channels (app_mention).
+        // Only consider Slack connected when the stored chat ID is a DM
+        // channel (D-prefixed) to prevent leaking notifications.
+        const slackGuardian = findGuardianForChannel("slack", assistantId);
+        const chatId = slackGuardian?.channel.externalChatId;
+        if (slackGuardian && chatId && chatId.startsWith("D")) {
           channels.push(channel);
         }
         break;


### PR DESCRIPTION
Address Codex review: Slack notifications now only route to DM channel IDs (D-prefixed) to prevent leaking to shared channels.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
