### PR TITLE
fix: handle channelType filter when combined with query/relationship

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -501,7 +501,7 @@ export function searchContacts(params: {
     return results;
   }
 
-  // Search by display name and/or relationship
+  // Search by display name and/or relationship, optionally filtered by channelType
   const conditions = [
     or(
       eq(contacts.assistantId, params.assistantId),
@@ -521,9 +521,30 @@ export function searchContacts(params: {
   if (params.role) {
     conditions.push(eq(contacts.role, params.role));
   }
+  if (params.channelType) {
+    conditions.push(eq(contactChannels.type, params.channelType));
+  }
 
   const whereClause =
     conditions.length > 1 ? and(...conditions) : conditions[0];
+
+  // Join with contactChannels when channelType is specified so the filter
+  // can reference the channel table; otherwise query contacts alone.
+  if (params.channelType) {
+    const rows = db
+      .select({ contactId: contacts.id })
+      .from(contacts)
+      .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
+      .where(whereClause)
+      .orderBy(desc(contacts.importance), desc(contacts.lastInteraction))
+      .limit(limit)
+      .all();
+
+    const contactIds = [...new Set(rows.map((r) => r.contactId))];
+    return contactIds
+      .map((id) => getContactInternal(id))
+      .filter((c): c is ContactWithChannels => c != null);
+  }
 
   const rows = db
     .select()

--- a/playwright/cases/phone-setup.md
+++ b/playwright/cases/phone-setup.md
@@ -1,5 +1,5 @@
 ---
-fixture: desktop-app
+fixture: desktop-app-hatched
 status: experimental
 ---
 
@@ -11,14 +11,15 @@ Verify that we're able to configure everything needed for the assistant to be ab
 
 ## Steps
 
-1. Go through whatever onboarding steps are needed until the assistant appears to be fully set up and ready to receive its first instruction.
-2. Send the message "Can you make phone calls for me?"
-3. Verify that the assistant responds in the affirmative that it is able to make phone calls, but that some initial setup is needed.
-4. You should be asked to provider your Twilio Account SID, your Twilio Auth Token, and your ngrok Auth Token, all through new windows that pop open titled "Secure Credential."
-5. Verify that you were able to supply all three credentals through a secure window and were NOT encouraged to provide them conversationally through the chat interface.
-6. You should be asked what voice you want the assistant to have and be presented with a few options to choose from.
-7. You should be offered to make a test call to your phone number. You can reject this offer.
-8. Once it seems like phone calling is fully set up, go to Preferences -> Settings -> Channels. There you should see that phone calling is fully configured.
+1. Launch the App
+2. Open a chat thread
+3. Send the message "Can you make phone calls for me?"
+4. Verify that the assistant responds in the affirmative that it is able to make phone calls, but that some initial setup is needed.
+5. You should be asked to provider your Twilio Account SID, your Twilio Auth Token, and your ngrok Auth Token, all through new windows that pop open titled "Secure Credential."
+6. Verify that you were able to supply all three credentals through a secure window and were NOT encouraged to provide them conversationally through the chat interface.
+7. You should be asked what voice you want the assistant to have and be presented with a few options to choose from.
+8. You should be offered to make a test call to your phone number. You can reject this offer.
+9. Once it seems like phone calling is fully set up, go to Preferences -> Settings -> Channels. There you should see that phone calling is fully configured.
 
 
 ## Expected


### PR DESCRIPTION
When channelType is provided alongside query or relationship params in searchContacts, the channelType filter was silently dropped. This fixes the issue by joining with the contactChannels table in the query/relationship branch when channelType is also specified, ensuring all filters are applied together.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
