### PR TITLE
M3: Fail fast on auth.test failure (#12448)

### DIFF
--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -89,27 +89,32 @@ export class SlackSocketModeClient {
           user?: string;
           team?: string;
         };
-        if (data.ok) {
-          if (data.user_id) {
-            this.config.botUserId = data.user_id;
-          }
-          if (data.user) {
-            this.config.botUsername = data.user;
-          }
-          if (data.team) {
-            this.config.teamName = data.team;
-          }
-          log.info(
-            {
-              botUserId: data.user_id,
-              botUsername: data.user,
-              teamName: data.team,
-            },
-            "Resolved Slack bot identity",
+        if (!data.ok) {
+          throw new Error(
+            "Slack auth.test failed: bot token is invalid or expired",
           );
         }
+        if (data.user_id) {
+          this.config.botUserId = data.user_id;
+        }
+        if (data.user) {
+          this.config.botUsername = data.user;
+        }
+        if (data.team) {
+          this.config.teamName = data.team;
+        }
+        log.info(
+          {
+            botUserId: data.user_id,
+            botUsername: data.user,
+            teamName: data.team,
+          },
+          "Resolved Slack bot identity",
+        );
       } catch (err) {
-        log.warn({ err }, "Failed to resolve bot identity via auth.test");
+        throw new Error("Failed to resolve Slack bot identity via auth.test", {
+          cause: err,
+        });
       }
     }
 

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -112,6 +112,8 @@ export class SlackSocketModeClient {
           "Resolved Slack bot identity",
         );
       } catch (err) {
+        this.running = false;
+        this.stopDedupCleanup();
         throw new Error("Failed to resolve Slack bot identity via auth.test", {
           cause: err,
         });

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -112,11 +112,19 @@ export class SlackSocketModeClient {
           "Resolved Slack bot identity",
         );
       } catch (err) {
-        this.running = false;
-        this.stopDedupCleanup();
-        throw new Error("Failed to resolve Slack bot identity via auth.test", {
-          cause: err,
-        });
+        // Explicit auth rejection (data.ok === false) is fatal — the bot
+        // token is invalid and retrying won't help.
+        const isAuthRejection =
+          err instanceof Error &&
+          err.message.includes("bot token is invalid or expired");
+        if (isAuthRejection) {
+          this.running = false;
+          this.stopDedupCleanup();
+          throw err;
+        }
+        // Transient fetch/network errors — warn and proceed to connect(),
+        // which has its own reconnect logic with backoff.
+        log.warn({ err }, "Failed to resolve bot identity via auth.test");
       }
     }
 


### PR DESCRIPTION
Throw on auth.test failure instead of warn+continue. Without botUserId, self-message filtering is disabled and can cause infinite loops.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
