### PR TITLE
fix(macos): dismiss popover when tapping already-active thread [LUM-9]

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1616,6 +1616,9 @@ struct MainWindowView: View {
                             VStack(spacing: 0) {
                                 ForEach(regularThreads) { thread in
                                     threadItem(thread)
+                                        .simultaneousGesture(TapGesture().onEnded {
+                                            showThreadSwitcher = false
+                                        })
                                         .padding(.bottom, VSpacing.xxs)
                                         .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
                                             if sidebar.dropTargetThreadId == thread.id {


### PR DESCRIPTION
## Summary
- Add `simultaneousGesture(TapGesture)` to popover thread rows to dismiss on any tap
- Fixes regression where tapping the already-active thread left the popover open (since `onChange(of: activeThreadId)` doesn't fire when the value is unchanged)

Addresses review feedback from Codex and Devin on #12470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
