### PR TITLE
fix: use rawChanges() in deleteAssistantContactMetadata

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, isNull, like, or, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../memory/db.js";
+import { rawChanges } from "../memory/raw-query.js";
 import {
   assistantContactMetadata,
   contactChannels,
@@ -1088,10 +1089,9 @@ export function getAssistantContactMetadata(
 
 export function deleteAssistantContactMetadata(contactId: string): boolean {
   const db = getDb();
-  const result = db
-    .delete(assistantContactMetadata)
+  db.delete(assistantContactMetadata)
     .where(eq(assistantContactMetadata.contactId, contactId))
     .run();
 
-  return result.changes > 0;
+  return rawChanges() > 0;
 }


### PR DESCRIPTION
## Summary
- `db.delete(...).run()` returns `void` in Drizzle, so accessing `.changes` on it is a type error
- Use `rawChanges()` (the existing pattern in this codebase) to check affected rows after delete

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22689060573/job/65779593413

🤖 Generated with [Claude Code](https://claude.com/claude-code)