### PR TITLE
fix: remove stale appType references after IPC contract removal

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -655,7 +655,7 @@ extension AppDelegate {
                     let daemonItems = response.apps.map {
                         AppListManager.AppItem_Daemon(
                             id: $0.id, name: $0.name, description: $0.description,
-                            icon: $0.icon, appType: $0.appType, createdAt: $0.createdAt
+                            icon: $0.icon, appType: nil, createdAt: $0.createdAt
                         )
                     }
                     self.mainWindow?.appListManager.syncFromDaemon(daemonItems)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppDirectoryView.swift
@@ -378,7 +378,7 @@ struct AppDirectoryView: View {
                 preview: nil,
                 dateLabel: formatDate(app.createdAt),
                 isShared: false,
-                appType: app.appType,
+                appType: nil,
                 localAppId: app.id,
                 sharedUUID: nil
             ))


### PR DESCRIPTION
## Summary
- `appType` was removed from `IPCAppsListResponseApp` in a prior PR but two callsites still referenced it
- Pass `nil` instead of `$0.appType` / `app.appType` in `AppDelegate+MenuBar.swift` and `AppDirectoryView.swift`

## Original prompt
fix this issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22694359910/job/65797307146

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
