### PR TITLE
Fix Gmail proxied OAuth token injection

### DIFF
--- a/assistant/src/__tests__/oauth-provider-profiles.test.ts
+++ b/assistant/src/__tests__/oauth-provider-profiles.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getProviderProfile,
+  resolveService,
+} from "../oauth/provider-profiles.js";
+
+describe("oauth provider profiles", () => {
+  test("gmail profile defines bearer injection templates for Google API hosts", () => {
+    const service = resolveService("gmail");
+    const profile = getProviderProfile(service);
+
+    expect(service).toBe("integration:gmail");
+    expect(profile).toBeDefined();
+    expect(profile?.injectionTemplates).toBeDefined();
+    expect(profile?.injectionTemplates).toHaveLength(3);
+
+    const byHost = new Map(
+      (profile?.injectionTemplates ?? []).map((t) => [t.hostPattern, t]),
+    );
+
+    for (const host of [
+      "gmail.googleapis.com",
+      "www.googleapis.com",
+      "people.googleapis.com",
+    ]) {
+      const tpl = byHost.get(host);
+      expect(tpl).toBeDefined();
+      expect(tpl?.injectionType).toBe("header");
+      expect(tpl?.headerName).toBe("Authorization");
+      expect(tpl?.valuePrefix).toBe("Bearer ");
+    }
+  });
+});

--- a/assistant/src/__tests__/script-proxy-profile-template-fallback.test.ts
+++ b/assistant/src/__tests__/script-proxy-profile-template-fallback.test.ts
@@ -1,0 +1,127 @@
+import * as http from "node:http";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import type { ResolvedCredential } from "../tools/credentials/resolve.js";
+
+let resolveByIdResults = new Map<string, ResolvedCredential | undefined>();
+let secureKeyValues = new Map<string, string | undefined>();
+let providerProfiles = new Map<
+  string,
+  { injectionTemplates?: Array<Record<string, string>> }
+>();
+
+mock.module("../tools/credentials/resolve.js", () => ({
+  resolveById: (credentialId: string) => resolveByIdResults.get(credentialId),
+  resolveByServiceField: () => undefined,
+  resolveForDomain: () => [],
+}));
+
+mock.module("../tools/credentials/metadata-store.js", () => ({
+  listCredentialMetadata: () => [],
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKey: (account: string) => secureKeyValues.get(account),
+  setSecureKey: () => true,
+  deleteSecureKey: () => true,
+  listSecureKeys: () => [],
+  getBackendType: () => "encrypted",
+  _resetBackend: () => {},
+  _setBackend: () => {},
+}));
+
+mock.module("../oauth/provider-profiles.js", () => ({
+  getProviderProfile: (service: string) => providerProfiles.get(service),
+}));
+
+import {
+  createSession,
+  startSession,
+  stopAllSessions,
+} from "../tools/network/script-proxy/session-manager.js";
+
+afterEach(async () => {
+  await stopAllSessions();
+  resolveByIdResults = new Map();
+  secureKeyValues = new Map();
+  providerProfiles = new Map();
+});
+
+function proxyRequest(port: number, targetUrl: string): Promise<number> {
+  return new Promise<number>((resolve) => {
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path: targetUrl,
+        method: "GET",
+      },
+      (res) => {
+        res.resume();
+        resolve(res.statusCode ?? 0);
+      },
+    );
+    req.on("error", () => resolve(-1));
+    req.end();
+  });
+}
+
+describe("script proxy profile-template fallback", () => {
+  test("falls back to provider profile templates for access_token credentials", async () => {
+    let receivedHeaders: http.IncomingHttpHeaders = {};
+    const echo = http.createServer((req, res) => {
+      receivedHeaders = req.headers;
+      res.writeHead(200);
+      res.end("ok");
+    });
+    await new Promise<void>((resolve) => echo.listen(0, "127.0.0.1", resolve));
+    const echoPort = (echo.address() as { port: number }).port;
+
+    try {
+      providerProfiles.set("integration:gmail", {
+        injectionTemplates: [
+          {
+            hostPattern: "127.0.0.1",
+            injectionType: "header",
+            headerName: "Authorization",
+            valuePrefix: "Bearer ",
+          },
+        ],
+      });
+
+      resolveByIdResults.set("cred-gmail", {
+        credentialId: "cred-gmail",
+        service: "integration:gmail",
+        field: "access_token",
+        storageKey: "credential:integration:gmail:access_token",
+        injectionTemplates: [],
+        metadata: {
+          credentialId: "cred-gmail",
+          service: "integration:gmail",
+          field: "access_token",
+          allowedTools: [],
+          allowedDomains: [],
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      });
+      secureKeyValues.set(
+        "credential:integration:gmail:access_token",
+        "gmail_token_123",
+      );
+
+      const session = createSession("conv-fallback", ["cred-gmail"]);
+      const started = await startSession(session.id);
+
+      const status = await proxyRequest(
+        started.port!,
+        `http://127.0.0.1:${echoPort}/v1/test`,
+      );
+
+      expect(status).toBe(200);
+      expect(receivedHeaders["authorization"]).toBe("Bearer gmail_token_123");
+    } finally {
+      echo.close();
+    }
+  });
+});

--- a/assistant/src/oauth/provider-profiles.ts
+++ b/assistant/src/oauth/provider-profiles.ts
@@ -43,6 +43,28 @@ export const PROVIDER_PROFILES: Record<string, OAuthProviderProfile> = {
     ],
     scopePolicy: DEFAULT_SCOPE_POLICY,
     userinfoUrl: "https://www.googleapis.com/oauth2/v2/userinfo",
+    // Google APIs for Gmail/Calendar/Contacts span multiple hosts; register
+    // all of them so proxied bash can inject the OAuth bearer token reliably.
+    injectionTemplates: [
+      {
+        hostPattern: "gmail.googleapis.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+      {
+        hostPattern: "www.googleapis.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+      {
+        hostPattern: "people.googleapis.com",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Bearer ",
+      },
+    ],
     extraParams: { access_type: "offline", prompt: "consent" },
     callbackTransport: "loopback",
     setupSkillId: "google-oauth-setup",

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { Server } from "node:http";
 import { join } from "node:path";
 
+import { getProviderProfile } from "../../../oauth/provider-profiles.js";
 import {
   buildDecisionTrace,
   createProxyServer,
@@ -29,7 +30,10 @@ import {
 } from "../../credentials/host-pattern-match.js";
 import { listCredentialMetadata } from "../../credentials/metadata-store.js";
 import type { CredentialInjectionTemplate } from "../../credentials/policy-types.js";
-import { resolveById } from "../../credentials/resolve.js";
+import {
+  resolveById,
+  type ResolvedCredential,
+} from "../../credentials/resolve.js";
 
 const log = getLogger("proxy-session");
 
@@ -61,6 +65,26 @@ const sessions = new Map<ProxySessionId, ManagedSession>();
  * duplicate sessions (check-then-act race).
  */
 const acquireLocks = new Map<string, Promise<ProxySession>>();
+
+/**
+ * Resolve injection templates for a credential.
+ *
+ * Preferred source is credential metadata. For legacy OAuth credentials that
+ * predate provider-level template registration, fall back to well-known
+ * profile templates when this is an access_token credential.
+ */
+function resolveInjectionTemplates(
+  resolved: ResolvedCredential | undefined,
+): CredentialInjectionTemplate[] {
+  if (!resolved) return [];
+  if (resolved.injectionTemplates.length > 0)
+    return resolved.injectionTemplates;
+  if (resolved.field !== "access_token") return [];
+
+  const profile = getProviderProfile(resolved.service);
+  if (!profile?.injectionTemplates?.length) return [];
+  return profile.injectionTemplates;
+}
 
 /** Return a defensive copy so callers cannot mutate internal state. */
 function cloneSession(s: ProxySession): ProxySession {
@@ -153,8 +177,9 @@ export async function startSession(
   const templates = new Map<string, CredentialInjectionTemplate[]>();
   for (const credId of managed.session.credentialIds) {
     const resolved = resolveById(credId);
-    if (resolved?.injectionTemplates?.length) {
-      templates.set(credId, resolved.injectionTemplates);
+    const injectionTemplates = resolveInjectionTemplates(resolved);
+    if (injectionTemplates.length > 0) {
+      templates.set(credId, injectionTemplates);
     }
   }
 


### PR DESCRIPTION
## Summary
- add Gmail provider `injectionTemplates` for Google API hosts used by Gmail/Calendar/Contacts
- add script-proxy fallback: when an `access_token` credential has no metadata templates, use provider-profile templates
- add regression tests for Gmail profile templates and legacy template fallback in script proxy

## Why
Legacy Gmail OAuth credentials often have `injectionTemplates: []` in metadata. In proxied bash mode this prevented Authorization header injection, causing 401 `CREDENTIALS_MISSING` for Gmail API calls.

## Validation
- `cd assistant && bun test src/__tests__/script-proxy-profile-template-fallback.test.ts src/__tests__/script-proxy-session-manager.test.ts src/__tests__/oauth-provider-profiles.test.ts`
- Result: 33 passed, 0 failed