### PR TITLE
feat: add description under Settings item in drawer menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1976,7 +1976,7 @@ private struct DrawerMenuView: View {
             VColor.surfaceBorder.frame(height: 1)
                 .padding(.vertical, VSpacing.xs)
 
-            DrawerMenuItem(icon: "gearshape", label: "Settings", description: "Ask the assistant to help you with any settings you wish to change", action: onSettings)
+            DrawerMenuItem(icon: "gearshape", label: String(localized: "Settings"), description: String(localized: "Ask the assistant to help you with any settings you wish to change"), action: onSettings)
 
             VColor.surfaceBorder.frame(height: 1)
                 .padding(.vertical, VSpacing.xs)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -2166,7 +2166,7 @@ private struct DrawerMenuItem: View {
 
     var body: some View {
         Button(action: action) {
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: VSpacing.md) {
                     Image(systemName: icon)
                         .font(.system(size: 12, weight: .medium))

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1976,7 +1976,7 @@ private struct DrawerMenuView: View {
             VColor.surfaceBorder.frame(height: 1)
                 .padding(.vertical, VSpacing.xs)
 
-            DrawerMenuItem(icon: "gearshape", label: "Settings", action: onSettings)
+            DrawerMenuItem(icon: "gearshape", label: "Settings", description: "Ask the assistant to help you with any settings you wish to change", action: onSettings)
 
             VColor.surfaceBorder.frame(height: 1)
                 .padding(.vertical, VSpacing.xs)
@@ -2160,22 +2160,32 @@ private struct ScheduleGroupHeaderDropDelegate: DropDelegate {
 private struct DrawerMenuItem: View {
     let icon: String
     let label: String
+    var description: String? = nil
     let action: () -> Void
     @State private var isHovered = false
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: VSpacing.md) {
+            HStack(alignment: .top, spacing: VSpacing.md) {
                 Image(systemName: icon)
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(isHovered ? VColor.textPrimary : VColor.textSecondary)
                     .frame(width: 18)
+                    .padding(.top, 1)
                     .rotationEffect(.degrees(isHovered ? -10 : 0))
                     .scaleEffect(isHovered ? 1.15 : 1.0)
                     .animation(VAnimation.fast, value: isHovered)
-                Text(label)
-                    .font(.custom("Inter", size: 13))
-                    .foregroundColor(VColor.textPrimary)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label)
+                        .font(.custom("Inter", size: 13))
+                        .foregroundColor(VColor.textPrimary)
+                    if let description {
+                        Text(description)
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
                 Spacer()
             }
             .padding(.horizontal, VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -2167,7 +2167,7 @@ private struct DrawerMenuItem: View {
     var body: some View {
         Button(action: action) {
             VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: VSpacing.md) {
+                HStack(spacing: VSpacing.sm) {
                     Image(systemName: icon)
                         .font(.system(size: 12, weight: .medium))
                         .foregroundColor(isHovered ? VColor.textPrimary : VColor.textSecondary)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -2166,27 +2166,26 @@ private struct DrawerMenuItem: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(alignment: .top, spacing: VSpacing.md) {
-                Image(systemName: icon)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(isHovered ? VColor.textPrimary : VColor.textSecondary)
-                    .frame(width: 18)
-                    .padding(.top, 1)
-                    .rotationEffect(.degrees(isHovered ? -10 : 0))
-                    .scaleEffect(isHovered ? 1.15 : 1.0)
-                    .animation(VAnimation.fast, value: isHovered)
-                VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: VSpacing.md) {
+                    Image(systemName: icon)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(isHovered ? VColor.textPrimary : VColor.textSecondary)
+                        .frame(width: 18)
+                        .rotationEffect(.degrees(isHovered ? -10 : 0))
+                        .scaleEffect(isHovered ? 1.15 : 1.0)
+                        .animation(VAnimation.fast, value: isHovered)
                     Text(label)
                         .font(.custom("Inter", size: 13))
                         .foregroundColor(VColor.textPrimary)
-                    if let description {
-                        Text(description)
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textSecondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
+                    Spacer()
                 }
-                Spacer()
+                if let description {
+                    Text(description)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -2167,7 +2167,7 @@ private struct DrawerMenuItem: View {
     var body: some View {
         Button(action: action) {
             VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: VSpacing.sm) {
+                HStack(spacing: VSpacing.xs) {
                     Image(systemName: icon)
                         .font(.system(size: 12, weight: .medium))
                         .foregroundColor(isHovered ? VColor.textPrimary : VColor.textSecondary)


### PR DESCRIPTION
## Summary
- Adds a subtitle description "Ask the assistant to help you with any settings you wish to change" under the Settings label in the drawer menu
- Updated `DrawerMenuItem` to support an optional `description` parameter shown as a caption below the label

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
