### PR TITLE
fix: add opaque backgrounds to StepDetailRow for clean expand animation

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -526,7 +526,7 @@ private struct StepDetailRow: View {
             .buttonStyle(.plain)
             .padding(.horizontal, VSpacing.sm)
             .padding(.vertical, VSpacing.xxs)
-            .background(isHovered && hasDetails ? VColor.surfaceBorder.opacity(0.3) : .clear)
+            .background(isHovered && hasDetails ? VColor.surfaceBorder.opacity(0.3) : VColor.surface.opacity(0.5))
             .onHover { isHovered = $0 }
 
             // Expanded detail section (completed only)
@@ -547,6 +547,7 @@ private struct StepDetailRow: View {
                     }
             }
         }
+        .clipped()
         .animation(VAnimation.fast, value: isDetailExpanded)
         .onChange(of: isDetailExpanded) { _, newValue in
             if newValue, cachedInputFull == nil {


### PR DESCRIPTION
Fixes the glitchy visual effect where expanding detail content text is visible through transparent sibling rows during animation. Adds an opaque background to StepDetailRow and clips the expanding content. Closes #12553
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
