### PR TITLE
fix: clean up stale index.lock between enrichment tests

### DIFF
--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -42,6 +42,10 @@ describe("CommitEnrichmentService", () => {
   beforeEach(() => {
     _resetGitServiceRegistry();
     _resetEnrichmentService();
+    // Previous tests' enrichment jobs may leave a stale index.lock if
+    // the git process exits but the lock file isn't flushed before the
+    // next test runs git operations in the shared testDir.
+    rmSync(join(testDir, ".git", "index.lock"), { force: true });
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Summary
- Add `rmSync` of `.git/index.lock` in `beforeEach` of the enrichment service test to prevent flaky `index.lock` conflicts between tests sharing the same git directory
- Fixes intermittent CI failure in "enqueue is fire-and-forget and never throws even when called rapidly" test

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22694699018/job/65798363438

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
