### PR TITLE
refactor: make IPC guardian-actions handler a thin wrapper over shared service

### DIFF
--- a/assistant/src/daemon/handlers/guardian-actions.ts
+++ b/assistant/src/daemon/handlers/guardian-actions.ts
@@ -1,9 +1,4 @@
-import { applyCanonicalGuardianDecision } from "../../approvals/guardian-decision-primitive.js";
-import {
-  getCanonicalGuardianRequest,
-  isRequestInConversationScope,
-} from "../../memory/canonical-guardian-store.js";
-import type { ApprovalAction } from "../../runtime/channel-approval-types.js";
+import { processGuardianDecision } from "../../runtime/guardian-action-service.js";
 import { resolveLocalIpcTrustContext } from "../../runtime/local-actor-identity.js";
 import { listGuardianDecisionPrompts } from "../../runtime/routes/guardian-action-routes.js";
 import type {
@@ -11,14 +6,6 @@ import type {
   GuardianActionsPendingRequest,
 } from "../ipc-protocol.js";
 import { defineHandlers, log } from "./shared.js";
-
-const VALID_ACTIONS = new Set<string>([
-  "approve_once",
-  "approve_10m",
-  "approve_thread",
-  "approve_always",
-  "reject",
-]);
 
 export const guardianActionsHandlers = defineHandlers({
   guardian_actions_pending_request: (
@@ -43,95 +30,41 @@ export const guardianActionsHandlers = defineHandlers({
     ctx,
   ) => {
     try {
-      // Validate the action is one of the known actions
-      if (!VALID_ACTIONS.has(msg.action)) {
-        log.warn(
-          { requestId: msg.requestId, action: msg.action },
-          "Invalid guardian action",
-        );
+      const localTrustCtx = resolveLocalIpcTrustContext("vellum");
+
+      const result = await processGuardianDecision({
+        requestId: msg.requestId,
+        action: msg.action,
+        conversationId: msg.conversationId,
+        channel: "vellum",
+        actorContext: {
+          externalUserId: localTrustCtx.guardianExternalUserId,
+          guardianPrincipalId: localTrustCtx.guardianPrincipalId ?? undefined,
+        },
+      });
+
+      if (!result.ok) {
         ctx.send(socket, {
           type: "guardian_action_decision_response",
           applied: false,
-          reason: "invalid_action",
+          reason: result.error,
           requestId: msg.requestId,
         });
         return;
       }
 
-      // Verify conversationId scoping before applying the canonical decision.
-      // The decision is allowed when the conversationId matches the request's
-      // source conversation OR a recorded delivery destination conversation.
-      if (msg.conversationId) {
-        const canonicalRequest = getCanonicalGuardianRequest(msg.requestId);
-        if (
-          canonicalRequest &&
-          canonicalRequest.conversationId &&
-          !isRequestInConversationScope(
-            msg.requestId,
-            msg.conversationId,
-            "vellum",
-          )
-        ) {
-          log.warn(
-            {
-              requestId: msg.requestId,
-              expected: canonicalRequest.conversationId,
-              got: msg.conversationId,
-            },
-            "conversationId not in scope",
-          );
-          ctx.send(socket, {
-            type: "guardian_action_decision_response",
-            applied: false,
-            reason: "not_found",
-            requestId: msg.requestId,
-          });
-          return;
-        }
-      }
-
-      // Resolve the local IPC actor's principal via the vellum guardian binding.
-      const localTrustCtx = resolveLocalIpcTrustContext("vellum");
-      const canonicalResult = await applyCanonicalGuardianDecision({
-        requestId: msg.requestId,
-        action: msg.action as ApprovalAction,
-        actorContext: {
-          externalUserId: localTrustCtx.guardianExternalUserId,
-          channel: "vellum",
-          guardianPrincipalId: localTrustCtx.guardianPrincipalId ?? undefined,
-        },
-        userText: undefined,
-      });
-
-      if (canonicalResult.applied) {
-        // When the CAS committed but the resolver failed, the side effect
-        // (e.g. minting a verification session) did not happen. From the
-        // caller's perspective the decision was not truly applied.
-        if (canonicalResult.resolverFailed) {
-          ctx.send(socket, {
-            type: "guardian_action_decision_response",
-            applied: false,
-            reason: "resolver_failed",
-            resolverFailureReason: canonicalResult.resolverFailureReason,
-            requestId: canonicalResult.requestId,
-          });
-          return;
-        }
-
-        ctx.send(socket, {
-          type: "guardian_action_decision_response",
-          applied: true,
-          requestId: canonicalResult.requestId,
-        });
-        return;
-      }
-
-      // Return the reason for failure (stale, expired, not_found, etc.)
       ctx.send(socket, {
         type: "guardian_action_decision_response",
-        applied: false,
-        reason: canonicalResult.reason,
-        requestId: msg.requestId,
+        applied: result.applied,
+        ...(result.applied
+          ? { requestId: result.requestId }
+          : {
+              reason: result.reason,
+              ...(result.resolverFailureReason
+                ? { resolverFailureReason: result.resolverFailureReason }
+                : {}),
+              requestId: result.requestId ?? msg.requestId,
+            }),
       });
     } catch (err) {
       log.error(


### PR DESCRIPTION
## Summary
- Rewrite the IPC `guardian_action_decision` handler to delegate all validation, scope checking, and canonical decision logic to the shared `processGuardianDecision()` service
- Remove duplicated `VALID_ACTIONS` set and direct imports of `applyCanonicalGuardianDecision`, `getCanonicalGuardianRequest`, `isRequestInConversationScope`
- The IPC handler's only unique responsibility is now resolving the local IPC actor identity and formatting the IPC response envelope

Part of plan: approval-code-sharing.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)