### PR TITLE
fix: remove leftover merge conflict marker in slack-deliver test

### DIFF
--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -880,6 +880,5 @@ describe("slack attachment delivery", () => {
     );
     expect(completeCall).toBeDefined();
     expect((completeCall!.body as any).thread_ts).toBe("1700000000.000050");
->>>>>>> origin/main
   });
 });


### PR DESCRIPTION
## Summary
- Remove a stray `>>>>>>> origin/main` merge conflict marker left at line 883 of `gateway/src/__tests__/slack-deliver.test.ts`
- This was causing eslint to fail with "Parsing error: Merge conflict marker encountered" on main (14 consecutive CI failures)

## Original prompt
fix the errors in CI here: https://github.com/vellum-ai/vellum-assistant/actions/runs/22681807181

🤖 Generated with [Claude Code](https://claude.com/claude-code)