### PR TITLE
fix: add temporary_override to domain events decision type

### DIFF
--- a/assistant/src/events/domain-events.ts
+++ b/assistant/src/events/domain-events.ts
@@ -26,7 +26,8 @@ export interface ToolDomainEvents {
       | "allow_thread"
       | "always_allow"
       | "deny"
-      | "always_deny";
+      | "always_deny"
+      | "temporary_override";
     riskLevel: string;
     decidedAtMs: number;
   };


### PR DESCRIPTION
Address feedback from PR #11330: add temporary_override to the tool.permission.decided domain event type. Note: temporaryOptionsAvailable was already being passed to the prompter in permission-checker.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
