### PR TITLE
fix: add missing self. for closure capture in stale message ID warning

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -413,7 +413,7 @@ extension ChatViewModel {
             // Message ID is set but message not found — stale reference after
             // history replacement or reconnect. Discard the buffer to avoid
             // creating an orphan message.
-            log.warning("Stale currentAssistantMessageId \(currentAssistantMessageId!.uuidString) — discarding \(buffered.count) buffered chars")
+            log.warning("Stale currentAssistantMessageId \(self.currentAssistantMessageId!.uuidString) — discarding \(buffered.count) buffered chars")
             currentAssistantMessageId = nil
             return
         } else {


### PR DESCRIPTION
## Summary
- Fixes build error in `ChatViewModel+MessageHandling.swift:416` where `currentAssistantMessageId` was referenced without `self.` inside a closure
- Introduced in PR #12516

## Test plan
- [ ] Clean build succeeds: `swift package clean && swift build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
