### PR TITLE
fix(macos): use onSelect closure to dismiss popover without catching button taps

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -865,7 +865,7 @@ struct MainWindowView: View {
     }
 
     @ViewBuilder
-    private func threadItem(_ thread: ThreadModel) -> some View {
+    private func threadItem(_ thread: ThreadModel, onSelect: (() -> Void)? = nil) -> some View {
         let isSelected: Bool = {
             switch windowState.selection {
             case .panel:
@@ -979,6 +979,7 @@ struct MainWindowView: View {
         }
         .onTapGesture {
             selectThread(thread)
+            onSelect?()
         }
         .accessibilityAddTraits(.isButton)
         .accessibilityLabel("Thread: \(thread.title)")
@@ -1622,15 +1623,8 @@ struct MainWindowView: View {
                         ScrollView {
                             VStack(spacing: 0) {
                                 ForEach(regularThreads) { thread in
-                                    threadItem(thread)
+                                    threadItem(thread, onSelect: { showThreadSwitcher = false })
                                         .padding(.bottom, VSpacing.xxs)
-                                        .simultaneousGesture(TapGesture().onEnded {
-                                            // Only dismiss for same-thread taps. Different-thread taps
-                                            // are handled by onChange(of: activeThreadId).
-                                            if thread.id == threadManager.activeThreadId {
-                                                showThreadSwitcher = false
-                                            }
-                                        })
                                         .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
                                             if sidebar.dropTargetThreadId == thread.id {
                                                 Rectangle()


### PR DESCRIPTION
## Summary
Replaces the simultaneousGesture-based popover dismiss with an onSelect closure parameter on threadItem(). The closure is called from the row's onTapGesture, which only fires for taps on the row itself — not on child Buttons (pin, archive). This correctly dismisses the popover on any thread row tap (including the active thread) without interfering with button interactions.

Addresses review feedback on PR #12529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
