### PR TITLE
style: make all settings screen buttons small

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/GatewaySettingsCard.swift
@@ -76,7 +76,7 @@ struct GatewaySettingsCard: View {
 
             // Running badge — only shown when gateway is reachable
             if store.gatewayReachable == true {
-                VButton(label: "Running", leftIcon: "checkmark.circle.fill", style: .success, size: .medium) {}
+                VButton(label: "Running", leftIcon: "checkmark.circle.fill", style: .success) {}
             }
 
             Text("Point your tunnel (ngrok, Cloudflare, etc.) to this address.")
@@ -107,7 +107,7 @@ struct GatewaySettingsCard: View {
 
             // Save button at the bottom
             HStack {
-                VButton(label: "Save", style: .primary, size: .medium) {
+                VButton(label: "Save", style: .primary) {
                     store.saveIngressPublicBaseUrl(gatewayUrlText)
                     isGatewayUrlFocused = false
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -116,7 +116,7 @@ struct SettingsAccountTab: View {
                 .foregroundColor(VColor.textPrimary)
                 .focused($isPlatformUrlFocused)
 
-            VButton(label: "Save", style: .primary, size: .medium) {
+            VButton(label: "Save", style: .primary) {
                 store.savePlatformBaseUrl(platformUrlText)
                 isPlatformUrlFocused = false
             }
@@ -143,8 +143,7 @@ struct SettingsAccountTab: View {
             } else {
                 VButton(
                     label: authManager.isSubmitting ? "Signing in..." : "Sign In",
-                    style: .primary,
-                    size: .medium
+                    style: .primary
                 ) {
                     Task { await authManager.startWorkOSLogin() }
                 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAdvancedDevTab.swift
@@ -235,7 +235,7 @@ struct SettingsAdvancedDevTab: View {
                             .font(VFont.caption)
                             .foregroundColor(VColor.textMuted)
                     }
-                    VButton(label: "View...", style: .secondary, size: .medium) {
+                    VButton(label: "View...", style: .secondary) {
                         appEnvVars = ProcessInfo.processInfo.environment
                             .sorted(by: { $0.key < $1.key })
                             .map { ($0.key, $0.value) }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAutomationTab.swift
@@ -28,7 +28,7 @@ struct SettingsAutomationTab: View {
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.textMuted)
                         }
-                        VButton(label: "Manage...", style: .secondary, size: .medium) {
+                        VButton(label: "Manage...", style: .secondary) {
                             showingReminders = true
                         }
                     }
@@ -52,7 +52,7 @@ struct SettingsAutomationTab: View {
                                 .font(VFont.caption)
                                 .foregroundColor(VColor.textMuted)
                         }
-                        VButton(label: "Manage...", style: .secondary, size: .medium) {
+                        VButton(label: "Manage...", style: .secondary) {
                             showingScheduledTasks = true
                         }
                     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -178,7 +178,7 @@ struct SettingsChannelsTab: View {
 
                 }
 
-                VButton(label: "Regenerate", style: .tertiary, size: .medium) {
+                VButton(label: "Regenerate", style: .tertiary) {
                     showingRegenerateConfirmation = true
                 }
             }
@@ -275,8 +275,8 @@ struct SettingsChannelsTab: View {
             // Bot credential row
             if store.telegramHasBotToken {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .medium) {}
-                    VButton(label: "Disconnect", style: .danger, size: .medium, isDisabled: store.telegramSaveInProgress) {
+                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success) {}
+                    VButton(label: "Disconnect", style: .danger, isDisabled: store.telegramSaveInProgress) {
                         store.clearTelegramCredentials()
                         telegramBotTokenText = ""
                         telegramSetupExpanded = false
@@ -285,7 +285,7 @@ struct SettingsChannelsTab: View {
             } else if telegramSetupExpanded {
                 telegramCredentialEntry
             } else {
-                VButton(label: "Set Up", style: .secondary, size: .medium) {
+                VButton(label: "Set Up", style: .secondary) {
                     telegramSetupExpanded = true
                 }
             }
@@ -353,7 +353,7 @@ struct SettingsChannelsTab: View {
                             }
                         }
                         Spacer()
-                        VButton(label: "Revoke", style: .secondary, size: .medium) {
+                        VButton(label: "Revoke", style: .secondary) {
                             store.revokeTelegramApprovedMember(memberId: member.id)
                         }
                         .disabled(store.telegramRevokingMemberIds.contains(member.id))
@@ -396,13 +396,13 @@ struct SettingsChannelsTab: View {
                 }
             } else {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connect", style: .secondary, size: .medium) {
+                    VButton(label: "Connect", style: .secondary) {
                         store.saveTelegramToken(botToken: telegramBotTokenText)
                         telegramBotTokenText = ""
                         telegramSetupExpanded = false
                     }
                     .disabled(telegramBotTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                    VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                    VButton(label: "Cancel", style: .tertiary) {
                         telegramSetupExpanded = false
                         telegramBotTokenText = ""
                     }
@@ -426,8 +426,8 @@ struct SettingsChannelsTab: View {
 
             if store.slackChannelHasBotToken && store.slackChannelHasAppToken {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .medium) {}
-                    VButton(label: "Disconnect", style: .danger, size: .medium, isDisabled: store.slackChannelSaveInProgress) {
+                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success) {}
+                    VButton(label: "Disconnect", style: .danger, isDisabled: store.slackChannelSaveInProgress) {
                         store.clearSlackChannelConfig()
                         slackChannelBotTokenInput = ""
                         slackChannelAppTokenInput = ""
@@ -437,7 +437,7 @@ struct SettingsChannelsTab: View {
             } else if slackChannelSetupExpanded {
                 slackChannelCredentialEntry
             } else {
-                VButton(label: "Set Up", style: .secondary, size: .medium) {
+                VButton(label: "Set Up", style: .secondary) {
                     slackChannelSetupExpanded = true
                 }
             }
@@ -492,7 +492,7 @@ struct SettingsChannelsTab: View {
                 }
             } else {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connect", style: .secondary, size: .medium) {
+                    VButton(label: "Connect", style: .secondary) {
                         store.saveSlackChannelConfig(
                             botToken: slackChannelBotTokenInput,
                             appToken: slackChannelAppTokenInput
@@ -505,7 +505,7 @@ struct SettingsChannelsTab: View {
                         slackChannelBotTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                         || slackChannelAppTokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                     )
-                    VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                    VButton(label: "Cancel", style: .tertiary) {
                         slackChannelSetupExpanded = false
                         slackChannelBotTokenInput = ""
                         slackChannelAppTokenInput = ""
@@ -531,15 +531,15 @@ struct SettingsChannelsTab: View {
             // Credentials row
             if store.twilioHasCredentials {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .medium) {}
-                    VButton(label: "Disconnect", style: .danger, size: .medium, isDisabled: store.twilioSaveInProgress) {
+                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success) {}
+                    VButton(label: "Disconnect", style: .danger, isDisabled: store.twilioSaveInProgress) {
                         store.clearTwilioCredentials()
                     }
                 }
             } else if twilioSetupExpanded {
                 twilioCredentialEntry
             } else {
-                VButton(label: "Set Up", style: .secondary, size: .medium) {
+                VButton(label: "Set Up", style: .secondary) {
                     twilioSetupExpanded = true
                 }
             }
@@ -606,15 +606,15 @@ struct SettingsChannelsTab: View {
             // Credentials row
             if store.twilioHasCredentials {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success, size: .medium) {}
-                    VButton(label: "Disconnect", style: .danger, size: .medium, isDisabled: store.twilioSaveInProgress) {
+                    VButton(label: "Connected", leftIcon: "checkmark.circle.fill", style: .success) {}
+                    VButton(label: "Disconnect", style: .danger, isDisabled: store.twilioSaveInProgress) {
                         store.clearTwilioCredentials()
                     }
                 }
             } else if voiceSetupExpanded {
                 voiceCredentialEntry
             } else {
-                VButton(label: "Set Up", style: .secondary, size: .medium) {
+                VButton(label: "Set Up", style: .secondary) {
                     voiceSetupExpanded = true
                 }
             }
@@ -694,7 +694,7 @@ struct SettingsChannelsTab: View {
                 }
             } else {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connect", style: .secondary, size: .medium) {
+                    VButton(label: "Connect", style: .secondary) {
                         store.saveTwilioCredentials(
                             accountSid: twilioAccountSidText,
                             authToken: twilioAuthTokenText
@@ -707,7 +707,7 @@ struct SettingsChannelsTab: View {
                         twilioAccountSidText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
                         twilioAuthTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                     )
-                    VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                    VButton(label: "Cancel", style: .tertiary) {
                         twilioSetupExpanded = false
                         twilioAccountSidText = ""
                         twilioAuthTokenText = ""
@@ -745,7 +745,7 @@ struct SettingsChannelsTab: View {
                 }
             } else {
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: "Connect", style: .secondary, size: .medium) {
+                    VButton(label: "Connect", style: .secondary) {
                         store.saveTwilioCredentials(
                             accountSid: voiceAccountSidText,
                             authToken: voiceAuthTokenText
@@ -758,7 +758,7 @@ struct SettingsChannelsTab: View {
                         voiceAccountSidText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
                         voiceAuthTokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                     )
-                    VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                    VButton(label: "Cancel", style: .tertiary) {
                         voiceSetupExpanded = false
                         voiceAccountSidText = ""
                         voiceAuthTokenText = ""
@@ -817,7 +817,7 @@ struct SettingsChannelsTab: View {
             }
 
             if let action {
-                VButton(label: action.label, style: action.style, size: .medium, action: action.action)
+                VButton(label: action.label, style: action.style, action: action.action)
                     .disabled(action.disabled)
             }
         }
@@ -1026,7 +1026,7 @@ struct SettingsChannelsTab: View {
                         }
                         Spacer()
                     }
-                    VButton(label: "Revoke", style: .secondary, size: .medium) {
+                    VButton(label: "Revoke", style: .secondary) {
                         store.revokeChannelGuardian(channel: channel)
                     }
                 }
@@ -1060,7 +1060,7 @@ struct SettingsChannelsTab: View {
                         .font(VFont.caption)
                         .foregroundColor(VColor.error)
                     if alreadyBound {
-                        VButton(label: "Replace", style: .secondary, size: .medium) {
+                        VButton(label: "Replace", style: .secondary) {
                             store.startChannelGuardianVerification(channel: channel, rebind: true)
                         }
                     }
@@ -1123,7 +1123,7 @@ struct SettingsChannelsTab: View {
                     .foregroundColor(VColor.textMuted)
             }
 
-            VButton(label: "Send", style: .secondary, size: .medium) {
+            VButton(label: "Send", style: .secondary) {
                 store.startOutboundGuardianVerification(channel: channel, destination: destination)
             }
             .disabled(destination.isEmpty)
@@ -1245,13 +1245,13 @@ struct SettingsChannelsTab: View {
                 // Disable resend during bootstrap: when bootstrapUrl is set the session is
                 // in pending_bootstrap state and the daemon rejects resend attempts.
                 HStack(spacing: VSpacing.sm) {
-                    VButton(label: resendCooldownText ?? "Resend", style: .secondary, size: .medium, isFullWidth: true) {
+                    VButton(label: resendCooldownText ?? "Resend", style: .secondary, isFullWidth: true) {
                         store.resendOutboundGuardian(channel: channel)
                     }
                     .disabled(!canResend)
                     .frame(width: 160)
 
-                    VButton(label: "Cancel", style: .tertiary, size: .medium) {
+                    VButton(label: "Cancel", style: .tertiary) {
                         store.cancelOutboundGuardian(channel: channel)
                     }
                 }
@@ -1434,7 +1434,7 @@ struct SettingsChannelsTab: View {
                     .padding(.leading, labelColumnWidth + VSpacing.sm)
             }
 
-            VButton(label: "Cancel", style: .tertiary, size: .medium) {
+            VButton(label: "Cancel", style: .tertiary) {
                 store.cancelGuardianChallenge(channel: channel)
             }
         }
@@ -1559,12 +1559,12 @@ struct SettingsChannelsTab: View {
                         .font(VFont.body)
                         .foregroundColor(VColor.warning)
                 }
-                VButton(label: "Generate Token", style: .secondary, size: .medium) {
+                VButton(label: "Generate Token", style: .secondary) {
                     regenerateHttpToken()
                 }
             }
         } else {
-            VButton(label: "Pair Device", leftIcon: "qrcode", style: .primary, size: .medium) {
+            VButton(label: "Pair Device", leftIcon: "qrcode", style: .primary) {
                 showingPairingQR = true
             }
         }

--- a/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/VoiceSettingsView.swift
@@ -447,7 +447,7 @@ struct VoiceSettingsView: View {
                     }
 
                     HStack(spacing: VSpacing.sm) {
-                        VButton(label: "Connect", style: .secondary, size: .medium, isDisabled: elevenLabsKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                        VButton(label: "Connect", style: .secondary, isDisabled: elevenLabsKeyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
                             store.saveElevenLabsKey(elevenLabsKeyText)
                             elevenLabsKeyText = ""
                             ttsSetupExpanded = false


### PR DESCRIPTION
Remove explicit `size: .medium` from all VButton instances on the settings screen. Since VButton defaults to `.small`, this makes all buttons render at the smaller 24pt height instead of the previous 28pt.

Files changed:
- SettingsAccountTab.swift
- SettingsChannelsTab.swift
- SettingsAutomationTab.swift
- SettingsAdvancedDevTab.swift
- VoiceSettingsView.swift

Closes #12562
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
