### PR TITLE
fix: apply LIMIT after dedup in channelType+query search branch

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -537,13 +537,20 @@ export function searchContacts(params: {
       .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
       .where(whereClause)
       .orderBy(desc(contacts.importance), desc(contacts.lastInteraction))
-      .limit(limit)
       .all();
 
     const contactIds = [...new Set(rows.map((r) => r.contactId))];
-    return contactIds
-      .map((id) => getContactInternal(id))
-      .filter((c): c is ContactWithChannels => c != null);
+    if (contactIds.length === 0) return [];
+
+    const results: ContactWithChannels[] = [];
+    for (const id of contactIds) {
+      if (results.length >= limit) break;
+      const contact = getContactInternal(id);
+      if (contact) {
+        results.push(contact);
+      }
+    }
+    return results;
   }
 
   const rows = db


### PR DESCRIPTION
Fix the channelType + query/relationship branch in searchContacts to match the existing pattern: fetch all matching rows from the join, deduplicate contact IDs, then enforce the limit in a for-loop. Previously LIMIT was applied at SQL level before dedup, which could return fewer unique contacts than expected when contacts have multiple channels.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
