### PR TITLE
Fix feedback on PR #12395: verification dedup + template

### DIFF
--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -182,10 +182,11 @@ describe("Slack inbound trusted contact verification", () => {
     expect(json.reason).toBe("verification_challenge_sent");
     expect(json.verificationSessionId).toBeDefined();
 
-    // Verification DM was sent to the user
+    // Verification DM was sent to the user and includes the actual code
     expect(slackDmCalls.length).toBe(1);
     expect(slackDmCalls[0].userId).toBe("U0123UNKNOWN");
     expect(slackDmCalls[0].text).toContain("verification");
+    expect(slackDmCalls[0].text).toContain("your code is");
 
     // Channel reply tells user to check DMs
     expect(deliverReplyCalls.length).toBe(1);
@@ -255,6 +256,42 @@ describe("Slack inbound trusted contact verification", () => {
 
     // No additional DM was sent
     expect(slackDmCalls.length).toBe(1);
+  });
+
+  test("different Slack user is not suppressed by existing session for another user", async () => {
+    // First message from user A creates a session
+    const req1 = buildSlackInboundRequest({
+      actorExternalId: "U_USER_A",
+      actorDisplayName: "User A",
+    });
+    const resp1 = await handleChannelInbound(
+      req1,
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    const json1 = (await resp1.json()) as Record<string, unknown>;
+    expect(json1.reason).toBe("verification_challenge_sent");
+    expect(slackDmCalls.length).toBe(1);
+    expect(slackDmCalls[0].userId).toBe("U_USER_A");
+
+    // Second message from user B — should get their own challenge
+    const req2 = buildSlackInboundRequest({
+      actorExternalId: "U_USER_B",
+      actorDisplayName: "User B",
+      externalMessageId: `msg-${Date.now()}-user-b`,
+    });
+    const resp2 = await handleChannelInbound(
+      req2,
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    const json2 = (await resp2.json()) as Record<string, unknown>;
+    expect(json2.reason).toBe("verification_challenge_sent");
+    expect(json2.verificationSessionId).toBeDefined();
+
+    // A second DM was sent — to user B
+    expect(slackDmCalls.length).toBe(2);
+    expect(slackDmCalls[1].userId).toBe("U_USER_B");
   });
 
   test("non-Slack channels still use standard access request flow", async () => {

--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Tests for Slack inbound trusted contact verification.
+ *
+ * When an unknown Slack user messages the bot, the system should:
+ * 1. Create an outbound verification session bound to the user's identity
+ * 2. Send the verification code to the user's DM via the gateway
+ * 3. Reply in the original channel telling the user to check their DMs
+ * 4. Notify the guardian of the access attempt
+ * 5. When the user replies with the code in the DM, verify and activate
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Test isolation: in-memory SQLite via temp directory
+// ---------------------------------------------------------------------------
+
+const testDir = mkdtempSync(join(tmpdir(), "slack-inbound-verification-test-"));
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getSocketPath: () => join(testDir, "test.sock"),
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+  readHttpToken: () => "test-bearer-token",
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../security/secret-ingress.js", () => ({
+  checkIngressForSecrets: () => ({ blocked: false }),
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+}));
+
+// Track emitNotificationSignal calls
+const emitSignalCalls: Array<Record<string, unknown>> = [];
+mock.module("../notifications/emit-signal.js", () => ({
+  emitNotificationSignal: async (params: Record<string, unknown>) => {
+    emitSignalCalls.push(params);
+    return {
+      signalId: "mock-signal-id",
+      deduplicated: false,
+      dispatched: true,
+      reason: "mock",
+      deliveryResults: [],
+    };
+  },
+}));
+
+// Track deliverChannelReply calls
+const deliverReplyCalls: Array<{
+  url: string;
+  payload: Record<string, unknown>;
+}> = [];
+mock.module("../runtime/gateway-client.js", () => ({
+  deliverChannelReply: async (
+    url: string,
+    payload: Record<string, unknown>,
+  ) => {
+    deliverReplyCalls.push({ url, payload });
+  },
+}));
+
+// Track Slack verification DM sends
+const slackDmCalls: Array<{
+  userId: string;
+  text: string;
+  assistantId: string;
+}> = [];
+mock.module(
+  "../runtime/routes/inbound-stages/slack-verification-challenge.js",
+  () => ({
+    sendSlackVerificationDm: (
+      userId: string,
+      text: string,
+      assistantId: string,
+    ) => {
+      slackDmCalls.push({ userId, text, assistantId });
+    },
+  }),
+);
+
+import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { findActiveSession } from "../runtime/channel-guardian-service.js";
+import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_BEARER_TOKEN = "test-token";
+
+function resetState(): void {
+  const db = getDb();
+  db.run("DELETE FROM channel_guardian_approval_requests");
+  db.run("DELETE FROM channel_guardian_verification_challenges");
+  db.run("DELETE FROM channel_guardian_rate_limits");
+  db.run("DELETE FROM channel_inbound_events");
+  db.run("DELETE FROM conversations");
+  db.run("DELETE FROM notification_events");
+  db.run("DELETE FROM canonical_guardian_requests");
+  db.run("DELETE FROM canonical_guardian_deliveries");
+  db.run("DELETE FROM contact_channels");
+  db.run("DELETE FROM contacts");
+  emitSignalCalls.length = 0;
+  deliverReplyCalls.length = 0;
+  slackDmCalls.length = 0;
+}
+
+function buildSlackInboundRequest(
+  overrides: Record<string, unknown> = {},
+): Request {
+  const body: Record<string, unknown> = {
+    sourceChannel: "slack",
+    interface: "slack",
+    conversationExternalId: "C0123CHANNEL",
+    externalMessageId: `msg-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}`,
+    content: "Hello, can I use this assistant?",
+    actorExternalId: "U0123UNKNOWN",
+    actorDisplayName: "Alice Unknown",
+    actorUsername: "alice_unknown",
+    replyCallbackUrl: "http://localhost:7830/deliver/slack",
+    ...overrides,
+  };
+
+  return new Request("http://localhost:8080/channels/inbound", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Gateway-Origin": TEST_BEARER_TOKEN,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Slack inbound trusted contact verification", () => {
+  beforeEach(() => {
+    resetState();
+  });
+
+  test("unknown Slack user receives verification challenge via DM", async () => {
+    const req = buildSlackInboundRequest();
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = (await resp.json()) as Record<string, unknown>;
+
+    expect(json.denied).toBe(true);
+    expect(json.reason).toBe("verification_challenge_sent");
+    expect(json.verificationSessionId).toBeDefined();
+
+    // Verification DM was sent to the user
+    expect(slackDmCalls.length).toBe(1);
+    expect(slackDmCalls[0].userId).toBe("U0123UNKNOWN");
+    expect(slackDmCalls[0].text).toContain("verification");
+
+    // Channel reply tells user to check DMs
+    expect(deliverReplyCalls.length).toBe(1);
+    expect(
+      (deliverReplyCalls[0].payload as Record<string, unknown>).text,
+    ).toContain("verification code via DM");
+  });
+
+  test("verification session is identity-bound to the Slack user", async () => {
+    const req = buildSlackInboundRequest();
+    await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+
+    // An active outbound session should exist for the slack channel
+    const session = findActiveSession("self", "slack");
+    expect(session).not.toBeNull();
+    expect(session!.expectedExternalUserId).toBe("U0123UNKNOWN");
+    expect(session!.expectedChatId).toBe("U0123UNKNOWN");
+    expect(session!.identityBindingStatus).toBe("bound");
+    expect(session!.verificationPurpose).toBe("trusted_contact");
+  });
+
+  test("guardian is notified of the access attempt alongside verification", async () => {
+    // Set up a guardian binding so the notification can target it
+    createGuardianBindingContactsFirst({
+      assistantId: "self",
+      channel: "slack",
+      guardianExternalUserId: "U_GUARDIAN",
+      guardianDeliveryChatId: "D_GUARDIAN_DM",
+      guardianPrincipalId: "guardian-principal",
+      verifiedVia: "test",
+    });
+
+    const req = buildSlackInboundRequest();
+    await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+
+    // Guardian should have been notified
+    expect(emitSignalCalls.length).toBe(1);
+    expect(emitSignalCalls[0].sourceEventName).toBe("ingress.access_request");
+    expect(emitSignalCalls[0].sourceChannel).toBe("slack");
+  });
+
+  test("duplicate challenge is not sent when session already exists", async () => {
+    // First message creates the session
+    const req1 = buildSlackInboundRequest();
+    const resp1 = await handleChannelInbound(
+      req1,
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    const json1 = (await resp1.json()) as Record<string, unknown>;
+    expect(json1.reason).toBe("verification_challenge_sent");
+    expect(slackDmCalls.length).toBe(1);
+
+    // Second message from the same user — session already exists, so
+    // falls through to standard deny path
+    const req2 = buildSlackInboundRequest({
+      externalMessageId: `msg-${Date.now()}-second`,
+    });
+    const resp2 = await handleChannelInbound(
+      req2,
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    const json2 = (await resp2.json()) as Record<string, unknown>;
+    expect(json2.denied).toBe(true);
+    expect(json2.reason).toBe("not_a_member");
+
+    // No additional DM was sent
+    expect(slackDmCalls.length).toBe(1);
+  });
+
+  test("non-Slack channels still use standard access request flow", async () => {
+    const req = buildSlackInboundRequest({
+      sourceChannel: "telegram",
+      interface: "telegram",
+      replyCallbackUrl: "http://localhost:7830/deliver/telegram",
+    });
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = (await resp.json()) as Record<string, unknown>;
+
+    // Standard deny path — no verification challenge
+    expect(json.denied).toBe(true);
+    expect(json.reason).toBe("not_a_member");
+
+    // No Slack DM was sent
+    expect(slackDmCalls.length).toBe(0);
+  });
+
+  test("user can verify by replying with the code in the DM", async () => {
+    // Step 1: Unknown user sends a message, gets verification challenge
+    const req = buildSlackInboundRequest();
+    await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+
+    const session = findActiveSession("self", "slack");
+    expect(session).not.toBeNull();
+
+    // The challenge hash is stored in the session — extract the secret
+    // from the DM text sent to the user. The code is embedded in the
+    // template text. Since we're using a 6-digit code for identity-bound
+    // sessions, extract it from the session's challengeHash by consuming
+    // the challenge directly.
+    // The session was created with createOutboundSession which generates
+    // a 6-digit code. We can validate by calling validateAndConsumeChallenge
+    // with the correct secret. Since the mock captures the DM text, we
+    // can extract the code indirectly. But for testing, we just verify
+    // the session properties and that validateAndConsumeChallenge works
+    // with the correct identity.
+
+    // The actual secret was sent in the DM. For this test, let's use the
+    // session directly via the channel-guardian-service to verify the
+    // consume path works.
+    // The DM text contains the verification code implicitly (it's in the
+    // template message). Since we need to test the full round-trip, let's
+    // verify via the inbound handler by sending the code as a message.
+
+    // Extract the session's challenge hash and verify that submitting the
+    // correct code works. We create a fresh session with a known secret for
+    // this part of the test.
+    resetState();
+
+    // Create a verification session manually to test the consume path
+    const { createOutboundSession } =
+      await import("../runtime/channel-guardian-service.js");
+
+    const outboundSession = createOutboundSession({
+      assistantId: "self",
+      channel: "slack",
+      expectedExternalUserId: "U0123UNKNOWN",
+      expectedChatId: "U0123UNKNOWN",
+      identityBindingStatus: "bound",
+      destinationAddress: "U0123UNKNOWN",
+      verificationPurpose: "trusted_contact",
+    });
+
+    // User replies with the code in the DM
+    const verifyReq = buildSlackInboundRequest({
+      conversationExternalId: "U0123UNKNOWN",
+      content: outboundSession.secret,
+      externalMessageId: `msg-verify-${Date.now()}`,
+    });
+    const verifyResp = await handleChannelInbound(
+      verifyReq,
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    const verifyJson = (await verifyResp.json()) as Record<string, unknown>;
+
+    expect(verifyJson.accepted).toBe(true);
+    expect(verifyJson.guardianVerification).toBe("verified");
+  });
+});

--- a/assistant/src/runtime/guardian-verification-templates.ts
+++ b/assistant/src/runtime/guardian-verification-templates.ts
@@ -25,6 +25,11 @@ export const GUARDIAN_VERIFY_TEMPLATE_KEYS = {
   SLACK_CHALLENGE_REQUEST: "guardian_verify.slack.challenge_request",
   /** Resend Slack DM verification prompt. */
   SLACK_RESEND: "guardian_verify.slack.resend",
+  /** Slack DM verification for inbound trusted contact (includes the code). */
+  SLACK_TRUSTED_CONTACT_CHALLENGE:
+    "guardian_verify.slack.trusted_contact_challenge",
+  /** Resend Slack DM verification for inbound trusted contact (includes the code). */
+  SLACK_TRUSTED_CONTACT_RESEND: "guardian_verify.slack.trusted_contact_resend",
   /** Outbound voice call intro prompt: asks guardian to enter verification code via keypad. */
   VOICE_CALL_INTRO: "guardian_verify.voice.call_intro",
   /** Voice retry prompt after an incorrect code entry. */
@@ -55,7 +60,9 @@ type TextVerifyTemplateKey =
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_RESEND
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_CHALLENGE_REQUEST
-  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_RESEND;
+  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_RESEND
+  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_TRUSTED_CONTACT_CHALLENGE
+  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_TRUSTED_CONTACT_RESEND;
 
 /** Template keys for deterministic channel verification reply messages. */
 export type ChannelVerifyReplyTemplateKey =
@@ -118,6 +125,14 @@ const templates: Record<
 
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_RESEND]: (_vars) => {
     return "Vellum assistant guardian verification requested. Reply with the 6-digit code you were given. (resent)";
+  },
+
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_TRUSTED_CONTACT_CHALLENGE]: (vars) => {
+    return `Vellum assistant verification: your code is ${vars.code}. Reply with this code to verify your identity. It expires in ${vars.expiresInMinutes} minutes.`;
+  },
+
+  [GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_TRUSTED_CONTACT_RESEND]: (vars) => {
+    return `Vellum assistant verification: your code is ${vars.code}. Reply with this code to verify your identity. It expires in ${vars.expiresInMinutes} minutes. (resent)`;
   },
 };
 

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -15,14 +15,20 @@ import * as channelDeliveryStore from "../../../memory/channel-delivery-store.js
 import { getLogger } from "../../../util/logger.js";
 import { notifyGuardianOfAccessRequest } from "../../access-request-helper.js";
 import {
+  createOutboundSession,
   findActiveSession,
   getPendingChallenge,
   resolveBootstrapToken,
 } from "../../channel-guardian-service.js";
 import { getTransport } from "../../channel-invite-transport.js";
 import { deliverChannelReply } from "../../gateway-client.js";
+import {
+  composeVerificationSlack,
+  GUARDIAN_VERIFY_TEMPLATE_KEYS,
+} from "../../guardian-verification-templates.js";
 import { redeemInvite } from "../../invite-redemption-service.js";
 import { getInviteRedemptionReply } from "../../invite-redemption-templates.js";
+import { sendSlackVerificationDm } from "./slack-verification-challenge.js";
 
 const log = getLogger("runtime-http");
 
@@ -240,6 +246,70 @@ export async function enforceIngressAcl(
           "Ingress ACL: no member record, denying",
         );
 
+        // Slack-specific: send a verification challenge directly to the
+        // user's DM instead of requiring guardian-mediated approval. The
+        // user can reply with the code in the DM to self-verify.
+        if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
+          const slackVerifyResult = initiateSlackVerificationChallenge({
+            canonicalAssistantId,
+            sourceChannel,
+            conversationExternalId,
+            senderUserId: (canonicalSenderId ?? rawSenderId)!,
+            replyCallbackUrl,
+            mintBearerToken,
+            assistantId,
+          });
+
+          if (slackVerifyResult.initiated) {
+            // Still notify the guardian about the access attempt
+            try {
+              notifyGuardianOfAccessRequest({
+                canonicalAssistantId,
+                sourceChannel,
+                conversationExternalId,
+                actorExternalId: canonicalSenderId ?? rawSenderId,
+                actorDisplayName,
+                actorUsername,
+              });
+            } catch (err) {
+              log.error(
+                { err, sourceChannel, conversationExternalId },
+                "Failed to notify guardian of access request (Slack verification)",
+              );
+            }
+
+            if (replyCallbackUrl) {
+              try {
+                await deliverChannelReply(
+                  replyCallbackUrl,
+                  {
+                    chatId: conversationExternalId,
+                    text: "I've sent you a verification code via DM. Please reply with the code there to verify your identity.",
+                    assistantId,
+                  },
+                  mintBearerToken(),
+                );
+              } catch (err) {
+                log.error(
+                  { err, conversationExternalId },
+                  "Failed to deliver Slack verification prompt reply",
+                );
+              }
+            }
+
+            return {
+              resolvedMember: null,
+              earlyResponse: Response.json({
+                accepted: true,
+                denied: true,
+                reason: "verification_challenge_sent",
+                verificationSessionId: slackVerifyResult.sessionId,
+              }),
+              guardianVerifyCode,
+            };
+          }
+        }
+
         // Notify the guardian about the access request so they can approve/deny.
         // Uses the shared helper which handles guardian binding lookup,
         // deduplication, canonical request creation, and notification emission.
@@ -385,6 +455,74 @@ export async function enforceIngressAcl(
             },
             "Ingress ACL: member not active, denying",
           );
+
+          // Slack-specific: re-verify inactive members via DM challenge
+          // (same as non-member path). Blocked members are excluded —
+          // the guardian made an explicit decision to block them.
+          if (
+            sourceChannel === "slack" &&
+            resolvedMember.status !== "blocked" &&
+            (canonicalSenderId ?? rawSenderId)
+          ) {
+            const slackVerifyResult = initiateSlackVerificationChallenge({
+              canonicalAssistantId,
+              sourceChannel,
+              conversationExternalId,
+              senderUserId: (canonicalSenderId ?? rawSenderId)!,
+              replyCallbackUrl,
+              mintBearerToken,
+              assistantId,
+            });
+
+            if (slackVerifyResult.initiated) {
+              try {
+                notifyGuardianOfAccessRequest({
+                  canonicalAssistantId,
+                  sourceChannel,
+                  conversationExternalId,
+                  actorExternalId: canonicalSenderId ?? rawSenderId,
+                  actorDisplayName,
+                  actorUsername,
+                  previousMemberStatus: resolvedMember.status,
+                });
+              } catch (err) {
+                log.error(
+                  { err, sourceChannel, conversationExternalId },
+                  "Failed to notify guardian of access request (Slack verification, inactive member)",
+                );
+              }
+
+              if (replyCallbackUrl) {
+                try {
+                  await deliverChannelReply(
+                    replyCallbackUrl,
+                    {
+                      chatId: conversationExternalId,
+                      text: "I've sent you a verification code via DM. Please reply with the code there to verify your identity.",
+                      assistantId,
+                    },
+                    mintBearerToken(),
+                  );
+                } catch (err) {
+                  log.error(
+                    { err, conversationExternalId },
+                    "Failed to deliver Slack verification prompt reply (inactive member)",
+                  );
+                }
+              }
+
+              return {
+                resolvedMember,
+                earlyResponse: Response.json({
+                  accepted: true,
+                  denied: true,
+                  reason: "verification_challenge_sent",
+                  verificationSessionId: slackVerifyResult.sessionId,
+                }),
+                guardianVerifyCode,
+              };
+            }
+          }
 
           // For revoked/pending members, notify the guardian so they can
           // re-approve. Blocked members are intentionally excluded — the
@@ -635,4 +773,91 @@ async function handleInviteTokenIntercept(params: {
     denied: true,
     inviteRedemption: outcome.reason,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Slack verification challenge
+// ---------------------------------------------------------------------------
+
+interface SlackVerificationResult {
+  initiated: boolean;
+  sessionId?: string;
+}
+
+/**
+ * Create an outbound verification session for a Slack user and send the
+ * verification code to their DM. The session is identity-bound with
+ * `verificationPurpose: "trusted_contact"` so consuming the code
+ * creates a trusted contact record (not a guardian binding).
+ */
+function initiateSlackVerificationChallenge(params: {
+  canonicalAssistantId: string;
+  sourceChannel: ChannelId;
+  conversationExternalId: string;
+  senderUserId: string;
+  replyCallbackUrl: string | undefined;
+  mintBearerToken: () => string;
+  assistantId: string;
+}): SlackVerificationResult {
+  const { canonicalAssistantId, sourceChannel, senderUserId, assistantId } =
+    params;
+
+  // Skip if there is already a pending challenge or active session for
+  // this channel to avoid flooding the user with duplicate codes.
+  const existingChallenge = getPendingChallenge(
+    canonicalAssistantId,
+    sourceChannel,
+  );
+  const existingSession = findActiveSession(
+    canonicalAssistantId,
+    sourceChannel,
+  );
+  if (existingChallenge || existingSession) {
+    log.debug(
+      {
+        sourceChannel,
+        senderUserId,
+        hasChallenge: !!existingChallenge,
+        hasSession: !!existingSession,
+      },
+      "Slack verification: skipping — existing challenge/session",
+    );
+    return { initiated: false };
+  }
+
+  try {
+    const session = createOutboundSession({
+      assistantId: canonicalAssistantId,
+      channel: sourceChannel,
+      expectedExternalUserId: senderUserId,
+      expectedChatId: senderUserId,
+      identityBindingStatus: "bound",
+      destinationAddress: senderUserId,
+      verificationPurpose: "trusted_contact",
+    });
+
+    const slackBody = composeVerificationSlack(
+      GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_CHALLENGE_REQUEST,
+      {
+        code: session.secret,
+        expiresInMinutes: Math.floor(session.ttlSeconds / 60),
+      },
+    );
+
+    // Fire-and-forget DM delivery via the gateway
+    sendSlackVerificationDm(senderUserId, slackBody, assistantId);
+
+    log.info(
+      { sourceChannel, senderUserId, sessionId: session.sessionId },
+      "Slack verification challenge initiated for unknown contact",
+    );
+
+    return { initiated: true, sessionId: session.sessionId };
+  } catch (err) {
+    log.error(
+      { err, sourceChannel, senderUserId },
+      "Failed to initiate Slack verification challenge",
+    );
+    return { initiated: false };
+  }
 }

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -803,7 +803,9 @@ function initiateSlackVerificationChallenge(params: {
     params;
 
   // Skip if there is already a pending challenge or active session for
-  // this channel to avoid flooding the user with duplicate codes.
+  // this sender to avoid flooding them with duplicate codes. We scope by
+  // sender identity (expectedExternalUserId) so that a pending session for
+  // user A does not suppress challenges for user B.
   const existingChallenge = getPendingChallenge(
     canonicalAssistantId,
     sourceChannel,
@@ -812,7 +814,12 @@ function initiateSlackVerificationChallenge(params: {
     canonicalAssistantId,
     sourceChannel,
   );
-  if (existingChallenge || existingSession) {
+  const senderHasPending =
+    (existingChallenge &&
+      existingChallenge.expectedExternalUserId === senderUserId) ||
+    (existingSession &&
+      existingSession.expectedExternalUserId === senderUserId);
+  if (senderHasPending) {
     log.debug(
       {
         sourceChannel,
@@ -820,7 +827,7 @@ function initiateSlackVerificationChallenge(params: {
         hasChallenge: !!existingChallenge,
         hasSession: !!existingSession,
       },
-      "Slack verification: skipping — existing challenge/session",
+      "Slack verification: skipping — existing challenge/session for this sender",
     );
     return { initiated: false };
   }
@@ -837,7 +844,7 @@ function initiateSlackVerificationChallenge(params: {
     });
 
     const slackBody = composeVerificationSlack(
-      GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_CHALLENGE_REQUEST,
+      GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_TRUSTED_CONTACT_CHALLENGE,
       {
         code: session.secret,
         expiresInMinutes: Math.floor(session.ttlSeconds / 60),

--- a/assistant/src/runtime/routes/inbound-stages/slack-verification-challenge.ts
+++ b/assistant/src/runtime/routes/inbound-stages/slack-verification-challenge.ts
@@ -1,0 +1,54 @@
+/**
+ * Slack verification DM delivery helper.
+ *
+ * Sends a verification message to a Slack user's DM via the gateway's
+ * /deliver/slack endpoint. The gateway handles opening the DM channel
+ * via Slack's conversations.open API and posting the message.
+ */
+
+import { getGatewayInternalBaseUrl } from "../../../config/env.js";
+import { getLogger } from "../../../util/logger.js";
+import { mintDaemonDeliveryToken } from "../../auth/token-service.js";
+
+const log = getLogger("slack-verification-challenge");
+
+/**
+ * Deliver a verification code to a Slack user's DM via the gateway.
+ * Fire-and-forget with error logging — the caller should not be blocked
+ * on gateway/Slack API latency.
+ */
+export function sendSlackVerificationDm(
+  userId: string,
+  text: string,
+  assistantId: string,
+): void {
+  (async () => {
+    try {
+      const gatewayUrl = getGatewayInternalBaseUrl();
+      const bearerToken = mintDaemonDeliveryToken();
+      const url = `${gatewayUrl}/deliver/slack`;
+      const resp = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${bearerToken}`,
+        },
+        body: JSON.stringify({ chatId: userId, text, assistantId }),
+      });
+      if (!resp.ok) {
+        const body = await resp.text().catch(() => "<unreadable>");
+        log.error(
+          { userId, assistantId, status: resp.status, body },
+          "Gateway /deliver/slack failed for verification DM",
+        );
+      } else {
+        log.info({ userId, assistantId }, "Slack verification DM delivered");
+      }
+    } catch (err) {
+      log.error(
+        { err, userId, assistantId },
+        "Failed to deliver Slack verification DM",
+      );
+    }
+  })();
+}


### PR DESCRIPTION
## Summary
- Scope Slack challenge deduplication by sender identity (`expectedExternalUserId`) so a pending session for user A does not suppress challenges for user B
- Add `SLACK_TRUSTED_CONTACT_CHALLENGE` template that includes the verification code in the DM message, since the DM is the only delivery mechanism for inbound trusted contact verification
- Add test for concurrent onboarding of different users

## Test plan
- [x] Existing Slack inbound verification tests pass (7/7)
- [x] New test verifies different users get independent challenges
- [x] DM text now asserts `"your code is"` is present in the message
- [x] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
