### PR TITLE
docs: fix stale ingress references in gateway ARCHITECTURE.md

### DIFF
--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -122,9 +122,9 @@ Runtime health is exposed directly by the gateway at `GET /v1/health` and forwar
 | `gateway/src/http/routes/runtime-health-proxy.ts` | Runtime health proxy handler and upstream forwarding            |
 | `gateway/src/index.ts`                            | Route registration and bearer-auth enforcement for `/v1/health` |
 
-### Telegram + Ingress Control-Plane Proxies
+### Telegram + Contacts Control-Plane Proxies
 
-Telegram integration setup/config endpoints and ingress members/invites endpoints are also exposed directly by the gateway and forwarded to runtime handlers even when the broad runtime proxy is disabled.
+Telegram integration setup/config endpoints and contacts/invites endpoints are also exposed directly by the gateway and forwarded to runtime handlers even when the broad runtime proxy is disabled.
 
 **Forwarded Telegram endpoints:**
 
@@ -154,11 +154,11 @@ Telegram integration setup/config endpoints and ingress members/invites endpoint
 
 **Key source files:**
 
-| File                                                      | Purpose                                                                                              |
-| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `gateway/src/http/routes/telegram-control-plane-proxy.ts` | Telegram control-plane proxy handlers and upstream forwarding                                        |
-| `gateway/src/http/routes/ingress-control-plane-proxy.ts`  | Ingress control-plane proxy handlers and upstream forwarding                                         |
-| `gateway/src/index.ts`                                    | Route registration and bearer-auth enforcement for `/v1/integrations/telegram/*` and `/v1/ingress/*` |
+| File                                                      | Purpose                                                                                                       |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `gateway/src/http/routes/telegram-control-plane-proxy.ts` | Telegram control-plane proxy handlers and upstream forwarding                                                 |
+| `gateway/src/http/routes/contacts-control-plane-proxy.ts` | Contacts control-plane proxy handlers and upstream forwarding                                                 |
+| `gateway/src/index.ts`                                    | Route registration and bearer-auth enforcement for `/v1/integrations/telegram/*` and `/v1/contacts/invites/*` |
 
 ### Twilio Control-Plane Proxy
 


### PR DESCRIPTION
## Summary
- Rename section heading from 'Ingress Control-Plane Proxies' to 'Contacts Control-Plane Proxies'
- Update description to reference contacts/invites instead of ingress members/invites
- Update source file table to reference new filename and correct route paths

Part of plan: ingress-naming-cleanup.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)