### PR TITLE
fix: reset streaming state before populateFromHistory replaces messages

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2289,6 +2289,16 @@ public final class ChatViewModel: ObservableObject {
         }
 
         self.isLoadingHistory = true
+
+        // Discard any in-flight streaming text that references the pre-replacement
+        // message array. Without this, a scheduled flushStreamingBuffer() can fire
+        // after the messages array is replaced, creating an orphan assistant message
+        // or appending text to a stale currentAssistantMessageId.
+        discardStreamingBuffer()
+        currentAssistantMessageId = nil
+        currentAssistantHasText = false
+        lastContentWasToolCall = false
+
         if needsReconnectCatchUp {
             // Reconnect catch-up: the SSE stream dropped while a run was
             // in progress, so the client may have missed the assistant's


### PR DESCRIPTION
## Summary
- Add streaming state cleanup (`discardStreamingBuffer()`, `currentAssistantMessageId = nil`, etc.) at the start of `populateFromHistory()` before the messages array is replaced
- Prevents orphan assistant messages from stale `flushStreamingBuffer()` calls after history replacement
- Prevents text from being appended to a `currentAssistantMessageId` that no longer exists in the new messages array

Part of plan: fix-msg-stream-reconnect.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
