### PR TITLE
fix: align CI tests with current integrations CLI and email-setup SKILL

### DIFF
--- a/assistant/src/__tests__/integrations-cli.test.ts
+++ b/assistant/src/__tests__/integrations-cli.test.ts
@@ -108,7 +108,6 @@ describe("vellum integrations CLI", () => {
 
   afterEach(() => {
     delete process.env.GATEWAY_AUTH_TOKEN;
-    delete process.env.INTERNAL_GATEWAY_BASE_URL;
     process.exitCode = 0;
   });
 
@@ -141,8 +140,8 @@ describe("vellum integrations CLI", () => {
     expect(mintCalls).toBe(1);
   });
 
-  test("prefers INTERNAL_GATEWAY_BASE_URL when it is injected", async () => {
-    process.env.INTERNAL_GATEWAY_BASE_URL = "http://gateway.internal:9900/";
+  test("uses configured gateway base for requests", async () => {
+    gatewayBase = "http://gateway.internal:9900";
     const result = await runCli(["--json", "twilio", "config"], {
       success: true,
     });
@@ -170,7 +169,6 @@ describe("vellum integrations CLI", () => {
         publicBaseUrl: "https://public.example.com",
       },
     };
-    process.env.INTERNAL_GATEWAY_BASE_URL = "http://gateway.internal:9900/";
     const result = await runCli(["--json", "ingress", "config"], { ok: true });
 
     expect(result.exitCode).toBe(0);
@@ -179,7 +177,7 @@ describe("vellum integrations CLI", () => {
       success: true,
       enabled: true,
       publicBaseUrl: "https://public.example.com",
-      localGatewayTarget: "http://gateway.internal:9900",
+      localGatewayTarget: "http://gateway.test",
     });
   });
 

--- a/assistant/src/config/bundled-skills/email-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/email-setup/SKILL.md
@@ -26,18 +26,12 @@ Inspect `addresses` in the response. If at least one address exists, tell the us
 Create a new inbox through the CLI:
 
 ```bash
-vellum email create <your-username>
+vellum email inbox create --username <your-username>
 ```
 
 For `<your-username>`, use your assistant name (lowercased, alphanumeric only). Check your identity from `IDENTITY.md` or `USER.md` to determine your name. If you don't have a name yet, ask the user what username they'd like for your email.
 
 Use the returned `inbox.address` (or `inbox.id` if `address` is empty) as the created email address.
-
-After successfully creating the inbox, persist the email address to config so the desktop app can display it:
-
-```bash
-vellum config set email.address <address>
-```
 
 ## Step 3: Verify Status
 


### PR DESCRIPTION
## Summary
- Update `integrations-cli.test.ts` to use the mock `gatewayBase` variable instead of `process.env.INTERNAL_GATEWAY_BASE_URL`, matching the removal of `resolveGatewayBaseUrl()` from `integrations.ts`
- Fix `email-setup/SKILL.md` to use `vellum email inbox create` instead of `vellum email create`, and remove `vellum config set email.address` — both were banned snippets caught by the bundled-skill-retrieval-guard test

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22693403086/job/65794202882

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
