### PR TITLE
fix: remove unused scrollPositionId that caused scroll crashes

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -104,9 +104,6 @@ struct MessageListView: View {
     /// regardless of whether messages.count changes. This covers the edge
     /// case where pagination stalls without adding/removing messages.
     @State private var anchorTimeoutTask: Task<Void, Never>?
-    /// Tracks the top-visible item so SwiftUI can stabilize the viewport
-    /// when content height changes above it during LazyVStack re-layouts.
-    @State private var scrollPositionId: AnyHashable?
 
     /// The subset of messages actually shown, honoring the pagination window.
     private var visibleMessages: [ChatMessage] {
@@ -495,7 +492,6 @@ struct MessageListView: View {
             }
             .scrollContentBackground(.hidden)
             .coordinateSpace(name: "chatScrollView")
-            .scrollPosition(id: $scrollPositionId, anchor: .top)
             .scrollDisabled(messages.isEmpty && !isSending)
             .onHover { hovering in
                 handleThreadContentHover(hovering)


### PR DESCRIPTION
## Summary
- Remove unused `scrollPositionId` state variable and `.scrollPosition(id:anchor:)` modifier from `MessageListView`
- This was added in a recent commit to stabilize viewport during LazyVStack re-layouts, but was never wired up — it stayed `nil` indefinitely
- SwiftUI's `.scrollPosition` with a perpetually-nil binding caused crashes during content re-layouts (pagination, streaming, viewport resize)

## Test plan
- [ ] Scroll through long message threads without crashes
- [ ] Verify pagination (loading older messages) works correctly
- [ ] Verify auto-scroll during streaming still works
- [ ] Verify scroll-to-bottom button still functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
