### PR TITLE
fix(macos): use wasHovered guard to prevent cursor double-pop and stack leak

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1036,6 +1036,7 @@ struct MainWindowView: View {
             }
         }
         .onHover { hovering in
+            let wasHovered = sidebar.isHoveredThread == thread.id
             withAnimation(VAnimation.fast) {
                 if hovering {
                     sidebar.isHoveredThread = thread.id
@@ -1045,7 +1046,7 @@ struct MainWindowView: View {
                     }
                 }
             }
-            if hovering { NSCursor.pointingHand.push() } else if sidebar.isHoveredThread == nil { NSCursor.pop() }
+            if hovering { NSCursor.pointingHand.push() } else if wasHovered { NSCursor.pop() }
         }
         .onDrag {
             sidebar.draggingThreadId = thread.id


### PR DESCRIPTION
## Summary
Fixes cursor double-pop and stack leak in thread item onHover handler.

Captures `wasHovered = sidebar.isHoveredThread == thread.id` before the animation block clears it, then uses `wasHovered` to decide whether to pop. This correctly handles:
- onDisappear firing before onHover(false) — wasHovered is false, no double-pop
- Mouse moving between threads with out-of-order delivery — wasHovered is true for thread A, pop fires correctly

Addresses review feedback on PR #12521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
