### PR TITLE
fix: resolve gateway URL from INTERNAL_GATEWAY_BASE_URL and fix guardian status default channel

### DIFF
--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -58,14 +58,6 @@ function toQueryString(params: Record<string, string | undefined>): string {
   return encoded ? `?${encoded}` : "";
 }
 
-function resolveGatewayBaseUrl(): string {
-  const injectedGatewayBase = process.env.INTERNAL_GATEWAY_BASE_URL?.trim();
-  if (injectedGatewayBase && injectedGatewayBase.length > 0) {
-    return injectedGatewayBase.replace(/\/+$/, "");
-  }
-  return getGatewayInternalBaseUrl();
-}
-
 function readIngressConfig(): {
   success: true;
   enabled: boolean;
@@ -86,7 +78,7 @@ function readIngressConfig(): {
     success: true,
     enabled,
     publicBaseUrl: configuredUrl || undefined,
-    localGatewayTarget: resolveGatewayBaseUrl(),
+    localGatewayTarget: getGatewayInternalBaseUrl(),
   };
 }
 
@@ -112,11 +104,11 @@ function readVoiceConfig(): {
   };
 }
 
-// CLI-specific gateway helper — uses GATEWAY_AUTH_TOKEN / INTERNAL_GATEWAY_BASE_URL
-// env vars for out-of-process access. See runtime/gateway-internal-client.ts for
-// daemon-internal usage which mints fresh tokens and uses GATEWAY_INTERNAL_BASE_URL.
+// CLI-specific gateway helper — uses GATEWAY_AUTH_TOKEN env var for out-of-process
+// access. See runtime/gateway-internal-client.ts for daemon-internal usage which
+// mints fresh tokens.
 async function gatewayGet(path: string): Promise<unknown> {
-  const gatewayBase = resolveGatewayBaseUrl();
+  const gatewayBase = getGatewayInternalBaseUrl();
   const token = getGatewayToken();
 
   const response = await fetch(`${gatewayBase}${path}`, {
@@ -240,9 +232,9 @@ export function registerIntegrationsCommand(program: Command): void {
   guardian
     .command("status")
     .description("Get guardian status for a channel")
-    .option("--channel <channel>", "Channel: telegram|voice|sms", "voice")
+    .option("--channel <channel>", "Channel: telegram|voice|sms", "telegram")
     .action(async (opts: { channel?: GuardianChannel }, cmd: Command) => {
-      const channel = opts.channel ?? "voice";
+      const channel = opts.channel ?? "telegram";
       await runRead(cmd, async () =>
         gatewayGet(
           `/v1/integrations/guardian/status${toQueryString({ channel })}`,

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -57,11 +57,14 @@ export function getGatewayPort(): number {
 
 /**
  * Resolve the gateway base URL for internal service-to-service calls.
- * Prefers GATEWAY_INTERNAL_BASE_URL if set, otherwise derives from port.
+ * Prefers GATEWAY_INTERNAL_BASE_URL if set, then INTERNAL_GATEWAY_BASE_URL
+ * (used by skill subprocesses), otherwise derives from port.
  */
 export function getGatewayInternalBaseUrl(): string {
   const explicit = str("GATEWAY_INTERNAL_BASE_URL");
   if (explicit) return explicit.replace(/\/+$/, "");
+  const skillInjected = str("INTERNAL_GATEWAY_BASE_URL");
+  if (skillInjected) return skillInjected.replace(/\/+$/, "");
   return `http://127.0.0.1:${getGatewayPort()}`;
 }
 


### PR DESCRIPTION
Address feedback from PR #11908: make getGatewayInternalBaseUrl() check INTERNAL_GATEWAY_BASE_URL as fallback so CLI works from skill subprocesses, and change guardian status default channel from voice to telegram to match runtime.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
