### PR TITLE
feat: add ContactType, AssistantSpecies, and assistant metadata types

### DIFF
--- a/assistant/src/contacts/types.ts
+++ b/assistant/src/contacts/types.ts
@@ -1,5 +1,29 @@
 export type ContactRole = "guardian" | "contact";
 
+export type ContactType = "human" | "assistant";
+
+export type AssistantSpecies = "vellum" | "openclaw";
+
+export interface VellumAssistantMetadata {
+  assistantId: string;
+  gatewayUrl: string;
+}
+
+export interface OpenClawAssistantMetadata {
+  [key: string]: unknown;
+}
+
+export type AssistantMetadataBySpecies = {
+  vellum: VellumAssistantMetadata;
+  openclaw: OpenClawAssistantMetadata;
+};
+
+export interface AssistantContactMetadata {
+  contactId: string;
+  species: AssistantSpecies;
+  metadata: AssistantMetadataBySpecies[AssistantSpecies] | null;
+}
+
 export interface Contact {
   id: string;
   displayName: string;
@@ -12,6 +36,7 @@ export interface Contact {
   createdAt: number;
   updatedAt: number;
   role: ContactRole;
+  contactType: ContactType;
   principalId: string | null;
   assistantId: string | null;
 }


### PR DESCRIPTION
## Summary
- Add ContactType ('human' | 'assistant') and AssistantSpecies ('vellum' | 'openclaw') type aliases
- Add species-specific metadata interfaces (VellumAssistantMetadata, OpenClawAssistantMetadata) with discriminated union
- Add AssistantContactMetadata interface and contactType field to Contact interface

Part of plan: assistant-contact-model.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
