### PR TITLE
M2: Add managed avatar HTTP client

### DIFF
--- a/assistant/src/__tests__/managed-avatar-client.test.ts
+++ b/assistant/src/__tests__/managed-avatar-client.test.ts
@@ -1,0 +1,247 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock dependencies — must be before importing the module under test
+// ---------------------------------------------------------------------------
+
+let mockApiKey: string | undefined = "test-api-key-123";
+let mockBaseUrl = "https://platform.vellum.ai";
+let mockPlatformEnvUrl = "https://env.vellum.ai";
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKey: (account: string) => {
+    if (account === "credential:vellum:assistant_api_key") return mockApiKey;
+    return undefined;
+  },
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    platform: { baseUrl: mockBaseUrl },
+  }),
+}));
+
+mock.module("../config/env.js", () => ({
+  getPlatformBaseUrl: () => mockPlatformEnvUrl,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+// Mock global fetch
+let lastFetchArgs: [string, RequestInit] | null = null;
+let fetchResponse: { ok: boolean; status: number; json: () => Promise<unknown> } = {
+  ok: true,
+  status: 200,
+  json: async () => ({}),
+};
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = (async (url: string, init: RequestInit) => {
+  lastFetchArgs = [url, init];
+  return fetchResponse;
+}) as typeof globalThis.fetch;
+
+// Import after mocking
+import {
+  isManagedAvailable,
+  generateManagedAvatar,
+  getAssistantApiKey,
+} from "../media/managed-avatar-client.js";
+import {
+  ManagedAvatarError,
+  AVATAR_PROMPT_MAX_LENGTH,
+  AVATAR_MAX_DECODED_BYTES,
+} from "../media/avatar-types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function successResponse() {
+  return {
+    image: {
+      mime_type: "image/png",
+      data_base64: "iVBORw0KGgo=",
+      bytes: 1024,
+      sha256: "abc123",
+    },
+    usage: { billable: true, class_name: "avatar" },
+    generation_source: "managed",
+    profile: "default",
+    correlation_id: "test-corr-id",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockApiKey = "test-api-key-123";
+  mockBaseUrl = "https://platform.vellum.ai";
+  mockPlatformEnvUrl = "https://env.vellum.ai";
+  lastFetchArgs = null;
+  fetchResponse = {
+    ok: true,
+    status: 200,
+    json: async () => successResponse(),
+  };
+});
+
+describe("generateManagedAvatar", () => {
+  test("successful generation returns parsed response", async () => {
+    const result = await generateManagedAvatar("a friendly robot avatar");
+
+    expect(result.image.mime_type).toBe("image/png");
+    expect(result.image.data_base64).toBe("iVBORw0KGgo=");
+    expect(result.image.bytes).toBe(1024);
+    expect(result.generation_source).toBe("managed");
+  });
+
+  test("prompt exceeding max length throws ManagedAvatarError with code validation_error", async () => {
+    const longPrompt = "x".repeat(AVATAR_PROMPT_MAX_LENGTH + 1);
+
+    try {
+      await generateManagedAvatar(longPrompt);
+      expect(true).toBe(false); // should not reach here
+    } catch (err) {
+      expect(err).toBeInstanceOf(ManagedAvatarError);
+      const avatarErr = err as ManagedAvatarError;
+      expect(avatarErr.code).toBe("validation_error");
+      expect(avatarErr.subcode).toBe("prompt_too_long");
+    }
+  });
+
+  test("HTTP 429 response throws ManagedAvatarError with retryable true", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 429,
+      json: async () => ({
+        code: "rate_limit",
+        subcode: "too_many_requests",
+        detail: "Rate limit exceeded",
+        retryable: true,
+        correlation_id: "corr-429",
+      }),
+    };
+
+    try {
+      await generateManagedAvatar("test prompt");
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ManagedAvatarError);
+      const avatarErr = err as ManagedAvatarError;
+      expect(avatarErr.retryable).toBe(true);
+      expect(avatarErr.statusCode).toBe(429);
+    }
+  });
+
+  test("HTTP 500 response throws ManagedAvatarError with upstream error details", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 500,
+      json: async () => ({
+        code: "internal_error",
+        subcode: "server_fault",
+        detail: "Internal server error",
+        retryable: true,
+        correlation_id: "corr-500",
+      }),
+    };
+
+    try {
+      await generateManagedAvatar("test prompt");
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ManagedAvatarError);
+      const avatarErr = err as ManagedAvatarError;
+      expect(avatarErr.code).toBe("internal_error");
+      expect(avatarErr.subcode).toBe("server_fault");
+      expect(avatarErr.statusCode).toBe(500);
+    }
+  });
+
+  test("response with disallowed MIME type throws validation error", async () => {
+    fetchResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ...successResponse(),
+        image: { ...successResponse().image, mime_type: "image/gif" },
+      }),
+    };
+
+    try {
+      await generateManagedAvatar("test prompt");
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ManagedAvatarError);
+      const avatarErr = err as ManagedAvatarError;
+      expect(avatarErr.code).toBe("validation_error");
+      expect(avatarErr.subcode).toBe("disallowed_mime_type");
+    }
+  });
+
+  test("response with oversized bytes throws validation error", async () => {
+    fetchResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ...successResponse(),
+        image: { ...successResponse().image, bytes: AVATAR_MAX_DECODED_BYTES + 1 },
+      }),
+    };
+
+    try {
+      await generateManagedAvatar("test prompt");
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ManagedAvatarError);
+      const avatarErr = err as ManagedAvatarError;
+      expect(avatarErr.code).toBe("validation_error");
+      expect(avatarErr.subcode).toBe("oversized_image");
+    }
+  });
+
+  test("Authorization header uses Api-Key prefix", async () => {
+    await generateManagedAvatar("test prompt");
+
+    expect(lastFetchArgs).not.toBeNull();
+    const headers = lastFetchArgs![1].headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Api-Key test-api-key-123");
+    expect(headers.Authorization).not.toContain("Bearer");
+  });
+
+  test("Idempotency-Key header is present on every request", async () => {
+    await generateManagedAvatar("test prompt");
+
+    expect(lastFetchArgs).not.toBeNull();
+    const headers = lastFetchArgs![1].headers as Record<string, string>;
+    expect(headers["Idempotency-Key"]).toBeDefined();
+    expect(headers["Idempotency-Key"].length).toBeGreaterThan(0);
+  });
+});
+
+describe("isManagedAvailable", () => {
+  test("returns false when API key is missing", () => {
+    mockApiKey = undefined;
+    expect(isManagedAvailable()).toBe(false);
+  });
+
+  test("returns false when base URL is missing", () => {
+    mockBaseUrl = "";
+    mockPlatformEnvUrl = "";
+    expect(isManagedAvailable()).toBe(false);
+  });
+
+  test("returns true when both API key and base URL are present", () => {
+    expect(isManagedAvailable()).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/managed-avatar-client.test.ts
+++ b/assistant/src/__tests__/managed-avatar-client.test.ts
@@ -210,6 +210,30 @@ describe("generateManagedAvatar", () => {
     }
   });
 
+  test("response with oversized base64 estimated decoded size throws validation error", async () => {
+    // Create a base64 string whose estimated decoded size exceeds the limit,
+    // even though the server-reported bytes field is under the limit
+    const oversizedBase64 = "A".repeat(Math.ceil((AVATAR_MAX_DECODED_BYTES + 100) * 4 / 3));
+    fetchResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ...successResponse(),
+        image: { ...successResponse().image, data_base64: oversizedBase64, bytes: 1024 },
+      }),
+    };
+
+    try {
+      await generateManagedAvatar("test prompt");
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ManagedAvatarError);
+      const avatarErr = err as ManagedAvatarError;
+      expect(avatarErr.code).toBe("validation_error");
+      expect(avatarErr.subcode).toBe("oversized_image");
+    }
+  });
+
   test("Authorization header uses Api-Key prefix", async () => {
     await generateManagedAvatar("test prompt");
 
@@ -226,6 +250,15 @@ describe("generateManagedAvatar", () => {
     const headers = lastFetchArgs![1].headers as Record<string, string>;
     expect(headers["Idempotency-Key"]).toBeDefined();
     expect(headers["Idempotency-Key"].length).toBeGreaterThan(0);
+  });
+
+  test("caller-provided idempotencyKey is used in the request header", async () => {
+    const customKey = "my-custom-idempotency-key-123";
+    await generateManagedAvatar("test prompt", { idempotencyKey: customKey });
+
+    expect(lastFetchArgs).not.toBeNull();
+    const headers = lastFetchArgs![1].headers as Record<string, string>;
+    expect(headers["Idempotency-Key"]).toBe(customKey);
   });
 });
 

--- a/assistant/src/media/managed-avatar-client.ts
+++ b/assistant/src/media/managed-avatar-client.ts
@@ -31,7 +31,7 @@ export function isManagedAvailable(): boolean {
 
 export async function generateManagedAvatar(
   prompt: string,
-  options?: { correlationId?: string },
+  options?: { correlationId?: string; idempotencyKey?: string },
 ): Promise<ManagedAvatarResponse> {
   if (prompt.length > AVATAR_PROMPT_MAX_LENGTH) {
     throw new ManagedAvatarError({
@@ -57,8 +57,19 @@ export async function generateManagedAvatar(
   }
 
   const baseUrl = getManagedAvatarBaseUrl();
+  if (!baseUrl) {
+    throw new ManagedAvatarError({
+      code: "configuration_error",
+      subcode: "missing_base_url",
+      detail: "Platform base URL is not configured. Set platform.baseUrl in config or PLATFORM_BASE_URL environment variable.",
+      retryable: false,
+      correlationId: options?.correlationId ?? crypto.randomUUID(),
+      statusCode: 0,
+    });
+  }
+
   const url = `${baseUrl}/v1/assistants/avatar/generate/`;
-  const idempotencyKey = crypto.randomUUID();
+  const idempotencyKey = options?.idempotencyKey ?? crypto.randomUUID();
   const correlationId = options?.correlationId ?? crypto.randomUUID();
 
   const headers: Record<string, string> = {
@@ -70,12 +81,25 @@ export async function generateManagedAvatar(
 
   log.debug({ url, correlationId }, "Requesting managed avatar generation");
 
-  const response = await fetch(url, {
-    method: "POST",
-    body: JSON.stringify({ prompt }),
-    signal: AbortSignal.timeout(60_000),
-    headers,
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      body: JSON.stringify({ prompt }),
+      signal: AbortSignal.timeout(60_000),
+      headers,
+    });
+  } catch (err) {
+    const isTimeout = err instanceof DOMException && err.name === "TimeoutError";
+    throw new ManagedAvatarError({
+      code: "avatar_generation_failed",
+      subcode: isTimeout ? "upstream_timeout" : "network_error",
+      detail: isTimeout ? "Request to avatar generation service timed out" : `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      retryable: true,
+      correlationId,
+      statusCode: 0,
+    });
+  }
 
   if (!response.ok) {
     let errorBody: ManagedAvatarErrorResponse;
@@ -115,11 +139,12 @@ export async function generateManagedAvatar(
     });
   }
 
-  if (body.image.bytes > AVATAR_MAX_DECODED_BYTES) {
+  const estimatedDecodedBytes = Math.ceil(body.image.data_base64.length * 3 / 4);
+  if (estimatedDecodedBytes > AVATAR_MAX_DECODED_BYTES || body.image.bytes > AVATAR_MAX_DECODED_BYTES) {
     throw new ManagedAvatarError({
       code: "validation_error",
       subcode: "oversized_image",
-      detail: `Response image size ${body.image.bytes} exceeds maximum of ${AVATAR_MAX_DECODED_BYTES} bytes`,
+      detail: `Response image size ${Math.max(estimatedDecodedBytes, body.image.bytes)} exceeds maximum of ${AVATAR_MAX_DECODED_BYTES} bytes`,
       retryable: false,
       correlationId,
       statusCode: 0,

--- a/assistant/src/media/managed-avatar-client.ts
+++ b/assistant/src/media/managed-avatar-client.ts
@@ -139,7 +139,9 @@ export async function generateManagedAvatar(
     });
   }
 
-  const estimatedDecodedBytes = Math.ceil(body.image.data_base64.length * 3 / 4);
+  const b64 = body.image.data_base64;
+  const padding = b64.endsWith("==") ? 2 : b64.endsWith("=") ? 1 : 0;
+  const estimatedDecodedBytes = Math.ceil(b64.length * 3 / 4) - padding;
   if (estimatedDecodedBytes > AVATAR_MAX_DECODED_BYTES || body.image.bytes > AVATAR_MAX_DECODED_BYTES) {
     throw new ManagedAvatarError({
       code: "validation_error",

--- a/assistant/src/media/managed-avatar-client.ts
+++ b/assistant/src/media/managed-avatar-client.ts
@@ -1,0 +1,135 @@
+import { getSecureKey } from "../security/secure-keys.js";
+import { getConfig } from "../config/loader.js";
+import { getPlatformBaseUrl } from "../config/env.js";
+import { getLogger } from "../util/logger.js";
+import {
+  type ManagedAvatarResponse,
+  type ManagedAvatarErrorResponse,
+  ManagedAvatarError,
+  AVATAR_MIME_ALLOWLIST,
+  AVATAR_MAX_DECODED_BYTES,
+  AVATAR_PROMPT_MAX_LENGTH,
+} from "./avatar-types.js";
+
+const log = getLogger("managed-avatar-client");
+
+export function getAssistantApiKey(): string | undefined {
+  return getSecureKey("credential:vellum:assistant_api_key");
+}
+
+export function getManagedAvatarBaseUrl(): string {
+  const baseUrl =
+    getConfig().platform.baseUrl || getPlatformBaseUrl();
+  return baseUrl.replace(/\/+$/, "");
+}
+
+export function isManagedAvailable(): boolean {
+  const apiKey = getAssistantApiKey();
+  const baseUrl = getManagedAvatarBaseUrl();
+  return !!apiKey && apiKey.length > 0 && !!baseUrl && baseUrl.length > 0;
+}
+
+export async function generateManagedAvatar(
+  prompt: string,
+  options?: { correlationId?: string },
+): Promise<ManagedAvatarResponse> {
+  if (prompt.length > AVATAR_PROMPT_MAX_LENGTH) {
+    throw new ManagedAvatarError({
+      code: "validation_error",
+      subcode: "prompt_too_long",
+      detail: `Prompt exceeds maximum length of ${AVATAR_PROMPT_MAX_LENGTH} characters`,
+      retryable: false,
+      correlationId: options?.correlationId ?? crypto.randomUUID(),
+      statusCode: 0,
+    });
+  }
+
+  const apiKey = getAssistantApiKey();
+  if (!apiKey) {
+    throw new ManagedAvatarError({
+      code: "configuration_error",
+      subcode: "missing_api_key",
+      detail: "Assistant API key is not configured",
+      retryable: false,
+      correlationId: options?.correlationId ?? crypto.randomUUID(),
+      statusCode: 0,
+    });
+  }
+
+  const baseUrl = getManagedAvatarBaseUrl();
+  const url = `${baseUrl}/v1/assistants/avatar/generate/`;
+  const idempotencyKey = crypto.randomUUID();
+  const correlationId = options?.correlationId ?? crypto.randomUUID();
+
+  const headers: Record<string, string> = {
+    Authorization: `Api-Key ${apiKey}`,
+    "Content-Type": "application/json",
+    "Idempotency-Key": idempotencyKey,
+    "X-Correlation-Id": correlationId,
+  };
+
+  log.debug({ url, correlationId }, "Requesting managed avatar generation");
+
+  const response = await fetch(url, {
+    method: "POST",
+    body: JSON.stringify({ prompt }),
+    signal: AbortSignal.timeout(60_000),
+    headers,
+  });
+
+  if (!response.ok) {
+    let errorBody: ManagedAvatarErrorResponse;
+    try {
+      errorBody = (await response.json()) as ManagedAvatarErrorResponse;
+    } catch {
+      throw new ManagedAvatarError({
+        code: "upstream_error",
+        subcode: "unparseable_response",
+        detail: `HTTP ${response.status}: unable to parse error response`,
+        retryable: response.status >= 500 || response.status === 429,
+        correlationId,
+        statusCode: response.status,
+      });
+    }
+
+    throw new ManagedAvatarError({
+      code: errorBody.code ?? "upstream_error",
+      subcode: errorBody.subcode ?? "unknown",
+      detail: errorBody.detail ?? `HTTP ${response.status}`,
+      retryable: errorBody.retryable ?? (response.status >= 500 || response.status === 429),
+      correlationId: errorBody.correlation_id ?? correlationId,
+      statusCode: response.status,
+    });
+  }
+
+  const body = (await response.json()) as ManagedAvatarResponse;
+
+  if (!AVATAR_MIME_ALLOWLIST.has(body.image.mime_type)) {
+    throw new ManagedAvatarError({
+      code: "validation_error",
+      subcode: "disallowed_mime_type",
+      detail: `Response MIME type "${body.image.mime_type}" is not in the allowlist`,
+      retryable: false,
+      correlationId,
+      statusCode: 0,
+    });
+  }
+
+  if (body.image.bytes > AVATAR_MAX_DECODED_BYTES) {
+    throw new ManagedAvatarError({
+      code: "validation_error",
+      subcode: "oversized_image",
+      detail: `Response image size ${body.image.bytes} exceeds maximum of ${AVATAR_MAX_DECODED_BYTES} bytes`,
+      retryable: false,
+      correlationId,
+      statusCode: 0,
+    });
+  }
+
+  log.debug(
+    { correlationId, mimeType: body.image.mime_type, bytes: body.image.bytes },
+    "Managed avatar generation succeeded",
+  );
+
+  return body;
+}

--- a/assistant/src/media/managed-avatar-client.ts
+++ b/assistant/src/media/managed-avatar-client.ts
@@ -1,14 +1,14 @@
-import { getSecureKey } from "../security/secure-keys.js";
-import { getConfig } from "../config/loader.js";
 import { getPlatformBaseUrl } from "../config/env.js";
+import { getConfig } from "../config/loader.js";
+import { getSecureKey } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import {
-  type ManagedAvatarResponse,
-  type ManagedAvatarErrorResponse,
-  ManagedAvatarError,
-  AVATAR_MIME_ALLOWLIST,
   AVATAR_MAX_DECODED_BYTES,
+  AVATAR_MIME_ALLOWLIST,
   AVATAR_PROMPT_MAX_LENGTH,
+  ManagedAvatarError,
+  type ManagedAvatarErrorResponse,
+  type ManagedAvatarResponse,
 } from "./avatar-types.js";
 
 const log = getLogger("managed-avatar-client");
@@ -18,8 +18,7 @@ export function getAssistantApiKey(): string | undefined {
 }
 
 export function getManagedAvatarBaseUrl(): string {
-  const baseUrl =
-    getConfig().platform.baseUrl || getPlatformBaseUrl();
+  const baseUrl = getConfig().platform.baseUrl || getPlatformBaseUrl();
   return baseUrl.replace(/\/+$/, "");
 }
 
@@ -61,7 +60,8 @@ export async function generateManagedAvatar(
     throw new ManagedAvatarError({
       code: "configuration_error",
       subcode: "missing_base_url",
-      detail: "Platform base URL is not configured. Set platform.baseUrl in config or PLATFORM_BASE_URL environment variable.",
+      detail:
+        "Platform base URL is not configured. Set platform.baseUrl in config or PLATFORM_BASE_URL environment variable.",
       retryable: false,
       correlationId: options?.correlationId ?? crypto.randomUUID(),
       statusCode: 0,
@@ -90,11 +90,14 @@ export async function generateManagedAvatar(
       headers,
     });
   } catch (err) {
-    const isTimeout = err instanceof DOMException && err.name === "TimeoutError";
+    const isTimeout =
+      err instanceof DOMException && err.name === "TimeoutError";
     throw new ManagedAvatarError({
       code: "avatar_generation_failed",
       subcode: isTimeout ? "upstream_timeout" : "network_error",
-      detail: isTimeout ? "Request to avatar generation service timed out" : `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      detail: isTimeout
+        ? "Request to avatar generation service timed out"
+        : `Network error: ${err instanceof Error ? err.message : String(err)}`,
       retryable: true,
       correlationId,
       statusCode: 0,
@@ -120,43 +123,67 @@ export async function generateManagedAvatar(
       code: errorBody.code ?? "upstream_error",
       subcode: errorBody.subcode ?? "unknown",
       detail: errorBody.detail ?? `HTTP ${response.status}`,
-      retryable: errorBody.retryable ?? (response.status >= 500 || response.status === 429),
+      retryable:
+        errorBody.retryable ??
+        (response.status >= 500 || response.status === 429),
       correlationId: errorBody.correlation_id ?? correlationId,
       statusCode: response.status,
     });
   }
 
-  const body = (await response.json()) as ManagedAvatarResponse;
+  let body: ManagedAvatarResponse;
+  try {
+    body = (await response.json()) as ManagedAvatarResponse;
 
-  if (!AVATAR_MIME_ALLOWLIST.has(body.image.mime_type)) {
+    if (!AVATAR_MIME_ALLOWLIST.has(body.image.mime_type)) {
+      throw new ManagedAvatarError({
+        code: "validation_error",
+        subcode: "disallowed_mime_type",
+        detail: `Response MIME type "${body.image.mime_type}" is not in the allowlist`,
+        retryable: false,
+        correlationId,
+        statusCode: 0,
+      });
+    }
+
+    const b64 = body.image.data_base64;
+    const padding = b64.endsWith("==") ? 2 : b64.endsWith("=") ? 1 : 0;
+    const estimatedDecodedBytes = Math.ceil((b64.length * 3) / 4) - padding;
+    if (
+      estimatedDecodedBytes > AVATAR_MAX_DECODED_BYTES ||
+      body.image.bytes > AVATAR_MAX_DECODED_BYTES
+    ) {
+      throw new ManagedAvatarError({
+        code: "validation_error",
+        subcode: "oversized_image",
+        detail: `Response image size ${Math.max(estimatedDecodedBytes, body.image.bytes)} exceeds maximum of ${AVATAR_MAX_DECODED_BYTES} bytes`,
+        retryable: false,
+        correlationId,
+        statusCode: 0,
+      });
+    }
+
+    log.debug(
+      {
+        correlationId,
+        mimeType: body.image.mime_type,
+        bytes: body.image.bytes,
+      },
+      "Managed avatar generation succeeded",
+    );
+
+    return body;
+  } catch (err) {
+    if (err instanceof ManagedAvatarError) {
+      throw err;
+    }
     throw new ManagedAvatarError({
-      code: "validation_error",
-      subcode: "disallowed_mime_type",
-      detail: `Response MIME type "${body.image.mime_type}" is not in the allowlist`,
+      code: "upstream_error",
+      subcode: "unparseable_response",
+      detail: `Failed to parse avatar generation response: ${err instanceof Error ? err.message : String(err)}`,
       retryable: false,
       correlationId,
       statusCode: 0,
     });
   }
-
-  const b64 = body.image.data_base64;
-  const padding = b64.endsWith("==") ? 2 : b64.endsWith("=") ? 1 : 0;
-  const estimatedDecodedBytes = Math.ceil(b64.length * 3 / 4) - padding;
-  if (estimatedDecodedBytes > AVATAR_MAX_DECODED_BYTES || body.image.bytes > AVATAR_MAX_DECODED_BYTES) {
-    throw new ManagedAvatarError({
-      code: "validation_error",
-      subcode: "oversized_image",
-      detail: `Response image size ${Math.max(estimatedDecodedBytes, body.image.bytes)} exceeds maximum of ${AVATAR_MAX_DECODED_BYTES} bytes`,
-      retryable: false,
-      correlationId,
-      statusCode: 0,
-    });
-  }
-
-  log.debug(
-    { correlationId, mimeType: body.image.mime_type, bytes: body.image.bytes },
-    "Managed avatar generation succeeded",
-  );
-
-  return body;
 }


### PR DESCRIPTION
## Summary
- Add managed-avatar-client.ts with HTTP client for platform avatar generation endpoint
- Authenticates with AssistantAPIKey via Api-Key header
- Includes Idempotency-Key and X-Correlation-Id headers on every request
- Validates response MIME type and size
- Add comprehensive test suite with 10 test cases

Part of #12572 (Managed Avatar Generation)
Closes #12574

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
