### PR TITLE
refactor: extract `requireBoundGuardian` to shared auth module

### DIFF
--- a/assistant/src/runtime/auth/require-bound-guardian.ts
+++ b/assistant/src/runtime/auth/require-bound-guardian.ts
@@ -1,0 +1,44 @@
+import { isHttpAuthDisabled } from "../../config/env.js";
+import { findGuardianForChannel } from "../../contacts/contact-store.js";
+import { httpError } from "../http-errors.js";
+import type { AuthContext } from "./types.js";
+
+/**
+ * Verify the actor from AuthContext is the bound guardian for the vellum channel.
+ * Returns an error Response if not, or null if allowed.
+ */
+export function requireBoundGuardian(
+  authContext: AuthContext,
+): Response | null {
+  // Dev bypass: when auth is disabled, skip guardian binding check
+  // (mirrors enforcePolicy dev bypass in route-policy.ts)
+  if (isHttpAuthDisabled()) {
+    return null;
+  }
+  if (!authContext.actorPrincipalId) {
+    return httpError(
+      "FORBIDDEN",
+      "Actor is not the bound guardian for this channel",
+      403,
+    );
+  }
+  const guardianResult = findGuardianForChannel(
+    "vellum",
+    authContext.assistantId,
+  );
+  if (!guardianResult) {
+    // No guardian yet — in pre-bootstrap state, allow through
+    return null;
+  }
+  if (
+    (guardianResult.channel.externalUserId ??
+      guardianResult.contact.principalId) !== authContext.actorPrincipalId
+  ) {
+    return httpError(
+      "FORBIDDEN",
+      "Actor is not the bound guardian for this channel",
+      403,
+    );
+  }
+  return null;
+}

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -8,56 +8,17 @@
  * header. Guardian decisions additionally verify that the actor is the
  * bound guardian.
  */
-import { isHttpAuthDisabled } from "../../config/env.js";
-import { findGuardianForChannel } from "../../contacts/contact-store.js";
 import { getConversationByKey } from "../../memory/conversation-key-store.js";
 import { addRule } from "../../permissions/trust-store.js";
 import type { UserDecision } from "../../permissions/types.js";
 import { getTool } from "../../tools/registry.js";
 import { getLogger } from "../../util/logger.js";
+import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
 import type { AuthContext } from "../auth/types.js";
 import { httpError } from "../http-errors.js";
 import * as pendingInteractions from "../pending-interactions.js";
 
 const log = getLogger("approval-routes");
-
-/**
- * Verify the actor from AuthContext is the bound guardian for the vellum channel.
- * Returns an error Response if not, or null if allowed.
- */
-function requireBoundGuardian(authContext: AuthContext): Response | null {
-  // Dev bypass: when auth is disabled, skip guardian binding check
-  // (mirrors enforcePolicy dev bypass in route-policy.ts)
-  if (isHttpAuthDisabled()) {
-    return null;
-  }
-  if (!authContext.actorPrincipalId) {
-    return httpError(
-      "FORBIDDEN",
-      "Actor is not the bound guardian for this channel",
-      403,
-    );
-  }
-  const guardianResult = findGuardianForChannel(
-    "vellum",
-    authContext.assistantId,
-  );
-  if (!guardianResult) {
-    // No guardian yet — in pre-bootstrap state, allow through
-    return null;
-  }
-  if (
-    (guardianResult.channel.externalUserId ??
-      guardianResult.contact.principalId) !== authContext.actorPrincipalId
-  ) {
-    return httpError(
-      "FORBIDDEN",
-      "Actor is not the bound guardian for this channel",
-      403,
-    );
-  }
-  return null;
-}
 
 /**
  * POST /v1/confirm — resolve a pending confirmation by requestId.

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -11,16 +11,15 @@
  * Guardian decisions additionally verify the actor is the bound guardian
  * via the AuthContext's actorPrincipalId.
  */
-import { isHttpAuthDisabled } from "../../config/env.js";
-import { findGuardianForChannel } from "../../contacts/contact-store.js";
 import {
   type CanonicalGuardianRequest,
   listPendingRequestsByConversationScope,
 } from "../../memory/canonical-guardian-store.js";
+import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
 import type { AuthContext } from "../auth/types.js";
+import { processGuardianDecision } from "../guardian-action-service.js";
 import type { GuardianDecisionPrompt } from "../guardian-decision-types.js";
 import { buildDecisionActions } from "../guardian-decision-types.js";
-import { processGuardianDecision } from "../guardian-action-service.js";
 import { httpError } from "../http-errors.js";
 
 // ---------------------------------------------------------------------------
@@ -59,44 +58,6 @@ export function handleGuardianActionsPending(
 // ---------------------------------------------------------------------------
 // POST /v1/guardian-actions/decision
 // ---------------------------------------------------------------------------
-
-/**
- * Verify that the actor from AuthContext is the bound guardian for the
- * vellum channel. Returns an error Response if not, or null if allowed.
- */
-function requireBoundGuardian(authContext: AuthContext): Response | null {
-  // Dev bypass: when auth is disabled, skip guardian binding check
-  // (mirrors enforcePolicy dev bypass in route-policy.ts)
-  if (isHttpAuthDisabled()) {
-    return null;
-  }
-  if (!authContext.actorPrincipalId) {
-    return httpError(
-      "FORBIDDEN",
-      "Actor is not the bound guardian for this channel",
-      403,
-    );
-  }
-  const guardianResult = findGuardianForChannel(
-    "vellum",
-    authContext.assistantId,
-  );
-  if (!guardianResult) {
-    // No guardian yet — in pre-bootstrap state, allow through
-    return null;
-  }
-  if (
-    (guardianResult.channel.externalUserId ??
-      guardianResult.contact.principalId) !== authContext.actorPrincipalId
-  ) {
-    return httpError(
-      "FORBIDDEN",
-      "Actor is not the bound guardian for this channel",
-      403,
-    );
-  }
-  return null;
-}
 
 /**
  * Submit a guardian action decision.


### PR DESCRIPTION
## Summary
- Extract the identical `requireBoundGuardian()` function from both `approval-routes.ts` and `guardian-action-routes.ts` into a shared `runtime/auth/require-bound-guardian.ts` module
- Both route files now import from the shared module, eliminating code duplication
- Remove now-unused direct imports of `isHttpAuthDisabled` and `findGuardianForChannel` from both route files

Part of plan: approval-code-sharing.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
