### PR TITLE
fix: align Slack tests with implementation changes

### DIFF
--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -97,7 +97,7 @@ mock.module(
   }),
 );
 
-import { createGuardianBindingContactsFirst } from "../contacts/contacts-write.js";
+import { createGuardianBinding } from "../contacts/contacts-write.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { findActiveSession } from "../runtime/channel-guardian-service.js";
 import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
@@ -210,7 +210,7 @@ describe("Slack inbound trusted contact verification", () => {
 
   test("guardian is notified of the access attempt alongside verification", async () => {
     // Set up a guardian binding so the notification can target it
-    createGuardianBindingContactsFirst({
+    createGuardianBinding({
       assistantId: "self",
       channel: "slack",
       guardianExternalUserId: "U_GUARDIAN",

--- a/assistant/src/__tests__/slack-skill.test.ts
+++ b/assistant/src/__tests__/slack-skill.test.ts
@@ -64,10 +64,11 @@ describe("slack skill TOOLS.json", () => {
     expect(names).toContain("slack_edit_message");
     expect(names).toContain("slack_delete_message");
     expect(names).toContain("slack_leave_channel");
+    expect(names).toContain("slack_channel_permissions");
   });
 
-  test("has 7 tools total", () => {
-    expect(toolsJson.tools.length).toBe(7);
+  test("has 8 tools total", () => {
+    expect(toolsJson.tools.length).toBe(8);
   });
 
   test("all tools have required fields", () => {

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -196,7 +196,7 @@ describe("normalizeSlackReactionAdded", () => {
     expect(result!.event.message.content).toBe("reaction:thumbsup");
     expect(result!.event.message.conversationExternalId).toBe("C456");
     expect(result!.event.message.externalMessageId).toBe(
-      "C456:1234567890.123456:thumbsup",
+      "C456:1234567890.123456:thumbsup:U123",
     );
     expect(result!.event.actor.actorExternalId).toBe("U123");
     expect(result!.event.source.messageId).toBe("1234567890.123456");


### PR DESCRIPTION
## Summary
- Fix `slack-inbound-verification.test.ts`: import renamed `createGuardianBinding` (was `createGuardianBindingContactsFirst`)
- Fix `slack-skill.test.ts`: update tool count to 8 and add `slack_channel_permissions` assertion
- Fix `gateway/slack/normalize.test.ts`: update reaction `externalMessageId` to include user ID suffix (`:U123`)

## Test plan
- [x] All 3 previously-failing tests pass locally
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
