### PR TITLE
fix: update guardian routing invariant test to accept processGuardianDecision wrapper

### DIFF
--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -169,22 +169,37 @@ function registerPendingToolApprovalInteraction(
 describe("routing invariant: all decision paths reference applyCanonicalGuardianDecision", () => {
   const srcRoot = resolve(__dirname, "..");
 
-  // The files that constitute decision entrypoints. Each must import
-  // `applyCanonicalGuardianDecision` from the guardian-decision-primitive.
-  const DECISION_ENTRYPOINTS = [
+  // The files that constitute decision entrypoints. Each must reference
+  // `applyCanonicalGuardianDecision` (directly) or `processGuardianDecision`
+  // (shared wrapper that calls applyCanonicalGuardianDecision internally).
+  const DECISION_ENTRYPOINTS: Array<{
+    path: string;
+    symbols: string[];
+  }> = [
     // Inbound channel router (Telegram/SMS/WhatsApp)
-    "runtime/guardian-reply-router.ts",
-    // HTTP API route handler (desktop and API clients)
-    "runtime/routes/guardian-action-routes.ts",
+    {
+      path: "runtime/guardian-reply-router.ts",
+      symbols: ["applyCanonicalGuardianDecision"],
+    },
+    // HTTP API route handler (desktop and API clients) — uses processGuardianDecision
+    // which is a shared wrapper around applyCanonicalGuardianDecision
+    {
+      path: "runtime/routes/guardian-action-routes.ts",
+      symbols: ["processGuardianDecision"],
+    },
     // IPC handler (desktop socket clients)
-    "daemon/handlers/guardian-actions.ts",
+    {
+      path: "daemon/handlers/guardian-actions.ts",
+      symbols: ["applyCanonicalGuardianDecision"],
+    },
   ];
 
-  for (const relPath of DECISION_ENTRYPOINTS) {
-    test(`${relPath} imports applyCanonicalGuardianDecision`, () => {
+  for (const { path: relPath, symbols } of DECISION_ENTRYPOINTS) {
+    test(`${relPath} imports ${symbols.join(" or ")}`, () => {
       const fullPath = join(srcRoot, relPath);
       const source = readFileSync(fullPath, "utf-8");
-      expect(source).toContain("applyCanonicalGuardianDecision");
+      const found = symbols.some((s) => source.includes(s));
+      expect(found).toBe(true);
     });
   }
 


### PR DESCRIPTION
## Summary
- The guardian-action-routes.ts was refactored to use `processGuardianDecision` (a shared wrapper around `applyCanonicalGuardianDecision`) but the import-verification guard test still expected the file to contain `applyCanonicalGuardianDecision` directly.
- Updated the test to accept either `applyCanonicalGuardianDecision` or `processGuardianDecision` per entrypoint, since `processGuardianDecision` is a known wrapper that routes through the canonical primitive.

## Original prompt
fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22691243249

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
