### PR TITLE
docs: encourage AGENTS.md updates when fixing generalizable bugs

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -172,3 +172,4 @@ Swift's type checker has quadratic complexity with chained view modifiers. Compl
 
 ## Maintenance
 - Refresh this guidance after major Apple OS or SwiftUI releases (for example, post-WWDC).
+- **When fixing a bug, consider whether the root cause represents a generalizable pitfall.** If an API was misused in a way that compiled but caused runtime crashes, freezes, or subtle misbehavior — and another developer or agent could plausibly make the same mistake — add a rule to the relevant section of this file (or the pitfalls table). This file is the team's collective memory for hard-won lessons; keeping it current prevents repeat bugs.


### PR DESCRIPTION
## Summary
- Add a maintenance rule encouraging developers and agents to update AGENTS.md when a bug fix reveals a generalizable pitfall
- If an API was misused in a way that compiled but caused runtime issues, and someone else could make the same mistake, it should be documented here
- This builds the team's collective memory and prevents repeat bugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
