### PR TITLE
refactor: extract guardian decision processing into shared service function

### DIFF
--- a/assistant/src/runtime/guardian-action-service.ts
+++ b/assistant/src/runtime/guardian-action-service.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared service for processing guardian action decisions.
+ *
+ * Encapsulates the core business logic — validation, conversation scoping,
+ * canonical decision application, and result mapping — so both the HTTP
+ * handler and the IPC handler can delegate here without duplicating code.
+ */
+
+import { applyCanonicalGuardianDecision } from "../approvals/guardian-decision-primitive.js";
+import {
+  getCanonicalGuardianRequest,
+  isRequestInConversationScope,
+} from "../memory/canonical-guardian-store.js";
+import type { ApprovalAction } from "./channel-approval-types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Canonical set of valid guardian actions, shared across all entrypoints. */
+export const VALID_GUARDIAN_ACTIONS: ReadonlySet<string> = new Set<string>([
+  "approve_once",
+  "approve_10m",
+  "approve_thread",
+  "approve_always",
+  "reject",
+]);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ProcessGuardianDecisionParams {
+  requestId: string;
+  action: string;
+  conversationId?: string;
+  channel: string; // e.g. "vellum"
+  actorContext: {
+    externalUserId: string | undefined;
+    guardianPrincipalId: string | undefined;
+  };
+}
+
+export type ProcessGuardianDecisionResult =
+  | { ok: true; applied: true; requestId: string }
+  | {
+      ok: true;
+      applied: false;
+      reason: string;
+      resolverFailureReason?: string;
+      requestId?: string;
+    }
+  | { ok: false; error: "invalid_action" | "invalid_scope"; message: string };
+
+// ---------------------------------------------------------------------------
+// Core decision processing
+// ---------------------------------------------------------------------------
+
+/**
+ * Process a guardian decision through the canonical request primitive.
+ *
+ * Validates the action, checks conversation scope if applicable, applies the
+ * canonical decision, and maps the result to a caller-agnostic shape that
+ * both HTTP and IPC handlers can interpret.
+ */
+export async function processGuardianDecision(
+  params: ProcessGuardianDecisionParams,
+): Promise<ProcessGuardianDecisionResult> {
+  const { requestId, action, conversationId, channel, actorContext } = params;
+
+  // 1. Validate action
+  if (!VALID_GUARDIAN_ACTIONS.has(action)) {
+    return {
+      ok: false,
+      error: "invalid_action",
+      message: `Invalid action: ${action}. Must be one of: approve_once, approve_10m, approve_thread, approve_always, reject`,
+    };
+  }
+
+  // 2. Verify conversationId scoping before applying the canonical decision.
+  //    The decision is allowed when the conversationId matches the request's
+  //    source conversation OR a recorded delivery destination conversation.
+  if (conversationId) {
+    const canonicalRequest = getCanonicalGuardianRequest(requestId);
+    if (
+      canonicalRequest &&
+      canonicalRequest.conversationId &&
+      !isRequestInConversationScope(requestId, conversationId, channel)
+    ) {
+      return { ok: true, applied: false, reason: "not_found" };
+    }
+  }
+
+  // 3. Apply the canonical decision
+  const canonicalResult = await applyCanonicalGuardianDecision({
+    requestId,
+    action: action as ApprovalAction,
+    actorContext: {
+      externalUserId: actorContext.externalUserId,
+      channel,
+      guardianPrincipalId: actorContext.guardianPrincipalId,
+    },
+    userText: undefined,
+  });
+
+  // 4. Map the canonical result
+  if (canonicalResult.applied) {
+    if (canonicalResult.resolverFailed) {
+      return {
+        ok: true,
+        applied: false,
+        reason: "resolver_failed",
+        resolverFailureReason: canonicalResult.resolverFailureReason,
+        requestId: canonicalResult.requestId,
+      };
+    }
+
+    return { ok: true, applied: true, requestId: canonicalResult.requestId };
+  }
+
+  return {
+    ok: true,
+    applied: false,
+    reason: canonicalResult.reason,
+    requestId,
+  };
+}

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -11,19 +11,16 @@
  * Guardian decisions additionally verify the actor is the bound guardian
  * via the AuthContext's actorPrincipalId.
  */
-import { applyCanonicalGuardianDecision } from "../../approvals/guardian-decision-primitive.js";
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { findGuardianForChannel } from "../../contacts/contact-store.js";
 import {
   type CanonicalGuardianRequest,
-  getCanonicalGuardianRequest,
-  isRequestInConversationScope,
   listPendingRequestsByConversationScope,
 } from "../../memory/canonical-guardian-store.js";
 import type { AuthContext } from "../auth/types.js";
-import type { ApprovalAction } from "../channel-approval-types.js";
 import type { GuardianDecisionPrompt } from "../guardian-decision-types.js";
 import { buildDecisionActions } from "../guardian-decision-types.js";
+import { processGuardianDecision } from "../guardian-action-service.js";
 import { httpError } from "../http-errors.js";
 
 // ---------------------------------------------------------------------------
@@ -132,77 +129,24 @@ export async function handleGuardianActionDecision(
     return httpError("BAD_REQUEST", "action is required", 400);
   }
 
-  const VALID_ACTIONS = new Set<string>([
-    "approve_once",
-    "approve_10m",
-    "approve_thread",
-    "approve_always",
-    "reject",
-  ]);
-  if (!VALID_ACTIONS.has(action)) {
-    return httpError(
-      "BAD_REQUEST",
-      `Invalid action: ${action}. Must be one of: approve_once, approve_10m, approve_thread, approve_always, reject`,
-      400,
-    );
-  }
-
-  // Verify conversationId scoping before applying the canonical decision.
-  // The decision is allowed when the conversationId matches the request's
-  // source conversation OR a recorded delivery destination conversation.
-  // Channel is scoped to 'vellum' to prevent cross-channel approval when
-  // conversation ID namespaces overlap.
-  if (conversationId) {
-    const canonicalRequest = getCanonicalGuardianRequest(requestId);
-    if (
-      canonicalRequest &&
-      canonicalRequest.conversationId &&
-      !isRequestInConversationScope(requestId, conversationId, "vellum")
-    ) {
-      return httpError(
-        "NOT_FOUND",
-        "No pending guardian action found for this requestId",
-        404,
-      );
-    }
-  }
-
-  // Resolve actor identity from the AuthContext (set by JWT middleware).
-  const actorExternalUserId = authContext.actorPrincipalId ?? undefined;
-  const actorPrincipalId = authContext.actorPrincipalId ?? undefined;
-
-  const canonicalResult = await applyCanonicalGuardianDecision({
+  const result = await processGuardianDecision({
     requestId,
-    action: action as ApprovalAction,
+    action,
+    conversationId,
+    channel: "vellum",
     actorContext: {
-      externalUserId: actorExternalUserId,
-      channel: "vellum",
-      guardianPrincipalId: actorPrincipalId,
+      externalUserId: authContext.actorPrincipalId ?? undefined,
+      guardianPrincipalId: authContext.actorPrincipalId ?? undefined,
     },
-    userText: undefined,
   });
 
-  if (canonicalResult.applied) {
-    // When the CAS committed but the resolver failed, the side effect
-    // (e.g. minting a verification session) did not happen. From the
-    // caller's perspective the decision was not truly applied.
-    if (canonicalResult.resolverFailed) {
-      return Response.json({
-        applied: false,
-        reason: "resolver_failed",
-        resolverFailureReason: canonicalResult.resolverFailureReason,
-        requestId: canonicalResult.requestId,
-      });
-    }
-
-    return Response.json({
-      applied: true,
-      requestId: canonicalResult.requestId,
-    });
+  if (!result.ok) {
+    return httpError("BAD_REQUEST", result.message, 400);
   }
-
-  // Return the reason for failure (stale, expired, not_found, etc.)
-  return canonicalResult.reason === "not_found"
+  if (result.applied) {
+    return Response.json({ applied: true, requestId: result.requestId });
+  }
+  return result.reason === "not_found"
     ? httpError(
         "NOT_FOUND",
         "No pending guardian action found for this requestId",
@@ -210,8 +154,11 @@ export async function handleGuardianActionDecision(
       )
     : Response.json({
         applied: false,
-        reason: canonicalResult.reason,
-        requestId,
+        reason: result.reason,
+        ...(result.resolverFailureReason
+          ? { resolverFailureReason: result.resolverFailureReason }
+          : {}),
+        requestId: result.requestId ?? requestId,
       });
 }
 


### PR DESCRIPTION
## Summary
- Create `guardian-action-service.ts` with a shared `processGuardianDecision()` function that encapsulates validation, conversation scoping, canonical decision application, and result mapping
- Export `VALID_GUARDIAN_ACTIONS` constant from a single location (consolidating duplicates from guardian-action-routes.ts and handlers/guardian-actions.ts)
- Refactor `handleGuardianActionDecision` HTTP handler to delegate business logic to the shared service

Part of plan: approval-code-sharing.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
