### PR TITLE
fix: prevent non-DM Slack events from being processed as direct messages

### DIFF
--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -369,15 +369,35 @@ export class SlackSocketModeClient {
       this.store.hasThread(reactionEvent.item.ts);
 
     // Process app_mention events, DMs, message edits, scoped reactions, and replies in active bot threads
-    if (
-      !isAppMention &&
-      !isDm &&
-      !isMessageChanged &&
-      !isReactionAdded &&
-      !isActiveThreadReply
-    ) {
+    const matchedFilter = isAppMention
+      ? "app_mention"
+      : isDm
+        ? "dm"
+        : isMessageChanged
+          ? "message_changed"
+          : isReactionAdded
+            ? "reaction_added"
+            : isActiveThreadReply
+              ? "active_thread_reply"
+              : null;
+
+    if (!matchedFilter) {
       return;
     }
+
+    log.info(
+      {
+        eventId: eventPayload.event_id,
+        filter: matchedFilter,
+        type: event.type,
+        channelType: (event as { channel_type?: string }).channel_type,
+        channel: (event as { channel?: string }).channel,
+        subtype: (event as { subtype?: string }).subtype,
+        user: (event as { user?: string }).user,
+        hasThreadTs: !!(event as { thread_ts?: string }).thread_ts,
+      },
+      "Slack event accepted by filter",
+    );
 
     // Deduplicate on event_id
     const eventId = eventPayload.event_id;
@@ -410,7 +430,7 @@ export class SlackSocketModeClient {
     isActiveThreadReply: boolean,
     isReactionAdded: boolean,
     isMessageChanged: boolean,
-    _isDm: boolean,
+    isDm: boolean,
   ): void {
     let normalized: NormalizedSlackEvent | null;
     if (isReactionAdded) {
@@ -440,13 +460,23 @@ export class SlackSocketModeClient {
         this.config.gatewayConfig,
         this.config.botUserId,
       );
-    } else {
+    } else if (isDm) {
       normalized = normalizeSlackDirectMessage(
         event as SlackDirectMessageEvent,
         eventId,
         this.config.gatewayConfig,
         this.config.botUserId,
       );
+    } else {
+      log.warn(
+        {
+          eventId,
+          type: event.type,
+          channel: (event as { channel?: string }).channel,
+        },
+        "Slack event passed filter but no normalizer matched — dropping",
+      );
+      return;
     }
 
     if (!normalized) {


### PR DESCRIPTION
## Summary
- The `normalizeAndEmit` method in `socket-mode.ts` had a bare `else` fallback that treated any event passing the filter as a DM, routing it to the default assistant with guardian verification
- This caused every channel message the bot received (via `message.channels` subscription) to trigger guardian verification for all workspace users
- Fix: explicitly check `isDm` before calling `normalizeSlackDirectMessage`, and drop unclassified events with a warning log
- Added info-level logging showing which filter each accepted event matched (`app_mention`, `dm`, `message_changed`, `reaction_added`, `active_thread_reply`) for easier debugging

## Test plan
- [x] Plain channel message without @mention — silently dropped
- [x] @mention in channel — processed correctly
- [x] DM to bot — processed correctly
- [x] Thread reply in active bot thread (no @mention) — processed correctly
- [x] Message in different channel without @mention — silently dropped
- [x] Message edit — processed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
