### PR TITLE
M6: Retry transient 5xx errors (#12452)

### DIFF
--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -60,6 +60,23 @@ async function callSlackApiWithRetries(
       continue;
     }
 
+    // Handle 5xx server errors with retry
+    if (response.status >= 500) {
+      if (attempt >= MAX_RATE_LIMIT_RETRIES) {
+        tlog.error(
+          { chatId, status: response.status },
+          "Slack 5xx error after retries",
+        );
+        return Response.json({ error: "Delivery failed" }, { status: 502 });
+      }
+      tlog.warn(
+        { chatId, status: response.status, attempt },
+        "Slack 5xx error, retrying",
+      );
+      await new Promise((r) => setTimeout(r, DEFAULT_RETRY_AFTER_S * 1000));
+      continue;
+    }
+
     const data = (await response.json()) as {
       ok?: boolean;
       error?: string;

--- a/gateway/src/slack/errors.ts
+++ b/gateway/src/slack/errors.ts
@@ -11,6 +11,7 @@ export type SlackErrorCategory =
   | "not_found"
   | "permission"
   | "channel_not_found"
+  | "transient"
   | "unknown";
 
 const ERROR_CODE_MAP: Record<string, SlackErrorCategory> = {
@@ -58,5 +59,9 @@ export function classifySlackError(
  * Whether the error category indicates the request could succeed on retry.
  */
 export function isRetryable(category: SlackErrorCategory): boolean {
-  return category === "rate_limit" || category === "unknown";
+  return (
+    category === "rate_limit" ||
+    category === "transient" ||
+    category === "unknown"
+  );
 }


### PR DESCRIPTION
Add 5xx retry logic to callSlackApiWithRetries() and add 'transient' to SlackErrorCategory. 5xx errors now retry with the same backoff as rate limits.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
