### PR TITLE
feat: add avatarGenerationStrategy config field

### DIFF
--- a/assistant/src/__tests__/avatar-router.test.ts
+++ b/assistant/src/__tests__/avatar-router.test.ts
@@ -25,15 +25,9 @@ const isManagedAvailableFn = mock(() => mockManagedAvailable);
 // ---------------------------------------------------------------------------
 
 mock.module("../config/loader.js", () => ({
-  loadRawConfig: () => {
-    const raw: Record<string, unknown> = {};
-    if (mockStrategy !== undefined) {
-      raw.avatarGenerationStrategy = mockStrategy;
-    }
-    return raw;
-  },
   getConfig: () => ({
     apiKeys: { gemini: mockGeminiKey },
+    avatar: { generationStrategy: mockStrategy ?? "local_only" },
   }),
 }));
 
@@ -187,9 +181,6 @@ describe("avatar-router", () => {
     expect(getAvatarStrategy()).toBe("local_only");
   });
 
-  // 9. Invalid strategy value defaults to local_only
-  test("invalid strategy value defaults to local_only", () => {
-    mockStrategy = "not_a_real_strategy";
-    expect(getAvatarStrategy()).toBe("local_only");
-  });
+  // 9. Removed: Invalid strategy values are now rejected at config parse time
+  // by the Zod schema, so they cannot reach getAvatarStrategy().
 });

--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -334,6 +334,22 @@ export const IngressConfigSchema = IngressBaseSchema.default(
   enabled: val.enabled ?? (val.publicBaseUrl ? true : undefined),
 }));
 
+export const VALID_AVATAR_STRATEGIES = [
+  "managed_required",
+  "managed_prefer",
+  "local_only",
+] as const;
+
+export const AvatarConfigSchema = z.object({
+  generationStrategy: z
+    .enum(VALID_AVATAR_STRATEGIES, {
+      error: `avatar.generationStrategy must be one of: ${VALID_AVATAR_STRATEGIES.join(", ")}`,
+    })
+    .default("local_only"),
+});
+
+export type AvatarConfig = z.infer<typeof AvatarConfigSchema>;
+
 export const PlatformConfigSchema = z.object({
   baseUrl: z
     .string({ error: "platform.baseUrl must be a string" })

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -32,6 +32,7 @@ export {
 } from "./calls-schema.js";
 export type {
   AuditLogConfig,
+  AvatarConfig,
   ContextOverflowRecoveryConfig,
   ContextWindowConfig,
   DaemonConfig,
@@ -52,6 +53,7 @@ export type {
 } from "./core-schema.js";
 export {
   AuditLogConfigSchema,
+  AvatarConfigSchema,
   ContextOverflowRecoveryConfigSchema,
   ContextWindowConfigSchema,
   DaemonConfigSchema,
@@ -147,6 +149,7 @@ import {
 import { CallsConfigSchema } from "./calls-schema.js";
 import {
   AuditLogConfigSchema,
+  AvatarConfigSchema,
   ContextWindowConfigSchema,
   DaemonConfigSchema,
   EffortSchema,
@@ -267,6 +270,7 @@ export const AssistantConfigSchema = z
     notifications: NotificationsConfigSchema.default(
       NotificationsConfigSchema.parse({}),
     ),
+    avatar: AvatarConfigSchema.default(AvatarConfigSchema.parse({})),
     ui: UiConfigSchema.default(UiConfigSchema.parse({})),
     featureFlags: z
       .record(

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -3,7 +3,7 @@
  * Selects managed platform or local Gemini path based on config.
  */
 
-import { getConfig, loadRawConfig } from "../config/loader.js";
+import { getConfig } from "../config/loader.js";
 import { ConfigError, ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import type {
@@ -18,23 +18,8 @@ import {
 
 const log = getLogger("avatar-router");
 
-const VALID_STRATEGIES: ReadonlySet<string> = new Set([
-  "managed_required",
-  "managed_prefer",
-  "local_only",
-]);
-
 export function getAvatarStrategy(): AvatarGenerationStrategy {
-  try {
-    const raw = loadRawConfig();
-    const strategy = raw.avatarGenerationStrategy as string | undefined;
-    if (strategy && VALID_STRATEGIES.has(strategy)) {
-      return strategy as AvatarGenerationStrategy;
-    }
-  } catch {
-    /* fall through */
-  }
-  return "local_only";
+  return getConfig().avatar.generationStrategy;
 }
 
 async function generateLocal(


### PR DESCRIPTION
## Summary
- Add VALID_AVATAR_STRATEGIES const and AvatarConfigSchema to core-schema.ts
- Add avatar field to AssistantConfigSchema in schema.ts
- Update avatar-router.ts to use typed config instead of loadRawConfig()

Part of managed avatar generation feature (M4, #12576)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
