### PR TITLE
fix: update routing invariant test for IPC thin wrapper refactor

### DIFF
--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -187,10 +187,11 @@ describe("routing invariant: all decision paths reference applyCanonicalGuardian
       path: "runtime/routes/guardian-action-routes.ts",
       symbols: ["processGuardianDecision"],
     },
-    // IPC handler (desktop socket clients)
+    // IPC handler (desktop socket clients) — uses processGuardianDecision
+    // which is a shared wrapper around applyCanonicalGuardianDecision
     {
       path: "daemon/handlers/guardian-actions.ts",
-      symbols: ["applyCanonicalGuardianDecision"],
+      symbols: ["processGuardianDecision"],
     },
   ];
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for approval-code-sharing.md.

**Gap:** Routing invariant test expects IPC handler to reference `applyCanonicalGuardianDecision`
**What was expected:** Test should verify IPC handler uses the shared `processGuardianDecision` wrapper
**What was found:** Line 193 still expected `applyCanonicalGuardianDecision` after PR 3 changed the IPC handler to use `processGuardianDecision`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
