### PR TITLE
fix: make html optional in app_create and remove appType

### DIFF
--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -180,28 +180,18 @@ describe("executeAppCreate", () => {
     expect(capturedPages).toEqual({ "settings.html": "<div/>" });
   });
 
-  test('maps type "site" to appType "site"', async () => {
-    let capturedType: "app" | "site" | undefined;
+  test("defaults html to minimal scaffold when omitted", async () => {
+    let capturedHtml: string | undefined;
     const store = makeMockStore({
       createApp: (params) => {
-        capturedType = params.appType;
+        capturedHtml = params.htmlDefinition;
         return makeApp({ name: params.name });
       },
     });
-    await executeAppCreate({ name: "Site", html: "<p/>", type: "site" }, store);
-    expect(capturedType).toBe("site");
-  });
-
-  test('defaults appType to "app" when type is not "site"', async () => {
-    let capturedType: "app" | "site" | undefined;
-    const store = makeMockStore({
-      createApp: (params) => {
-        capturedType = params.appType;
-        return makeApp({ name: params.name });
-      },
-    });
-    await executeAppCreate({ name: "App", html: "<p/>" }, store);
-    expect(capturedType).toBe("app");
+    await executeAppCreate({ name: "No HTML" }, store);
+    expect(capturedHtml).toBe(
+      "<!DOCTYPE html><html><head></head><body></body></html>",
+    );
   });
 });
 

--- a/assistant/src/__tests__/starter-task-flow.test.ts
+++ b/assistant/src/__tests__/starter-task-flow.test.ts
@@ -8,7 +8,6 @@ mock.module("../memory/app-store.js", () => ({
     return {
       id,
       name: "Home Base",
-      appType: "app",
       htmlDefinition:
         '<main id="home-base-root" data-vellum-home-base="v1"></main>',
     };

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -325,7 +325,7 @@ Call `app_create` with:
 - `name`: Short descriptive name
 - `description`: One-sentence summary
 - `schema_json`: JSON schema as string
-- `html`: Complete HTML document as string
+- `html`: (optional) Complete HTML document as string for `index.html`. If omitted, a minimal scaffold is created — you can then write `index.html` and other files via `app_file_write`.
 - `auto_open`: (optional, defaults to `true`) Shows an inline preview card in chat
 - `preview`: Always include — `title` (required), `subtitle`, `description`, `icon` (image URL preferred, emoji fallback), `metrics` (up to 3 key-value pills)
 

--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -23,7 +23,7 @@
           },
           "html": {
             "type": "string",
-            "description": "HTML definition for rendering the app (main index.html page)"
+            "description": "Optional HTML definition for the main index.html page. If omitted, a minimal scaffold is created and you can write index.html later via app_file_write."
           },
           "pages": {
             "type": "object",
@@ -31,11 +31,6 @@
             "additionalProperties": {
               "type": "string"
             }
-          },
-          "type": {
-            "type": "string",
-            "enum": ["app", "site"],
-            "description": "Type of creation: 'app' for interactive apps with data/state, 'site' for presentational content (portfolios, landing pages, blogs)"
           },
           "auto_open": {
             "type": "boolean",
@@ -89,7 +84,7 @@
             "description": "Brief non-technical explanation of why this tool is being called"
           }
         },
-        "required": ["name", "html"]
+        "required": ["name"]
       },
       "executor": "tools/app-create.ts",
       "execution_target": "host"

--- a/assistant/src/daemon/handlers/apps.ts
+++ b/assistant/src/daemon/handlers/apps.ts
@@ -128,7 +128,7 @@ export function handleAppOpenRequest(
         surfaceId,
         surfaceType: "dynamic_page",
         title: app.name,
-        data: { html: app.htmlDefinition, appId: app.id, appType: app.appType },
+        data: { html: app.htmlDefinition, appId: app.id },
         display: "panel",
       } as UiSurfaceShow);
       return;
@@ -233,7 +233,6 @@ export function handleAppsList(socket: net.Socket, ctx: HandlerContext): void {
           createdAt: a.createdAt,
           version,
           contentId,
-          appType: a.appType,
         };
       }),
     });

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -1648,7 +1648,6 @@ export function handleHistoryRequest(
                   ? {
                       ...(s.data.preview ? { preview: s.data.preview } : {}),
                       ...(s.data.appId ? { appId: s.data.appId } : {}),
-                      ...(s.data.appType ? { appType: s.data.appType } : {}),
                     }
                   : {}),
               } as Record<string, unknown>,

--- a/assistant/src/daemon/ipc-contract/apps.ts
+++ b/assistant/src/daemon/ipc-contract/apps.ts
@@ -178,7 +178,6 @@ export interface AppsListResponse {
     createdAt: number;
     version?: string;
     contentId?: string;
-    appType?: string;
   }>;
 }
 

--- a/assistant/src/daemon/ipc-contract/surfaces.ts
+++ b/assistant/src/daemon/ipc-contract/surfaces.ts
@@ -98,7 +98,6 @@ export interface DynamicPageSurfaceData {
   width?: number;
   height?: number;
   appId?: string;
-  appType?: string;
   reloadGeneration?: number;
   status?: string;
   preview?: DynamicPagePreview;

--- a/assistant/src/daemon/session-surfaces.ts
+++ b/assistant/src/daemon/session-surfaces.ts
@@ -1119,7 +1119,6 @@ export async function surfaceProxyResolver(
     const surfaceData: DynamicPageSurfaceData = {
       html: app.htmlDefinition,
       appId: app.id,
-      appType: app.appType,
       preview: {
         ...defaultPreview,
         ...preview,

--- a/assistant/src/home-base/prebuilt/seed.ts
+++ b/assistant/src/home-base/prebuilt/seed.ts
@@ -115,7 +115,6 @@ export function ensurePrebuiltHomeBaseSeeded(): {
     description: buildDescription(metadata),
     schemaJson: "{}",
     htmlDefinition: html,
-    appType: "app",
   });
 
   log.info({ appId: created.id }, "Seeded prebuilt Home Base app");

--- a/assistant/src/memory/app-store.ts
+++ b/assistant/src/memory/app-store.ts
@@ -47,7 +47,6 @@ export interface AppDefinition {
   schemaJson: string;
   htmlDefinition: string;
   version?: string;
-  appType?: "app" | "site";
   /** Additional pages keyed by filename (e.g. "settings.html" → HTML content). */
   pages?: Record<string, string>;
   createdAt: number;
@@ -195,7 +194,6 @@ export function createApp(params: {
   schemaJson: string;
   htmlDefinition: string;
   version?: string;
-  appType?: "app" | "site";
   pages?: Record<string, string>;
 }): AppDefinition {
   const dir = getAppsDir();
@@ -209,7 +207,6 @@ export function createApp(params: {
     schemaJson: params.schemaJson,
     htmlDefinition: params.htmlDefinition,
     version: params.version,
-    appType: params.appType,
     createdAt: now,
     updatedAt: now,
   };
@@ -355,7 +352,6 @@ export function updateApp(
       | "schemaJson"
       | "htmlDefinition"
       | "version"
-      | "appType"
       | "pages"
     >
   >,

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -43,7 +43,6 @@ export interface AppStoreWriter {
     schemaJson: string;
     htmlDefinition: string;
     pages?: Record<string, string>;
-    appType?: "app" | "site";
   }): AppDefinition;
   updateApp(
     id: string,
@@ -84,9 +83,8 @@ export interface AppCreateInput {
   name: string;
   description?: string;
   schema_json?: string;
-  html: string;
+  html?: string;
   pages?: Record<string, string>;
-  type?: "app" | "site";
   auto_open?: boolean;
   set_as_home_base?: boolean;
   preview?: Record<string, unknown>;
@@ -100,26 +98,19 @@ export async function executeAppCreate(
   const name = input.name;
   const description = input.description;
   const schemaJson = input.schema_json ?? "{}";
-  const htmlDefinition = input.html;
+  const htmlDefinition =
+    typeof input.html === "string"
+      ? input.html
+      : "<!DOCTYPE html><html><head></head><body></body></html>";
   const pages = input.pages;
   const autoOpen = input.auto_open !== false; // default true
   const preview = input.preview;
-  const appType = input.type === "site" ? ("site" as const) : ("app" as const);
 
   // Validate required fields — LLM input is not type-checked at runtime
   if (typeof name !== "string" || name.trim() === "") {
     return {
       content: JSON.stringify({
         error: "name is required and must be a non-empty string",
-      }),
-      isError: true,
-    };
-  }
-  if (typeof htmlDefinition !== "string") {
-    return {
-      content: JSON.stringify({
-        error:
-          "html is required and must be a string containing the HTML definition",
       }),
       isError: true,
     };
@@ -143,7 +134,6 @@ export async function executeAppCreate(
     schemaJson,
     htmlDefinition,
     pages,
-    appType,
   });
 
   if (input.set_as_home_base) {

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -98,10 +98,21 @@ export async function executeAppCreate(
   const name = input.name;
   const description = input.description;
   const schemaJson = input.schema_json ?? "{}";
-  const htmlDefinition =
-    typeof input.html === "string"
-      ? input.html
-      : "<!DOCTYPE html><html><head></head><body></body></html>";
+  // Default to a minimal scaffold only when html is truly omitted; reject
+  // invalid types (e.g. object/number) so malformed tool calls surface errors.
+  let htmlDefinition: string;
+  if (typeof input.html === "string") {
+    htmlDefinition = input.html;
+  } else if (input.html == null) {
+    htmlDefinition = "<!DOCTYPE html><html><head></head><body></body></html>";
+  } else {
+    return {
+      content: JSON.stringify({
+        error: `html must be a string, got ${typeof input.html}`,
+      }),
+      isError: true,
+    };
+  }
   const pages = input.pages;
   const autoOpen = input.auto_open !== false; // default true
   const preview = input.preview;


### PR DESCRIPTION
## Summary
- Make `html` optional in `app_create` — defaults to a minimal HTML scaffold so the LLM can create an app first, then write files via `app_file_write`
- Remove `appType: "app" | "site"` distinction across the stack since both types should be bundlable and deployable uniformly

## Test plan
- [ ] Verify `app_create` succeeds without `html` parameter and creates a working app with scaffold `index.html`
- [ ] Verify `app_create` still works when `html` is provided
- [ ] Verify existing apps without `appType` load correctly
- [ ] Run existing test suite (`app-executors.test.ts`, `starter-task-flow.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
