### PR TITLE
fix(macos): prevent popover dismiss when tapping pin/archive buttons

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1622,9 +1622,6 @@ struct MainWindowView: View {
                             VStack(spacing: 0) {
                                 ForEach(regularThreads) { thread in
                                     threadItem(thread)
-                                        .simultaneousGesture(TapGesture().onEnded {
-                                            showThreadSwitcher = false
-                                        })
                                         .padding(.bottom, VSpacing.xxs)
                                         .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
                                             if sidebar.dropTargetThreadId == thread.id {


### PR DESCRIPTION
## Summary
- Remove `simultaneousGesture(TapGesture())` from popover thread items that was dismissing the popover on ALL taps, including pin/archive buttons
- Thread switching still dismisses the popover via the existing `onChange(of: threadManager.activeThreadId)` handler
- Fixes broken archive confirmation flow in the popover

## Test plan
- [ ] Open collapsed sidebar popover
- [ ] Hover over a thread, click pin button — popover should stay open
- [ ] Hover over a thread, click archive button — popover should stay open, confirm button should appear
- [ ] Click a different thread — popover should dismiss
- [ ] Verify clicking outside the popover still dismisses it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
