### PR TITLE
Fix feedback on PR #12393: interactive routing + dedup

### DIFF
--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -363,9 +363,10 @@ export class SlackSocketModeClient {
 
     const messageTs = payload.message?.ts;
 
-    // Build a dedup key from the action value + message ts to prevent
-    // double-processing if Slack retries the interactive payload.
-    const dedupKey = `interactive:${callbackData}:${messageTs ?? "no-ts"}`;
+    // Build a dedup key from the actor, action value, and message ts to prevent
+    // double-processing if Slack retries the interactive payload. Including userId
+    // ensures that different users clicking the same button are not collapsed.
+    const dedupKey = `interactive:${userId}:${callbackData}:${messageTs ?? "no-ts"}`;
     if (this.dedupMap.has(dedupKey)) {
       log.debug({ dedupKey }, "Duplicate interactive payload, skipping");
       return;
@@ -378,8 +379,13 @@ export class SlackSocketModeClient {
       userId,
     );
     if (isRejection(routing)) {
-      // DMs are always directed at the bot, so fall back to default assistant
-      if (this.config.gatewayConfig.defaultAssistantId) {
+      // Only fall back to the default assistant when unmappedPolicy allows it.
+      // When the policy is "reject", interactive payloads from unmapped
+      // channels/actors must be dropped to preserve routing isolation.
+      if (
+        this.config.gatewayConfig.unmappedPolicy === "default" &&
+        this.config.gatewayConfig.defaultAssistantId
+      ) {
         const defaultRouting = {
           assistantId: this.config.gatewayConfig.defaultAssistantId,
           routeSource: "default" as const,
@@ -395,7 +401,7 @@ export class SlackSocketModeClient {
       } else {
         log.info(
           { channelId, userId },
-          "block_actions dropped: no route and no default assistant",
+          "block_actions dropped: no route for channel/actor",
         );
       }
       return;


### PR DESCRIPTION
## Summary

- **Respect unmapped policy for interactive callbacks**: The fallback in `handleInteractivePayload` was routing rejected interactive payloads to `defaultAssistantId` regardless of `unmappedPolicy`. Now only falls back when `unmappedPolicy` is `"default"`, preserving routing isolation when policy is `"reject"`.
- **Include actor identity in interactive dedup key**: Added `userId` to the dedup key so identical button clicks from different users in the same message are not collapsed to one event.

Addresses Codex review feedback on PR #12393.

## Test plan

- [x] `bunx tsc --noEmit` passes in gateway
- [x] Pre-commit lint/format hooks pass
- [ ] Verify in staging: block_actions from unmapped channel are dropped when `unmappedPolicy=reject`
- [ ] Verify in staging: two different users can click the same approval button independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
