### PR TITLE
refactor: extract AssistantStatus and InteractionType from AppDelegate.swift

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -10,52 +10,6 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppDelegate")
 
-enum AssistantStatus {
-    case idle
-    case thinking
-    case error(String)
-    case disconnected
-
-    var menuTitle: String {
-        switch self {
-        case .idle: return "Assistant is idle"
-        case .thinking: return "Assistant is thinking..."
-        case .error(let msg): return "Error: \(msg)"
-        case .disconnected: return "Disconnected from daemon"
-        }
-    }
-
-    var statusColor: NSColor {
-        switch self {
-        case .idle: return .systemGray
-        case .thinking: return .systemGreen
-        case .error: return .systemRed
-        case .disconnected: return .systemOrange
-        }
-    }
-
-    var statusIcon: NSImage? {
-        let size: CGFloat = 8
-        let image = NSImage(size: NSSize(width: size, height: size))
-        image.lockFocus()
-        statusColor.setFill()
-        NSBezierPath(ovalIn: NSRect(x: 0, y: 0, width: size, height: size)).fill()
-        image.unlockFocus()
-        return image
-    }
-
-    /// Whether the dot should pulse (animate opacity)
-    var shouldPulse: Bool {
-        if case .thinking = self { return true }
-        return false
-    }
-}
-
-enum InteractionType {
-    case computerUse
-    case textQA
-}
-
 /// Tracks the first-launch bootstrap sequence so the app can resume
 /// from the correct phase after a restart mid-bootstrap.
 /// Raw values are persisted in UserDefaults under `"bootstrapState"`.

--- a/clients/macos/vellum-assistant/App/AppDelegateTypes.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegateTypes.swift
@@ -1,0 +1,47 @@
+import AppKit
+
+enum AssistantStatus {
+    case idle
+    case thinking
+    case error(String)
+    case disconnected
+
+    var menuTitle: String {
+        switch self {
+        case .idle: return "Assistant is idle"
+        case .thinking: return "Assistant is thinking..."
+        case .error(let msg): return "Error: \(msg)"
+        case .disconnected: return "Disconnected from daemon"
+        }
+    }
+
+    var statusColor: NSColor {
+        switch self {
+        case .idle: return .systemGray
+        case .thinking: return .systemGreen
+        case .error: return .systemRed
+        case .disconnected: return .systemOrange
+        }
+    }
+
+    var statusIcon: NSImage? {
+        let size: CGFloat = 8
+        let image = NSImage(size: NSSize(width: size, height: size))
+        image.lockFocus()
+        statusColor.setFill()
+        NSBezierPath(ovalIn: NSRect(x: 0, y: 0, width: size, height: size)).fill()
+        image.unlockFocus()
+        return image
+    }
+
+    /// Whether the dot should pulse (animate opacity)
+    var shouldPulse: Bool {
+        if case .thinking = self { return true }
+        return false
+    }
+}
+
+enum InteractionType {
+    case computerUse
+    case textQA
+}


### PR DESCRIPTION
## Summary
- Extracts `AssistantStatus` enum (with `menuTitle`, `statusColor`, `statusIcon`, `shouldPulse` computed properties) and `InteractionType` enum from AppDelegate.swift into a new `AppDelegateTypes.swift` file
- Pure mechanical move with zero logic changes
- `BootstrapState`, `BootstrapFailureKind`, and `quickInputHotKeyHandler` intentionally left in place for later PRs

Part of plan: appdelegate-refactor.md (PR 1 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
