### PR TITLE
fix: respect Retry-After header from provider API responses

### DIFF
--- a/assistant/src/__tests__/provider-error-scenarios.test.ts
+++ b/assistant/src/__tests__/provider-error-scenarios.test.ts
@@ -65,6 +65,18 @@ mock.module("../util/retry.js", () => {
     return false;
   }
 
+  function extractRetryAfterMs(headers: unknown): number | undefined {
+    if (!headers) return undefined;
+    let raw: string | null | undefined;
+    if (typeof (headers as { get?: unknown }).get === "function") {
+      raw = (headers as { get(k: string): string | null }).get("retry-after");
+    } else if (typeof headers === "object") {
+      raw = (headers as Record<string, string>)["retry-after"];
+    }
+    if (typeof raw === "string") return parseRetryAfterMs(raw);
+    return undefined;
+  }
+
   return {
     DEFAULT_MAX_RETRIES,
     DEFAULT_BASE_DELAY_MS,
@@ -73,6 +85,7 @@ mock.module("../util/retry.js", () => {
     getHttpRetryDelay,
     isRetryableStatus,
     isRetryableNetworkError,
+    extractRetryAfterMs,
     sleep: () => Promise.resolve(),
     abortableSleep: () => Promise.resolve(),
   };
@@ -199,6 +212,47 @@ describe("RetryProvider — rate limit backoff", () => {
       expect(pe.statusCode).toBe(429);
       expect(pe.message).toBe("quota exceeded");
     }
+  });
+
+  test("uses retryAfterMs from ProviderError when present", async () => {
+    const error = new ProviderError("rate limited", "anthropic", 429, {
+      retryAfterMs: 30_000,
+    });
+    const inner = makeFlaky(1, error);
+    const provider = new RetryProvider(inner);
+
+    const result = await provider.sendMessage(MESSAGES);
+    expect(result.content[0]).toMatchObject({ type: "text", text: "ok" });
+    expect(inner.calls).toBe(2);
+  });
+
+  test("preserves retryAfterMs on ProviderError through retry exhaustion", async () => {
+    const error = new ProviderError("rate limited", "anthropic", 429, {
+      retryAfterMs: 60_000,
+    });
+    const inner = makeFailing(error);
+    const provider = new RetryProvider(inner);
+
+    try {
+      await provider.sendMessage(MESSAGES);
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProviderError);
+      const pe = err as ProviderError;
+      expect(pe.retryAfterMs).toBe(60_000);
+      expect(pe.statusCode).toBe(429);
+    }
+  });
+
+  test("falls back to exponential backoff when retryAfterMs is absent", async () => {
+    const error = new ProviderError("rate limited", "test", 429);
+    expect(error.retryAfterMs).toBeUndefined();
+    const inner = makeFlaky(1, error);
+    const provider = new RetryProvider(inner);
+
+    const result = await provider.sendMessage(MESSAGES);
+    expect(result.content[0]).toMatchObject({ type: "text", text: "ok" });
+    expect(inner.calls).toBe(2);
   });
 });
 

--- a/assistant/src/__tests__/retry-after-extraction.test.ts
+++ b/assistant/src/__tests__/retry-after-extraction.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+
+import { ProviderError } from "../util/errors.js";
+import { extractRetryAfterMs, parseRetryAfterMs } from "../util/retry.js";
+
+// ---------------------------------------------------------------------------
+// parseRetryAfterMs
+// ---------------------------------------------------------------------------
+
+describe("parseRetryAfterMs", () => {
+  test("parses integer seconds", () => {
+    expect(parseRetryAfterMs("30")).toBe(30_000);
+  });
+
+  test("parses fractional seconds", () => {
+    expect(parseRetryAfterMs("1.5")).toBe(1_500);
+  });
+
+  test("returns undefined for non-numeric non-date string", () => {
+    expect(parseRetryAfterMs("not-a-date")).toBeUndefined();
+  });
+
+  test("parses HTTP-date format", () => {
+    const futureDate = new Date(Date.now() + 60_000).toUTCString();
+    const result = parseRetryAfterMs(futureDate);
+    expect(result).toBeDefined();
+    // Should be roughly 60 seconds (allow some tolerance for test execution time)
+    expect(result!).toBeGreaterThan(55_000);
+    expect(result!).toBeLessThan(65_000);
+  });
+
+  test("returns 0 for past HTTP-date", () => {
+    const pastDate = new Date(Date.now() - 10_000).toUTCString();
+    expect(parseRetryAfterMs(pastDate)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractRetryAfterMs
+// ---------------------------------------------------------------------------
+
+describe("extractRetryAfterMs", () => {
+  test("returns undefined for null/undefined headers", () => {
+    expect(extractRetryAfterMs(null)).toBeUndefined();
+    expect(extractRetryAfterMs(undefined)).toBeUndefined();
+  });
+
+  test("extracts from plain object headers (Anthropic SDK style)", () => {
+    const headers = { "retry-after": "45" };
+    expect(extractRetryAfterMs(headers)).toBe(45_000);
+  });
+
+  test("extracts from Headers instance (OpenAI SDK style)", () => {
+    const headers = new Headers({ "retry-after": "10" });
+    expect(extractRetryAfterMs(headers)).toBe(10_000);
+  });
+
+  test("extracts from Map-like object with .get()", () => {
+    const headers = {
+      get(key: string) {
+        return key === "retry-after" ? "25" : null;
+      },
+    };
+    expect(extractRetryAfterMs(headers)).toBe(25_000);
+  });
+
+  test("returns undefined when retry-after header is missing", () => {
+    expect(extractRetryAfterMs({})).toBeUndefined();
+    expect(extractRetryAfterMs(new Headers())).toBeUndefined();
+  });
+
+  test("returns undefined for non-object headers", () => {
+    expect(extractRetryAfterMs(42)).toBeUndefined();
+    expect(extractRetryAfterMs("string")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ProviderError.retryAfterMs
+// ---------------------------------------------------------------------------
+
+describe("ProviderError.retryAfterMs", () => {
+  test("stores retryAfterMs when provided in options", () => {
+    const err = new ProviderError("rate limited", "anthropic", 429, {
+      retryAfterMs: 30_000,
+    });
+    expect(err.retryAfterMs).toBe(30_000);
+    expect(err.statusCode).toBe(429);
+    expect(err.provider).toBe("anthropic");
+  });
+
+  test("retryAfterMs is undefined when not provided", () => {
+    const err = new ProviderError("rate limited", "anthropic", 429);
+    expect(err.retryAfterMs).toBeUndefined();
+  });
+
+  test("retryAfterMs is undefined with empty options", () => {
+    const err = new ProviderError("error", "test", 500, {});
+    expect(err.retryAfterMs).toBeUndefined();
+  });
+
+  test("preserves cause alongside retryAfterMs", () => {
+    const cause = new Error("original");
+    const err = new ProviderError("wrapped", "test", 429, {
+      cause,
+      retryAfterMs: 5_000,
+    });
+    expect(err.retryAfterMs).toBe(5_000);
+    expect(err.cause).toBe(cause);
+  });
+});

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -2,6 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 
 import { ProviderError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
+import { extractRetryAfterMs } from "../../util/retry.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import type {
   ContentBlock,
@@ -751,10 +752,12 @@ export class AnthropicProvider implements Provider {
             "Anthropic 400: tool_use/tool_result pairing error — dumping message structure",
           );
         }
+        const retryAfterMs = extractRetryAfterMs(error.headers);
         throw new ProviderError(
           `Anthropic API error (${error.status}): ${error.message}`,
           "anthropic",
           error.status,
+          retryAfterMs !== undefined ? { retryAfterMs } : undefined,
         );
       }
       throw new ProviderError(

--- a/assistant/src/providers/openai/client.ts
+++ b/assistant/src/providers/openai/client.ts
@@ -1,6 +1,7 @@
 import OpenAI from "openai";
 
 import { ProviderError } from "../../util/errors.js";
+import { extractRetryAfterMs } from "../../util/retry.js";
 import { escapeXmlAttr } from "../../util/xml.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import type {
@@ -196,10 +197,12 @@ export class OpenAIProvider implements Provider {
       };
     } catch (error) {
       if (error instanceof OpenAI.APIError) {
+        const retryAfterMs = extractRetryAfterMs(error.headers);
         throw new ProviderError(
           `${this.providerLabel} API error (${error.status}): ${error.message}`,
           this.name,
           error.status,
+          retryAfterMs !== undefined ? { retryAfterMs } : undefined,
         );
       }
       throw new ProviderError(

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -138,7 +138,11 @@ export class RetryProvider implements Provider {
         lastError = error;
 
         if (attempt < DEFAULT_MAX_RETRIES && isRetryableError(error)) {
-          const delay = computeRetryDelay(attempt, DEFAULT_BASE_DELAY_MS);
+          // Prefer server-provided Retry-After; fall back to exponential backoff.
+          const retryAfter =
+            error instanceof ProviderError ? error.retryAfterMs : undefined;
+          const delay =
+            retryAfter ?? computeRetryDelay(attempt, DEFAULT_BASE_DELAY_MS);
           const errorType =
             error instanceof ProviderError && error.statusCode === 429
               ? "rate_limit"
@@ -152,6 +156,7 @@ export class RetryProvider implements Provider {
               attempt: attempt + 1,
               maxRetries: DEFAULT_MAX_RETRIES,
               delay,
+              retryAfterHeader: retryAfter !== undefined,
               errorType,
               provider: this.name,
             },

--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -109,14 +109,18 @@ export class AssistantError extends VellumError {
 }
 
 export class ProviderError extends AssistantError {
+  /** Delay (in ms) suggested by the server's Retry-After header, if present. */
+  public readonly retryAfterMs?: number;
+
   constructor(
     message: string,
     public readonly provider: string,
     public readonly statusCode?: number,
-    options?: { cause?: unknown },
+    options?: { cause?: unknown; retryAfterMs?: number },
   ) {
     super(message, ErrorCode.PROVIDER_ERROR, options);
     this.name = "ProviderError";
+    this.retryAfterMs = options?.retryAfterMs;
   }
 }
 

--- a/assistant/src/util/retry.ts
+++ b/assistant/src/util/retry.ts
@@ -125,4 +125,25 @@ export function abortableSleep(
   });
 }
 
+/**
+ * Extract retry-after milliseconds from an SDK error's headers object.
+ * Handles both Map-like (OpenAI: Headers with .get()) and plain-object
+ * (Anthropic: Record<string, string>) header shapes.
+ */
+export function extractRetryAfterMs(headers: unknown): number | undefined {
+  if (!headers) return undefined;
+
+  let raw: string | null | undefined;
+  if (typeof (headers as { get?: unknown }).get === "function") {
+    raw = (headers as { get(k: string): string | null }).get("retry-after");
+  } else if (typeof headers === "object") {
+    raw = (headers as Record<string, string>)["retry-after"];
+  }
+
+  if (typeof raw === "string") {
+    return parseRetryAfterMs(raw);
+  }
+  return undefined;
+}
+
 export { DEFAULT_BASE_DELAY_MS, DEFAULT_MAX_RETRIES };


### PR DESCRIPTION
## Summary
- Added `retryAfterMs` field to `ProviderError` to carry server-suggested retry delay
- Added `extractRetryAfterMs()` utility to parse `retry-after` from both Anthropic (plain object) and OpenAI (Headers) SDK error shapes
- Anthropic and OpenAI providers now extract `retry-after` from API error headers and attach it to `ProviderError`
- `RetryProvider` now prefers server-provided `Retry-After` over computed exponential backoff, with observability logging (`retryAfterHeader: true/false`)
- Added comprehensive tests: unit tests for extraction/parsing + integration tests for retry behavior

## Test plan
- [x] All 55 existing + new tests pass (`bun test provider-error-scenarios retry-after-extraction`)
- [ ] Verify retry-after is respected in production by checking logs for `retryAfterHeader: true` on 429 responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
