### PR TITLE
fix: make AssistantContactMetadata a discriminated union for type safety

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -1024,11 +1024,13 @@ export function updateChannelLastSeenById(channelId: string): void {
 function parseAssistantMetadata(
   row: typeof assistantContactMetadata.$inferSelect,
 ): AssistantContactMetadata {
+  // Species–metadata pairing is enforced at write time; the cast bridges the
+  // runtime DB row into the compile-time discriminated union.
   return {
     contactId: row.contactId,
-    species: row.species as AssistantSpecies,
+    species: row.species,
     metadata: row.metadata ? JSON.parse(row.metadata) : null,
-  };
+  } as AssistantContactMetadata;
 }
 
 export function upsertAssistantContactMetadata(params: {

--- a/assistant/src/contacts/types.ts
+++ b/assistant/src/contacts/types.ts
@@ -13,16 +13,17 @@ export interface OpenClawAssistantMetadata {
   [key: string]: unknown;
 }
 
-export type AssistantMetadataBySpecies = {
-  vellum: VellumAssistantMetadata;
-  openclaw: OpenClawAssistantMetadata;
-};
-
-export interface AssistantContactMetadata {
-  contactId: string;
-  species: AssistantSpecies;
-  metadata: AssistantMetadataBySpecies[AssistantSpecies] | null;
-}
+export type AssistantContactMetadata =
+  | {
+      contactId: string;
+      species: "vellum";
+      metadata: VellumAssistantMetadata | null;
+    }
+  | {
+      contactId: string;
+      species: "openclaw";
+      metadata: OpenClawAssistantMetadata | null;
+    };
 
 export interface Contact {
   id: string;


### PR DESCRIPTION
Addresses Codex review feedback on #12533. Changes AssistantContactMetadata from an interface with a widened union to a discriminated union keyed on species, so that metadata type is enforced per species at compile time.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
