### PR TITLE
refactor: extract auth lifecycle into AppDelegate+AuthLifecycle.swift, fix teardown gaps

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -1,0 +1,362 @@
+import AppKit
+import Combine
+import SwiftUI
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppDelegate+AuthLifecycle")
+
+// MARK: - Auth lifecycle: login, logout, restart, retire, switch assistant
+
+extension AppDelegate {
+
+    func startAuthenticatedFlow() {
+        Task {
+            await authManager.checkSession()
+            if authManager.isAuthenticated || APIKeyManager.hasAnyKey() {
+                proceedToApp()
+            } else {
+                showAuthWindow()
+            }
+        }
+    }
+
+    func showAuthWindow() {
+        if let existing = authWindow {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        OnboardingState.clearPersistedState()
+        let state = OnboardingState()
+        state.shouldPersist = false
+        let authView = OnboardingFlowView(
+            state: state,
+            daemonClient: daemonClient,
+            authManager: authManager,
+            managedBootstrapEnabled: isCurrentAssistantManaged,
+            onComplete: { [weak self] in
+                self?.proceedToApp()
+            },
+            onOpenSettings: {}
+        )
+
+        let hostingController = NSHostingController(rootView: authView)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 460, height: 620),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentViewController = hostingController
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.isMovableByWindowBackground = true
+        window.backgroundColor = NSColor(VColor.background)
+        window.isReleasedWhenClosed = false
+        window.contentMinSize = NSSize(width: 420, height: 580)
+
+        let startWidth: CGFloat = 460
+        let startHeight: CGFloat = 620
+        if let visibleFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame {
+            let x = visibleFrame.midX - startWidth / 2
+            let y = visibleFrame.midY - startHeight / 2
+            window.setFrame(NSRect(x: x, y: y, width: startWidth, height: startHeight), display: true)
+        } else {
+            window.setContentSize(NSSize(width: startWidth, height: startHeight))
+            window.center()
+        }
+
+        NSApp.setActivationPolicy(.regular)
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        authWindow = window
+    }
+
+    @objc func performRestart() {
+        let bundleURL = Bundle.main.bundleURL
+        let config = NSWorkspace.OpenConfiguration()
+        config.createsNewApplicationInstance = true
+        NSWorkspace.shared.openApplication(at: bundleURL, configuration: config) { [weak self] _, error in
+            if let error {
+                log.error("Restart failed — could not launch new instance: \(error.localizedDescription)")
+                return
+            }
+            DispatchQueue.main.async {
+                self?.assistantCli.stop()
+                NSApp.terminate(nil)
+            }
+        }
+    }
+
+    @objc func performLogout() {
+        Task {
+            await authManager.logout()
+
+            mainWindow?.close()
+            mainWindow = nil
+            conversationZoomEnabledCancellable = nil
+            conversationBadgeCancellable?.cancel()
+            conversationBadgeCancellable = nil
+            NSApp.dockTile.badgeLabel = nil
+            isConversationZoomEnabled = false
+
+            if let hotKeyMonitor {
+                NSEvent.removeMonitor(hotKeyMonitor)
+                self.hotKeyMonitor = nil
+            }
+            tearDownHotKeyState()
+            quickInputWindow?.dismiss()
+            quickInputWindow = nil
+            globalHotkeyObserver?.cancel()
+            globalHotkeyObserver = nil
+            if let escapeMonitor {
+                NSEvent.removeMonitor(escapeMonitor)
+                self.escapeMonitor = nil
+            }
+            voiceInput?.stop()
+            voiceInput = nil
+            wakeWordErrorCancellable?.cancel()
+            wakeWordErrorCancellable = nil
+            wakeWordCoordinator = nil
+            ambientAgent.teardown()
+
+            if let observer = windowObserver {
+                NotificationCenter.default.removeObserver(observer)
+                windowObserver = nil
+            }
+            statusIconCancellable?.cancel()
+            statusIconCancellable = nil
+            connectionStatusCancellable?.cancel()
+            connectionStatusCancellable = nil
+            pulseTimer?.invalidate()
+            pulseTimer = nil
+
+            if let item = statusItem {
+                NSStatusBar.system.removeStatusItem(item)
+                statusItem = nil
+            }
+
+            if let mainMenu = NSApp.mainMenu {
+                for title in ["File", "View"] {
+                    let idx = mainMenu.indexOfItem(withTitle: title)
+                    if idx >= 0 { mainMenu.removeItem(at: idx) }
+                }
+            }
+
+            actorTokenBootstrapTask?.cancel()
+            actorTokenBootstrapTask = nil
+            ActorTokenManager.deleteToken()
+
+            assistantCli.stopMonitoring()
+            hasSetupApp = false
+            hasSetupDaemon = false
+            showAuthWindow()
+        }
+    }
+
+    /// Switches the app to a different lockfile assistant: stops the current
+    /// daemon, resets assistant-scoped state, updates persisted state, and
+    /// restarts with the new assistant.
+    ///
+    /// The sequence is intentionally ordered to avoid stale references:
+    /// 1. Stop lifecycle monitoring
+    /// 2. Clear assistant-scoped runtime state (recording, windows, callbacks)
+    /// 3. Stop daemon processes and disconnect transport
+    /// 4. Persist the new assistant selection
+    /// 5. Reconfigure daemon transport and reconnect
+    /// 6. Resume monitoring and credential bootstrap
+    func performSwitchAssistant(to assistant: LockfileAssistant) {
+        // 1. Stop lifecycle monitoring
+        assistantCli.stopMonitoring()
+
+        // 2. Clear assistant-scoped runtime state while the daemon is still
+        // running so forceStop can deliver a recording_status IPC message.
+        recordingManager.forceStop()
+        recordingHUDWindow?.dismiss()
+
+        // 3. Stop daemon processes and disconnect transport
+        assistantCli.stop()
+        daemonClient.disconnect()
+        // Close and recreate the main window to reset thread/session state
+        mainWindow?.close()
+        mainWindow = nil
+
+        // Cancel any in-progress bootstrap tasks from the previous assistant
+        bootstrapRetryTask?.cancel()
+        bootstrapRetryTask = nil
+
+        // 4. Persist the new assistant selection
+        UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")
+        assistant.writeToWorkspaceConfig()
+
+        // Clear stale actor token for the previous assistant
+        actorTokenBootstrapTask?.cancel()
+        actorTokenBootstrapTask = nil
+        ActorTokenManager.deleteToken()
+
+        // 5. Reconfigure daemon transport and reconnect
+        hasSetupDaemon = false
+        setupDaemonClient()
+
+        // 6. Resume credential bootstrap and show UI
+        if !isCurrentAssistantManaged {
+            ensureActorCredentials()
+        }
+        showMainWindow()
+    }
+
+    @objc func performRetire() {
+        Task { await performRetireAsync() }
+    }
+
+    /// Async retire implementation callable from SwiftUI so callers can
+    /// await completion and dismiss their loading UI.
+    ///
+    /// Returns `true` if the retire completed (or the user chose to force-remove),
+    /// `false` if the user cancelled after a failure.
+    @discardableResult
+    func performRetireAsync() async -> Bool {
+        let assistantName = UserDefaults.standard.string(forKey: "connectedAssistantId")
+
+        if assistantName == nil {
+            log.error("No stored connected assistant ID found — skipping retire")
+        }
+
+        if let name = assistantName {
+            do {
+                try await assistantCli.retire(name: name)
+            } catch {
+                log.error("CLI retire failed: \(error.localizedDescription)")
+                let alert = NSAlert()
+                alert.messageText = "Failed to Retire Remote Instance"
+                alert.informativeText = "\(error.localizedDescription)\n\nYou can force-remove the local configuration, but the remote cloud instance may still be running and will need to be deleted manually."
+                alert.alertStyle = .warning
+                alert.addButton(withTitle: "Force Remove")
+                alert.addButton(withTitle: "Cancel")
+                if alert.runModal() != .alertFirstButtonReturn {
+                    // Daemon is still running — user can continue using the app.
+                    // retire() already set isStopping=true and stopped monitoring;
+                    // restart monitoring so the health check remains active.
+                    assistantCli.startMonitoring()
+                    return false
+                }
+                // Retire failed but user chose Force Remove — stop the daemon
+                // before cleaning up local state.
+                daemonClient.disconnect()
+                assistantCli.stop()
+                self.removeLockfileEntry(assistantId: name)
+            }
+
+            // Stop processes after retire succeeds (or user chose Force Remove).
+            // This keeps the daemon alive if the user cancels a failed retire.
+            daemonClient.disconnect()
+            assistantCli.stop()
+        } else {
+            assistantCli.stop()
+        }
+
+        // Check if other assistants remain in the lockfile
+        let remaining = LockfileAssistant.loadAll().filter { $0.assistantId != assistantName }
+        if let next = remaining.first {
+            // Auto-switch to the next available assistant
+            performSwitchAssistant(to: next)
+            return true
+        }
+
+        // No assistants left — tear down fully and show onboarding
+        OnboardingState.clearPersistedState()
+        UserDefaults.standard.removeObject(forKey: "bootstrapState")
+        UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
+        UserDefaults.standard.removeObject(forKey: "lastActivePanel")
+
+        // Kill the daemon process so ensureDaemonRunning() actually spawns
+        // a fresh instance during re-onboarding (equivalent to `vellum sleep`).
+        daemonClient.disconnect()
+        assistantCli.stop()
+        // Cancel any in-progress bootstrap retry so it doesn't race with the
+        // new onboarding flow.
+        bootstrapRetryTask?.cancel()
+        bootstrapRetryTask = nil
+        actorTokenBootstrapTask?.cancel()
+        actorTokenBootstrapTask = nil
+        ActorTokenManager.deleteToken()
+
+        mainWindow?.close()
+        mainWindow = nil
+        conversationZoomEnabledCancellable = nil
+        conversationBadgeCancellable?.cancel()
+        conversationBadgeCancellable = nil
+        NSApp.dockTile.badgeLabel = nil
+        isConversationZoomEnabled = false
+
+        if let hotKeyMonitor {
+            NSEvent.removeMonitor(hotKeyMonitor)
+            self.hotKeyMonitor = nil
+        }
+        tearDownHotKeyState()
+        quickInputWindow?.dismiss()
+        quickInputWindow = nil
+        globalHotkeyObserver?.cancel()
+        globalHotkeyObserver = nil
+        if let escapeMonitor {
+            NSEvent.removeMonitor(escapeMonitor)
+            self.escapeMonitor = nil
+        }
+        voiceInput?.stop()
+        voiceInput = nil
+        wakeWordErrorCancellable?.cancel()
+        wakeWordErrorCancellable = nil
+        wakeWordCoordinator = nil
+        ambientAgent.teardown()
+
+        if let observer = windowObserver {
+            NotificationCenter.default.removeObserver(observer)
+            windowObserver = nil
+        }
+        statusIconCancellable?.cancel()
+        statusIconCancellable = nil
+        connectionStatusCancellable?.cancel()
+        connectionStatusCancellable = nil
+        pulseTimer?.invalidate()
+        pulseTimer = nil
+
+        if let item = statusItem {
+            NSStatusBar.system.removeStatusItem(item)
+            statusItem = nil
+        }
+
+        if let mainMenu = NSApp.mainMenu {
+            for title in ["File", "View"] {
+                let idx = mainMenu.indexOfItem(withTitle: title)
+                if idx >= 0 { mainMenu.removeItem(at: idx) }
+            }
+        }
+
+        hasSetupApp = false
+        hasSetupDaemon = false
+        daemonClient.disconnect()
+        UserDefaults.standard.removeObject(forKey: "user.profile")
+        showOnboarding()
+        return true
+    }
+
+    // MARK: - Shared teardown helpers
+
+    /// Resets hotkey registration state so hotkeys are properly re-registered
+    /// on the next login cycle. Called by both `performLogout` and `performRetireAsync`.
+    ///
+    /// Consolidates three bug fixes:
+    /// 1. Resets `hasSetupHotKey` so `setupHotKey()` re-registers on next login
+    /// 2. Clears both `lastRegisteredGlobalHotkey` and `lastRegisteredQuickInputHotkey`
+    ///    so re-registration is not short-circuited
+    /// 3. Tears down quick-input monitors (including `cmdKLocalMonitor`)
+    func tearDownHotKeyState() {
+        hasSetupHotKey = false
+        lastRegisteredGlobalHotkey = nil
+        lastRegisteredQuickInputHotkey = nil
+        tearDownQuickInputMonitors()
+    }
+}

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -47,11 +47,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     public static var shared: AppDelegate?
 
     var statusItem: NSStatusItem!
-    private var hotKeyMonitor: Any?
-    private var lastRegisteredGlobalHotkey: String?
-    private var lastRegisteredQuickInputHotkey: String?
-    private var globalHotkeyObserver: AnyCancellable?
-    private var escapeMonitor: Any?
+    var hotKeyMonitor: Any?
+    var lastRegisteredGlobalHotkey: String?
+    var lastRegisteredQuickInputHotkey: String?
+    var globalHotkeyObserver: AnyCancellable?
+    var escapeMonitor: Any?
     private var fnVGlobalMonitor: Any?
     private var fnVLocalMonitor: Any?
     var overlayWindow: SessionOverlayWindow?
@@ -63,14 +63,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var startSessionTask: Task<Void, Never>?
     var textResponseWindow: TextResponseWindow?
     var voiceInput: VoiceInputManager?
-    private var wakeWordCoordinator: WakeWordCoordinator?
+    var wakeWordCoordinator: WakeWordCoordinator?
     private var voiceTranscriptionWindow: VoiceTranscriptionWindow?
     var thinkingWindow: ThinkingIndicatorWindow?
-    private var quickInputWindow: QuickInputWindow?
+    var quickInputWindow: QuickInputWindow?
     private var quickInputHotKeyRef: EventHotKeyRef?
     private var quickInputEventHandlerRef: EventHandlerRef?
     private var commandPaletteWindow: CommandPaletteWindow?
-    private var cmdKLocalMonitor: Any?
+    var cmdKLocalMonitor: Any?
     public let services = AppServices()
     let assistantCli = AssistantCli()
     public let updateManager = UpdateManager()
@@ -90,8 +90,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var recordingPickerWindow: RecordingSourcePickerWindow?
     var recordingHUDWindow: RecordingHUDWindow?
 
-    private var onboardingWindow: OnboardingWindow?
-    private var authWindow: NSWindow?
+    var onboardingWindow: OnboardingWindow?
+    var authWindow: NSWindow?
     var authManager: AuthManager { services.authManager }
     public var mainWindow: MainWindow?
     var bundleConfirmationWindow: BundleConfirmationWindow?
@@ -113,7 +113,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     #if DEBUG
     var galleryWindow: ComponentGalleryWindow?
     #endif
-    private var windowObserver: Any?
+    var windowObserver: Any?
     private weak var recordingViewModel: ChatViewModel?
     /// Text that was in the chat input before PTT voice recording started,
     /// so we can prepend it to partial/final transcriptions instead of overwriting.
@@ -121,8 +121,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var statusIconCancellable: AnyCancellable?
     var connectionStatusCancellable: AnyCancellable?
     private var quickInputAttachmentCancellable: AnyCancellable?
-    private var conversationZoomEnabledCancellable: AnyCancellable?
-    private var conversationBadgeCancellable: AnyCancellable?
+    var conversationZoomEnabledCancellable: AnyCancellable?
+    var conversationBadgeCancellable: AnyCancellable?
     /// Observable state for SwiftUI command group `.disabled()` modifiers.
     /// Updated via Combine subscription to `MainWindowState.objectWillChange`.
     @Published public var isConversationZoomEnabled: Bool = false
@@ -212,17 +212,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         startAuthenticatedFlow()
     }
 
-    private func startAuthenticatedFlow() {
-        Task {
-            await authManager.checkSession()
-            if authManager.isAuthenticated || APIKeyManager.hasAnyKey() {
-                proceedToApp()
-            } else {
-                showAuthWindow()
-            }
-        }
-    }
-
     var hasSetupApp = false
     var hasSetupDaemon = false
 
@@ -248,7 +237,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// it with the wake-up greeting once sequencing completes.
     var isBootstrapping: Bool { bootstrapState != .complete }
 
-    private func proceedToApp(isFirstLaunch: Bool = false) {
+    func proceedToApp(isFirstLaunch: Bool = false) {
         authWindow?.close()
         authWindow = nil
 
@@ -324,331 +313,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             setupWakeWordCoordinator()
             debugStateWriter.start(appDelegate: self)
         }
-    }
-
-    private func showAuthWindow() {
-        if let existing = authWindow {
-            existing.makeKeyAndOrderFront(nil)
-            NSApp.activate(ignoringOtherApps: true)
-            return
-        }
-
-        OnboardingState.clearPersistedState()
-        let state = OnboardingState()
-        state.shouldPersist = false
-        let authView = OnboardingFlowView(
-            state: state,
-            daemonClient: daemonClient,
-            authManager: authManager,
-            managedBootstrapEnabled: isCurrentAssistantManaged,
-            onComplete: { [weak self] in
-                self?.proceedToApp()
-            },
-            onOpenSettings: {}
-        )
-
-        let hostingController = NSHostingController(rootView: authView)
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 460, height: 620),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
-            backing: .buffered,
-            defer: false
-        )
-        window.contentViewController = hostingController
-        window.titleVisibility = .hidden
-        window.titlebarAppearsTransparent = true
-        window.isMovableByWindowBackground = true
-        window.backgroundColor = NSColor(VColor.background)
-        window.isReleasedWhenClosed = false
-        window.contentMinSize = NSSize(width: 420, height: 580)
-
-        let startWidth: CGFloat = 460
-        let startHeight: CGFloat = 620
-        if let visibleFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame {
-            let x = visibleFrame.midX - startWidth / 2
-            let y = visibleFrame.midY - startHeight / 2
-            window.setFrame(NSRect(x: x, y: y, width: startWidth, height: startHeight), display: true)
-        } else {
-            window.setContentSize(NSSize(width: startWidth, height: startHeight))
-            window.center()
-        }
-
-        NSApp.setActivationPolicy(.regular)
-        window.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
-
-        authWindow = window
-    }
-
-    @objc func performRestart() {
-        let bundleURL = Bundle.main.bundleURL
-        let config = NSWorkspace.OpenConfiguration()
-        config.createsNewApplicationInstance = true
-        NSWorkspace.shared.openApplication(at: bundleURL, configuration: config) { [weak self] _, error in
-            if let error {
-                log.error("Restart failed — could not launch new instance: \(error.localizedDescription)")
-                return
-            }
-            DispatchQueue.main.async {
-                self?.assistantCli.stop()
-                NSApp.terminate(nil)
-            }
-        }
-    }
-
-    @objc func performLogout() {
-        Task {
-            await authManager.logout()
-
-            mainWindow?.close()
-            mainWindow = nil
-            conversationZoomEnabledCancellable = nil
-            conversationBadgeCancellable?.cancel()
-            conversationBadgeCancellable = nil
-            NSApp.dockTile.badgeLabel = nil
-            isConversationZoomEnabled = false
-
-            if let hotKeyMonitor {
-                NSEvent.removeMonitor(hotKeyMonitor)
-                self.hotKeyMonitor = nil
-            }
-            self.tearDownQuickInputMonitors()
-            quickInputWindow?.dismiss()
-            quickInputWindow = nil
-            lastRegisteredGlobalHotkey = nil
-            lastRegisteredQuickInputHotkey = nil
-            globalHotkeyObserver?.cancel()
-            globalHotkeyObserver = nil
-            if let escapeMonitor {
-                NSEvent.removeMonitor(escapeMonitor)
-                self.escapeMonitor = nil
-            }
-            voiceInput?.stop()
-            voiceInput = nil
-            wakeWordErrorCancellable?.cancel()
-            wakeWordErrorCancellable = nil
-            wakeWordCoordinator = nil
-            ambientAgent.teardown()
-
-            if let observer = windowObserver {
-                NotificationCenter.default.removeObserver(observer)
-                windowObserver = nil
-            }
-            statusIconCancellable?.cancel()
-            statusIconCancellable = nil
-            connectionStatusCancellable?.cancel()
-            connectionStatusCancellable = nil
-            pulseTimer?.invalidate()
-            pulseTimer = nil
-
-            if let item = statusItem {
-                NSStatusBar.system.removeStatusItem(item)
-                statusItem = nil
-            }
-
-            if let mainMenu = NSApp.mainMenu {
-                for title in ["File", "View"] {
-                    let idx = mainMenu.indexOfItem(withTitle: title)
-                    if idx >= 0 { mainMenu.removeItem(at: idx) }
-                }
-            }
-
-            actorTokenBootstrapTask?.cancel()
-            actorTokenBootstrapTask = nil
-            ActorTokenManager.deleteToken()
-
-            assistantCli.stopMonitoring()
-            hasSetupApp = false
-            hasSetupDaemon = false
-            showAuthWindow()
-        }
-    }
-
-    /// Switches the app to a different lockfile assistant: stops the current
-    /// daemon, resets assistant-scoped state, updates persisted state, and
-    /// restarts with the new assistant.
-    ///
-    /// The sequence is intentionally ordered to avoid stale references:
-    /// 1. Stop lifecycle monitoring
-    /// 2. Clear assistant-scoped runtime state (recording, windows, callbacks)
-    /// 3. Stop daemon processes and disconnect transport
-    /// 4. Persist the new assistant selection
-    /// 5. Reconfigure daemon transport and reconnect
-    /// 6. Resume monitoring and credential bootstrap
-    func performSwitchAssistant(to assistant: LockfileAssistant) {
-        // 1. Stop lifecycle monitoring
-        assistantCli.stopMonitoring()
-
-        // 2. Clear assistant-scoped runtime state while the daemon is still
-        // running so forceStop can deliver a recording_status IPC message.
-        recordingManager.forceStop()
-        recordingHUDWindow?.dismiss()
-
-        // 3. Stop daemon processes and disconnect transport
-        assistantCli.stop()
-        daemonClient.disconnect()
-        // Close and recreate the main window to reset thread/session state
-        mainWindow?.close()
-        mainWindow = nil
-
-        // Cancel any in-progress bootstrap tasks from the previous assistant
-        bootstrapRetryTask?.cancel()
-        bootstrapRetryTask = nil
-
-        // 4. Persist the new assistant selection
-        UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")
-        assistant.writeToWorkspaceConfig()
-
-        // Clear stale actor token for the previous assistant
-        actorTokenBootstrapTask?.cancel()
-        actorTokenBootstrapTask = nil
-        ActorTokenManager.deleteToken()
-
-        // 5. Reconfigure daemon transport and reconnect
-        hasSetupDaemon = false
-        setupDaemonClient()
-
-        // 6. Resume credential bootstrap and show UI
-        if !isCurrentAssistantManaged {
-            ensureActorCredentials()
-        }
-        showMainWindow()
-    }
-
-    @objc func performRetire() {
-        Task { await performRetireAsync() }
-    }
-
-    /// Async retire implementation callable from SwiftUI so callers can
-    /// await completion and dismiss their loading UI.
-    ///
-    /// Returns `true` if the retire completed (or the user chose to force-remove),
-    /// `false` if the user cancelled after a failure.
-    @discardableResult
-    func performRetireAsync() async -> Bool {
-        let assistantName = UserDefaults.standard.string(forKey: "connectedAssistantId")
-
-        if assistantName == nil {
-            log.error("No stored connected assistant ID found — skipping retire")
-        }
-
-        if let name = assistantName {
-            do {
-                try await assistantCli.retire(name: name)
-            } catch {
-                log.error("CLI retire failed: \(error.localizedDescription)")
-                let alert = NSAlert()
-                alert.messageText = "Failed to Retire Remote Instance"
-                alert.informativeText = "\(error.localizedDescription)\n\nYou can force-remove the local configuration, but the remote cloud instance may still be running and will need to be deleted manually."
-                alert.alertStyle = .warning
-                alert.addButton(withTitle: "Force Remove")
-                alert.addButton(withTitle: "Cancel")
-                if alert.runModal() != .alertFirstButtonReturn {
-                    // Daemon is still running — user can continue using the app.
-                    // retire() already set isStopping=true and stopped monitoring;
-                    // restart monitoring so the health check remains active.
-                    assistantCli.startMonitoring()
-                    return false
-                }
-                // Retire failed but user chose Force Remove — stop the daemon
-                // before cleaning up local state.
-                daemonClient.disconnect()
-                assistantCli.stop()
-                self.removeLockfileEntry(assistantId: name)
-            }
-
-            // Stop processes after retire succeeds (or user chose Force Remove).
-            // This keeps the daemon alive if the user cancels a failed retire.
-            daemonClient.disconnect()
-            assistantCli.stop()
-        } else {
-            assistantCli.stop()
-        }
-
-        // Check if other assistants remain in the lockfile
-        let remaining = LockfileAssistant.loadAll().filter { $0.assistantId != assistantName }
-        if let next = remaining.first {
-            // Auto-switch to the next available assistant
-            performSwitchAssistant(to: next)
-            return true
-        }
-
-        // No assistants left — tear down fully and show onboarding
-        OnboardingState.clearPersistedState()
-        UserDefaults.standard.removeObject(forKey: "bootstrapState")
-        UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
-        UserDefaults.standard.removeObject(forKey: "lastActivePanel")
-
-        // Kill the daemon process so ensureDaemonRunning() actually spawns
-        // a fresh instance during re-onboarding (equivalent to `vellum sleep`).
-        daemonClient.disconnect()
-        assistantCli.stop()
-        // Cancel any in-progress bootstrap retry so it doesn't race with the
-        // new onboarding flow.
-        bootstrapRetryTask?.cancel()
-        bootstrapRetryTask = nil
-        actorTokenBootstrapTask?.cancel()
-        actorTokenBootstrapTask = nil
-        ActorTokenManager.deleteToken()
-
-        mainWindow?.close()
-        mainWindow = nil
-        conversationZoomEnabledCancellable = nil
-        conversationBadgeCancellable?.cancel()
-        conversationBadgeCancellable = nil
-        NSApp.dockTile.badgeLabel = nil
-        isConversationZoomEnabled = false
-
-        if let hotKeyMonitor {
-            NSEvent.removeMonitor(hotKeyMonitor)
-            self.hotKeyMonitor = nil
-        }
-        tearDownQuickInputMonitors()
-        quickInputWindow?.dismiss()
-        quickInputWindow = nil
-        lastRegisteredGlobalHotkey = nil
-        globalHotkeyObserver?.cancel()
-        globalHotkeyObserver = nil
-        if let escapeMonitor {
-            NSEvent.removeMonitor(escapeMonitor)
-            self.escapeMonitor = nil
-        }
-        voiceInput?.stop()
-        voiceInput = nil
-        wakeWordErrorCancellable?.cancel()
-        wakeWordErrorCancellable = nil
-        wakeWordCoordinator = nil
-        ambientAgent.teardown()
-
-        if let observer = windowObserver {
-            NotificationCenter.default.removeObserver(observer)
-            windowObserver = nil
-        }
-        statusIconCancellable?.cancel()
-        statusIconCancellable = nil
-        connectionStatusCancellable?.cancel()
-        connectionStatusCancellable = nil
-        pulseTimer?.invalidate()
-        pulseTimer = nil
-
-        if let item = statusItem {
-            NSStatusBar.system.removeStatusItem(item)
-            statusItem = nil
-        }
-
-        if let mainMenu = NSApp.mainMenu {
-            for title in ["File", "View"] {
-                let idx = mainMenu.indexOfItem(withTitle: title)
-                if idx >= 0 { mainMenu.removeItem(at: idx) }
-            }
-        }
-
-        hasSetupApp = false
-        hasSetupDaemon = false
-        daemonClient.disconnect()
-        UserDefaults.standard.removeObject(forKey: "user.profile")
-        showOnboarding()
-        return true
     }
 
     /// Applies the user's theme preference to the app appearance.
@@ -872,7 +536,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     // MARK: - Hotkey
 
-    private var hasSetupHotKey = false
+    var hasSetupHotKey = false
 
     private func setupHotKey() {
         guard !hasSetupHotKey else { return }
@@ -941,8 +605,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         lastRegisteredQuickInputHotkey = shortcut
     }
 
-    /// Removes the Carbon hotkey and event handler registrations.
-    private func tearDownQuickInputMonitors() {
+    /// Removes the Carbon hotkey and event handler registrations,
+    /// plus the Cmd+K local monitor.
+    func tearDownQuickInputMonitors() {
         if let ref = quickInputHotKeyRef {
             UnregisterEventHotKey(ref)
             quickInputHotKeyRef = nil
@@ -958,6 +623,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         if let monitor = fnVLocalMonitor {
             NSEvent.removeMonitor(monitor)
             fnVLocalMonitor = nil
+        }
+        if let monitor = cmdKLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            cmdKLocalMonitor = nil
         }
     }
 
@@ -1391,7 +1060,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
     // MARK: - Wake Word Coordinator
 
-    private var wakeWordErrorCancellable: AnyCancellable?
+    var wakeWordErrorCancellable: AnyCancellable?
 
     func setupWakeWordCoordinator() {
         guard let mainWindow else {
@@ -1509,7 +1178,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     /// Remove a specific assistant entry from the lockfile. Used after a
     /// failed retire + Force Remove to clean up the stale entry so the
     /// next onboarding run starts with a fresh lockfile.
-    private func removeLockfileEntry(assistantId: String) {
+    func removeLockfileEntry(assistantId: String) {
         guard let json = LockfilePaths.read(),
               let assistants = json["assistants"] as? [[String: Any]] else {
             return
@@ -1531,7 +1200,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         }
     }
 
-    private func showOnboarding() {
+    func showOnboarding() {
         let onboarding = OnboardingWindow(daemonClient: daemonClient, authManager: authManager)
         onboarding.onComplete = { [weak self] state in
             OnboardingState.clearPersistedState()


### PR DESCRIPTION
## Summary
- Extracts auth/lifecycle methods from AppDelegate.swift into `AppDelegate+AuthLifecycle.swift`
- Adds shared `tearDownHotKeyState()` helper to eliminate duplicate teardown code
- Includes three targeted bug fixes:

### Bug fixes
1. **Hotkey teardown gap**: `hasSetupHotKey` was not reset during logout/retire, preventing hotkeys from being re-registered on next login. Now reset in both paths via `tearDownHotKeyState()`.
2. **Missing quick-input cache clear in retire**: `performRetireAsync()` cleared `lastRegisteredGlobalHotkey` but not `lastRegisteredQuickInputHotkey`. Now cleared in both paths via `tearDownHotKeyState()`.
3. **cmdKLocalMonitor leak**: `tearDownQuickInputMonitors()` did not remove `cmdKLocalMonitor`, causing duplicate Cmd+K monitors to accumulate across login cycles. Now cleaned up.

### Methods moved
- `startAuthenticatedFlow()`
- `showAuthWindow()`
- `performRestart()`
- `performLogout()`
- `performSwitchAssistant(to:)`
- `performRetire()` / `performRetireAsync()`

### Access-level widenings (private → internal)
Listed in implementation — all properties referenced by moved methods that were still private.

Part of plan: appdelegate-refactor.md (PR 4 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
