### PR TITLE
feat: post-settings nudge — assistant message on settings close

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -133,6 +133,7 @@ struct SettingsPanel: View {
             // Snapshotting before those responses land captures stale `false` values,
             // which then look like user-made changes and trigger false-positive nudges.
             try? await Task.sleep(for: .milliseconds(700))
+            guard !Task.isCancelled else { return }
             if settingsSnapshot == nil {
                 settingsSnapshot = SettingsSnapshot(store: store)
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -127,8 +127,17 @@ struct SettingsPanel: View {
             // Refresh permission status when the view appears
             await refreshPermissionStatus()
         }
+        .task {
+            // Delay baseline snapshot until after async IPC refreshes (refreshTwitterStatus,
+            // refreshTelegramStatus, etc.) have had time to update @Published properties.
+            // Snapshotting before those responses land captures stale `false` values,
+            // which then look like user-made changes and trigger false-positive nudges.
+            try? await Task.sleep(for: .milliseconds(700))
+            if settingsSnapshot == nil {
+                settingsSnapshot = SettingsSnapshot(store: store)
+            }
+        }
         .onAppear {
-            settingsSnapshot = SettingsSnapshot(store: store)
             store.refreshAPIKeyState()
             store.refreshTwitterStatus()
             store.refreshTelegramStatus()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -96,6 +96,7 @@ struct SettingsPanel: View {
     @State private var notificationBadgesGranted: Bool = false
     @State private var permissionCheckTask: Task<Void, Never>?
     @State private var selectedTab: SettingsTab = .account
+    @State private var settingsSnapshot: SettingsSnapshot? = nil
 
     var body: some View {
         // Two-column layout: bare nav on window background, content in its own surface panel
@@ -127,6 +128,7 @@ struct SettingsPanel: View {
             await refreshPermissionStatus()
         }
         .onAppear {
+            settingsSnapshot = SettingsSnapshot(store: store)
             store.refreshAPIKeyState()
             store.refreshTwitterStatus()
             store.refreshTelegramStatus()
@@ -202,7 +204,7 @@ struct SettingsPanel: View {
     private var settingsNav: some View {
         VStack(alignment: .leading, spacing: VSpacing.xxs) {
             // Back to app link at top of sidebar
-            Button(action: onClose) {
+            Button(action: closeWithNudge) {
                 HStack(spacing: VSpacing.sm) {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 12, weight: .medium))
@@ -952,6 +954,19 @@ struct SettingsPanel: View {
         case "gmail": return "\u{1F4E7}"
         default: return "\u{1F517}"
         }
+    }
+
+    /// Closes the settings panel, injecting a proactive assistant nudge if meaningful changes were made.
+    private func closeWithNudge() {
+        if let snapshot = settingsSnapshot {
+            let after = SettingsSnapshot(store: store)
+            let changes = SettingsChangeDetector.detect(before: snapshot, after: after)
+            if !changes.isEmpty {
+                let msg = SettingsChangeDetector.buildNudgeMessage(changes: changes)
+                threadManager.activeViewModel?.injectAssistantMessage(msg)
+            }
+        }
+        onClose()
     }
 
     private func setupIntegrationCallbacks() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -143,6 +143,11 @@ struct SettingsPanel: View {
             store.refreshTelegramStatus()
             store.refreshTwilioStatus()
             store.refreshIngressConfig()
+            // Prefetch Slack config here so slackChannelConnected is populated before the
+            // 700ms baseline snapshot. Without this, the snapshot captures false and a later
+            // visit to the Channels tab (which calls fetchSlackChannelConfig) would flip it to
+            // true, producing a spurious "Slack connected" nudge on close.
+            store.fetchSlackChannelConfig()
             setupIntegrationCallbacks()
             try? daemonClient?.sendIntegrationList()
             if let pending = store.pendingSettingsTab {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChangeDetector.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChangeDetector.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Snapshots a subset of SettingsStore at a point in time and detects meaningful changes.
+struct SettingsSnapshot {
+    let model: String
+    let hasTelegram: Bool
+    let hasTwitter: Bool
+    let hasTwilio: Bool
+    let hasSlack: Bool
+    let hasBraveKey: Bool
+    let hasPerplexityKey: Bool
+    let hasElevenLabsKey: Bool
+    let platformBaseUrl: String
+
+    init(store: SettingsStore) {
+        model = store.selectedModel
+        hasTelegram = store.telegramConnected
+        hasTwitter = store.twitterConnected
+        hasTwilio = store.twilioHasCredentials
+        hasSlack = store.slackChannelConnected
+        hasBraveKey = store.hasBraveKey
+        hasPerplexityKey = store.hasPerplexityKey
+        hasElevenLabsKey = store.hasElevenLabsKey
+        platformBaseUrl = store.platformBaseUrl
+    }
+}
+
+struct SettingsChange {
+    let description: String
+    let suggestedPrompt: String
+}
+
+struct SettingsChangeDetector {
+    static func detect(before: SettingsSnapshot, after: SettingsSnapshot) -> [SettingsChange] {
+        var changes: [SettingsChange] = []
+
+        if before.model != after.model {
+            let displayName = SettingsStore.modelDisplayNames[after.model] ?? after.model
+            changes.append(SettingsChange(
+                description: "AI model changed to \(displayName)",
+                suggestedPrompt: "What can you help me with using \(displayName)?"
+            ))
+        }
+        if !before.hasTelegram && after.hasTelegram {
+            changes.append(SettingsChange(
+                description: "Telegram connected",
+                suggestedPrompt: "Send me a message on Telegram"
+            ))
+        }
+        if !before.hasTwitter && after.hasTwitter {
+            changes.append(SettingsChange(
+                description: "Twitter/X connected",
+                suggestedPrompt: "Post a tweet saying..."
+            ))
+        }
+        if !before.hasTwilio && after.hasTwilio {
+            changes.append(SettingsChange(
+                description: "SMS set up",
+                suggestedPrompt: "Text me when this task is done"
+            ))
+        }
+        if !before.hasSlack && after.hasSlack {
+            changes.append(SettingsChange(
+                description: "Slack connected",
+                suggestedPrompt: "Send a Slack message to #general"
+            ))
+        }
+        if !before.hasBraveKey && after.hasBraveKey {
+            changes.append(SettingsChange(
+                description: "Brave Search API key added",
+                suggestedPrompt: "Search the web for..."
+            ))
+        }
+        if !before.hasPerplexityKey && after.hasPerplexityKey {
+            changes.append(SettingsChange(
+                description: "Perplexity API key added",
+                suggestedPrompt: "Use Perplexity to research..."
+            ))
+        }
+        if !before.hasElevenLabsKey && after.hasElevenLabsKey {
+            changes.append(SettingsChange(
+                description: "ElevenLabs API key added",
+                suggestedPrompt: "Generate speech saying..."
+            ))
+        }
+
+        return changes
+    }
+
+    static func buildNudgeMessage(changes: [SettingsChange]) -> String {
+        guard !changes.isEmpty else { return "" }
+        var lines = ["I see you made some changes \u{2728}"]
+        for change in changes {
+            lines.append("\u{2022} \(change.description) \u{2014} try: \"\(change.suggestedPrompt)\"")
+        }
+        lines.append("\nFeel free to just ask me!")
+        return lines.joined(separator: "\n")
+    }
+}

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -910,6 +910,15 @@ public final class ChatViewModel: ObservableObject {
     }
     #endif
 
+    // MARK: - Synthetic Messages
+
+    /// Injects a synthetic assistant message directly into the chat, without going through the daemon.
+    /// Used for proactive/contextual nudges (e.g., post-settings suggestions).
+    @MainActor public func injectAssistantMessage(_ text: String) {
+        let message = ChatMessage(role: .assistant, text: text, status: .sent)
+        messages.append(message)
+    }
+
     // MARK: - Sending
 
     public func sendMessage(hidden: Bool = false) {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -914,6 +914,11 @@ public final class ChatViewModel: ObservableObject {
 
     /// Injects a synthetic assistant message directly into the chat, without going through the daemon.
     /// Used for proactive/contextual nudges (e.g., post-settings suggestions).
+    ///
+    /// This message is intentionally client-only (UI hint, not a conversation turn):
+    /// - It is NOT sent to the daemon and will NOT appear in the daemon's conversation history.
+    /// - It will NOT survive reconnect or reload — history loads from the daemon will not include it.
+    /// - It should not be used for messages that need to influence future LLM context.
     @MainActor public func injectAssistantMessage(_ text: String) {
         let message = ChatMessage(role: .assistant, text: text, status: .sent)
         messages.append(message)


### PR DESCRIPTION
## Summary

- Adds `injectAssistantMessage(_ text: String)` to `ChatViewModel` for injecting synthetic assistant messages directly into the chat without going through the daemon
- Creates `SettingsChangeDetector.swift` with `SettingsSnapshot` (captures relevant settings state) and `SettingsChangeDetector` (diffs two snapshots and builds nudge message)
- Wires it into `SettingsPanel`: snapshot is taken on `.onAppear`, and the "Back to app" button now calls `closeWithNudge()` which diffs the snapshot and injects a nudge if changes were made

## Test plan

- [ ] Open Settings, change AI model, click "Back to app" — assistant sends a nudge mentioning the model change
- [ ] Open Settings, connect Telegram/Slack/etc, click "Back to app" — assistant sends a nudge mentioning the new integration
- [ ] Open Settings, make no changes, click "Back to app" — no nudge is sent
- [ ] Programmatic close paths (integration setup flow, switch assistant, replay onboarding) do NOT trigger nudge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
