### PR TITLE
feat: standardize nav colors (transparent/hover/active)

### DIFF
--- a/clients/shared/DesignSystem/Components/Navigation/VSegmentedControl.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VSegmentedControl.swift
@@ -121,14 +121,14 @@ private struct PillSegment: View {
     }
 
     private var selectedTextColor: Color {
-        .white
+        VColor.textPrimary
     }
 
     private var segmentBackground: Color {
         if isSelected {
-            return Forest._600
+            return VColor.navActive
         } else if isHovered {
-            return VColor.ghostHover
+            return VColor.navHover
         } else {
             return .clear
         }

--- a/clients/shared/DesignSystem/Core/Navigation/VTab.swift
+++ b/clients/shared/DesignSystem/Core/Navigation/VTab.swift
@@ -28,11 +28,12 @@ public struct VTab: View {
     }
 
     private var background: Color {
-        switch style {
-        case .pill, .rectangular:
-            return isSelected ? VColor.surfaceBorder : (isHovered ? VColor.surfaceBorder.opacity(0.5) : .clear)
-        case .flat:
-            return isHovered ? VColor.ghostHover : .clear
+        if isSelected {
+            return VColor.navActive
+        } else if isHovered {
+            return VColor.navHover
+        } else {
+            return .clear
         }
     }
 
@@ -77,7 +78,7 @@ public struct VTab: View {
         .overlay(
             RoundedRectangle(cornerRadius: cornerRadius)
                 .stroke(VColor.surfaceBorder, lineWidth: 1)
-                .opacity((style == .pill || style == .rectangular) && isSelected ? 1 : 0)
+                .opacity(isSelected ? 1 : 0)
         )
         .onHover { hovering in isHovered = hovering }
     }

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -204,6 +204,10 @@ public enum VColor {
     public static let userBubbleText = adaptiveColor(light: Stone._900, dark: Moss._50)
     public static let userBubbleTextSecondary = adaptiveColor(light: Stone._600, dark: Moss._50.opacity(0.8))
 
+    // Navigation
+    public static let navHover = adaptiveColor(light: Color(hex: 0xE8E6DA), dark: Moss._700)
+    public static let navActive = adaptiveColor(light: Color(hex: 0xD4DFD0), dark: Moss._600)
+
     // Interactive states
     public static let ghostHover = adaptiveColor(light: Stone._100, dark: Moss._700)
     public static let ghostPressed = adaptiveColor(light: Stone._200, dark: Moss._600)


### PR DESCRIPTION
## Summary
- Add `VColor.navHover` (`#E8E6DA`) and `VColor.navActive` (`#D4DFD0`) color tokens
- Update `VTab` to use consistent nav colors across all styles (pill, flat, rectangular)
- Update `VSegmentedControl` pill segments to use the same tokens
- Colors: default transparent, hover warm beige, active soft green

## Test plan
- [ ] VTab hover shows `#E8E6DA` background
- [ ] VTab selected shows `#D4DFD0` background
- [ ] VSegmentedControl pill segments use the same hover/active colors
- [ ] Dark mode uses appropriate Moss equivalents
- [ ] No regressions in thread tab bar or settings tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
