### PR TITLE
fix: avoid double-encoding contactId and channelId in gateway proxy

### DIFF
--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -107,8 +107,7 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
     },
 
     async handleGetContact(req: Request, contactId: string): Promise<Response> {
-      const encoded = encodeURIComponent(contactId);
-      return proxyToRuntime(req, `/v1/contacts/${encoded}`, "");
+      return proxyToRuntime(req, `/v1/contacts/${contactId}`, "");
     },
 
     async handleMergeContacts(req: Request): Promise<Response> {
@@ -119,8 +118,7 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
       req: Request,
       channelId: string,
     ): Promise<Response> {
-      const encoded = encodeURIComponent(channelId);
-      return proxyToRuntime(req, `/v1/contacts/channels/${encoded}`, "");
+      return proxyToRuntime(req, `/v1/contacts/channels/${channelId}`, "");
     },
 
     // ── Invite routes ──
@@ -141,8 +139,7 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
       req: Request,
       inviteId: string,
     ): Promise<Response> {
-      const encoded = encodeURIComponent(inviteId);
-      return proxyToRuntime(req, `/v1/contacts/invites/${encoded}`, "");
+      return proxyToRuntime(req, `/v1/contacts/invites/${inviteId}`, "");
     },
   };
 }


### PR DESCRIPTION
Addresses review feedback from PR #12460. Removes redundant encodeURIComponent calls on path params that are already percent-encoded from URL parsing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
