### PR TITLE
fix: use scrollPosition API to stabilize viewport during content re-layouts

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -104,6 +104,9 @@ struct MessageListView: View {
     /// regardless of whether messages.count changes. This covers the edge
     /// case where pagination stalls without adding/removing messages.
     @State private var anchorTimeoutTask: Task<Void, Never>?
+    /// Tracks the top-visible item so SwiftUI can stabilize the viewport
+    /// when content height changes above it during LazyVStack re-layouts.
+    @State private var scrollPositionId: AnyHashable?
 
     /// The subset of messages actually shown, honoring the pagination window.
     private var visibleMessages: [ChatMessage] {
@@ -492,6 +495,7 @@ struct MessageListView: View {
             }
             .scrollContentBackground(.hidden)
             .coordinateSpace(name: "chatScrollView")
+            .scrollPosition(id: $scrollPositionId, anchor: .top)
             .scrollDisabled(messages.isEmpty && !isSending)
             .onHover { hovering in
                 handleThreadContentHover(hovering)


### PR DESCRIPTION
## Summary
- Add scrollPosition(id:anchor:) modifier to the chat ScrollView to anchor viewport to the top-visible item
- SwiftUI automatically compensates for content height changes above the viewport during LazyVStack re-layouts
- Works alongside existing ScrollViewReader — proxy.scrollTo() calls still function normally
- Prevents random upward scroll jumps when content re-renders in a long thread

Part of plan: scroll-jump-fix.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
