### PR TITLE
fix: default contacts list --role to contact

### DIFF
--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -169,7 +169,7 @@ export function registerContactsCommand(program: Command): void {
   contacts
     .command("list")
     .description("List contacts (calls /v1/contacts)")
-    .option("--role <role>", "Filter by role")
+    .option("--role <role>", "Filter by role (default: contact)", "contact")
     .option("--limit <limit>", "Maximum number of contacts to return")
     .option("--query <query>", "Search query to filter contacts")
     .action(


### PR DESCRIPTION
## Summary

- Adds `"contact"` as the default value for the `--role` option in `vellum contacts list`
- Preserves the implicit `role=contact` filtering that the removed `vellum integrations ingress members` command had
- Without this, `contacts list` returns all roles (including guardians), silently changing result scope for users who migrated from the deprecated command

Addresses review feedback on PR #12337.

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
