### PR TITLE
feat: add eyes reaction as Slack typing indicator

### DIFF
--- a/assistant/src/__tests__/gemini-image-service.test.ts
+++ b/assistant/src/__tests__/gemini-image-service.test.ts
@@ -137,8 +137,8 @@ describe("generateImage", () => {
       .contents as Array<Record<string, unknown>>;
     const parts = contents[0].parts as Array<Record<string, unknown>>;
 
-    // First part is the text prompt
-    expect(parts[0]).toEqual({ text: "remove background" });
+    // First part is the text prompt (with appended title instruction)
+    expect((parts[0] as { text: string }).text).toContain("remove background");
     // Second part is the source image
     expect(parts[1]).toEqual({
       inlineData: { mimeType: "image/jpeg", data: "srcdata" },

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -109,14 +109,20 @@ export async function run(
       content += `\n\n${result.text}`;
     }
 
-    const contentBlocks: ImageContent[] = result.images.map((img) => ({
-      type: "image" as const,
-      source: {
-        type: "base64" as const,
-        media_type: img.mimeType,
-        data: img.dataBase64,
-      },
-    }));
+    const contentBlocks: ImageContent[] = result.images.map((img) => {
+      const block: ImageContent = {
+        type: "image" as const,
+        source: {
+          type: "base64" as const,
+          media_type: img.mimeType,
+          data: img.dataBase64,
+        },
+      };
+      if (img.title) {
+        (block as unknown as Record<string, unknown>)._title = img.title;
+      }
+      return block;
+    });
 
     return {
       content,

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -639,9 +639,11 @@ export function contentBlocksToDrafts(
       const data = src.data;
       const mimeType = src.media_type;
       const ext = mimeType.split("/")[1] ?? "png";
+      const title = typeof b._title === "string" ? b._title : undefined;
+      const prefix = title || toolNameToFilePrefix(toolName);
       drafts.push({
         sourceType: "tool_block",
-        filename: `${toolNameToFilePrefix(toolName)}.${ext}`,
+        filename: `${prefix}.${ext}`,
         mimeType,
         dataBase64: data,
         sizeBytes: estimateBase64Bytes(data),

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -606,16 +606,34 @@ interface FileBlock {
 }
 
 /**
+ * Derive a human-friendly filename from the tool name that produced the
+ * content block. Falls back to "tool-output" for unknown tools.
+ */
+function toolNameToFilePrefix(toolName?: string): string {
+  if (!toolName) return "tool-output";
+  // Convert snake_case / camelCase tool names to kebab-case labels
+  return toolName
+    .replace(/([a-z])([A-Z])/g, "$1-$2")
+    .replace(/_/g, "-")
+    .toLowerCase();
+}
+
+/**
  * Convert tool content blocks (images/files from tool results) into
  * attachment drafts. Blocks that aren't image or file types are skipped.
+ *
+ * An optional `toolNames` map (index → tool name) produces friendlier
+ * filenames than the default "tool-output".
  */
 export function contentBlocksToDrafts(
   blocks: readonly unknown[],
+  toolNames?: ReadonlyMap<number, string>,
 ): AssistantAttachmentDraft[] {
   const drafts: AssistantAttachmentDraft[] = [];
 
-  for (const block of blocks) {
-    const b = block as Record<string, unknown>;
+  for (let i = 0; i < blocks.length; i++) {
+    const b = blocks[i] as Record<string, unknown>;
+    const toolName = toolNames?.get(i);
     if (b.type === "image") {
       const src = b.source as ImageBlock["source"];
       const data = src.data;
@@ -623,7 +641,7 @@ export function contentBlocksToDrafts(
       const ext = mimeType.split("/")[1] ?? "png";
       drafts.push({
         sourceType: "tool_block",
-        filename: `tool-output.${ext}`,
+        filename: `${toolNameToFilePrefix(toolName)}.${ext}`,
         mimeType,
         dataBase64: data,
         sizeBytes: estimateBase64Bytes(data),

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -56,6 +56,8 @@ export interface EventHandlerState {
   readonly persistedToolUseIds: Set<string>;
   readonly accumulatedDirectives: DirectiveRequest[];
   readonly accumulatedToolContentBlocks: ContentBlock[];
+  /** Maps index in accumulatedToolContentBlocks → tool name that produced it. */
+  readonly toolContentBlockToolNames: Map<number, string>;
   readonly directiveWarnings: string[];
   readonly toolUseIdToName: Map<string, string>;
   currentTurnToolNames: string[];
@@ -99,6 +101,7 @@ export function createEventHandlerState(): EventHandlerState {
     persistedToolUseIds: new Set(),
     accumulatedDirectives: [],
     accumulatedToolContentBlocks: [],
+    toolContentBlockToolNames: new Map(),
     directiveWarnings: [],
     toolUseIdToName: new Map(),
     currentTurnToolNames: [],
@@ -400,6 +403,12 @@ export function handleToolResult(
     for (const cb of event.contentBlocks) {
       if (cb.type === "image" || cb.type === "file") {
         state.accumulatedToolContentBlocks.push(cb);
+        if (toolName) {
+          state.toolContentBlockToolNames.set(
+            state.accumulatedToolContentBlocks.length - 1,
+            toolName,
+          );
+        }
       }
     }
   }

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -1238,6 +1238,7 @@ export async function runAgentLoopImpl(
           ctx.hasNoClient,
         ),
       state.lastAssistantMessageId,
+      state.toolContentBlockToolNames,
     );
     const { assistantAttachments, emittedAttachments } = attachmentResult;
 

--- a/assistant/src/daemon/session-attachments.ts
+++ b/assistant/src/daemon/session-attachments.ts
@@ -124,6 +124,7 @@ export async function resolveAssistantAttachments(
   workingDir: string,
   approveHostRead: ApproveHostRead,
   lastAssistantMessageId: string | undefined,
+  toolContentBlockToolNames?: ReadonlyMap<number, string>,
 ): Promise<AttachmentResolutionResult> {
   let assistantAttachments: AssistantAttachmentDraft[] = [];
   const emittedAttachments: UserMessageAttachment[] = [];
@@ -170,7 +171,10 @@ export async function resolveAssistantAttachments(
       "Directive resolution complete",
     );
 
-    const toolDrafts = contentBlocksToDrafts(accumulatedToolContentBlocks);
+    const toolDrafts = contentBlocksToDrafts(
+      accumulatedToolContentBlocks,
+      toolContentBlockToolNames,
+    );
     // Most recent tool outputs (e.g., final browser screenshot) should win
     // the MAX_ASSISTANT_ATTACHMENTS cap over older intermediate screenshots.
     toolDrafts.reverse();

--- a/assistant/src/media/gemini-image-service.ts
+++ b/assistant/src/media/gemini-image-service.ts
@@ -16,6 +16,8 @@ export interface ImageGenerationRequest {
 export interface GeneratedImage {
   mimeType: string;
   dataBase64: string;
+  /** Short title derived from the model's text response, if available. */
+  title?: string;
 }
 
 export interface ImageGenerationResult {
@@ -74,10 +76,12 @@ export async function generateImage(
 
   const client = new GoogleGenAI({ apiKey });
 
-  // Build contents array
+  // Build contents array — append a title request so the model's text
+  // response contains a short filename-safe title for the generated image.
+  const promptWithTitle = `${request.prompt}\n\nAlso respond with a short title (max 6 words) for the image on its own line, prefixed with "Title: ".`;
   const parts: Array<
     { text: string } | { inlineData: { mimeType: string; data: string } }
-  > = [{ text: request.prompt }];
+  > = [{ text: promptWithTitle }];
 
   if (request.mode === "edit" && request.sourceImages) {
     for (const img of request.sourceImages) {
@@ -114,7 +118,15 @@ export async function generateImage(
       }
     }
 
-    return { images, text };
+    // Extract title from the text response and apply to images
+    const title = extractTitle(text);
+    if (title) {
+      for (const img of images) {
+        img.title = title;
+      }
+    }
+
+    return { images, text: stripTitleLine(text), title };
   };
 
   if (variants === 1) {
@@ -140,4 +152,37 @@ export async function generateImage(
   }
 
   return { images: allImages, text: combinedText, resolvedModel: model };
+}
+
+// --- Title extraction helpers ---
+
+const TITLE_RE = /^Title:\s*(.+)/im;
+
+/**
+ * Extract a title from the model's text response.
+ * Looks for a line starting with "Title: " and sanitizes it for use as a filename.
+ */
+function extractTitle(text?: string): string | undefined {
+  if (!text) return undefined;
+  const match = TITLE_RE.exec(text);
+  if (!match?.[1]) return undefined;
+  return match[1]
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .toLowerCase()
+    .slice(0, 60);
+}
+
+/**
+ * Remove the "Title: ..." line from text so it doesn't appear in
+ * the tool result content shown to the user.
+ */
+function stripTitleLine(text?: string): string | undefined {
+  if (!text) return undefined;
+  const stripped = text
+    .replace(TITLE_RE, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  return stripped.length > 0 ? stripped : undefined;
 }

--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -37,6 +37,8 @@ export interface ChannelReplyPayload {
   messageTs?: string;
   /** When true, auto-generate Block Kit blocks from text via textToBlocks(). */
   useBlocks?: boolean;
+  /** When provided, add or remove an emoji reaction on a message. */
+  reaction?: { action: "add" | "remove"; name: string; messageTs: string };
 }
 
 export interface ChannelDeliveryResult {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -615,6 +615,7 @@ export async function handleChannelInbound(
       mintBearerToken,
       assistantId: canonicalAssistantId,
       approvalCopyGenerator,
+      externalMessageId: sourceMessageId ?? externalMessageId,
     });
   }
 

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -289,9 +289,15 @@ export function shouldEmitSlackReaction(
   }
 }
 
+const SLACK_EYES_MAX_DURATION_MS = 120_000;
+
 /**
  * Add a 👀 reaction to the inbound Slack message and return a cleanup
  * function that removes it. Both operations are fire-and-forget.
+ *
+ * A safety timer auto-removes the reaction after {@link SLACK_EYES_MAX_DURATION_MS}
+ * to prevent stuck eyes when `processMessage` hangs (e.g. queued behind
+ * an active session turn that never completes for this message).
  */
 export function addSlackEyesReaction(
   callbackUrl: string,
@@ -300,19 +306,12 @@ export function addSlackEyesReaction(
   mintBearerToken: () => string,
   assistantId?: string,
 ): () => void {
-  void deliverChannelReply(
-    callbackUrl,
-    {
-      chatId,
-      assistantId,
-      reaction: { action: "add", name: "eyes", messageTs },
-    },
-    mintBearerToken(),
-  ).catch((err) => {
-    log.debug({ err, chatId, messageTs }, "Failed to add Slack eyes reaction");
-  });
+  let removed = false;
 
-  return () => {
+  const removeReaction = () => {
+    if (removed) return;
+    removed = true;
+    clearTimeout(safetyTimer);
     void deliverChannelReply(
       callbackUrl,
       {
@@ -328,6 +327,23 @@ export function addSlackEyesReaction(
       );
     });
   };
+
+  void deliverChannelReply(
+    callbackUrl,
+    {
+      chatId,
+      assistantId,
+      reaction: { action: "add", name: "eyes", messageTs },
+    },
+    mintBearerToken(),
+  ).catch((err) => {
+    log.debug({ err, chatId, messageTs }, "Failed to add Slack eyes reaction");
+  });
+
+  const safetyTimer = setTimeout(removeReaction, SLACK_EYES_MAX_DURATION_MS);
+  (safetyTimer as { unref?: () => void }).unref?.();
+
+  return removeReaction;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -308,27 +308,9 @@ export function addSlackEyesReaction(
 ): () => void {
   let removed = false;
 
-  const removeReaction = () => {
-    if (removed) return;
-    removed = true;
-    clearTimeout(safetyTimer);
-    void deliverChannelReply(
-      callbackUrl,
-      {
-        chatId,
-        assistantId,
-        reaction: { action: "remove", name: "eyes", messageTs },
-      },
-      mintBearerToken(),
-    ).catch((err) => {
-      log.debug(
-        { err, chatId, messageTs },
-        "Failed to remove Slack eyes reaction",
-      );
-    });
-  };
-
-  void deliverChannelReply(
+  // Track the add promise so remove waits for it to settle first,
+  // preventing a race where remove arrives at Slack before add.
+  const addPromise = deliverChannelReply(
     callbackUrl,
     {
       chatId,
@@ -339,6 +321,28 @@ export function addSlackEyesReaction(
   ).catch((err) => {
     log.debug({ err, chatId, messageTs }, "Failed to add Slack eyes reaction");
   });
+
+  const removeReaction = () => {
+    if (removed) return;
+    removed = true;
+    clearTimeout(safetyTimer);
+    void addPromise.then(() =>
+      deliverChannelReply(
+        callbackUrl,
+        {
+          chatId,
+          assistantId,
+          reaction: { action: "remove", name: "eyes", messageTs },
+        },
+        mintBearerToken(),
+      ).catch((err) => {
+        log.debug(
+          { err, chatId, messageTs },
+          "Failed to remove Slack eyes reaction",
+        );
+      }),
+    );
+  };
 
   const safetyTimer = setTimeout(removeReaction, SLACK_EYES_MAX_DURATION_MS);
   (safetyTimer as { unref?: () => void }).unref?.();

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -58,6 +58,8 @@ export interface BackgroundProcessingParams {
   approvalCopyGenerator?: ApprovalCopyGenerator;
   commandIntent?: Record<string, unknown>;
   sourceLanguageCode?: string;
+  /** External message ID (e.g. Slack message ts) used for reaction indicators. */
+  externalMessageId?: string;
 }
 
 /**
@@ -85,6 +87,7 @@ export function processChannelMessageInBackground(
     approvalCopyGenerator,
     commandIntent,
     sourceLanguageCode,
+    externalMessageId,
   } = params;
 
   (async () => {
@@ -102,6 +105,19 @@ export function processChannelMessageInBackground(
           assistantId,
         )
       : undefined;
+
+    // Add 👀 reaction to the inbound Slack message as a processing indicator
+    const removeSlackReaction =
+      shouldEmitSlackReaction(sourceChannel, replyCallbackUrl) &&
+      externalMessageId
+        ? addSlackEyesReaction(
+            replyCallbackUrl!,
+            externalChatId,
+            externalMessageId,
+            mintBearerToken,
+            assistantId,
+          )
+        : undefined;
     const stopApprovalWatcher = replyCallbackUrl
       ? startPendingApprovalPromptWatcher({
           conversationId,
@@ -193,6 +209,7 @@ export function processChannelMessageInBackground(
       channelDeliveryStore.recordProcessingFailure(eventId, err);
     } finally {
       stopTypingHeartbeat?.();
+      removeSlackReaction?.();
       stopApprovalWatcher?.();
       stopTcApprovalNotifier?.();
     }
@@ -253,6 +270,63 @@ export function startTelegramTypingHeartbeat(
   return () => {
     active = false;
     clearInterval(interval);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Slack eyes reaction indicator
+// ---------------------------------------------------------------------------
+
+export function shouldEmitSlackReaction(
+  sourceChannel: ChannelId,
+  replyCallbackUrl?: string,
+): boolean {
+  if (sourceChannel !== "slack" || !replyCallbackUrl) return false;
+  try {
+    return new URL(replyCallbackUrl).pathname.endsWith("/deliver/slack");
+  } catch {
+    return replyCallbackUrl.endsWith("/deliver/slack");
+  }
+}
+
+/**
+ * Add a 👀 reaction to the inbound Slack message and return a cleanup
+ * function that removes it. Both operations are fire-and-forget.
+ */
+export function addSlackEyesReaction(
+  callbackUrl: string,
+  chatId: string,
+  messageTs: string,
+  mintBearerToken: () => string,
+  assistantId?: string,
+): () => void {
+  void deliverChannelReply(
+    callbackUrl,
+    {
+      chatId,
+      assistantId,
+      reaction: { action: "add", name: "eyes", messageTs },
+    },
+    mintBearerToken(),
+  ).catch((err) => {
+    log.debug({ err, chatId, messageTs }, "Failed to add Slack eyes reaction");
+  });
+
+  return () => {
+    void deliverChannelReply(
+      callbackUrl,
+      {
+        chatId,
+        assistantId,
+        reaction: { action: "remove", name: "eyes", messageTs },
+      },
+      mintBearerToken(),
+    ).catch((err) => {
+      log.debug(
+        { err, chatId, messageTs },
+        "Failed to remove Slack eyes reaction",
+      );
+    });
   };
 }
 

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -341,6 +341,8 @@ export function createSlackDeliverHandler(
       ephemeral?: boolean;
       user?: string;
       chatAction?: "typing";
+      /** Add or remove an emoji reaction on a message. */
+      reaction?: { action: "add" | "remove"; name: string; messageTs: string };
       /** Message timestamp to update instead of posting a new message. */
       updateTs?: string;
       /** When provided, use chat.update to edit an existing message instead of posting a new one. */
@@ -412,7 +414,12 @@ export function createSlackDeliverHandler(
 
     const { text } = body;
 
-    if (!text && !chatAction && (!attachments || attachments.length === 0)) {
+    if (
+      !text &&
+      !chatAction &&
+      !body.reaction &&
+      (!attachments || attachments.length === 0)
+    ) {
       return Response.json(
         { error: "text or attachments required" },
         { status: 400 },
@@ -518,6 +525,52 @@ export function createSlackDeliverHandler(
     );
 
     try {
+      // Emoji reaction: add or remove a reaction on an existing message.
+      // Fire-and-forget — reaction failures are logged but don't fail the request.
+      if (body.reaction) {
+        const { action, name, messageTs: reactionTs } = body.reaction;
+        const method = action === "add" ? "reactions.add" : "reactions.remove";
+        const reactionBody = {
+          channel: chatId,
+          name,
+          timestamp: reactionTs,
+        };
+
+        try {
+          const res = await fetchImpl(`https://slack.com/api/${method}`, {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${config.slackChannelBotToken}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(reactionBody),
+          });
+          const data = (await res.json()) as {
+            ok?: boolean;
+            error?: string;
+          };
+          if (!data.ok) {
+            // "already_reacted" and "no_reaction" are expected race conditions
+            if (
+              data.error !== "already_reacted" &&
+              data.error !== "no_reaction"
+            ) {
+              tlog.warn(
+                { chatId, method, slackError: data.error },
+                "Slack reaction API returned error",
+              );
+            }
+          }
+        } catch (err) {
+          tlog.warn(
+            { err, chatId, method },
+            "Failed to deliver Slack reaction",
+          );
+        }
+
+        return Response.json({ ok: true });
+      }
+
       // Typing indicator: post a placeholder message that the runtime can
       // later update via `updateTs` when the real response is ready.
       // Slack bots have no native typing indicator API, so this serves as

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -325,6 +325,7 @@ export function normalizeSlackDirectMessage(
       },
       source: {
         updateId: eventId,
+        messageId: event.ts,
       },
       raw: event as unknown as Record<string, unknown>,
     },
@@ -382,6 +383,7 @@ export function normalizeSlackChannelMessage(
       },
       source: {
         updateId: eventId,
+        messageId: event.ts,
         chatType: "channel",
       },
       raw: event as unknown as Record<string, unknown>,
@@ -437,6 +439,7 @@ export function normalizeSlackAppMention(
       },
       source: {
         updateId: eventId,
+        messageId: event.ts,
       },
       raw: event as unknown as Record<string, unknown>,
     },


### PR DESCRIPTION
## Summary
- Adds 👀 emoji reaction to inbound Slack messages when processing starts, removes it when done (or on error via `finally` block)
- Mirrors the existing Telegram typing heartbeat pattern as a Slack-native visual cue
- Passes Slack `event.ts` as `source.messageId` in the normalizer so the assistant has the correct message timestamp for reactions

## Files Changed
- `gateway/src/http/routes/slack-deliver.ts` — reaction add/remove handler via Slack `reactions.add`/`reactions.remove` API
- `gateway/src/slack/normalize.ts` — pass `event.ts` as `source.messageId` for DM, channel, and app_mention events
- `assistant/src/runtime/gateway-client.ts` — `reaction` field on `ChannelReplyPayload`
- `assistant/src/runtime/routes/inbound-stages/background-dispatch.ts` — `shouldEmitSlackReaction`/`addSlackEyesReaction` helpers
- `assistant/src/runtime/routes/inbound-message-handler.ts` — thread `externalMessageId` (preferring `sourceMessageId`) to background dispatch

## Test plan
- [x] DM the bot in Slack → 👀 appears on your message immediately
- [x] When the bot responds → 👀 disappears
- [x] If the bot decides not to respond (e.g., filtered message) → 👀 should still disappear (finally block)
- [x] Telegram typing still works unchanged
- [x] Type-check both `assistant` and `gateway` projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
