### PR TITLE
fix: only treat 404 GatewayRequestError as 'not found' in contact-merge

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
@@ -49,7 +49,10 @@ export async function executeContactMerge(
     ]);
 
     if (keepResult.status === "rejected") {
-      if (keepResult.reason instanceof GatewayRequestError) {
+      if (
+        keepResult.reason instanceof GatewayRequestError &&
+        keepResult.reason.statusCode === 404
+      ) {
         return {
           content: `Error: Contact "${keepId}" not found`,
           isError: true,
@@ -58,7 +61,10 @@ export async function executeContactMerge(
       throw keepResult.reason;
     }
     if (mergeResult.status === "rejected") {
-      if (mergeResult.reason instanceof GatewayRequestError) {
+      if (
+        mergeResult.reason instanceof GatewayRequestError &&
+        mergeResult.reason.statusCode === 404
+      ) {
         return {
           content: `Error: Contact "${mergeId}" not found`,
           isError: true,


### PR DESCRIPTION
Narrows the GatewayRequestError handling in contact-merge to only report 'Contact not found' for 404 responses. Non-404 errors (500, 403, 429, etc.) are now rethrown as unexpected errors instead of being silently misattributed.

Addresses feedback from PR #12560.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
