### PR TITLE
fix: validate channels is array before iterating in upsert contact handler

### DIFF
--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -165,6 +165,9 @@ export async function handleUpsertContact(
   }
 
   if (body.channels) {
+    if (!Array.isArray(body.channels)) {
+      return httpError("BAD_REQUEST", "channels must be an array", 400);
+    }
     for (const ch of body.channels) {
       if (ch.status !== undefined && !isChannelStatus(ch.status)) {
         return httpError(


### PR DESCRIPTION
Addresses review feedback on #12341. Adds Array.isArray check for body.channels before the pre-validation loop in the upsert contact handler. Returns 400 BAD_REQUEST if channels is truthy but not an array, preventing a 500 TypeError on malformed input.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
