### PR TITLE
fix: use Promise.allSettled for independent error attribution in contact-merge

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
@@ -39,39 +39,36 @@ export async function executeContactMerge(
 
   try {
     // Validate both contacts exist before merging
-    let keepData: { ok: boolean; contact: ContactResponse };
-    let mergeData: { ok: boolean; contact: ContactResponse };
+    const [keepResult, mergeResult] = await Promise.allSettled([
+      gatewayGet<{ ok: boolean; contact: ContactResponse }>(
+        `/v1/contacts/${keepId}`,
+      ),
+      gatewayGet<{ ok: boolean; contact: ContactResponse }>(
+        `/v1/contacts/${mergeId}`,
+      ),
+    ]);
 
-    try {
-      [keepData, mergeData] = await Promise.all([
-        gatewayGet<{ ok: boolean; contact: ContactResponse }>(
-          `/v1/contacts/${keepId}`,
-        ),
-        gatewayGet<{ ok: boolean; contact: ContactResponse }>(
-          `/v1/contacts/${mergeId}`,
-        ),
-      ]);
-    } catch (err) {
-      if (err instanceof GatewayRequestError) {
-        // Determine which contact failed by retrying individually
-        try {
-          await gatewayGet(`/v1/contacts/${keepId}`);
-        } catch {
-          return {
-            content: `Error: Contact "${keepId}" not found`,
-            isError: true,
-          };
-        }
+    if (keepResult.status === "rejected") {
+      if (keepResult.reason instanceof GatewayRequestError) {
+        return {
+          content: `Error: Contact "${keepId}" not found`,
+          isError: true,
+        };
+      }
+      throw keepResult.reason;
+    }
+    if (mergeResult.status === "rejected") {
+      if (mergeResult.reason instanceof GatewayRequestError) {
         return {
           content: `Error: Contact "${mergeId}" not found`,
           isError: true,
         };
       }
-      throw err;
+      throw mergeResult.reason;
     }
 
-    const keepContact = keepData.contact;
-    const mergeContact = mergeData.contact;
+    const keepContact = keepResult.value.contact;
+    const mergeContact = mergeResult.value.contact;
 
     // Execute the merge
     const { data: resultData } = await gatewayPost<{


### PR DESCRIPTION
Addresses Codex and Devin review feedback on #12546. Replaces Promise.all + retry with Promise.allSettled so each contact lookup's success/failure is tracked independently, preventing misattribution of errors and masking of non-not-found failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
