### PR TITLE
M1: Reset scrollPositionId on thread switch (#12659)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -104,6 +104,9 @@ struct MessageListView: View {
     /// regardless of whether messages.count changes. This covers the edge
     /// case where pagination stalls without adding/removing messages.
     @State private var anchorTimeoutTask: Task<Void, Never>?
+    /// Tracks the top-visible item so SwiftUI can stabilize the viewport
+    /// when content height changes above it during LazyVStack re-layouts.
+    @State private var scrollPositionId: AnyHashable?
 
     /// The subset of messages actually shown, honoring the pagination window.
     private var visibleMessages: [ChatMessage] {
@@ -492,6 +495,7 @@ struct MessageListView: View {
             }
             .scrollContentBackground(.hidden)
             .coordinateSpace(name: "chatScrollView")
+            .scrollPosition(id: $scrollPositionId, anchor: .top)
             .scrollDisabled(messages.isEmpty && !isSending)
             .onHover { hovering in
                 handleThreadContentHover(hovering)
@@ -703,6 +707,7 @@ struct MessageListView: View {
                 isNearBottom = true
                 anchorIsVisible = true
                 hasReceivedScrollEvent = false
+                scrollPositionId = nil
                 hoverExitDebounceTask?.cancel()
                 hoverExitDebounceTask = nil
                 anchorTimeoutTask?.cancel()


### PR DESCRIPTION
## Summary
- Re-adds `scrollPositionId` state variable and `.scrollPosition(id:anchor:)` modifier (originally from PR #12618, removed in #12631 due to crashes from never being reset)
- Resets `scrollPositionId = nil` in the `onChange(of: threadId)` handler alongside other state resets
- This prevents the `.scrollPosition` modifier from anchoring to a stale item ID from the previous thread, which caused the chat to briefly flash to the top when switching threads

## Test plan
- [ ] Build succeeds (`cd clients/macos && ./build.sh`) — verified
- [ ] Switch between threads and verify no visible flash/jump at the top
- [ ] Verify scroll position stabilization still works during streaming and pagination within a single thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
