### PR TITLE
fix(macos): align popover and thread item styling with Figma

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1607,7 +1607,8 @@ struct MainWindowView: View {
                         Text("\(regularThreads.count) threads")
                             .font(VFont.body)
                             .foregroundColor(VColor.textMuted)
-                            .padding(.horizontal, VSpacing.sm)
+                            .padding(.leading, VSpacing.sm + 2)
+                            .padding(.trailing, VSpacing.sm)
                             .padding(.top, VSpacing.md)
                             .padding(.bottom, VSpacing.sm)
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -964,9 +964,9 @@ struct MainWindowView: View {
             .padding(.vertical, VSpacing.sm)
             .background {
                 if isSelected {
-                    adaptiveColor(light: Color(hex: 0xD4DFD4), dark: Color(hex: 0x3A3A37))
+                    adaptiveColor(light: Forest._200, dark: Moss._700)
                 } else if isHovered {
-                    adaptiveColor(light: Color(hex: 0xD4DFD4), dark: Color(hex: 0x3A3A37)).opacity(0.5)
+                    adaptiveColor(light: Forest._200, dark: Moss._700).opacity(0.5)
                 } else if thread.kind == .private {
                     VColor.accent.opacity(0.04)
                 } else {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1607,7 +1607,7 @@ struct MainWindowView: View {
                         Text("\(regularThreads.count) threads")
                             .font(VFont.body)
                             .foregroundColor(VColor.textMuted)
-                            .padding(.leading, VSpacing.sm + 2)
+                            .padding(.leading, VSpacing.md)
                             .padding(.trailing, VSpacing.sm)
                             .padding(.top, VSpacing.md)
                             .padding(.bottom, VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1661,7 +1661,7 @@ struct MainWindowView: View {
                     }
                     .frame(width: 220)
                     .padding(.bottom, VSpacing.sm)
-                    .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+                    .background(VColor.backgroundSubtle)
                     .onChange(of: threadManager.activeThreadId) { _, _ in
                         showThreadSwitcher = false
                     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -964,9 +964,9 @@ struct MainWindowView: View {
             .padding(.vertical, VSpacing.sm)
             .background {
                 if isSelected {
-                    adaptiveColor(light: Moss._100, dark: Moss._700)
+                    adaptiveColor(light: Color(hex: 0xD4DFD4), dark: Color(hex: 0x3A3A37))
                 } else if isHovered {
-                    adaptiveColor(light: Moss._100, dark: Moss._700).opacity(0.5)
+                    adaptiveColor(light: Color(hex: 0xD4DFD4), dark: Color(hex: 0x3A3A37)).opacity(0.5)
                 } else if thread.kind == .private {
                     VColor.accent.opacity(0.04)
                 } else {
@@ -1614,6 +1614,7 @@ struct MainWindowView: View {
                         VColor.divider
                             .frame(height: 1)
                             .padding(.horizontal, VSpacing.xs)
+                            .padding(.bottom, VSpacing.sm)
 
                         // Thread list
                         ScrollView {
@@ -1659,7 +1660,7 @@ struct MainWindowView: View {
                     }
                     .frame(width: 220)
                     .padding(.bottom, VSpacing.sm)
-                    .background(VColor.background)
+                    .background(adaptiveColor(light: Moss._50, dark: Moss._950))
                     .onChange(of: threadManager.activeThreadId) { _, _ in
                         showThreadSwitcher = false
                     }


### PR DESCRIPTION
## Summary
- Update selected/hovered thread row color to match the secondary button green (`0xD4DFD4` light / `0x3A3A37` dark) used by the Preferences button — applies everywhere `threadItem()` is used (sidebar + popover)
- Add symmetric padding below divider in thread switcher popover
- Set popover background to sidebar background color (`Moss._50` / `Moss._950`)

## Test plan
- [ ] Verify selected thread row in expanded sidebar shows green-tinted background matching Preferences button
- [ ] Verify hovered thread row shows same green at 50% opacity
- [ ] Verify collapsed sidebar popover background matches sidebar background
- [ ] Verify spacing above and below divider in popover is equal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
