### PR TITLE
fix(macos): align popover header and width with Figma design [LUM-9]

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1604,9 +1604,8 @@ struct MainWindowView: View {
                 .popover(isPresented: $showThreadSwitcher, arrowEdge: .trailing) {
                     VStack(alignment: .leading, spacing: VSpacing.xs) {
                         // Header
-                        Text("\(regularThreads.count) THREADS")
-                            .font(VFont.caption)
-                            .fontWeight(.medium)
+                        Text("\(regularThreads.count) threads")
+                            .font(VFont.body)
                             .foregroundColor(VColor.textMuted)
                             .padding(.horizontal, VSpacing.sm)
                             .padding(.top, VSpacing.sm)
@@ -1653,7 +1652,7 @@ struct MainWindowView: View {
                         }
                         .frame(maxHeight: 300)
                     }
-                    .frame(width: 260)
+                    .frame(width: 220)
                     .padding(.bottom, VSpacing.sm)
                     .onChange(of: threadManager.activeThreadId) { _, _ in
                         showThreadSwitcher = false


### PR DESCRIPTION
## Summary
- Change header from uppercase "N THREADS" (VFont.caption, medium weight) to lowercase "N threads" (VFont.body) matching Figma
- Reduce popover width from 260pt to 220pt for a more compact look matching Figma

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
