### PR TITLE
refactor: consolidate duplicated isUntrustedTrustClass helper

### DIFF
--- a/assistant/src/daemon/session-lifecycle.ts
+++ b/assistant/src/daemon/session-lifecycle.ts
@@ -13,7 +13,10 @@ import * as conversationStore from "../memory/conversation-store.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import type { ContentBlock, Message } from "../providers/types.js";
-import type { TrustClass } from "../runtime/actor-trust-resolver.js";
+import {
+  type TrustClass,
+  isUntrustedTrustClass,
+} from "../runtime/actor-trust-resolver.js";
 import { unregisterSessionSender } from "../tools/browser/browser-screencast.js";
 import { getLogger } from "../util/logger.js";
 import { repairHistory } from "./history-repair.js";
@@ -45,10 +48,6 @@ function parseProvenanceTrustClass(
     // Ignore malformed metadata and treat as unknown provenance.
   }
   return undefined;
-}
-
-function isUntrustedTrustClass(trustClass: TrustClass | undefined): boolean {
-  return trustClass === "trusted_contact" || trustClass === "unknown";
 }
 
 function filterMessagesForUntrustedActor(

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -43,6 +43,14 @@ export type { TrustContext } from "../daemon/session-runtime-assembly.js";
  *   actors are fail-closed with no escalation path.
  */
 export type TrustClass = "guardian" | "trusted_contact" | "unknown";
+
+/** Returns `true` for actors that are not fully trusted (i.e. not the guardian). */
+export function isUntrustedTrustClass(
+  trustClass: TrustClass | undefined,
+): boolean {
+  return trustClass === "trusted_contact" || trustClass === "unknown";
+}
+
 /**
  * Reason an actor was denied access during trust resolution.
  *

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -4,6 +4,7 @@ import {
   getCanonicalGuardianRequest,
   updateCanonicalGuardianRequest,
 } from "../memory/canonical-guardian-store.js";
+import { isUntrustedTrustClass } from "../runtime/actor-trust-resolver.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { createOrReuseToolGrantRequest } from "../runtime/tool-grant-request-helper.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
@@ -128,10 +129,6 @@ export async function waitForInlineGrant(
     "Inline grant wait timed out — no guardian decision within budget",
   );
   return { outcome: "timeout", requestId: escalationRequestId };
-}
-
-function isUntrustedTrustClass(role: ToolContext["trustClass"]): boolean {
-  return role === "trusted_contact" || role === "unknown";
 }
 
 function requiresGuardianApprovalForActor(


### PR DESCRIPTION
## Summary
- Extract `isUntrustedTrustClass()` from duplicated definitions in `session-lifecycle.ts` and `tool-approval-handler.ts` into a single shared export in `actor-trust-resolver.ts` alongside the `TrustClass` type
- Both consumers now import the shared helper instead of defining their own copy

## Original prompt
lets do this cleanup:

The isUntrustedTrustClass() helper is duplicated in session-lifecycle.ts and tool-approval-handler.ts.
  Consolidating it into a single shared utility (maybe in contacts/types.ts alongside TrustClass) would reduce the surface area for drift. But
  that's a 5-line cleanup, not a permissions system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
