### PR TITLE
refactor: remove /v1/ingress/invites gateway routes, matchers, and schema entries

### DIFF
--- a/gateway/src/__tests__/ingress-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/ingress-control-plane-proxy.test.ts
@@ -85,30 +85,30 @@ describe("ingress control-plane proxy", () => {
     const handler = createIngressControlPlaneProxyHandler(makeConfig());
 
     await handler.handleListInvites(
-      new Request("http://localhost:7830/v1/ingress/invites?status=active"),
+      new Request("http://localhost:7830/v1/contacts/invites?status=active"),
     );
     await handler.handleCreateInvite(
-      new Request("http://localhost:7830/v1/ingress/invites", {
+      new Request("http://localhost:7830/v1/contacts/invites", {
         method: "POST",
       }),
     );
     await handler.handleRedeemInvite(
-      new Request("http://localhost:7830/v1/ingress/invites/redeem", {
+      new Request("http://localhost:7830/v1/contacts/invites/redeem", {
         method: "POST",
       }),
     );
     await handler.handleRevokeInvite(
-      new Request("http://localhost:7830/v1/ingress/invites/inv_123", {
+      new Request("http://localhost:7830/v1/contacts/invites/inv_123", {
         method: "DELETE",
       }),
       "inv_123",
     );
 
     expect(captured).toEqual([
-      "http://localhost:7821/v1/ingress/invites?status=active",
-      "http://localhost:7821/v1/ingress/invites",
-      "http://localhost:7821/v1/ingress/invites/redeem",
-      "http://localhost:7821/v1/ingress/invites/inv_123",
+      "http://localhost:7821/v1/contacts/invites?status=active",
+      "http://localhost:7821/v1/contacts/invites",
+      "http://localhost:7821/v1/contacts/invites/redeem",
+      "http://localhost:7821/v1/contacts/invites/inv_123",
     ]);
   });
 
@@ -123,7 +123,7 @@ describe("ingress control-plane proxy", () => {
 
     const handler = createIngressControlPlaneProxyHandler(makeConfig());
     const res = await handler.handleCreateInvite(
-      new Request("http://localhost:7830/v1/ingress/invites", {
+      new Request("http://localhost:7830/v1/contacts/invites", {
         method: "POST",
         headers: {
           authorization: "Bearer caller-token",
@@ -154,7 +154,7 @@ describe("ingress control-plane proxy", () => {
 
     const handler = createIngressControlPlaneProxyHandler(makeConfig());
     const res = await handler.handleCreateInvite(
-      new Request("http://localhost:7830/v1/ingress/invites", {
+      new Request("http://localhost:7830/v1/contacts/invites", {
         method: "POST",
       }),
     );
@@ -178,7 +178,7 @@ describe("ingress control-plane proxy", () => {
       makeConfig({ runtimeTimeoutMs: 100 }),
     );
     const res = await handler.handleListInvites(
-      new Request("http://localhost:7830/v1/ingress/invites"),
+      new Request("http://localhost:7830/v1/contacts/invites"),
     );
 
     expect(res.status).toBe(504);

--- a/gateway/src/__tests__/ingress-control-plane-route-match.test.ts
+++ b/gateway/src/__tests__/ingress-control-plane-route-match.test.ts
@@ -4,33 +4,33 @@ import { matchIngressControlPlaneRoute } from "../http/routes/ingress-control-pl
 describe("matchIngressControlPlaneRoute", () => {
   test("matches redeem invite only for POST", () => {
     expect(
-      matchIngressControlPlaneRoute("/v1/ingress/invites/redeem", "POST"),
+      matchIngressControlPlaneRoute("/v1/contacts/invites/redeem", "POST"),
     ).toEqual({
       kind: "redeemInvite",
     });
 
     // DELETE should treat `redeem` as an invite ID so revoke routing still works.
     expect(
-      matchIngressControlPlaneRoute("/v1/ingress/invites/redeem", "DELETE"),
+      matchIngressControlPlaneRoute("/v1/contacts/invites/redeem", "DELETE"),
     ).toEqual({
       kind: "revokeInvite",
       inviteId: "redeem",
     });
   });
 
-  test("matches ingress invite routes", () => {
-    expect(matchIngressControlPlaneRoute("/v1/ingress/invites", "GET")).toEqual(
-      {
-        kind: "listInvites",
-      },
-    );
+  test("matches contacts invite routes", () => {
     expect(
-      matchIngressControlPlaneRoute("/v1/ingress/invites", "POST"),
+      matchIngressControlPlaneRoute("/v1/contacts/invites", "GET"),
+    ).toEqual({
+      kind: "listInvites",
+    });
+    expect(
+      matchIngressControlPlaneRoute("/v1/contacts/invites", "POST"),
     ).toEqual({
       kind: "createInvite",
     });
     expect(
-      matchIngressControlPlaneRoute("/v1/ingress/invites/inv_1", "DELETE"),
+      matchIngressControlPlaneRoute("/v1/contacts/invites/inv_1", "DELETE"),
     ).toEqual({
       kind: "revokeInvite",
       inviteId: "inv_1",
@@ -39,10 +39,10 @@ describe("matchIngressControlPlaneRoute", () => {
 
   test("returns null for unsupported method/path combinations", () => {
     expect(
-      matchIngressControlPlaneRoute("/v1/ingress/invites/redeem", "GET"),
+      matchIngressControlPlaneRoute("/v1/contacts/invites/redeem", "GET"),
     ).toBeNull();
     expect(
-      matchIngressControlPlaneRoute("/v1/ingress/invites/inv_1", "POST"),
+      matchIngressControlPlaneRoute("/v1/contacts/invites/inv_1", "POST"),
     ).toBeNull();
     expect(
       matchIngressControlPlaneRoute("/v1/ingress/unknown", "GET"),

--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -64,9 +64,9 @@ describe("/schema route", () => {
     expect(body.paths["/v1/integrations/telegram/config"]).toBeDefined();
     expect(body.paths["/v1/integrations/telegram/commands"]).toBeDefined();
     expect(body.paths["/v1/integrations/telegram/setup"]).toBeDefined();
-    expect(body.paths["/v1/ingress/invites"]).toBeDefined();
-    expect(body.paths["/v1/ingress/invites/redeem"]).toBeDefined();
-    expect(body.paths["/v1/ingress/invites/{inviteId}"]).toBeDefined();
+    expect(body.paths["/v1/contacts/invites"]).toBeDefined();
+    expect(body.paths["/v1/contacts/invites/redeem"]).toBeDefined();
+    expect(body.paths["/v1/contacts/invites/{inviteId}"]).toBeDefined();
     expect(body.paths["/v1/integrations/guardian/challenge"]).toBeDefined();
     expect(body.paths["/v1/integrations/guardian/status"]).toBeDefined();
     expect(

--- a/gateway/src/http/routes/ingress-control-plane-route-match.ts
+++ b/gateway/src/http/routes/ingress-control-plane-route-match.ts
@@ -8,26 +8,17 @@ export function matchIngressControlPlaneRoute(
   pathname: string,
   method: string,
 ): IngressControlPlaneRoute | null {
-  if (
-    pathname === "/v1/ingress/invites" ||
-    pathname === "/v1/contacts/invites"
-  ) {
+  if (pathname === "/v1/contacts/invites") {
     if (method === "GET") return { kind: "listInvites" };
     if (method === "POST") return { kind: "createInvite" };
     return null;
   }
 
-  if (
-    (pathname === "/v1/ingress/invites/redeem" ||
-      pathname === "/v1/contacts/invites/redeem") &&
-    method === "POST"
-  ) {
+  if (pathname === "/v1/contacts/invites/redeem" && method === "POST") {
     return { kind: "redeemInvite" };
   }
 
-  const inviteMatch = pathname.match(
-    /^\/v1\/(?:ingress|contacts)\/invites\/([^/]+)$/,
-  );
+  const inviteMatch = pathname.match(/^\/v1\/contacts\/invites\/([^/]+)$/);
   if (inviteMatch && method === "DELETE") {
     return { kind: "revokeInvite", inviteId: inviteMatch[1] };
   }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -347,34 +347,7 @@ function main() {
       handler: (req) => telegramControlPlaneProxy.handleSetupTelegram(req),
     },
 
-    // ── Ingress control plane ──
-    {
-      path: "/v1/ingress/invites",
-      method: "GET",
-      auth: "edge",
-      handler: (req) => ingressControlPlaneProxy.handleListInvites(req),
-    },
-    {
-      path: "/v1/ingress/invites",
-      method: "POST",
-      auth: "edge",
-      handler: (req) => ingressControlPlaneProxy.handleCreateInvite(req),
-    },
-    {
-      path: "/v1/ingress/invites/redeem",
-      method: "POST",
-      auth: "edge",
-      handler: (req) => ingressControlPlaneProxy.handleRedeemInvite(req),
-    },
-    {
-      path: /^\/v1\/ingress\/invites\/([^/]+)$/,
-      method: "DELETE",
-      auth: "edge",
-      handler: (req, params) =>
-        ingressControlPlaneProxy.handleRevokeInvite(req, params[0]),
-    },
-
-    // ── Contacts/invites aliases (canonical paths) ──
+    // ── Contacts/invites control plane ──
     {
       path: "/v1/contacts/invites",
       method: "GET",

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -907,109 +907,11 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
-      "/v1/ingress/invites": {
-        get: {
-          summary: "List ingress invites",
-          description:
-            "Authenticated gateway endpoint that lists ingress invites via the assistant runtime.",
-          operationId: "ingressInvitesGet",
-          security: [{ BearerAuth: [] }],
-          responses: {
-            "200": { description: "Ingress invites returned" },
-            "401": {
-              description: "Unauthorized — missing or invalid bearer token",
-            },
-            "503": { description: "Bearer token not configured" },
-            "502": { description: "Failed to reach assistant runtime" },
-            "504": { description: "Assistant runtime request timed out" },
-          },
-        },
-        post: {
-          summary: "Create ingress invite",
-          description:
-            "Authenticated gateway endpoint that creates an ingress invite via the assistant runtime.",
-          operationId: "ingressInvitesPost",
-          security: [{ BearerAuth: [] }],
-          requestBody: {
-            required: true,
-            content: {
-              "application/json": {
-                schema: { type: "object", additionalProperties: true },
-              },
-            },
-          },
-          responses: {
-            "200": { description: "Ingress invite created" },
-            "400": { description: "Invalid request payload" },
-            "401": {
-              description: "Unauthorized — missing or invalid bearer token",
-            },
-            "503": { description: "Bearer token not configured" },
-            "502": { description: "Failed to reach assistant runtime" },
-            "504": { description: "Assistant runtime request timed out" },
-          },
-        },
-      },
-      "/v1/ingress/invites/redeem": {
-        post: {
-          summary: "Redeem ingress invite",
-          description:
-            "Authenticated gateway endpoint that redeems an ingress invite via the assistant runtime.",
-          operationId: "ingressInvitesRedeemPost",
-          security: [{ BearerAuth: [] }],
-          requestBody: {
-            required: true,
-            content: {
-              "application/json": {
-                schema: { type: "object", additionalProperties: true },
-              },
-            },
-          },
-          responses: {
-            "200": { description: "Ingress invite redeemed" },
-            "400": { description: "Invalid request payload" },
-            "401": {
-              description: "Unauthorized — missing or invalid bearer token",
-            },
-            "404": { description: "Invite not found" },
-            "503": { description: "Bearer token not configured" },
-            "502": { description: "Failed to reach assistant runtime" },
-            "504": { description: "Assistant runtime request timed out" },
-          },
-        },
-      },
-      "/v1/ingress/invites/{inviteId}": {
-        delete: {
-          summary: "Revoke ingress invite",
-          description:
-            "Authenticated gateway endpoint that revokes an ingress invite via the assistant runtime.",
-          operationId: "ingressInvitesDelete",
-          security: [{ BearerAuth: [] }],
-          parameters: [
-            {
-              name: "inviteId",
-              in: "path",
-              required: true,
-              schema: { type: "string" },
-            },
-          ],
-          responses: {
-            "200": { description: "Ingress invite revoked" },
-            "401": {
-              description: "Unauthorized — missing or invalid bearer token",
-            },
-            "404": { description: "Invite not found or already revoked" },
-            "503": { description: "Bearer token not configured" },
-            "502": { description: "Failed to reach assistant runtime" },
-            "504": { description: "Assistant runtime request timed out" },
-          },
-        },
-      },
       "/v1/contacts/invites": {
         get: {
           summary: "List contacts invites",
           description:
-            "Authenticated gateway endpoint that lists contacts invites via the assistant runtime. Canonical path for /v1/ingress/invites.",
+            "Authenticated gateway endpoint that lists contacts invites via the assistant runtime.",
           operationId: "contactsInvitesGet",
           security: [{ BearerAuth: [] }],
           responses: {
@@ -1025,7 +927,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Create contacts invite",
           description:
-            "Authenticated gateway endpoint that creates a contacts invite via the assistant runtime. Canonical path for /v1/ingress/invites.",
+            "Authenticated gateway endpoint that creates a contacts invite via the assistant runtime.",
           operationId: "contactsInvitesPost",
           security: [{ BearerAuth: [] }],
           requestBody: {
@@ -1052,7 +954,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Redeem contacts invite",
           description:
-            "Authenticated gateway endpoint that redeems a contacts invite via the assistant runtime. Canonical path for /v1/ingress/invites/redeem.",
+            "Authenticated gateway endpoint that redeems a contacts invite via the assistant runtime.",
           operationId: "contactsInvitesRedeemPost",
           security: [{ BearerAuth: [] }],
           requestBody: {
@@ -1080,7 +982,7 @@ export function buildSchema(): Record<string, unknown> {
         delete: {
           summary: "Revoke contacts invite",
           description:
-            "Authenticated gateway endpoint that revokes a contacts invite via the assistant runtime. Canonical path for /v1/ingress/invites/{inviteId}.",
+            "Authenticated gateway endpoint that revokes a contacts invite via the assistant runtime.",
           operationId: "contactsInvitesDelete",
           security: [{ BearerAuth: [] }],
           parameters: [


### PR DESCRIPTION
## Summary
- Remove 4 old /v1/ingress/invites route registrations from gateway
- Remove old route matcher patterns for /v1/ingress/invites
- Remove old OpenAPI schema entries for /v1/ingress/invites
- Update all gateway tests to use /v1/contacts/invites paths

Part of plan: rename-ingress-invites.md (PR 8 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)