### PR TITLE
fix: implement --role flag in CLI contacts list command

### DIFF
--- a/cli/src/commands/contacts.ts
+++ b/cli/src/commands/contacts.ts
@@ -136,7 +136,7 @@ function printUsage(): void {
   console.log("Usage: vellum contacts <subcommand> [options]");
   console.log("");
   console.log("Subcommands:");
-  console.log("  list [--limit N]               List all contacts");
+  console.log("  list [--limit N] [--role ROLE]  List all contacts");
   console.log("  get <id>                       Get a contact by ID");
   console.log("  merge <keepId> <mergeId>       Merge two contacts");
   console.log("");
@@ -161,7 +161,9 @@ export async function contacts(): Promise<void> {
   switch (subcommand) {
     case "list": {
       const limit = getFlagValue(args, "--limit") ?? "50";
-      const data = (await apiGet(`contacts?limit=${limit}`)) as {
+      const role = getFlagValue(args, "--role");
+      const query = `contacts?limit=${limit}${role ? `&role=${encodeURIComponent(role)}` : ""}`;
+      const data = (await apiGet(query)) as {
         ok: boolean;
         contacts: Contact[];
       };


### PR DESCRIPTION
Addresses review feedback from PR #12444. The CLI contacts list command now parses and forwards the --role flag to the API, making `vellum contacts list --role contact` work as documented in the runbook.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
