### PR TITLE
feat: add shared gateway internal client helpers

### DIFF
--- a/assistant/src/runtime/gateway-internal-client.ts
+++ b/assistant/src/runtime/gateway-internal-client.ts
@@ -1,0 +1,86 @@
+import { getGatewayInternalBaseUrl } from "../config/env.js";
+import { mintEdgeRelayToken } from "./auth/token-service.js";
+
+export class GatewayRequestError extends Error {
+  statusCode: number;
+  gatewayError: string | undefined;
+
+  constructor(
+    message: string,
+    statusCode: number,
+    gatewayError: string | undefined,
+  ) {
+    super(message);
+    this.name = "GatewayRequestError";
+    this.statusCode = statusCode;
+    this.gatewayError = gatewayError;
+  }
+}
+
+/**
+ * Parse a non-ok gateway response into a human-readable error message.
+ * Matches the existing pattern in contact tools: try JSON parse, extract
+ * `.error` string, fall back to raw body text, fall back to status code.
+ */
+async function parseErrorResponse(
+  resp: Response,
+): Promise<GatewayRequestError> {
+  const body = await resp.text();
+  let gatewayError: string | undefined;
+  let message = `Gateway request failed (${resp.status})`;
+
+  try {
+    const parsed = JSON.parse(body) as { error?: string };
+    if (parsed.error) {
+      gatewayError = parsed.error;
+      message = parsed.error;
+    }
+  } catch {
+    if (body) message = body;
+  }
+
+  return new GatewayRequestError(message, resp.status, gatewayError);
+}
+
+export async function gatewayGet<T>(path: string): Promise<T> {
+  const baseUrl = getGatewayInternalBaseUrl();
+  const token = mintEdgeRelayToken();
+
+  const resp = await fetch(`${baseUrl}${path}`, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!resp.ok) {
+    throw await parseErrorResponse(resp);
+  }
+
+  return (await resp.json()) as T;
+}
+
+export async function gatewayPost<T>(
+  path: string,
+  body: unknown,
+): Promise<{ status: number; data: T }> {
+  const baseUrl = getGatewayInternalBaseUrl();
+  const token = mintEdgeRelayToken();
+
+  const resp = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!resp.ok) {
+    throw await parseErrorResponse(resp);
+  }
+
+  const data = (await resp.json()) as T;
+  return { status: resp.status, data };
+}


### PR DESCRIPTION
## Summary
- Add `gateway-internal-client.ts` with `gatewayGet<T>`, `gatewayPost<T>`, and `GatewayRequestError`
- Encapsulates `getGatewayInternalBaseUrl()` + `mintEdgeRelayToken()` + fetch boilerplate
- Provides consistent error handling (JSON error parsing with text fallback)

Part of plan: gateway-internal-client-dry.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
