### PR TITLE
fix: log and discard stale streaming buffer instead of creating orphan messages

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -409,7 +409,15 @@ extension ChatViewModel {
             } else {
                 messages[index].textSegments[messages[index].textSegments.count - 1] += buffered
             }
+        } else if currentAssistantMessageId != nil {
+            // Message ID is set but message not found — stale reference after
+            // history replacement or reconnect. Discard the buffer to avoid
+            // creating an orphan message.
+            log.warning("Stale currentAssistantMessageId \(currentAssistantMessageId!.uuidString) — discarding \(buffered.count) buffered chars")
+            currentAssistantMessageId = nil
+            return
         } else {
+            // No existing assistant message — create a new one (first text delta)
             var msg = ChatMessage(role: .assistant, text: buffered, isStreaming: true)
             if currentTurnUserText == "/model" {
                 msg.modelPicker = ModelPickerData()


### PR DESCRIPTION
## Summary
- Add stale message ID detection in `flushStreamingBuffer()` — when `currentAssistantMessageId` is set but the message doesn't exist in the array, discard the buffer instead of creating an orphan message
- Log a warning when stale buffer is discarded for debugging visibility
- Defense-in-depth fix that catches edge cases where streaming state wasn't properly reset

Part of plan: fix-msg-stream-reconnect.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
