### PR TITLE
Fix Swift 6 actor isolation warning in ManagedAssistantBootstrapService

### DIFF
--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -46,8 +46,8 @@ public final class ManagedAssistantBootstrapService {
 
     private let authService: AuthService
 
-    public init(authService: AuthService = .shared) {
-        self.authService = authService
+    public init(authService: AuthService? = nil) {
+        self.authService = authService ?? AuthService.shared
     }
 
     public func ensureManagedAssistant(


### PR DESCRIPTION
## Summary
- Change `ManagedAssistantBootstrapService.init(authService:)` default parameter from `.shared` to `nil`, resolving the default value inside the init body instead
- This avoids referencing main actor-isolated `AuthService.shared` from a nonisolated default parameter context, fixing the Swift 6 warning

## Original prompt
Fix: /Users/sidd/vocify/vellum-assistant/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift:49:45: warning: main actor-isolated static property 'shared' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
