### PR TITLE
fix: add guardian-action-service to routing invariant test entrypoints

### DIFF
--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -193,6 +193,13 @@ describe("routing invariant: all decision paths reference applyCanonicalGuardian
       path: "daemon/handlers/guardian-actions.ts",
       symbols: ["processGuardianDecision"],
     },
+    // Shared service where processGuardianDecision is defined — must route
+    // through the canonical primitive to complete the chain:
+    // entrypoint → processGuardianDecision → applyCanonicalGuardianDecision
+    {
+      path: "runtime/guardian-action-service.ts",
+      symbols: ["applyCanonicalGuardianDecision"],
+    },
   ];
 
   for (const { path: relPath, symbols } of DECISION_ENTRYPOINTS) {


### PR DESCRIPTION
Addresses Codex review feedback on PR #12601: the invariant test now verifies that the shared processGuardianDecision wrapper in guardian-action-service.ts itself routes through applyCanonicalGuardianDecision, closing the gap in the architectural guarantee.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
