### PR TITLE
fix: remove stale appType reference in GeneratedPanel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -649,7 +649,7 @@ struct GeneratedPanel: View {
                 signerDisplayName: nil,
                 version: app.version,
                 updateAvailable: nil,
-                appType: app.appType,
+                appType: nil,
                 localAppId: app.id,
                 sharedUUID: nil
             ))


### PR DESCRIPTION
## Summary
- Remove `app.appType` reference in `GeneratedPanel.swift` that references a field no longer present on `IPCAppsListResponseApp` after the IPC contract removal in #12651
- Pass `nil` instead, matching the pattern used elsewhere in the file

## Original prompt
Fix: ~v/clients/macos git:(main❯❯❯ PLATFORM_BASE_URL=http://localhost:8000 VELLUM_ASSISTANT_PLATFORM_URL=http://localhost:3000 ./build.sh run
Building (debug)...
[1/1] Planning build
Building for debugging...
/Users/sidd/vocify/vellum-assistant/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift:652:30: error: value of type 'AppItem' (aka 'IPCAppsListResponseApp') has no member 'appType'
650 |                 version: app.version,
651 |                 updateAvailable: nil,
652 |                 appType: app.appType,
    |                              `- error: value of type 'AppItem' (aka 'IPCAppsListResponseApp') has no member 'appType'
653 |                 localAppId: app.id,
654 |                 sharedUUID: nil
[4/7] Compiling VellumAssistantLib GeneratedPanel.swift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
