### PR TITLE
refactor: migrate contact-search to shared gateway client

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/tools/contact-search.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-search.ts
@@ -1,5 +1,7 @@
-import { getGatewayInternalBaseUrl } from "../../../../config/env.js";
-import { mintEdgeRelayToken } from "../../../../runtime/auth/token-service.js";
+import {
+  gatewayGet,
+  GatewayRequestError,
+} from "../../../../runtime/gateway-internal-client.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -56,9 +58,6 @@ export async function executeContactSearch(
   }
 
   try {
-    const gatewayBase = getGatewayInternalBaseUrl();
-    const token = mintEdgeRelayToken();
-
     const params = new URLSearchParams();
     if (query) params.set("query", query);
     if (channelAddress) params.set("channelAddress", channelAddress);
@@ -67,32 +66,9 @@ export async function executeContactSearch(
     if (limit !== undefined) params.set("limit", String(limit));
 
     const qs = params.toString();
-    const url = `${gatewayBase}/v1/contacts${qs ? `?${qs}` : ""}`;
-
-    const resp = await fetch(url, {
-      method: "GET",
-      headers: {
-        Accept: "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-    });
-
-    if (!resp.ok) {
-      const body = await resp.text();
-      let message = `Gateway request failed (${resp.status})`;
-      try {
-        const parsed = JSON.parse(body) as { error?: string };
-        if (parsed.error) message = parsed.error;
-      } catch {
-        if (body) message = body;
-      }
-      return { content: `Error: ${message}`, isError: true };
-    }
-
-    const data = (await resp.json()) as {
-      ok: boolean;
-      contacts: ContactResponse[];
-    };
+    const data = await gatewayGet<{ ok: boolean; contacts: ContactResponse[] }>(
+      `/v1/contacts${qs ? `?${qs}` : ""}`,
+    );
     const results = data.contacts;
 
     if (results.length === 0) {
@@ -109,6 +85,10 @@ export async function executeContactSearch(
 
     return { content: lines.join("\n"), isError: false };
   } catch (err) {
+    if (err instanceof GatewayRequestError) {
+      const message = err.gatewayError ?? err.message;
+      return { content: `Error: ${message}`, isError: true };
+    }
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Error: ${msg}`, isError: true };
   }


### PR DESCRIPTION
## Summary
- Replace manual `getGatewayInternalBaseUrl()` + `mintEdgeRelayToken()` + `fetch()` in contact-search with shared `gatewayGet` helper
- Error handling now uses `GatewayRequestError` from the shared client

Part of plan: gateway-internal-client-dry.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
