### PR TITLE
fix: ban both legacy and new invite retrieval paths in SKILL.md guard test

### DIFF
--- a/assistant/src/__tests__/bundled-skill-retrieval-guard.test.ts
+++ b/assistant/src/__tests__/bundled-skill-retrieval-guard.test.ts
@@ -61,6 +61,7 @@ const GATEWAY_RETRIEVAL_BANLIST: Array<{
     skillPath: "contacts/SKILL.md",
     bannedSnippets: [
       'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/members',
+      'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/invites',
       'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/contacts/invites',
       'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/telegram/config',
     ],


### PR DESCRIPTION
Addresses review feedback on #12433. Adds /v1/ingress/invites back to the banlist alongside /v1/contacts/invites in the bundled-skill retrieval guard test. Both paths are routable and should be prevented from appearing as direct retrieval snippets in SKILL.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
