### PR TITLE
fix: trigger reconnect catch-up when currentAssistantMessageId is non-nil

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -820,7 +820,7 @@ public final class ChatViewModel: ObservableObject {
                 // so the UI catches up on anything that happened during the gap.
                 // Debounce: cancel any pending reconnect task and wait 500ms
                 // to coalesce rapid-fire reconnect notifications into one load.
-                if self?.isThinking == true || self?.isSending == true {
+                if self?.isThinking == true || self?.isSending == true || self?.currentAssistantMessageId != nil {
                     self?.isThinking = false
                     self?.isSending = false
                     self?.currentAssistantMessageId = nil


### PR DESCRIPTION
## Summary
- Widen the `daemonDidReconnect` handler's guard condition to also check `currentAssistantMessageId != nil`
- This ensures reconnect catch-up (history re-fetch) is triggered when streaming was in progress but `isThinking` had already been cleared (after first text delta)
- Prevents messages from appearing incomplete when a micro-disconnect occurs during active streaming

Part of plan: fix-msg-stream-reconnect.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
