### PR TITLE
refactor: add clarifying comment to CLI gateway helper

### DIFF
--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -112,6 +112,9 @@ function readVoiceConfig(): {
   };
 }
 
+// CLI-specific gateway helper — uses GATEWAY_AUTH_TOKEN / INTERNAL_GATEWAY_BASE_URL
+// env vars for out-of-process access. See runtime/gateway-internal-client.ts for
+// daemon-internal usage which mints fresh tokens and uses GATEWAY_INTERNAL_BASE_URL.
 async function gatewayGet(path: string): Promise<unknown> {
   const gatewayBase = resolveGatewayBaseUrl();
   const token = getGatewayToken();


### PR DESCRIPTION
## Summary
- Add clarifying comment to CLI's `gatewayGet` explaining why it's separate from the shared `runtime/gateway-internal-client.ts`
- CLI uses different env vars (GATEWAY_AUTH_TOKEN, INTERNAL_GATEWAY_BASE_URL) for out-of-process access

Part of plan: gateway-internal-client-dry.md (PR 6 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
