### PR TITLE
feat: add Log Out option to Preferences drawer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -645,7 +645,12 @@ struct MainWindowView: View {
                             onDebug: {
                                 sidebar.showPreferencesDrawer = false
                                 windowState.selection = .panel(.debug)
-                            }
+                            },
+                            onLogOut: {
+                                sidebar.showPreferencesDrawer = false
+                                AppDelegate.shared?.performLogout()
+                            },
+                            showLogOut: SessionTokenManager.getToken() != nil
                         )
                         .frame(width: drawerWidth)
                         .offset(x: drawerX, y: -28)
@@ -1882,6 +1887,8 @@ private struct PreferencesRow: View {
 private struct DrawerMenuView: View {
     let onSettings: () -> Void
     let onDebug: () -> Void
+    let onLogOut: () -> Void
+    let showLogOut: Bool
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             DrawerThemeToggle()
@@ -1897,6 +1904,13 @@ private struct DrawerMenuView: View {
                 .padding(.vertical, VSpacing.xs)
 
             DrawerMenuItem(icon: "ladybug", label: "Debug", action: onDebug)
+
+            if showLogOut {
+                VColor.surfaceBorder.frame(height: 1)
+                    .padding(.vertical, VSpacing.xs)
+
+                DrawerMenuItem(icon: "rectangle.portrait.and.arrow.right", label: "Log Out", action: onLogOut)
+            }
         }
         .padding(.vertical, VSpacing.sm)
         .background(VColor.surfaceSubtle)


### PR DESCRIPTION
## Summary
- Add "Log Out" item to the Preferences drawer (sidebar bottom) when the user has an active platform session
- Calls the existing `performLogout()` flow which tears down all state and shows the auth window
- Only visible when signed in (session token present)

## Original prompt
User was in a bricked state where the app couldn't connect to the assistant but had no way to sign out from the main window UI. The Preferences drawer (Theme / Settings / Debug) now includes a Log Out option to recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
