### PR TITLE
feat: wire avatar strategy router into set_avatar tool

### DIFF
--- a/assistant/src/__tests__/avatar-generator.test.ts
+++ b/assistant/src/__tests__/avatar-generator.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { ManagedAvatarError } from "../media/avatar-types.js";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockRouterResult: unknown;
+let mockRouterError: Error | undefined;
+let mockWorkspaceDir = "/tmp/test-workspace";
+
+const routedGenerateAvatarFn = mock(async () => {
+  if (mockRouterError) throw mockRouterError;
+  return mockRouterResult;
+});
+
+const mkdirSyncFn = mock(() => {});
+const writeFileSyncFn = mock(() => {});
+const renameSyncFn = mock(() => {});
+
+// ---------------------------------------------------------------------------
+// Mock modules — before importing module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../media/avatar-router.js", () => ({
+  routedGenerateAvatar: routedGenerateAvatarFn,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+mock.module("../util/platform.js", () => ({
+  getWorkspaceDir: () => mockWorkspaceDir,
+}));
+
+mock.module("node:fs", () => ({
+  mkdirSync: mkdirSyncFn,
+  writeFileSync: writeFileSyncFn,
+  renameSync: renameSyncFn,
+}));
+
+// Import after mocking
+import { setAvatarTool } from "../tools/system/avatar-generator.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function successResult() {
+  return {
+    imageBase64: "iVBORw0KGgoAAAANSUhEUg==",
+    mimeType: "image/png",
+    pathUsed: "local" as const,
+    correlationId: "test-corr-id",
+  };
+}
+
+function executeAvatar(description: string) {
+  return setAvatarTool.execute(
+    { description },
+    {} as Parameters<typeof setAvatarTool.execute>[1],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("setAvatarTool", () => {
+  beforeEach(() => {
+    mockRouterResult = successResult();
+    mockRouterError = undefined;
+    mockWorkspaceDir = "/tmp/test-workspace";
+    routedGenerateAvatarFn.mockClear();
+    mkdirSyncFn.mockClear();
+    writeFileSyncFn.mockClear();
+    renameSyncFn.mockClear();
+  });
+
+  test("successful generation writes PNG and returns success message", async () => {
+    const result = await executeAvatar("a friendly purple cat");
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Avatar updated");
+    expect(routedGenerateAvatarFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("empty description returns error", async () => {
+    const result = await executeAvatar("");
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("description is required");
+    expect(routedGenerateAvatarFn).not.toHaveBeenCalled();
+  });
+
+  test("no image data returned yields error", async () => {
+    mockRouterResult = { ...successResult(), imageBase64: "" };
+
+    const result = await executeAvatar("a cat");
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("No image data returned");
+  });
+
+  test("ManagedAvatarError with rate limit code returns user-friendly message", async () => {
+    mockRouterError = new ManagedAvatarError({
+      code: "avatar_rate_limited",
+      subcode: "too_many_requests",
+      detail: "Rate limited",
+      retryable: true,
+      correlationId: "corr-rate",
+      statusCode: 429,
+    });
+
+    const result = await executeAvatar("a cat");
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("rate limited");
+  });
+
+  test("ManagedAvatarError with 503 returns service unavailable message", async () => {
+    mockRouterError = new ManagedAvatarError({
+      code: "avatar_service_error",
+      subcode: "upstream_unavailable",
+      detail: "Service down",
+      retryable: true,
+      correlationId: "corr-503",
+      statusCode: 503,
+    });
+
+    const result = await executeAvatar("a cat");
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("temporarily unavailable");
+  });
+
+  test("ManagedAvatarError with other code returns detail message", async () => {
+    mockRouterError = new ManagedAvatarError({
+      code: "avatar_content_filtered",
+      subcode: "policy_violation",
+      detail: "Content was filtered by safety policy",
+      retryable: false,
+      correlationId: "corr-filter",
+      statusCode: 400,
+    });
+
+    const result = await executeAvatar("a cat");
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Content was filtered by safety policy");
+  });
+
+  test("generic error returns fallback message", async () => {
+    mockRouterError = new Error("Network timeout");
+
+    const result = await executeAvatar("a cat");
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Network timeout");
+  });
+
+  test("atomic write — file is written to .tmp then renamed", async () => {
+    await executeAvatar("a friendly cat");
+
+    const expectedPath = "/tmp/test-workspace/data/avatar/custom-avatar.png";
+    const expectedTmpPath = `${expectedPath}.tmp`;
+
+    // Verify mkdirSync was called for the directory
+    expect(mkdirSyncFn).toHaveBeenCalledTimes(1);
+    expect(mkdirSyncFn.mock.calls[0][1]).toEqual({ recursive: true });
+
+    // Verify writeFileSync writes to tmp path
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+    expect(writeFileSyncFn.mock.calls[0][0]).toBe(expectedTmpPath);
+
+    // Verify renameSync moves tmp to final path
+    expect(renameSyncFn).toHaveBeenCalledTimes(1);
+    expect(renameSyncFn.mock.calls[0][0]).toBe(expectedTmpPath);
+    expect(renameSyncFn.mock.calls[0][1]).toBe(expectedPath);
+  });
+});

--- a/assistant/src/__tests__/avatar-generator.test.ts
+++ b/assistant/src/__tests__/avatar-generator.test.ts
@@ -157,32 +157,35 @@ describe("setAvatarTool", () => {
     expect(result.content).toContain("Content was filtered by safety policy");
   });
 
-  test("generic error returns fallback message", async () => {
+  test("generic error returns mapped message", async () => {
     mockRouterError = new Error("Network timeout");
 
     const result = await executeAvatar("a cat");
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain("Network timeout");
+    expect(result.content).toContain(
+      "Image generation failed: Network timeout",
+    );
   });
 
   test("atomic write — file is written to .tmp then renamed", async () => {
     await executeAvatar("a friendly cat");
 
     const expectedPath = "/tmp/test-workspace/data/avatar/custom-avatar.png";
-    const expectedTmpPath = `${expectedPath}.tmp`;
 
     // Verify mkdirSync was called for the directory
     expect(mkdirSyncFn).toHaveBeenCalledTimes(1);
     expect(mkdirSyncFn.mock.calls[0][1]).toEqual({ recursive: true });
 
-    // Verify writeFileSync writes to tmp path
+    // Verify writeFileSync writes to a unique tmp path
     expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
-    expect(writeFileSyncFn.mock.calls[0][0]).toBe(expectedTmpPath);
+    const tmpPath = writeFileSyncFn.mock.calls[0][0] as string;
+    expect(tmpPath).toStartWith(expectedPath + ".");
+    expect(tmpPath).toEndWith(".tmp");
 
     // Verify renameSync moves tmp to final path
     expect(renameSyncFn).toHaveBeenCalledTimes(1);
-    expect(renameSyncFn.mock.calls[0][0]).toBe(expectedTmpPath);
+    expect(renameSyncFn.mock.calls[0][0]).toBe(tmpPath);
     expect(renameSyncFn.mock.calls[0][1]).toBe(expectedPath);
   });
 });

--- a/assistant/src/tools/system/avatar-generator.ts
+++ b/assistant/src/tools/system/avatar-generator.ts
@@ -1,11 +1,8 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-import { getConfig } from "../../config/loader.js";
-import {
-  generateImage,
-  mapGeminiError,
-} from "../../media/gemini-image-service.js";
+import { routedGenerateAvatar } from "../../media/avatar-router.js";
+import { ManagedAvatarError } from "../../media/avatar-types.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
@@ -66,21 +63,8 @@ export const setAvatarTool: Tool = {
       };
     }
 
-    const config = getConfig();
-    const apiKey = config.apiKeys.gemini ?? process.env.GEMINI_API_KEY;
-    if (!apiKey) {
-      return {
-        content:
-          "No Gemini API key configured. Please add your Gemini API key in Settings → Models & Services, or set the GEMINI_API_KEY environment variable.",
-        isError: true,
-      };
-    }
-
     try {
-      log.info(
-        { description: description.trim() },
-        "Generating avatar via Gemini",
-      );
+      log.info({ description: description.trim() }, "Generating avatar");
 
       const prompt =
         `Create an avatar image based on this description: ${description.trim()}\n\n` +
@@ -89,29 +73,31 @@ export const setAvatarTool: Tool = {
         "Circular or rounded composition filling the canvas. " +
         "Subtle background color (not white or transparent).";
 
-      const result = await generateImage(apiKey, {
-        prompt,
-        mode: "generate",
-        model: config.imageGenModel,
-      });
-
-      if (result.images.length === 0) {
+      const result = await routedGenerateAvatar(prompt);
+      if (!result.imageBase64) {
         return {
-          content: "Error: Gemini returned no image data. Please try again.",
+          content: "Error: No image data returned. Please try again.",
           isError: true,
         };
       }
-
-      const image = result.images[0];
-      const pngBuffer = Buffer.from(image.dataBase64, "base64");
+      const pngBuffer = Buffer.from(result.imageBase64, "base64");
 
       const avatarPath = getAvatarPath();
       const avatarDir = dirname(avatarPath);
 
+      const tmpPath = `${avatarPath}.tmp`;
       mkdirSync(avatarDir, { recursive: true });
-      writeFileSync(avatarPath, pngBuffer);
+      writeFileSync(tmpPath, pngBuffer);
+      renameSync(tmpPath, avatarPath);
 
-      log.info({ avatarPath }, "Avatar saved successfully");
+      log.info(
+        {
+          avatarPath,
+          pathUsed: result.pathUsed,
+          correlationId: result.correlationId,
+        },
+        "Avatar saved successfully",
+      );
 
       // Side-effect hook in tool-side-effects.ts broadcasts avatar_updated to all clients.
 
@@ -120,9 +106,42 @@ export const setAvatarTool: Tool = {
         isError: false,
       };
     } catch (error) {
-      const message = mapGeminiError(error);
-      log.error({ error: message }, "Avatar generation failed");
+      if (error instanceof ManagedAvatarError) {
+        if (error.code === "avatar_rate_limited") {
+          log.warn(
+            { correlationId: error.correlationId },
+            "Avatar generation rate limited",
+          );
+          return {
+            content:
+              "Avatar generation is rate limited. Please wait and try again.",
+            isError: true,
+          };
+        }
+        if (error.statusCode === 503) {
+          log.warn(
+            { correlationId: error.correlationId },
+            "Avatar generation service unavailable",
+          );
+          return {
+            content: "Avatar generation service is temporarily unavailable.",
+            isError: true,
+          };
+        }
+        const detail =
+          error.message || "Avatar generation failed. Please try again.";
+        log.error(
+          { error: detail, correlationId: error.correlationId },
+          "Managed avatar generation failed",
+        );
+        return {
+          content: `Avatar generation failed: ${detail}`,
+          isError: true,
+        };
+      }
 
+      const message = error instanceof Error ? error.message : String(error);
+      log.error({ error: message }, "Avatar generation failed");
       return {
         content: `Avatar generation failed: ${message}`,
         isError: true,

--- a/assistant/src/tools/system/avatar-generator.ts
+++ b/assistant/src/tools/system/avatar-generator.ts
@@ -1,8 +1,10 @@
+import { randomUUID } from "node:crypto";
 import { mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { routedGenerateAvatar } from "../../media/avatar-router.js";
 import { ManagedAvatarError } from "../../media/avatar-types.js";
+import { mapGeminiError } from "../../media/gemini-image-service.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
@@ -85,7 +87,7 @@ export const setAvatarTool: Tool = {
       const avatarPath = getAvatarPath();
       const avatarDir = dirname(avatarPath);
 
-      const tmpPath = `${avatarPath}.tmp`;
+      const tmpPath = `${avatarPath}.${randomUUID()}.tmp`;
       mkdirSync(avatarDir, { recursive: true });
       writeFileSync(tmpPath, pngBuffer);
       renameSync(tmpPath, avatarPath);
@@ -140,7 +142,7 @@ export const setAvatarTool: Tool = {
         };
       }
 
-      const message = error instanceof Error ? error.message : String(error);
+      const message = mapGeminiError(error);
       log.error({ error: message }, "Avatar generation failed");
       return {
         content: `Avatar generation failed: ${message}`,


### PR DESCRIPTION
## Summary
- Replace direct Gemini call with routedGenerateAvatar() from avatar router
- Add ManagedAvatarError handling for rate-limited and unavailable errors
- Implement atomic file writes (write to .tmp then rename)
- Add comprehensive tests for avatar-generator tool

Part of managed avatar generation feature (M5, #12577)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
