### PR TITLE
fix: guard channelType branch to preserve query/relationship filters

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -471,7 +471,7 @@ export function searchContacts(params: {
   }
 
   // Search by channel type alone (no address)
-  if (params.channelType) {
+  if (params.channelType && !params.query && !params.relationship) {
     const channelRows = db
       .select({ contactId: contactChannels.contactId })
       .from(contactChannels)


### PR DESCRIPTION
The channelType-only branch in searchContacts short-circuits when query or relationship params are also provided, silently dropping those filters. Guard the branch with !params.query && !params.relationship so it only enters when channelType is the sole search criterion. Addresses feedback from PR #12495.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
