### PR TITLE
fix: include contactType in searchContacts early-return guard

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -533,7 +533,13 @@ export function searchContacts(params: {
   ];
   if (params.query) {
     const sanitized = escapeLike(params.query);
-    if (!sanitized && !params.relationship && !params.role) return [];
+    if (
+      !sanitized &&
+      !params.relationship &&
+      !params.role &&
+      !params.contactType
+    )
+      return [];
     if (sanitized) {
       conditions.push(like(contacts.displayName, `%${sanitized}%`));
     }


### PR DESCRIPTION
Addresses Codex and Devin review feedback on #12542. Adds contactType to the early-return guard in searchContacts so that queries with only a contactType filter (and empty/sanitized query string) don't incorrectly return an empty array.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
