### PR TITLE
Fix feedback on PR #12375: text validation + upload check

### DIFF
--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -163,6 +163,11 @@ beforeEach(() => {
         return new Response('{"error":"not found"}', { status: 404 });
       }
 
+      // Slack file upload URL (step 2 of files.uploadV2 flow)
+      if (url.includes("files.slack.com/upload/")) {
+        return new Response("OK", { status: 200 });
+      }
+
       // Slack API responses
       if (url.includes("slack.com/api/")) {
         return new Response(
@@ -333,6 +338,15 @@ describe("slack-deliver endpoint", () => {
     );
     expect(slackCall).toBeDefined();
     expect((slackCall!.body as any).thread_ts).toBeUndefined();
+  });
+
+  test("returns 400 when text is a non-string truthy value", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({ chatId: "C123", text: { x: 1 } });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("text must be a string");
   });
 
   test("returns 400 when attachment is missing an id", async () => {

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -54,11 +54,17 @@ async function uploadFileToSlack(
   }
 
   // Step 2: Upload file content to the provided URL
-  await fetchImpl(urlData.upload_url, {
+  const uploadRes = await fetchImpl(urlData.upload_url, {
     method: "POST",
     headers: { "Content-Type": "application/octet-stream" },
     body: buffer,
   });
+
+  if (!uploadRes.ok) {
+    throw new Error(
+      `File upload to Slack failed with status ${uploadRes.status}`,
+    );
+  }
 
   // Step 3: Complete the upload and share to channel
   const completeBody: {
@@ -264,6 +270,10 @@ export function createSlackDeliverHandler(
         { error: "text or attachments required" },
         { status: 400 },
       );
+    }
+
+    if (text !== undefined && typeof text !== "string") {
+      return Response.json({ error: "text must be a string" }, { status: 400 });
     }
 
     // Support threading via query param


### PR DESCRIPTION
## Summary
- Reject non-string `text` payloads with 400 (e.g. `{ text: {x:1} }` was silently dropped)
- Check HTTP response status after file upload to Slack (step 2 of files.uploadV2 flow)
- Add test for non-string text rejection and mock for upload URL

Addresses review feedback on PR #12375 from Codex (P1) and Devin.

## Test plan
- [x] New test: non-string text returns 400
- [x] Upload URL mock added so attachment tests hit correct path
- [x] All pre-existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
