### PR TITLE
fix: mock token exchange in slack-deliver attachment tests

### DIFF
--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -13,6 +13,11 @@ mock.module("../fetch.js", () => ({
   fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
 }));
 
+mock.module("../auth/token-exchange.js", () => ({
+  mintIngressToken: () => "mock-ingress-token",
+  mintServiceToken: () => "mock-service-token",
+}));
+
 const { createSlackDeliverHandler } =
   await import("../http/routes/slack-deliver.js");
 


### PR DESCRIPTION
Add mock for mintServiceToken/mintIngressToken in slack-deliver tests. Without this, downloadAttachment throws before reaching fetchImpl because the signing key isn't initialized in the test environment.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
