### PR TITLE
fix: guard scroll-bottom-anchor onAppear to prevent premature isNearBottom

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -466,7 +466,14 @@ struct MessageListView: View {
                     Color.clear.frame(height: 1)
                         .id("scroll-bottom-anchor")
                         .onAppear {
-                            isNearBottom = true
+                            // Only auto-tether on initial load (before any scroll events).
+                            // After the user has scrolled, rely on ScrollWheelDetector and
+                            // anchorIsVisible preference tracking to manage isNearBottom —
+                            // LazyVStack fires onAppear in the prefetch zone (several screens
+                            // ahead) which would prematurely re-tether during normal scrolling.
+                            if !hasReceivedScrollEvent {
+                                isNearBottom = true
+                            }
                         }
                         .background {
                             GeometryReader { geo in


### PR DESCRIPTION
## Summary
- Guard the scroll-bottom-anchor .onAppear handler so it only sets isNearBottom=true on initial load (before any scroll events)
- After the user scrolls, ScrollWheelDetector handles re-tethering based on actual pixel proximity to the bottom
- Prevents LazyVStack prefetch zone from prematurely triggering auto-scroll during normal scrolling

Part of plan: scroll-jump-fix.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
