### PR TITLE
fix: pass contactType to store functions instead of client-side filtering

### DIFF
--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -60,8 +60,10 @@ export function handleListContacts(url: URL, assistantId: string): Response {
   const hasSearchParams =
     query || channelAddress || channelType || relationship;
 
-  // contactType filtering is parsed here but not yet passed to store functions.
-  // PR 6 will add contactType param support to listContacts/searchContacts.
+  const contactType = contactTypeParam
+    ? (contactTypeParam as ContactType)
+    : undefined;
+
   if (hasSearchParams) {
     const contacts = searchContacts({
       assistantId,
@@ -70,19 +72,19 @@ export function handleListContacts(url: URL, assistantId: string): Response {
       channelType: channelType ?? undefined,
       relationship: relationship ?? undefined,
       role: role ?? undefined,
+      contactType,
       limit,
     });
-    const filtered = contactTypeParam
-      ? contacts.filter((c) => c.contactType === contactTypeParam)
-      : contacts;
-    return Response.json({ ok: true, contacts: filtered });
+    return Response.json({ ok: true, contacts });
   }
 
-  const contacts = listContacts(assistantId, limit, role ?? undefined);
-  const filtered = contactTypeParam
-    ? contacts.filter((c) => c.contactType === contactTypeParam)
-    : contacts;
-  return Response.json({ ok: true, contacts: filtered });
+  const contacts = listContacts(
+    assistantId,
+    limit,
+    role ?? undefined,
+    contactType,
+  );
+  return Response.json({ ok: true, contacts });
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for assistant-contact-model.md.

**Gap:** Routes not passing contactType to store functions
**What was expected:** contactType should be passed to listContacts/searchContacts for database-level filtering
**What was found:** Client-side filtering was used as a workaround since PR 5 and PR 6 ran in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
