### PR TITLE
fix: prevent loading spinner from drifting across screen

### DIFF
--- a/clients/shared/DesignSystem/Core/Feedback/VLoadingIndicator.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VLoadingIndicator.swift
@@ -17,12 +17,10 @@ public struct VLoadingIndicator: View {
             .stroke(color, lineWidth: 2)
             .frame(width: size, height: size)
             .rotationEffect(Angle(degrees: isAnimating ? 360 : 0))
-            .animation(
-                .linear(duration: 0.8).repeatForever(autoreverses: false),
-                value: isAnimating
-            )
             .onAppear {
-                isAnimating = true
+                withAnimation(.linear(duration: 0.8).repeatForever(autoreverses: false)) {
+                    isAnimating = true
+                }
             }
             .onDisappear {
                 isAnimating = false


### PR DESCRIPTION
## Summary
- Replace implicit `.animation(_:value:)` with explicit `withAnimation` in `VLoadingIndicator`
- The `.repeatForever` animation was leaking to position properties, causing the spinner to drift rightward/downward when parent layout recalculated via GeometryReader

## Original prompt
yeah fix it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
