### PR TITLE
fix: make isLoadingHistory setter accessible for tests

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -464,7 +464,7 @@ public final class ChatViewModel: ObservableObject {
 
     /// True while `populateFromHistory` is actively inserting messages.
     /// Observers can check this to avoid treating the history hydration as new activity.
-    public private(set) var isLoadingHistory: Bool = false
+    public var isLoadingHistory: Bool = false
 
     // MARK: - Message Pagination
 


### PR DESCRIPTION
## Summary
- Remove `private(set)` from `ChatViewModel.isLoadingHistory` so that `@testable import` in `ChatViewModelTests` can set it directly to simulate an in-progress history load.
- Fixes macOS test CI failure: `cannot assign to property: 'isLoadingHistory' setter is inaccessible`

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22687179191/job/65773163808

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
