### PR TITLE
Remove deprecated network_request tool in favor of proxied bash

### DIFF
--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -219,15 +219,15 @@ The strategy is persisted in the Vellum config file as `twitterOperationStrategy
 
 #### Twitter OAuth2 Specifics
 
-| Aspect | Detail |
-|--------|--------|
-| Auth URL | `https://twitter.com/i/oauth2/authorize` (from provider profile) |
-| Token URL | `https://api.x.com/2/oauth2/token` (from provider profile) |
-| Flow | PKCE (S256), optional client secret, via connect orchestrator |
-| Default scopes | `tweet.read`, `tweet.write`, `users.read`, `offline.access` (from provider profile) |
-| Identity verification | Provider profile `identityVerifier` → `GET https://api.x.com/2/users/me` with Bearer token |
-| Credential names | Canonical: `client_id`, `client_secret`; reads fall back to legacy `oauth_client_id`, `oauth_client_secret` |
-| IPC messages | `oauth_connect_start` / `oauth_connect_result` (generic), plus legacy `twitter_auth_start` / `twitter_auth_status` |
+| Aspect                | Detail                                                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Auth URL              | `https://twitter.com/i/oauth2/authorize` (from provider profile)                                                   |
+| Token URL             | `https://api.x.com/2/oauth2/token` (from provider profile)                                                         |
+| Flow                  | PKCE (S256), optional client secret, via connect orchestrator                                                      |
+| Default scopes        | `tweet.read`, `tweet.write`, `users.read`, `offline.access` (from provider profile)                                |
+| Identity verification | Provider profile `identityVerifier` → `GET https://api.x.com/2/users/me` with Bearer token                         |
+| Credential names      | Canonical: `client_id`, `client_secret`; reads fall back to legacy `oauth_client_id`, `oauth_client_secret`        |
+| IPC messages          | `oauth_connect_start` / `oauth_connect_result` (generic), plus legacy `twitter_auth_start` / `twitter_auth_status` |
 
 #### Twitter Credential Metadata Structure
 
@@ -254,73 +254,73 @@ When the OAuth2 flow completes, the handler stores credential metadata at `integ
 
 #### Available Twitter Tools
 
-| Tool / Command | Mechanism | Description |
-|----------------|-----------|-------------|
-| `vellum x post` | Strategy router (OAuth or CDP) | Post a tweet. Uses the configured strategy (`auto` by default). |
-| `vellum x reply` | Strategy router (OAuth or CDP) | Reply to a tweet. Uses the configured strategy (`auto` by default). |
-| `vellum x timeline` | CDP | Fetch a user's recent tweets. Browser path only. |
-| `vellum x search` | CDP | Search tweets. Browser path only. |
-| `vellum x home` | CDP | Fetch home timeline. Browser path only. |
-| `vellum x notifications` | CDP | Fetch notifications. Browser path only. |
-| `vellum x bookmarks` | CDP | Fetch bookmarks. Browser path only. |
-| `vellum x likes` | CDP | Fetch a user's liked tweets. Browser path only. |
-| `vellum x followers` | CDP | Fetch a user's followers. Browser path only. |
-| `vellum x following` | CDP | Fetch who a user follows. Browser path only. |
-| `vellum x media` | CDP | Fetch a user's media tweets. Browser path only. |
-| `vellum x strategy` | Config | Get or set the operation strategy (`oauth`, `browser`, `auto`). |
-| `vellum x status` | IPC + local | Check browser session, OAuth connection, and strategy status. |
+| Tool / Command           | Mechanism                      | Description                                                         |
+| ------------------------ | ------------------------------ | ------------------------------------------------------------------- |
+| `vellum x post`          | Strategy router (OAuth or CDP) | Post a tweet. Uses the configured strategy (`auto` by default).     |
+| `vellum x reply`         | Strategy router (OAuth or CDP) | Reply to a tweet. Uses the configured strategy (`auto` by default). |
+| `vellum x timeline`      | CDP                            | Fetch a user's recent tweets. Browser path only.                    |
+| `vellum x search`        | CDP                            | Search tweets. Browser path only.                                   |
+| `vellum x home`          | CDP                            | Fetch home timeline. Browser path only.                             |
+| `vellum x notifications` | CDP                            | Fetch notifications. Browser path only.                             |
+| `vellum x bookmarks`     | CDP                            | Fetch bookmarks. Browser path only.                                 |
+| `vellum x likes`         | CDP                            | Fetch a user's liked tweets. Browser path only.                     |
+| `vellum x followers`     | CDP                            | Fetch a user's followers. Browser path only.                        |
+| `vellum x following`     | CDP                            | Fetch who a user follows. Browser path only.                        |
+| `vellum x media`         | CDP                            | Fetch a user's media tweets. Browser path only.                     |
+| `vellum x strategy`      | Config                         | Get or set the operation strategy (`oauth`, `browser`, `auto`).     |
+| `vellum x status`        | IPC + local                    | Check browser session, OAuth connection, and strategy status.       |
 
 Note: OAuth2 scopes (`tweet.read`, `tweet.write`, `users.read`, `offline.access`) are requested during the auth flow. The `post` and `reply` operations use these tokens when the OAuth path is selected. Read operations require the browser path.
 
 ### Key Design Decisions
 
-| Decision | Rationale |
-|----------|-----------|
-| PKCE by default, optional client_secret | Desktop apps prefer PKCE; some providers (Slack) require a secret, which is stored in credential metadata for autonomous refresh |
-| Shared connect orchestrator | All OAuth providers route through `orchestrateOAuthConnect()`, which resolves profiles, enforces scope policy, runs the flow, stores tokens, and verifies identity. Adding a provider is a declarative profile entry, not new orchestration code |
-| Canonical credential naming | Writes use `client_id`/`client_secret`; reads fall back to legacy `oauth_client_id`/`oauth_client_secret` for backward compatibility |
-| Gateway callback transport | OAuth callbacks are now routed through the gateway at `${ingress.publicBaseUrl}/webhooks/oauth/callback` instead of a loopback redirect URI. This enables OAuth flows to work in remote and tunneled deployments. |
-| Unified `MessagingProvider` interface | All platforms implement the same contract; generic tools work immediately for new providers |
-| Twitter outside unified messaging | Twitter is a broadcast/read platform, not a conversation platform — it doesn't fit the `MessagingProvider` contract |
-| Dual-path Twitter strategy | OAuth is more reliable for posting (no browser session dependency) but only supports post/reply. Browser path supports all operations. `auto` strategy gives the best of both: OAuth when possible, browser as fallback. User can override via `vellum x strategy set`. |
-| Provider auto-selection | If only one provider is connected, tools skip the `platform` parameter — seamless single-platform UX |
-| Token expiry in credential metadata | Reuses existing `CredentialMetadata` store; `expiresAt` field enables proactive refresh with 5min buffer |
-| Confidence scores on medium-risk tools | LLM self-reports confidence (0-1); enables future trust calibration without blocking execution |
-| Platform-specific extension tools | Operations unique to one platform (e.g. Gmail labels, Slack reactions) are separate tools, not forced into the generic interface |
-| Twitter identity verification before token storage | OAuth2 tokens are only persisted after a successful `GET /2/users/me` call, preventing storage of invalid or mismatched credentials |
+| Decision                                           | Rationale                                                                                                                                                                                                                                                               |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PKCE by default, optional client_secret            | Desktop apps prefer PKCE; some providers (Slack) require a secret, which is stored in credential metadata for autonomous refresh                                                                                                                                        |
+| Shared connect orchestrator                        | All OAuth providers route through `orchestrateOAuthConnect()`, which resolves profiles, enforces scope policy, runs the flow, stores tokens, and verifies identity. Adding a provider is a declarative profile entry, not new orchestration code                        |
+| Canonical credential naming                        | Writes use `client_id`/`client_secret`; reads fall back to legacy `oauth_client_id`/`oauth_client_secret` for backward compatibility                                                                                                                                    |
+| Gateway callback transport                         | OAuth callbacks are now routed through the gateway at `${ingress.publicBaseUrl}/webhooks/oauth/callback` instead of a loopback redirect URI. This enables OAuth flows to work in remote and tunneled deployments.                                                       |
+| Unified `MessagingProvider` interface              | All platforms implement the same contract; generic tools work immediately for new providers                                                                                                                                                                             |
+| Twitter outside unified messaging                  | Twitter is a broadcast/read platform, not a conversation platform — it doesn't fit the `MessagingProvider` contract                                                                                                                                                     |
+| Dual-path Twitter strategy                         | OAuth is more reliable for posting (no browser session dependency) but only supports post/reply. Browser path supports all operations. `auto` strategy gives the best of both: OAuth when possible, browser as fallback. User can override via `vellum x strategy set`. |
+| Provider auto-selection                            | If only one provider is connected, tools skip the `platform` parameter — seamless single-platform UX                                                                                                                                                                    |
+| Token expiry in credential metadata                | Reuses existing `CredentialMetadata` store; `expiresAt` field enables proactive refresh with 5min buffer                                                                                                                                                                |
+| Confidence scores on medium-risk tools             | LLM self-reports confidence (0-1); enables future trust calibration without blocking execution                                                                                                                                                                          |
+| Platform-specific extension tools                  | Operations unique to one platform (e.g. Gmail labels, Slack reactions) are separate tools, not forced into the generic interface                                                                                                                                        |
+| Twitter identity verification before token storage | OAuth2 tokens are only persisted after a successful `GET /2/users/me` call, preventing storage of invalid or mismatched credentials                                                                                                                                     |
 
 ### Source Files
 
-| File | Role |
-|------|------|
-| `assistant/src/security/oauth2.ts` | OAuth2 flow: PKCE or client_secret, Bun.serve callback, token exchange |
-| `assistant/src/security/token-manager.ts` | `withValidToken()` — auto-refresh, 401 retry, expiry buffer |
-| `assistant/src/messaging/provider.ts` | `MessagingProvider` interface |
-| `assistant/src/messaging/provider-types.ts` | Platform-agnostic types (Conversation, Message, SearchResult) |
-| `assistant/src/messaging/registry.ts` | Provider registry: register, lookup, list connected |
-| `assistant/src/messaging/activity-analyzer.ts` | Activity classification for conversations |
-| `assistant/src/messaging/style-analyzer.ts` | Writing style extraction from message corpus |
-| `assistant/src/messaging/draft-store.ts` | Local draft storage (platform/id JSON files) |
-| `assistant/src/messaging/providers/slack/` | Slack adapter, client, types |
-| `assistant/src/messaging/providers/gmail/` | Gmail adapter, client, types |
-| `assistant/src/config/bundled-skills/messaging/` | Unified messaging skill (SKILL.md, TOOLS.json, tools/) |
-| `assistant/src/watcher/providers/slack.ts` | Slack watcher for DMs, mentions, thread replies |
-| `assistant/src/watcher/providers/gmail.ts` | Gmail watcher using History API |
-| `assistant/src/watcher/providers/github.ts` | GitHub watcher for PRs, issues, review requests, and mentions |
-| `assistant/src/watcher/providers/linear.ts` | Linear watcher for assigned issues, status changes, and @mentions |
-| `assistant/src/oauth/provider-profiles.ts` | Provider profile registry: auth URLs, token URLs, scopes, policies, identity verifiers |
-| `assistant/src/oauth/connect-orchestrator.ts` | Shared OAuth connect orchestrator: profile resolution, scope policy, flow execution, token storage |
-| `assistant/src/oauth/scope-policy.ts` | Deterministic scope resolution and policy enforcement |
-| `assistant/src/oauth/connect-types.ts` | Shared types: `OAuthProviderProfile`, `OAuthScopePolicy`, `OAuthConnectResult` |
-| `assistant/src/oauth/token-persistence.ts` | Token storage helper: persists tokens, metadata, and runs post-connect hooks |
-| `assistant/src/daemon/handlers/oauth-connect.ts` | Generic OAuth connect IPC handler (`oauth_connect_start` / `oauth_connect_result`) |
-| `assistant/src/daemon/handlers/twitter-auth.ts` | Legacy Twitter OAuth2 flow handlers (`twitter_auth_start`, `twitter_auth_status`) |
-| `assistant/src/twitter/client.ts` | Twitter CDP client: GraphQL mutations/queries via Chrome DevTools Protocol |
-| `assistant/src/twitter/oauth-client.ts` | OAuth-backed Twitter client: X API v2 post/reply via stored tokens using `withValidToken()` |
-| `assistant/src/twitter/router.ts` | Strategy router: selects OAuth or browser path based on `twitterOperationStrategy` config |
-| `assistant/src/twitter/session.ts` | Twitter browser session persistence (cookie import/export) |
-| `assistant/src/cli/twitter.ts` | `vellum x` CLI command group (post, reply, strategy, refresh, status, login, logout, and read operations) |
-| `assistant/src/config/bundled-skills/twitter/SKILL.md` | X (Twitter) bundled skill instructions |
+| File                                                   | Role                                                                                                      |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| `assistant/src/security/oauth2.ts`                     | OAuth2 flow: PKCE or client_secret, Bun.serve callback, token exchange                                    |
+| `assistant/src/security/token-manager.ts`              | `withValidToken()` — auto-refresh, 401 retry, expiry buffer                                               |
+| `assistant/src/messaging/provider.ts`                  | `MessagingProvider` interface                                                                             |
+| `assistant/src/messaging/provider-types.ts`            | Platform-agnostic types (Conversation, Message, SearchResult)                                             |
+| `assistant/src/messaging/registry.ts`                  | Provider registry: register, lookup, list connected                                                       |
+| `assistant/src/messaging/activity-analyzer.ts`         | Activity classification for conversations                                                                 |
+| `assistant/src/messaging/style-analyzer.ts`            | Writing style extraction from message corpus                                                              |
+| `assistant/src/messaging/draft-store.ts`               | Local draft storage (platform/id JSON files)                                                              |
+| `assistant/src/messaging/providers/slack/`             | Slack adapter, client, types                                                                              |
+| `assistant/src/messaging/providers/gmail/`             | Gmail adapter, client, types                                                                              |
+| `assistant/src/config/bundled-skills/messaging/`       | Unified messaging skill (SKILL.md, TOOLS.json, tools/)                                                    |
+| `assistant/src/watcher/providers/slack.ts`             | Slack watcher for DMs, mentions, thread replies                                                           |
+| `assistant/src/watcher/providers/gmail.ts`             | Gmail watcher using History API                                                                           |
+| `assistant/src/watcher/providers/github.ts`            | GitHub watcher for PRs, issues, review requests, and mentions                                             |
+| `assistant/src/watcher/providers/linear.ts`            | Linear watcher for assigned issues, status changes, and @mentions                                         |
+| `assistant/src/oauth/provider-profiles.ts`             | Provider profile registry: auth URLs, token URLs, scopes, policies, identity verifiers                    |
+| `assistant/src/oauth/connect-orchestrator.ts`          | Shared OAuth connect orchestrator: profile resolution, scope policy, flow execution, token storage        |
+| `assistant/src/oauth/scope-policy.ts`                  | Deterministic scope resolution and policy enforcement                                                     |
+| `assistant/src/oauth/connect-types.ts`                 | Shared types: `OAuthProviderProfile`, `OAuthScopePolicy`, `OAuthConnectResult`                            |
+| `assistant/src/oauth/token-persistence.ts`             | Token storage helper: persists tokens, metadata, and runs post-connect hooks                              |
+| `assistant/src/daemon/handlers/oauth-connect.ts`       | Generic OAuth connect IPC handler (`oauth_connect_start` / `oauth_connect_result`)                        |
+| `assistant/src/daemon/handlers/twitter-auth.ts`        | Legacy Twitter OAuth2 flow handlers (`twitter_auth_start`, `twitter_auth_status`)                         |
+| `assistant/src/twitter/client.ts`                      | Twitter CDP client: GraphQL mutations/queries via Chrome DevTools Protocol                                |
+| `assistant/src/twitter/oauth-client.ts`                | OAuth-backed Twitter client: X API v2 post/reply via stored tokens using `withValidToken()`               |
+| `assistant/src/twitter/router.ts`                      | Strategy router: selects OAuth or browser path based on `twitterOperationStrategy` config                 |
+| `assistant/src/twitter/session.ts`                     | Twitter browser session persistence (cookie import/export)                                                |
+| `assistant/src/cli/twitter.ts`                         | `vellum x` CLI command group (post, reply, strategy, refresh, status, login, logout, and read operations) |
+| `assistant/src/config/bundled-skills/twitter/SKILL.md` | X (Twitter) bundled skill instructions                                                                    |
 
 ---
 
@@ -332,15 +332,15 @@ The OAuth extensibility layer makes adding a new OAuth provider a declarative op
 
 `assistant/src/oauth/provider-profiles.ts` contains the `PROVIDER_PROFILES` map — a canonical registry of well-known OAuth providers. Each profile (`OAuthProviderProfile`) declares:
 
-| Field | Purpose |
-|-------|---------|
-| `authUrl` / `tokenUrl` | OAuth2 authorization and token endpoints |
-| `defaultScopes` | Scopes requested on every connect attempt |
-| `scopePolicy` | Controls whether additional scopes are allowed (see Scope Policy below) |
-| `callbackTransport` | `'loopback'` (local redirect) or `'gateway'` (public ingress) |
-| `identityVerifier` | Async function that fetches human-readable account info (e.g. `@username`, email) after token exchange |
-| `setup` | Optional metadata for the generic OAuth setup skill (display name, dashboard URL, app type) |
-| `injectionTemplates` | Auto-applied credential injection rules for the script proxy |
+| Field                  | Purpose                                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| `authUrl` / `tokenUrl` | OAuth2 authorization and token endpoints                                                               |
+| `defaultScopes`        | Scopes requested on every connect attempt                                                              |
+| `scopePolicy`          | Controls whether additional scopes are allowed (see Scope Policy below)                                |
+| `callbackTransport`    | `'loopback'` (local redirect) or `'gateway'` (public ingress)                                          |
+| `identityVerifier`     | Async function that fetches human-readable account info (e.g. `@username`, email) after token exchange |
+| `setup`                | Optional metadata for the generic OAuth setup skill (display name, dashboard URL, app type)            |
+| `injectionTemplates`   | Auto-applied credential injection rules for the script proxy                                           |
 
 Registered providers: `integration:gmail`, `integration:slack`, `integration:notion`, `integration:twitter`. Short aliases (e.g. `gmail`, `twitter`) are resolved via `SERVICE_ALIASES`.
 
@@ -394,17 +394,16 @@ This replaces provider-specific IPC handlers — any provider in the registry ca
 
 ### Key Source Files
 
-| File | Role |
-|------|------|
-| `assistant/src/oauth/provider-profiles.ts` | Provider profile registry and alias resolution |
-| `assistant/src/oauth/scope-policy.ts` | Scope resolution and policy enforcement (pure, no I/O) |
-| `assistant/src/oauth/connect-orchestrator.ts` | Shared connect orchestrator (profile → scopes → flow → tokens) |
-| `assistant/src/oauth/connect-types.ts` | Shared types (`OAuthProviderProfile`, `OAuthScopePolicy`, `OAuthConnectResult`) |
-| `assistant/src/oauth/token-persistence.ts` | Token storage: keychain writes, metadata upsert, post-connect hooks |
-| `assistant/src/daemon/handlers/oauth-connect.ts` | Generic `oauth_connect_start` / `oauth_connect_result` IPC handler |
+| File                                             | Role                                                                            |
+| ------------------------------------------------ | ------------------------------------------------------------------------------- |
+| `assistant/src/oauth/provider-profiles.ts`       | Provider profile registry and alias resolution                                  |
+| `assistant/src/oauth/scope-policy.ts`            | Scope resolution and policy enforcement (pure, no I/O)                          |
+| `assistant/src/oauth/connect-orchestrator.ts`    | Shared connect orchestrator (profile → scopes → flow → tokens)                  |
+| `assistant/src/oauth/connect-types.ts`           | Shared types (`OAuthProviderProfile`, `OAuthScopePolicy`, `OAuthConnectResult`) |
+| `assistant/src/oauth/token-persistence.ts`       | Token storage: keychain writes, metadata upsert, post-connect hooks             |
+| `assistant/src/daemon/handlers/oauth-connect.ts` | Generic `oauth_connect_start` / `oauth_connect_result` IPC handler              |
 
 ---
-
 
 ---
 
@@ -424,8 +423,8 @@ graph TB
 
     subgraph "Permission Check"
         EXECUTOR["ToolExecutor"]
-        PERM["PermissionChecker<br/>classifyRisk → Medium<br/>(proxied bash)"]
-        PROMPT["Prompt user<br/>persistentDecisionsAllowed: false<br/>(no trust rule saving for proxied bash)"]
+        PERM["PermissionChecker<br/>normal bash risk classification<br/>(no proxied-mode special override)"]
+        PROMPT["Prompt user when required<br/>(standard trust-rule flow)"]
     end
 
     subgraph "Sandbox"
@@ -536,18 +535,18 @@ sequenceDiagram
 
 **Policy decisions** are deterministic and structured:
 
-| Decision | Meaning |
-|---|---|
-| `matched` | Exactly one credential template matches the host — inject it |
-| `ambiguous` | Multiple credential templates match — caller must disambiguate |
-| `missing` | Credentials exist but none match this host — no rewrite |
-| `unauthenticated` | No credentials configured for the session |
+| Decision                 | Meaning                                                                    |
+| ------------------------ | -------------------------------------------------------------------------- |
+| `matched`                | Exactly one credential template matches the host — inject it               |
+| `ambiguous`              | Multiple credential templates match — caller must disambiguate             |
+| `missing`                | Credentials exist but none match this host — no rewrite                    |
+| `unauthenticated`        | No credentials configured for the session                                  |
 | `ask_missing_credential` | A known template pattern matches but no credential is bound to the session |
-| `ask_unauthenticated` | Completely unknown host — prompt for unauthenticated access |
+| `ask_unauthenticated`    | Completely unknown host — prompt for unauthenticated access                |
 
-**Trust rule persistence**: The `createProxyApprovalCallback` in `session-tool-setup.ts` is wired into the session startup path and routes policy "ask" decisions through the existing `PermissionPrompter` UI. Trust rules use the `network_request` tool name (not `proxy:*`) with URL-based scope patterns (e.g., `https://api.example.com/*`), aligning with the `buildCommandCandidates()` allowlist generation in `checker.ts`.
+**Trust rule persistence**: The `createProxyApprovalCallback` in `session-tool-setup.ts` is wired into the session startup path and routes policy "ask" decisions through the existing `PermissionPrompter` UI. Trust rules now use the `bash` tool with proxy-specific URL patterns (`proxied_url:<encoded-url>` and `proxied_origin:<encoded-origin>`), so proxied destination approvals stay isolated from general shell command allowlists.
 
-**Proxied bash permission restriction**: The `ToolExecutor` sets `persistentDecisionsAllowed = false` when the bash tool is invoked with `network_mode: 'proxied'`. This prevents users from saving permanent trust rules for proxied bash commands, since the proxy session's credential scope can change between invocations.
+**Proxied bash approval model**: Proxied network destination approvals are handled by the proxy callback path and persisted as proxy-scoped bash rules. This keeps destination approvals host-aware while preserving the normal bash permission flow for command execution.
 
 ### Session Lifecycle
 
@@ -566,10 +565,10 @@ Each proxy session is bound to a conversation and tracks authorized credential I
 
 The proxy generates and manages a local Certificate Authority for MITM interception:
 
-| Component | Location | Purpose |
-|---|---|---|
-| CA cert | `{dataDir}/proxy-ca/ca.pem` | Self-signed root cert (valid 10 years, permissions 0644) |
-| CA key | `{dataDir}/proxy-ca/ca-key.pem` | CA private key (permissions 0600) |
+| Component  | Location                                   | Purpose                                                  |
+| ---------- | ------------------------------------------ | -------------------------------------------------------- |
+| CA cert    | `{dataDir}/proxy-ca/ca.pem`                | Self-signed root cert (valid 10 years, permissions 0644) |
+| CA key     | `{dataDir}/proxy-ca/ca-key.pem`            | CA private key (permissions 0600)                        |
 | Leaf certs | `{dataDir}/proxy-ca/issued/{hostname}.pem` | Per-hostname certs (cached, verified against current CA) |
 
 `ensureLocalCA()` is idempotent — it only generates the CA if the files do not already exist. Leaf certificates are cached and revalidated via `X509Certificate.checkIssued()` to detect stale certs from a previous CA.
@@ -587,7 +586,7 @@ All proxy logging passes through sanitization helpers (`logging.ts`) that redact
 1. **Credential values never reach the LLM** — The proxy injects credentials at the network layer; the model only sees tool results, never the injected headers or query parameters.
 2. **Minimal MITM surface** — Only hosts matching a credential injection template are MITM-intercepted. All other HTTPS traffic passes through an opaque TCP tunnel.
 3. **CA key isolation** — The CA private key has 0600 permissions and never leaves the host filesystem. Container processes only receive the CA cert via `NODE_EXTRA_CA_CERTS`.
-4. **No persistent trust rules for proxied bash** — `persistentDecisionsAllowed: false` prevents saving trust rules that could auto-allow proxied commands across sessions with different credential scopes.
+4. **Proxy-scoped trust rules for proxied destinations** — destination approvals persist as `proxied_url:` / `proxied_origin:` bash patterns so they do not silently grant unrelated shell command permissions.
 5. **Auditable routing** — Every CONNECT routing decision carries a deterministic `RouteReason` code (`mitm:credential_injection`, `tunnel:no_rewrite`, `tunnel:no_credentials`) for audit and testing.
 
 ### Credential Proxy Injection
@@ -602,20 +601,20 @@ The proxy subsystem intercepts outbound HTTPS requests and injects stored creden
 
 ### Key Source Files
 
-| File | Role |
-|---|---|
-| `assistant/src/tools/network/script-proxy/server.ts` | Proxy server factory — HTTP forwarding, CONNECT handling, MITM dispatch |
-| `assistant/src/tools/network/script-proxy/policy.ts` | Policy engine — evaluates requests against credential templates |
-| `assistant/src/tools/network/script-proxy/mitm-handler.ts` | MITM TLS interception — loopback TLS server, request rewrite, upstream forwarding |
-| `assistant/src/tools/network/script-proxy/connect-tunnel.ts` | Plain CONNECT tunnel — raw TCP bidirectional pipe |
-| `assistant/src/tools/network/script-proxy/http-forwarder.ts` | HTTP proxy forwarder — absolute-URL form forwarding with policy callback |
-| `assistant/src/tools/network/script-proxy/session-manager.ts` | Session lifecycle — create, start, stop, idle timeout, env var generation |
-| `assistant/src/tools/network/script-proxy/certs.ts` | Local CA management — ensureLocalCA, issueLeafCert, getCAPath |
-| `assistant/src/tools/network/script-proxy/logging.ts` | Log sanitization (header/URL redaction) and safe decision trace builders for policy and credential resolution |
-| `assistant/src/tools/network/script-proxy/types.ts` | Type definitions — session, policy decisions, approval callback |
-| `assistant/src/tools/executor.ts` | `persistentDecisionsAllowed` gate — disables trust rule saving for proxied bash |
-| `assistant/src/daemon/session-tool-setup.ts` | `createProxyApprovalCallback` — wired into session startup, uses `network_request` tool name with URL-based trust rules |
-| `assistant/src/permissions/checker.ts` | `network_request` trust rule matching and risk classification (Medium) |
+| File                                                          | Role                                                                                                                                               |
+| ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `assistant/src/tools/network/script-proxy/server.ts`          | Proxy server factory — HTTP forwarding, CONNECT handling, MITM dispatch                                                                            |
+| `assistant/src/tools/network/script-proxy/policy.ts`          | Policy engine — evaluates requests against credential templates                                                                                    |
+| `assistant/src/tools/network/script-proxy/mitm-handler.ts`    | MITM TLS interception — loopback TLS server, request rewrite, upstream forwarding                                                                  |
+| `assistant/src/tools/network/script-proxy/connect-tunnel.ts`  | Plain CONNECT tunnel — raw TCP bidirectional pipe                                                                                                  |
+| `assistant/src/tools/network/script-proxy/http-forwarder.ts`  | HTTP proxy forwarder — absolute-URL form forwarding with policy callback                                                                           |
+| `assistant/src/tools/network/script-proxy/session-manager.ts` | Session lifecycle — create, start, stop, idle timeout, env var generation                                                                          |
+| `assistant/src/tools/network/script-proxy/certs.ts`           | Local CA management — ensureLocalCA, issueLeafCert, getCAPath                                                                                      |
+| `assistant/src/tools/network/script-proxy/logging.ts`         | Log sanitization (header/URL redaction) and safe decision trace builders for policy and credential resolution                                      |
+| `assistant/src/tools/network/script-proxy/types.ts`           | Type definitions — session, policy decisions, approval callback                                                                                    |
+| `assistant/src/tools/executor.ts`                             | Tool execution pipeline and lifecycle events for bash/proxied bash invocations                                                                     |
+| `assistant/src/daemon/session-tool-setup.ts`                  | `createProxyApprovalCallback` — wired into session startup, routes proxy destination approvals through `bash` with proxy-scoped URL trust patterns |
+| `assistant/src/permissions/checker.ts`                        | Core trust-rule candidate generation, risk classification, and allowlist option strategies for first-party tools                                   |
 
 ### Runtime Wiring Summary
 
@@ -623,7 +622,7 @@ The proxy subsystem is fully wired, including credential injection. The session 
 
 - **MITM handler config**: `mitmHandler` is configured with the local CA path and a `rewriteCallback` that performs per-credential specificity-based template selection — for each credential it picks the most specific matching header template (exact > wildcard), blocks on same-credential equal-specificity ties or cross-credential ambiguity, and for the winning `header`-type template resolves the secret from secure storage and sets the outbound header. Wildcard patterns (`*.fal.run`) match the bare apex domain (`fal.run`) via apex-inclusive matching.
 - **Policy callback**: `evaluateRequestWithApproval()` is called via the `policyCallback`; for `'matched'` decisions it injects credential headers (reading the secret value at injection time), while `'ambiguous'` decisions are blocked and `'ask_*'` decisions route through the approval callback
-- **Approval callback**: `createProxyApprovalCallback()` from `session-tool-setup.ts` routes approval prompts through the `PermissionPrompter`, using the `network_request` tool name with URL-based trust rules
+- **Approval callback**: `createProxyApprovalCallback()` from `session-tool-setup.ts` routes approval prompts through the `PermissionPrompter`, using the `bash` tool with proxy-scoped URL trust rules
 - **networkMode plumbing**: `shell.ts` passes `{ networkMode }` to `wrapCommand()`, which forwards it to the native backend
 - **Session lifecycle**: `createSession` / `startSession` / `stopSession` with idle timeout and per-conversation limits
 
@@ -690,13 +689,13 @@ graph TB
 
 ### Search Capabilities
 
-| Parameter | Type | Description |
-|---|---|---|
-| `mime_type` | string | MIME type filter with wildcard support (`image/*`, `application/pdf`) |
-| `filename` | string | Case-insensitive substring match on original filename |
-| `recency` | enum | Time-based filter: `last_hour`, `last_24_hours`, `last_7_days`, `last_30_days`, `last_90_days` |
-| `conversation_id` | string | Scope results to attachments in a specific conversation |
-| `limit` | number | Maximum results (default 20, max 100) |
+| Parameter         | Type   | Description                                                                                    |
+| ----------------- | ------ | ---------------------------------------------------------------------------------------------- |
+| `mime_type`       | string | MIME type filter with wildcard support (`image/*`, `application/pdf`)                          |
+| `filename`        | string | Case-insensitive substring match on original filename                                          |
+| `recency`         | enum   | Time-based filter: `last_hour`, `last_24_hours`, `last_7_days`, `last_30_days`, `last_90_days` |
+| `conversation_id` | string | Scope results to attachments in a specific conversation                                        |
+| `limit`           | number | Maximum results (default 20, max 100)                                                          |
 
 ### Materialize Safeguards
 
@@ -707,13 +706,12 @@ graph TB
 
 ### Key Source Files
 
-| File | Role |
-|---|---|
-| `assistant/src/tools/assets/search.ts` | `asset_search` tool — cross-thread attachment metadata search with visibility filtering |
-| `assistant/src/tools/assets/materialize.ts` | `asset_materialize` tool — decode and write attachment to sandbox path |
-| `assistant/src/daemon/media-visibility-policy.ts` | Pure policy module — `isAttachmentVisible()`, `filterVisibleAttachments()` |
-| `assistant/src/memory/schema.ts` | `attachments` and `message_attachments` table schemas |
-| `assistant/src/memory/conversation-store.ts` | `getConversationThreadType()` — thread type lookup for visibility context |
+| File                                              | Role                                                                                    |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `assistant/src/tools/assets/search.ts`            | `asset_search` tool — cross-thread attachment metadata search with visibility filtering |
+| `assistant/src/tools/assets/materialize.ts`       | `asset_materialize` tool — decode and write attachment to sandbox path                  |
+| `assistant/src/daemon/media-visibility-policy.ts` | Pure policy module — `isAttachmentVisible()`, `filterVisibleAttachments()`              |
+| `assistant/src/memory/schema.ts`                  | `attachments` and `message_attachments` table schemas                                   |
+| `assistant/src/memory/conversation-store.ts`      | `getConversationThreadType()` — thread type lookup for visibility context               |
 
 ---
-

--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -252,20 +252,6 @@ describe("Permission Checker", () => {
       });
     });
 
-    describe("network_request", () => {
-      test("network_request is always medium risk", async () => {
-        const risk = await classifyRisk("network_request", {
-          url: "https://api.example.com/v1/data",
-        });
-        expect(risk).toBe(RiskLevel.Medium);
-      });
-
-      test("network_request is medium risk even without url", async () => {
-        const risk = await classifyRisk("network_request", {});
-        expect(risk).toBe(RiskLevel.Medium);
-      });
-    });
-
     // shell commands - low risk
     describe("shell — low risk", () => {
       test("ls is low risk", async () => {
@@ -1180,105 +1166,6 @@ describe("Permission Checker", () => {
       expect(result.decision).toBe("deny");
     });
 
-    // ── network_request trust rule integration ──────────────────
-
-    test("network_request prompts without a matching rule (medium risk)", async () => {
-      const result = await check(
-        "network_request",
-        { url: "https://api.example.com/v1/data" },
-        "/tmp",
-      );
-      expect(result.decision).toBe("prompt");
-    });
-
-    test("network_request allow rule auto-approves matching origin", async () => {
-      addRule(
-        "network_request",
-        "network_request:https://api.example.com/*",
-        "/tmp",
-      );
-      const result = await check(
-        "network_request",
-        { url: "https://api.example.com/v1/data" },
-        "/tmp",
-      );
-      expect(result.decision).toBe("allow");
-    });
-
-    test("network_request allow rule does not match a different host", async () => {
-      addRule(
-        "network_request",
-        "network_request:https://api.example.com/*",
-        "/tmp",
-      );
-      const result = await check(
-        "network_request",
-        { url: "https://api.other.com/v1/data" },
-        "/tmp",
-      );
-      expect(result.decision).toBe("prompt");
-    });
-
-    test("network_request deny rule blocks matching urls", async () => {
-      addRule(
-        "network_request",
-        "network_request:https://api.example.com/secret/*",
-        "everywhere",
-        "deny",
-      );
-      const result = await check(
-        "network_request",
-        { url: "https://api.example.com/secret/key" },
-        "/tmp",
-      );
-      expect(result.decision).toBe("deny");
-    });
-
-    test("network_request rule is scoped to working directory", async () => {
-      addRule(
-        "network_request",
-        "network_request:https://api.example.com/*",
-        "/home/user/project",
-      );
-      const allowed = await check(
-        "network_request",
-        { url: "https://api.example.com/v1/data" },
-        "/home/user/project",
-      );
-      expect(allowed.decision).toBe("allow");
-      const notAllowed = await check(
-        "network_request",
-        { url: "https://api.example.com/v1/data" },
-        "/tmp/other",
-      );
-      expect(notAllowed.decision).toBe("prompt");
-    });
-
-    test("network_request rules do not cross-match web_fetch rules", async () => {
-      addRule("web_fetch", "web_fetch:https://api.example.com/*", "/tmp");
-      const result = await check(
-        "network_request",
-        { url: "https://api.example.com/v1/data" },
-        "/tmp",
-      );
-      expect(result.decision).toBe("prompt");
-    });
-
-    test("network_request normalizes scheme-less host:port urls for rule matching", async () => {
-      addRule(
-        "network_request",
-        "network_request:https://api.example.com:8443/*",
-        "everywhere",
-        "deny",
-      );
-      const result = await check(
-        "network_request",
-        { url: "api.example.com:8443/v1/data" },
-        "/tmp",
-      );
-      expect(result.decision).toBe("deny");
-    });
-
     // Priority-based rule resolution
     test("higher-priority allow rule overrides lower-priority deny rule", async () => {
       addRule("bash", "chmod *", "/tmp", "deny", 0);
@@ -1790,85 +1677,6 @@ describe("Permission Checker", () => {
       );
       expect(options[1].pattern).toBe("web_fetch:https://\\[2001:db8::1\\]/*");
       expect(options[2].pattern).toBe("**");
-    });
-
-    // ── network_request allowlist options ─────────────────────────
-
-    test("network_request: generates exact url, origin wildcard, and tool wildcard", async () => {
-      const options = await generateAllowlistOptions("network_request", {
-        url: "https://api.example.com/v1/data",
-      });
-      expect(options).toHaveLength(3);
-      expect(options[0].pattern).toBe(
-        "network_request:https://api.example.com/v1/data",
-      );
-      expect(options[1].pattern).toBe(
-        "network_request:https://api.example.com/*",
-      );
-      expect(options[2].pattern).toBe("**");
-      expect(options[2].label).toBe("network_request:*");
-      expect(options[2].description).toBe("All network requests");
-    });
-
-    test("network_request: origin wildcard uses friendly hostname", async () => {
-      const options = await generateAllowlistOptions("network_request", {
-        url: "https://www.example.com/path",
-      });
-      expect(options[1].description).toBe("Any page on example.com");
-    });
-
-    test("network_request: normalizes scheme-less host:port input", async () => {
-      const options = await generateAllowlistOptions("network_request", {
-        url: "api.example.com:8443/v1/data",
-      });
-      expect(options).toHaveLength(3);
-      expect(options[0].pattern).toBe(
-        "network_request:https://api.example.com:8443/v1/data",
-      );
-      expect(options[1].pattern).toBe(
-        "network_request:https://api.example.com:8443/*",
-      );
-      expect(options[2].pattern).toBe("**");
-    });
-
-    test("network_request: strips fragments and userinfo", async () => {
-      const username = "demo";
-      const credential = ["c", "r", "e", "d", "1", "2", "3"].join("");
-      const credentialedUrl = new URL(
-        "https://api.example.com/v1/data#section",
-      );
-      credentialedUrl.username = username;
-      credentialedUrl.password = credential;
-      const options = await generateAllowlistOptions("network_request", {
-        url: credentialedUrl.href,
-      });
-      expect(options).toHaveLength(3);
-      expect(options[0].pattern).toBe(
-        "network_request:https://api.example.com/v1/data",
-      );
-      expect(options[0].pattern).not.toContain("demo:cred123@");
-      expect(options[0].pattern).not.toContain("#section");
-    });
-
-    test("network_request: escapes minimatch metacharacters", async () => {
-      const options = await generateAllowlistOptions("network_request", {
-        url: "https://[2001:db8::1]/api?key=val",
-      });
-      expect(options).toHaveLength(3);
-      expect(options[0].pattern).toBe(
-        "network_request:https://\\[2001:db8::1\\]/api\\?key=val",
-      );
-      expect(options[1].pattern).toBe(
-        "network_request:https://\\[2001:db8::1\\]/*",
-      );
-    });
-
-    test("network_request: empty url produces only tool wildcard", async () => {
-      const options = await generateAllowlistOptions("network_request", {
-        url: "",
-      });
-      expect(options).toHaveLength(1);
-      expect(options[0].pattern).toBe("**");
     });
   });
 
@@ -4758,16 +4566,6 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
     );
     expect(result.decision).toBe("allow");
     expect(result.reason).toContain("Low risk");
-  });
-
-  test("network_request → prompt (Medium risk, not workspace-scoped)", async () => {
-    const result = await check(
-      "network_request",
-      { url: "https://api.example.com/data" },
-      workspaceDir,
-    );
-    expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("risk");
   });
 });
 

--- a/assistant/src/__tests__/guardian-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/guardian-control-plane-policy.test.ts
@@ -223,11 +223,11 @@ describe("isGuardianControlPlaneInvocation", () => {
     });
   });
 
-  describe("network_request tool with guardian endpoint in url", () => {
+  describe("web_fetch tool with guardian endpoint in url", () => {
     for (const path of guardianPaths) {
       test(`detects ${path}`, () => {
         expect(
-          isGuardianControlPlaneInvocation("network_request", {
+          isGuardianControlPlaneInvocation("web_fetch", {
             url: `https://api.vellum.ai${path}`,
           }),
         ).toBe(true);
@@ -236,7 +236,7 @@ describe("isGuardianControlPlaneInvocation", () => {
 
     test("detects proxied local URL", () => {
       expect(
-        isGuardianControlPlaneInvocation("network_request", {
+        isGuardianControlPlaneInvocation("web_fetch", {
           url: "http://127.0.0.1:3000/v1/integrations/guardian/challenge",
         }),
       ).toBe(true);
@@ -244,16 +244,14 @@ describe("isGuardianControlPlaneInvocation", () => {
 
     test("does not match unrelated URLs", () => {
       expect(
-        isGuardianControlPlaneInvocation("network_request", {
+        isGuardianControlPlaneInvocation("web_fetch", {
           url: "https://api.example.com/v1/messages",
         }),
       ).toBe(false);
     });
 
     test("handles missing url field gracefully", () => {
-      expect(isGuardianControlPlaneInvocation("network_request", {})).toBe(
-        false,
-      );
+      expect(isGuardianControlPlaneInvocation("web_fetch", {})).toBe(false);
     });
   });
 
@@ -315,7 +313,7 @@ describe("isGuardianControlPlaneInvocation", () => {
   describe("path matching covers proxied and local variants", () => {
     test("matches endpoint with query string", () => {
       expect(
-        isGuardianControlPlaneInvocation("network_request", {
+        isGuardianControlPlaneInvocation("web_fetch", {
           url: "https://api.example.com/v1/integrations/guardian/challenge?token=abc",
         }),
       ).toBe(true);
@@ -323,7 +321,7 @@ describe("isGuardianControlPlaneInvocation", () => {
 
     test("matches endpoint with trailing slash", () => {
       expect(
-        isGuardianControlPlaneInvocation("network_request", {
+        isGuardianControlPlaneInvocation("web_fetch", {
           url: "https://api.example.com/v1/integrations/guardian/outbound/start/",
         }),
       ).toBe(true);
@@ -351,7 +349,7 @@ describe("isGuardianControlPlaneInvocation", () => {
 
     test("detects double-encoded path (%252F encoding)", () => {
       expect(
-        isGuardianControlPlaneInvocation("network_request", {
+        isGuardianControlPlaneInvocation("web_fetch", {
           url: "http://localhost:3000/v1/integrations%252Fguardian%252Fchallenge",
         }),
       ).toBe(true);
@@ -368,7 +366,7 @@ describe("isGuardianControlPlaneInvocation", () => {
 
     test("detects triple slashes in path", () => {
       expect(
-        isGuardianControlPlaneInvocation("network_request", {
+        isGuardianControlPlaneInvocation("web_fetch", {
           url: "http://localhost:3000/v1///integrations///guardian///status",
         }),
       ).toBe(true);
@@ -385,7 +383,7 @@ describe("isGuardianControlPlaneInvocation", () => {
 
     test("detects ALL CAPS path", () => {
       expect(
-        isGuardianControlPlaneInvocation("network_request", {
+        isGuardianControlPlaneInvocation("web_fetch", {
           url: "http://localhost:3000/V1/INTEGRATIONS/GUARDIAN/CHALLENGE",
         }),
       ).toBe(true);
@@ -402,7 +400,7 @@ describe("isGuardianControlPlaneInvocation", () => {
 
     test("detects combined obfuscation: double slashes + URL-encoding", () => {
       expect(
-        isGuardianControlPlaneInvocation("network_request", {
+        isGuardianControlPlaneInvocation("web_fetch", {
           url: "http://localhost:3000/v1//integrations%2Fguardian%2Fstatus",
         }),
       ).toBe(true);
@@ -491,7 +489,7 @@ describe("isGuardianControlPlaneInvocation", () => {
       // URL tools pass structured URLs, not shell commands. The fragment detector
       // is bash/host_bash only. For URL tools, we rely on exact/normalized matching.
       expect(
-        isGuardianControlPlaneInvocation("network_request", {
+        isGuardianControlPlaneInvocation("web_fetch", {
           url: "https://api.example.com/v1/messages",
         }),
       ).toBe(false);
@@ -519,7 +517,7 @@ describe("enforceGuardianOnlyPolicy", () => {
 
   test("unverified_channel actor denied for guardian endpoint", () => {
     const result = enforceGuardianOnlyPolicy(
-      "network_request",
+      "web_fetch",
       {
         url: "https://api.example.com/v1/integrations/guardian/challenge",
       },
@@ -613,10 +611,10 @@ describe("ToolExecutor guardian-only policy gate", () => {
     expect(result.content).toContain("restricted to guardian users");
   });
 
-  test("unverified_channel actor blocked from network_request to guardian endpoint", async () => {
+  test("unverified_channel actor blocked from web_fetch to guardian endpoint", async () => {
     const executor = new ToolExecutor(makePrompter());
     const result = await executor.execute(
-      "network_request",
+      "web_fetch",
       { url: "https://api.example.com/v1/integrations/guardian/challenge" },
       makeContext({ trustClass: "unknown" }),
     );
@@ -730,7 +728,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
     expect(result.content).toContain("restricted to guardian users");
   });
 
-  test("all five guardian endpoints are blocked for non-guardian via network_request", async () => {
+  test("all five guardian endpoints are blocked for non-guardian via web_fetch", async () => {
     const endpoints = [
       "/v1/integrations/guardian/challenge",
       "/v1/integrations/guardian/status",
@@ -742,7 +740,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
     for (const path of endpoints) {
       const executor = new ToolExecutor(makePrompter());
       const result = await executor.execute(
-        "network_request",
+        "web_fetch",
         { url: `https://api.example.com${path}` },
         makeContext({ trustClass: "trusted_contact" }),
       );

--- a/assistant/src/__tests__/proxy-approval-callback.test.ts
+++ b/assistant/src/__tests__/proxy-approval-callback.test.ts
@@ -168,8 +168,8 @@ describe("createProxyApprovalCallback", () => {
   test("skips prompting and returns true when trust store has an allow rule (medium risk)", async () => {
     findHighestPriorityRuleMock.mockReturnValue({
       id: "rule-1",
-      tool: "network_request",
-      pattern: "network_request:https://example.com/*",
+      tool: "bash",
+      pattern: "proxied_origin:https%3A%2F%2Fexample.com",
       scope: "/tmp/test-project",
       decision: "allow" as const,
       priority: 100,
@@ -189,11 +189,44 @@ describe("createProxyApprovalCallback", () => {
     expect(prompterSendToClient).not.toHaveBeenCalled();
   });
 
+  test("ignores default broad bash allow rules and still prompts", async () => {
+    findHighestPriorityRuleMock.mockReturnValue({
+      id: "default:allow-bash-global",
+      tool: "bash",
+      pattern: "**",
+      scope: "everywhere",
+      decision: "allow" as const,
+      priority: 50,
+      createdAt: Date.now(),
+      allowHighRisk: true,
+    });
+
+    const ctx = makeContext();
+    const prompterSendToClient = mock(() => {});
+    const prompter = new PermissionPrompter(prompterSendToClient);
+
+    const originalPrompt = prompter.prompt.bind(prompter);
+    prompter.prompt = async (...args) => {
+      const p = originalPrompt(...args);
+      await new Promise((r) => setTimeout(r, 10));
+      const call = (prompterSendToClient.mock.calls as unknown[][])[0];
+      const msg = call[0] as { requestId: string };
+      prompter.resolveConfirmation(msg.requestId, "allow");
+      return p;
+    };
+
+    const callback = createProxyApprovalCallback(prompter, ctx);
+    const result = await callback(makeAskUnauthenticatedRequest());
+
+    expect(result).toBe(true);
+    expect(prompterSendToClient).toHaveBeenCalled();
+  });
+
   test("high-risk with plain allow rule (no allowHighRisk) falls through to prompt", async () => {
     findHighestPriorityRuleMock.mockReturnValue({
       id: "rule-hr-1",
-      tool: "network_request",
-      pattern: "network_request:https://api.fal.ai:443/*",
+      tool: "bash",
+      pattern: "proxied_origin:https%3A%2F%2Fapi.fal.ai",
       scope: "/tmp/test-project",
       decision: "allow" as const,
       priority: 100,
@@ -227,8 +260,8 @@ describe("createProxyApprovalCallback", () => {
   test("high-risk with allowHighRisk allow rule auto-allows without prompting", async () => {
     findHighestPriorityRuleMock.mockReturnValue({
       id: "rule-hr-2",
-      tool: "network_request",
-      pattern: "network_request:https://api.fal.ai:443/*",
+      tool: "bash",
+      pattern: "proxied_origin:https%3A%2F%2Fapi.fal.ai",
       scope: "/tmp/test-project",
       decision: "allow" as const,
       priority: 100,
@@ -251,8 +284,8 @@ describe("createProxyApprovalCallback", () => {
   test("skips prompting and returns false when trust store has a deny rule", async () => {
     findHighestPriorityRuleMock.mockReturnValue({
       id: "rule-2",
-      tool: "network_request",
-      pattern: "network_request:https://example.com/*",
+      tool: "bash",
+      pattern: "proxied_origin:https%3A%2F%2Fexample.com",
       scope: "/tmp/test-project",
       decision: "deny" as const,
       priority: 100,
@@ -286,8 +319,8 @@ describe("createProxyApprovalCallback", () => {
   test("prompts when trust store has an ask rule", async () => {
     findHighestPriorityRuleMock.mockReturnValue({
       id: "rule-3",
-      tool: "network_request",
-      pattern: "network_request:https://example.com/*",
+      tool: "bash",
+      pattern: "proxied_origin:https%3A%2F%2Fexample.com",
       scope: "/tmp/test-project",
       decision: "ask" as const,
       priority: 100,
@@ -330,7 +363,7 @@ describe("createProxyApprovalCallback", () => {
       prompter.resolveConfirmation(
         msg.requestId,
         "always_allow",
-        "network_request:https://api.fal.ai:443/*",
+        "proxied_origin:https%3A%2F%2Fapi.fal.ai",
         "/tmp/test-project",
       );
       return p;
@@ -341,8 +374,8 @@ describe("createProxyApprovalCallback", () => {
 
     expect(result).toBe(true);
     expect(addRuleMock).toHaveBeenCalledWith(
-      "network_request",
-      "network_request:https://api.fal.ai:443/*",
+      "bash",
+      "proxied_origin:https%3A%2F%2Fapi.fal.ai",
       "/tmp/test-project",
       "allow",
       100,
@@ -364,7 +397,7 @@ describe("createProxyApprovalCallback", () => {
       prompter.resolveConfirmation(
         msg.requestId,
         "always_deny",
-        "network_request:https://example.com/*",
+        "proxied_origin:https%3A%2F%2Fexample.com",
         "everywhere",
       );
       return p;
@@ -375,8 +408,8 @@ describe("createProxyApprovalCallback", () => {
 
     expect(result).toBe(false);
     expect(addRuleMock).toHaveBeenCalledWith(
-      "network_request",
-      "network_request:https://example.com/*",
+      "bash",
+      "proxied_origin:https%3A%2F%2Fexample.com",
       "everywhere",
       "deny",
     );
@@ -397,9 +430,14 @@ describe("createProxyApprovalCallback", () => {
         toolName: string;
         input: Record<string, unknown>;
       };
-      // Verify the confirmation request uses the network_request tool name
-      expect(msg.toolName).toBe("network_request");
+      // Verify the confirmation request uses the bash tool name
+      expect(msg.toolName).toBe("bash");
       expect(msg.input).toHaveProperty("url", "https://api.fal.ai:443/v1/run");
+      expect(msg.input).toHaveProperty("network_mode", "proxied");
+      expect(msg.input).toHaveProperty(
+        "command",
+        "curl https://api.fal.ai:443/v1/run",
+      );
       expect(msg.input).toHaveProperty("matching_patterns", ["*.fal.ai"]);
       prompter.resolveConfirmation(msg.requestId, "allow");
       return p;
@@ -425,8 +463,9 @@ describe("createProxyApprovalCallback", () => {
         input: Record<string, unknown>;
         riskLevel: string;
       };
-      expect(msg.toolName).toBe("network_request");
+      expect(msg.toolName).toBe("bash");
       expect(msg.input).toHaveProperty("url", "https://example.com/data");
+      expect(msg.input).toHaveProperty("network_mode", "proxied");
       expect(msg.riskLevel).toBe("medium");
       prompter.resolveConfirmation(msg.requestId, "deny");
       return p;
@@ -457,7 +496,7 @@ describe("createProxyApprovalCallback", () => {
     await callback(makeAskMissingCredentialRequest());
   });
 
-  test("generates URL-based allowlist options via generateAllowlistOptions", async () => {
+  test("generates URL-based proxied bash allowlist options", async () => {
     const ctx = makeContext();
     const prompterSendToClient = mock(() => {});
     const prompter = new PermissionPrompter(prompterSendToClient);
@@ -471,16 +510,14 @@ describe("createProxyApprovalCallback", () => {
         requestId: string;
         allowlistOptions: Array<{ label: string; pattern: string }>;
       };
-      // The checker's generateAllowlistOptions for network_request produces
-      // URL-based options: exact URL, origin wildcard, and tool wildcard
+      // Proxied bash options include encoded exact URL, encoded origin, and
+      // a proxied-url wildcard.
       const patterns = msg.allowlistOptions.map((o) => o.pattern);
-      // Should include an origin-level wildcard pattern (port 443 is normalized
-      // away by the URL constructor since it's the default HTTPS port)
-      expect(patterns.some((p) => p.includes("https://api.fal.ai/*"))).toBe(
-        true,
+      expect(patterns).toContain(
+        "proxied_url:https%3A%2F%2Fapi.fal.ai%2Fv1%2Frun",
       );
-      // Should include the catch-all globstar wildcard
-      expect(patterns).toContain("**");
+      expect(patterns).toContain("proxied_origin:https%3A%2F%2Fapi.fal.ai");
+      expect(patterns).toContain("proxied_url:*");
       prompter.resolveConfirmation(msg.requestId, "allow");
       return p;
     };
@@ -505,9 +542,7 @@ describe("createProxyApprovalCallback", () => {
       };
       // Port is null — URL should be https://example.com/data (no port)
       const patterns = msg.allowlistOptions.map((o) => o.pattern);
-      expect(patterns.some((p) => p.includes("https://example.com/*"))).toBe(
-        true,
-      );
+      expect(patterns).toContain("proxied_origin:https%3A%2F%2Fexample.com");
       // Should NOT include ":null" in any pattern
       expect(patterns.every((p) => !p.includes(":null"))).toBe(true);
       prompter.resolveConfirmation(msg.requestId, "deny");
@@ -519,9 +554,8 @@ describe("createProxyApprovalCallback", () => {
   });
 
   // ── E2E persistence invariants (PR 32) ──────────────────────────────
-  // These tests verify the proxy approval path CAN save persistent rules,
-  // in contrast to the proxied bash activation path which CANNOT (tested
-  // in tool-executor.test.ts).
+  // These tests verify the proxy approval callback persists proxy-scoped
+  // destination rules when the user chooses an always_* decision.
 
   test("always_allow_high_risk persists rule with allowHighRisk flag", async () => {
     const ctx = makeContext();
@@ -537,7 +571,7 @@ describe("createProxyApprovalCallback", () => {
       prompter.resolveConfirmation(
         msg.requestId,
         "always_allow_high_risk",
-        "network_request:https://api.fal.ai:443/*",
+        "proxied_origin:https%3A%2F%2Fapi.fal.ai",
         "/tmp/test-project",
       );
       return p;
@@ -548,8 +582,8 @@ describe("createProxyApprovalCallback", () => {
 
     expect(result).toBe(true);
     expect(addRuleMock).toHaveBeenCalledWith(
-      "network_request",
-      "network_request:https://api.fal.ai:443/*",
+      "bash",
+      "proxied_origin:https%3A%2F%2Fapi.fal.ai",
       "/tmp/test-project",
       "allow",
       100,
@@ -626,8 +660,8 @@ describe("createProxyApprovalCallback", () => {
     expect(addRuleMock).not.toHaveBeenCalled();
   });
 
-  test("trust store candidates include URL-based patterns for network_request", async () => {
-    // Verify that findHighestPriorityRule is called with network_request
+  test("trust store candidates include encoded proxied URL patterns for bash", async () => {
+    // Verify that findHighestPriorityRule is called with bash
     // tool name and URL-based candidates
     findHighestPriorityRuleMock.mockReturnValue(null);
 
@@ -648,18 +682,18 @@ describe("createProxyApprovalCallback", () => {
     const callback = createProxyApprovalCallback(prompter, ctx);
     await callback(makeAskMissingCredentialRequest());
 
-    // Verify findHighestPriorityRule was called with network_request
+    // Verify findHighestPriorityRule was called with bash
     // and URL-based candidates
     expect(findHighestPriorityRuleMock).toHaveBeenCalledTimes(1);
     const [toolArg, candidatesArg] = findHighestPriorityRuleMock.mock
       .calls[0] as unknown as [string, string[], string];
-    expect(toolArg).toBe("network_request");
-    // Candidates should include URL-based patterns
+    expect(toolArg).toBe("bash");
+    // Candidates should include encoded URL-based proxy patterns.
     expect(
       candidatesArg.some((c: string) =>
-        c.startsWith("network_request:https://api.fal.ai"),
+        c.startsWith("proxied_url:https%3A%2F%2Fapi.fal.ai"),
       ),
     ).toBe(true);
-    expect(candidatesArg).toContain("network_request:*");
+    expect(candidatesArg).toContain("proxied_origin:https%3A%2F%2Fapi.fal.ai");
   });
 });

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1840,91 +1840,54 @@ describe("Trust Store", () => {
     });
   });
 
-  // ── network_request trust rule matching ────────────────────────
+  // ── proxied bash URL trust rule matching ────────────────────────
 
-  describe("network_request trust rules", () => {
-    test("exact origin rule matches network_request candidates", () => {
-      addRule(
-        "network_request",
-        "network_request:https://api.example.com/*",
-        "everywhere",
-      );
+  describe("proxied bash URL trust rules", () => {
+    const encodedOrigin = "https%3A%2F%2Fapi.example.com";
+    const encodedExact = "https%3A%2F%2Fapi.example.com%2Fv1%2Fdata";
+
+    test("origin rule matches proxied origin candidates", () => {
+      addRule("bash", `proxied_origin:${encodedOrigin}`, "everywhere");
       const rule = findHighestPriorityRule(
-        "network_request",
-        [
-          "network_request:https://api.example.com/v1/data",
-          "network_request:https://api.example.com/*",
-        ],
+        "bash",
+        [`proxied_url:${encodedExact}`, `proxied_origin:${encodedOrigin}`],
         "/tmp",
       );
       expect(rule).not.toBeNull();
       expect(rule!.decision).toBe("allow");
     });
 
-    test("exact url rule matches only that url candidate", () => {
-      addRule(
-        "network_request",
-        "network_request:https://api.example.com/v1/data",
-        "everywhere",
-      );
+    test("exact url rule matches only that proxied url candidate", () => {
+      addRule("bash", `proxied_url:${encodedExact}`, "everywhere");
       const match = findHighestPriorityRule(
-        "network_request",
-        [
-          "network_request:https://api.example.com/v1/data",
-          "network_request:https://api.example.com/*",
-        ],
+        "bash",
+        [`proxied_url:${encodedExact}`, `proxied_origin:${encodedOrigin}`],
         "/tmp",
       );
       expect(match).not.toBeNull();
 
       const noMatch = findHighestPriorityRule(
-        "network_request",
-        ["network_request:https://api.example.com/v2/other"],
+        "bash",
+        ["proxied_url:https%3A%2F%2Fapi.example.com%2Fv2%2Fother"],
         "/tmp",
       );
-      expect(noMatch).toBeNull();
+      expect(
+        noMatch == null || noMatch.pattern !== `proxied_url:${encodedExact}`,
+      ).toBe(true);
     });
 
-    test("globstar rule matches any network_request candidate", () => {
-      // minimatch treats standalone "**" as globstar (matching "/"), but
-      // "network_request:*" uses single "*" which doesn't cross slashes.
-      // The tool field is already filtered by findHighestPriorityRule, so
-      // "**" is the correct catch-all pattern.
-      addRule("network_request", "**", "everywhere");
+    test("single-star wildcard matches any encoded proxied URL candidate", () => {
+      addRule("bash", "proxied_url:*", "everywhere");
       const rule = findHighestPriorityRule(
-        "network_request",
-        ["network_request:https://any-host.example.org/path"],
+        "bash",
+        ["proxied_url:https%3A%2F%2Fany-host.example.org%2Fpath"],
         "/tmp",
       );
       expect(rule).not.toBeNull();
     });
 
-    test("single-star wildcard matches flat candidates only", () => {
-      // "network_request:*" won't match URLs with slashes — consistent
-      // with the behavior of web_fetch:* and browser_navigate:* patterns.
-      addRule("network_request", "network_request:*", "everywhere");
-      const noSlashMatch = findHighestPriorityRule(
-        "network_request",
-        ["network_request:flat-target"],
-        "/tmp",
-      );
-      expect(noSlashMatch).not.toBeNull();
-
-      const slashNoMatch = findHighestPriorityRule(
-        "network_request",
-        ["network_request:https://example.com/path"],
-        "/tmp",
-      );
-      // Single "*" does not match "/" so this URL candidate won't match.
-      expect(slashNoMatch).toBeNull();
-    });
-
-    test("network_request rule does not match web_fetch tool", () => {
-      addRule(
-        "network_request",
-        "network_request:https://api.example.com/*",
-        "everywhere",
-      );
+    test("proxied bash URL rule does not match web_fetch tool", () => {
+      addRule("bash", `proxied_origin:${encodedOrigin}`, "everywhere");
       const rule = findHighestPriorityRule(
         "web_fetch",
         [
@@ -1936,40 +1899,24 @@ describe("Trust Store", () => {
       expect(rule).toBeNull();
     });
 
-    test("web_fetch rule does not match network_request tool", () => {
+    test("web_fetch rule does not match proxied bash URL candidates", () => {
       addRule("web_fetch", "web_fetch:https://api.example.com/*", "everywhere");
       const rule = findHighestPriorityRule(
-        "network_request",
-        [
-          "network_request:https://api.example.com/v1/data",
-          "network_request:https://api.example.com/*",
-        ],
+        "bash",
+        [`proxied_url:${encodedExact}`, `proxied_origin:${encodedOrigin}`],
         "/tmp",
       );
-      expect(rule).toBeNull();
+      expect(
+        rule == null || rule.pattern !== "web_fetch:https://api.example.com/*",
+      ).toBe(true);
     });
 
     test("deny rule takes precedence over allow at same priority", () => {
-      addRule(
-        "network_request",
-        "network_request:https://api.example.com/*",
-        "everywhere",
-        "allow",
-        100,
-      );
-      addRule(
-        "network_request",
-        "network_request:https://api.example.com/*",
-        "everywhere",
-        "deny",
-        100,
-      );
+      addRule("bash", `proxied_origin:${encodedOrigin}`, "everywhere", "allow");
+      addRule("bash", `proxied_origin:${encodedOrigin}`, "everywhere", "deny");
       const rule = findHighestPriorityRule(
-        "network_request",
-        [
-          "network_request:https://api.example.com/v1/data",
-          "network_request:https://api.example.com/*",
-        ],
+        "bash",
+        [`proxied_url:${encodedExact}`, `proxied_origin:${encodedOrigin}`],
         "/tmp",
       );
       expect(rule).not.toBeNull();
@@ -1978,50 +1925,46 @@ describe("Trust Store", () => {
 
     test("higher-priority allow overrides lower-priority deny", () => {
       addRule(
-        "network_request",
-        "network_request:https://api.example.com/*",
+        "bash",
+        `proxied_origin:${encodedOrigin}`,
         "everywhere",
         "deny",
         50,
       );
       addRule(
-        "network_request",
-        "network_request:https://api.example.com/*",
+        "bash",
+        `proxied_origin:${encodedOrigin}`,
         "everywhere",
         "allow",
         100,
       );
       const rule = findHighestPriorityRule(
-        "network_request",
-        [
-          "network_request:https://api.example.com/v1/data",
-          "network_request:https://api.example.com/*",
-        ],
+        "bash",
+        [`proxied_url:${encodedExact}`, `proxied_origin:${encodedOrigin}`],
         "/tmp",
       );
       expect(rule).not.toBeNull();
       expect(rule!.decision).toBe("allow");
     });
 
-    test("scope restricts network_request rule matching", () => {
-      addRule(
-        "network_request",
-        "network_request:https://api.example.com/*",
-        "/home/user/project",
-      );
+    test("scope restricts proxied bash URL rule matching", () => {
+      addRule("bash", `proxied_origin:${encodedOrigin}`, "/home/user/project");
       const inScope = findHighestPriorityRule(
-        "network_request",
-        ["network_request:https://api.example.com/*"],
+        "bash",
+        [`proxied_origin:${encodedOrigin}`],
         "/home/user/project",
       );
       expect(inScope).not.toBeNull();
 
       const outOfScope = findHighestPriorityRule(
-        "network_request",
-        ["network_request:https://api.example.com/*"],
+        "bash",
+        [`proxied_origin:${encodedOrigin}`],
         "/tmp/other",
       );
-      expect(outOfScope).toBeNull();
+      expect(
+        outOfScope == null ||
+          outOfScope.pattern !== `proxied_origin:${encodedOrigin}`,
+      ).toBe(true);
     });
   });
 });

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -729,8 +729,12 @@ describe("voice-session-bridge", () => {
         clientHandler({
           type: "confirmation_request",
           requestId: "req-voice-2",
-          toolName: "network_request",
-          input: { url: "https://evil.com" },
+          toolName: "bash",
+          input: {
+            command: "curl https://evil.com",
+            url: "https://evil.com",
+            network_mode: "proxied",
+          },
           riskLevel: "medium",
           allowlistOptions: [],
           scopeOptions: [],

--- a/assistant/src/__tests__/workspace-policy.test.ts
+++ b/assistant/src/__tests__/workspace-policy.test.ts
@@ -221,7 +221,6 @@ describe("isWorkspaceScopedInvocation", () => {
       "browser_scroll",
       "browser_screenshot",
       "browser_close",
-      "network_request",
     ];
 
     for (const tool of networkTools) {

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -180,7 +180,7 @@ const pendingInteractionResolver: GuardianRequestResolver = {
         details.allowlistOptions?.length
       ) {
         const pattern = details.allowlistOptions[0].pattern;
-        // Non-scoped tools (web_fetch, network_request, etc.) have empty
+        // Non-scoped tools (web_fetch, browser_navigate, etc.) have empty
         // scopeOptions — default to 'everywhere' so approve_always still
         // persists a trust rule instead of silently degrading to one-time.
         const scope = details.scopeOptions?.length

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -9,7 +9,6 @@
 import { isHttpAuthDisabled } from "../config/env.js";
 import { getBindingByConversation } from "../memory/external-conversation-store.js";
 import {
-  generateAllowlistOptions,
   generateScopeOptions,
   normalizeWebFetchUrl,
 } from "../permissions/checker.js";
@@ -19,7 +18,7 @@ import {
   addRule,
   findHighestPriorityRule,
 } from "../permissions/trust-store.js";
-import { isAllowDecision } from "../permissions/types.js";
+import { type AllowlistOption, isAllowDecision } from "../permissions/types.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import { getEffectiveMode } from "../runtime/session-approval-overrides.js";
@@ -321,6 +320,88 @@ export function createToolExecutor(
 
 // ── createProxyApprovalCallback ──────────────────────────────────────
 
+const PROXIED_BASH_URL_PREFIX = "proxied_url:";
+const PROXIED_BASH_ORIGIN_PREFIX = "proxied_origin:";
+
+function encodeProxyRuleValue(value: string): string {
+  // Encode URL values so wildcard patterns (e.g. `proxied_url:*`) don't trip
+  // over minimatch "/" segment semantics.
+  return encodeURIComponent(value);
+}
+
+function buildProxiedBashUrlCandidates(url: string): string[] {
+  const rawUrl = url.trim();
+  const candidates: string[] = [];
+
+  if (rawUrl) {
+    candidates.push(
+      `${PROXIED_BASH_URL_PREFIX}${encodeProxyRuleValue(rawUrl)}`,
+    );
+  }
+
+  const normalized = normalizeWebFetchUrl(rawUrl);
+  if (normalized) {
+    candidates.push(
+      `${PROXIED_BASH_URL_PREFIX}${encodeProxyRuleValue(normalized.href)}`,
+    );
+    candidates.push(
+      `${PROXIED_BASH_ORIGIN_PREFIX}${encodeProxyRuleValue(normalized.origin)}`,
+    );
+  }
+
+  if (candidates.length === 0) {
+    candidates.push(PROXIED_BASH_URL_PREFIX);
+  }
+
+  return [...new Set(candidates)];
+}
+
+function buildProxiedBashAllowlistOptions(url: string): AllowlistOption[] {
+  const rawUrl = url.trim();
+  const normalized = normalizeWebFetchUrl(rawUrl);
+  const exact = normalized?.href ?? rawUrl;
+  const options: AllowlistOption[] = [];
+
+  if (exact) {
+    options.push({
+      label: exact,
+      description: "This exact URL",
+      pattern: `${PROXIED_BASH_URL_PREFIX}${encodeProxyRuleValue(exact)}`,
+    });
+  }
+
+  if (normalized) {
+    const host = normalized.hostname.replace(/^www\./, "");
+    options.push({
+      label: `${normalized.origin}/*`,
+      description: `Any page on ${host}`,
+      pattern: `${PROXIED_BASH_ORIGIN_PREFIX}${encodeProxyRuleValue(
+        normalized.origin,
+      )}`,
+    });
+  }
+
+  options.push({
+    label: `${PROXIED_BASH_URL_PREFIX}*`,
+    description: "All proxied network requests",
+    pattern: `${PROXIED_BASH_URL_PREFIX}*`,
+  });
+
+  const seen = new Set<string>();
+  return options.filter((option) => {
+    if (seen.has(option.pattern)) return false;
+    seen.add(option.pattern);
+    return true;
+  });
+}
+
+function isProxyScopedBashPattern(pattern: string): boolean {
+  return (
+    pattern.startsWith(PROXIED_BASH_URL_PREFIX) ||
+    pattern.startsWith(PROXIED_BASH_ORIGIN_PREFIX)
+  );
+}
+
 /**
  * Build a proxy approval callback that routes `ask_missing_credential` and
  * `ask_unauthenticated` policy decisions through the existing permission
@@ -335,13 +416,15 @@ export function createProxyApprovalCallback(
     const { decision } = request;
     const { hostname, port, path } = decision.target;
 
-    // Use the standard network_request tool name so trust rules align with
-    // the checker's URL-based candidate generation and allowlist options.
-    const toolName = "network_request";
+    // Route proxy network approvals through bash so there is no separate
+    // direct network tool path.
+    const toolName = "bash";
     const { scheme } = decision.target;
     const url = `${scheme}://${hostname}${port ? ":" + port : ""}${path}`;
 
     const input: Record<string, unknown> = {
+      command: `curl ${url}`,
+      network_mode: "proxied",
       url,
       proxy_session_id: request.sessionId,
     };
@@ -352,23 +435,26 @@ export function createProxyApprovalCallback(
     const riskLevel =
       decision.kind === "ask_missing_credential" ? "high" : "medium";
 
-    // Check trust store before prompting — build candidates that mirror
-    // buildCommandCandidates() in checker.ts for network_request.
-    const candidates: string[] = [`${toolName}:${url}`];
-    const normalized = normalizeWebFetchUrl(url);
-    if (normalized) {
-      candidates.push(`${toolName}:${normalized.href}`);
-      candidates.push(`${toolName}:${normalized.origin}/*`);
-    }
-    candidates.push(`${toolName}:*`);
-    // Deduplicate
-    const uniqueCandidates = [...new Set(candidates)];
+    // Proxied network approvals use URL-scoped bash candidates so persisted
+    // rules cannot accidentally match unrelated shell commands.
+    const uniqueCandidates = buildProxiedBashUrlCandidates(url);
 
-    const existingRule = findHighestPriorityRule(
+    const matchedRule = findHighestPriorityRule(
       toolName,
       uniqueCandidates,
       ctx.workingDir,
     );
+    // Ignore default broad bash allow rules here; proxied network requests
+    // require explicit proxy-scoped rules instead of inheriting generic shell
+    // permissions.
+    const existingRule =
+      matchedRule &&
+      matchedRule.decision === "allow" &&
+      matchedRule.id.startsWith("default:") &&
+      !isProxyScopedBashPattern(matchedRule.pattern)
+        ? null
+        : matchedRule;
+
     if (existingRule && existingRule.decision !== "ask") {
       if (existingRule.decision === "deny") return false;
       // For high-risk proxy decisions, a plain allow rule (without allowHighRisk)
@@ -377,10 +463,7 @@ export function createProxyApprovalCallback(
         return true;
     }
 
-    // Use the checker's built-in allowlist generation for network_request
-    const allowlistOptions = await generateAllowlistOptions("network_request", {
-      url,
-    });
+    const allowlistOptions = buildProxiedBashAllowlistOptions(url);
 
     const scopeOptions = generateScopeOptions(ctx.workingDir);
 

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -388,11 +388,7 @@ async function buildCommandCandidates(
     return [`${toolName}:${skillId}`];
   }
 
-  if (
-    toolName === "web_fetch" ||
-    toolName === "browser_navigate" ||
-    toolName === "network_request"
-  ) {
+  if (toolName === "web_fetch" || toolName === "browser_navigate") {
     const rawUrl = getStringField(input, "url").trim();
     const candidates: string[] = [];
 
@@ -542,9 +538,6 @@ async function classifyRiskUncached(
   }
   // All other browser tools are low risk — the browser is sandboxed and user-visible.
   if (toolName.startsWith("browser_")) return RiskLevel.Low;
-  // Proxy-authenticated network requests are Medium risk — they carry injected
-  // credentials and the user should approve the target host/origin.
-  if (toolName === "network_request") return RiskLevel.Medium;
   if (toolName === "skill_load") return RiskLevel.Low;
 
   // Escalate host file mutations targeting skill source paths to High risk.
@@ -856,7 +849,6 @@ const TOOL_DISPLAY_NAMES: Record<string, string> = {
   host_file_edit: "host file edits",
   web_fetch: "URL fetches",
   browser_navigate: "browser navigations",
-  network_request: "network requests",
 };
 
 function friendlyBasename(filePath: string): string {
@@ -1040,7 +1032,6 @@ const ALLOWLIST_STRATEGIES: Record<string, AllowlistStrategy> = {
   host_file_edit: fileAllowlistStrategy,
   web_fetch: urlAllowlistStrategy,
   browser_navigate: urlAllowlistStrategy,
-  network_request: urlAllowlistStrategy,
   scaffold_managed_skill: managedSkillAllowlistStrategy,
   delete_managed_skill: managedSkillAllowlistStrategy,
   skill_load: skillLoadAllowlistStrategy,

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -65,7 +65,6 @@ const NETWORK_TOOLS = new Set([
   "browser_hover",
   "browser_screenshot",
   "browser_close",
-  "network_request",
 ]);
 
 /** Host-level tools — operate outside the sandbox, never workspace-scoped. */

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -194,7 +194,7 @@ export function handleChannelDecision(
       details.allowlistOptions?.length
     ) {
       const pattern = details.allowlistOptions[0].pattern;
-      // Non-scoped tools (web_fetch, network_request, etc.) have empty
+      // Non-scoped tools (web_fetch, browser_navigate, etc.) have empty
       // scopeOptions — default to 'everywhere' so approve_always still
       // persists a trust rule instead of silently degrading to one-time.
       const scope = details.scopeOptions?.length

--- a/assistant/src/tools/guardian-control-plane-policy.ts
+++ b/assistant/src/tools/guardian-control-plane-policy.ts
@@ -30,7 +30,7 @@ const GUARDIAN_PATH_REGEX = /\/v1\/integrations\/guardian\//;
 const COMMAND_TOOLS = new Set(["bash", "host_bash"]);
 
 /** Tools whose `input.url` (string) may contain guardian endpoint paths. */
-const URL_TOOLS = new Set(["network_request", "web_fetch", "browser_navigate"]);
+const URL_TOOLS = new Set(["web_fetch", "browser_navigate"]);
 
 /**
  * Normalize a string to defeat common URL obfuscation techniques before matching:


### PR DESCRIPTION
## Summary
- remove all code-path references to the deprecated `network_request` tool
- route proxy approval callback prompts through `bash` with `network_mode: "proxied"`
- persist proxy destination approvals as proxy-scoped bash patterns (`proxied_url:<encoded-url>`, `proxied_origin:<encoded-origin>`) and ignore default broad bash allow rules for this callback path
- update permissions, guardian policy wiring, tests, and architecture docs to reflect the new model

## Validation
- `cd assistant && bunx tsc --noEmit`
- `cd assistant && bun test src/__tests__/proxy-approval-callback.test.ts`
- `cd assistant && bun test src/__tests__/checker.test.ts src/__tests__/workspace-policy.test.ts src/__tests__/guardian-control-plane-policy.test.ts src/__tests__/voice-session-bridge.test.ts`
- `cd assistant && bun test src/__tests__/trust-store.test.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
