### PR TITLE
M7: Wire Block Kit delivery in slack-deliver (#12453)

### DIFF
--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -412,6 +412,53 @@ export function createSlackDeliverHandler(
       );
     }
 
+    // Validate approval payload shape
+    if (body.approval) {
+      const apr = body.approval;
+      if (typeof apr !== "object" || apr === null || Array.isArray(apr)) {
+        return Response.json(
+          { error: "approval must be an object" },
+          { status: 400 },
+        );
+      }
+      if (!apr.requestId || typeof apr.requestId !== "string") {
+        return Response.json(
+          { error: "approval.requestId is required" },
+          { status: 400 },
+        );
+      }
+      if (!Array.isArray(apr.actions) || apr.actions.length === 0) {
+        return Response.json(
+          { error: "approval.actions must be a non-empty array" },
+          { status: 400 },
+        );
+      }
+      for (const action of apr.actions) {
+        if (
+          action === null ||
+          typeof action !== "object" ||
+          Array.isArray(action)
+        ) {
+          return Response.json(
+            { error: "each approval action must be an object" },
+            { status: 400 },
+          );
+        }
+        if (!action.id || typeof action.id !== "string") {
+          return Response.json(
+            { error: "each approval action must have an id" },
+            { status: 400 },
+          );
+        }
+        if (!action.label || typeof action.label !== "string") {
+          return Response.json(
+            { error: "each approval action must have a label" },
+            { status: 400 },
+          );
+        }
+      }
+    }
+
     // Support threading via query param
     const threadTs = new URL(req.url).searchParams.get("threadTs") ?? undefined;
     const messageTs = body.messageTs ?? updateTs;

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -330,13 +330,13 @@ export function createSlackDeliverHandler(
       messageTs?: string;
       /** When provided, generate Block Kit approval prompt blocks. */
       approval?: {
-        message: string;
         requestId: string;
         actions: Array<{
           id: string;
           label: string;
           style?: "primary" | "danger";
         }>;
+        plainTextFallback: string;
       };
     };
     try {
@@ -422,7 +422,11 @@ export function createSlackDeliverHandler(
       Array.isArray(body.blocks) && body.blocks.length > 0
         ? body.blocks
         : body.approval
-          ? approvalPrompt(body.approval)
+          ? approvalPrompt({
+              message: text || body.approval.plainTextFallback,
+              requestId: body.approval.requestId,
+              actions: body.approval.actions,
+            })
           : textToBlocks(text);
 
     try {

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -7,7 +7,7 @@ import {
   type RuntimeAttachmentMeta,
 } from "../../runtime/client.js";
 import { classifySlackError } from "../../slack/errors.js";
-import type { Block } from "../../slack/block-kit-builder.js";
+import { approvalPrompt, type Block } from "../../slack/block-kit-builder.js";
 import { textToBlocks } from "../../slack/text-to-blocks.js";
 
 const log = getLogger("slack-deliver");
@@ -328,6 +328,16 @@ export function createSlackDeliverHandler(
       updateTs?: string;
       /** When provided, use chat.update to edit an existing message instead of posting a new one. */
       messageTs?: string;
+      /** When provided, generate Block Kit approval prompt blocks. */
+      approval?: {
+        message: string;
+        requestId: string;
+        actions: Array<{
+          id: string;
+          label: string;
+          style?: "primary" | "danger";
+        }>;
+      };
     };
     try {
       body = (await req.json()) as typeof body;
@@ -407,11 +417,13 @@ export function createSlackDeliverHandler(
     const messageTs = body.messageTs ?? updateTs;
     const isUpdate = typeof messageTs === "string" && messageTs.length > 0;
 
-    // Resolve Block Kit blocks: use provided blocks, or auto-format text
+    // Resolve Block Kit blocks: use provided blocks, approval prompt, or auto-format text
     const blocks: Block[] =
       Array.isArray(body.blocks) && body.blocks.length > 0
         ? body.blocks
-        : textToBlocks(text);
+        : body.approval
+          ? approvalPrompt(body.approval)
+          : textToBlocks(text);
 
     try {
       // Typing indicator: post a placeholder message that the runtime can
@@ -491,13 +503,16 @@ export function createSlackDeliverHandler(
         let result: SlackApiResult | Response;
 
         if (isUpdate) {
-          // chat.update only accepts channel, ts, and text — thread_ts is not
-          // a valid parameter and would cause the call to fail silently.
-          const updateBody: Record<string, string> = {
+          // chat.update only accepts channel, ts, text, and blocks — thread_ts
+          // is not a valid parameter and would cause the call to fail silently.
+          const updateBody: Record<string, unknown> = {
             channel: chatId,
             text,
             ts: messageTs,
           };
+          if (blocks.length > 0) {
+            updateBody.blocks = blocks;
+          }
           result = await callSlackApiWithRetries(
             "https://slack.com/api/chat.update",
             updateBody,


### PR DESCRIPTION
Add approval payload handling (generates Block Kit blocks via approvalPrompt()) and include blocks in chat.update calls so edited messages retain rich formatting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
