### PR TITLE
fix(macos): dismiss popover on same-thread tap without catching button taps

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -1624,6 +1624,13 @@ struct MainWindowView: View {
                                 ForEach(regularThreads) { thread in
                                     threadItem(thread)
                                         .padding(.bottom, VSpacing.xxs)
+                                        .simultaneousGesture(TapGesture().onEnded {
+                                            // Only dismiss for same-thread taps. Different-thread taps
+                                            // are handled by onChange(of: activeThreadId).
+                                            if thread.id == threadManager.activeThreadId {
+                                                showThreadSwitcher = false
+                                            }
+                                        })
                                         .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
                                             if sidebar.dropTargetThreadId == thread.id {
                                                 Rectangle()


### PR DESCRIPTION
## Summary
Adds a targeted simultaneousGesture that only dismisses the popover when tapping the already-active thread. Different-thread taps are handled by onChange(of: activeThreadId). This avoids the previous issue where the blanket simultaneousGesture caught pin/archive button taps.

Addresses review feedback on PR #12522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
