### PR TITLE
Fix feedback on PR #12141: clip filename collisions

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
@@ -136,9 +136,10 @@ export async function run(
   const clipDir = join(dirname(asset.filePath), "pipeline", assetId, "clips");
   await mkdir(clipDir, { recursive: true });
 
+  const timestampSuffix = `${formatTimestamp(startTime).replace(/:/g, "")}-${formatTimestamp(endTime).replace(/:/g, "")}`;
   const clipFilename = title
-    ? `${sanitizeFilename(title)}.${outputFormat}`
-    : `clip-${formatTimestamp(startTime).replace(/:/g, "")}-${formatTimestamp(endTime).replace(/:/g, "")}.${outputFormat}`;
+    ? `${sanitizeFilename(title)}-${timestampSuffix}.${outputFormat}`
+    : `clip-${timestampSuffix}.${outputFormat}`;
   const clipPath = join(clipDir, clipFilename);
 
   try {


### PR DESCRIPTION
Addresses reviewer feedback on #12141 — appends timestamp suffix to title-based clip filenames to prevent overwrites when same title is reused.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
