### PR TITLE
fix: move species-metadata validation to route handler pre-flight checks

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -1045,7 +1045,7 @@ function parseAssistantMetadata(
  * Enforces the invariant that makes the discriminated union cast in
  * parseAssistantMetadata safe.
  */
-function validateSpeciesMetadata(
+export function validateSpeciesMetadata(
   species: AssistantSpecies,
   metadata: Record<string, unknown> | null | undefined,
 ): void {

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -18,6 +18,7 @@ import {
   updateChannelStatus,
   upsertAssistantContactMetadata,
   upsertContact,
+  validateSpeciesMetadata,
 } from "../../contacts/contact-store.js";
 import type {
   AssistantSpecies,
@@ -237,6 +238,18 @@ export async function handleUpsertContact(
       return httpError(
         "BAD_REQUEST",
         `Invalid species "${body.assistantMetadata.species}". Must be one of: ${VALID_ASSISTANT_SPECIES.join(", ")}`,
+        400,
+      );
+    }
+    try {
+      validateSpeciesMetadata(
+        body.assistantMetadata.species as AssistantSpecies,
+        body.assistantMetadata.metadata ?? null,
+      );
+    } catch (err) {
+      return httpError(
+        "BAD_REQUEST",
+        err instanceof Error ? err.message : String(err),
         400,
       );
     }


### PR DESCRIPTION
Move validateSpeciesMetadata to the route handler's pre-flight checks so that invalid metadata is rejected before any database writes occur, preventing partial writes where a contact is persisted without its metadata row. Keeps the existing validation inside upsertAssistantContactMetadata as a defensive check. Addresses feedback from PR #12586.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
