### PR TITLE
M2: Fix thread tracking race (#12447)

### DIFF
--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -466,14 +466,14 @@ export function createSlackDeliverHandler(
         return Response.json({ ok: true, placeholderTs: data.ts });
       }
 
-      if (text && typeof text === "string") {
-        // Track the thread early — before the API call — so replies arriving
-        // while the post is in-flight are still forwarded.  A spurious entry
-        // if the post ultimately fails is harmless (24h TTL expiry).
-        if (threadTs && onThreadReply && !isEphemeral) {
-          onThreadReply(threadTs);
-        }
+      // Track the thread early — before any API call — so replies arriving
+      // while the post is in-flight are still forwarded.  A spurious entry
+      // if the post ultimately fails is harmless (24h TTL expiry).
+      if (threadTs && onThreadReply && !isEphemeral) {
+        onThreadReply(threadTs);
+      }
 
+      if (text && typeof text === "string") {
         const slackBody: Record<string, unknown> = {
           channel: chatId,
           // `text` is always required as a fallback for notifications and accessibility

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -467,6 +467,13 @@ export function createSlackDeliverHandler(
       }
 
       if (text && typeof text === "string") {
+        // Track the thread early — before the API call — so replies arriving
+        // while the post is in-flight are still forwarded.  A spurious entry
+        // if the post ultimately fails is harmless (24h TTL expiry).
+        if (threadTs && onThreadReply && !isEphemeral) {
+          onThreadReply(threadTs);
+        }
+
         const slackBody: Record<string, unknown> = {
           channel: chatId,
           // `text` is always required as a fallback for notifications and accessibility
@@ -555,13 +562,6 @@ export function createSlackDeliverHandler(
         },
         isUpdate ? "Slack message updated" : "Slack message sent",
       );
-
-      // Track the thread so future replies without @mention are forwarded.
-      // Skip for ephemeral sends — they are user-specific and should not
-      // activate global thread tracking for all participants.
-      if (threadTs && onThreadReply && !isEphemeral) {
-        onThreadReply(threadTs);
-      }
 
       return Response.json({ ok: true });
     } catch (err) {


### PR DESCRIPTION
Move onThreadReply() before callSlackApiWithRetries() so that thread replies arriving during the API call are still forwarded. Spurious tracking on post failure is safe (24h TTL expiry).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
