### PR TITLE
Fix feedback on PR #12387: block limits + code fences

### DIFF
--- a/gateway/src/__tests__/text-to-blocks.test.ts
+++ b/gateway/src/__tests__/text-to-blocks.test.ts
@@ -1,0 +1,164 @@
+import { describe, test, expect } from "bun:test";
+import { textToBlocks } from "../slack/text-to-blocks.js";
+
+describe("textToBlocks", () => {
+  test("returns empty array for empty string", () => {
+    expect(textToBlocks("")).toEqual([]);
+    expect(textToBlocks("   ")).toEqual([]);
+  });
+
+  test("converts plain text into a single section block", () => {
+    const blocks = textToBlocks("Hello, world!");
+    expect(blocks).toEqual([
+      { type: "section", text: { type: "mrkdwn", text: "Hello, world!" } },
+    ]);
+  });
+
+  test("converts markdown heading to header block", () => {
+    const blocks = textToBlocks("# Welcome\n\nSome content here.");
+    expect(blocks).toHaveLength(3); // header, divider, section
+    expect(blocks[0]).toEqual({
+      type: "header",
+      text: { type: "plain_text", text: "Welcome", emoji: true },
+    });
+    expect(blocks[1]).toEqual({ type: "divider" });
+    expect(blocks[2]).toEqual({
+      type: "section",
+      text: { type: "mrkdwn", text: "Some content here." },
+    });
+  });
+
+  test("wraps fenced code blocks in triple backticks", () => {
+    const input = "Here is code:\n\n```js\nconsole.log('hi');\n```";
+    const blocks = textToBlocks(input);
+
+    expect(blocks).toHaveLength(3); // text, divider, code
+    expect(blocks[0]).toEqual({
+      type: "section",
+      text: { type: "mrkdwn", text: "Here is code:" },
+    });
+    expect(blocks[1]).toEqual({ type: "divider" });
+    expect(blocks[2]).toEqual({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "```js\nconsole.log('hi');\n```",
+      },
+    });
+  });
+
+  test("converts markdown links to Slack mrkdwn format", () => {
+    const blocks = textToBlocks("Check [this link](https://example.com).");
+    expect(blocks[0]).toEqual({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "Check <https://example.com|this link>.",
+      },
+    });
+  });
+
+  test("converts **bold** to *bold*", () => {
+    const blocks = textToBlocks("This is **important**.");
+    expect(blocks[0]).toEqual({
+      type: "section",
+      text: { type: "mrkdwn", text: "This is *important*." },
+    });
+  });
+
+  test("inserts dividers between multiple sections", () => {
+    const input =
+      "# Title\n\nFirst paragraph.\n\n## Subtitle\n\nSecond paragraph.";
+    const blocks = textToBlocks(input);
+
+    // header, divider, section, divider, header, divider, section
+    const types = blocks.map((b) => b.type);
+    expect(types).toEqual([
+      "header",
+      "divider",
+      "section",
+      "divider",
+      "header",
+      "divider",
+      "section",
+    ]);
+  });
+
+  test("handles code block without language specifier", () => {
+    const input = "```\nplain code\n```";
+    const blocks = textToBlocks(input);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toEqual({
+      type: "section",
+      text: { type: "mrkdwn", text: "```\nplain code\n```" },
+    });
+  });
+
+  test("handles mixed content with multiple code blocks", () => {
+    const input =
+      "Intro text.\n\n```python\nprint('hello')\n```\n\nMiddle text.\n\n```\nmore code\n```";
+    const blocks = textToBlocks(input);
+
+    const types = blocks.map((b) => b.type);
+    // text, divider, code, divider, text, divider, code
+    expect(types).toEqual([
+      "section",
+      "divider",
+      "section",
+      "divider",
+      "section",
+      "divider",
+      "section",
+    ]);
+  });
+
+  test("parses code fence languages with special characters (c++, c#, f#)", () => {
+    const input = "```c++\nint main() {}\n```";
+    const blocks = textToBlocks(input);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toEqual({
+      type: "section",
+      text: { type: "mrkdwn", text: "```c++\nint main() {}\n```" },
+    });
+
+    const input2 = "```c#\nConsole.WriteLine();\n```";
+    const blocks2 = textToBlocks(input2);
+    expect(blocks2).toHaveLength(1);
+    expect(blocks2[0]).toEqual({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "```c#\nConsole.WriteLine();\n```",
+      },
+    });
+  });
+
+  test("splits oversized text sections at 3000-char limit", () => {
+    // Build a string with many lines that exceeds 3000 chars total
+    const line = "x".repeat(100) + "\n";
+    const longText = line.repeat(40).trimEnd(); // 40 * 101 = 4040 chars
+    const blocks = textToBlocks(longText);
+
+    // Should be split into multiple sections with dividers between them
+    expect(blocks.length).toBeGreaterThanOrEqual(3); // at least 2 sections + 1 divider
+    for (const block of blocks) {
+      if (block.type === "section") {
+        expect(block.text.text.length).toBeLessThanOrEqual(3000);
+      }
+    }
+  });
+
+  test("splits oversized code block at 3000-char limit", () => {
+    const codeLine = "console.log('hello');\n";
+    // ~22 chars per line, need >3000 chars total including fences
+    const codeContent = codeLine.repeat(150).trimEnd(); // ~3300 chars
+    const input = "```js\n" + codeContent + "\n```";
+    const blocks = textToBlocks(input);
+
+    for (const block of blocks) {
+      if (block.type === "section") {
+        expect(block.text.text.length).toBeLessThanOrEqual(3000);
+      }
+    }
+  });
+});

--- a/gateway/src/slack/text-to-blocks.ts
+++ b/gateway/src/slack/text-to-blocks.ts
@@ -1,0 +1,225 @@
+/**
+ * Converts plain or markdown-formatted text into Slack Block Kit blocks.
+ *
+ * Slack's `mrkdwn` format is close to markdown but not identical.
+ * This utility splits text into logical sections (paragraphs, code blocks,
+ * headings) and wraps each in the appropriate Block Kit block type.
+ */
+
+import { type Block, BlockKitBuilder } from "./block-kit-builder.js";
+
+/** Slack mrkdwn text sections have a 3000-character limit. */
+const SLACK_MRKDWN_MAX_LENGTH = 3000;
+
+/**
+ * Convert a markdown/plain-text string into an array of Block Kit blocks.
+ *
+ * Strategy:
+ * 1. Split the input into logical segments separated by blank lines.
+ * 2. Fenced code blocks (``` ... ```) become section blocks with code
+ *    wrapped in triple backticks (Slack mrkdwn supports these).
+ * 3. Lines starting with `#` become header blocks (plain_text).
+ * 4. Everything else becomes mrkdwn section blocks.
+ * 5. Dividers are inserted between logical sections for readability.
+ */
+export function textToBlocks(text: string): Block[] {
+  if (!text || text.trim().length === 0) return [];
+
+  const segments = splitIntoSegments(text);
+  const builder = new BlockKitBuilder();
+
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+
+    if (i > 0) {
+      builder.divider();
+    }
+
+    if (segment.type === "code") {
+      // Wrap in triple backticks for Slack mrkdwn rendering
+      const lang = segment.lang ? segment.lang : "";
+      const codeText = "```" + lang + "\n" + segment.content + "\n```";
+      addSectionChunks(builder, codeText);
+    } else if (segment.type === "header") {
+      builder.header(segment.content);
+    } else {
+      // Convert markdown formatting to Slack mrkdwn
+      addSectionChunks(builder, markdownToMrkdwn(segment.content));
+    }
+  }
+
+  return builder.toBlocks();
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface TextSegment {
+  type: "text";
+  content: string;
+}
+
+interface CodeSegment {
+  type: "code";
+  content: string;
+  lang?: string;
+}
+
+interface HeaderSegment {
+  type: "header";
+  content: string;
+}
+
+type Segment = TextSegment | CodeSegment | HeaderSegment;
+
+// ---------------------------------------------------------------------------
+// Segment splitting
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the input text into an ordered list of segments, distinguishing
+ * fenced code blocks, headers, and regular text paragraphs.
+ */
+function splitIntoSegments(text: string): Segment[] {
+  const lines = text.split("\n");
+  const segments: Segment[] = [];
+  let currentTextLines: string[] = [];
+
+  function flushText(): void {
+    const joined = currentTextLines.join("\n").trim();
+    if (joined.length > 0) {
+      segments.push({ type: "text", content: joined });
+    }
+    currentTextLines = [];
+  }
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const fenceMatch = line.match(/^```([^\s`]*)\s*$/);
+
+    if (fenceMatch) {
+      flushText();
+      const lang = fenceMatch[1] || undefined;
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].match(/^```\s*$/)) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      segments.push({ type: "code", content: codeLines.join("\n"), lang });
+      i++; // skip closing fence
+      continue;
+    }
+
+    // Detect markdown headings (# through ###)
+    const headingMatch = line.match(/^#{1,3}\s+(.+)$/);
+    if (headingMatch) {
+      flushText();
+      segments.push({ type: "header", content: headingMatch[1].trim() });
+      i++;
+      continue;
+    }
+
+    currentTextLines.push(line);
+    i++;
+  }
+
+  flushText();
+  return segments;
+}
+
+// ---------------------------------------------------------------------------
+// Block length guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Add one or more section blocks for `text`, splitting at line boundaries
+ * when the content exceeds Slack's 3000-char mrkdwn limit.
+ */
+function addSectionChunks(builder: BlockKitBuilder, text: string): void {
+  if (text.length <= SLACK_MRKDWN_MAX_LENGTH) {
+    builder.section(text);
+    return;
+  }
+
+  const chunks = splitTextAtLimit(text, SLACK_MRKDWN_MAX_LENGTH);
+  for (let j = 0; j < chunks.length; j++) {
+    if (j > 0) builder.divider();
+    builder.section(chunks[j]);
+  }
+}
+
+/**
+ * Split `text` into chunks that each fit within `maxLen`, preferring to
+ * break at newline boundaries. Falls back to hard-splitting mid-line only
+ * when a single line exceeds the limit.
+ */
+function splitTextAtLimit(text: string, maxLen: number): string[] {
+  const lines = text.split("\n");
+  const chunks: string[] = [];
+  let current = "";
+
+  for (const line of lines) {
+    const candidate = current.length === 0 ? line : current + "\n" + line;
+
+    if (candidate.length <= maxLen) {
+      current = candidate;
+    } else {
+      // Flush what we have so far
+      if (current.length > 0) {
+        chunks.push(current);
+        current = "";
+      }
+
+      // If a single line exceeds the limit, hard-split it
+      if (line.length > maxLen) {
+        let remaining = line;
+        while (remaining.length > maxLen) {
+          chunks.push(remaining.slice(0, maxLen));
+          remaining = remaining.slice(maxLen);
+        }
+        current = remaining;
+      } else {
+        current = line;
+      }
+    }
+  }
+
+  if (current.length > 0) {
+    chunks.push(current);
+  }
+
+  return chunks;
+}
+
+// ---------------------------------------------------------------------------
+// Markdown → Slack mrkdwn conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert common markdown formatting to Slack mrkdwn equivalents.
+ *
+ * Slack mrkdwn differences from standard markdown:
+ * - Bold: *text* (not **text**)
+ * - Italic: _text_ (same)
+ * - Strikethrough: ~text~ (same)
+ * - Inline code: `text` (same)
+ * - Links: <url|text> (not [text](url))
+ */
+function markdownToMrkdwn(text: string): string {
+  let result = text;
+
+  // Convert markdown links [text](url) → Slack <url|text>
+  result = result.replace(
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    (_match, linkText, url) => `<${url}|${linkText}>`,
+  );
+
+  // Convert **bold** → *bold* (Slack mrkdwn bold)
+  // Must run before single-star italic conversion
+  result = result.replace(/\*\*(.+?)\*\*/g, "*$1*");
+
+  return result;
+}


### PR DESCRIPTION
Address Codex review: split oversized blocks at 3000 chars, accept non-word chars in code fence language tags.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
