### PR TITLE
feat(cli): add --watch flag to vellum wake command

### DIFF
--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -13,11 +13,18 @@ import {
 export async function wake(): Promise<void> {
   const args = process.argv.slice(3);
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum wake");
+    console.log("Usage: vellum wake [options]");
     console.log("");
     console.log("Start the assistant and gateway processes.");
+    console.log("");
+    console.log("Options:");
+    console.log(
+      "  --watch    Run assistant and gateway in watch mode (hot reload on source changes)",
+    );
     process.exit(0);
   }
+
+  const watch = args.includes("--watch");
 
   const assistants = loadAllAssistants();
   const hasLocal = assistants.some((a) => a.cloud === "local");
@@ -48,7 +55,7 @@ export async function wake(): Promise<void> {
   }
 
   if (!daemonRunning) {
-    await startLocalDaemon();
+    await startLocalDaemon(watch);
   }
 
   // Start gateway (non-desktop only)
@@ -58,12 +65,12 @@ export async function wake(): Promise<void> {
     if (alive) {
       console.log(`Gateway already running (pid ${pid}).`);
     } else {
-      await startGateway();
+      await startGateway(undefined, watch);
     }
   }
 
   // Start outbound proxy
-  await startOutboundProxy();
+  await startOutboundProxy(watch);
 
   console.log("✅ Wake complete.");
 }


### PR DESCRIPTION
## Summary
- Adds `--watch` flag to `vellum wake` command for hot code reloading support
- Mirrors the existing functionality in `vellum hatch --watch`
- When `--watch` is passed, daemon, gateway, and outbound proxy all start with `bun --watch` for automatic restart on source file changes

## Test plan
- [ ] Run `vellum wake --help` and verify the `--watch` option is documented
- [ ] Run `vellum wake --watch` from a git worktree with source code
- [ ] Verify processes restart automatically when source files are modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
