### PR TITLE
Fix: Scroll-to-latest button not appearing on initial load of long threads

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -86,6 +86,11 @@ struct MessageListView: View {
     /// visible viewport. Used alongside `isNearBottom` to suppress the "Scroll
     /// to latest" button when all content fits on screen.
     @State private var anchorIsVisible: Bool = true
+    /// Whether a physical scroll event (wheel/trackpad) has been received since
+    /// the current thread loaded. Before any scroll event, `isNearBottom`
+    /// (which defaults to `true`) is not trusted; the button relies solely on
+    /// `anchorIsVisible` to decide visibility.
+    @State private var hasReceivedScrollEvent: Bool = false
     /// The scroll view's viewport height, captured via preference key. Used by
     /// the anchor GeometryReader to determine if the anchor is within bounds.
     @State private var scrollViewportHeight: CGFloat = .infinity
@@ -493,8 +498,12 @@ struct MessageListView: View {
                         scrollDebounceTask?.cancel()
                         scrollDebounceTask = nil
                         isNearBottom = false
+                        hasReceivedScrollEvent = true
                     },
-                    onScrollToBottom: { isNearBottom = true }
+                    onScrollToBottom: {
+                        isNearBottom = true
+                        hasReceivedScrollEvent = true
+                    }
                 )
                 ThreadScrollbarVisibilityController(shouldShow: shouldShowThreadScrollbar)
             }
@@ -507,8 +516,9 @@ struct MessageListView: View {
                 anchorIsVisible = minY >= -20 && minY <= scrollViewportHeight + 20
             }
             .overlay(alignment: .bottom) {
-                if !isNearBottom && !anchorIsVisible {
+                if (!isNearBottom || !hasReceivedScrollEvent) && !anchorIsVisible {
                     Button(action: {
+                        hasReceivedScrollEvent = true
                         isNearBottom = true
                         withAnimation(VAnimation.fast) {
                             proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
@@ -585,6 +595,7 @@ struct MessageListView: View {
             }
             .onChange(of: isSending) {
                 if isSending {
+                    hasReceivedScrollEvent = true
                     isNearBottom = true
                     withAnimation(VAnimation.standard) {
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
@@ -684,6 +695,7 @@ struct MessageListView: View {
                 isSuppressingBottomScroll = false
                 isNearBottom = true
                 anchorIsVisible = true
+                hasReceivedScrollEvent = false
                 hoverExitDebounceTask?.cancel()
                 hoverExitDebounceTask = nil
                 anchorTimeoutTask?.cancel()


### PR DESCRIPTION
## Summary
Fixes a bug where the "Scroll to latest" button doesn't appear when a user lands on or refreshes a thread with many messages and isn't scrolled to the bottom. The button only appeared after scrolling UP — scrolling down or doing nothing left it hidden.

## Changes
- Added `hasReceivedScrollEvent` flag that tracks whether any physical scroll event has occurred
- Before any scroll event, `isNearBottom` (which defaults to `true`) is not trusted — the button relies solely on `anchorIsVisible` (continuous GeometryReader signal)
- After a scroll event, both signals are used as designed
- Flag is also set on "Scroll to latest" button click and `isSending` to prevent flash during streaming
- Flag resets on thread switch

## Milestone PRs (merged into feature branch)
- #12526: M1: Add hasReceivedScrollEvent flag to fix scroll button on initial load

## Project issue
Closes #12524

## Test plan
- [ ] Open a thread with many messages — "Scroll to latest" button appears if not at bottom
- [ ] Scrolling down keeps button visible until reaching bottom
- [ ] Scrolling up shows button (existing behavior preserved)
- [ ] Short threads / empty threads do NOT show the button
- [ ] Thread switching resets correctly
- [ ] Sending a message auto-scrolls to bottom, no button flash during streaming
- [ ] Clicking "Scroll to latest" scrolls to bottom, no re-flash during streaming

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
