### PR TITLE
fix(macos): prevent double NSCursor.pop on popover dismiss

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1045,7 +1045,7 @@ struct MainWindowView: View {
                     }
                 }
             }
-            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            if hovering { NSCursor.pointingHand.push() } else if sidebar.isHoveredThread == nil { NSCursor.pop() }
         }
         .onDrag {
             sidebar.draggingThreadId = thread.id
@@ -1665,16 +1665,14 @@ struct MainWindowView: View {
                     .onChange(of: threadManager.activeThreadId) { _, _ in
                         showThreadSwitcher = false
                     }
-                    .onChange(of: showThreadSwitcher) { _, isShowing in
-                        if !isShowing {
-                            // Clean up hover/cursor state when popover dismisses —
-                            // onHover(false) may not fire if the view is removed.
-                            if sidebar.isHoveredThread != nil {
-                                sidebar.isHoveredThread = nil
-                                NSCursor.pop()
-                            }
-                            sidebar.threadPendingDeletion = nil
+                    .onDisappear {
+                        // Clean up hover/cursor state when popover dismisses —
+                        // onHover(false) may not fire if the view is removed.
+                        if sidebar.isHoveredThread != nil {
+                            sidebar.isHoveredThread = nil
+                            NSCursor.pop()
                         }
+                        sidebar.threadPendingDeletion = nil
                     }
                     .onChange(of: sidebar.isHoveredThread) { _, newValue in
                         if let pending = sidebar.threadPendingDeletion, newValue != pending {


### PR DESCRIPTION
## Summary
- Gate `NSCursor.pop()` in `onHover` handler on `sidebar.isHoveredThread == nil` to prevent double-pop when `onDisappear` already cleaned up
- Replace `onChange(of: showThreadSwitcher)` with `onDisappear` for reliable cursor/state cleanup when popover content is torn down

Addresses review feedback on PR #12474.

## Test plan
- [ ] Hover over thread items in popover, verify pointing hand cursor appears
- [ ] Dismiss popover, verify cursor returns to default (no stuck cursor)
- [ ] Verify no cursor corruption after repeated popover open/close cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
