### PR TITLE
fix: validate species-specific metadata shape at write time

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -1039,11 +1039,38 @@ function parseAssistantMetadata(
   } as AssistantContactMetadata;
 }
 
+/**
+ * Validate that metadata matches the expected shape for the given species.
+ * Enforces the invariant that makes the discriminated union cast in
+ * parseAssistantMetadata safe.
+ */
+function validateSpeciesMetadata(
+  species: AssistantSpecies,
+  metadata: Record<string, unknown> | null | undefined,
+): void {
+  if (metadata == null) return;
+
+  if (species === "vellum") {
+    if (typeof metadata.assistantId !== "string" || !metadata.assistantId) {
+      throw new Error(
+        'Vellum assistant metadata requires a non-empty "assistantId" string',
+      );
+    }
+    if (typeof metadata.gatewayUrl !== "string" || !metadata.gatewayUrl) {
+      throw new Error(
+        'Vellum assistant metadata requires a non-empty "gatewayUrl" string',
+      );
+    }
+  }
+}
+
 export function upsertAssistantContactMetadata(params: {
   contactId: string;
   species: AssistantSpecies;
   metadata?: Record<string, unknown> | null;
 }): AssistantContactMetadata {
+  validateSpeciesMetadata(params.species, params.metadata);
+
   const db = getDb();
   const metadataJson =
     params.metadata != null ? JSON.stringify(params.metadata) : null;


### PR DESCRIPTION
Adds runtime validation in upsertAssistantContactMetadata to ensure metadata matches the expected shape for the given species before persisting. This makes the discriminated union cast in parseAssistantMetadata safe by enforcing the invariant at write time.

Addresses feedback from PR #12559.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
