### PR TITLE
M5: Make lifecycle + retire fully instance-scoped

### DIFF
--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -4,6 +4,7 @@ import { homedir } from "os";
 import { basename, dirname, join } from "path";
 
 import {
+  defaultLocalResources,
   findAssistantByName,
   removeAssistantEntry,
 } from "../lib/assistant-config";
@@ -40,18 +41,15 @@ function extractHostFromUrl(url: string): string {
   }
 }
 
-function getBaseDir(): string {
-  return process.env.BASE_DATA_DIR?.trim() || homedir();
-}
-
 async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   console.log("\u{1F5D1}\ufe0f  Stopping local assistant...\n");
 
-  const vellumDir = join(getBaseDir(), ".vellum");
+  const resources = entry.resources ?? defaultLocalResources();
+  const vellumDir = join(resources.instanceDir, ".vellum");
 
   // Stop daemon via PID file
-  const daemonPidFile = join(vellumDir, "vellum.pid");
-  const socketFile = join(vellumDir, "vellum.sock");
+  const daemonPidFile = resources.pidFile;
+  const socketFile = resources.socketPath;
   const daemonStopped = await stopProcessByPidFile(daemonPidFile, "daemon", [
     socketFile,
   ]);
@@ -70,14 +68,23 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
     await stopOrphanedDaemonProcesses();
   }
 
+  // For named instances (instanceDir under ~/.vellum/instances/<name>/),
+  // archive and remove the entire instance directory. For default instances
+  // (instanceDir is homedir), archive only the .vellum subdirectory.
+  const instancesBase = join(homedir(), ".vellum", "instances");
+  const isNamedInstance = resources.instanceDir.startsWith(instancesBase + "/");
+  const dirToArchive = isNamedInstance ? resources.instanceDir : vellumDir;
+
   // Move the data directory out of the way so the path is immediately available
   // for the next hatch, then kick off the tar archive in the background.
   const archivePath = getArchivePath(name);
   const metadataPath = getMetadataPath(name);
   const stagingDir = `${archivePath}.staging`;
 
-  if (!existsSync(vellumDir)) {
-    console.log(`   No data directory at ${vellumDir} — nothing to archive.`);
+  if (!existsSync(dirToArchive)) {
+    console.log(
+      `   No data directory at ${dirToArchive} — nothing to archive.`,
+    );
     console.log("\u2705 Local instance retired.");
     return;
   }
@@ -86,10 +93,10 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   mkdirSync(dirname(stagingDir), { recursive: true });
 
   try {
-    renameSync(vellumDir, stagingDir);
+    renameSync(dirToArchive, stagingDir);
   } catch (err) {
     console.warn(
-      `⚠️  Failed to move ${vellumDir}: ${err instanceof Error ? err.message : err}`,
+      `⚠️  Failed to move ${dirToArchive}: ${err instanceof Error ? err.message : err}`,
     );
     console.warn("Skipping archive.");
     console.log("\u2705 Local instance retired.");

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -44,12 +44,20 @@ function extractHostFromUrl(url: string): string {
 async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   console.log("\u{1F5D1}\ufe0f  Stopping local assistant...\n");
 
+  // Use entry resources when available; for legacy entries, derive paths
+  // from baseDataDir (which may differ from homedir if BASE_DATA_DIR was set).
   const resources = entry.resources ?? defaultLocalResources();
-  const vellumDir = join(resources.instanceDir, ".vellum");
+  const legacyDir = entry.baseDataDir;
+  const vellumDir = legacyDir ?? join(resources.instanceDir, ".vellum");
 
-  // Stop daemon via PID file
-  const daemonPidFile = resources.pidFile;
-  const socketFile = resources.socketPath;
+  // Stop daemon via PID file — prefer resources paths, but for legacy entries
+  // with a custom baseDataDir, derive from that directory instead.
+  const daemonPidFile = legacyDir
+    ? join(legacyDir, "vellum.pid")
+    : resources.pidFile;
+  const socketFile = legacyDir
+    ? join(legacyDir, "vellum.sock")
+    : resources.socketPath;
   const daemonStopped = await stopProcessByPidFile(daemonPidFile, "daemon", [
     socketFile,
   ]);


### PR DESCRIPTION
Updates retireLocal() to use instance-specific resources for PID files, socket paths, and data directory cleanup. Part of #12604.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
