### PR TITLE
fix: move contacts/invites routes before contacts/:id to prevent shadowing

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -1128,16 +1128,9 @@ export class RuntimeHttpServer {
         handler: async ({ req, params, authContext }) =>
           handleUpdateContactChannel(req, params.id, authContext.assistantId),
       },
-      {
-        endpoint: "contacts/:id",
-        method: "GET",
-        policyKey: "contacts",
-        handler: ({ params, authContext }) =>
-          handleGetContact(params.id, authContext.assistantId),
-      },
 
       // ------------------------------------------------------------------
-      // Contacts invites
+      // Contacts invites — must precede contacts/:id to avoid shadowing
       // ------------------------------------------------------------------
       {
         endpoint: "contacts/invites",
@@ -1159,6 +1152,14 @@ export class RuntimeHttpServer {
         method: "DELETE",
         policyKey: "contacts/invites",
         handler: ({ params }) => handleRevokeInvite(params.id),
+      },
+
+      {
+        endpoint: "contacts/:id",
+        method: "GET",
+        policyKey: "contacts",
+        handler: ({ params, authContext }) =>
+          handleGetContact(params.id, authContext.assistantId),
       },
 
       // ------------------------------------------------------------------


### PR DESCRIPTION
Addresses review feedback on #12429. The contacts/invites GET route was shadowed by the contacts/:id wildcard route because HttpRouter uses first-match dispatch. Moves contacts/invites routes before contacts/:id, following the same pattern used for contacts/merge and contacts/channels/:id.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
