### PR TITLE
feat: add contact_type and assistantContactMetadata to Drizzle schema

### DIFF
--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -417,6 +417,7 @@ export const contacts = sqliteTable("contacts", {
   role: text("role").notNull().default("contact"), // 'guardian' | 'contact'
   principalId: text("principal_id"), // internal auth principal (nullable)
   assistantId: text("assistant_id"), // which assistant this guardian is for (nullable, daemon default is DAEMON_INTERNAL_ASSISTANT_ID)
+  contactType: text("contact_type").notNull().default("human"), // 'human' | 'assistant'
 });
 
 export const contactChannels = sqliteTable(
@@ -454,6 +455,17 @@ export const contactChannels = sqliteTable(
       table.externalChatId,
     ),
   ],
+);
+
+export const assistantContactMetadata = sqliteTable(
+  "assistant_contact_metadata",
+  {
+    contactId: text("contact_id")
+      .primaryKey()
+      .references(() => contacts.id, { onDelete: "cascade" }),
+    species: text("species").notNull(), // 'vellum' | 'openclaw'
+    metadata: text("metadata"), // JSON blob for species-specific fields
+  },
 );
 
 // ── Triage Results ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add contactType column to contacts Drizzle schema definition (TEXT NOT NULL DEFAULT 'human')
- Add assistantContactMetadata table definition with contactId FK, species, and metadata fields

Part of plan: assistant-contact-model.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
