### PR TITLE
M1: Add hasReceivedScrollEvent flag to fix scroll button on initial load

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -518,6 +518,7 @@ struct MessageListView: View {
             .overlay(alignment: .bottom) {
                 if (!isNearBottom || !hasReceivedScrollEvent) && !anchorIsVisible {
                     Button(action: {
+                        hasReceivedScrollEvent = true
                         isNearBottom = true
                         withAnimation(VAnimation.fast) {
                             proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
@@ -594,6 +595,7 @@ struct MessageListView: View {
             }
             .onChange(of: isSending) {
                 if isSending {
+                    hasReceivedScrollEvent = true
                     isNearBottom = true
                     withAnimation(VAnimation.standard) {
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -86,6 +86,11 @@ struct MessageListView: View {
     /// visible viewport. Used alongside `isNearBottom` to suppress the "Scroll
     /// to latest" button when all content fits on screen.
     @State private var anchorIsVisible: Bool = true
+    /// Whether a physical scroll event (wheel/trackpad) has been received since
+    /// the current thread loaded. Before any scroll event, `isNearBottom`
+    /// (which defaults to `true`) is not trusted; the button relies solely on
+    /// `anchorIsVisible` to decide visibility.
+    @State private var hasReceivedScrollEvent: Bool = false
     /// The scroll view's viewport height, captured via preference key. Used by
     /// the anchor GeometryReader to determine if the anchor is within bounds.
     @State private var scrollViewportHeight: CGFloat = .infinity
@@ -493,8 +498,12 @@ struct MessageListView: View {
                         scrollDebounceTask?.cancel()
                         scrollDebounceTask = nil
                         isNearBottom = false
+                        hasReceivedScrollEvent = true
                     },
-                    onScrollToBottom: { isNearBottom = true }
+                    onScrollToBottom: {
+                        isNearBottom = true
+                        hasReceivedScrollEvent = true
+                    }
                 )
                 ThreadScrollbarVisibilityController(shouldShow: shouldShowThreadScrollbar)
             }
@@ -507,7 +516,7 @@ struct MessageListView: View {
                 anchorIsVisible = minY >= -20 && minY <= scrollViewportHeight + 20
             }
             .overlay(alignment: .bottom) {
-                if !isNearBottom && !anchorIsVisible {
+                if (!isNearBottom || !hasReceivedScrollEvent) && !anchorIsVisible {
                     Button(action: {
                         isNearBottom = true
                         withAnimation(VAnimation.fast) {
@@ -684,6 +693,7 @@ struct MessageListView: View {
                 isSuppressingBottomScroll = false
                 isNearBottom = true
                 anchorIsVisible = true
+                hasReceivedScrollEvent = false
                 hoverExitDebounceTask?.cancel()
                 hoverExitDebounceTask = nil
                 anchorTimeoutTask?.cancel()


### PR DESCRIPTION
Fixes the 'Scroll to latest' button not appearing when landing on a long thread mid-scroll. Adds a hasReceivedScrollEvent flag that tracks whether any physical scroll event has occurred. Before any scroll event, isNearBottom (which defaults to true) is not trusted, and the button relies solely on anchorIsVisible. Closes #12525.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
