### PR TITLE
M8: Enforce 50-block limit in textToBlocks (#12455)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1655,6 +1655,17 @@ struct MainWindowView: View {
                     .onChange(of: threadManager.activeThreadId) { _, _ in
                         showThreadSwitcher = false
                     }
+                    .onChange(of: showThreadSwitcher) { _, isShowing in
+                        if !isShowing {
+                            // Clean up hover/cursor state when popover dismisses —
+                            // onHover(false) may not fire if the view is removed.
+                            if sidebar.isHoveredThread != nil {
+                                sidebar.isHoveredThread = nil
+                                NSCursor.pop()
+                            }
+                            sidebar.threadPendingDeletion = nil
+                        }
+                    }
                     .onChange(of: sidebar.isHoveredThread) { _, newValue in
                         if let pending = sidebar.threadPendingDeletion, newValue != pending {
                             sidebar.threadPendingDeletion = nil

--- a/gateway/src/slack/text-to-blocks.ts
+++ b/gateway/src/slack/text-to-blocks.ts
@@ -11,6 +11,9 @@ import { type Block, BlockKitBuilder } from "./block-kit-builder.js";
 /** Slack mrkdwn text sections have a 3000-character limit. */
 const SLACK_MRKDWN_MAX_LENGTH = 3000;
 
+/** Slack rejects messages with more than 50 blocks. */
+const SLACK_BLOCK_LIMIT = 50;
+
 /**
  * Convert a markdown/plain-text string into an array of Block Kit blocks.
  *
@@ -48,7 +51,23 @@ export function textToBlocks(text: string): Block[] {
     }
   }
 
-  return builder.toBlocks();
+  const blocks = builder.toBlocks();
+
+  if (blocks.length > SLACK_BLOCK_LIMIT) {
+    const totalBlocks = blocks.length;
+    const truncationNote: Block = {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: `_Content truncated — ${totalBlocks - 49} blocks omitted due to Slack's ${SLACK_BLOCK_LIMIT}-block limit_`,
+        },
+      ],
+    };
+    return [...blocks.slice(0, 49), truncationNote];
+  }
+
+  return blocks;
 }
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/slack/text-to-blocks.ts
+++ b/gateway/src/slack/text-to-blocks.ts
@@ -60,11 +60,11 @@ export function textToBlocks(text: string): Block[] {
       elements: [
         {
           type: "mrkdwn",
-          text: `_Content truncated — ${totalBlocks - 49} blocks omitted due to Slack's ${SLACK_BLOCK_LIMIT}-block limit_`,
+          text: `_Content truncated — ${totalBlocks - (SLACK_BLOCK_LIMIT - 1)} blocks omitted due to Slack's ${SLACK_BLOCK_LIMIT}-block limit_`,
         },
       ],
     };
-    return [...blocks.slice(0, 49), truncationNote];
+    return [...blocks.slice(0, SLACK_BLOCK_LIMIT - 1), truncationNote];
   }
 
   return blocks;


### PR DESCRIPTION
Truncate blocks to 49 + 1 context block when textToBlocks() produces more than 50 blocks. Prevents Slack API rejection for long messages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
