### PR TITLE
refactor: rename ingress-control-plane-route-match to contacts-control-plane-route-match

### DIFF
--- a/gateway/src/__tests__/contacts-control-plane-route-match.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-route-match.test.ts
@@ -1,37 +1,37 @@
 import { describe, expect, test } from "bun:test";
-import { matchIngressControlPlaneRoute } from "../http/routes/ingress-control-plane-route-match.js";
+import { matchContactsControlPlaneRoute } from "../http/routes/contacts-control-plane-route-match.js";
 
-describe("matchIngressControlPlaneRoute", () => {
+describe("matchContactsControlPlaneRoute", () => {
   test("matches contact CRUD routes", () => {
-    expect(matchIngressControlPlaneRoute("/v1/contacts", "GET")).toEqual({
+    expect(matchContactsControlPlaneRoute("/v1/contacts", "GET")).toEqual({
       kind: "listContacts",
     });
-    expect(matchIngressControlPlaneRoute("/v1/contacts", "POST")).toEqual({
+    expect(matchContactsControlPlaneRoute("/v1/contacts", "POST")).toEqual({
       kind: "upsertContact",
     });
-    expect(matchIngressControlPlaneRoute("/v1/contacts/merge", "POST")).toEqual(
+    expect(matchContactsControlPlaneRoute("/v1/contacts/merge", "POST")).toEqual(
       { kind: "mergeContacts" },
     );
     expect(
-      matchIngressControlPlaneRoute("/v1/contacts/channels/ch_1", "PATCH"),
+      matchContactsControlPlaneRoute("/v1/contacts/channels/ch_1", "PATCH"),
     ).toEqual({ kind: "updateContactChannel", channelId: "ch_1" });
-    expect(matchIngressControlPlaneRoute("/v1/contacts/ct_1", "GET")).toEqual({
+    expect(matchContactsControlPlaneRoute("/v1/contacts/ct_1", "GET")).toEqual({
       kind: "getContact",
       contactId: "ct_1",
     });
   });
 
   test("returns null for unsupported methods on contact routes", () => {
-    expect(matchIngressControlPlaneRoute("/v1/contacts", "DELETE")).toBeNull();
+    expect(matchContactsControlPlaneRoute("/v1/contacts", "DELETE")).toBeNull();
     // GET /v1/contacts/channels/ch_1 does not match (PATCH only)
     expect(
-      matchIngressControlPlaneRoute("/v1/contacts/channels/ch_1", "GET"),
+      matchContactsControlPlaneRoute("/v1/contacts/channels/ch_1", "GET"),
     ).toBeNull();
   });
 
   test("GET /v1/contacts/merge falls through to getContact", () => {
     // No GET handler for /merge, so the contactId catch-all picks it up
-    expect(matchIngressControlPlaneRoute("/v1/contacts/merge", "GET")).toEqual({
+    expect(matchContactsControlPlaneRoute("/v1/contacts/merge", "GET")).toEqual({
       kind: "getContact",
       contactId: "merge",
     });
@@ -39,14 +39,14 @@ describe("matchIngressControlPlaneRoute", () => {
 
   test("matches redeem invite only for POST", () => {
     expect(
-      matchIngressControlPlaneRoute("/v1/contacts/invites/redeem", "POST"),
+      matchContactsControlPlaneRoute("/v1/contacts/invites/redeem", "POST"),
     ).toEqual({
       kind: "redeemInvite",
     });
 
     // DELETE should treat `redeem` as an invite ID so revoke routing still works.
     expect(
-      matchIngressControlPlaneRoute("/v1/contacts/invites/redeem", "DELETE"),
+      matchContactsControlPlaneRoute("/v1/contacts/invites/redeem", "DELETE"),
     ).toEqual({
       kind: "revokeInvite",
       inviteId: "redeem",
@@ -55,17 +55,17 @@ describe("matchIngressControlPlaneRoute", () => {
 
   test("matches contacts invite routes", () => {
     expect(
-      matchIngressControlPlaneRoute("/v1/contacts/invites", "GET"),
+      matchContactsControlPlaneRoute("/v1/contacts/invites", "GET"),
     ).toEqual({
       kind: "listInvites",
     });
     expect(
-      matchIngressControlPlaneRoute("/v1/contacts/invites", "POST"),
+      matchContactsControlPlaneRoute("/v1/contacts/invites", "POST"),
     ).toEqual({
       kind: "createInvite",
     });
     expect(
-      matchIngressControlPlaneRoute("/v1/contacts/invites/inv_1", "DELETE"),
+      matchContactsControlPlaneRoute("/v1/contacts/invites/inv_1", "DELETE"),
     ).toEqual({
       kind: "revokeInvite",
       inviteId: "inv_1",
@@ -74,13 +74,13 @@ describe("matchIngressControlPlaneRoute", () => {
 
   test("returns null for unsupported method/path combinations", () => {
     expect(
-      matchIngressControlPlaneRoute("/v1/contacts/invites/redeem", "GET"),
+      matchContactsControlPlaneRoute("/v1/contacts/invites/redeem", "GET"),
     ).toBeNull();
     expect(
-      matchIngressControlPlaneRoute("/v1/contacts/invites/inv_1", "POST"),
+      matchContactsControlPlaneRoute("/v1/contacts/invites/inv_1", "POST"),
     ).toBeNull();
     expect(
-      matchIngressControlPlaneRoute("/v1/ingress/unknown", "GET"),
+      matchContactsControlPlaneRoute("/v1/ingress/unknown", "GET"),
     ).toBeNull();
   });
 });

--- a/gateway/src/http/routes/contacts-control-plane-route-match.ts
+++ b/gateway/src/http/routes/contacts-control-plane-route-match.ts
@@ -1,4 +1,4 @@
-export type IngressControlPlaneRoute =
+export type ContactsControlPlaneRoute =
   | { kind: "listContacts" }
   | { kind: "upsertContact" }
   | { kind: "getContact"; contactId: string }
@@ -9,10 +9,10 @@ export type IngressControlPlaneRoute =
   | { kind: "redeemInvite" }
   | { kind: "revokeInvite"; inviteId: string };
 
-export function matchIngressControlPlaneRoute(
+export function matchContactsControlPlaneRoute(
   pathname: string,
   method: string,
-): IngressControlPlaneRoute | null {
+): ContactsControlPlaneRoute | null {
   // ── Contact CRUD ──
   if (pathname === "/v1/contacts") {
     if (method === "GET") return { kind: "listContacts" };


### PR DESCRIPTION
## Summary
- Rename gateway route-match file from ingress-control-plane-route-match.ts to contacts-control-plane-route-match.ts
- Update exported type and function names
- Rename test file and update all references

Part of plan: ingress-naming-cleanup.md (PR 4 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
