### PR TITLE
Fix feedback on PR #12388: interaction dedup + thread fixes

### DIFF
--- a/assistant/src/memory/conversation-attention-store.ts
+++ b/assistant/src/memory/conversation-attention-store.ts
@@ -23,7 +23,9 @@ export type SignalType =
   | "macos_notification_view"
   | "macos_conversation_opened"
   | "telegram_inbound_message"
-  | "telegram_callback";
+  | "telegram_callback"
+  | "slack_inbound_message"
+  | "slack_callback";
 
 export type Confidence = "explicit" | "inferred";
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -13,7 +13,10 @@ import {
 import type { TrustContext } from "../../daemon/session-runtime-assembly.js";
 import * as attachmentsStore from "../../memory/attachments-store.js";
 import * as channelDeliveryStore from "../../memory/channel-delivery-store.js";
-import { recordConversationSeenSignal } from "../../memory/conversation-attention-store.js";
+import {
+  recordConversationSeenSignal,
+  type SignalType,
+} from "../../memory/conversation-attention-store.js";
 import * as externalConversationStore from "../../memory/external-conversation-store.js";
 import { canonicalizeInboundIdentity } from "../../util/canonicalize-identity.js";
 import { getLogger } from "../../util/logger.js";
@@ -458,8 +461,8 @@ export async function handleChannelInbound(
     });
 
     if (approvalResult.handled) {
-      // Record inferred seen signal for all handled Telegram approval interactions
-      if (sourceChannel === "telegram") {
+      // Record inferred seen signal for handled approval interactions
+      if (sourceChannel === "telegram" || sourceChannel === "slack") {
         try {
           if (hasCallbackData) {
             const cbPreview =
@@ -469,9 +472,9 @@ export async function handleChannelInbound(
             recordConversationSeenSignal({
               conversationId: result.conversationId,
               assistantId: canonicalAssistantId,
-              signalType: "telegram_callback",
+              signalType: `${sourceChannel}_callback` as SignalType,
               confidence: "inferred",
-              sourceChannel: "telegram",
+              sourceChannel,
               source: "inbound-message-handler",
               evidenceText: `User tapped callback: '${cbPreview}'`,
             });
@@ -483,9 +486,9 @@ export async function handleChannelInbound(
             recordConversationSeenSignal({
               conversationId: result.conversationId,
               assistantId: canonicalAssistantId,
-              signalType: "telegram_inbound_message",
+              signalType: `${sourceChannel}_inbound_message` as SignalType,
               confidence: "inferred",
-              sourceChannel: "telegram",
+              sourceChannel,
               source: "inbound-message-handler",
               evidenceText: `User sent plain-text approval reply: '${msgPreview}'`,
             });
@@ -493,7 +496,7 @@ export async function handleChannelInbound(
         } catch (err) {
           log.warn(
             { err, conversationId: result.conversationId },
-            "Failed to record seen signal for Telegram approval interaction",
+            "Failed to record seen signal for approval interaction",
           );
         }
       }
@@ -513,7 +516,7 @@ export async function handleChannelInbound(
     // so checking for empty content alone would miss stale callbacks.
     if (hasCallbackData) {
       // Record seen signal even for stale callbacks — the user still interacted
-      if (sourceChannel === "telegram") {
+      if (sourceChannel === "telegram" || sourceChannel === "slack") {
         try {
           const cbPreview =
             body.callbackData!.length > 80
@@ -522,16 +525,16 @@ export async function handleChannelInbound(
           recordConversationSeenSignal({
             conversationId: result.conversationId,
             assistantId: canonicalAssistantId,
-            signalType: "telegram_callback",
+            signalType: `${sourceChannel}_callback` as SignalType,
             confidence: "inferred",
-            sourceChannel: "telegram",
+            sourceChannel,
             source: "inbound-message-handler",
             evidenceText: `User tapped stale callback: '${cbPreview}'`,
           });
         } catch (err) {
           log.warn(
             { err, conversationId: result.conversationId },
-            "Failed to record seen signal for stale Telegram callback",
+            "Failed to record seen signal for stale callback",
           );
         }
       }

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -90,6 +90,31 @@ describe("normalizeSlackBlockActions", () => {
     expect(result!.threadTs).toBe("1234567890.123456");
   });
 
+  it("uses thread root timestamp when message is a threaded reply", () => {
+    const config = makeConfig();
+    const payload = makeBlockActionsPayload();
+    // Simulate a button click on a message that lives inside a thread
+    payload.message = {
+      ts: "1234567890.999999",
+      thread_ts: "1234567890.000001",
+      text: "Choose an option",
+    };
+    const result = normalizeSlackBlockActions(payload, "env-thread", config);
+
+    expect(result).not.toBeNull();
+    // threadTs should be the thread root, not the clicked message's ts
+    expect(result!.threadTs).toBe("1234567890.000001");
+  });
+
+  it("falls back to message ts when no thread_ts is present", () => {
+    const config = makeConfig();
+    const payload = makeBlockActionsPayload();
+    const result = normalizeSlackBlockActions(payload, "env-no-thread", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.threadTs).toBe("1234567890.123456");
+  });
+
   it("generates unique externalMessageId per click via action_ts", () => {
     const config = makeConfig();
     const payload1 = makeBlockActionsPayload();

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -431,7 +431,7 @@ export interface SlackBlockActionsPayload {
   trigger_id: string;
   user: { id: string; username?: string; name?: string };
   channel?: { id: string; name?: string };
-  message?: { ts: string; text?: string };
+  message?: { ts: string; thread_ts?: string; text?: string };
   actions: Array<{
     action_id: string;
     value?: string;
@@ -515,7 +515,9 @@ export function normalizeSlackBlockActions(
       raw: payload as unknown as Record<string, unknown>,
     },
     routing,
-    threadTs: messageTs ?? envelopeId,
+    // Prefer the thread root so follow-up messages land in the original
+    // conversation thread, not a reply's sub-thread.
+    threadTs: payload.message?.thread_ts ?? messageTs ?? envelopeId,
     channel: channelId,
   };
 }

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -231,7 +231,7 @@ export class SlackSocketModeClient {
         trigger_id?: string;
         user?: { id: string; username?: string; name?: string };
         channel?: { id: string; name?: string };
-        message?: { ts: string; text?: string };
+        message?: { ts: string; thread_ts?: string; text?: string };
         actions?: SlackBlockActionsPayload["actions"];
       };
       reason?: string;


### PR DESCRIPTION
Address Codex+Devin review on PR #12388:

- Include actor ID in interactive dedup key (P1): already resolved on main via action_ts-based externalMessageId
- Use thread root for interactive events (P2): prefer message.thread_ts over message.ts for threadTs in normalizeSlackBlockActions
- Extend SignalType union (Devin): add slack_callback and slack_inbound_message to SignalType, generalize seen-signal recording to support Slack channel
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
