### PR TITLE
fix: support injection_templates in credential prompt-update action

### DIFF
--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -227,7 +227,7 @@ class CredentialStoreTool implements Tool {
               required: ["hostPattern", "injectionType"],
             },
             description:
-              "Templates describing how to inject this credential into proxied requests (only for store action)",
+              "Templates describing how to inject this credential into proxied requests (for store and prompt actions)",
           },
           reason: {
             type: "string",

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -568,6 +568,88 @@ class CredentialStoreTool implements Tool {
         }
         const promptPolicy = toPolicyFromInput(promptPolicyInput);
 
+        // Parse and validate injection templates (same logic as store action)
+        const promptRawTemplates = input.injection_templates as unknown[] | undefined;
+        let promptInjectionTemplates: CredentialInjectionTemplate[] | undefined;
+        if (promptRawTemplates !== undefined) {
+          if (!Array.isArray(promptRawTemplates)) {
+            return {
+              content: "Error: injection_templates must be an array",
+              isError: true,
+            };
+          }
+          const promptTemplateErrors: string[] = [];
+          promptInjectionTemplates = [];
+          for (let i = 0; i < promptRawTemplates.length; i++) {
+            const t = promptRawTemplates[i] as Record<string, unknown>;
+            if (typeof t !== "object" || t == null) {
+              promptTemplateErrors.push(
+                `injection_templates[${i}] must be an object`,
+              );
+              continue;
+            }
+            if (
+              typeof t.hostPattern !== "string" ||
+              t.hostPattern.trim().length === 0
+            ) {
+              promptTemplateErrors.push(
+                `injection_templates[${i}].hostPattern must be a non-empty string`,
+              );
+            }
+            if (t.injectionType !== "header" && t.injectionType !== "query") {
+              promptTemplateErrors.push(
+                `injection_templates[${i}].injectionType must be 'header' or 'query'`,
+              );
+            } else if (t.injectionType === "header") {
+              if (
+                typeof t.headerName !== "string" ||
+                t.headerName.trim().length === 0
+              ) {
+                promptTemplateErrors.push(
+                  `injection_templates[${i}].headerName is required when injectionType is 'header'`,
+                );
+              }
+            } else if (t.injectionType === "query") {
+              if (
+                typeof t.queryParamName !== "string" ||
+                t.queryParamName.trim().length === 0
+              ) {
+                promptTemplateErrors.push(
+                  `injection_templates[${i}].queryParamName is required when injectionType is 'query'`,
+                );
+              }
+            }
+            if (
+              t.valuePrefix !== undefined &&
+              typeof t.valuePrefix !== "string"
+            ) {
+              promptTemplateErrors.push(
+                `injection_templates[${i}].valuePrefix must be a string`,
+              );
+            }
+            if (promptTemplateErrors.length === 0) {
+              promptInjectionTemplates.push({
+                hostPattern: t.hostPattern as string,
+                injectionType: t.injectionType as "header" | "query",
+                headerName:
+                  typeof t.headerName === "string" ? t.headerName : undefined,
+                valuePrefix:
+                  typeof t.valuePrefix === "string" ? t.valuePrefix : undefined,
+                queryParamName:
+                  typeof t.queryParamName === "string"
+                    ? t.queryParamName
+                    : undefined,
+              });
+            }
+          }
+          if (promptTemplateErrors.length > 0) {
+            return {
+              content: `Error: ${promptTemplateErrors.join("; ")}`,
+              isError: true,
+            };
+          }
+        }
+
         try {
           assertMetadataWritable();
         } catch {
@@ -626,6 +708,7 @@ class CredentialStoreTool implements Tool {
                 allowedTools: promptPolicy.allowedTools,
                 allowedDomains: promptPolicy.allowedDomains,
                 usageDescription: promptPolicy.usageDescription,
+                injectionTemplates: promptInjectionTemplates,
               });
             } catch (err) {
               // Without metadata the broker's policy checks will reject usage,
@@ -666,6 +749,7 @@ class CredentialStoreTool implements Tool {
             allowedTools: promptPolicy.allowedTools,
             allowedDomains: promptPolicy.allowedDomains,
             usageDescription: promptPolicy.usageDescription,
+            injectionTemplates: promptInjectionTemplates,
           });
         } catch (err) {
           log.warn(
@@ -673,7 +757,7 @@ class CredentialStoreTool implements Tool {
             "metadata write failed after storing credential",
           );
         }
-        const promptMeta = getCredentialMetadata(service, field);
+      const promptMeta = getCredentialMetadata(service, field);
         const promptCredIdSuffix = promptMeta
           ? ` (credential_id: ${promptMeta.credentialId})`
           : "";


### PR DESCRIPTION
## Summary
- Add injection_templates parsing and validation to the credential `prompt-update` action, matching the existing `store` action behavior
- Persist injection templates when updating credential policies via both broker and direct metadata paths

## Test plan
- [ ] Verify `prompt-update` action accepts and validates `injection_templates` input
- [ ] Confirm invalid templates (missing hostPattern, wrong injectionType) return proper error messages
- [ ] Ensure templates are persisted to credential metadata after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
