### PR TITLE
Fix feedback on PR #12393: interactive routing + dedup

### DIFF
--- a/assistant/src/__tests__/channel-approval.test.ts
+++ b/assistant/src/__tests__/channel-approval.test.ts
@@ -229,6 +229,14 @@ describe("parseCallbackData", () => {
     expect(result!.source).toBe("whatsapp_button");
   });
 
+  test("parses slack source channel", () => {
+    const result = parseCallbackData("apr:req-789:approve_once", "slack");
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe("approve_once");
+    expect(result!.requestId).toBe("req-789");
+    expect(result!.source).toBe("slack_button");
+  });
+
   test("returns null for unknown action", () => {
     expect(parseCallbackData("apr:req-123:unknown_action")).toBeNull();
   });

--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -478,8 +478,11 @@ describe("channelSupportsRichApprovalUI", () => {
     expect(channelSupportsRichApprovalUI("sms")).toBe(false);
   });
 
+  test("returns true for slack", () => {
+    expect(channelSupportsRichApprovalUI("slack")).toBe(true);
+  });
+
   test("returns false for unknown channels", () => {
-    expect(channelSupportsRichApprovalUI("slack")).toBe(false);
     expect(channelSupportsRichApprovalUI("")).toBe(false);
   });
 });

--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -234,6 +234,41 @@ describe("buildApprovalUIMetadata", () => {
     expect(metadata.requestId).toBe("req-abc");
     expect(metadata.actions).toEqual(prompt.actions);
     expect(metadata.plainTextFallback).toBe("Reply yes or no.");
+    expect(metadata.permissionDetails).toEqual({
+      toolName: "shell",
+      riskLevel: "low",
+      toolInput: { command: "ls" },
+    });
+  });
+
+  test("includes requesterIdentifier in permissionDetails when provided", () => {
+    const prompt: ChannelApprovalPrompt = {
+      promptText: "Allow deploy?",
+      actions: [
+        { id: "approve_once", label: "Approve once" },
+        { id: "reject", label: "Reject" },
+      ],
+      plainTextFallback: "Reply yes or no.",
+    };
+
+    const approvalInfo: PendingApprovalInfo = {
+      requestId: "req-guard",
+      toolName: "deploy",
+      input: { target: "prod" },
+      riskLevel: "high",
+    };
+
+    const metadata = buildApprovalUIMetadata(
+      prompt,
+      approvalInfo,
+      "alice@example.com",
+    );
+    expect(metadata.permissionDetails).toEqual({
+      toolName: "deploy",
+      riskLevel: "high",
+      toolInput: { target: "prod" },
+      requesterIdentifier: "alice@example.com",
+    });
   });
 });
 

--- a/assistant/src/runtime/channel-approval-types.ts
+++ b/assistant/src/runtime/channel-approval-types.ts
@@ -79,6 +79,7 @@ export interface ApprovalUIMetadata {
 export type ApprovalDecisionSource =
   | "telegram_button"
   | "whatsapp_button"
+  | "slack_button"
   | "plain_text";
 
 /** The structured result of a user's approval decision. */

--- a/assistant/src/runtime/channel-approval-types.ts
+++ b/assistant/src/runtime/channel-approval-types.ts
@@ -61,6 +61,20 @@ export interface ChannelApprovalPrompt {
 // ---------------------------------------------------------------------------
 
 /**
+ * Tool-permission-specific details carried alongside the approval payload.
+ * Channels that support rich UI (e.g. Slack Block Kit) use these fields
+ * to render a detailed permission request card with risk indicators,
+ * tool arguments, and requester identity.
+ */
+export interface PermissionRequestDetails {
+  toolName: string;
+  riskLevel: string;
+  toolInput: Record<string, unknown>;
+  /** Present for guardian-escalated requests to identify who is asking. */
+  requesterIdentifier?: string;
+}
+
+/**
  * Metadata attached to gateway callback payloads so the channel adapter
  * can render approval UI and route the user's decision back to the
  * correct pending interaction.
@@ -69,6 +83,8 @@ export interface ApprovalUIMetadata {
   requestId: string;
   actions: ApprovalActionOption[];
   plainTextFallback: string;
+  /** When present, the approval is a tool permission request with extra context. */
+  permissionDetails?: PermissionRequestDetails;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -112,11 +112,18 @@ function buildPromptFromApprovalInfo(
 export function buildApprovalUIMetadata(
   prompt: ChannelApprovalPrompt,
   info: PendingApprovalInfo,
+  requesterIdentifier?: string,
 ): ApprovalUIMetadata {
   return {
     requestId: info.requestId,
     actions: prompt.actions,
     plainTextFallback: prompt.plainTextFallback,
+    permissionDetails: {
+      toolName: info.toolName,
+      riskLevel: info.riskLevel,
+      toolInput: info.input,
+      ...(requesterIdentifier ? { requesterIdentifier } : {}),
+    },
   };
 }
 

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -273,6 +273,7 @@ export function buildGuardianApprovalPrompt(
 const RICH_APPROVAL_CHANNELS: ReadonlySet<string> = new Set([
   "telegram",
   "whatsapp",
+  "slack",
 ]);
 
 /**

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -64,7 +64,9 @@ export function parseCallbackData(
   const source =
     sourceChannel === "whatsapp"
       ? ("whatsapp_button" as const)
-      : ("telegram_button" as const);
+      : sourceChannel === "slack"
+        ? ("slack_button" as const)
+        : ("telegram_button" as const);
   return { action: action as ApprovalAction, source, requestId };
 }
 

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -458,8 +458,8 @@ export async function handleChannelInbound(
     });
 
     if (approvalResult.handled) {
-      // Record inferred seen signal for all handled Telegram approval interactions
-      if (sourceChannel === "telegram") {
+      // Record inferred seen signal for handled approval interactions
+      if (sourceChannel === "telegram" || sourceChannel === "slack") {
         try {
           if (hasCallbackData) {
             const cbPreview =
@@ -469,9 +469,9 @@ export async function handleChannelInbound(
             recordConversationSeenSignal({
               conversationId: result.conversationId,
               assistantId: canonicalAssistantId,
-              signalType: "telegram_callback",
+              signalType: `${sourceChannel}_callback`,
               confidence: "inferred",
-              sourceChannel: "telegram",
+              sourceChannel,
               source: "inbound-message-handler",
               evidenceText: `User tapped callback: '${cbPreview}'`,
             });
@@ -483,9 +483,9 @@ export async function handleChannelInbound(
             recordConversationSeenSignal({
               conversationId: result.conversationId,
               assistantId: canonicalAssistantId,
-              signalType: "telegram_inbound_message",
+              signalType: `${sourceChannel}_inbound_message`,
               confidence: "inferred",
-              sourceChannel: "telegram",
+              sourceChannel,
               source: "inbound-message-handler",
               evidenceText: `User sent plain-text approval reply: '${msgPreview}'`,
             });
@@ -493,7 +493,7 @@ export async function handleChannelInbound(
         } catch (err) {
           log.warn(
             { err, conversationId: result.conversationId },
-            "Failed to record seen signal for Telegram approval interaction",
+            "Failed to record seen signal for approval interaction",
           );
         }
       }
@@ -513,7 +513,7 @@ export async function handleChannelInbound(
     // so checking for empty content alone would miss stale callbacks.
     if (hasCallbackData) {
       // Record seen signal even for stale callbacks — the user still interacted
-      if (sourceChannel === "telegram") {
+      if (sourceChannel === "telegram" || sourceChannel === "slack") {
         try {
           const cbPreview =
             body.callbackData!.length > 80
@@ -522,16 +522,16 @@ export async function handleChannelInbound(
           recordConversationSeenSignal({
             conversationId: result.conversationId,
             assistantId: canonicalAssistantId,
-            signalType: "telegram_callback",
+            signalType: `${sourceChannel}_callback`,
             confidence: "inferred",
-            sourceChannel: "telegram",
+            sourceChannel,
             source: "inbound-message-handler",
             evidenceText: `User tapped stale callback: '${cbPreview}'`,
           });
         } catch (err) {
           log.warn(
             { err, conversationId: result.conversationId },
-            "Failed to record seen signal for stale Telegram callback",
+            "Failed to record seen signal for stale callback",
           );
         }
       }

--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -17,6 +17,7 @@ const {
   createSlackDeliverHandler,
   buildApprovalBlocks,
   buildDecisionResultBlocks,
+  buildSlackPermissionRequestBlocks,
 } = await import("../http/routes/slack-deliver.js");
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
@@ -465,5 +466,238 @@ describe("buildDecisionResultBlocks", () => {
     expect((blocks[0].text as any).text).toBe("Allow shell?");
     expect(blocks[1].type).toBe("context");
     expect((blocks[1].elements as any[])[0].text).toBe("Approved by user");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Permission request Block Kit builder unit tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("buildSlackPermissionRequestBlocks", () => {
+  test("renders header, tool info, arguments, context, and actions blocks", () => {
+    const blocks = buildSlackPermissionRequestBlocks("Allow shell?", {
+      requestId: "req-perm-1",
+      actions: [
+        { id: "approve_once", label: "Approve once" },
+        { id: "reject", label: "Reject" },
+      ],
+      plainTextFallback: "Reply yes or no.",
+      permissionDetails: {
+        toolName: "shell",
+        riskLevel: "high",
+        toolInput: { command: "rm -rf /tmp/test" },
+      },
+    });
+
+    expect(blocks).toHaveLength(5);
+
+    // Header block
+    expect(blocks[0].type).toBe("header");
+    expect((blocks[0].text as any).text).toBe("Permission Request");
+
+    // Tool info section with risk emoji
+    expect(blocks[1].type).toBe("section");
+    const toolText = (blocks[1].text as any).text as string;
+    expect(toolText).toContain("`shell`");
+    expect(toolText).toContain("high");
+    // Red circle emoji for high risk
+    expect(toolText).toContain("\u{1F534}");
+
+    // Arguments section
+    expect(blocks[2].type).toBe("section");
+    const argsText = (blocks[2].text as any).text as string;
+    expect(argsText).toContain("*Arguments*");
+    expect(argsText).toContain("*command:*");
+    expect(argsText).toContain("`rm -rf /tmp/test`");
+
+    // Context block (no requester in this case)
+    expect(blocks[3].type).toBe("context");
+    const contextElements = blocks[3].elements as any[];
+    // Only timestamp element when no requester
+    expect(contextElements).toHaveLength(1);
+
+    // Actions block
+    expect(blocks[4].type).toBe("actions");
+    expect(blocks[4].elements as any[]).toHaveLength(2);
+    expect((blocks[4].elements as any[])[0].value).toBe(
+      "apr:req-perm-1:approve_once",
+    );
+  });
+
+  test("includes requester identifier in context block for guardian-escalated requests", () => {
+    const blocks = buildSlackPermissionRequestBlocks("Allow deploy?", {
+      requestId: "req-perm-2",
+      actions: [
+        { id: "approve_once", label: "Approve once" },
+        { id: "reject", label: "Reject" },
+      ],
+      plainTextFallback: "Reply yes or no.",
+      permissionDetails: {
+        toolName: "deploy",
+        riskLevel: "medium",
+        toolInput: { target: "production" },
+        requesterIdentifier: "alice",
+      },
+    });
+
+    // Context block should have 2 elements: requester + timestamp
+    const contextBlock = blocks.find((b) => b.type === "context") as any;
+    expect(contextBlock).toBeDefined();
+    expect(contextBlock.elements).toHaveLength(2);
+    expect(contextBlock.elements[0].text).toContain("alice");
+    expect(contextBlock.elements[0].text).toContain("Requested by");
+  });
+
+  test("uses correct risk emoji for each level", () => {
+    const riskLevels = [
+      { level: "low", emoji: "\u{1F7E2}" },
+      { level: "medium", emoji: "\u{1F7E1}" },
+      { level: "high", emoji: "\u{1F534}" },
+    ];
+
+    for (const { level, emoji } of riskLevels) {
+      const blocks = buildSlackPermissionRequestBlocks("Allow tool?", {
+        requestId: "req-risk",
+        actions: [{ id: "approve_once", label: "Approve" }],
+        plainTextFallback: "Reply yes or no.",
+        permissionDetails: {
+          toolName: "test_tool",
+          riskLevel: level,
+          toolInput: {},
+        },
+      });
+
+      const toolSection = blocks[1] as any;
+      expect(toolSection.text.text).toContain(emoji);
+    }
+  });
+
+  test("shows 'No arguments' when tool input is empty", () => {
+    const blocks = buildSlackPermissionRequestBlocks("Allow tool?", {
+      requestId: "req-empty",
+      actions: [{ id: "approve_once", label: "Approve" }],
+      plainTextFallback: "Reply yes or no.",
+      permissionDetails: {
+        toolName: "read_file",
+        riskLevel: "low",
+        toolInput: {},
+      },
+    });
+
+    const argsSection = blocks[2] as any;
+    expect(argsSection.text.text).toContain("No arguments");
+  });
+
+  test("truncates long argument values", () => {
+    const longValue = "x".repeat(300);
+    const blocks = buildSlackPermissionRequestBlocks("Allow tool?", {
+      requestId: "req-long",
+      actions: [{ id: "approve_once", label: "Approve" }],
+      plainTextFallback: "Reply yes or no.",
+      permissionDetails: {
+        toolName: "write_file",
+        riskLevel: "medium",
+        toolInput: { content: longValue },
+      },
+    });
+
+    const argsSection = blocks[2] as any;
+    const argsText = argsSection.text.text as string;
+    expect(argsText.length).toBeLessThan(longValue.length);
+    expect(argsText).toContain("...");
+  });
+
+  test("button styles match approval pattern (primary for approve, danger for reject)", () => {
+    const blocks = buildSlackPermissionRequestBlocks("Allow tool?", {
+      requestId: "req-styles",
+      actions: [
+        { id: "approve_once", label: "Approve once" },
+        { id: "approve_10m", label: "Allow 10 min" },
+        { id: "reject", label: "Reject" },
+      ],
+      plainTextFallback: "Reply yes or no.",
+      permissionDetails: {
+        toolName: "shell",
+        riskLevel: "high",
+        toolInput: {},
+      },
+    });
+
+    const actionsBlock = blocks.find((b) => b.type === "actions") as any;
+    expect(actionsBlock.elements[0].style).toBe("primary");
+    expect(actionsBlock.elements[1].style).toBeUndefined();
+    expect(actionsBlock.elements[2].style).toBe("danger");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Permission request integration tests (deliver handler)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("slack-deliver with permission details", () => {
+  test("uses rich permission blocks when permissionDetails is present in approval", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({
+      chatId: "C123",
+      text: "Allow shell?",
+      approval: {
+        requestId: "req-perm-int",
+        actions: [
+          { id: "approve_once", label: "Approve once" },
+          { id: "reject", label: "Reject" },
+        ],
+        plainTextFallback: "Reply yes or no.",
+        permissionDetails: {
+          toolName: "shell",
+          riskLevel: "high",
+          toolInput: { command: "ls -la" },
+        },
+      },
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const slackCall = fetchCalls.find((c) =>
+      c.url.includes("chat.postMessage"),
+    );
+    expect(slackCall).toBeDefined();
+    const slackBody = slackCall!.body as any;
+    expect(slackBody.blocks).toBeDefined();
+    // Rich permission blocks: header, tool info, args, context, actions = 5
+    expect(slackBody.blocks).toHaveLength(5);
+    expect(slackBody.blocks[0].type).toBe("header");
+    expect(slackBody.blocks[1].type).toBe("section");
+    expect(slackBody.blocks[4].type).toBe("actions");
+    expect(slackBody.blocks[4].elements[0].value).toBe(
+      "apr:req-perm-int:approve_once",
+    );
+  });
+
+  test("falls back to basic approval blocks when permissionDetails is absent", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({
+      chatId: "C123",
+      text: "Allow shell?",
+      approval: {
+        requestId: "req-basic",
+        actions: [
+          { id: "approve_once", label: "Approve once" },
+          { id: "reject", label: "Reject" },
+        ],
+        plainTextFallback: "Reply yes or no.",
+      },
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const slackCall = fetchCalls.find((c) =>
+      c.url.includes("chat.postMessage"),
+    );
+    expect(slackCall).toBeDefined();
+    const slackBody = slackCall!.body as any;
+    // Basic approval blocks: section + actions = 2
+    expect(slackBody.blocks).toHaveLength(2);
+    expect(slackBody.blocks[0].type).toBe("section");
+    expect(slackBody.blocks[1].type).toBe("actions");
   });
 });

--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -13,8 +13,11 @@ mock.module("../fetch.js", () => ({
   fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
 }));
 
-const { createSlackDeliverHandler } =
-  await import("../http/routes/slack-deliver.js");
+const {
+  createSlackDeliverHandler,
+  buildApprovalBlocks,
+  buildDecisionResultBlocks,
+} = await import("../http/routes/slack-deliver.js");
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -110,6 +113,15 @@ beforeEach(() => {
 
       // Slack API response
       if (url.includes("slack.com/api/chat.postMessage")) {
+        return new Response(
+          JSON.stringify({ ok: true, ts: "1700000000.000100" }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }
+      if (url.includes("slack.com/api/chat.update")) {
         return new Response(JSON.stringify({ ok: true }), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -286,5 +298,172 @@ describe("slack-deliver endpoint", () => {
     );
     expect(slackCall).toBeDefined();
     expect((slackCall!.body as any).thread_ts).toBeUndefined();
+  });
+
+  test("sends Block Kit blocks when approval payload is present", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({
+      chatId: "C123",
+      text: "Allow shell?",
+      approval: {
+        requestId: "req-abc",
+        actions: [
+          { id: "approve_once", label: "Approve once" },
+          { id: "reject", label: "Reject" },
+        ],
+        plainTextFallback: "Reply yes or no.",
+      },
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; ts: string };
+    expect(body.ok).toBe(true);
+    expect(body.ts).toBe("1700000000.000100");
+
+    const slackCall = fetchCalls.find((c) =>
+      c.url.includes("chat.postMessage"),
+    );
+    expect(slackCall).toBeDefined();
+    const slackBody = slackCall!.body as any;
+    expect(slackBody.blocks).toBeDefined();
+    expect(slackBody.blocks).toHaveLength(2);
+    expect(slackBody.blocks[0].type).toBe("section");
+    expect(slackBody.blocks[1].type).toBe("actions");
+    expect(slackBody.blocks[1].elements).toHaveLength(2);
+    expect(slackBody.blocks[1].elements[0].value).toBe(
+      "apr:req-abc:approve_once",
+    );
+    expect(slackBody.blocks[1].elements[0].style).toBe("primary");
+    expect(slackBody.blocks[1].elements[1].value).toBe("apr:req-abc:reject");
+    expect(slackBody.blocks[1].elements[1].style).toBe("danger");
+  });
+
+  test("returns 400 when approval is present but requestId is missing", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({
+      chatId: "C123",
+      text: "Allow shell?",
+      approval: {
+        actions: [{ id: "approve_once", label: "Approve once" }],
+        plainTextFallback: "Reply yes or no.",
+      },
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("requestId");
+  });
+
+  test("returns 400 when approval actions is empty", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({
+      chatId: "C123",
+      text: "Allow shell?",
+      approval: {
+        requestId: "req-abc",
+        actions: [],
+        plainTextFallback: "Reply yes or no.",
+      },
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("non-empty array");
+  });
+
+  test("uses chat.update when updateTs is provided", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({
+      chatId: "C123",
+      text: "Allow shell?",
+      updateTs: "1700000000.000100",
+      decisionLabel: "Approved",
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+
+    const updateCall = fetchCalls.find((c) => c.url.includes("chat.update"));
+    expect(updateCall).toBeDefined();
+    const updateBody = updateCall!.body as any;
+    expect(updateBody.channel).toBe("C123");
+    expect(updateBody.ts).toBe("1700000000.000100");
+    expect(updateBody.blocks).toBeDefined();
+    // Should have a section block and a context block with the decision label
+    expect(updateBody.blocks[0].type).toBe("section");
+    expect(updateBody.blocks[1].type).toBe("context");
+    expect(updateBody.blocks[1].elements[0].text).toBe("Approved");
+  });
+
+  test("does not call chat.postMessage when updateTs is provided", async () => {
+    const handler = createSlackDeliverHandler(makeConfig());
+    const req = makeRequest({
+      chatId: "C123",
+      text: "Allow shell?",
+      updateTs: "1700000000.000100",
+    });
+    await handler(req);
+
+    const postCall = fetchCalls.find((c) => c.url.includes("chat.postMessage"));
+    expect(postCall).toBeUndefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Block Kit builder unit tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("buildApprovalBlocks", () => {
+  test("generates section and actions blocks with correct button values", () => {
+    const blocks = buildApprovalBlocks("Allow shell?", {
+      requestId: "req-123",
+      actions: [
+        { id: "approve_once", label: "Approve once" },
+        { id: "approve_10m", label: "Allow 10 min" },
+        { id: "approve_always", label: "Approve always" },
+        { id: "reject", label: "Reject" },
+      ],
+      plainTextFallback: "Reply yes or no.",
+    });
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe("section");
+    expect((blocks[0].text as any).text).toBe("Allow shell?");
+
+    const actions = blocks[1] as any;
+    expect(actions.type).toBe("actions");
+    expect(actions.block_id).toBe("approval_req-123");
+    expect(actions.elements).toHaveLength(4);
+
+    // Approve once gets primary style
+    expect(actions.elements[0].value).toBe("apr:req-123:approve_once");
+    expect(actions.elements[0].style).toBe("primary");
+    expect(actions.elements[0].text.text).toBe("Approve once");
+
+    // Approve 10m has no style override
+    expect(actions.elements[1].value).toBe("apr:req-123:approve_10m");
+    expect(actions.elements[1].style).toBeUndefined();
+
+    // Approve always has no style override
+    expect(actions.elements[2].value).toBe("apr:req-123:approve_always");
+    expect(actions.elements[2].style).toBeUndefined();
+
+    // Reject gets danger style
+    expect(actions.elements[3].value).toBe("apr:req-123:reject");
+    expect(actions.elements[3].style).toBe("danger");
+  });
+});
+
+describe("buildDecisionResultBlocks", () => {
+  test("replaces action blocks with context block showing decision", () => {
+    const blocks = buildDecisionResultBlocks(
+      "Allow shell?",
+      "Approved by user",
+    );
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].type).toBe("section");
+    expect((blocks[0].text as any).text).toBe("Allow shell?");
+    expect(blocks[1].type).toBe("context");
+    expect((blocks[1].elements as any[])[0].text).toBe("Approved by user");
   });
 });

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -10,10 +10,18 @@ export type SlackApprovalAction = {
   label: string;
 };
 
+export type SlackPermissionDetails = {
+  toolName: string;
+  riskLevel: string;
+  toolInput: Record<string, unknown>;
+  requesterIdentifier?: string;
+};
+
 export type SlackApprovalPayload = {
   requestId: string;
   actions: SlackApprovalAction[];
   plainTextFallback: string;
+  permissionDetails?: SlackPermissionDetails;
 };
 
 /**
@@ -62,6 +70,117 @@ export function buildApprovalBlocks(
       elements: buttons,
     },
   ];
+}
+
+const RISK_EMOJI: Record<string, string> = {
+  low: "\u{1F7E2}",
+  medium: "\u{1F7E1}",
+  high: "\u{1F534}",
+};
+
+/**
+ * Format tool arguments as mrkdwn key-value pairs for display in a
+ * Block Kit section. Truncates long values to keep the message readable.
+ */
+function formatToolInput(input: Record<string, unknown>): string {
+  const entries = Object.entries(input);
+  if (entries.length === 0) return "_No arguments_";
+  return entries
+    .map(([key, value]) => {
+      const str =
+        typeof value === "string" ? value : (JSON.stringify(value) ?? "");
+      const truncated = str.length > 200 ? str.slice(0, 197) + "..." : str;
+      return `*${key}:* \`${truncated}\``;
+    })
+    .join("\n");
+}
+
+/**
+ * Build rich Block Kit blocks for a tool permission request.
+ *
+ * Renders a detailed card with:
+ * - Header block with "Permission Request" title
+ * - Section block with tool name and risk level emoji
+ * - Section block with tool arguments formatted as key-value pairs
+ * - Context block showing requester identity and timestamp
+ * - Actions block with Approve/Deny buttons (same `apr:{requestId}:{actionId}` pattern)
+ */
+export function buildSlackPermissionRequestBlocks(
+  text: string,
+  approval: SlackApprovalPayload,
+): Array<Record<string, unknown>> {
+  const details = approval.permissionDetails!;
+  const emoji = RISK_EMOJI[details.riskLevel] ?? RISK_EMOJI.medium;
+
+  const buttons = approval.actions.map((action) => {
+    const value = `apr:${approval.requestId}:${action.id}`;
+    const button: Record<string, unknown> = {
+      type: "button",
+      text: {
+        type: "plain_text",
+        text: action.label,
+        emoji: true,
+      },
+      action_id: `approval_${action.id}`,
+      value,
+    };
+    if (action.id === "approve_once") {
+      button.style = "primary";
+    } else if (action.id === "reject") {
+      button.style = "danger";
+    }
+    return button;
+  });
+
+  const blocks: Array<Record<string, unknown>> = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: "Permission Request",
+        emoji: true,
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `${emoji} *Tool:* \`${details.toolName}\`  |  *Risk:* ${details.riskLevel}`,
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Arguments*\n${formatToolInput(details.toolInput)}`,
+      },
+    },
+  ];
+
+  // Context block with requester identity and timestamp
+  const contextElements: Array<Record<string, unknown>> = [];
+  if (details.requesterIdentifier) {
+    contextElements.push({
+      type: "mrkdwn",
+      text: `*Requested by:* ${details.requesterIdentifier}`,
+    });
+  }
+  contextElements.push({
+    type: "mrkdwn",
+    text: `<!date^${Math.floor(Date.now() / 1000)}^{date_short_pretty} at {time}|${new Date().toISOString()}>`,
+  });
+  blocks.push({
+    type: "context",
+    elements: contextElements,
+  });
+
+  blocks.push({
+    type: "actions",
+    block_id: `approval_${approval.requestId}`,
+    elements: buttons,
+  });
+
+  return blocks;
 }
 
 /**
@@ -269,8 +388,11 @@ export function createSlackDeliverHandler(
       }
 
       // When an approval payload is present, render Block Kit blocks.
+      // Use the richer permission-specific layout when permission details are available.
       if (approval) {
-        slackBody.blocks = buildApprovalBlocks(text, approval);
+        slackBody.blocks = approval.permissionDetails
+          ? buildSlackPermissionRequestBlocks(text, approval)
+          : buildApprovalBlocks(text, approval);
       }
 
       const response = await fetchImpl(

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -5,6 +5,94 @@ import { checkDeliverAuth } from "../middleware/deliver-auth.js";
 
 const log = getLogger("slack-deliver");
 
+export type SlackApprovalAction = {
+  id: string;
+  label: string;
+};
+
+export type SlackApprovalPayload = {
+  requestId: string;
+  actions: SlackApprovalAction[];
+  plainTextFallback: string;
+};
+
+/**
+ * Build Block Kit blocks for an approval prompt.
+ *
+ * Produces a section block with the prompt text followed by an actions
+ * block containing buttons for each approval action. Button values
+ * encode `apr:{requestId}:{actionId}` matching the convention used by
+ * Telegram and the interactive actions handler.
+ */
+export function buildApprovalBlocks(
+  text: string,
+  approval: SlackApprovalPayload,
+): Array<Record<string, unknown>> {
+  const buttons = approval.actions.map((action) => {
+    const value = `apr:${approval.requestId}:${action.id}`;
+    const button: Record<string, unknown> = {
+      type: "button",
+      text: {
+        type: "plain_text",
+        text: action.label,
+        emoji: true,
+      },
+      action_id: `approval_${action.id}`,
+      value,
+    };
+    if (action.id === "approve_once") {
+      button.style = "primary";
+    } else if (action.id === "reject") {
+      button.style = "danger";
+    }
+    return button;
+  });
+
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text,
+      },
+    },
+    {
+      type: "actions",
+      block_id: `approval_${approval.requestId}`,
+      elements: buttons,
+    },
+  ];
+}
+
+/**
+ * Build Block Kit blocks that show the decision result after an
+ * approval has been consumed. Replaces the action buttons with a
+ * context line indicating the outcome.
+ */
+export function buildDecisionResultBlocks(
+  originalText: string,
+  decisionLabel: string,
+): Array<Record<string, unknown>> {
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: originalText,
+      },
+    },
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: decisionLabel,
+        },
+      ],
+    },
+  ];
+}
+
 export function createSlackDeliverHandler(
   config: GatewayConfig,
   onThreadReply?: (threadTs: string) => void,
@@ -38,6 +126,11 @@ export function createSlackDeliverHandler(
       text?: string;
       assistantId?: string;
       attachments?: unknown[];
+      approval?: SlackApprovalPayload;
+      /** When set, update an existing message instead of posting a new one. */
+      updateTs?: string;
+      /** Decision label used when editing the message after approval consumption. */
+      decisionLabel?: string;
     };
     try {
       body = (await req.json()) as typeof body;
@@ -67,22 +160,117 @@ export function createSlackDeliverHandler(
       return Response.json({ error: "chatId is required" }, { status: 400 });
     }
 
-    const { text } = body;
+    const { text, approval, updateTs, decisionLabel } = body;
 
     if (!text || typeof text !== "string") {
       return Response.json({ error: "text is required" }, { status: 400 });
+    }
+
+    // Validate approval payload shape when present.
+    if (approval !== undefined) {
+      if (
+        approval === null ||
+        typeof approval !== "object" ||
+        Array.isArray(approval)
+      ) {
+        return Response.json(
+          { error: "approval must be an object" },
+          { status: 400 },
+        );
+      }
+      if (!approval.requestId || typeof approval.requestId !== "string") {
+        return Response.json(
+          { error: "approval.requestId is required" },
+          { status: 400 },
+        );
+      }
+      if (!Array.isArray(approval.actions) || approval.actions.length === 0) {
+        return Response.json(
+          { error: "approval.actions must be a non-empty array" },
+          { status: 400 },
+        );
+      }
+      for (const action of approval.actions) {
+        if (
+          action === null ||
+          typeof action !== "object" ||
+          Array.isArray(action)
+        ) {
+          return Response.json(
+            { error: "each approval action must be an object" },
+            { status: 400 },
+          );
+        }
+        if (!action.id || typeof action.id !== "string") {
+          return Response.json(
+            { error: "each approval action must have an id" },
+            { status: 400 },
+          );
+        }
+        if (!action.label || typeof action.label !== "string") {
+          return Response.json(
+            { error: "each approval action must have a label" },
+            { status: 400 },
+          );
+        }
+      }
     }
 
     // Support threading via query param
     const threadTs = new URL(req.url).searchParams.get("threadTs") ?? undefined;
 
     try {
-      const slackBody: Record<string, string> = {
+      // ── Message update path (post-decision edit) ──
+      if (updateTs && typeof updateTs === "string") {
+        const blocks =
+          decisionLabel && typeof decisionLabel === "string"
+            ? buildDecisionResultBlocks(text, decisionLabel)
+            : [{ type: "section", text: { type: "mrkdwn", text } }];
+
+        const updateBody: Record<string, unknown> = {
+          channel: chatId,
+          ts: updateTs,
+          text,
+          blocks,
+        };
+
+        const response = await fetchImpl("https://slack.com/api/chat.update", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${config.slackChannelBotToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(updateBody),
+        });
+
+        const data = (await response.json()) as {
+          ok?: boolean;
+          error?: string;
+        };
+        if (!data.ok) {
+          tlog.error(
+            { chatId, updateTs, slackError: data.error },
+            "Slack chat.update API returned error",
+          );
+          return Response.json({ error: "Update failed" }, { status: 502 });
+        }
+
+        tlog.info({ chatId, updateTs }, "Slack message updated");
+        return Response.json({ ok: true });
+      }
+
+      // ── New message path ──
+      const slackBody: Record<string, unknown> = {
         channel: chatId,
         text,
       };
       if (threadTs) {
         slackBody.thread_ts = threadTs;
+      }
+
+      // When an approval payload is present, render Block Kit blocks.
+      if (approval) {
+        slackBody.blocks = buildApprovalBlocks(text, approval);
       }
 
       const response = await fetchImpl(
@@ -97,7 +285,11 @@ export function createSlackDeliverHandler(
         },
       );
 
-      const data = (await response.json()) as { ok?: boolean; error?: string };
+      const data = (await response.json()) as {
+        ok?: boolean;
+        error?: string;
+        ts?: string;
+      };
 
       if (!data.ok) {
         tlog.error(
@@ -106,18 +298,22 @@ export function createSlackDeliverHandler(
         );
         return Response.json({ error: "Delivery failed" }, { status: 502 });
       }
+
+      tlog.info(
+        { chatId, hasThreadTs: !!threadTs, hasApproval: !!approval },
+        "Slack message sent",
+      );
+
+      // Track the thread so future replies without @mention are forwarded
+      if (threadTs && onThreadReply) {
+        onThreadReply(threadTs);
+      }
+
+      // Return the message timestamp so callers can reference it for updates.
+      return Response.json({ ok: true, ts: data.ts });
     } catch (err) {
       tlog.error({ err, chatId }, "Failed to deliver Slack message");
       return Response.json({ error: "Delivery failed" }, { status: 502 });
     }
-
-    tlog.info({ chatId, hasThreadTs: !!threadTs }, "Slack message sent");
-
-    // Track the thread so future replies without @mention are forwarded
-    if (threadTs && onThreadReply) {
-      onThreadReply(threadTs);
-    }
-
-    return Response.json({ ok: true });
   };
 }

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -1,6 +1,8 @@
 import { getLogger } from "../logger.js";
 import { fetchImpl } from "../fetch.js";
 import type { GatewayConfig } from "../config.js";
+import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
+import type { RouteResult } from "../routing/types.js";
 import {
   normalizeSlackAppMention,
   normalizeSlackDirectMessage,
@@ -192,6 +194,20 @@ export class SlackSocketModeClient {
           | SlackAppMentionEvent
           | SlackDirectMessageEvent
           | SlackChannelMessageEvent;
+        // interactive envelope fields (block_actions)
+        type?: string;
+        user?: { id?: string; username?: string; name?: string };
+        channel?: { id?: string };
+        actions?: Array<{
+          action_id?: string;
+          value?: string;
+          block_id?: string;
+        }>;
+        message?: {
+          ts?: string;
+          text?: string;
+        };
+        trigger_id?: string;
       };
       reason?: string;
     };
@@ -229,6 +245,12 @@ export class SlackSocketModeClient {
       // Reconnect immediately (attempt 0 = minimal backoff)
       this.reconnectAttempt = 0;
       this.scheduleReconnect();
+      return;
+    }
+
+    // Handle interactive payloads (block_actions from approval buttons)
+    if (envelope.type === "interactive") {
+      this.handleInteractivePayload(envelope.payload);
       return;
     }
 
@@ -298,6 +320,130 @@ export class SlackSocketModeClient {
       return;
     }
 
+    this.onEvent(normalized);
+  }
+
+  /**
+   * Normalize a Slack `block_actions` interactive payload into a
+   * `NormalizedSlackEvent` with `callbackData` set, so the runtime's
+   * approval interception pipeline can parse `apr:{requestId}:{actionId}`.
+   */
+  private handleInteractivePayload(
+    payload:
+      | {
+          type?: string;
+          user?: { id?: string; username?: string; name?: string };
+          channel?: { id?: string };
+          actions?: Array<{
+            action_id?: string;
+            value?: string;
+            block_id?: string;
+          }>;
+          message?: { ts?: string; text?: string };
+          trigger_id?: string;
+        }
+      | undefined,
+  ): void {
+    if (!payload || payload.type !== "block_actions") return;
+
+    const userId = payload.user?.id;
+    const channelId = payload.channel?.id;
+    const action = payload.actions?.[0];
+    if (!userId || !channelId || !action?.value) return;
+
+    // Only process approval-related callbacks
+    const callbackData = action.value;
+    if (!callbackData.startsWith("apr:")) {
+      log.debug(
+        { callbackData, channelId },
+        "Ignoring non-approval block_actions payload",
+      );
+      return;
+    }
+
+    const messageTs = payload.message?.ts;
+
+    // Build a dedup key from the action value + message ts to prevent
+    // double-processing if Slack retries the interactive payload.
+    const dedupKey = `interactive:${callbackData}:${messageTs ?? "no-ts"}`;
+    if (this.dedupMap.has(dedupKey)) {
+      log.debug({ dedupKey }, "Duplicate interactive payload, skipping");
+      return;
+    }
+    this.dedupMap.set(dedupKey, Date.now());
+
+    const routing = resolveAssistant(
+      this.config.gatewayConfig,
+      channelId,
+      userId,
+    );
+    if (isRejection(routing)) {
+      // DMs are always directed at the bot, so fall back to default assistant
+      if (this.config.gatewayConfig.defaultAssistantId) {
+        const defaultRouting = {
+          assistantId: this.config.gatewayConfig.defaultAssistantId,
+          routeSource: "default" as const,
+        };
+        this.emitInteractiveEvent(
+          channelId,
+          userId,
+          callbackData,
+          messageTs,
+          payload,
+          defaultRouting,
+        );
+      } else {
+        log.info(
+          { channelId, userId },
+          "block_actions dropped: no route and no default assistant",
+        );
+      }
+      return;
+    }
+
+    this.emitInteractiveEvent(
+      channelId,
+      userId,
+      callbackData,
+      messageTs,
+      payload,
+      routing,
+    );
+  }
+
+  private emitInteractiveEvent(
+    channelId: string,
+    userId: string,
+    callbackData: string,
+    messageTs: string | undefined,
+    rawPayload: Record<string, unknown>,
+    routing: RouteResult,
+  ): void {
+    const eventId = `interactive:${channelId}:${Date.now()}`;
+    const normalized: NormalizedSlackEvent = {
+      event: {
+        version: "v1",
+        sourceChannel: "slack",
+        receivedAt: new Date().toISOString(),
+        message: {
+          content: callbackData,
+          conversationExternalId: channelId,
+          externalMessageId: eventId,
+          callbackData,
+        },
+        actor: {
+          actorExternalId: userId,
+        },
+        source: {
+          updateId: eventId,
+          messageId: messageTs,
+        },
+        raw: rawPayload as Record<string, unknown>,
+      },
+      routing,
+      threadTs: messageTs ?? `${channelId}:${Date.now()}`,
+      channel: channelId,
+    };
     this.onEvent(normalized);
   }
 

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -363,9 +363,10 @@ export class SlackSocketModeClient {
 
     const messageTs = payload.message?.ts;
 
-    // Build a dedup key from the action value + message ts to prevent
-    // double-processing if Slack retries the interactive payload.
-    const dedupKey = `interactive:${callbackData}:${messageTs ?? "no-ts"}`;
+    // Build a dedup key from the actor, action value, and message ts to prevent
+    // double-processing if Slack retries the interactive payload. Including userId
+    // ensures that different users clicking the same button are not collapsed.
+    const dedupKey = `interactive:${userId}:${callbackData}:${messageTs ?? "no-ts"}`;
     if (this.dedupMap.has(dedupKey)) {
       log.debug({ dedupKey }, "Duplicate interactive payload, skipping");
       return;
@@ -378,8 +379,13 @@ export class SlackSocketModeClient {
       userId,
     );
     if (isRejection(routing)) {
-      // DMs are always directed at the bot, so fall back to default assistant
-      if (this.config.gatewayConfig.defaultAssistantId) {
+      // Only fall back to the default assistant when unmappedPolicy allows it.
+      // When the policy is "reject", interactive payloads from unmapped
+      // channels/actors must be dropped to preserve routing isolation.
+      if (
+        this.config.gatewayConfig.unmappedPolicy === "default" &&
+        this.config.gatewayConfig.defaultAssistantId
+      ) {
         const defaultRouting = {
           assistantId: this.config.gatewayConfig.defaultAssistantId,
           routeSource: "default" as const,
@@ -395,7 +401,7 @@ export class SlackSocketModeClient {
       } else {
         log.info(
           { channelId, userId },
-          "block_actions dropped: no route and no default assistant",
+          "block_actions dropped: no route for channel/actor",
         );
       }
       return;


### PR DESCRIPTION
## Summary

- **Respect unmapped policy for interactive callbacks**: The fallback in `handleInteractivePayload` was routing rejected interactive payloads to `defaultAssistantId` regardless of `unmappedPolicy`. Now only falls back when `unmappedPolicy` is `"default"`, preserving routing isolation when policy is `"reject"`.
- **Include actor identity in interactive dedup key**: Added `userId` to the dedup key so identical button clicks from different users in the same message are not collapsed to one event.

Addresses Codex review feedback on PR #12393.

## Test plan

- [x] `bunx tsc --noEmit` passes in gateway
- [x] Pre-commit lint/format hooks pass
- [ ] Verify in staging: block_actions from unmapped channel are dropped when `unmappedPolicy=reject`
- [ ] Verify in staging: two different users can click the same approval button independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
