### PR TITLE
fix(macos): clear hover state and cursor on popover dismiss [LUM-9]

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1655,6 +1655,17 @@ struct MainWindowView: View {
                     .onChange(of: threadManager.activeThreadId) { _, _ in
                         showThreadSwitcher = false
                     }
+                    .onChange(of: showThreadSwitcher) { _, isShowing in
+                        if !isShowing {
+                            // Clean up hover/cursor state when popover dismisses —
+                            // onHover(false) may not fire if the view is removed.
+                            if sidebar.isHoveredThread != nil {
+                                sidebar.isHoveredThread = nil
+                                NSCursor.pop()
+                            }
+                            sidebar.threadPendingDeletion = nil
+                        }
+                    }
                     .onChange(of: sidebar.isHoveredThread) { _, newValue in
                         if let pending = sidebar.threadPendingDeletion, newValue != pending {
                             sidebar.threadPendingDeletion = nil


### PR DESCRIPTION
## Summary
- Add `onChange(of: showThreadSwitcher)` to reset `sidebar.isHoveredThread`, pop cursor, and clear `threadPendingDeletion` when popover dismisses
- Prevents ghost hover highlights in expanded sidebar and unbalanced cursor stack

Addresses review feedback from Codex and Devin on #12390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
