### PR TITLE
M3: Add avatar generation strategy router

### DIFF
--- a/assistant/src/__tests__/avatar-router.test.ts
+++ b/assistant/src/__tests__/avatar-router.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockStrategy: string | undefined;
+let mockGeminiKey: string | undefined = "test-gemini-key";
+let mockManagedAvailable = true;
+let mockManagedResult: unknown;
+let mockManagedError: Error | undefined;
+let mockGeminiResult: unknown;
+
+const generateManagedAvatarFn = mock(async () => {
+  if (mockManagedError) throw mockManagedError;
+  return mockManagedResult;
+});
+
+const generateImageFn = mock(async () => mockGeminiResult);
+
+const isManagedAvailableFn = mock(() => mockManagedAvailable);
+
+// ---------------------------------------------------------------------------
+// Mock modules — before importing module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../config/loader.js", () => ({
+  loadRawConfig: () => {
+    const raw: Record<string, unknown> = {};
+    if (mockStrategy !== undefined) {
+      raw.avatarGenerationStrategy = mockStrategy;
+    }
+    return raw;
+  },
+  getConfig: () => ({
+    apiKeys: { gemini: mockGeminiKey },
+  }),
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+mock.module("../media/managed-avatar-client.js", () => ({
+  isManagedAvailable: isManagedAvailableFn,
+  generateManagedAvatar: generateManagedAvatarFn,
+}));
+
+mock.module("../media/gemini-image-service.js", () => ({
+  generateImage: generateImageFn,
+}));
+
+// Import after mocking
+import {
+  getAvatarStrategy,
+  routedGenerateAvatar,
+} from "../media/avatar-router.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function managedResponse() {
+  return {
+    image: {
+      mime_type: "image/png",
+      data_base64: "base64data",
+      bytes: 1024,
+      sha256: "abc",
+    },
+    usage: { billable: false, class_name: "assistant_avatar_system" },
+    generation_source: "vertex",
+    profile: "avatar_v1",
+    correlation_id: "test-correlation-id",
+  };
+}
+
+function geminiResponse() {
+  return {
+    images: [{ mimeType: "image/png", dataBase64: "base64data" }],
+    resolvedModel: "gemini-2.5-flash-image",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("avatar-router", () => {
+  beforeEach(() => {
+    mockStrategy = undefined;
+    mockGeminiKey = "test-gemini-key";
+    mockManagedAvailable = true;
+    mockManagedResult = managedResponse();
+    mockManagedError = undefined;
+    mockGeminiResult = geminiResponse();
+    generateManagedAvatarFn.mockClear();
+    generateImageFn.mockClear();
+    isManagedAvailableFn.mockClear();
+  });
+
+  // 1. managed_required — managed success
+  test("managed_required returns pathUsed managed on success", async () => {
+    mockStrategy = "managed_required";
+    const result = await routedGenerateAvatar("a cute cat");
+    expect(result.pathUsed).toBe("managed");
+    expect(result.imageBase64).toBe("base64data");
+    expect(result.mimeType).toBe("image/png");
+    expect(generateManagedAvatarFn).toHaveBeenCalledTimes(1);
+    expect(generateImageFn).not.toHaveBeenCalled();
+  });
+
+  // 2. managed_required — managed failure throws, no fallback
+  test("managed_required throws on managed failure without fallback", async () => {
+    mockStrategy = "managed_required";
+    mockManagedError = new Error("upstream error");
+    await expect(routedGenerateAvatar("a cute cat")).rejects.toThrow(
+      "upstream error",
+    );
+    expect(generateImageFn).not.toHaveBeenCalled();
+  });
+
+  // 3. local_only — calls local Gemini, never managed
+  test("local_only calls local Gemini and never managed", async () => {
+    mockStrategy = "local_only";
+    const result = await routedGenerateAvatar("a cute cat");
+    expect(result.pathUsed).toBe("local");
+    expect(result.imageBase64).toBe("base64data");
+    expect(generateImageFn).toHaveBeenCalledTimes(1);
+    expect(generateManagedAvatarFn).not.toHaveBeenCalled();
+  });
+
+  // 4. local_only — missing Gemini API key throws
+  test("local_only throws when Gemini API key is missing", async () => {
+    mockStrategy = "local_only";
+    mockGeminiKey = undefined;
+    // Also clear the env var to ensure no fallback
+    const saved = process.env.GEMINI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    try {
+      await expect(routedGenerateAvatar("a cute cat")).rejects.toThrow(
+        "Gemini API key is not configured",
+      );
+      expect(generateImageFn).not.toHaveBeenCalled();
+    } finally {
+      if (saved !== undefined) process.env.GEMINI_API_KEY = saved;
+    }
+  });
+
+  // 5. managed_prefer — managed success
+  test("managed_prefer returns pathUsed managed on success", async () => {
+    mockStrategy = "managed_prefer";
+    const result = await routedGenerateAvatar("a cute cat");
+    expect(result.pathUsed).toBe("managed");
+    expect(generateManagedAvatarFn).toHaveBeenCalledTimes(1);
+    expect(generateImageFn).not.toHaveBeenCalled();
+  });
+
+  // 6. managed_prefer — managed failure falls back to local
+  test("managed_prefer falls back to local on managed failure", async () => {
+    mockStrategy = "managed_prefer";
+    mockManagedError = new Error("managed failed");
+    const result = await routedGenerateAvatar("a cute cat");
+    expect(result.pathUsed).toBe("local");
+    expect(generateManagedAvatarFn).toHaveBeenCalledTimes(1);
+    expect(generateImageFn).toHaveBeenCalledTimes(1);
+  });
+
+  // 7. managed_prefer — managed unavailable goes directly to local
+  test("managed_prefer goes to local when managed unavailable", async () => {
+    mockStrategy = "managed_prefer";
+    mockManagedAvailable = false;
+    const result = await routedGenerateAvatar("a cute cat");
+    expect(result.pathUsed).toBe("local");
+    expect(generateManagedAvatarFn).not.toHaveBeenCalled();
+    expect(generateImageFn).toHaveBeenCalledTimes(1);
+  });
+
+  // 8. Default strategy is local_only when config key absent
+  test("defaults to local_only when config key is absent", () => {
+    mockStrategy = undefined;
+    expect(getAvatarStrategy()).toBe("local_only");
+  });
+
+  // 9. Invalid strategy value defaults to local_only
+  test("invalid strategy value defaults to local_only", () => {
+    mockStrategy = "not_a_real_strategy";
+    expect(getAvatarStrategy()).toBe("local_only");
+  });
+});

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -41,7 +41,8 @@ async function generateLocal(
   prompt: string,
   correlationId?: string,
 ): Promise<AvatarGenerationResult> {
-  const geminiKey = getConfig().apiKeys.gemini ?? process.env.GEMINI_API_KEY;
+  const config = getConfig();
+  const geminiKey = config.apiKeys.gemini ?? process.env.GEMINI_API_KEY;
   if (!geminiKey) {
     throw new ConfigError(
       "Gemini API key is not configured. Set it via `config set apiKeys.gemini <key>` or the GEMINI_API_KEY environment variable.",
@@ -51,6 +52,7 @@ async function generateLocal(
   const result = await generateImage(geminiKey, {
     prompt,
     mode: "generate",
+    model: config.imageGenModel,
   });
 
   const image = result.images[0];

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -4,6 +4,7 @@
  */
 
 import { getConfig, loadRawConfig } from "../config/loader.js";
+import { ConfigError, ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import type {
   AvatarGenerationResult,
@@ -42,7 +43,7 @@ async function generateLocal(
 ): Promise<AvatarGenerationResult> {
   const geminiKey = getConfig().apiKeys.gemini ?? process.env.GEMINI_API_KEY;
   if (!geminiKey) {
-    throw new Error(
+    throw new ConfigError(
       "Gemini API key is not configured. Set it via `config set apiKeys.gemini <key>` or the GEMINI_API_KEY environment variable.",
     );
   }
@@ -54,7 +55,10 @@ async function generateLocal(
 
   const image = result.images[0];
   if (!image) {
-    throw new Error("Local Gemini image generation returned no images.");
+    throw new ProviderError(
+      "Local Gemini image generation returned no images.",
+      "gemini",
+    );
   }
 
   return {

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -1,0 +1,108 @@
+/**
+ * Strategy router for avatar generation.
+ * Selects managed platform or local Gemini path based on config.
+ */
+
+import { getConfig, loadRawConfig } from "../config/loader.js";
+import { getLogger } from "../util/logger.js";
+import type {
+  AvatarGenerationResult,
+  AvatarGenerationStrategy,
+} from "./avatar-types.js";
+import { generateImage } from "./gemini-image-service.js";
+import {
+  generateManagedAvatar,
+  isManagedAvailable,
+} from "./managed-avatar-client.js";
+
+const log = getLogger("avatar-router");
+
+const VALID_STRATEGIES: ReadonlySet<string> = new Set([
+  "managed_required",
+  "managed_prefer",
+  "local_only",
+]);
+
+export function getAvatarStrategy(): AvatarGenerationStrategy {
+  try {
+    const raw = loadRawConfig();
+    const strategy = raw.avatarGenerationStrategy as string | undefined;
+    if (strategy && VALID_STRATEGIES.has(strategy)) {
+      return strategy as AvatarGenerationStrategy;
+    }
+  } catch {
+    /* fall through */
+  }
+  return "local_only";
+}
+
+async function generateLocal(
+  prompt: string,
+  correlationId?: string,
+): Promise<AvatarGenerationResult> {
+  const geminiKey = getConfig().apiKeys.gemini ?? process.env.GEMINI_API_KEY;
+  if (!geminiKey) {
+    throw new Error(
+      "Gemini API key is not configured. Set it via `config set apiKeys.gemini <key>` or the GEMINI_API_KEY environment variable.",
+    );
+  }
+
+  const result = await generateImage(geminiKey, {
+    prompt,
+    mode: "generate",
+  });
+
+  const image = result.images[0];
+  if (!image) {
+    throw new Error("Local Gemini image generation returned no images.");
+  }
+
+  return {
+    imageBase64: image.dataBase64,
+    mimeType: image.mimeType,
+    pathUsed: "local",
+    correlationId,
+  };
+}
+
+export async function routedGenerateAvatar(
+  prompt: string,
+  options?: { correlationId?: string },
+): Promise<AvatarGenerationResult> {
+  const strategy = getAvatarStrategy();
+  const correlationId = options?.correlationId;
+
+  if (strategy === "managed_required") {
+    const managed = await generateManagedAvatar(prompt, { correlationId });
+    return {
+      imageBase64: managed.image.data_base64,
+      mimeType: managed.image.mime_type,
+      pathUsed: "managed",
+      correlationId: managed.correlation_id,
+    };
+  }
+
+  if (strategy === "local_only") {
+    return generateLocal(prompt, correlationId);
+  }
+
+  // managed_prefer: try managed first if available, fall back to local
+  if (isManagedAvailable()) {
+    try {
+      const managed = await generateManagedAvatar(prompt, { correlationId });
+      return {
+        imageBase64: managed.image.data_base64,
+        mimeType: managed.image.mime_type,
+        pathUsed: "managed",
+        correlationId: managed.correlation_id,
+      };
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Managed avatar generation failed, falling back to local Gemini",
+      );
+    }
+  }
+
+  return generateLocal(prompt, correlationId);
+}


### PR DESCRIPTION
## Summary
- Add avatar-router.ts following the Twitter router pattern
- Routes between managed platform and local Gemini based on strategy config
- Supports managed_required, managed_prefer, local_only modes
- No silent fallback in managed_required mode
- Add comprehensive test suite with 9 test cases

Part of #12572 (Managed Avatar Generation)
Closes #12575

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
