### PR TITLE
M6: Reconcile multi-instance identity/routing

### DIFF
--- a/assistant/src/runtime/assistant-scope.ts
+++ b/assistant/src/runtime/assistant-scope.ts
@@ -6,5 +6,10 @@
  * gateway and platform layers (hatch, invite links, etc.). Daemon code
  * should never derive scoping decisions from externally-provided assistant
  * IDs — use this constant instead.
+ *
+ * Multi-instance invariant: each daemon process is single-tenant within
+ * its own BASE_DATA_DIR. The fixed "self" value works across multiple
+ * local instances because each instance has isolated storage — there is
+ * no cross-instance data sharing that would require disambiguating IDs.
  */
 export const DAEMON_INTERNAL_ASSISTANT_ID = "self" as const;

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -85,6 +85,11 @@ export function readLockfile(): Record<string, unknown> | null {
  * inbound call path resolves phone numbers to config keys (typically
  * "self"). This function maps any known lockfile assistant ID to "self"
  * so both sides use a consistent DB key.
+ *
+ * Multi-instance safety: each daemon process runs with a scoped
+ * BASE_DATA_DIR, so readLockfile() only sees the lockfile for this
+ * instance. The mapping to "self" is correct because each daemon is
+ * single-tenant — it only manages its own instance's data.
  */
 export function normalizeAssistantId(assistantId: string): string {
   if (assistantId === "self") return "self";

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -133,6 +133,10 @@ export function loadConfig(): GatewayConfig {
   const telegramApiBaseUrl =
     process.env.TELEGRAM_API_BASE_URL || "https://api.telegram.org";
 
+  // Port-based routing: each gateway instance reads RUNTIME_HTTP_PORT to
+  // discover its co-located daemon's HTTP port. In multi-instance setups,
+  // the CLI passes a per-instance daemon port so each gateway proxies to
+  // the correct daemon process (see cli/src/lib/local.ts startGateway).
   const runtimePort = process.env.RUNTIME_HTTP_PORT || "7821";
   const assistantRuntimeBaseUrl =
     process.env.ASSISTANT_RUNTIME_BASE_URL || `http://localhost:${runtimePort}`;


### PR DESCRIPTION
Verifies and documents the identity/routing invariants that ensure multiple local instances don't interfere with each other. Each daemon is single-tenant with scoped BASE_DATA_DIR, and each gateway proxies to its co-located daemon via RUNTIME_HTTP_PORT. Part of #12604.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
