### PR TITLE
feat: gateway Save button → primary style

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -107,7 +107,7 @@ struct GatewaySettingsCard: View {
 
             // Save button at the bottom
             HStack {
-                VButton(label: "Save", style: .secondary, size: .medium) {
+                VButton(label: "Save", style: .primary, size: .medium) {
                     store.saveIngressPublicBaseUrl(gatewayUrlText)
                     isGatewayUrlFocused = false
                 }


### PR DESCRIPTION
## Summary
- Changes the Save button in `GatewaySettingsCard` from `.secondary` to `.primary` style to match the design mockup (solid green button).

## Files modified
- `clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift` — one-line change on line 110

## Test plan
- [ ] Build and run the macOS app
- [ ] Navigate to Settings → Gateway
- [ ] Confirm the Save button renders as a solid green (primary) button instead of an outlined (secondary) button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
