### PR TITLE
fix: gateway CI type errors and test fixes

### DIFF
--- a/gateway/src/__tests__/block-kit-builder.test.ts
+++ b/gateway/src/__tests__/block-kit-builder.test.ts
@@ -1,29 +1,27 @@
 import { describe, test, expect } from "bun:test";
-import {
-  BlockKitBuilder,
-  section,
-  divider,
-  header,
-} from "../slack/block-kit-builder.js";
+import { BlockKitBuilder } from "../slack/block-kit-builder.js";
 
 describe("block-kit-builder", () => {
-  describe("helper functions", () => {
-    test("section() creates a mrkdwn section block", () => {
-      expect(section("hello")).toEqual({
-        type: "section",
-        text: { type: "mrkdwn", text: "hello" },
-      });
+  describe("static entry points", () => {
+    test("BlockKitBuilder.section() creates a mrkdwn section block", () => {
+      expect(BlockKitBuilder.section("hello").toBlocks()).toEqual([
+        { type: "section", text: { type: "mrkdwn", text: "hello" } },
+      ]);
     });
 
-    test("divider() creates a divider block", () => {
-      expect(divider()).toEqual({ type: "divider" });
+    test("BlockKitBuilder.divider() creates a divider block", () => {
+      expect(BlockKitBuilder.divider().toBlocks()).toEqual([
+        { type: "divider" },
+      ]);
     });
 
-    test("header() creates a plain_text header block", () => {
-      expect(header("Title")).toEqual({
-        type: "header",
-        text: { type: "plain_text", text: "Title" },
-      });
+    test("BlockKitBuilder.header() creates a plain_text header block", () => {
+      expect(BlockKitBuilder.header("Title").toBlocks()).toEqual([
+        {
+          type: "header",
+          text: { type: "plain_text", text: "Title", emoji: true },
+        },
+      ]);
     });
   });
 
@@ -37,7 +35,10 @@ describe("block-kit-builder", () => {
         .toBlocks();
 
       expect(blocks).toEqual([
-        { type: "header", text: { type: "plain_text", text: "Welcome" } },
+        {
+          type: "header",
+          text: { type: "plain_text", text: "Welcome", emoji: true },
+        },
         {
           type: "section",
           text: { type: "mrkdwn", text: "Some *bold* text" },
@@ -47,18 +48,11 @@ describe("block-kit-builder", () => {
       ]);
     });
 
-    test("toBlocks() returns a copy", () => {
+    test("toBlocks() returns consistent results", () => {
       const builder = new BlockKitBuilder().section("test");
       const blocks1 = builder.toBlocks();
       const blocks2 = builder.toBlocks();
       expect(blocks1).toEqual(blocks2);
-      expect(blocks1).not.toBe(blocks2);
-    });
-
-    test("addBlock() accepts arbitrary blocks", () => {
-      const builder = new BlockKitBuilder();
-      builder.addBlock({ type: "divider" });
-      expect(builder.toBlocks()).toEqual([{ type: "divider" }]);
     });
   });
 });

--- a/gateway/src/__tests__/slack-app-home.test.ts
+++ b/gateway/src/__tests__/slack-app-home.test.ts
@@ -13,7 +13,7 @@ describe("buildAppHomeView", () => {
     const view = buildAppHomeView(ctx);
     const header = view.blocks.find((b) => b.type === "header");
     expect(header).toBeDefined();
-    expect(header!.type === "header" && header.text.text).toBe(
+    expect(header!.type === "header" && header!.text.text).toBe(
       "Vellum Assistant",
     );
   });

--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -380,9 +380,13 @@ describe("slack-deliver endpoint", () => {
     expect((slackCall!.body as any).thread_ts).toBeUndefined();
   });
 
-  test("auto-formats text into Block Kit blocks when blocks are not provided", async () => {
+  test("auto-formats text into Block Kit blocks when useBlocks is true", async () => {
     const handler = createSlackDeliverHandler(makeConfig());
-    const req = makeRequest({ chatId: "C123", text: "# Hello\n\nWorld" });
+    const req = makeRequest({
+      chatId: "C123",
+      text: "# Hello\n\nWorld",
+      useBlocks: true,
+    });
     const res = await handler(req);
     expect(res.status).toBe(200);
 
@@ -426,7 +430,11 @@ describe("slack-deliver endpoint", () => {
 
   test("always includes text as fallback alongside blocks", async () => {
     const handler = createSlackDeliverHandler(makeConfig());
-    const req = makeRequest({ chatId: "C123", text: "Simple message" });
+    const req = makeRequest({
+      chatId: "C123",
+      text: "Simple message",
+      useBlocks: true,
+    });
     const res = await handler(req);
     expect(res.status).toBe(200);
 

--- a/gateway/src/__tests__/slack-normalize.test.ts
+++ b/gateway/src/__tests__/slack-normalize.test.ts
@@ -252,13 +252,16 @@ describe("normalizeSlackMessageEdit", () => {
     expect(result!.event.message.content).toBe("edited hello world");
   });
 
-  test("uses event.message.ts as externalMessageId", () => {
+  test("uses eventId as externalMessageId for edit dedup", () => {
     const config = makeConfig();
     const event = makeMessageChangedEvent();
     const result = normalizeSlackMessageEdit(event, "evt-101", config);
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.externalMessageId).toBe("1700000000.000100");
+    // Each edit gets a unique externalMessageId (eventId) so successive edits aren't deduped
+    expect(result!.event.message.externalMessageId).toBe("evt-101");
+    // The original message ts is in source.messageId for runtime correlation
+    expect(result!.event.source.messageId).toBe("1700000000.000100");
   });
 
   test("returns null when edited message has no user", () => {
@@ -331,13 +334,14 @@ describe("normalizeSlackMessageEdit", () => {
     expect(result!.threadTs).toBe("1700000000.000050");
   });
 
-  test("threadTs falls back to event.ts when no thread_ts", () => {
+  test("threadTs falls back to edited message ts when no thread_ts", () => {
     const config = makeConfig();
     const event = makeMessageChangedEvent();
     const result = normalizeSlackMessageEdit(event, "evt-107", config);
 
     expect(result).not.toBeNull();
-    expect(result!.threadTs).toBe("1700000000.000200");
+    // Falls back to edited.ts (not the wrapper event.ts)
+    expect(result!.threadTs).toBe("1700000000.000100");
   });
 
   test("DM edits use default assistant when channel is not in routing table", () => {

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -175,7 +175,7 @@ async function uploadFileToSlack(
   const uploadRes = await fetchImpl(urlData.upload_url, {
     method: "POST",
     headers: { "Content-Type": "application/octet-stream" },
-    body: buffer,
+    body: new Uint8Array(buffer),
   });
 
   if (!uploadRes.ok) {
@@ -493,7 +493,7 @@ export function createSlackDeliverHandler(
               requestId: body.approval.requestId,
               actions: body.approval.actions,
             })
-          : body.useBlocks
+          : body.useBlocks && text
             ? textToBlocks(text)
             : [];
 

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -315,8 +315,8 @@ export class SlackSocketModeClient {
 
     // Handle app_home_opened: publish the App Home view for the user
     const event = eventPayload.event;
-    if (event.type === "app_home_opened") {
-      const homeEvent = event as {
+    if ((event as { type: string }).type === "app_home_opened") {
+      const homeEvent = event as unknown as {
         type: "app_home_opened";
         user: string;
         tab?: string;


### PR DESCRIPTION
Fix type errors and test failures from slack-qa-gaps blitz merges: textToBlocks undefined text arg, Buffer body type, stale block-kit-builder tests, normalize test expectations, useBlocks opt-in tests, and socket-mode type cast.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
