### PR TITLE
feat: add /v1/contacts/invites route aliases at runtime

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -173,6 +173,10 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "ingress/invites:POST", scopes: ["settings.write"] },
   { endpoint: "ingress/invites/redeem", scopes: ["settings.write"] },
   { endpoint: "ingress/invites:DELETE", scopes: ["settings.write"] },
+  { endpoint: "contacts/invites", scopes: ["settings.read"] },
+  { endpoint: "contacts/invites:POST", scopes: ["settings.write"] },
+  { endpoint: "contacts/invites/redeem", scopes: ["settings.write"] },
+  { endpoint: "contacts/invites:DELETE", scopes: ["settings.write"] },
   { endpoint: "integrations/telegram/config", scopes: ["settings.read"] },
   { endpoint: "integrations/telegram/config:POST", scopes: ["settings.write"] },
   {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -1162,6 +1162,31 @@ export class RuntimeHttpServer {
       },
 
       // ------------------------------------------------------------------
+      // Contacts invites (alias for ingress/invites during migration)
+      // ------------------------------------------------------------------
+      {
+        endpoint: "contacts/invites",
+        method: "GET",
+        handler: ({ url }) => handleListInvites(url),
+      },
+      {
+        endpoint: "contacts/invites",
+        method: "POST",
+        handler: async ({ req }) => handleCreateInvite(req),
+      },
+      {
+        endpoint: "contacts/invites/redeem",
+        method: "POST",
+        handler: async ({ req }) => handleRedeemInvite(req),
+      },
+      {
+        endpoint: "contacts/invites/:id",
+        method: "DELETE",
+        policyKey: "contacts/invites",
+        handler: ({ params }) => handleRevokeInvite(params.id),
+      },
+
+      // ------------------------------------------------------------------
       // Integrations — Telegram
       // ------------------------------------------------------------------
       {


### PR DESCRIPTION
## Summary
- Add 4 new route entries for /v1/contacts/invites paths pointing to existing invite handlers
- Add 4 new policy entries with identical scopes for the new paths
- Both old and new paths work simultaneously during migration

Part of plan: rename-ingress-invites.md (PR 1 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
