### PR TITLE
M1: Add avatar generation types and constants

### DIFF
--- a/assistant/src/media/avatar-types.ts
+++ b/assistant/src/media/avatar-types.ts
@@ -1,0 +1,60 @@
+export type AvatarGenerationStrategy = "managed_required" | "managed_prefer" | "local_only";
+
+export interface ManagedAvatarImagePayload {
+  mime_type: string;
+  data_base64: string;
+  bytes: number;
+  sha256: string;
+}
+
+export interface ManagedAvatarResponse {
+  image: ManagedAvatarImagePayload;
+  usage: { billable: boolean; class_name: string };
+  generation_source: string;
+  profile: string;
+  correlation_id: string;
+}
+
+export interface ManagedAvatarErrorResponse {
+  code: string;
+  subcode: string;
+  detail: string;
+  retryable: boolean;
+  correlation_id: string;
+}
+
+export class ManagedAvatarError extends Error {
+  readonly code: string;
+  readonly subcode: string;
+  readonly retryable: boolean;
+  readonly correlationId: string;
+  readonly statusCode: number;
+
+  constructor(opts: {
+    code: string;
+    subcode: string;
+    detail: string;
+    retryable: boolean;
+    correlationId: string;
+    statusCode: number;
+  }) {
+    super(opts.detail);
+    this.name = "ManagedAvatarError";
+    this.code = opts.code;
+    this.subcode = opts.subcode;
+    this.retryable = opts.retryable;
+    this.correlationId = opts.correlationId;
+    this.statusCode = opts.statusCode;
+  }
+}
+
+export interface AvatarGenerationResult {
+  imageBase64: string;
+  mimeType: string;
+  pathUsed: "managed" | "local";
+  correlationId?: string;
+}
+
+export const AVATAR_MIME_ALLOWLIST = new Set(["image/png", "image/jpeg", "image/webp"]);
+export const AVATAR_MAX_DECODED_BYTES = 10 * 1024 * 1024;
+export const AVATAR_PROMPT_MAX_LENGTH = 2000;


### PR DESCRIPTION
## Summary
- Add AvatarGenerationStrategy type, ManagedAvatarResponse/ErrorResponse interfaces
- Add ManagedAvatarError class for structured error handling
- Add AvatarGenerationResult interface for strategy router
- Add validation constants (MIME allowlist, max bytes, prompt length)

Part of #12572 (Managed Avatar Generation)
Closes #12573

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
