### PR TITLE
refactor: rename ingress-service.ts to invite-service.ts

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -43,7 +43,7 @@ import {
   composeVerificationVoice,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,
 } from "../runtime/guardian-verification-templates.js";
-import { redeemVoiceInviteCode } from "../runtime/ingress-service.js";
+import { redeemVoiceInviteCode } from "../runtime/invite-service.js";
 import { parseJsonSafe } from "../util/json.js";
 import { getLogger } from "../util/logger.js";
 import {

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -19,7 +19,7 @@ import {
   listIngressInvites,
   redeemIngressInvite,
   revokeIngressInvite,
-} from "../../runtime/ingress-service.js";
+} from "../../runtime/invite-service.js";
 import type {
   AssistantInboxEscalationRequest,
   ContactsInviteRequest,

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -1,5 +1,5 @@
 /**
- * Shared business logic for ingress invite management.
+ * Shared business logic for invite management.
  *
  * Extracted from the IPC handlers in daemon/handlers/config-inbox.ts so that
  * both the HTTP routes and the IPC handlers call the same logic.

--- a/assistant/src/runtime/routes/invite-routes.ts
+++ b/assistant/src/runtime/routes/invite-routes.ts
@@ -14,7 +14,7 @@ import {
   redeemIngressInvite,
   redeemVoiceInviteCode,
   revokeIngressInvite,
-} from "../ingress-service.js";
+} from "../invite-service.js";
 
 // ---------------------------------------------------------------------------
 // Invites


### PR DESCRIPTION
## Summary
- Rename assistant/src/runtime/ingress-service.ts to invite-service.ts
- Update module comment to remove 'ingress' prefix
- Update all 3 import paths (invite-routes.ts, config-inbox.ts, relay-server.ts)

Part of plan: ingress-naming-cleanup.md (PR 5 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
