### PR TITLE
feat: add approved users list with revoke to Slack channel settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -72,6 +72,7 @@ struct SettingsChannelsTab: View {
             store.refreshChannelGuardianStatus(channel: "voice")
             store.refreshChannelGuardianStatus(channel: "slack")
             store.refreshTelegramApprovedMembers()
+            store.refreshSlackApprovedMembers()
             store.fetchSlackChannelConfig()
             if store.twilioHasCredentials {
                 store.refreshTwilioNumbers()
@@ -452,12 +453,70 @@ struct SettingsChannelsTab: View {
             if store.slackChannelHasBotToken && store.slackChannelHasAppToken {
                 Divider().background(VColor.surfaceBorder)
                 guardianStatusRow(channel: "slack")
+
+                Divider().background(VColor.surfaceBorder)
+                slackApprovedUsersSection
             }
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
         .vCard(background: VColor.surfaceSubtle)
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Slack Approved Users
+
+    private var slackApprovedUsersSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.xs) {
+                Text("Approved Users")
+                VInfoTooltip("Users who have been granted access to interact with your assistant via Slack.")
+            }
+            .font(VFont.caption)
+            .foregroundColor(VColor.textSecondary)
+
+            if store.slackApprovedMembersLoading {
+                HStack(spacing: VSpacing.sm) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading...")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            } else if store.slackApprovedMembers.isEmpty {
+                Text("No approved users.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            } else {
+                ForEach(store.slackApprovedMembers) { member in
+                    HStack(spacing: VSpacing.sm) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(member.displayName ?? member.username ?? member.externalUserId ?? member.id)
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textPrimary)
+                                .lineLimit(1)
+                            if let username = member.username, member.displayName != nil {
+                                Text("@\(username)")
+                                    .font(VFont.caption)
+                                    .foregroundColor(VColor.textMuted)
+                                    .lineLimit(1)
+                            }
+                        }
+                        Spacer()
+                        VButton(label: "Revoke", style: .secondary) {
+                            store.revokeSlackApprovedMember(memberId: member.id)
+                        }
+                        .disabled(store.slackRevokingMemberIds.contains(member.id))
+                    }
+                }
+            }
+
+            if let error = store.slackApprovedMembersError {
+                Text(error)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+            }
+        }
     }
 
     // MARK: - Slack Channel Credential Entry

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -201,6 +201,13 @@ public final class SettingsStore: ObservableObject {
     @Published var slackGuardianError: String?
     @Published var slackGuardianAlreadyBound: Bool = false
 
+    // MARK: - Approved Ingress Contacts (Slack)
+
+    @Published var slackApprovedMembers: [ApprovedMember] = []
+    @Published var slackApprovedMembersLoading: Bool = false
+    @Published var slackApprovedMembersError: String?
+    @Published var slackRevokingMemberIds: Set<String> = []
+
     // MARK: - Outbound Guardian Session State (Slack)
 
     @Published var slackOutboundSessionId: String?
@@ -1664,6 +1671,89 @@ public final class SettingsStore: ObservableObject {
                 self.telegramRevokingMemberIds.remove(memberId)
                 self.telegramApprovedMembers.append(contentsOf: removed)
                 self.telegramApprovedMembersError = "Failed to revoke: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    func refreshSlackApprovedMembers() {
+        guard let http = resolveRuntimeHTTP() else { return }
+        guard let url = URL(string: "\(http.baseURL)/v1/contacts?channelType=slack") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+        slackApprovedMembersLoading = true
+        slackApprovedMembersError = nil
+        Task {
+            do {
+                let (data, response) = try await URLSession.shared.data(for: request)
+                self.slackApprovedMembersLoading = false
+                guard let httpResp = response as? HTTPURLResponse else { return }
+                if httpResp.statusCode == 200 {
+                    if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                       let contactsList = json["contacts"] as? [[String: Any]] {
+                        let guardianId = self.slackGuardianIdentity
+                        var approvedMembers: [ApprovedMember] = []
+                        for contact in contactsList {
+                            let displayName = contact["displayName"] as? String
+                            guard let channels = contact["channels"] as? [[String: Any]] else { continue }
+                            for channel in channels {
+                                guard let channelType = channel["type"] as? String,
+                                      channelType == "slack",
+                                      let status = channel["status"] as? String,
+                                      status == "active",
+                                      let channelId = channel["id"] as? String else { continue }
+                                let externalUserId = channel["externalUserId"] as? String
+                                // Skip the guardian — they're already shown in the Guardian Verification row
+                                if let guardianId, let externalUserId, externalUserId == guardianId {
+                                    continue
+                                }
+                                approvedMembers.append(ApprovedMember(
+                                    id: channelId,
+                                    displayName: displayName,
+                                    username: channel["address"] as? String,
+                                    externalUserId: externalUserId
+                                ))
+                            }
+                        }
+                        self.slackApprovedMembers = approvedMembers
+                        self.slackApprovedMembersError = nil
+                    }
+                } else {
+                    self.slackApprovedMembersError = "Failed to load (HTTP \(httpResp.statusCode))"
+                }
+            } catch {
+                self.slackApprovedMembersLoading = false
+                self.slackApprovedMembersError = "Failed to load: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    func revokeSlackApprovedMember(memberId: String) {
+        guard let http = resolveRuntimeHTTP() else { return }
+        guard let url = URL(string: "\(http.baseURL)/v1/contacts/channels/\(memberId)") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "PATCH"
+        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: ["status": "revoked"])
+        request.timeoutInterval = 10
+        slackRevokingMemberIds.insert(memberId)
+        let removed = slackApprovedMembers.filter { $0.id == memberId }
+        slackApprovedMembers.removeAll { $0.id == memberId }
+        Task {
+            do {
+                let (_, response) = try await URLSession.shared.data(for: request)
+                self.slackRevokingMemberIds.remove(memberId)
+                guard let httpResp = response as? HTTPURLResponse else { return }
+                if !(200..<300).contains(httpResp.statusCode) {
+                    self.slackApprovedMembers.append(contentsOf: removed)
+                    self.slackApprovedMembersError = "Failed to revoke (HTTP \(httpResp.statusCode))"
+                }
+            } catch {
+                self.slackRevokingMemberIds.remove(memberId)
+                self.slackApprovedMembers.append(contentsOf: removed)
+                self.slackApprovedMembersError = "Failed to revoke: \(error.localizedDescription)"
             }
         }
     }


### PR DESCRIPTION
## Summary
- Adds an "Approved Users" section to the Slack channel card in Settings > Channels
- Lists active Slack contacts fetched via `GET /v1/contacts?channelType=slack`, with a "Revoke" button per user
- Mirrors the existing Telegram approved users pattern (same API, same UI layout, same optimistic revoke with rollback)

## Test plan
- [ ] Open Settings > Channels with Slack connected and verify approved users appear
- [ ] Click "Revoke" on a user and verify they are removed from the list
- [ ] Verify the guardian user is not duplicated (excluded from the list since they appear in Guardian Verification row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
