### PR TITLE
fix: complete green color migration to #537D53 in VIconButton and MainWindowView

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1549,7 +1549,7 @@ struct MainWindowView: View {
                     // Active thread icon — SF Symbol chat bubble matching SidebarNavRow style
                     Image(systemName: "ellipsis.message")
                         .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._400))
+                        .foregroundColor(adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400))
                         .frame(width: 28, height: 28)
                         .accessibilityLabel("Thread: \(activeThread.title)")
 
@@ -1860,7 +1860,7 @@ private struct SidebarPrimaryRow: View {
             HStack(spacing: isExpanded ? VSpacing.xs : 0) {
                 Image(systemName: icon)
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._400))
+                    .foregroundColor(adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400))
                     .frame(width: 20)
                 Text(label)
                     .font(VFont.bodyMedium)

--- a/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VIconButton.swift
@@ -82,9 +82,9 @@ public struct VIconButton: View {
 
     private var iconForegroundColor: Color {
         if isActive {
-            return adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._300)
+            return adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._300)
         }
-        return adaptiveColor(light: Color(hex: 0x4B6845), dark: Forest._400)
+        return adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400)
     }
 }
 


### PR DESCRIPTION
## Summary
- Updated `VIconButton.swift` to use `0x537D53` instead of old `0x4B6845` for icon foreground colors
- Updated `MainWindowView.swift` to use `0x537D53` instead of old `0x4B6845` for sidebar icon colors
- Completes the color migration started in PR #11850

Addresses review feedback from PR #11850.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
