### PR TITLE
feat: add managed avatar generation path

### DIFF
--- a/assistant/src/__tests__/avatar-e2e.test.ts
+++ b/assistant/src/__tests__/avatar-e2e.test.ts
@@ -1,0 +1,448 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock state — mutable variables control per-test behavior
+// ---------------------------------------------------------------------------
+
+let mockStrategy: string = "local_only";
+let mockGeminiKey: string | undefined = "test-gemini-key";
+let mockApiKey: string | undefined = "test-api-key-123";
+let mockBaseUrl = "https://platform.test.vellum.ai";
+let mockPlatformEnvUrl = "https://env.test.vellum.ai";
+let mockWorkspaceDir = "/tmp/test-workspace-e2e";
+
+const mkdirSyncFn = mock(() => {});
+const writeFileSyncFn = mock(() => {});
+const renameSyncFn = mock(() => {});
+
+let logInfoCalls: Array<[unknown, string]> = [];
+let logWarnCalls: Array<[unknown, string]> = [];
+let logErrorCalls: Array<[unknown, string]> = [];
+
+// ---------------------------------------------------------------------------
+// Gemini mock state
+// ---------------------------------------------------------------------------
+
+let geminiGenerateContentResult: unknown;
+const geminiGenerateContentFn = mock(async () => geminiGenerateContentResult);
+
+// ---------------------------------------------------------------------------
+// Mock modules — must be before importing the module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    apiKeys: { gemini: mockGeminiKey },
+    avatar: { generationStrategy: mockStrategy },
+    platform: { baseUrl: mockBaseUrl },
+    imageGenModel: "gemini-2.5-flash-image",
+  }),
+}));
+
+mock.module("../config/env.js", () => ({
+  getPlatformBaseUrl: () => mockPlatformEnvUrl,
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKey: (account: string) => {
+    if (account === "credential:vellum:assistant_api_key") return mockApiKey;
+    return undefined;
+  },
+}));
+
+mock.module("../util/platform.js", () => ({
+  getWorkspaceDir: () => mockWorkspaceDir,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    info: (...args: unknown[]) => {
+      logInfoCalls.push(args as [unknown, string]);
+    },
+    warn: (...args: unknown[]) => {
+      logWarnCalls.push(args as [unknown, string]);
+    },
+    error: (...args: unknown[]) => {
+      logErrorCalls.push(args as [unknown, string]);
+    },
+  }),
+}));
+
+mock.module("node:fs", () => ({
+  mkdirSync: mkdirSyncFn,
+  writeFileSync: writeFileSyncFn,
+  renameSync: renameSyncFn,
+}));
+
+mock.module("node:crypto", () => ({
+  randomUUID: () => "00000000-0000-0000-0000-000000000000",
+}));
+
+mock.module("@google/genai", () => ({
+  GoogleGenAI: class {
+    models = {
+      generateContent: geminiGenerateContentFn,
+    };
+  },
+  ApiError: class extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+// Import after all mocks are set up
+import { AVATAR_MAX_DECODED_BYTES } from "../media/avatar-types.js";
+import { setAvatarTool } from "../tools/system/avatar-generator.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function executeAvatar(description: string) {
+  return setAvatarTool.execute(
+    { description },
+    {} as Parameters<typeof setAvatarTool.execute>[1],
+  );
+}
+
+/** Standard successful managed avatar platform response. */
+function managedPlatformResponse() {
+  return {
+    image: {
+      mime_type: "image/png",
+      data_base64: "iVBORw0KGgoAAAANSUhEUg==",
+      bytes: 1024,
+      sha256: "abc123",
+    },
+    usage: { billable: true, class_name: "assistant_avatar_system" },
+    generation_source: "vertex",
+    profile: "avatar_v1",
+    correlation_id: "managed-corr-id-123",
+  };
+}
+
+/** Standard successful Gemini generateContent response. */
+function geminiContentResponse() {
+  return {
+    candidates: [
+      {
+        content: {
+          parts: [
+            {
+              inlineData: {
+                mimeType: "image/png",
+                data: "iVBORw0KGgoAAAANSUhEUg==",
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+function mockFetchReturning(response: {
+  ok: boolean;
+  status: number;
+  body: unknown;
+}) {
+  globalThis.fetch = mock(() =>
+    Promise.resolve({
+      ok: response.ok,
+      status: response.status,
+      json: async () => response.body,
+    }),
+  ) as typeof globalThis.fetch;
+}
+
+const originalFetch = globalThis.fetch;
+
+const expectedAvatarPath =
+  "/tmp/test-workspace-e2e/data/avatar/custom-avatar.png";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("avatar E2E integration", () => {
+  // Save original GEMINI_API_KEY to restore after each test
+  const originalGeminiKey = process.env.GEMINI_API_KEY;
+
+  beforeEach(() => {
+    mockStrategy = "local_only";
+    mockGeminiKey = "test-gemini-key";
+    mockApiKey = "test-api-key-123";
+    mockBaseUrl = "https://platform.test.vellum.ai";
+    mockPlatformEnvUrl = "https://env.test.vellum.ai";
+    mockWorkspaceDir = "/tmp/test-workspace-e2e";
+
+    mkdirSyncFn.mockClear();
+    writeFileSyncFn.mockClear();
+    renameSyncFn.mockClear();
+    geminiGenerateContentFn.mockClear();
+
+    logInfoCalls = [];
+    logWarnCalls = [];
+    logErrorCalls = [];
+
+    geminiGenerateContentResult = geminiContentResponse();
+    globalThis.fetch = originalFetch;
+
+    // Clear env var so tests control the key entirely via config mock
+    delete process.env.GEMINI_API_KEY;
+  });
+
+  afterEach(() => {
+    // Restore original GEMINI_API_KEY
+    if (originalGeminiKey === undefined) {
+      delete process.env.GEMINI_API_KEY;
+    } else {
+      process.env.GEMINI_API_KEY = originalGeminiKey;
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // 1. Managed success E2E
+  // -----------------------------------------------------------------------
+
+  test("managed_required success — file written, correct content, success message", async () => {
+    mockStrategy = "managed_required";
+    mockFetchReturning({
+      ok: true,
+      status: 200,
+      body: managedPlatformResponse(),
+    });
+
+    const result = await executeAvatar("a friendly robot");
+
+    // Verify success message
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Avatar updated");
+
+    // Verify file was written
+    expect(mkdirSyncFn).toHaveBeenCalledTimes(1);
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+    expect(renameSyncFn).toHaveBeenCalledTimes(1);
+
+    // Verify rename target is the expected avatar path
+    expect(renameSyncFn.mock.calls[0][1]).toBe(expectedAvatarPath);
+
+    // Verify the written buffer content matches the base64 data
+    const writtenBuffer = writeFileSyncFn.mock.calls[0][1] as Buffer;
+    const expectedBuffer = Buffer.from("iVBORw0KGgoAAAANSUhEUg==", "base64");
+    expect(writtenBuffer.equals(expectedBuffer)).toBe(true);
+
+    // Verify Gemini was never called
+    expect(geminiGenerateContentFn).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // 2. Managed-required failure E2E — no fallback
+  // -----------------------------------------------------------------------
+
+  test("managed_required failure — error surfaced, no file written, no fallback", async () => {
+    mockStrategy = "managed_required";
+    mockFetchReturning({
+      ok: false,
+      status: 500,
+      body: {
+        code: "internal_error",
+        subcode: "server_fault",
+        detail: "Internal server error",
+        retryable: true,
+        correlation_id: "corr-500",
+      },
+    });
+
+    const result = await executeAvatar("a friendly robot");
+
+    // Verify error is surfaced
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("failed");
+
+    // Verify no file was written
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+    expect(renameSyncFn).not.toHaveBeenCalled();
+
+    // Verify Gemini was never called (no fallback)
+    expect(geminiGenerateContentFn).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // 3. Managed-prefer fallback E2E
+  // -----------------------------------------------------------------------
+
+  test("managed_prefer fallback — managed fails, local Gemini used, file written", async () => {
+    mockStrategy = "managed_prefer";
+    mockFetchReturning({
+      ok: false,
+      status: 502,
+      body: {
+        code: "upstream_error",
+        subcode: "bad_gateway",
+        detail: "Bad gateway",
+        retryable: true,
+        correlation_id: "corr-502",
+      },
+    });
+
+    const result = await executeAvatar("a cute cat");
+
+    // Verify success — local path was used
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Avatar updated");
+
+    // Verify file was written
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+    expect(renameSyncFn).toHaveBeenCalledTimes(1);
+
+    // Verify Gemini was called as fallback
+    expect(geminiGenerateContentFn).toHaveBeenCalledTimes(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // 4. Managed-prefer no-fallback when managed unavailable (no API key)
+  // -----------------------------------------------------------------------
+
+  test("managed_prefer without API key — goes straight to local Gemini", async () => {
+    mockStrategy = "managed_prefer";
+    mockApiKey = undefined; // No managed API key available
+
+    const result = await executeAvatar("a cute cat");
+
+    // Verify success via local path
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Avatar updated");
+
+    // Verify Gemini was called directly (no managed attempt)
+    expect(geminiGenerateContentFn).toHaveBeenCalledTimes(1);
+
+    // Verify file was written
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+    expect(renameSyncFn).toHaveBeenCalledTimes(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // 5. Local-only E2E
+  // -----------------------------------------------------------------------
+
+  test("local_only — only local Gemini called, managed never contacted", async () => {
+    mockStrategy = "local_only";
+    const fetchMock = mock(() =>
+      Promise.resolve({ ok: true, status: 200, json: async () => ({}) }),
+    );
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+
+    const result = await executeAvatar("a whimsical owl");
+
+    // Verify success
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Avatar updated");
+
+    // Verify Gemini was called
+    expect(geminiGenerateContentFn).toHaveBeenCalledTimes(1);
+
+    // Verify managed endpoint was never contacted
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Verify file was written
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+    expect(renameSyncFn).toHaveBeenCalledTimes(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // 6. Response validation — bad MIME type
+  // -----------------------------------------------------------------------
+
+  test("managed response with disallowed MIME type — rejected, no file written", async () => {
+    mockStrategy = "managed_required";
+    const badResponse = managedPlatformResponse();
+    badResponse.image.mime_type = "image/gif";
+    mockFetchReturning({ ok: true, status: 200, body: badResponse });
+
+    const result = await executeAvatar("a cat");
+
+    // Verify error returned
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("failed");
+
+    // Verify no file was written
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+    expect(renameSyncFn).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // 7. Response validation — oversized image
+  // -----------------------------------------------------------------------
+
+  test("managed response with oversized data — rejected, no file written", async () => {
+    mockStrategy = "managed_required";
+    const oversizedResponse = managedPlatformResponse();
+    oversizedResponse.image.bytes = AVATAR_MAX_DECODED_BYTES + 1;
+    mockFetchReturning({ ok: true, status: 200, body: oversizedResponse });
+
+    const result = await executeAvatar("a cat");
+
+    // Verify error returned
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("failed");
+
+    // Verify no file was written
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+    expect(renameSyncFn).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // 8. Rate limit user message
+  // -----------------------------------------------------------------------
+
+  test("managed 429 response — user-friendly rate limit message", async () => {
+    mockStrategy = "managed_required";
+    mockFetchReturning({
+      ok: false,
+      status: 429,
+      body: {
+        code: "avatar_rate_limited",
+        subcode: "too_many_requests",
+        detail: "Rate limit exceeded",
+        retryable: true,
+        correlation_id: "corr-429",
+      },
+    });
+
+    const result = await executeAvatar("a cat");
+
+    expect(result.isError).toBe(true);
+    expect(result.content.toLowerCase()).toContain("rate limited");
+  });
+
+  // -----------------------------------------------------------------------
+  // 9. Correlation ID propagation
+  // -----------------------------------------------------------------------
+
+  test("managed success — correlation ID from response is logged", async () => {
+    mockStrategy = "managed_required";
+    const response = managedPlatformResponse();
+    response.correlation_id = "unique-corr-id-xyz";
+    mockFetchReturning({ ok: true, status: 200, body: response });
+
+    await executeAvatar("a robot");
+
+    // Look for the correlation ID in info log calls
+    const correlationLogged = logInfoCalls.some(([meta]) => {
+      if (meta && typeof meta === "object" && "correlationId" in meta) {
+        return (
+          (meta as { correlationId: string }).correlationId ===
+          "unique-corr-id-xyz"
+        );
+      }
+      return false;
+    });
+
+    expect(correlationLogged).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/avatar-e2e.test.ts
+++ b/assistant/src/__tests__/avatar-e2e.test.ts
@@ -156,7 +156,7 @@ function mockFetchReturning(response: {
       status: response.status,
       json: async () => response.body,
     }),
-  ) as typeof globalThis.fetch;
+  ) as unknown as typeof globalThis.fetch;
 }
 
 const originalFetch = globalThis.fetch;
@@ -229,10 +229,14 @@ describe("avatar E2E integration", () => {
     expect(renameSyncFn).toHaveBeenCalledTimes(1);
 
     // Verify rename target is the expected avatar path
-    expect(renameSyncFn.mock.calls[0][1]).toBe(expectedAvatarPath);
+    expect((renameSyncFn.mock.calls[0] as unknown[])[1]).toBe(
+      expectedAvatarPath,
+    );
 
     // Verify the written buffer content matches the base64 data
-    const writtenBuffer = writeFileSyncFn.mock.calls[0][1] as Buffer;
+    const writtenBuffer = (
+      writeFileSyncFn.mock.calls[0] as unknown[]
+    )[1] as Buffer;
     const expectedBuffer = Buffer.from("iVBORw0KGgoAAAANSUhEUg==", "base64");
     expect(writtenBuffer.equals(expectedBuffer)).toBe(true);
 
@@ -335,7 +339,7 @@ describe("avatar E2E integration", () => {
     const fetchMock = mock(() =>
       Promise.resolve({ ok: true, status: 200, json: async () => ({}) }),
     );
-    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
 
     const result = await executeAvatar("a whimsical owl");
 

--- a/assistant/src/__tests__/avatar-generator.test.ts
+++ b/assistant/src/__tests__/avatar-generator.test.ts
@@ -175,17 +175,19 @@ describe("setAvatarTool", () => {
 
     // Verify mkdirSync was called for the directory
     expect(mkdirSyncFn).toHaveBeenCalledTimes(1);
-    expect(mkdirSyncFn.mock.calls[0][1]).toEqual({ recursive: true });
+    expect((mkdirSyncFn.mock.calls[0] as unknown[])[1]).toEqual({
+      recursive: true,
+    });
 
     // Verify writeFileSync writes to a unique tmp path
     expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
-    const tmpPath = writeFileSyncFn.mock.calls[0][0] as string;
+    const tmpPath = (writeFileSyncFn.mock.calls[0] as unknown[])[0] as string;
     expect(tmpPath).toStartWith(expectedPath + ".");
     expect(tmpPath).toEndWith(".tmp");
 
     // Verify renameSync moves tmp to final path
     expect(renameSyncFn).toHaveBeenCalledTimes(1);
-    expect(renameSyncFn.mock.calls[0][0]).toBe(tmpPath);
-    expect(renameSyncFn.mock.calls[0][1]).toBe(expectedPath);
+    expect((renameSyncFn.mock.calls[0] as unknown[])[0]).toBe(tmpPath);
+    expect((renameSyncFn.mock.calls[0] as unknown[])[1]).toBe(expectedPath);
   });
 });

--- a/assistant/src/__tests__/avatar-generator.test.ts
+++ b/assistant/src/__tests__/avatar-generator.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { ManagedAvatarError } from "../media/avatar-types.js";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockRouterResult: unknown;
+let mockRouterError: Error | undefined;
+let mockWorkspaceDir = "/tmp/test-workspace";
+
+const routedGenerateAvatarFn = mock(async () => {
+  if (mockRouterError) throw mockRouterError;
+  return mockRouterResult;
+});
+
+const mkdirSyncFn = mock(() => {});
+const writeFileSyncFn = mock(() => {});
+const renameSyncFn = mock(() => {});
+
+// ---------------------------------------------------------------------------
+// Mock modules — before importing module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../media/avatar-router.js", () => ({
+  routedGenerateAvatar: routedGenerateAvatarFn,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+mock.module("../util/platform.js", () => ({
+  getWorkspaceDir: () => mockWorkspaceDir,
+}));
+
+mock.module("node:fs", () => ({
+  mkdirSync: mkdirSyncFn,
+  writeFileSync: writeFileSyncFn,
+  renameSync: renameSyncFn,
+}));
+
+// Import after mocking
+import { setAvatarTool } from "../tools/system/avatar-generator.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function successResult() {
+  return {
+    imageBase64: "iVBORw0KGgoAAAANSUhEUg==",
+    mimeType: "image/png",
+    pathUsed: "local" as const,
+    correlationId: "test-corr-id",
+  };
+}
+
+function executeAvatar(description: string) {
+  return setAvatarTool.execute(
+    { description },
+    {} as Parameters<typeof setAvatarTool.execute>[1],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("setAvatarTool", () => {
+  beforeEach(() => {
+    mockRouterResult = successResult();
+    mockRouterError = undefined;
+    mockWorkspaceDir = "/tmp/test-workspace";
+    routedGenerateAvatarFn.mockClear();
+    mkdirSyncFn.mockClear();
+    writeFileSyncFn.mockClear();
+    renameSyncFn.mockClear();
+  });
+
+  test("successful generation writes PNG and returns success message", async () => {
+    const result = await executeAvatar("a friendly purple cat");
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Avatar updated");
+    expect(routedGenerateAvatarFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("empty description returns error", async () => {
+    const result = await executeAvatar("");
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("description is required");
+    expect(routedGenerateAvatarFn).not.toHaveBeenCalled();
+  });
+
+  test("no image data returned yields error", async () => {
+    mockRouterResult = { ...successResult(), imageBase64: "" };
+
+    const result = await executeAvatar("a cat");
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("No image data returned");
+  });
+
+  test("ManagedAvatarError with rate limit code returns user-friendly message", async () => {
+    mockRouterError = new ManagedAvatarError({
+      code: "avatar_rate_limited",
+      subcode: "too_many_requests",
+      detail: "Rate limited",
+      retryable: true,
+      correlationId: "corr-rate",
+      statusCode: 429,
+    });
+
+    const result = await executeAvatar("a cat");
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("rate limited");
+  });
+
+  test("ManagedAvatarError with 503 returns service unavailable message", async () => {
+    mockRouterError = new ManagedAvatarError({
+      code: "avatar_service_error",
+      subcode: "upstream_unavailable",
+      detail: "Service down",
+      retryable: true,
+      correlationId: "corr-503",
+      statusCode: 503,
+    });
+
+    const result = await executeAvatar("a cat");
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("temporarily unavailable");
+  });
+
+  test("ManagedAvatarError with other code returns detail message", async () => {
+    mockRouterError = new ManagedAvatarError({
+      code: "avatar_content_filtered",
+      subcode: "policy_violation",
+      detail: "Content was filtered by safety policy",
+      retryable: false,
+      correlationId: "corr-filter",
+      statusCode: 400,
+    });
+
+    const result = await executeAvatar("a cat");
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Content was filtered by safety policy");
+  });
+
+  test("generic error returns mapped message", async () => {
+    mockRouterError = new Error("Network timeout");
+
+    const result = await executeAvatar("a cat");
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      "Image generation failed: Network timeout",
+    );
+  });
+
+  test("atomic write — file is written to .tmp then renamed", async () => {
+    await executeAvatar("a friendly cat");
+
+    const expectedPath = "/tmp/test-workspace/data/avatar/custom-avatar.png";
+
+    // Verify mkdirSync was called for the directory
+    expect(mkdirSyncFn).toHaveBeenCalledTimes(1);
+    expect(mkdirSyncFn.mock.calls[0][1]).toEqual({ recursive: true });
+
+    // Verify writeFileSync writes to a unique tmp path
+    expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+    const tmpPath = writeFileSyncFn.mock.calls[0][0] as string;
+    expect(tmpPath).toStartWith(expectedPath + ".");
+    expect(tmpPath).toEndWith(".tmp");
+
+    // Verify renameSync moves tmp to final path
+    expect(renameSyncFn).toHaveBeenCalledTimes(1);
+    expect(renameSyncFn.mock.calls[0][0]).toBe(tmpPath);
+    expect(renameSyncFn.mock.calls[0][1]).toBe(expectedPath);
+  });
+});

--- a/assistant/src/__tests__/avatar-generator.test.ts
+++ b/assistant/src/__tests__/avatar-generator.test.ts
@@ -109,9 +109,9 @@ describe("setAvatarTool", () => {
     expect(result.content).toContain("No image data returned");
   });
 
-  test("ManagedAvatarError with rate limit code returns user-friendly message", async () => {
+  test("ManagedAvatarError with statusCode 429 returns user-friendly rate limit message", async () => {
     mockRouterError = new ManagedAvatarError({
-      code: "avatar_rate_limited",
+      code: "some_error_code",
       subcode: "too_many_requests",
       detail: "Rate limited",
       retryable: true,

--- a/assistant/src/__tests__/avatar-router.test.ts
+++ b/assistant/src/__tests__/avatar-router.test.ts
@@ -25,15 +25,9 @@ const isManagedAvailableFn = mock(() => mockManagedAvailable);
 // ---------------------------------------------------------------------------
 
 mock.module("../config/loader.js", () => ({
-  loadRawConfig: () => {
-    const raw: Record<string, unknown> = {};
-    if (mockStrategy !== undefined) {
-      raw.avatarGenerationStrategy = mockStrategy;
-    }
-    return raw;
-  },
   getConfig: () => ({
     apiKeys: { gemini: mockGeminiKey },
+    avatar: { generationStrategy: mockStrategy ?? "local_only" },
   }),
 }));
 
@@ -187,9 +181,6 @@ describe("avatar-router", () => {
     expect(getAvatarStrategy()).toBe("local_only");
   });
 
-  // 9. Invalid strategy value defaults to local_only
-  test("invalid strategy value defaults to local_only", () => {
-    mockStrategy = "not_a_real_strategy";
-    expect(getAvatarStrategy()).toBe("local_only");
-  });
+  // 9. Removed: Invalid strategy values are now rejected at config parse time
+  // by the Zod schema, so they cannot reach getAvatarStrategy().
 });

--- a/assistant/src/__tests__/avatar-router.test.ts
+++ b/assistant/src/__tests__/avatar-router.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockStrategy: string | undefined;
+let mockGeminiKey: string | undefined = "test-gemini-key";
+let mockManagedAvailable = true;
+let mockManagedResult: unknown;
+let mockManagedError: Error | undefined;
+let mockGeminiResult: unknown;
+
+const generateManagedAvatarFn = mock(async () => {
+  if (mockManagedError) throw mockManagedError;
+  return mockManagedResult;
+});
+
+const generateImageFn = mock(async () => mockGeminiResult);
+
+const isManagedAvailableFn = mock(() => mockManagedAvailable);
+
+// ---------------------------------------------------------------------------
+// Mock modules — before importing module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../config/loader.js", () => ({
+  loadRawConfig: () => {
+    const raw: Record<string, unknown> = {};
+    if (mockStrategy !== undefined) {
+      raw.avatarGenerationStrategy = mockStrategy;
+    }
+    return raw;
+  },
+  getConfig: () => ({
+    apiKeys: { gemini: mockGeminiKey },
+  }),
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+mock.module("../media/managed-avatar-client.js", () => ({
+  isManagedAvailable: isManagedAvailableFn,
+  generateManagedAvatar: generateManagedAvatarFn,
+}));
+
+mock.module("../media/gemini-image-service.js", () => ({
+  generateImage: generateImageFn,
+}));
+
+// Import after mocking
+import {
+  getAvatarStrategy,
+  routedGenerateAvatar,
+} from "../media/avatar-router.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function managedResponse() {
+  return {
+    image: {
+      mime_type: "image/png",
+      data_base64: "base64data",
+      bytes: 1024,
+      sha256: "abc",
+    },
+    usage: { billable: false, class_name: "assistant_avatar_system" },
+    generation_source: "vertex",
+    profile: "avatar_v1",
+    correlation_id: "test-correlation-id",
+  };
+}
+
+function geminiResponse() {
+  return {
+    images: [{ mimeType: "image/png", dataBase64: "base64data" }],
+    resolvedModel: "gemini-2.5-flash-image",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("avatar-router", () => {
+  beforeEach(() => {
+    mockStrategy = undefined;
+    mockGeminiKey = "test-gemini-key";
+    mockManagedAvailable = true;
+    mockManagedResult = managedResponse();
+    mockManagedError = undefined;
+    mockGeminiResult = geminiResponse();
+    generateManagedAvatarFn.mockClear();
+    generateImageFn.mockClear();
+    isManagedAvailableFn.mockClear();
+  });
+
+  // 1. managed_required — managed success
+  test("managed_required returns pathUsed managed on success", async () => {
+    mockStrategy = "managed_required";
+    const result = await routedGenerateAvatar("a cute cat");
+    expect(result.pathUsed).toBe("managed");
+    expect(result.imageBase64).toBe("base64data");
+    expect(result.mimeType).toBe("image/png");
+    expect(generateManagedAvatarFn).toHaveBeenCalledTimes(1);
+    expect(generateImageFn).not.toHaveBeenCalled();
+  });
+
+  // 2. managed_required — managed failure throws, no fallback
+  test("managed_required throws on managed failure without fallback", async () => {
+    mockStrategy = "managed_required";
+    mockManagedError = new Error("upstream error");
+    await expect(routedGenerateAvatar("a cute cat")).rejects.toThrow(
+      "upstream error",
+    );
+    expect(generateImageFn).not.toHaveBeenCalled();
+  });
+
+  // 3. local_only — calls local Gemini, never managed
+  test("local_only calls local Gemini and never managed", async () => {
+    mockStrategy = "local_only";
+    const result = await routedGenerateAvatar("a cute cat");
+    expect(result.pathUsed).toBe("local");
+    expect(result.imageBase64).toBe("base64data");
+    expect(generateImageFn).toHaveBeenCalledTimes(1);
+    expect(generateManagedAvatarFn).not.toHaveBeenCalled();
+  });
+
+  // 4. local_only — missing Gemini API key throws
+  test("local_only throws when Gemini API key is missing", async () => {
+    mockStrategy = "local_only";
+    mockGeminiKey = undefined;
+    // Also clear the env var to ensure no fallback
+    const saved = process.env.GEMINI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    try {
+      await expect(routedGenerateAvatar("a cute cat")).rejects.toThrow(
+        "Gemini API key is not configured",
+      );
+      expect(generateImageFn).not.toHaveBeenCalled();
+    } finally {
+      if (saved !== undefined) process.env.GEMINI_API_KEY = saved;
+    }
+  });
+
+  // 5. managed_prefer — managed success
+  test("managed_prefer returns pathUsed managed on success", async () => {
+    mockStrategy = "managed_prefer";
+    const result = await routedGenerateAvatar("a cute cat");
+    expect(result.pathUsed).toBe("managed");
+    expect(generateManagedAvatarFn).toHaveBeenCalledTimes(1);
+    expect(generateImageFn).not.toHaveBeenCalled();
+  });
+
+  // 6. managed_prefer — managed failure falls back to local
+  test("managed_prefer falls back to local on managed failure", async () => {
+    mockStrategy = "managed_prefer";
+    mockManagedError = new Error("managed failed");
+    const result = await routedGenerateAvatar("a cute cat");
+    expect(result.pathUsed).toBe("local");
+    expect(generateManagedAvatarFn).toHaveBeenCalledTimes(1);
+    expect(generateImageFn).toHaveBeenCalledTimes(1);
+  });
+
+  // 7. managed_prefer — managed unavailable goes directly to local
+  test("managed_prefer goes to local when managed unavailable", async () => {
+    mockStrategy = "managed_prefer";
+    mockManagedAvailable = false;
+    const result = await routedGenerateAvatar("a cute cat");
+    expect(result.pathUsed).toBe("local");
+    expect(generateManagedAvatarFn).not.toHaveBeenCalled();
+    expect(generateImageFn).toHaveBeenCalledTimes(1);
+  });
+
+  // 8. Default strategy is local_only when config key absent
+  test("defaults to local_only when config key is absent", () => {
+    mockStrategy = undefined;
+    expect(getAvatarStrategy()).toBe("local_only");
+  });
+
+  // 9. Invalid strategy value defaults to local_only
+  test("invalid strategy value defaults to local_only", () => {
+    mockStrategy = "not_a_real_strategy";
+    expect(getAvatarStrategy()).toBe("local_only");
+  });
+});

--- a/assistant/src/__tests__/managed-avatar-client.test.ts
+++ b/assistant/src/__tests__/managed-avatar-client.test.ts
@@ -1,0 +1,280 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock dependencies — must be before importing the module under test
+// ---------------------------------------------------------------------------
+
+let mockApiKey: string | undefined = "test-api-key-123";
+let mockBaseUrl = "https://platform.vellum.ai";
+let mockPlatformEnvUrl = "https://env.vellum.ai";
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKey: (account: string) => {
+    if (account === "credential:vellum:assistant_api_key") return mockApiKey;
+    return undefined;
+  },
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    platform: { baseUrl: mockBaseUrl },
+  }),
+}));
+
+mock.module("../config/env.js", () => ({
+  getPlatformBaseUrl: () => mockPlatformEnvUrl,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+// Mock global fetch
+let lastFetchArgs: [string, RequestInit] | null = null;
+let fetchResponse: { ok: boolean; status: number; json: () => Promise<unknown> } = {
+  ok: true,
+  status: 200,
+  json: async () => ({}),
+};
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = (async (url: string, init: RequestInit) => {
+  lastFetchArgs = [url, init];
+  return fetchResponse;
+}) as typeof globalThis.fetch;
+
+// Import after mocking
+import {
+  isManagedAvailable,
+  generateManagedAvatar,
+  getAssistantApiKey,
+} from "../media/managed-avatar-client.js";
+import {
+  ManagedAvatarError,
+  AVATAR_PROMPT_MAX_LENGTH,
+  AVATAR_MAX_DECODED_BYTES,
+} from "../media/avatar-types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function successResponse() {
+  return {
+    image: {
+      mime_type: "image/png",
+      data_base64: "iVBORw0KGgo=",
+      bytes: 1024,
+      sha256: "abc123",
+    },
+    usage: { billable: true, class_name: "avatar" },
+    generation_source: "managed",
+    profile: "default",
+    correlation_id: "test-corr-id",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockApiKey = "test-api-key-123";
+  mockBaseUrl = "https://platform.vellum.ai";
+  mockPlatformEnvUrl = "https://env.vellum.ai";
+  lastFetchArgs = null;
+  fetchResponse = {
+    ok: true,
+    status: 200,
+    json: async () => successResponse(),
+  };
+});
+
+describe("generateManagedAvatar", () => {
+  test("successful generation returns parsed response", async () => {
+    const result = await generateManagedAvatar("a friendly robot avatar");
+
+    expect(result.image.mime_type).toBe("image/png");
+    expect(result.image.data_base64).toBe("iVBORw0KGgo=");
+    expect(result.image.bytes).toBe(1024);
+    expect(result.generation_source).toBe("managed");
+  });
+
+  test("prompt exceeding max length throws ManagedAvatarError with code validation_error", async () => {
+    const longPrompt = "x".repeat(AVATAR_PROMPT_MAX_LENGTH + 1);
+
+    try {
+      await generateManagedAvatar(longPrompt);
+      expect(true).toBe(false); // should not reach here
+    } catch (err) {
+      expect(err).toBeInstanceOf(ManagedAvatarError);
+      const avatarErr = err as ManagedAvatarError;
+      expect(avatarErr.code).toBe("validation_error");
+      expect(avatarErr.subcode).toBe("prompt_too_long");
+    }
+  });
+
+  test("HTTP 429 response throws ManagedAvatarError with retryable true", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 429,
+      json: async () => ({
+        code: "rate_limit",
+        subcode: "too_many_requests",
+        detail: "Rate limit exceeded",
+        retryable: true,
+        correlation_id: "corr-429",
+      }),
+    };
+
+    try {
+      await generateManagedAvatar("test prompt");
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ManagedAvatarError);
+      const avatarErr = err as ManagedAvatarError;
+      expect(avatarErr.retryable).toBe(true);
+      expect(avatarErr.statusCode).toBe(429);
+    }
+  });
+
+  test("HTTP 500 response throws ManagedAvatarError with upstream error details", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 500,
+      json: async () => ({
+        code: "internal_error",
+        subcode: "server_fault",
+        detail: "Internal server error",
+        retryable: true,
+        correlation_id: "corr-500",
+      }),
+    };
+
+    try {
+      await generateManagedAvatar("test prompt");
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ManagedAvatarError);
+      const avatarErr = err as ManagedAvatarError;
+      expect(avatarErr.code).toBe("internal_error");
+      expect(avatarErr.subcode).toBe("server_fault");
+      expect(avatarErr.statusCode).toBe(500);
+    }
+  });
+
+  test("response with disallowed MIME type throws validation error", async () => {
+    fetchResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ...successResponse(),
+        image: { ...successResponse().image, mime_type: "image/gif" },
+      }),
+    };
+
+    try {
+      await generateManagedAvatar("test prompt");
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ManagedAvatarError);
+      const avatarErr = err as ManagedAvatarError;
+      expect(avatarErr.code).toBe("validation_error");
+      expect(avatarErr.subcode).toBe("disallowed_mime_type");
+    }
+  });
+
+  test("response with oversized bytes throws validation error", async () => {
+    fetchResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ...successResponse(),
+        image: { ...successResponse().image, bytes: AVATAR_MAX_DECODED_BYTES + 1 },
+      }),
+    };
+
+    try {
+      await generateManagedAvatar("test prompt");
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ManagedAvatarError);
+      const avatarErr = err as ManagedAvatarError;
+      expect(avatarErr.code).toBe("validation_error");
+      expect(avatarErr.subcode).toBe("oversized_image");
+    }
+  });
+
+  test("response with oversized base64 estimated decoded size throws validation error", async () => {
+    // Create a base64 string whose estimated decoded size exceeds the limit,
+    // even though the server-reported bytes field is under the limit
+    const oversizedBase64 = "A".repeat(Math.ceil((AVATAR_MAX_DECODED_BYTES + 100) * 4 / 3));
+    fetchResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ...successResponse(),
+        image: { ...successResponse().image, data_base64: oversizedBase64, bytes: 1024 },
+      }),
+    };
+
+    try {
+      await generateManagedAvatar("test prompt");
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ManagedAvatarError);
+      const avatarErr = err as ManagedAvatarError;
+      expect(avatarErr.code).toBe("validation_error");
+      expect(avatarErr.subcode).toBe("oversized_image");
+    }
+  });
+
+  test("Authorization header uses Api-Key prefix", async () => {
+    await generateManagedAvatar("test prompt");
+
+    expect(lastFetchArgs).not.toBeNull();
+    const headers = lastFetchArgs![1].headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Api-Key test-api-key-123");
+    expect(headers.Authorization).not.toContain("Bearer");
+  });
+
+  test("Idempotency-Key header is present on every request", async () => {
+    await generateManagedAvatar("test prompt");
+
+    expect(lastFetchArgs).not.toBeNull();
+    const headers = lastFetchArgs![1].headers as Record<string, string>;
+    expect(headers["Idempotency-Key"]).toBeDefined();
+    expect(headers["Idempotency-Key"].length).toBeGreaterThan(0);
+  });
+
+  test("caller-provided idempotencyKey is used in the request header", async () => {
+    const customKey = "my-custom-idempotency-key-123";
+    await generateManagedAvatar("test prompt", { idempotencyKey: customKey });
+
+    expect(lastFetchArgs).not.toBeNull();
+    const headers = lastFetchArgs![1].headers as Record<string, string>;
+    expect(headers["Idempotency-Key"]).toBe(customKey);
+  });
+});
+
+describe("isManagedAvailable", () => {
+  test("returns false when API key is missing", () => {
+    mockApiKey = undefined;
+    expect(isManagedAvailable()).toBe(false);
+  });
+
+  test("returns false when base URL is missing", () => {
+    mockBaseUrl = "";
+    mockPlatformEnvUrl = "";
+    expect(isManagedAvailable()).toBe(false);
+  });
+
+  test("returns true when both API key and base URL are present", () => {
+    expect(isManagedAvailable()).toBe(true);
+  });
+});

--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -349,6 +349,22 @@ export const IngressConfigSchema = IngressBaseSchema.default(
   enabled: val.enabled ?? (val.publicBaseUrl ? true : undefined),
 }));
 
+export const VALID_AVATAR_STRATEGIES = [
+  "managed_required",
+  "managed_prefer",
+  "local_only",
+] as const;
+
+export const AvatarConfigSchema = z.object({
+  generationStrategy: z
+    .enum(VALID_AVATAR_STRATEGIES, {
+      error: `avatar.generationStrategy must be one of: ${VALID_AVATAR_STRATEGIES.join(", ")}`,
+    })
+    .default("local_only"),
+});
+
+export type AvatarConfig = z.infer<typeof AvatarConfigSchema>;
+
 export const PlatformConfigSchema = z.object({
   baseUrl: z
     .string({ error: "platform.baseUrl must be a string" })

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -32,6 +32,7 @@ export {
 } from "./calls-schema.js";
 export type {
   AuditLogConfig,
+  AvatarConfig,
   ContextOverflowRecoveryConfig,
   ContextWindowConfig,
   DaemonConfig,
@@ -54,6 +55,7 @@ export type {
 } from "./core-schema.js";
 export {
   AuditLogConfigSchema,
+  AvatarConfigSchema,
   ContextOverflowRecoveryConfigSchema,
   ContextWindowConfigSchema,
   DaemonConfigSchema,
@@ -151,6 +153,7 @@ import {
 import { CallsConfigSchema } from "./calls-schema.js";
 import {
   AuditLogConfigSchema,
+  AvatarConfigSchema,
   ContextWindowConfigSchema,
   DaemonConfigSchema,
   EffortSchema,
@@ -275,6 +278,7 @@ export const AssistantConfigSchema = z
     notifications: NotificationsConfigSchema.default(
       NotificationsConfigSchema.parse({}),
     ),
+    avatar: AvatarConfigSchema.default(AvatarConfigSchema.parse({})),
     ui: UiConfigSchema.default(UiConfigSchema.parse({})),
     featureFlags: z
       .record(

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -350,7 +350,7 @@ function buildInChatConfigurationSection(): string {
     "",
     "### Avatar Customisation",
     "",
-    'You can change your avatar appearance using the `set_avatar` tool. When the user asks to change, update, or customise your avatar, use `set_avatar` with a `description` parameter describing the desired appearance (e.g. "a friendly purple cat with green eyes wearing a tiny hat"). The tool generates an avatar image via Gemini and updates all connected clients automatically. Requires a Gemini API key (the same one used for image generation).',
+    'You can change your avatar appearance using the `set_avatar` tool. When the user asks to change, update, or customise your avatar, use `set_avatar` with a `description` parameter describing the desired appearance (e.g. "a friendly purple cat with green eyes wearing a tiny hat"). The tool generates an avatar image and updates all connected clients automatically. If managed avatar generation is configured, no local API key is needed.',
     "",
     "**After generating a new avatar**, always update the `## Avatar` section in `IDENTITY.md` with a brief description of the current avatar appearance. This ensures you remember what you look like across sessions. Example:",
     "```",

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -3,7 +3,7 @@
  * Selects managed platform or local Gemini path based on config.
  */
 
-import { getConfig, loadRawConfig } from "../config/loader.js";
+import { getConfig } from "../config/loader.js";
 import { ConfigError, ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import type {
@@ -18,23 +18,8 @@ import {
 
 const log = getLogger("avatar-router");
 
-const VALID_STRATEGIES: ReadonlySet<string> = new Set([
-  "managed_required",
-  "managed_prefer",
-  "local_only",
-]);
-
 export function getAvatarStrategy(): AvatarGenerationStrategy {
-  try {
-    const raw = loadRawConfig();
-    const strategy = raw.avatarGenerationStrategy as string | undefined;
-    if (strategy && VALID_STRATEGIES.has(strategy)) {
-      return strategy as AvatarGenerationStrategy;
-    }
-  } catch {
-    /* fall through */
-  }
-  return "local_only";
+  return getConfig().avatar.generationStrategy;
 }
 
 async function generateLocal(

--- a/assistant/src/media/avatar-router.ts
+++ b/assistant/src/media/avatar-router.ts
@@ -1,0 +1,114 @@
+/**
+ * Strategy router for avatar generation.
+ * Selects managed platform or local Gemini path based on config.
+ */
+
+import { getConfig, loadRawConfig } from "../config/loader.js";
+import { ConfigError, ProviderError } from "../util/errors.js";
+import { getLogger } from "../util/logger.js";
+import type {
+  AvatarGenerationResult,
+  AvatarGenerationStrategy,
+} from "./avatar-types.js";
+import { generateImage } from "./gemini-image-service.js";
+import {
+  generateManagedAvatar,
+  isManagedAvailable,
+} from "./managed-avatar-client.js";
+
+const log = getLogger("avatar-router");
+
+const VALID_STRATEGIES: ReadonlySet<string> = new Set([
+  "managed_required",
+  "managed_prefer",
+  "local_only",
+]);
+
+export function getAvatarStrategy(): AvatarGenerationStrategy {
+  try {
+    const raw = loadRawConfig();
+    const strategy = raw.avatarGenerationStrategy as string | undefined;
+    if (strategy && VALID_STRATEGIES.has(strategy)) {
+      return strategy as AvatarGenerationStrategy;
+    }
+  } catch {
+    /* fall through */
+  }
+  return "local_only";
+}
+
+async function generateLocal(
+  prompt: string,
+  correlationId?: string,
+): Promise<AvatarGenerationResult> {
+  const config = getConfig();
+  const geminiKey = config.apiKeys.gemini ?? process.env.GEMINI_API_KEY;
+  if (!geminiKey) {
+    throw new ConfigError(
+      "Gemini API key is not configured. Set it via `config set apiKeys.gemini <key>` or the GEMINI_API_KEY environment variable.",
+    );
+  }
+
+  const result = await generateImage(geminiKey, {
+    prompt,
+    mode: "generate",
+    model: config.imageGenModel,
+  });
+
+  const image = result.images[0];
+  if (!image) {
+    throw new ProviderError(
+      "Local Gemini image generation returned no images.",
+      "gemini",
+    );
+  }
+
+  return {
+    imageBase64: image.dataBase64,
+    mimeType: image.mimeType,
+    pathUsed: "local",
+    correlationId,
+  };
+}
+
+export async function routedGenerateAvatar(
+  prompt: string,
+  options?: { correlationId?: string },
+): Promise<AvatarGenerationResult> {
+  const strategy = getAvatarStrategy();
+  const correlationId = options?.correlationId;
+
+  if (strategy === "managed_required") {
+    const managed = await generateManagedAvatar(prompt, { correlationId });
+    return {
+      imageBase64: managed.image.data_base64,
+      mimeType: managed.image.mime_type,
+      pathUsed: "managed",
+      correlationId: managed.correlation_id,
+    };
+  }
+
+  if (strategy === "local_only") {
+    return generateLocal(prompt, correlationId);
+  }
+
+  // managed_prefer: try managed first if available, fall back to local
+  if (isManagedAvailable()) {
+    try {
+      const managed = await generateManagedAvatar(prompt, { correlationId });
+      return {
+        imageBase64: managed.image.data_base64,
+        mimeType: managed.image.mime_type,
+        pathUsed: "managed",
+        correlationId: managed.correlation_id,
+      };
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Managed avatar generation failed, falling back to local Gemini",
+      );
+    }
+  }
+
+  return generateLocal(prompt, correlationId);
+}

--- a/assistant/src/media/avatar-types.ts
+++ b/assistant/src/media/avatar-types.ts
@@ -1,0 +1,60 @@
+export type AvatarGenerationStrategy = "managed_required" | "managed_prefer" | "local_only";
+
+export interface ManagedAvatarImagePayload {
+  mime_type: string;
+  data_base64: string;
+  bytes: number;
+  sha256: string;
+}
+
+export interface ManagedAvatarResponse {
+  image: ManagedAvatarImagePayload;
+  usage: { billable: boolean; class_name: string };
+  generation_source: string;
+  profile: string;
+  correlation_id: string;
+}
+
+export interface ManagedAvatarErrorResponse {
+  code: string;
+  subcode: string;
+  detail: string;
+  retryable: boolean;
+  correlation_id: string;
+}
+
+export class ManagedAvatarError extends Error {
+  readonly code: string;
+  readonly subcode: string;
+  readonly retryable: boolean;
+  readonly correlationId: string;
+  readonly statusCode: number;
+
+  constructor(opts: {
+    code: string;
+    subcode: string;
+    detail: string;
+    retryable: boolean;
+    correlationId: string;
+    statusCode: number;
+  }) {
+    super(opts.detail);
+    this.name = "ManagedAvatarError";
+    this.code = opts.code;
+    this.subcode = opts.subcode;
+    this.retryable = opts.retryable;
+    this.correlationId = opts.correlationId;
+    this.statusCode = opts.statusCode;
+  }
+}
+
+export interface AvatarGenerationResult {
+  imageBase64: string;
+  mimeType: string;
+  pathUsed: "managed" | "local";
+  correlationId?: string;
+}
+
+export const AVATAR_MIME_ALLOWLIST = new Set(["image/png", "image/jpeg", "image/webp"]);
+export const AVATAR_MAX_DECODED_BYTES = 10 * 1024 * 1024;
+export const AVATAR_PROMPT_MAX_LENGTH = 2000;

--- a/assistant/src/media/managed-avatar-client.ts
+++ b/assistant/src/media/managed-avatar-client.ts
@@ -1,0 +1,189 @@
+import { getPlatformBaseUrl } from "../config/env.js";
+import { getConfig } from "../config/loader.js";
+import { getSecureKey } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
+import {
+  AVATAR_MAX_DECODED_BYTES,
+  AVATAR_MIME_ALLOWLIST,
+  AVATAR_PROMPT_MAX_LENGTH,
+  ManagedAvatarError,
+  type ManagedAvatarErrorResponse,
+  type ManagedAvatarResponse,
+} from "./avatar-types.js";
+
+const log = getLogger("managed-avatar-client");
+
+export function getAssistantApiKey(): string | undefined {
+  return getSecureKey("credential:vellum:assistant_api_key");
+}
+
+export function getManagedAvatarBaseUrl(): string {
+  const baseUrl = getConfig().platform.baseUrl || getPlatformBaseUrl();
+  return baseUrl.replace(/\/+$/, "");
+}
+
+export function isManagedAvailable(): boolean {
+  const apiKey = getAssistantApiKey();
+  const baseUrl = getManagedAvatarBaseUrl();
+  return !!apiKey && apiKey.length > 0 && !!baseUrl && baseUrl.length > 0;
+}
+
+export async function generateManagedAvatar(
+  prompt: string,
+  options?: { correlationId?: string; idempotencyKey?: string },
+): Promise<ManagedAvatarResponse> {
+  if (prompt.length > AVATAR_PROMPT_MAX_LENGTH) {
+    throw new ManagedAvatarError({
+      code: "validation_error",
+      subcode: "prompt_too_long",
+      detail: `Prompt exceeds maximum length of ${AVATAR_PROMPT_MAX_LENGTH} characters`,
+      retryable: false,
+      correlationId: options?.correlationId ?? crypto.randomUUID(),
+      statusCode: 0,
+    });
+  }
+
+  const apiKey = getAssistantApiKey();
+  if (!apiKey) {
+    throw new ManagedAvatarError({
+      code: "configuration_error",
+      subcode: "missing_api_key",
+      detail: "Assistant API key is not configured",
+      retryable: false,
+      correlationId: options?.correlationId ?? crypto.randomUUID(),
+      statusCode: 0,
+    });
+  }
+
+  const baseUrl = getManagedAvatarBaseUrl();
+  if (!baseUrl) {
+    throw new ManagedAvatarError({
+      code: "configuration_error",
+      subcode: "missing_base_url",
+      detail:
+        "Platform base URL is not configured. Set platform.baseUrl in config or PLATFORM_BASE_URL environment variable.",
+      retryable: false,
+      correlationId: options?.correlationId ?? crypto.randomUUID(),
+      statusCode: 0,
+    });
+  }
+
+  const url = `${baseUrl}/v1/assistants/avatar/generate/`;
+  const idempotencyKey = options?.idempotencyKey ?? crypto.randomUUID();
+  const correlationId = options?.correlationId ?? crypto.randomUUID();
+
+  const headers: Record<string, string> = {
+    Authorization: `Api-Key ${apiKey}`,
+    "Content-Type": "application/json",
+    "Idempotency-Key": idempotencyKey,
+    "X-Correlation-Id": correlationId,
+  };
+
+  log.debug({ url, correlationId }, "Requesting managed avatar generation");
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      body: JSON.stringify({ prompt }),
+      signal: AbortSignal.timeout(60_000),
+      headers,
+    });
+  } catch (err) {
+    const isTimeout =
+      err instanceof DOMException && err.name === "TimeoutError";
+    throw new ManagedAvatarError({
+      code: "avatar_generation_failed",
+      subcode: isTimeout ? "upstream_timeout" : "network_error",
+      detail: isTimeout
+        ? "Request to avatar generation service timed out"
+        : `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      retryable: true,
+      correlationId,
+      statusCode: 0,
+    });
+  }
+
+  if (!response.ok) {
+    let errorBody: ManagedAvatarErrorResponse;
+    try {
+      errorBody = (await response.json()) as ManagedAvatarErrorResponse;
+    } catch {
+      throw new ManagedAvatarError({
+        code: "upstream_error",
+        subcode: "unparseable_response",
+        detail: `HTTP ${response.status}: unable to parse error response`,
+        retryable: response.status >= 500 || response.status === 429,
+        correlationId,
+        statusCode: response.status,
+      });
+    }
+
+    throw new ManagedAvatarError({
+      code: errorBody.code ?? "upstream_error",
+      subcode: errorBody.subcode ?? "unknown",
+      detail: errorBody.detail ?? `HTTP ${response.status}`,
+      retryable:
+        errorBody.retryable ??
+        (response.status >= 500 || response.status === 429),
+      correlationId: errorBody.correlation_id ?? correlationId,
+      statusCode: response.status,
+    });
+  }
+
+  let body: ManagedAvatarResponse;
+  try {
+    body = (await response.json()) as ManagedAvatarResponse;
+
+    if (!AVATAR_MIME_ALLOWLIST.has(body.image.mime_type)) {
+      throw new ManagedAvatarError({
+        code: "validation_error",
+        subcode: "disallowed_mime_type",
+        detail: `Response MIME type "${body.image.mime_type}" is not in the allowlist`,
+        retryable: false,
+        correlationId,
+        statusCode: 0,
+      });
+    }
+
+    const b64 = body.image.data_base64;
+    const padding = b64.endsWith("==") ? 2 : b64.endsWith("=") ? 1 : 0;
+    const estimatedDecodedBytes = Math.ceil((b64.length * 3) / 4) - padding;
+    if (
+      estimatedDecodedBytes > AVATAR_MAX_DECODED_BYTES ||
+      body.image.bytes > AVATAR_MAX_DECODED_BYTES
+    ) {
+      throw new ManagedAvatarError({
+        code: "validation_error",
+        subcode: "oversized_image",
+        detail: `Response image size ${Math.max(estimatedDecodedBytes, body.image.bytes)} exceeds maximum of ${AVATAR_MAX_DECODED_BYTES} bytes`,
+        retryable: false,
+        correlationId,
+        statusCode: 0,
+      });
+    }
+
+    log.debug(
+      {
+        correlationId,
+        mimeType: body.image.mime_type,
+        bytes: body.image.bytes,
+      },
+      "Managed avatar generation succeeded",
+    );
+
+    return body;
+  } catch (err) {
+    if (err instanceof ManagedAvatarError) {
+      throw err;
+    }
+    throw new ManagedAvatarError({
+      code: "upstream_error",
+      subcode: "unparseable_response",
+      detail: `Failed to parse avatar generation response: ${err instanceof Error ? err.message : String(err)}`,
+      retryable: false,
+      correlationId,
+      statusCode: 0,
+    });
+  }
+}

--- a/assistant/src/tools/system/avatar-generator.ts
+++ b/assistant/src/tools/system/avatar-generator.ts
@@ -109,7 +109,7 @@ export const setAvatarTool: Tool = {
       };
     } catch (error) {
       if (error instanceof ManagedAvatarError) {
-        if (error.code === "avatar_rate_limited") {
+        if (error.statusCode === 429) {
           log.warn(
             { correlationId: error.correlationId },
             "Avatar generation rate limited",

--- a/assistant/src/tools/system/avatar-generator.ts
+++ b/assistant/src/tools/system/avatar-generator.ts
@@ -1,11 +1,10 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-import { getConfig } from "../../config/loader.js";
-import {
-  generateImage,
-  mapGeminiError,
-} from "../../media/gemini-image-service.js";
+import { routedGenerateAvatar } from "../../media/avatar-router.js";
+import { ManagedAvatarError } from "../../media/avatar-types.js";
+import { mapGeminiError } from "../../media/gemini-image-service.js";
 import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
@@ -66,21 +65,8 @@ export const setAvatarTool: Tool = {
       };
     }
 
-    const config = getConfig();
-    const apiKey = config.apiKeys.gemini ?? process.env.GEMINI_API_KEY;
-    if (!apiKey) {
-      return {
-        content:
-          "No Gemini API key configured. Please add your Gemini API key in Settings → Models & Services, or set the GEMINI_API_KEY environment variable.",
-        isError: true,
-      };
-    }
-
     try {
-      log.info(
-        { description: description.trim() },
-        "Generating avatar via Gemini",
-      );
+      log.info({ description: description.trim() }, "Generating avatar");
 
       const prompt =
         `Create an avatar image based on this description: ${description.trim()}\n\n` +
@@ -89,29 +75,31 @@ export const setAvatarTool: Tool = {
         "Circular or rounded composition filling the canvas. " +
         "Subtle background color (not white or transparent).";
 
-      const result = await generateImage(apiKey, {
-        prompt,
-        mode: "generate",
-        model: config.imageGenModel,
-      });
-
-      if (result.images.length === 0) {
+      const result = await routedGenerateAvatar(prompt);
+      if (!result.imageBase64) {
         return {
-          content: "Error: Gemini returned no image data. Please try again.",
+          content: "Error: No image data returned. Please try again.",
           isError: true,
         };
       }
-
-      const image = result.images[0];
-      const pngBuffer = Buffer.from(image.dataBase64, "base64");
+      const pngBuffer = Buffer.from(result.imageBase64, "base64");
 
       const avatarPath = getAvatarPath();
       const avatarDir = dirname(avatarPath);
 
+      const tmpPath = `${avatarPath}.${randomUUID()}.tmp`;
       mkdirSync(avatarDir, { recursive: true });
-      writeFileSync(avatarPath, pngBuffer);
+      writeFileSync(tmpPath, pngBuffer);
+      renameSync(tmpPath, avatarPath);
 
-      log.info({ avatarPath }, "Avatar saved successfully");
+      log.info(
+        {
+          avatarPath,
+          pathUsed: result.pathUsed,
+          correlationId: result.correlationId,
+        },
+        "Avatar saved successfully",
+      );
 
       // Side-effect hook in tool-side-effects.ts broadcasts avatar_updated to all clients.
 
@@ -120,9 +108,42 @@ export const setAvatarTool: Tool = {
         isError: false,
       };
     } catch (error) {
+      if (error instanceof ManagedAvatarError) {
+        if (error.code === "avatar_rate_limited") {
+          log.warn(
+            { correlationId: error.correlationId },
+            "Avatar generation rate limited",
+          );
+          return {
+            content:
+              "Avatar generation is rate limited. Please wait and try again.",
+            isError: true,
+          };
+        }
+        if (error.statusCode === 503) {
+          log.warn(
+            { correlationId: error.correlationId },
+            "Avatar generation service unavailable",
+          );
+          return {
+            content: "Avatar generation service is temporarily unavailable.",
+            isError: true,
+          };
+        }
+        const detail =
+          error.message || "Avatar generation failed. Please try again.";
+        log.error(
+          { error: detail, correlationId: error.correlationId },
+          "Managed avatar generation failed",
+        );
+        return {
+          content: `Avatar generation failed: ${detail}`,
+          isError: true,
+        };
+      }
+
       const message = mapGeminiError(error);
       log.error({ error: message }, "Avatar generation failed");
-
       return {
         content: `Avatar generation failed: ${message}`,
         isError: true,

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -329,7 +329,9 @@ extension AppDelegate {
 
         // Handle avatar_updated from daemon: reload the avatar image from disk
         daemonClient.onAvatarUpdated = { _ in
-            AvatarAppearanceManager.shared.reloadAvatar()
+            Task { @MainActor in
+                AvatarAppearanceManager.shared.reloadAvatar()
+            }
         }
 
         // Restart DaemonClient connection when the health monitor relaunches


### PR DESCRIPTION
## Summary
Add a managed avatar generation path to the assistant runtime that calls the platform's `POST /v1/assistants/avatar/generate/` endpoint. The assistant gets an explicit strategy router (`managed_required`, `managed_prefer`, `local_only`) modeled on the existing Twitter router pattern, a dedicated HTTP client for the platform endpoint, validation of managed responses, and end-to-end wiring into the existing `set_avatar` tool.

## Changes
- **Types & constants** (M1): `AvatarGenerationStrategy`, `ManagedAvatarResponse`, `ManagedAvatarError` class, validation constants
- **HTTP client** (M2): `generateManagedAvatar()` with MIME validation, base64 size estimation, structured error handling, idempotency key support
- **Strategy router** (M3): `routedGenerateAvatar()` with `managed_required`, `managed_prefer`, `local_only` modes and fallback logic
- **Config schema** (M4): `AvatarConfigSchema` with Zod validation, `generationStrategy` field defaulting to `local_only`
- **Tool wiring** (M5): `set_avatar` tool now uses the router, atomic file writes, structured error messages for rate-limited/unavailable states
- **E2E tests** (M6): Full-chain integration tests covering all strategy modes, response validation, error handling

## Milestone PRs (merged into feature branch)
- #12580: M1: Add avatar generation types and constants
- #12581: M2: Add managed avatar HTTP client
- #12593: M3: Add avatar generation strategy router
- #12633: M4: Add avatarGenerationStrategy config field
- #12638: M5: Wire avatar strategy router into set_avatar tool
- #12640: M6: Response validation and E2E integration tests

## Project issue
Closes #12572

## Test plan
- [ ] Verify `bun test avatar` passes all unit and E2E tests
- [ ] Verify `bunx tsc --noEmit` passes
- [ ] Verify `local_only` strategy (default) behaves identically to pre-change behavior
- [ ] Verify `managed_required` strategy calls platform endpoint
- [ ] Verify `managed_prefer` strategy falls back to local on managed failure

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
