### PR TITLE
fix: support channelType standalone filter and forward role to searchContacts

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -470,6 +470,37 @@ export function searchContacts(params: {
     return results;
   }
 
+  // Search by channel type alone (no address)
+  if (params.channelType) {
+    const channelRows = db
+      .select({ contactId: contactChannels.contactId })
+      .from(contactChannels)
+      .innerJoin(contacts, eq(contactChannels.contactId, contacts.id))
+      .where(
+        and(
+          or(
+            eq(contacts.assistantId, params.assistantId),
+            isNull(contacts.assistantId),
+          ),
+          eq(contactChannels.type, params.channelType),
+        ),
+      )
+      .all();
+
+    const contactIds = [...new Set(channelRows.map((r) => r.contactId))];
+    if (contactIds.length === 0) return [];
+
+    const results: ContactWithChannels[] = [];
+    for (const id of contactIds) {
+      if (results.length >= limit) break;
+      const contact = getContactInternal(id);
+      if (contact && (!params.role || contact.role === params.role)) {
+        results.push(contact);
+      }
+    }
+    return results;
+  }
+
   // Search by display name and/or relationship
   const conditions = [
     or(

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -48,6 +48,7 @@ export function handleListContacts(url: URL, assistantId: string): Response {
       channelAddress: channelAddress ?? undefined,
       channelType: channelType ?? undefined,
       relationship: relationship ?? undefined,
+      role: role ?? undefined,
       limit,
     });
     return Response.json({ ok: true, contacts });


### PR DESCRIPTION
Addresses review feedback from PR #12459. Adds channelType-only search branch in contact-store.ts and forwards the role parameter from contact-routes.ts to searchContacts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
