### PR TITLE
M2: Implement Qdrant isolation model for multiple local assistants

### DIFF
--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -163,6 +163,10 @@ export function getQdrantUrlEnv(): string | undefined {
   return str("QDRANT_URL");
 }
 
+export function getQdrantHttpPortEnv(): number | undefined {
+  return int("QDRANT_HTTP_PORT");
+}
+
 // ── Ollama ───────────────────────────────────────────────────────────────────
 
 export function getOllamaBaseUrlEnv(): string | undefined {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -11,6 +11,7 @@ import { TwilioConversationRelayProvider } from "../calls/twilio-provider.js";
 import { setVoiceBridgeDeps } from "../calls/voice-session-bridge.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import {
+  getQdrantHttpPortEnv,
   getQdrantUrlEnv,
   getRuntimeHttpHost,
   getRuntimeHttpPort,
@@ -281,7 +282,13 @@ export async function runDaemon(): Promise<void> {
     log.info("Daemon startup: DaemonServer started");
 
     // Initialize Qdrant vector store — non-fatal so the daemon stays up without it
-    const qdrantUrl = getQdrantUrlEnv() || config.memory.qdrant.url;
+    // Prefer QDRANT_HTTP_PORT (locally-spawned Qdrant on a specific port) over
+    // QDRANT_URL (external Qdrant instance) so the CLI can set the port without
+    // triggering QdrantManager's external mode which skips local process spawn.
+    const qdrantHttpPort = getQdrantHttpPortEnv();
+    const qdrantUrl = qdrantHttpPort
+      ? `http://127.0.0.1:${qdrantHttpPort}`
+      : getQdrantUrlEnv() || config.memory.qdrant.url;
     log.info({ qdrantUrl }, "Daemon startup: initializing Qdrant");
     const qdrantManager = new QdrantManager({ url: qdrantUrl });
     try {

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -233,6 +233,7 @@ async function startDaemonFromSource(
     env.RUNTIME_HTTP_PORT = String(resources.daemonPort);
     env.VELLUM_DAEMON_SOCKET = resources.socketPath;
     env.QDRANT_HTTP_PORT = String(resources.qdrantPort);
+    delete env.QDRANT_URL;
   }
 
   // Use fd inheritance instead of pipes so the daemon's stdout/stderr survive
@@ -321,6 +322,7 @@ async function startDaemonWatchFromSource(
     env.RUNTIME_HTTP_PORT = String(resources.daemonPort);
     env.VELLUM_DAEMON_SOCKET = resources.socketPath;
     env.QDRANT_HTTP_PORT = String(resources.qdrantPort);
+    delete env.QDRANT_URL;
   }
 
   const daemonLogFd = openLogFile("hatch.log");
@@ -711,6 +713,7 @@ export async function startLocalDaemon(
         daemonEnv.RUNTIME_HTTP_PORT = String(resources.daemonPort);
         daemonEnv.VELLUM_DAEMON_SOCKET = resources.socketPath;
         daemonEnv.QDRANT_HTTP_PORT = String(resources.qdrantPort);
+        delete daemonEnv.QDRANT_URL;
       }
 
       const daemonLogFd = openLogFile("hatch.log");

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -232,7 +232,7 @@ async function startDaemonFromSource(
     env.BASE_DATA_DIR = resources.instanceDir;
     env.RUNTIME_HTTP_PORT = String(resources.daemonPort);
     env.VELLUM_DAEMON_SOCKET = resources.socketPath;
-    env.QDRANT_URL = `http://127.0.0.1:${resources.qdrantPort}`;
+    env.QDRANT_HTTP_PORT = String(resources.qdrantPort);
   }
 
   // Use fd inheritance instead of pipes so the daemon's stdout/stderr survive
@@ -320,7 +320,7 @@ async function startDaemonWatchFromSource(
     env.BASE_DATA_DIR = resources.instanceDir;
     env.RUNTIME_HTTP_PORT = String(resources.daemonPort);
     env.VELLUM_DAEMON_SOCKET = resources.socketPath;
-    env.QDRANT_URL = `http://127.0.0.1:${resources.qdrantPort}`;
+    env.QDRANT_HTTP_PORT = String(resources.qdrantPort);
   }
 
   const daemonLogFd = openLogFile("hatch.log");
@@ -688,6 +688,7 @@ export async function startLocalDaemon(
       for (const key of [
         "ANTHROPIC_API_KEY",
         "BASE_DATA_DIR",
+        "QDRANT_HTTP_PORT",
         "QDRANT_URL",
         "RUNTIME_HTTP_PORT",
         "VELLUM_DAEMON_TCP_PORT",
@@ -709,7 +710,7 @@ export async function startLocalDaemon(
         daemonEnv.BASE_DATA_DIR = resources.instanceDir;
         daemonEnv.RUNTIME_HTTP_PORT = String(resources.daemonPort);
         daemonEnv.VELLUM_DAEMON_SOCKET = resources.socketPath;
-        daemonEnv.QDRANT_URL = `http://127.0.0.1:${resources.qdrantPort}`;
+        daemonEnv.QDRANT_HTTP_PORT = String(resources.qdrantPort);
       }
 
       const daemonLogFd = openLogFile("hatch.log");

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -232,6 +232,7 @@ async function startDaemonFromSource(
     env.BASE_DATA_DIR = resources.instanceDir;
     env.RUNTIME_HTTP_PORT = String(resources.daemonPort);
     env.VELLUM_DAEMON_SOCKET = resources.socketPath;
+    env.QDRANT_URL = `http://127.0.0.1:${resources.qdrantPort}`;
   }
 
   // Use fd inheritance instead of pipes so the daemon's stdout/stderr survive
@@ -319,6 +320,7 @@ async function startDaemonWatchFromSource(
     env.BASE_DATA_DIR = resources.instanceDir;
     env.RUNTIME_HTTP_PORT = String(resources.daemonPort);
     env.VELLUM_DAEMON_SOCKET = resources.socketPath;
+    env.QDRANT_URL = `http://127.0.0.1:${resources.qdrantPort}`;
   }
 
   const daemonLogFd = openLogFile("hatch.log");
@@ -686,6 +688,7 @@ export async function startLocalDaemon(
       for (const key of [
         "ANTHROPIC_API_KEY",
         "BASE_DATA_DIR",
+        "QDRANT_URL",
         "RUNTIME_HTTP_PORT",
         "VELLUM_DAEMON_TCP_PORT",
         "VELLUM_DAEMON_TCP_HOST",
@@ -706,6 +709,7 @@ export async function startLocalDaemon(
         daemonEnv.BASE_DATA_DIR = resources.instanceDir;
         daemonEnv.RUNTIME_HTTP_PORT = String(resources.daemonPort);
         daemonEnv.VELLUM_DAEMON_SOCKET = resources.socketPath;
+        daemonEnv.QDRANT_URL = `http://127.0.0.1:${resources.qdrantPort}`;
       }
 
       const daemonLogFd = openLogFile("hatch.log");


### PR DESCRIPTION
Part of #12604. Passes QDRANT_URL env var with the instance-specific Qdrant port to all daemon spawn paths, ensuring each local assistant instance binds Qdrant to its allocated port. Qdrant data/binary isolation was already handled by BASE_DATA_DIR. Closes #12606.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
