### PR TITLE
fix: update deprecation notice to recommend contacts list with role filter

### DIFF
--- a/assistant/docs/runbook-trusted-contacts.md
+++ b/assistant/docs/runbook-trusted-contacts.md
@@ -45,7 +45,7 @@ curl -s "$BASE/v1/contacts" \
 ### Via CLI
 
 ```bash
-vellum contacts list
+vellum contacts list --role contact
 ```
 
 Response shape:


### PR DESCRIPTION
Addresses review feedback on #12337. The old `integrations ingress members` CLI command implicitly filtered by role=contact. Updates the runbook CLI example to use `vellum contacts list --role contact` for behavioral parity with the HTTP example and the removed command's default behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
