### PR TITLE
refactor: rename ingress-control-plane-proxy to contacts-control-plane-proxy

### DIFF
--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -17,8 +17,8 @@ mock.module("../fetch.js", () => ({
   fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
 }));
 
-const { createIngressControlPlaneProxyHandler } =
-  await import("../http/routes/ingress-control-plane-proxy.js");
+const { createContactsControlPlaneProxyHandler } =
+  await import("../http/routes/contacts-control-plane-proxy.js");
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -71,7 +71,7 @@ afterEach(() => {
   fetchMock = mock(async () => new Response());
 });
 
-describe("ingress control-plane proxy", () => {
+describe("contacts control-plane proxy", () => {
   test("forwards contact endpoints to the runtime", async () => {
     const captured: string[] = [];
     fetchMock = mock(async (input: string | URL | Request) => {
@@ -82,7 +82,7 @@ describe("ingress control-plane proxy", () => {
       });
     });
 
-    const handler = createIngressControlPlaneProxyHandler(makeConfig());
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
 
     await handler.handleListContacts(
       new Request("http://localhost:7830/v1/contacts?limit=10"),
@@ -125,7 +125,7 @@ describe("ingress control-plane proxy", () => {
       });
     });
 
-    const handler = createIngressControlPlaneProxyHandler(makeConfig());
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
 
     await handler.handleListInvites(
       new Request("http://localhost:7830/v1/contacts/invites?status=active"),
@@ -164,7 +164,7 @@ describe("ingress control-plane proxy", () => {
       },
     );
 
-    const handler = createIngressControlPlaneProxyHandler(makeConfig());
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
     const res = await handler.handleCreateInvite(
       new Request("http://localhost:7830/v1/contacts/invites", {
         method: "POST",
@@ -195,7 +195,7 @@ describe("ingress control-plane proxy", () => {
       );
     });
 
-    const handler = createIngressControlPlaneProxyHandler(makeConfig());
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
     const res = await handler.handleCreateInvite(
       new Request("http://localhost:7830/v1/contacts/invites", {
         method: "POST",
@@ -217,7 +217,7 @@ describe("ingress control-plane proxy", () => {
       );
     });
 
-    const handler = createIngressControlPlaneProxyHandler(
+    const handler = createContactsControlPlaneProxyHandler(
       makeConfig({ runtimeTimeoutMs: 100 }),
     );
     const res = await handler.handleListInvites(

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -11,9 +11,9 @@ import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
 import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
 
-const log = getLogger("ingress-control-plane-proxy");
+const log = getLogger("contacts-control-plane-proxy");
 
-export function createIngressControlPlaneProxyHandler(config: GatewayConfig) {
+export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
   async function proxyToRuntime(
     req: Request,
     upstreamPath: string,

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -39,7 +39,7 @@ import {
 } from "./http/routes/feature-flags.js";
 import { createGuardianControlPlaneProxyHandler } from "./http/routes/guardian-control-plane-proxy.js";
 import { createTelegramControlPlaneProxyHandler } from "./http/routes/telegram-control-plane-proxy.js";
-import { createIngressControlPlaneProxyHandler } from "./http/routes/ingress-control-plane-proxy.js";
+import { createContactsControlPlaneProxyHandler } from "./http/routes/contacts-control-plane-proxy.js";
 import { createTwilioControlPlaneProxyHandler } from "./http/routes/twilio-control-plane-proxy.js";
 import { createChannelReadinessProxyHandler } from "./http/routes/channel-readiness-proxy.js";
 import { createRuntimeHealthProxyHandler } from "./http/routes/runtime-health-proxy.js";
@@ -144,8 +144,8 @@ function main() {
     createGuardianControlPlaneProxyHandler(config);
   const telegramControlPlaneProxy =
     createTelegramControlPlaneProxyHandler(config);
-  const ingressControlPlaneProxy =
-    createIngressControlPlaneProxyHandler(config);
+  const contactsControlPlaneProxy =
+    createContactsControlPlaneProxyHandler(config);
   const twilioControlPlaneProxy = createTwilioControlPlaneProxyHandler(config);
   const channelReadinessProxy = createChannelReadinessProxyHandler(config);
   const runtimeHealthProxy = createRuntimeHealthProxyHandler(config);
@@ -352,26 +352,26 @@ function main() {
       path: "/v1/contacts",
       method: "GET",
       auth: "edge",
-      handler: (req) => ingressControlPlaneProxy.handleListContacts(req),
+      handler: (req) => contactsControlPlaneProxy.handleListContacts(req),
     },
     {
       path: "/v1/contacts",
       method: "POST",
       auth: "edge",
-      handler: (req) => ingressControlPlaneProxy.handleUpsertContact(req),
+      handler: (req) => contactsControlPlaneProxy.handleUpsertContact(req),
     },
     {
       path: "/v1/contacts/merge",
       method: "POST",
       auth: "edge",
-      handler: (req) => ingressControlPlaneProxy.handleMergeContacts(req),
+      handler: (req) => contactsControlPlaneProxy.handleMergeContacts(req),
     },
     {
       path: /^\/v1\/contacts\/channels\/([^/]+)$/,
       method: "PATCH",
       auth: "edge",
       handler: (req, params) =>
-        ingressControlPlaneProxy.handleUpdateContactChannel(req, params[0]),
+        contactsControlPlaneProxy.handleUpdateContactChannel(req, params[0]),
     },
 
     // ── Contacts/invites control plane ──
@@ -379,33 +379,33 @@ function main() {
       path: "/v1/contacts/invites",
       method: "GET",
       auth: "edge",
-      handler: (req) => ingressControlPlaneProxy.handleListInvites(req),
+      handler: (req) => contactsControlPlaneProxy.handleListInvites(req),
     },
     {
       path: "/v1/contacts/invites",
       method: "POST",
       auth: "edge",
-      handler: (req) => ingressControlPlaneProxy.handleCreateInvite(req),
+      handler: (req) => contactsControlPlaneProxy.handleCreateInvite(req),
     },
     {
       path: "/v1/contacts/invites/redeem",
       method: "POST",
       auth: "edge",
-      handler: (req) => ingressControlPlaneProxy.handleRedeemInvite(req),
+      handler: (req) => contactsControlPlaneProxy.handleRedeemInvite(req),
     },
     {
       path: /^\/v1\/contacts\/invites\/([^/]+)$/,
       method: "DELETE",
       auth: "edge",
       handler: (req, params) =>
-        ingressControlPlaneProxy.handleRevokeInvite(req, params[0]),
+        contactsControlPlaneProxy.handleRevokeInvite(req, params[0]),
     },
     {
       path: /^\/v1\/contacts\/([^/]+)$/,
       method: "GET",
       auth: "edge",
       handler: (req, params) =>
-        ingressControlPlaneProxy.handleGetContact(req, params[0]),
+        contactsControlPlaneProxy.handleGetContact(req, params[0]),
     },
 
     // ── Guardian control plane ──


### PR DESCRIPTION
## Summary
- Rename gateway proxy file from ingress-control-plane-proxy.ts to contacts-control-plane-proxy.ts
- Update exported function name, logger name, and all import references in index.ts
- Rename test file accordingly

Part of plan: ingress-naming-cleanup.md (PR 3 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
