### PR TITLE
Fix feedback on PR #12085: clip filename collisions

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -200,7 +200,7 @@ Be specific and factual. Describe what you see, not what you infer happened betw
 
 ### Clip Delivery
 
-The `generate_clip` tool automatically opens clips in the user's default video player after extraction (handled internally — do **not** run `open` via `host_bash`). Clips are saved persistently in the asset's pipeline directory (`pipeline/<assetId>/clips/`). The `clipPath` field in the tool response contains the absolute file path.
+The `generate_clip` tool automatically opens clips in the user's default video player after extraction (handled internally — do **not** run `open` via `host_bash`). Clips are saved persistently in the asset's pipeline directory (`pipeline/<assetId>/clips/`), falling back to a temp directory when the source location is read-only. Each clip gets a unique filename so concurrent or repeated extractions at the same range never collide. The `clipPath` field in the tool response contains the absolute file path.
 
 The tool handles high-bitrate and incompatible codec sources automatically — it tries stream copy first for speed, then falls back to H.264 re-encoding if needed. **Always use `generate_clip` rather than manual ffmpeg commands.**
 

--- a/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
@@ -6,7 +6,9 @@
  * This is a generic media-processing primitive with no domain-specific logic.
  */
 
-import { mkdir, stat } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { access, constants, mkdir, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import { uploadFileBackedAttachment } from "../../../../memory/attachments-store.js";
@@ -132,14 +134,31 @@ export async function run(
 
   // Save clips to the asset's pipeline directory so they persist for
   // attachment delivery (tmpdir files get cleaned up before the sandbox
-  // attachment system can serve them).
-  const clipDir = join(dirname(asset.filePath), "pipeline", assetId, "clips");
-  await mkdir(clipDir, { recursive: true });
+  // attachment system can serve them). Fall back to a temp directory when the
+  // source directory is read-only (external mounts, protected folders, etc.).
+  const preferredDir = join(
+    dirname(asset.filePath),
+    "pipeline",
+    assetId,
+    "clips",
+  );
+  let clipDir: string;
+  try {
+    await mkdir(preferredDir, { recursive: true });
+    await access(preferredDir, constants.W_OK);
+    clipDir = preferredDir;
+  } catch {
+    clipDir = join(tmpdir(), "vellum-clips", assetId);
+    await mkdir(clipDir, { recursive: true });
+  }
 
+  // Include a short unique suffix to prevent filename collisions when
+  // concurrent or repeated calls target the same time range.
   const timestampSuffix = `${formatTimestamp(startTime).replace(/:/g, "")}-${formatTimestamp(endTime).replace(/:/g, "")}`;
+  const uniqueSuffix = randomUUID().slice(0, 8);
   const clipFilename = title
-    ? `${sanitizeFilename(title)}-${timestampSuffix}.${outputFormat}`
-    : `clip-${timestampSuffix}.${outputFormat}`;
+    ? `${sanitizeFilename(title)}-${timestampSuffix}-${uniqueSuffix}.${outputFormat}`
+    : `clip-${timestampSuffix}-${uniqueSuffix}.${outputFormat}`;
   const clipPath = join(clipDir, clipFilename);
 
   try {


### PR DESCRIPTION
Addresses reviewer feedback on #12085 — prevents filename collisions for concurrent clips and handles read-only source directories.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
