### PR TITLE
fix: replace thread switcher tap gesture with accessible Button

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -497,22 +497,31 @@ extension MainWindowView {
 
             // MARK: Thread Section (collapsed)
             if let activeThread = threadManager.activeThread {
-                ZStack(alignment: .bottomTrailing) {
-                    // Active thread icon — SF Symbol chat bubble matching SidebarNavRow style
-                    Image(systemName: "ellipsis.message")
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400))
-                        .frame(width: 28, height: 28)
-                        .accessibilityLabel("Thread: \(activeThread.title)")
+                Button {
+                    guard regularThreads.count > 1 else { return }
+                    threadSwitcherHoverTask?.cancel()
+                    threadSwitcherHoverTask = nil
+                    showThreadSwitcher.toggle()
+                } label: {
+                    ZStack(alignment: .bottomTrailing) {
+                        // Active thread icon — SF Symbol chat bubble matching SidebarNavRow style
+                        Image(systemName: "ellipsis.message")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400))
+                            .frame(width: 28, height: 28)
 
-                    // Unseen dot overlay (bottom-right) — shows when any thread has unseen messages
-                    if regularThreads.contains(where: { $0.hasUnseenLatestAssistantMessage }) {
-                        Circle()
-                            .fill(Color(hex: 0xE86B40))
-                            .frame(width: 8, height: 8)
-                            .offset(x: 4, y: 4)
+                        // Unseen dot overlay (bottom-right) — shows when any thread has unseen messages
+                        if regularThreads.contains(where: { $0.hasUnseenLatestAssistantMessage }) {
+                            Circle()
+                                .fill(Color(hex: 0xE86B40))
+                                .frame(width: 8, height: 8)
+                                .offset(x: 4, y: 4)
+                        }
                     }
                 }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Switch threads: \(activeThread.title)")
+                .accessibilityValue(regularThreads.count > 1 ? "\(regularThreads.count) threads" : "")
                 .onDisappear {
                     threadSwitcherHoverTask?.cancel()
                     threadSwitcherHoverTask = nil
@@ -520,15 +529,8 @@ extension MainWindowView {
                     threadSwitcherDismissTask = nil
                     showThreadSwitcher = false
                 }
-                .contentShape(Rectangle())
                 .if(regularThreads.count > 1) { view in
                     view.pointerCursor()
-                }
-                .onTapGesture {
-                    guard regularThreads.count > 1 else { return }
-                    threadSwitcherHoverTask?.cancel()
-                    threadSwitcherHoverTask = nil
-                    showThreadSwitcher.toggle()
                 }
                 .onHover { hovering in
                     guard regularThreads.count > 1 else { return }


### PR DESCRIPTION
## Summary
- Replace onTapGesture on collapsed thread switcher with a plain-style Button for proper keyboard navigation and VoiceOver support
- Add accessibility label and value to the thread switcher button

Addresses feedback from #10425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
