### PR TITLE
fix: add Vellum-Organization-Id header to platform API calls

### DIFF
--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -111,6 +111,18 @@ public enum AuthServiceError: LocalizedError {
 
 public struct EmptyData: Codable, Sendable {}
 
+// MARK: - Organization Models
+
+public struct PlatformOrganization: Codable, Sendable {
+    public let id: String
+    public let name: String?
+}
+
+public struct PaginatedOrganizationsResponse: Codable, Sendable {
+    public let count: Int
+    public let results: [PlatformOrganization]
+}
+
 // MARK: - Platform Assistant API Models
 
 public struct PlatformAssistant: Codable, Sendable {

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -113,11 +113,60 @@ public final class AuthService {
         return response
     }
 
+    // MARK: - Platform Organizations API
+
+    /// Fetch the current user's organizations. Does not require Vellum-Organization-Id header.
+    public func getOrganizations() async throws -> [PlatformOrganization] {
+        let urlString = "\(baseURL)/v1/organizations/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request GET organizations/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            let paginated = try JSONDecoder().decode(PaginatedOrganizationsResponse.self, from: data)
+            return paginated.results
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
     // MARK: - Platform Assistant API
 
     /// Fetch the current user's managed assistant.
     /// Returns `.found` with the assistant on 200, `.notFound` on 404.
-    public func getCurrentAssistant() async throws -> PlatformAssistantResult {
+    public func getCurrentAssistant(organizationId: String) async throws -> PlatformAssistantResult {
         let urlString = "\(baseURL)/v1/assistants/current/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
@@ -126,6 +175,7 @@ public final class AuthService {
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "GET"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
 
         if let token = await SessionTokenManager.getTokenAsync() {
             urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
@@ -169,6 +219,7 @@ public final class AuthService {
 
     /// Create a new managed assistant via the platform hatch endpoint.
     public func hatchAssistant(
+        organizationId: String,
         name: String? = nil,
         description: String? = nil,
         anthropicApiKey: String? = nil
@@ -182,6 +233,7 @@ public final class AuthService {
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
 
         if let token = await SessionTokenManager.getTokenAsync() {
             urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")

--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -55,9 +55,22 @@ public final class ManagedAssistantBootstrapService {
         description: String? = nil,
         anthropicApiKey: String? = nil
     ) async throws -> ManagedBootstrapOutcome {
+        // Resolve the user's organization ID first — required for all platform API calls.
+        let organizationId: String
+        do {
+            let orgs = try await authService.getOrganizations()
+            guard let firstOrg = orgs.first else {
+                throw ManagedBootstrapError.serverError(statusCode: 0, detail: "No organizations found for this account")
+            }
+            organizationId = firstOrg.id
+            log.info("Resolved organization: \(organizationId, privacy: .public)")
+        } catch let error as PlatformAPIError {
+            throw mapPlatformError(error)
+        }
+
         let currentResult: PlatformAssistantResult
         do {
-            currentResult = try await authService.getCurrentAssistant()
+            currentResult = try await authService.getCurrentAssistant(organizationId: organizationId)
         } catch let error as PlatformAPIError {
             throw mapPlatformError(error)
         }
@@ -72,6 +85,7 @@ public final class ManagedAssistantBootstrapService {
             let newAssistant: PlatformAssistant
             do {
                 newAssistant = try await authService.hatchAssistant(
+                    organizationId: organizationId,
                     name: name,
                     description: description,
                     anthropicApiKey: anthropicApiKey


### PR DESCRIPTION
## Summary
- Add `getOrganizations()` to `AuthService` to fetch the user's org ID after authentication
- Include `Vellum-Organization-Id` header in `getCurrentAssistant()` and `hatchAssistant()` platform API calls
- Bootstrap service now resolves org ID before making assistant API calls, fixing the 400 "missing header" error on sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
