### PR TITLE
Fix feedback on PR #12392: reaction approval fixes

### DIFF
--- a/assistant/src/__tests__/slack-reaction-approvals.test.ts
+++ b/assistant/src/__tests__/slack-reaction-approvals.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseReactionCallbackData } from "../runtime/routes/channel-route-shared.js";
+
+// =============================================================================
+// parseReactionCallbackData
+// =============================================================================
+
+describe("parseReactionCallbackData", () => {
+  test("maps +1 emoji to approve_once", () => {
+    const result = parseReactionCallbackData("reaction:+1");
+    expect(result).toEqual({
+      action: "approve_once",
+      source: "slack_reaction",
+    });
+  });
+
+  test("maps thumbsup emoji to approve_once", () => {
+    const result = parseReactionCallbackData("reaction:thumbsup");
+    expect(result).toEqual({
+      action: "approve_once",
+      source: "slack_reaction",
+    });
+  });
+
+  test("maps -1 emoji to reject", () => {
+    const result = parseReactionCallbackData("reaction:-1");
+    expect(result).toEqual({
+      action: "reject",
+      source: "slack_reaction",
+    });
+  });
+
+  test("maps thumbsdown emoji to reject", () => {
+    const result = parseReactionCallbackData("reaction:thumbsdown");
+    expect(result).toEqual({
+      action: "reject",
+      source: "slack_reaction",
+    });
+  });
+
+  test("maps alarm_clock emoji to approve_10m", () => {
+    const result = parseReactionCallbackData("reaction:alarm_clock");
+    expect(result).toEqual({
+      action: "approve_10m",
+      source: "slack_reaction",
+    });
+  });
+
+  test("maps white_check_mark emoji to approve_always", () => {
+    const result = parseReactionCallbackData("reaction:white_check_mark");
+    expect(result).toEqual({
+      action: "approve_always",
+      source: "slack_reaction",
+    });
+  });
+
+  test("returns null for unknown emoji", () => {
+    const result = parseReactionCallbackData("reaction:tada");
+    expect(result).toBeNull();
+  });
+
+  test("returns null for empty emoji name", () => {
+    const result = parseReactionCallbackData("reaction:");
+    expect(result).toBeNull();
+  });
+
+  test("returns null for non-reaction callback data", () => {
+    const result = parseReactionCallbackData("apr:req-1:approve_once");
+    expect(result).toBeNull();
+  });
+
+  test("returns null for plain text", () => {
+    const result = parseReactionCallbackData("yes");
+    expect(result).toBeNull();
+  });
+});

--- a/assistant/src/runtime/channel-approval-types.ts
+++ b/assistant/src/runtime/channel-approval-types.ts
@@ -79,6 +79,7 @@ export interface ApprovalUIMetadata {
 export type ApprovalDecisionSource =
   | "telegram_button"
   | "whatsapp_button"
+  | "slack_reaction"
   | "plain_text";
 
 /** The structured result of a user's approval decision. */

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -69,6 +69,38 @@ export function parseCallbackData(
 }
 
 // ---------------------------------------------------------------------------
+// Reaction callback data parser — format: "reaction:<emoji_name>"
+// ---------------------------------------------------------------------------
+
+/**
+ * Map of Slack emoji names to approval actions. Multiple emoji names can
+ * map to the same action to handle Slack's aliasing (e.g. `+1` and `thumbsup`
+ * both represent the thumbs-up emoji).
+ */
+const REACTION_EMOJI_MAP: ReadonlyMap<string, ApprovalAction> = new Map([
+  ["+1", "approve_once"],
+  ["thumbsup", "approve_once"],
+  ["-1", "reject"],
+  ["thumbsdown", "reject"],
+  ["alarm_clock", "approve_10m"],
+  ["white_check_mark", "approve_always"],
+]);
+
+/**
+ * Parse a `reaction:<emoji_name>` callback data string into an approval
+ * decision. Returns null if the emoji is not mapped to any action.
+ */
+export function parseReactionCallbackData(
+  data: string,
+): ApprovalDecisionResult | null {
+  if (!data.startsWith("reaction:")) return null;
+  const emoji = data.slice("reaction:".length);
+  const action = REACTION_EMOJI_MAP.get(emoji);
+  if (!action) return null;
+  return { action, source: "slack_reaction" };
+}
+
+// ---------------------------------------------------------------------------
 // Context builders
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -36,6 +36,7 @@ import { handleGuardianTextEngineDecision } from "./approval-strategies/guardian
 import {
   buildGuardianDenyContext,
   parseCallbackData,
+  parseReactionCallbackData,
 } from "./channel-route-shared.js";
 import { deliverStaleApprovalReply } from "./guardian-approval-reply-helpers.js";
 
@@ -392,6 +393,30 @@ export async function handleApprovalInterception(
         return { handled: true, type: "assistant_turn" };
       }
     }
+  }
+
+  // ── Slack reaction path ──
+  // Reactions produce `callbackData` of the form `reaction:<emoji_name>`.
+  // Only guardians can approve via reaction — non-guardian reactions are
+  // silently ignored to prevent self-approval.
+  if (callbackData?.startsWith("reaction:")) {
+    if (trustCtx.trustClass !== "guardian") {
+      return { handled: true, type: "stale_ignored" };
+    }
+    const reactionDecision = parseReactionCallbackData(callbackData);
+    if (!reactionDecision) {
+      // Unknown emoji — ignore silently
+      return { handled: true, type: "stale_ignored" };
+    }
+    const pending = getApprovalInfoByConversation(conversationId);
+    if (pending.length === 0) {
+      return { handled: true, type: "stale_ignored" };
+    }
+    const result = handleChannelDecision(conversationId, reactionDecision);
+    if (result.applied) {
+      return { handled: true, type: "decision_applied" };
+    }
+    return { handled: true, type: "stale_ignored" };
   }
 
   // Try to extract a decision from callback data (button press) first.

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -116,6 +116,33 @@ export async function handleApprovalInterception(
     }
   }
 
+  // ── Slack reaction path ──
+  // Reactions produce `callbackData` of the form `reaction:<emoji_name>`.
+  // Handled before the pendingPrompt guard because guardian reactions arrive
+  // on the guardian's chat (guardianChatId), not the requester's conversation,
+  // so getChannelApprovalPrompt(conversationId) would return null.
+  // Only guardians can approve via reaction — non-guardian reactions are
+  // silently ignored to prevent self-approval.
+  if (callbackData?.startsWith("reaction:")) {
+    if (trustCtx.trustClass !== "guardian") {
+      return { handled: true, type: "stale_ignored" };
+    }
+    const reactionDecision = parseReactionCallbackData(callbackData);
+    if (!reactionDecision) {
+      // Unknown emoji — ignore silently
+      return { handled: true, type: "stale_ignored" };
+    }
+    const pending = getApprovalInfoByConversation(conversationId);
+    if (pending.length === 0) {
+      return { handled: true, type: "stale_ignored" };
+    }
+    const result = handleChannelDecision(conversationId, reactionDecision);
+    if (result.applied) {
+      return { handled: true, type: "decision_applied" };
+    }
+    return { handled: true, type: "stale_ignored" };
+  }
+
   // ── Standard approval interception (existing flow) ──
   const pendingPrompt = getChannelApprovalPrompt(conversationId);
   if (!pendingPrompt) return { handled: false };
@@ -393,30 +420,6 @@ export async function handleApprovalInterception(
         return { handled: true, type: "assistant_turn" };
       }
     }
-  }
-
-  // ── Slack reaction path ──
-  // Reactions produce `callbackData` of the form `reaction:<emoji_name>`.
-  // Only guardians can approve via reaction — non-guardian reactions are
-  // silently ignored to prevent self-approval.
-  if (callbackData?.startsWith("reaction:")) {
-    if (trustCtx.trustClass !== "guardian") {
-      return { handled: true, type: "stale_ignored" };
-    }
-    const reactionDecision = parseReactionCallbackData(callbackData);
-    if (!reactionDecision) {
-      // Unknown emoji — ignore silently
-      return { handled: true, type: "stale_ignored" };
-    }
-    const pending = getApprovalInfoByConversation(conversationId);
-    if (pending.length === 0) {
-      return { handled: true, type: "stale_ignored" };
-    }
-    const result = handleChannelDecision(conversationId, reactionDecision);
-    if (result.applied) {
-      return { handled: true, type: "decision_applied" };
-    }
-    return { handled: true, type: "stale_ignored" };
   }
 
   // Try to extract a decision from callback data (button press) first.

--- a/gateway/src/__tests__/slack-reaction-normalize.test.ts
+++ b/gateway/src/__tests__/slack-reaction-normalize.test.ts
@@ -132,8 +132,11 @@ describe("normalizeSlackReactionAdded", () => {
     expect(result).toBeNull();
   });
 
-  test("falls back to default assistant for unrouted channels", () => {
-    const config = makeConfig({ defaultAssistantId: "default-ast" });
+  test("falls back to default assistant for unrouted DM channels", () => {
+    const config = makeConfig({
+      defaultAssistantId: "default-ast",
+      unmappedPolicy: "reject",
+    });
     const event = makeReactionEvent({
       item: { type: "message", channel: "D999", ts: "111.222" },
     });
@@ -143,7 +146,20 @@ describe("normalizeSlackReactionAdded", () => {
     expect(result!.channel).toBe("D999");
   });
 
-  test("generates unique externalMessageId including reaction name", () => {
+  test("does not fall back to default assistant for unrouted public channels", () => {
+    const config = makeConfig({
+      defaultAssistantId: "default-ast",
+      unmappedPolicy: "reject",
+    });
+    const event = makeReactionEvent({
+      item: { type: "message", channel: "C999", ts: "111.222" },
+    });
+    const result = normalizeSlackReactionAdded(event, "ev-6b", config);
+
+    expect(result).toBeNull();
+  });
+
+  test("generates unique externalMessageId including reaction name and user", () => {
     const config = makeConfig({
       routingEntries: [
         { type: "conversation_id", key: "C123", assistantId: "ast-1" },
@@ -154,7 +170,7 @@ describe("normalizeSlackReactionAdded", () => {
 
     expect(result).not.toBeNull();
     expect(result!.event.message.externalMessageId).toBe(
-      "C123:1234567890.123456:reaction:alarm_clock",
+      "C123:1234567890.123456:reaction:alarm_clock:U001",
     );
   });
 });

--- a/gateway/src/__tests__/slack-reaction-normalize.test.ts
+++ b/gateway/src/__tests__/slack-reaction-normalize.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeSlackReactionAdded,
+  type SlackReactionAddedEvent,
+} from "../slack/normalize.js";
+import type { GatewayConfig } from "../config.js";
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    defaultAssistantId: "default-assistant",
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    maxWebhookPayloadBytes: 1048576,
+    port: 7830,
+    routingEntries: [],
+    runtimeInitialBackoffMs: 500,
+    runtimeMaxRetries: 2,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: false,
+    runtimeTimeoutMs: 30000,
+    shutdownDrainMs: 5000,
+    telegramApiBaseUrl: "https://api.telegram.org",
+    telegramBotToken: undefined,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    telegramWebhookSecret: undefined,
+    twilioAuthToken: undefined,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    unmappedPolicy: "default",
+    whatsappPhoneNumberId: undefined,
+    whatsappAccessToken: undefined,
+    whatsappAppSecret: undefined,
+    whatsappWebhookVerifyToken: undefined,
+    whatsappDeliverAuthBypass: false,
+    whatsappTimeoutMs: 15000,
+    whatsappMaxRetries: 3,
+    whatsappInitialBackoffMs: 1000,
+    slackChannelBotToken: undefined,
+    slackChannelAppToken: undefined,
+    slackDeliverAuthBypass: false,
+    trustProxy: false,
+    ...overrides,
+  } as GatewayConfig;
+}
+
+function makeReactionEvent(
+  overrides?: Partial<SlackReactionAddedEvent>,
+): SlackReactionAddedEvent {
+  return {
+    type: "reaction_added",
+    user: "U001",
+    reaction: "+1",
+    item: {
+      type: "message",
+      channel: "C123",
+      ts: "1234567890.123456",
+    },
+    event_ts: "1234567890.123457",
+    ...overrides,
+  };
+}
+
+describe("normalizeSlackReactionAdded", () => {
+  test("normalizes a reaction_added event with callbackData", () => {
+    const config = makeConfig({
+      routingEntries: [
+        { type: "conversation_id", key: "C123", assistantId: "ast-1" },
+      ],
+    });
+    const event = makeReactionEvent();
+    const result = normalizeSlackReactionAdded(event, "ev-1", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.sourceChannel).toBe("slack");
+    expect(result!.event.message.callbackData).toBe("reaction:+1");
+    expect(result!.event.message.content).toBe("");
+    expect(result!.event.actor.actorExternalId).toBe("U001");
+    expect(result!.event.message.conversationExternalId).toBe("C123");
+    expect(result!.channel).toBe("C123");
+    expect(result!.threadTs).toBe("1234567890.123456");
+  });
+
+  test("encodes emoji name in callbackData", () => {
+    const config = makeConfig({
+      routingEntries: [
+        { type: "conversation_id", key: "C123", assistantId: "ast-1" },
+      ],
+    });
+    const event = makeReactionEvent({ reaction: "white_check_mark" });
+    const result = normalizeSlackReactionAdded(event, "ev-2", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.callbackData).toBe(
+      "reaction:white_check_mark",
+    );
+  });
+
+  test("ignores reactions from the bot itself", () => {
+    const config = makeConfig();
+    const event = makeReactionEvent({ user: "BOT1" });
+    const result = normalizeSlackReactionAdded(event, "ev-3", config, "BOT1");
+
+    expect(result).toBeNull();
+  });
+
+  test("ignores reactions on non-message items", () => {
+    const config = makeConfig({
+      routingEntries: [
+        { type: "conversation_id", key: "C123", assistantId: "ast-1" },
+      ],
+    });
+    const event = makeReactionEvent();
+    (event.item as unknown as { type: string }).type = "file";
+    const result = normalizeSlackReactionAdded(event, "ev-4", config);
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null for unroutable channels without default", () => {
+    const config = makeConfig({ defaultAssistantId: undefined });
+    const event = makeReactionEvent();
+    const result = normalizeSlackReactionAdded(event, "ev-5", config);
+
+    expect(result).toBeNull();
+  });
+
+  test("falls back to default assistant for unrouted channels", () => {
+    const config = makeConfig({ defaultAssistantId: "default-ast" });
+    const event = makeReactionEvent({
+      item: { type: "message", channel: "D999", ts: "111.222" },
+    });
+    const result = normalizeSlackReactionAdded(event, "ev-6", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.channel).toBe("D999");
+  });
+
+  test("generates unique externalMessageId including reaction name", () => {
+    const config = makeConfig({
+      routingEntries: [
+        { type: "conversation_id", key: "C123", assistantId: "ast-1" },
+      ],
+    });
+    const event = makeReactionEvent({ reaction: "alarm_clock" });
+    const result = normalizeSlackReactionAdded(event, "ev-7", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.event.message.externalMessageId).toBe(
+      "C123:1234567890.123456:reaction:alarm_clock",
+    );
+  });
+});

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -34,6 +34,23 @@ export interface SlackDirectMessageEvent {
 }
 
 /**
+ * Slack `reaction_added` event shape.
+ * Fired when a user adds an emoji reaction to a message.
+ */
+export interface SlackReactionAddedEvent {
+  type: "reaction_added";
+  user: string;
+  reaction: string;
+  item: {
+    type: "message";
+    channel: string;
+    ts: string;
+  };
+  item_user?: string;
+  event_ts?: string;
+}
+
+/**
  * Slack `message` event shape for channel/group messages (non-DM).
  * Used to pick up thread replies in threads the bot is already participating in.
  */
@@ -223,5 +240,63 @@ export function normalizeSlackAppMention(
     routing,
     threadTs: event.thread_ts ?? event.ts,
     channel: event.channel,
+  };
+}
+
+/**
+ * Normalize a Slack `reaction_added` event into the gateway's canonical
+ * inbound event shape. The emoji name is encoded as `callbackData` with
+ * the format `reaction:{emoji_name}` so the runtime can map it to an
+ * approval action.
+ *
+ * Returns null if the event cannot be routed or has an unexpected item type.
+ */
+export function normalizeSlackReactionAdded(
+  event: SlackReactionAddedEvent,
+  eventId: string,
+  config: GatewayConfig,
+  botUserId?: string,
+): NormalizedSlackEvent | null {
+  // Ignore reactions from the bot itself
+  if (botUserId && event.user === botUserId) return null;
+  // Only handle reactions on messages
+  if (event.item.type !== "message") return null;
+
+  const channel = event.item.channel;
+
+  // DM reactions should still route via default assistant (same as DM messages)
+  let routing = resolveAssistant(config, channel, event.user);
+  if (isRejection(routing) && config.defaultAssistantId) {
+    routing = {
+      assistantId: config.defaultAssistantId,
+      routeSource: "default" as const,
+    };
+  }
+  if (isRejection(routing)) return null;
+
+  const externalMessageId = `${channel}:${event.item.ts}:reaction:${event.reaction}`;
+
+  return {
+    event: {
+      version: "v1",
+      sourceChannel: "slack",
+      receivedAt: new Date().toISOString(),
+      message: {
+        content: "",
+        conversationExternalId: channel,
+        externalMessageId,
+        callbackData: `reaction:${event.reaction}`,
+      },
+      actor: {
+        actorExternalId: event.user,
+      },
+      source: {
+        updateId: eventId,
+      },
+      raw: event as unknown as Record<string, unknown>,
+    },
+    routing,
+    threadTs: event.item.ts,
+    channel,
   };
 }

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -264,9 +264,15 @@ export function normalizeSlackReactionAdded(
 
   const channel = event.item.channel;
 
-  // DM reactions should still route via default assistant (same as DM messages)
+  // DM reactions should still route via default assistant (same as DM messages).
+  // Only apply fallback to DM channels (D...) — reactions from unrouted public
+  // channels should not bypass explicit routing policy.
   let routing = resolveAssistant(config, channel, event.user);
-  if (isRejection(routing) && config.defaultAssistantId) {
+  if (
+    isRejection(routing) &&
+    config.defaultAssistantId &&
+    channel.startsWith("D")
+  ) {
     routing = {
       assistantId: config.defaultAssistantId,
       routeSource: "default" as const,
@@ -274,7 +280,7 @@ export function normalizeSlackReactionAdded(
   }
   if (isRejection(routing)) return null;
 
-  const externalMessageId = `${channel}:${event.item.ts}:reaction:${event.reaction}`;
+  const externalMessageId = `${channel}:${event.item.ts}:reaction:${event.reaction}:${event.user}`;
 
   return {
     event: {

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -303,7 +303,18 @@ export class SlackSocketModeClient {
 
     if (!normalized) {
       log.info(
-        { eventId, channel: event.channel, type: event.type },
+        {
+          eventId,
+          channel: isReactionAdded
+            ? (event as SlackReactionAddedEvent).item.channel
+            : (
+                event as
+                  | SlackAppMentionEvent
+                  | SlackDirectMessageEvent
+                  | SlackChannelMessageEvent
+              ).channel,
+          type: event.type,
+        },
         "Slack event dropped by normalization/routing",
       );
       return;

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -5,9 +5,11 @@ import {
   normalizeSlackAppMention,
   normalizeSlackDirectMessage,
   normalizeSlackChannelMessage,
+  normalizeSlackReactionAdded,
   type SlackAppMentionEvent,
   type SlackDirectMessageEvent,
   type SlackChannelMessageEvent,
+  type SlackReactionAddedEvent,
   type NormalizedSlackEvent,
 } from "./normalize.js";
 
@@ -191,7 +193,8 @@ export class SlackSocketModeClient {
         event?:
           | SlackAppMentionEvent
           | SlackDirectMessageEvent
-          | SlackChannelMessageEvent;
+          | SlackChannelMessageEvent
+          | SlackReactionAddedEvent;
       };
       reason?: string;
     };
@@ -242,6 +245,7 @@ export class SlackSocketModeClient {
     const dmEvent = event as SlackDirectMessageEvent;
     const channelEvent = event as SlackChannelMessageEvent;
 
+    const isReactionAdded = event.type === "reaction_added";
     const isAppMention = event.type === "app_mention";
     const isDm = event.type === "message" && dmEvent.channel_type === "im";
     const mentionsBot =
@@ -254,8 +258,8 @@ export class SlackSocketModeClient {
       !!channelEvent.thread_ts &&
       this.activeThreads.has(channelEvent.thread_ts);
 
-    // Process app_mention events, DMs, and replies in active bot threads
-    if (!isAppMention && !isDm && !isActiveThreadReply) {
+    // Process app_mention events, DMs, replies in active bot threads, and reactions
+    if (!isAppMention && !isDm && !isActiveThreadReply && !isReactionAdded) {
       return;
     }
 
@@ -268,7 +272,14 @@ export class SlackSocketModeClient {
     this.dedupMap.set(eventId, Date.now());
 
     let normalized: NormalizedSlackEvent | null;
-    if (isAppMention) {
+    if (isReactionAdded) {
+      normalized = normalizeSlackReactionAdded(
+        event as SlackReactionAddedEvent,
+        eventId,
+        this.config.gatewayConfig,
+        this.config.botUserId,
+      );
+    } else if (isAppMention) {
       normalized = normalizeSlackAppMention(
         event as SlackAppMentionEvent,
         eventId,


### PR DESCRIPTION
## Summary
- Move reaction callback handling before `pendingPrompt` guard so guardian reactions arriving on `guardianChatId` (different from requester's conversation) are processed instead of being rejected as stale
- Include reactor user ID in reaction `externalMessageId` (`channel:ts:reaction:emoji:user`) to prevent dedup collisions when multiple users react with the same emoji on the same message
- Gate default assistant fallback for reactions to DM channels only (`D...`), preventing unrouted public channel reactions from bypassing explicit routing policy when `unmappedPolicy: "reject"` is set
- Fix pre-existing TS error accessing `.channel` on `SlackReactionAddedEvent` (which uses `item.channel`)

## Test plan
- [x] Gateway reaction normalize tests pass (8/8)
- [x] Assistant reaction approval parser tests pass (10/10)
- [x] TypeScript type-check passes for both gateway and assistant
- [x] New test: verifies unrouted public channel reactions return null with `unmappedPolicy: "reject"`

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
