### PR TITLE
fix(macos): add accessibility labels and archive cleanup to popover rows [LUM-9]

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1640,6 +1640,7 @@ struct MainWindowView: View {
                                             }
                                             .buttonStyle(.plain)
                                             .transition(.opacity)
+                                            .accessibilityLabel(thread.isPinned ? "Unpin \(thread.title)" : "Pin \(thread.title)")
                                         } else {
                                             switch interactionState {
                                             case .processing:
@@ -1717,6 +1718,7 @@ struct MainWindowView: View {
                                             }
                                             .buttonStyle(.plain)
                                             .padding(.trailing, VSpacing.xs)
+                                            .accessibilityLabel("Archive \(thread.title)")
                                         }
                                     }
                                     .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
@@ -1761,6 +1763,11 @@ struct MainWindowView: View {
                     }
                     .frame(width: 240)
                     .padding(.bottom, VSpacing.sm)
+                    .onChange(of: sidebar.isHoveredThread) { _, newValue in
+                        if let pending = sidebar.threadPendingDeletion, newValue != pending {
+                            sidebar.threadPendingDeletion = nil
+                        }
+                    }
                     .onHover { hovering in
                         if hovering {
                             // Mouse entered popover — cancel pending dismiss


### PR DESCRIPTION
## Summary
- Add `.accessibilityLabel` to pin toggle button in popover thread rows (matching `threadItem()`)
- Add `.accessibilityLabel` to archive button in popover thread rows
- Add `onChange(of: sidebar.isHoveredThread)` handler to clear `threadPendingDeletion` when hover moves away, preventing sticky Confirm buttons

Addresses review feedback from Codex and Devin on #12394 and #12397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
