### PR TITLE
refactor: extract daemon setup and transport wiring into AppDelegate+DaemonSetup.swift

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -1,0 +1,524 @@
+import AppKit
+import Sentry
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppDelegate+DaemonSetup")
+
+extension AppDelegate {
+
+    // MARK: - Theme
+
+    func applyThemePreference() {
+        let pref = UserDefaults.standard.string(forKey: "themePreference") ?? "system"
+        let appearance: NSAppearance?
+        switch pref {
+        case "light":
+            appearance = NSAppearance(named: .aqua)
+        case "dark":
+            appearance = NSAppearance(named: .darkAqua)
+        default:
+            appearance = nil // follow system
+        }
+
+        NSApp.appearance = appearance
+        for window in NSApp.windows {
+            window.appearance = appearance
+            window.invalidateShadow()
+            window.contentView?.needsDisplay = true
+        }
+    }
+
+    // MARK: - Lockfile & Transport
+
+    /// Reads `connectedAssistantId` from UserDefaults, looks it up in the lockfile
+    /// (falling back to the latest entry), and writes its config so the daemon connects
+    /// to the correct assistant.
+    ///
+    /// Returns the loaded assistant for transport selection, or nil if none found.
+    @discardableResult
+    func loadAssistantFromLockfile() -> LockfileAssistant? {
+        let storedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+        let assistant: LockfileAssistant?
+
+        if let storedId, let found = LockfileAssistant.loadByName(storedId) {
+            assistant = found
+        } else {
+            assistant = LockfileAssistant.loadLatest()
+        }
+
+        guard let assistant else { return nil }
+
+        UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")
+        assistant.writeToWorkspaceConfig()
+        return assistant
+    }
+
+    /// Configure the daemon client's transport based on the lockfile assistant.
+    /// Managed assistants (cloud == "vellum") use platform proxy with session token auth.
+    /// Other remote assistants (cloud != "local") use HTTP+SSE via the gateway URL.
+    /// Local assistants use the default Unix domain socket, unless the
+    /// `localHttpEnabled` flag redirects them to the daemon's runtime HTTP server.
+    func configureDaemonTransport(for assistant: LockfileAssistant?) {
+        isCurrentAssistantRemote = assistant?.isRemote ?? false
+        isCurrentAssistantManaged = assistant?.isManaged ?? false
+
+        // Managed assistant: use platform proxy URLs with session token auth.
+        if let assistant, assistant.isManaged {
+            let platformBaseURL = assistant.runtimeUrl ?? AuthService.shared.baseURL
+            let metadata = TransportMetadata(
+                routeMode: .platformAssistantProxy,
+                authMode: .sessionToken,
+                platformAssistantId: assistant.assistantId
+            )
+            let config = DaemonConfig(
+                transport: .http(
+                    baseURL: platformBaseURL,
+                    bearerToken: nil,
+                    conversationKey: assistant.assistantId
+                ),
+                transportMetadata: metadata
+            )
+            services.reconfigureDaemonClient(config: config)
+            log.info("Configured managed transport for assistant \(assistant.assistantId) via platform at \(platformBaseURL, privacy: .public)")
+            return
+        }
+
+        guard let assistant, assistant.isRemote, let runtimeUrl = assistant.runtimeUrl else {
+            // Local assistant or no assistant.
+            if MacOSClientFeatureFlagManager.shared.isEnabled("local_http_enabled") {
+                // Use HTTP transport for the local daemon instead of IPC.
+                // Bearer token is nil; resolved lazily at connect time.
+                let portString = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "7821"
+                let port = Int(portString) ?? 7821
+                let baseURL = "http://localhost:\(port)"
+                let conversationKey = assistant?.assistantId ?? UUID().uuidString
+                let config = DaemonConfig(transport: .http(
+                    baseURL: baseURL,
+                    bearerToken: nil,
+                    conversationKey: conversationKey
+                ))
+                services.reconfigureDaemonClient(config: config)
+                log.info("Configured local HTTP transport (localHttpEnabled flag) on port \(port)")
+            } else {
+                // Reset to default socket transport in case the previous assistant used HTTP.
+                services.reconfigureDaemonClient(config: .default)
+            }
+            return
+        }
+
+        let config = DaemonConfig(transport: .http(
+            baseURL: runtimeUrl,
+            bearerToken: assistant.bearerToken,
+            conversationKey: assistant.assistantId
+        ))
+
+        // Reconfigure the daemon client's transport in place. This preserves
+        // object identity so all long-lived holders keep a valid reference.
+        services.reconfigureDaemonClient(config: config)
+
+        log.info("Configured HTTP transport for remote assistant \(assistant.assistantId) at \(runtimeUrl, privacy: .public)")
+    }
+
+    // MARK: - Daemon Client Setup
+
+    func setupDaemonClient(isFirstLaunch: Bool = false) {
+        guard !hasSetupDaemon else { return }
+        hasSetupDaemon = true
+
+        let assistant = loadAssistantFromLockfile()
+
+        // Ensure the daemon starts its runtime HTTP server so the
+        // gateway can proxy iOS traffic to it.
+        if ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] == nil {
+            setenv("RUNTIME_HTTP_PORT", "7821", 0)
+        }
+
+        configureDaemonTransport(for: assistant)
+
+        // Rebind the menu bar icon observer after transport reconfiguration
+        // so connection status changes continue to update the icon.
+        rebindConnectionStatusObserver()
+
+        daemonClient.onNotificationIntent = { [weak self] msg in
+            self?.deliverNotificationIntent(msg)
+        }
+
+        // Handle open_bundle_response from the daemon
+        daemonClient.onOpenBundleResponse = { [weak self] response in
+            guard let self else { return }
+            self.handleOpenBundleResponse(response)
+        }
+
+        // Refresh skills cache whenever skill state changes through any path
+        daemonClient.onSkillStateChanged = { [weak self] _ in
+            self?.refreshSkillsCache()
+        }
+
+        // Open URL: daemon -> Swift -> interstitial -> browser
+        daemonClient.onOpenUrl = { msg in
+            guard let url = URL(string: msg.url) else { return }
+            let alert = NSAlert()
+            alert.messageText = "Open External Link?"
+            alert.informativeText = msg.url
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: "Open in Browser")
+            alert.addButton(withTitle: "Cancel")
+            if alert.runModal() == .alertFirstButtonReturn {
+                NSWorkspace.shared.open(url)
+            }
+        }
+
+        daemonClient.onNavigateSettings = { [weak self] msg in
+            Task { @MainActor in
+                self?.showSettingsTab(msg.tab)
+            }
+        }
+
+        daemonClient.onPairingApprovalRequest = { [weak self] msg in
+            guard let self else { return }
+            if self.pairingApprovalWindow == nil {
+                self.pairingApprovalWindow = PairingApprovalWindow(daemonClient: self.daemonClient)
+            }
+            self.pairingApprovalWindow?.show(
+                pairingRequestId: msg.pairingRequestId,
+                deviceName: msg.deviceName
+            )
+        }
+
+        // Automatically surface threads created by scheduled task runs so
+        // the user sees them in the sidebar without restarting the app.
+        daemonClient.onTaskRunThreadCreated = { [weak self] msg in
+            guard let self, !self.isBootstrapping else { return }
+            self.mainWindow?.threadManager.createTaskRunThread(
+                conversationId: msg.conversationId,
+                workItemId: msg.workItemId,
+                title: msg.title
+            )
+        }
+
+        // Schedule threads — created when the scheduler fires and creates a conversation.
+        daemonClient.onScheduleThreadCreated = { [weak self] msg in
+            guard let self, !self.isBootstrapping else { return }
+            self.mainWindow?.threadManager.createScheduleThread(
+                conversationId: msg.conversationId,
+                scheduleJobId: msg.scheduleJobId,
+                title: msg.title
+            )
+        }
+
+        // Notification threads — created when the notification pipeline delivers
+        // to the vellum channel with start_new_conversation strategy.
+        daemonClient.onNotificationThreadCreated = { [weak self] msg in
+            guard let self, !self.isBootstrapping else { return }
+            self.handleNotificationThreadCreated(msg)
+        }
+
+        // Handle escalation: text_qa -> computer_use via computer_use_request_control
+        daemonClient.onTaskRouted = { [weak self] routed in
+            guard let self else { return }
+            // Only handle escalation messages (those with escalatedFrom set)
+            guard routed.escalatedFrom != nil,
+                  routed.interactionType == "computer_use" else {
+                log.debug("Ignoring non-escalation task_routed: type=\(routed.interactionType), escalatedFrom=\(routed.escalatedFrom ?? "nil")")
+                return
+            }
+            self.handleEscalationToComputerUse(routed: routed)
+        }
+
+        // Forward dictation responses from the daemon to VoiceInputManager
+        daemonClient.onDictationResponse = { [weak self] msg in
+            self?.voiceInput?.onDictationResponse?(msg)
+        }
+
+        daemonClient.onDocumentEditorShow = { [weak self] msg in
+            self?.mainWindow?.handleDocumentEditorShow(msg)
+        }
+        daemonClient.onDocumentEditorUpdate = { [weak self] msg in
+            self?.mainWindow?.handleDocumentEditorUpdate(msg)
+        }
+        daemonClient.onDocumentSaveResponse = { [weak self] msg in
+            self?.mainWindow?.handleDocumentSaveResponse(msg)
+        }
+        daemonClient.onDocumentLoadResponse = { [weak self] msg in
+            self?.mainWindow?.handleDocumentLoadResponse(msg)
+        }
+
+        // Handle diagnostics export response — show a toast in the main window
+        daemonClient.onDiagnosticsExportResponse = { [weak self] response in
+            guard let self else { return }
+            Task { @MainActor in
+                if response.success, let filePath = response.filePath {
+                    self.mainWindow?.windowState.showToast(
+                        message: "Report exported successfully.",
+                        style: .success,
+                        primaryAction: VToastAction(label: "Reveal in Finder") {
+                            NSWorkspace.shared.selectFile(filePath, inFileViewerRootedAtPath: "")
+                        }
+                    )
+                } else {
+                    let errorDetail = response.error ?? "Unknown error"
+                    self.mainWindow?.windowState.showToast(
+                        message: "Failed to export report: \(errorDetail)",
+                        style: .error
+                    )
+                }
+            }
+        }
+
+        // Handle recording_start from daemon: check permission, then start recording
+        daemonClient.onRecordingStart = { [weak self] msg in
+            guard let self else { return }
+            self.handleRecordingStart(msg)
+        }
+
+        // Handle recording_stop from daemon
+        daemonClient.onRecordingStop = { [weak self] msg in
+            guard let self else { return }
+            Task {
+                _ = await self.recordingManager.stop(sessionId: msg.recordingId)
+                self.recordingHUDWindow?.dismiss()
+            }
+        }
+
+        // Handle recording_pause from daemon
+        daemonClient.onRecordingPause = { [weak self] msg in
+            guard let self else { return }
+            self.handleRecordingPause(msg)
+        }
+
+        // Handle recording_resume from daemon
+        daemonClient.onRecordingResume = { [weak self] msg in
+            guard let self else { return }
+            self.handleRecordingResume(msg)
+        }
+
+        // Handle client_settings_update from daemon: write to UserDefaults and post notification
+        daemonClient.onClientSettingsUpdate = { msg in
+            UserDefaults.standard.set(msg.value, forKey: msg.key)
+            if msg.key == "activationKey" {
+                NotificationCenter.default.post(name: .activationKeyChanged, object: nil)
+            }
+        }
+
+        daemonClient.onIdentityChanged = { msg in
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(
+                    name: .identityChanged,
+                    object: nil,
+                    userInfo: [
+                        "name": msg.name,
+                        "role": msg.role,
+                        "personality": msg.personality,
+                        "emoji": msg.emoji,
+                        "home": msg.home
+                    ]
+                )
+            }
+        }
+
+        // Handle avatar_updated from daemon: reload the avatar image from disk
+        daemonClient.onAvatarUpdated = { _ in
+            AvatarAppearanceManager.shared.reloadAvatar()
+        }
+
+        // Restart DaemonClient connection when the health monitor relaunches
+        // the daemon process so we don't wait for the backoff timer to expire.
+        assistantCli.onDaemonRestarted = { [weak self] in
+            guard let self else { return }
+            Task {
+                // Don't reset an in-progress connection attempt
+                guard !self.daemonClient.isConnected, !self.daemonClient.isConnecting else { return }
+                do {
+                    try await self.daemonClient.connect()
+                } catch {
+                    log.error("Failed to reconnect to daemon after restart: \(error)")
+                }
+                if self.daemonClient.isConnected {
+                    self.setupAmbientAgent()
+                    self.refreshAppsCache()
+                    self.refreshSkillsCache()
+                    self.checkAndApplyPrivacyFlag()
+                }
+            }
+        }
+
+        Task {
+            if !isCurrentAssistantRemote {
+                // If the hatching step already started the gateway (e.g. `vellum-cli hatch --remote local`),
+                // skip the CLI hatch to avoid spawning a duplicate gateway process.
+                // Require BOTH lockfile and healthy gateway — a stale lockfile with an unhealthy
+                // gateway falls through to the normal hatch path.
+                let lockfileExists = self.lockfileHasAssistants()
+                var gatewayHealthy = false
+                if lockfileExists {
+                    if isFirstLaunch {
+                        // Retry window: gateway may still be starting from onboarding hatch
+                        for _ in 0..<3 {
+                            if await isGatewayHealthy() { gatewayHealthy = true; break }
+                            try? await Task.sleep(nanoseconds: 1_000_000_000)
+                        }
+                    } else {
+                        // Non-first-launch: single check, no retry delay
+                        gatewayHealthy = await isGatewayHealthy()
+                    }
+                }
+
+                if lockfileExists && gatewayHealthy {
+                    log.info("Lockfile and gateway already present — skipping CLI hatch to avoid duplicate gateway")
+                    assistantCli.startMonitoring()
+                } else {
+                    // On first launch post-onboarding, use daemonOnly: false so the CLI
+                    // creates a lockfile entry. On subsequent launches, daemonOnly: true
+                    // prevents duplicates.
+                    let needsLockfileEntry = isFirstLaunch && !lockfileExists
+                    let daemonOnly = !needsLockfileEntry
+                    // Pass the selected assistant ID so the gateway starts
+                    // with the correct default assistant (not a random name).
+                    let assistantName = assistant?.assistantId
+                    do {
+                        try await assistantCli.hatch(name: assistantName, daemonOnly: daemonOnly)
+                    } catch {
+                        log.error("Failed to hatch assistant during daemon setup: \(error)")
+                        if needsLockfileEntry {
+                            log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
+                            try? await assistantCli.hatch(name: assistantName, daemonOnly: true)
+                        }
+                    }
+                    if needsLockfileEntry {
+                        _ = self.loadAssistantFromLockfile()
+                    }
+                    assistantCli.startMonitoring()
+                }
+            }
+            // Skip connect if the bootstrap retry coordinator already connected
+            // or has a connect in flight (hatch can take a long time; the
+            // coordinator connects independently). Checking isConnecting
+            // prevents tearing down the coordinator's in-flight NWConnection
+            // via disconnectInternal().
+            if !daemonClient.isConnected && !daemonClient.isConnecting {
+                do {
+                    try await daemonClient.connect()
+                } catch {
+                    log.error("Failed to connect to daemon during setup: \(error)")
+                }
+            }
+            // Once connected, start ambient agent if it was waiting for daemon
+            if daemonClient.isConnected {
+                setupAmbientAgent()
+                refreshAppsCache()
+                refreshSkillsCache()
+                // Apply the privacy flag now that the gateway is reachable:
+                // close Sentry if the user has opted out of usage data collection.
+                checkAndApplyPrivacyFlag()
+            }
+        }
+    }
+
+    // MARK: - Privacy
+
+    /// Queries the gateway feature-flags API for the collect-usage-data flag and,
+    /// if the user has opted out, shuts down Sentry to stop future event capturing.
+    /// Called after the daemon is first connected so the gateway is reachable.
+    func checkAndApplyPrivacyFlag() {
+        Task {
+            do {
+                let flags = try await daemonClient.getFeatureFlags()
+                let collectUsageData = flags
+                    .first(where: { $0.key == "feature_flags.collect-usage-data.enabled" })
+                    .map { $0.enabled }
+                    ?? true
+                if !collectUsageData {
+                    SentrySDK.close()
+                }
+            } catch {
+                // Flag check is best-effort; Sentry stays active when the flag
+                // cannot be read (e.g. gateway not yet ready on first boot).
+                log.debug("Could not read privacy flag from gateway: \(error)")
+            }
+        }
+    }
+
+    // MARK: - Auto-Update
+
+    func setupAutoUpdate() {
+        updateManager.onWillInstallUpdate = { [weak self] in
+            self?.assistantCli.stop()
+        }
+        updateManager.startAutomaticChecks()
+    }
+
+    // MARK: - CLI Symlink
+
+    /// Installs a `/usr/local/bin/vellum` symlink pointing to the bundled
+    /// CLI binary so users can run `vellum` from their terminal.
+    ///
+    /// Skipped when dev mode is active (developers manage their own PATH)
+    /// or when `vellum` already resolves to a different executable
+    /// (avoids overwriting a developer's locally-built binary).
+    func installCLISymlinkIfNeeded() {
+        guard !services.settingsStore.isDevMode else { return }
+
+        guard let execURL = Bundle.main.executableURL else { return }
+        let cliBinary = execURL.deletingLastPathComponent()
+            .appendingPathComponent("vellum-cli")
+        guard FileManager.default.fileExists(atPath: cliBinary.path) else { return }
+
+        let symlinkPath = "/usr/local/bin/vellum"
+        let fm = FileManager.default
+
+        // If the path exists, check whether it's our symlink or something else
+        if let attrs = try? fm.attributesOfItem(atPath: symlinkPath),
+           let type = attrs[.type] as? FileAttributeType {
+            if type == .typeSymbolicLink {
+                // Already a symlink — skip if it already points to our binary
+                if let dest = try? fm.destinationOfSymbolicLink(atPath: symlinkPath),
+                   dest == cliBinary.path {
+                    return
+                }
+            } else {
+                // Real file (not a symlink) — don't overwrite
+                return
+            }
+        }
+
+        // Check if `vellum` resolves elsewhere on PATH (developer's local build)
+        let whichProc = Process()
+        whichProc.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        whichProc.arguments = ["vellum"]
+        let pipe = Pipe()
+        whichProc.standardOutput = pipe
+        whichProc.standardError = FileHandle.nullDevice
+        do {
+            try whichProc.run()
+            whichProc.waitUntilExit()
+            if whichProc.terminationStatus == 0 {
+                let resolved = String(
+                    data: pipe.fileHandleForReading.readDataToEndOfFile(),
+                    encoding: .utf8
+                )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                if !resolved.isEmpty && resolved != symlinkPath {
+                    return
+                }
+            }
+        } catch {
+            // `which` failed to run — continue with symlink creation
+        }
+
+        // Create /usr/local/bin if needed, then create symlink
+        do {
+            let dir = (symlinkPath as NSString).deletingLastPathComponent
+            if !fm.fileExists(atPath: dir) {
+                try fm.createDirectory(atPath: dir, withIntermediateDirectories: true)
+            }
+            // Remove stale symlink before creating a new one
+            if (try? fm.attributesOfItem(atPath: symlinkPath)) != nil {
+                try fm.removeItem(atPath: symlinkPath)
+            }
+            try fm.createSymbolicLink(atPath: symlinkPath, withDestinationPath: cliBinary.path)
+            log.info("Installed CLI symlink: \(symlinkPath) → \(cliBinary.path)")
+        } catch {
+            log.warning("Could not install CLI symlink at \(symlinkPath): \(error.localizedDescription)")
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -83,7 +83,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var isStartingSession = false
     var startSessionTask: Task<Void, Never>?
     var textResponseWindow: TextResponseWindow?
-    private var voiceInput: VoiceInputManager?
+    var voiceInput: VoiceInputManager?
     private var wakeWordCoordinator: WakeWordCoordinator?
     private var voiceTranscriptionWindow: VoiceTranscriptionWindow?
     var thinkingWindow: ThinkingIndicatorWindow?
@@ -93,7 +93,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     private var commandPaletteWindow: CommandPaletteWindow?
     private var cmdKLocalMonitor: Any?
     public let services = AppServices()
-    private let assistantCli = AssistantCli()
+    let assistantCli = AssistantCli()
     public let updateManager = UpdateManager()
     private let debugStateWriter = DebugStateWriter()
 
@@ -117,7 +117,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     public var mainWindow: MainWindow?
     var bundleConfirmationWindow: BundleConfirmationWindow?
 
-    private var pairingApprovalWindow: PairingApprovalWindow?
+    var pairingApprovalWindow: PairingApprovalWindow?
     /// Window shown during first-launch bootstrap when daemon is slow to start.
     private var bootstrapInterstitialWindow: NSWindow?
     /// Active task for the bootstrap retry coordinator. Cancelled on dismiss.
@@ -169,12 +169,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     /// Whether the current assistant runs remotely (cloud != "local").
     /// When true, local daemon hatching is skipped.
-    private var isCurrentAssistantRemote = false
+    var isCurrentAssistantRemote = false
 
     /// Whether the current assistant is platform-managed (cloud == "vellum").
     /// When true, actor credential bootstrap is skipped since identity is
     /// derived from the platform session, not local actor tokens.
-    private var isCurrentAssistantManaged = false
+    var isCurrentAssistantManaged = false
 
     @AppStorage("themePreference") private var themePreference: String = "system"
 
@@ -244,8 +244,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         }
     }
 
-    private var hasSetupApp = false
-    private var hasSetupDaemon = false
+    var hasSetupApp = false
+    var hasSetupDaemon = false
 
     /// Tracks the current phase of the first-launch bootstrap sequence.
     /// Persisted in UserDefaults (`"bootstrapState"`) so the app can
@@ -1113,510 +1113,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     /// Applies the user's theme preference to the app appearance.
     /// Called on launch and whenever the setting changes.
-    func applyThemePreference() {
-        let pref = UserDefaults.standard.string(forKey: "themePreference") ?? "system"
-        let appearance: NSAppearance?
-        switch pref {
-        case "light":
-            appearance = NSAppearance(named: .aqua)
-        case "dark":
-            appearance = NSAppearance(named: .darkAqua)
-        default:
-            appearance = nil // follow system
-        }
-
-        NSApp.appearance = appearance
-        for window in NSApp.windows {
-            window.appearance = appearance
-            window.invalidateShadow()
-            window.contentView?.needsDisplay = true
-        }
-    }
-
-    /// Reads `connectedAssistantId` from UserDefaults, looks it up in the lockfile
-    /// (falling back to the latest entry), and writes its config so the daemon connects
-    /// to the correct assistant.
-    ///
-    /// Returns the loaded assistant for transport selection, or nil if none found.
-    @discardableResult
-    private func loadAssistantFromLockfile() -> LockfileAssistant? {
-        let storedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
-        let assistant: LockfileAssistant?
-
-        if let storedId, let found = LockfileAssistant.loadByName(storedId) {
-            assistant = found
-        } else {
-            assistant = LockfileAssistant.loadLatest()
-        }
-
-        guard let assistant else { return nil }
-
-        UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")
-        assistant.writeToWorkspaceConfig()
-        return assistant
-    }
-
-    /// Configure the daemon client's transport based on the lockfile assistant.
-    /// Managed assistants (cloud == "vellum") use platform proxy with session token auth.
-    /// Other remote assistants (cloud != "local") use HTTP+SSE via the gateway URL.
-    /// Local assistants use the default Unix domain socket, unless the
-    /// `localHttpEnabled` flag redirects them to the daemon's runtime HTTP server.
-    private func configureDaemonTransport(for assistant: LockfileAssistant?) {
-        isCurrentAssistantRemote = assistant?.isRemote ?? false
-        isCurrentAssistantManaged = assistant?.isManaged ?? false
-
-        // Managed assistant: use platform proxy URLs with session token auth.
-        if let assistant, assistant.isManaged {
-            let platformBaseURL = assistant.runtimeUrl ?? AuthService.shared.baseURL
-            let metadata = TransportMetadata(
-                routeMode: .platformAssistantProxy,
-                authMode: .sessionToken,
-                platformAssistantId: assistant.assistantId
-            )
-            let config = DaemonConfig(
-                transport: .http(
-                    baseURL: platformBaseURL,
-                    bearerToken: nil,
-                    conversationKey: assistant.assistantId
-                ),
-                transportMetadata: metadata
-            )
-            services.reconfigureDaemonClient(config: config)
-            log.info("Configured managed transport for assistant \(assistant.assistantId) via platform at \(platformBaseURL, privacy: .public)")
-            return
-        }
-
-        guard let assistant, assistant.isRemote, let runtimeUrl = assistant.runtimeUrl else {
-            // Local assistant or no assistant.
-            if MacOSClientFeatureFlagManager.shared.isEnabled("local_http_enabled") {
-                // Use HTTP transport for the local daemon instead of IPC.
-                // Bearer token is nil; resolved lazily at connect time.
-                let portString = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "7821"
-                let port = Int(portString) ?? 7821
-                let baseURL = "http://localhost:\(port)"
-                let conversationKey = assistant?.assistantId ?? UUID().uuidString
-                let config = DaemonConfig(transport: .http(
-                    baseURL: baseURL,
-                    bearerToken: nil,
-                    conversationKey: conversationKey
-                ))
-                services.reconfigureDaemonClient(config: config)
-                log.info("Configured local HTTP transport (localHttpEnabled flag) on port \(port)")
-            } else {
-                // Reset to default socket transport in case the previous assistant used HTTP.
-                services.reconfigureDaemonClient(config: .default)
-            }
-            return
-        }
-
-        let config = DaemonConfig(transport: .http(
-            baseURL: runtimeUrl,
-            bearerToken: assistant.bearerToken,
-            conversationKey: assistant.assistantId
-        ))
-
-        // Reconfigure the daemon client's transport in place. This preserves
-        // object identity so all long-lived holders keep a valid reference.
-        services.reconfigureDaemonClient(config: config)
-
-        log.info("Configured HTTP transport for remote assistant \(assistant.assistantId) at \(runtimeUrl, privacy: .public)")
-    }
-
-    // MARK: - Pairing Override Migration
-
-    func setupDaemonClient(isFirstLaunch: Bool = false) {
-        guard !hasSetupDaemon else { return }
-        hasSetupDaemon = true
-
-        let assistant = loadAssistantFromLockfile()
-
-        // Ensure the daemon starts its runtime HTTP server so the
-        // gateway can proxy iOS traffic to it.
-        if ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] == nil {
-            setenv("RUNTIME_HTTP_PORT", "7821", 0)
-        }
-
-        configureDaemonTransport(for: assistant)
-
-        // Rebind the menu bar icon observer after transport reconfiguration
-        // so connection status changes continue to update the icon.
-        rebindConnectionStatusObserver()
-
-        daemonClient.onNotificationIntent = { [weak self] msg in
-            self?.deliverNotificationIntent(msg)
-        }
-
-        // Handle open_bundle_response from the daemon
-        daemonClient.onOpenBundleResponse = { [weak self] response in
-            guard let self else { return }
-            self.handleOpenBundleResponse(response)
-        }
-
-        // Refresh skills cache whenever skill state changes through any path
-        daemonClient.onSkillStateChanged = { [weak self] _ in
-            self?.refreshSkillsCache()
-        }
-
-        // Open URL: daemon -> Swift -> interstitial -> browser
-        daemonClient.onOpenUrl = { msg in
-            guard let url = URL(string: msg.url) else { return }
-            let alert = NSAlert()
-            alert.messageText = "Open External Link?"
-            alert.informativeText = msg.url
-            alert.alertStyle = .informational
-            alert.addButton(withTitle: "Open in Browser")
-            alert.addButton(withTitle: "Cancel")
-            if alert.runModal() == .alertFirstButtonReturn {
-                NSWorkspace.shared.open(url)
-            }
-        }
-
-        daemonClient.onNavigateSettings = { [weak self] msg in
-            Task { @MainActor in
-                self?.showSettingsTab(msg.tab)
-            }
-        }
-
-        daemonClient.onPairingApprovalRequest = { [weak self] msg in
-            guard let self else { return }
-            if self.pairingApprovalWindow == nil {
-                self.pairingApprovalWindow = PairingApprovalWindow(daemonClient: self.daemonClient)
-            }
-            self.pairingApprovalWindow?.show(
-                pairingRequestId: msg.pairingRequestId,
-                deviceName: msg.deviceName
-            )
-        }
-
-        // Automatically surface threads created by scheduled task runs so
-        // the user sees them in the sidebar without restarting the app.
-        daemonClient.onTaskRunThreadCreated = { [weak self] msg in
-            guard let self, !self.isBootstrapping else { return }
-            self.mainWindow?.threadManager.createTaskRunThread(
-                conversationId: msg.conversationId,
-                workItemId: msg.workItemId,
-                title: msg.title
-            )
-        }
-
-        // Schedule threads — created when the scheduler fires and creates a conversation.
-        daemonClient.onScheduleThreadCreated = { [weak self] msg in
-            guard let self, !self.isBootstrapping else { return }
-            self.mainWindow?.threadManager.createScheduleThread(
-                conversationId: msg.conversationId,
-                scheduleJobId: msg.scheduleJobId,
-                title: msg.title
-            )
-        }
-
-        // Notification threads — created when the notification pipeline delivers
-        // to the vellum channel with start_new_conversation strategy.
-        daemonClient.onNotificationThreadCreated = { [weak self] msg in
-            guard let self, !self.isBootstrapping else { return }
-            self.handleNotificationThreadCreated(msg)
-        }
-
-        // Handle escalation: text_qa -> computer_use via computer_use_request_control
-        daemonClient.onTaskRouted = { [weak self] routed in
-            guard let self else { return }
-            // Only handle escalation messages (those with escalatedFrom set)
-            guard routed.escalatedFrom != nil,
-                  routed.interactionType == "computer_use" else {
-                log.debug("Ignoring non-escalation task_routed: type=\(routed.interactionType), escalatedFrom=\(routed.escalatedFrom ?? "nil")")
-                return
-            }
-            self.handleEscalationToComputerUse(routed: routed)
-        }
-
-        // Forward dictation responses from the daemon to VoiceInputManager
-        daemonClient.onDictationResponse = { [weak self] msg in
-            self?.voiceInput?.onDictationResponse?(msg)
-        }
-
-        daemonClient.onDocumentEditorShow = { [weak self] msg in
-            self?.mainWindow?.handleDocumentEditorShow(msg)
-        }
-        daemonClient.onDocumentEditorUpdate = { [weak self] msg in
-            self?.mainWindow?.handleDocumentEditorUpdate(msg)
-        }
-        daemonClient.onDocumentSaveResponse = { [weak self] msg in
-            self?.mainWindow?.handleDocumentSaveResponse(msg)
-        }
-        daemonClient.onDocumentLoadResponse = { [weak self] msg in
-            self?.mainWindow?.handleDocumentLoadResponse(msg)
-        }
-
-        // Handle diagnostics export response — show a toast in the main window
-        daemonClient.onDiagnosticsExportResponse = { [weak self] response in
-            guard let self else { return }
-            Task { @MainActor in
-                if response.success, let filePath = response.filePath {
-                    self.mainWindow?.windowState.showToast(
-                        message: "Report exported successfully.",
-                        style: .success,
-                        primaryAction: VToastAction(label: "Reveal in Finder") {
-                            NSWorkspace.shared.selectFile(filePath, inFileViewerRootedAtPath: "")
-                        }
-                    )
-                } else {
-                    let errorDetail = response.error ?? "Unknown error"
-                    self.mainWindow?.windowState.showToast(
-                        message: "Failed to export report: \(errorDetail)",
-                        style: .error
-                    )
-                }
-            }
-        }
-
-        // Handle recording_start from daemon: check permission, then start recording
-        daemonClient.onRecordingStart = { [weak self] msg in
-            guard let self else { return }
-            self.handleRecordingStart(msg)
-        }
-
-        // Handle recording_stop from daemon
-        daemonClient.onRecordingStop = { [weak self] msg in
-            guard let self else { return }
-            Task {
-                _ = await self.recordingManager.stop(sessionId: msg.recordingId)
-                self.recordingHUDWindow?.dismiss()
-            }
-        }
-
-        // Handle recording_pause from daemon
-        daemonClient.onRecordingPause = { [weak self] msg in
-            guard let self else { return }
-            self.handleRecordingPause(msg)
-        }
-
-        // Handle recording_resume from daemon
-        daemonClient.onRecordingResume = { [weak self] msg in
-            guard let self else { return }
-            self.handleRecordingResume(msg)
-        }
-
-        // Handle client_settings_update from daemon: write to UserDefaults and post notification
-        daemonClient.onClientSettingsUpdate = { msg in
-            UserDefaults.standard.set(msg.value, forKey: msg.key)
-            if msg.key == "activationKey" {
-                NotificationCenter.default.post(name: .activationKeyChanged, object: nil)
-            }
-        }
-
-        daemonClient.onIdentityChanged = { msg in
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(
-                    name: .identityChanged,
-                    object: nil,
-                    userInfo: [
-                        "name": msg.name,
-                        "role": msg.role,
-                        "personality": msg.personality,
-                        "emoji": msg.emoji,
-                        "home": msg.home
-                    ]
-                )
-            }
-        }
-
-        // Handle avatar_updated from daemon: reload the avatar image from disk
-        daemonClient.onAvatarUpdated = { _ in
-            AvatarAppearanceManager.shared.reloadAvatar()
-        }
-
-        // Restart DaemonClient connection when the health monitor relaunches
-        // the daemon process so we don't wait for the backoff timer to expire.
-        assistantCli.onDaemonRestarted = { [weak self] in
-            guard let self else { return }
-            Task {
-                // Don't reset an in-progress connection attempt
-                guard !self.daemonClient.isConnected, !self.daemonClient.isConnecting else { return }
-                do {
-                    try await self.daemonClient.connect()
-                } catch {
-                    log.error("Failed to reconnect to daemon after restart: \(error)")
-                }
-                if self.daemonClient.isConnected {
-                    self.setupAmbientAgent()
-                    self.refreshAppsCache()
-                    self.refreshSkillsCache()
-                    self.checkAndApplyPrivacyFlag()
-                }
-            }
-        }
-
-        Task {
-            if !isCurrentAssistantRemote {
-                // If the hatching step already started the gateway (e.g. `vellum-cli hatch --remote local`),
-                // skip the CLI hatch to avoid spawning a duplicate gateway process.
-                // Require BOTH lockfile and healthy gateway — a stale lockfile with an unhealthy
-                // gateway falls through to the normal hatch path.
-                let lockfileExists = self.lockfileHasAssistants()
-                var gatewayHealthy = false
-                if lockfileExists {
-                    if isFirstLaunch {
-                        // Retry window: gateway may still be starting from onboarding hatch
-                        for _ in 0..<3 {
-                            if await isGatewayHealthy() { gatewayHealthy = true; break }
-                            try? await Task.sleep(nanoseconds: 1_000_000_000)
-                        }
-                    } else {
-                        // Non-first-launch: single check, no retry delay
-                        gatewayHealthy = await isGatewayHealthy()
-                    }
-                }
-
-                if lockfileExists && gatewayHealthy {
-                    log.info("Lockfile and gateway already present — skipping CLI hatch to avoid duplicate gateway")
-                    assistantCli.startMonitoring()
-                } else {
-                    // On first launch post-onboarding, use daemonOnly: false so the CLI
-                    // creates a lockfile entry. On subsequent launches, daemonOnly: true
-                    // prevents duplicates.
-                    let needsLockfileEntry = isFirstLaunch && !lockfileExists
-                    let daemonOnly = !needsLockfileEntry
-                    // Pass the selected assistant ID so the gateway starts
-                    // with the correct default assistant (not a random name).
-                    let assistantName = assistant?.assistantId
-                    do {
-                        try await assistantCli.hatch(name: assistantName, daemonOnly: daemonOnly)
-                    } catch {
-                        log.error("Failed to hatch assistant during daemon setup: \(error)")
-                        if needsLockfileEntry {
-                            log.info("Full hatch failed on first launch — retrying daemon-only as fallback")
-                            try? await assistantCli.hatch(name: assistantName, daemonOnly: true)
-                        }
-                    }
-                    if needsLockfileEntry {
-                        _ = self.loadAssistantFromLockfile()
-                    }
-                    assistantCli.startMonitoring()
-                }
-            }
-            // Skip connect if the bootstrap retry coordinator already connected
-            // or has a connect in flight (hatch can take a long time; the
-            // coordinator connects independently). Checking isConnecting
-            // prevents tearing down the coordinator's in-flight NWConnection
-            // via disconnectInternal().
-            if !daemonClient.isConnected && !daemonClient.isConnecting {
-                do {
-                    try await daemonClient.connect()
-                } catch {
-                    log.error("Failed to connect to daemon during setup: \(error)")
-                }
-            }
-            // Once connected, start ambient agent if it was waiting for daemon
-            if daemonClient.isConnected {
-                setupAmbientAgent()
-                refreshAppsCache()
-                refreshSkillsCache()
-                // Apply the privacy flag now that the gateway is reachable:
-                // close Sentry if the user has opted out of usage data collection.
-                checkAndApplyPrivacyFlag()
-            }
-        }
-    }
-
-    /// Queries the gateway feature-flags API for the collect-usage-data flag and,
-    /// if the user has opted out, shuts down Sentry to stop future event capturing.
-    /// Called after the daemon is first connected so the gateway is reachable.
-    private func checkAndApplyPrivacyFlag() {
-        Task {
-            do {
-                let flags = try await daemonClient.getFeatureFlags()
-                let collectUsageData = flags
-                    .first(where: { $0.key == "feature_flags.collect-usage-data.enabled" })
-                    .map { $0.enabled }
-                    ?? true
-                if !collectUsageData {
-                    SentrySDK.close()
-                }
-            } catch {
-                // Flag check is best-effort; Sentry stays active when the flag
-                // cannot be read (e.g. gateway not yet ready on first boot).
-                log.debug("Could not read privacy flag from gateway: \(error)")
-            }
-        }
-    }
-
-    private func setupAutoUpdate() {
-        updateManager.onWillInstallUpdate = { [weak self] in
-            self?.assistantCli.stop()
-        }
-        updateManager.startAutomaticChecks()
-    }
-
-    /// Installs a `/usr/local/bin/vellum` symlink pointing to the bundled
-    /// CLI binary so users can run `vellum` from their terminal.
-    ///
-    /// Skipped when dev mode is active (developers manage their own PATH)
-    /// or when `vellum` already resolves to a different executable
-    /// (avoids overwriting a developer's locally-built binary).
-    private func installCLISymlinkIfNeeded() {
-        guard !services.settingsStore.isDevMode else { return }
-
-        guard let execURL = Bundle.main.executableURL else { return }
-        let cliBinary = execURL.deletingLastPathComponent()
-            .appendingPathComponent("vellum-cli")
-        guard FileManager.default.fileExists(atPath: cliBinary.path) else { return }
-
-        let symlinkPath = "/usr/local/bin/vellum"
-        let fm = FileManager.default
-
-        // If the path exists, check whether it's our symlink or something else
-        if let attrs = try? fm.attributesOfItem(atPath: symlinkPath),
-           let type = attrs[.type] as? FileAttributeType {
-            if type == .typeSymbolicLink {
-                // Already a symlink — skip if it already points to our binary
-                if let dest = try? fm.destinationOfSymbolicLink(atPath: symlinkPath),
-                   dest == cliBinary.path {
-                    return
-                }
-            } else {
-                // Real file (not a symlink) — don't overwrite
-                return
-            }
-        }
-
-        // Check if `vellum` resolves elsewhere on PATH (developer's local build)
-        let whichProc = Process()
-        whichProc.executableURL = URL(fileURLWithPath: "/usr/bin/which")
-        whichProc.arguments = ["vellum"]
-        let pipe = Pipe()
-        whichProc.standardOutput = pipe
-        whichProc.standardError = FileHandle.nullDevice
-        do {
-            try whichProc.run()
-            whichProc.waitUntilExit()
-            if whichProc.terminationStatus == 0 {
-                let resolved = String(
-                    data: pipe.fileHandleForReading.readDataToEndOfFile(),
-                    encoding: .utf8
-                )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                if !resolved.isEmpty && resolved != symlinkPath {
-                    return
-                }
-            }
-        } catch {
-            // `which` failed to run — continue with symlink creation
-        }
-
-        // Create /usr/local/bin if needed, then create symlink
-        do {
-            let dir = (symlinkPath as NSString).deletingLastPathComponent
-            if !fm.fileExists(atPath: dir) {
-                try fm.createDirectory(atPath: dir, withIntermediateDirectories: true)
-            }
-            // Remove stale symlink before creating a new one
-            if (try? fm.attributesOfItem(atPath: symlinkPath)) != nil {
-                try fm.removeItem(atPath: symlinkPath)
-            }
-            try fm.createSymbolicLink(atPath: symlinkPath, withDestinationPath: cliBinary.path)
-            log.info("Installed CLI symlink: \(symlinkPath) → \(cliBinary.path)")
-        } catch {
-            log.warning("Could not install CLI symlink at \(symlinkPath): \(error.localizedDescription)")
-        }
-    }
 
     private func setupSurfaceManager() {
         daemonClient.onSurfaceShow = { [weak self] msg in
@@ -2444,7 +1940,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     /// Returns `true` when `~/.vellum.lock.json` contains at least one
     /// assistant entry.
-    private func lockfileHasAssistants() -> Bool {
+    func lockfileHasAssistants() -> Bool {
         guard let json = LockfilePaths.read(),
               let assistants = json["assistants"] as? [[String: Any]] else {
             return false
@@ -2454,7 +1950,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     /// Check whether the local gateway is healthy by hitting its /healthz endpoint.
     /// Reads port from GATEWAY_PORT env var (default 7830) to match local.ts runtime behavior.
-    private func isGatewayHealthy() async -> Bool {
+    func isGatewayHealthy() async -> Bool {
         let port = ProcessInfo.processInfo.environment["GATEWAY_PORT"] ?? "7830"
         guard let url = URL(string: "http://localhost:\(port)/healthz") else { return false }
         var request = URLRequest(url: url)


### PR DESCRIPTION
## Summary
Extracts daemon setup, transport wiring, auto-update, CLI symlink, and theme preference methods from AppDelegate.swift into a new `AppDelegate+DaemonSetup.swift` extension file. Pure mechanical move with zero logic changes.

## Methods moved
- `loadAssistantFromLockfile()`
- `configureDaemonTransport(for:)`
- `setupDaemonClient(isFirstLaunch:)`
- `checkAndApplyPrivacyFlag()`
- `setupAutoUpdate()`
- `installCLISymlinkIfNeeded()`
- `applyThemePreference()`

## Access-level widenings (private → internal)

### Properties
- `isCurrentAssistantRemote` — read/written by `configureDaemonTransport` and `setupDaemonClient`
- `isCurrentAssistantManaged` — read/written by `configureDaemonTransport` and `setupDaemonClient`
- `hasSetupDaemon` — guard flag used by `setupDaemonClient`
- `hasSetupApp` — guard flag used by `proceedToApp` (stays in AppDelegate.swift but needed for symmetry with `hasSetupDaemon`)
- `assistantCli` — used by `setupDaemonClient`, `setupAutoUpdate`, and several methods remaining in AppDelegate.swift
- `voiceInput` — accessed in daemon callback closure within `setupDaemonClient`
- `pairingApprovalWindow` — accessed in daemon callback closure within `setupDaemonClient`

### Methods
- `lockfileHasAssistants()` — called from `setupDaemonClient`
- `isGatewayHealthy()` — called from `setupDaemonClient`

## Files changed
- `clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift` (new, 524 lines)
- `clients/macos/vellum-assistant/App/AppDelegate.swift` (modified, 2731 → 2227 lines)

Part of plan: appdelegate-refactor.md (PR 2 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
