### PR TITLE
M9: Use textToBlocks in notification adapter (#12456)

### DIFF
--- a/assistant/src/notifications/adapters/slack.ts
+++ b/assistant/src/notifications/adapters/slack.ts
@@ -68,7 +68,7 @@ export class SlackAdapter implements ChannelAdapter {
     try {
       await deliverChannelReply(
         deliverUrl,
-        { chatId, text: messageText },
+        { chatId, text: messageText, useBlocks: true },
         mintDaemonDeliveryToken(),
       );
 

--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -35,6 +35,8 @@ export interface ChannelReplyPayload {
   user?: string;
   /** When provided, instructs the delivery endpoint to update an existing message instead of posting a new one. */
   messageTs?: string;
+  /** When true, auto-generate Block Kit blocks from text via textToBlocks(). */
+  useBlocks?: boolean;
 }
 
 export interface ChannelDeliveryResult {

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -328,6 +328,8 @@ export function createSlackDeliverHandler(
       updateTs?: string;
       /** When provided, use chat.update to edit an existing message instead of posting a new one. */
       messageTs?: string;
+      /** When true, auto-generate Block Kit blocks from text via textToBlocks(). */
+      useBlocks?: boolean;
     };
     try {
       body = (await req.json()) as typeof body;
@@ -407,11 +409,13 @@ export function createSlackDeliverHandler(
     const messageTs = body.messageTs ?? updateTs;
     const isUpdate = typeof messageTs === "string" && messageTs.length > 0;
 
-    // Resolve Block Kit blocks: use provided blocks, or auto-format text
+    // Resolve Block Kit blocks: use provided blocks, or auto-format text when useBlocks is set
     const blocks: Block[] =
       Array.isArray(body.blocks) && body.blocks.length > 0
         ? body.blocks
-        : textToBlocks(text);
+        : body.useBlocks
+          ? textToBlocks(text)
+          : [];
 
     try {
       // Typing indicator: post a placeholder message that the runtime can


### PR DESCRIPTION
Add useBlocks flag to ChannelReplyPayload and slack-deliver request body. Set useBlocks: true in the Slack notification adapter so notifications get rich Block Kit formatting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
