### PR TITLE
test: add regression tests for message streaming during reconnect

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -2644,4 +2644,90 @@ final class ChatViewModelTests: XCTestCase {
 
         XCTAssertNil(viewModel.pendingSendDirectText)
     }
+
+    // MARK: - Reconnect Streaming Race Regression
+
+    func testReconnectDuringStreamingTriggersHistoryCatchUp() {
+        // Simulate an in-progress streaming run: session exists, isSending is
+        // true, and currentAssistantMessageId is set (assistant was mid-stream).
+        viewModel.sessionId = "sess-reconnect"
+        viewModel.isSending = true
+        viewModel.currentAssistantMessageId = UUID()
+
+        // Set up the callback to capture the reconnect history request.
+        var reconnectSessionId: String?
+        let expectation = XCTestExpectation(description: "onReconnectHistoryNeeded called")
+        viewModel.onReconnectHistoryNeeded = { sessionId in
+            reconnectSessionId = sessionId
+            expectation.fulfill()
+        }
+
+        // Fire the reconnect notification — the observer clears streaming state
+        // immediately and schedules a 500ms-debounced history catch-up.
+        NotificationCenter.default.post(name: .daemonDidReconnect, object: nil)
+
+        // Wait for the debounced reconnect handler (500ms) plus margin.
+        wait(for: [expectation], timeout: 2.0)
+
+        // The observer should have cleared currentAssistantMessageId immediately
+        // and then triggered the catch-up callback after debounce.
+        XCTAssertNil(viewModel.currentAssistantMessageId,
+                     "Reconnect should clear currentAssistantMessageId")
+        XCTAssertEqual(reconnectSessionId, "sess-reconnect",
+                       "onReconnectHistoryNeeded should be called with the session ID")
+    }
+
+    func testPopulateFromHistoryResetsStreamingState() {
+        // Simulate mid-stream state: an assistant message is being built,
+        // the delta buffer has accumulated text, and a flush task is scheduled.
+        let staleId = UUID()
+        viewModel.currentAssistantMessageId = staleId
+        viewModel.streamingDeltaBuffer = "partial response text"
+        viewModel.streamingFlushTask = Task { @MainActor in
+            // Simulate a pending flush — should be cancelled by populateFromHistory.
+        }
+
+        // Call populateFromHistory with an empty history payload.
+        viewModel.populateFromHistory([], hasMore: false)
+
+        XCTAssertNil(viewModel.currentAssistantMessageId,
+                     "populateFromHistory should clear currentAssistantMessageId")
+        XCTAssertTrue(viewModel.streamingDeltaBuffer.isEmpty,
+                      "populateFromHistory should clear streamingDeltaBuffer")
+        XCTAssertNil(viewModel.streamingFlushTask,
+                     "populateFromHistory should cancel and nil out streamingFlushTask")
+    }
+
+    func testTextDeltaIgnoredDuringHistoryLoad() {
+        // Set isLoadingHistory to true to simulate an in-progress history load.
+        viewModel.isLoadingHistory = true
+        let initialMessageCount = viewModel.messages.count
+
+        // Send a text delta while history is loading — should be dropped.
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "stale delta")))
+
+        XCTAssertTrue(viewModel.streamingDeltaBuffer.isEmpty,
+                      "Text deltas should not accumulate in the buffer during history load")
+        XCTAssertEqual(viewModel.messages.count, initialMessageCount,
+                       "No new messages should be created during history load")
+    }
+
+    func testFlushDiscardsStaleBuffer() {
+        // Set currentAssistantMessageId to a UUID that doesn't correspond to
+        // any message in the messages array (stale reference after a history
+        // replacement or reconnect).
+        let staleId = UUID()
+        viewModel.currentAssistantMessageId = staleId
+        viewModel.streamingDeltaBuffer = "orphaned buffer text"
+        let initialMessageCount = viewModel.messages.count
+
+        // Flush should detect the stale ID and discard the buffer instead of
+        // creating an orphan assistant message.
+        viewModel.flushStreamingBuffer()
+
+        XCTAssertEqual(viewModel.messages.count, initialMessageCount,
+                       "Stale flush should not create a new message")
+        XCTAssertNil(viewModel.currentAssistantMessageId,
+                     "Stale flush should reset currentAssistantMessageId to nil")
+    }
 }


### PR DESCRIPTION
## Summary
- Add four regression tests covering the reconnect streaming race conditions fixed in PRs 1-4
- Tests cover: reconnect catch-up trigger, history streaming state reset, delta ignored during history load, and stale buffer discard
- Ensures the fixes for incomplete message population during IPC reconnects don't regress

Part of plan: fix-msg-stream-reconnect.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
