### PR TITLE
feat: compact inputs to 28pt and simplify VToggle

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -828,6 +828,13 @@ struct DynamicWorkspaceWrapper: View {
 
                 Spacer(minLength: 0)
 
+                Text(surface.title ?? data.preview?.title ?? "App")
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(adaptiveColor(light: VColor.textPrimary, dark: VColor.textSecondary))
+                    .lineLimit(1)
+
+                Spacer(minLength: 0)
+
                 // Right: History + Share + Close outlined icon buttons
                 HStack(spacing: VSpacing.sm) {
                     if data.appId != nil {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1024,7 +1024,7 @@ struct SettingsPanel: View {
 
                 Spacer()
 
-                VToggle(isOn: .constant(granted), size: .medium).allowsHitTesting(false)
+                VToggle(isOn: .constant(granted)).allowsHitTesting(false)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())

--- a/clients/macos/vellum-assistant/Features/Settings/HeartbeatConfigView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/HeartbeatConfigView.swift
@@ -62,7 +62,7 @@ struct HeartbeatConfigView: View {
                                     .foregroundColor(VColor.textMuted)
                             }
                             Spacer()
-                            VToggle(isOn: $enabled, size: .medium)
+                            VToggle(isOn: $enabled)
                                 .onChange(of: enabled) { _, newValue in
                                     guard !isApplyingFromServer else { return }
                                     saveConfig(enabled: newValue)
@@ -112,7 +112,7 @@ struct HeartbeatConfigView: View {
                                         .foregroundColor(VColor.textMuted)
                                 }
                                 Spacer()
-                                VToggle(isOn: $activeHoursEnabled, size: .medium)
+                                VToggle(isOn: $activeHoursEnabled)
                                     .onChange(of: activeHoursEnabled) { _, newValue in
                                         guard !isApplyingFromServer else { return }
                                         if newValue {

--- a/clients/macos/vellum-assistant/Features/Settings/ScheduledTasksView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ScheduledTasksView.swift
@@ -222,7 +222,7 @@ private struct ScheduleRow: View {
                 VToggle(isOn: Binding(
                     get: { schedule.enabled },
                     set: { onToggle($0) }
-                ), size: .medium)
+                ))
 
                 Button {
                     onDelete()

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -117,21 +117,21 @@ struct SettingsAccountTab: View {
                 // visible so the URL can still be changed.
                 // When not reachable/configured, show the inline field or a Set Up prompt.
                 if store.vellumPlatformReachable == true {
-                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .medium) {}
+                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success) {}
                     TextField("https://platform.vellum.ai", text: $platformUrlText)
                         .vInputStyle()
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
                         .focused($isPlatformUrlFocused)
                     HStack(spacing: VSpacing.sm) {
-                        VButton(label: "Save", style: .secondary, size: .medium) {
+                        VButton(label: "Save", style: .secondary) {
                             store.savePlatformBaseUrl(platformUrlText)
                             Task { await store.checkVellumPlatform() }
                             isPlatformUrlFocused = false
                             platformUrlExpanded = false
                         }
                         .disabled(platformUrlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                        VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                        VButton(label: "Cancel", style: .tertiary) {
                             platformUrlText = store.platformBaseUrl
                             isPlatformUrlFocused = false
                             platformUrlExpanded = false
@@ -144,21 +144,21 @@ struct SettingsAccountTab: View {
                         .foregroundColor(VColor.textPrimary)
                         .focused($isPlatformUrlFocused)
                     HStack(spacing: VSpacing.sm) {
-                        VButton(label: "Save", style: .secondary, size: .medium) {
+                        VButton(label: "Save", style: .secondary) {
                             store.savePlatformBaseUrl(platformUrlText)
                             Task { await store.checkVellumPlatform() }
                             isPlatformUrlFocused = false
                             platformUrlExpanded = false
                         }
                         .disabled(platformUrlText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                        VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                        VButton(label: "Cancel", style: .tertiary) {
                             platformUrlText = store.platformBaseUrl
                             isPlatformUrlFocused = false
                             platformUrlExpanded = false
                         }
                     }
                 } else {
-                    VButton(label: "Set Up", style: .secondary, size: .medium) {
+                    VButton(label: "Set Up", style: .secondary) {
                         platformUrlExpanded = true
                     }
                 }
@@ -175,7 +175,7 @@ struct SettingsAccountTab: View {
                         .foregroundColor(VColor.textSecondary)
                 }
             } else if authManager.currentUser != nil {
-                VButton(label: "Log Out", style: .danger, size: .medium) {
+                VButton(label: "Log Out", style: .danger) {
                     Task { await authManager.logout() }
                 }
             } else {
@@ -320,7 +320,7 @@ struct SettingsAccountTab: View {
                             set: { isOn in
                                 if isOn { switchToAssistant(assistant) }
                             }
-                        ), size: .medium)
+                        ))
                     }
                     .padding(.vertical, VSpacing.xs)
                     .contentShape(Rectangle())
@@ -366,7 +366,7 @@ struct SettingsAccountTab: View {
                             .foregroundColor(VColor.textMuted)
                     }
                 }
-                VButton(label: "Retire...", style: .danger, size: .medium) {
+                VButton(label: "Retire...", style: .danger) {
                     showingRetireConfirmation = true
                 }
             }
@@ -449,7 +449,7 @@ struct SettingsAccountTab: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textMuted)
                     }
-                    VButton(label: "Hatch...", style: .primary, size: .medium) {
+                    VButton(label: "Hatch...", style: .primary) {
                         AppDelegate.shared?.replayOnboarding()
                         onClose()
                     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -152,7 +152,7 @@ struct SettingsAdvancedDevTab: View {
                 }
             }
             Spacer()
-            VToggle(isOn: flagBinding, size: .medium)
+            VToggle(isOn: flagBinding)
                 .accessibilityLabel(flag.displayName)
         }
         .contentShape(Rectangle())
@@ -179,7 +179,7 @@ struct SettingsAdvancedDevTab: View {
                 }
             }
             Spacer()
-            VToggle(isOn: flagBinding, size: .medium)
+            VToggle(isOn: flagBinding)
                 .accessibilityLabel(entry.label)
         }
         .contentShape(Rectangle())

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -110,11 +110,11 @@ struct SettingsAppearanceTab: View {
                     }
 
                     if isRecordingGlobalHotkey {
-                        VButton(label: "Press shortcut...", style: .outlined, size: .medium) {
+                        VButton(label: "Press shortcut...", style: .outlined) {
                             stopRecording()
                         }
                     } else {
-                        VButton(label: "Record", style: .outlined, size: .medium) {
+                        VButton(label: "Record", style: .outlined) {
                             startRecording()
                         }
                     }
@@ -143,11 +143,11 @@ struct SettingsAppearanceTab: View {
                     }
 
                     if isRecordingQuickInputHotkey {
-                        VButton(label: "Press shortcut...", style: .outlined, size: .medium) {
+                        VButton(label: "Press shortcut...", style: .outlined) {
                             stopRecording()
                         }
                     } else {
-                        VButton(label: "Record", style: .outlined, size: .medium) {
+                        VButton(label: "Record", style: .outlined) {
                             startRecordingQuickInput()
                         }
                     }
@@ -173,7 +173,7 @@ struct SettingsAppearanceTab: View {
                     VToggle(isOn: Binding(
                         get: { store.cmdEnterToSend },
                         set: { store.cmdEnterToSend = $0 }
-                    ), size: .medium)
+                    ))
                 }
                 .padding(.vertical, VSpacing.md)
             }
@@ -198,7 +198,7 @@ struct SettingsAppearanceTab: View {
                     VToggle(isOn: Binding(
                         get: { store.mediaEmbedsEnabled },
                         set: { store.setMediaEmbedsEnabled($0) }
-                    ), size: .medium)
+                    ))
                 }
 
                 Text("Automatically embed images, videos, and other media shared in chat messages.")
@@ -244,7 +244,7 @@ struct SettingsAppearanceTab: View {
                         .padding(.vertical, VSpacing.xs)
                     }
 
-                    VButton(label: "Reset to Defaults", style: .secondary, size: .medium) {
+                    VButton(label: "Reset to Defaults", style: .secondary) {
                         store.setMediaEmbedVideoAllowlistDomains(MediaEmbedSettings.defaultDomains)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -66,7 +66,7 @@ struct SettingsPrivacyTab: View {
                         collectUsageData = newValue
                         Task { await setCollectUsageData(newValue) }
                     }
-                ), size: .medium)
+                ))
                 .disabled(isLoading || isUpdating || daemonClient == nil)
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ToolPermissionTesterView.swift
@@ -55,11 +55,11 @@ struct ToolPermissionTesterView: View {
 
             // Toggles
             HStack(spacing: VSpacing.xl) {
-                VToggle(isOn: $model.isInteractive, label: "Interactive", size: .medium)
+                VToggle(isOn: $model.isInteractive, label: "Interactive")
                     .font(VFont.body)
                     .foregroundColor(VColor.textSecondary)
 
-                VToggle(isOn: $model.forcePromptSideEffects, label: "In Temporary Chat", size: .medium)
+                VToggle(isOn: $model.forcePromptSideEffects, label: "In Temporary Chat")
                     .font(VFont.body)
                     .foregroundColor(VColor.textSecondary)
             }
@@ -91,7 +91,7 @@ struct ToolPermissionTesterView: View {
             } else {
                 // Optional fields have a checkbox
                 HStack(spacing: VSpacing.xs) {
-                    VToggle(isOn: fieldEnabledBinding(for: field.id), size: .medium)
+                    VToggle(isOn: fieldEnabledBinding(for: field.id))
                     fieldNameLabel(field)
                 }
 
@@ -139,7 +139,7 @@ struct ToolPermissionTesterView: View {
                 .font(VFont.mono)
 
         case .boolean:
-            VToggle(isOn: fieldBoolBinding(for: field.id), size: .medium)
+            VToggle(isOn: fieldBoolBinding(for: field.id))
 
         case .enumeration(let values):
             VDropdown(
@@ -193,7 +193,7 @@ struct ToolPermissionTesterView: View {
     @ViewBuilder
     private var simulateButton: some View {
         HStack(spacing: VSpacing.sm) {
-            VButton(label: model.isSimulating ? "Simulating\u{2026}" : "Simulate", style: .primary, size: .medium) {
+            VButton(label: model.isSimulating ? "Simulating\u{2026}" : "Simulate", style: .primary) {
                 model.simulate()
             }
             .disabled(!model.canSimulate)

--- a/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/TrustRulesView.swift
@@ -248,7 +248,7 @@ private struct TrustRuleFormView: View {
 
                 TextField("Pattern", text: $pattern, prompt: Text("e.g., git *"))
 
-                VToggle(isOn: $isEverywhere, label: "Everywhere", size: .medium)
+                VToggle(isOn: $isEverywhere, label: "Everywhere")
                 if !isEverywhere {
                     TextField("Scope", text: $scope, prompt: Text("e.g., /Users/me/project"))
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -81,7 +81,7 @@ struct VoiceSettingsView: View {
                             selectActivator(.off)
                         }
                     }
-                ), size: .medium)
+                ))
                 .accessibilityLabel("Enable Push to Talk")
             }
 
@@ -298,7 +298,7 @@ struct VoiceSettingsView: View {
                         .foregroundColor(VColor.textMuted)
                 }
                 Spacer()
-                VToggle(isOn: $wakeWordEnabled, size: .medium)
+                VToggle(isOn: $wakeWordEnabled)
                     .accessibilityLabel("Enable wake word listening")
             }
 
@@ -419,8 +419,8 @@ struct VoiceSettingsView: View {
 
             if store.hasElevenLabsKey {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .medium) {}
-                    VButton(label: "Disconnect", style: .danger, size: .medium) {
+                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success) {}
+                    VButton(label: "Disconnect", style: .danger) {
                         store.clearElevenLabsKey()
                         elevenLabsKeyText = ""
                         ttsSetupExpanded = false
@@ -452,14 +452,14 @@ struct VoiceSettingsView: View {
                             elevenLabsKeyText = ""
                             ttsSetupExpanded = false
                         }
-                        VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                        VButton(label: "Cancel", style: .tertiary) {
                             ttsSetupExpanded = false
                             elevenLabsKeyText = ""
                         }
                     }
                 }
             } else {
-                VButton(label: "Set Up", style: .secondary, size: .medium) {
+                VButton(label: "Set Up", style: .secondary) {
                     ttsSetupExpanded = true
                 }
             }

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -288,7 +288,7 @@ struct RecordingSourcePickerView: View {
                     .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
-                VToggle(isOn: $viewModel.includeAudio, size: .large)
+                VToggle(isOn: $viewModel.includeAudio)
                     .accessibilityLabel("System audio")
             }
             .padding(.horizontal, VSpacing.xl)
@@ -302,7 +302,7 @@ struct RecordingSourcePickerView: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
                     Spacer()
-                    VToggle(isOn: $viewModel.includeMicrophone, size: .large)
+                    VToggle(isOn: $viewModel.includeMicrophone)
                         .accessibilityLabel("Microphone")
                 }
                 .padding(.horizontal, VSpacing.xl)

--- a/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VDropdown.swift
@@ -47,10 +47,12 @@ public struct VDropdown<T: Hashable>: View {
 
                 Image(systemName: "chevron.down")
                     .foregroundColor(VColor.textMuted)
-                    .font(.system(size: 14))
+                    .font(.system(size: 13))
                     .accessibilityHidden(true)
             }
-            .padding(VSpacing.md)
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.xs)
+            .frame(height: 28)
             .background(VColor.inputBackground)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .overlay(

--- a/clients/shared/DesignSystem/Core/Inputs/VInlineActionField.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VInlineActionField.swift
@@ -59,7 +59,7 @@ public struct VInlineActionField: View {
             inputField
                 .focused($fieldFocused)
                 .padding(.leading, VSpacing.md)
-                .padding(.vertical, VSpacing.md)
+                .padding(.vertical, VSpacing.xs)
                 .onSubmit {
                     if !isActionDisabled { action() }
                 }

--- a/clients/shared/DesignSystem/Core/Inputs/VSearchBar.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VSearchBar.swift
@@ -30,7 +30,9 @@ public struct VSearchBar: View {
                 .accessibilityLabel("Clear search")
             }
         }
-        .padding(VSpacing.md)
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.xs)
+        .frame(height: 28)
         .background(VColor.inputBackground)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
     }

--- a/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VTextField.swift
@@ -9,7 +9,9 @@ public struct VInputStyleModifier: ViewModifier {
     public func body(content: Content) -> some View {
         content
             .textFieldStyle(.plain)
-            .padding(VSpacing.md)
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.xs)
+            .frame(height: 28)
             .background(VColor.inputBackground)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
             .overlay(
@@ -47,7 +49,7 @@ public struct VTextField: View {
             if let leadingIcon = leadingIcon {
                 Image(systemName: leadingIcon)
                     .foregroundColor(VColor.textMuted)
-                    .font(.system(size: 14))
+                    .font(.system(size: 13))
                     .accessibilityHidden(true)
             }
 
@@ -63,11 +65,13 @@ public struct VTextField: View {
             if let trailingIcon = trailingIcon {
                 Image(systemName: trailingIcon)
                     .foregroundColor(VColor.textMuted)
-                    .font(.system(size: 14))
+                    .font(.system(size: 13))
                     .accessibilityHidden(true)
             }
         }
-        .padding(VSpacing.md)
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.xs)
+        .frame(height: 28)
         .background(VColor.inputBackground)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .overlay(

--- a/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
@@ -3,48 +3,16 @@ import SwiftUI
 public struct VToggle: View {
     @Binding public var isOn: Bool
     public var label: String? = nil
-    public var size: Size = .large
     @Environment(\.isEnabled) private var isEnabled
 
-    public enum Size {
-        /// Original large size: track 50×28, knob 22×22, padding 3.
-        case large
-        /// Smaller variant for settings panels: track 40×22, knob 18×18, padding 2.
-        case medium
+    private let trackWidth: CGFloat = 34
+    private let trackHeight: CGFloat = 18
+    private let knobSize: CGFloat = 14
+    private let knobPadding: CGFloat = 2
 
-        var trackWidth: CGFloat {
-            switch self {
-            case .large: return 50
-            case .medium: return 40
-            }
-        }
-
-        var trackHeight: CGFloat {
-            switch self {
-            case .large: return 28
-            case .medium: return 22
-            }
-        }
-
-        var knobSize: CGFloat {
-            switch self {
-            case .large: return 22
-            case .medium: return 18
-            }
-        }
-
-        var knobPadding: CGFloat {
-            switch self {
-            case .large: return 3
-            case .medium: return 2
-            }
-        }
-    }
-
-    public init(isOn: Binding<Bool>, label: String? = nil, size: Size = .large) {
+    public init(isOn: Binding<Bool>, label: String? = nil) {
         self._isOn = isOn
         self.label = label
-        self.size = size
     }
 
     public var body: some View {
@@ -76,16 +44,16 @@ public struct VToggle: View {
     private var toggleTrack: some View {
         ZStack(alignment: isOn ? .trailing : .leading) {
             // Track background
-            RoundedRectangle(cornerRadius: size.trackHeight / 2)
+            RoundedRectangle(cornerRadius: trackHeight / 2)
                 .fill(isOn ? Forest._600 : VColor.toggleOff)
-                .frame(width: size.trackWidth, height: size.trackHeight)
+                .frame(width: trackWidth, height: trackHeight)
 
             // Knob
-            RoundedRectangle(cornerRadius: size.knobSize / 2)
+            RoundedRectangle(cornerRadius: knobSize / 2)
                 .fill(Color.white)
-                .frame(width: size.knobSize, height: size.knobSize)
+                .frame(width: knobSize, height: knobSize)
                 .shadow(color: Color.black.opacity(0.15), radius: 3, x: 0, y: 1)
-                .padding(.horizontal, size.knobPadding)
+                .padding(.horizontal, knobPadding)
         }
     }
 }
@@ -110,7 +78,6 @@ private struct VTogglePreviewWrapper: View {
                 VToggle(isOn: $isOnA, label: "Enabled toggle")
                 VToggle(isOn: $isOnB, label: "Disabled toggle")
                 VToggle(isOn: $isOnA)
-                VToggle(isOn: $isOnA, label: "Large toggle", size: .large)
             }
             .padding()
         }


### PR DESCRIPTION
## Summary
- Standardize all input components (VTextField, VSearchBar, VDropdown, VInlineActionField) to 28pt height, matching medium-sized buttons
- Simplify VToggle by removing the `Size` enum — single compact size (34x18 track, 14pt knob)
- Add centered app name to the workspace toolbar

## Test plan
- [ ] All inputs render at consistent 28pt height
- [ ] VToggle renders at compact size across all settings panels
- [ ] App name displays centered in workspace toolbar
- [ ] No layout regressions in settings panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
