### PR TITLE
refactor: extract input monitors into AppDelegate+InputMonitors.swift, fix UserDefaults observer

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -1,0 +1,447 @@
+import AppKit
+import Carbon
+import Combine
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppDelegate")
+
+/// Carbon event handler for the Quick Input hotkey (Cmd+Shift+/).
+/// Must be a free function because Carbon callbacks are C function pointers.
+func quickInputHotKeyHandler(
+    _: EventHandlerCallRef?,
+    event: EventRef?,
+    _: UnsafeMutableRawPointer?
+) -> OSStatus {
+    guard let event else { return OSStatus(eventNotHandledErr) }
+
+    var hotKeyID = EventHotKeyID()
+    let status = GetEventParameter(
+        event,
+        EventParamName(kEventParamDirectObject),
+        EventParamType(typeEventHotKeyID),
+        nil,
+        MemoryLayout<EventHotKeyID>.size,
+        nil,
+        &hotKeyID
+    )
+    guard status == noErr, hotKeyID.id == 1 else { return OSStatus(eventNotHandledErr) }
+
+    Task { @MainActor in
+        guard let appDelegate = AppDelegate.shared,
+              !appDelegate.isBootstrapping else { return }
+        appDelegate.toggleQuickInput()
+    }
+    return noErr
+}
+
+// KVO-observable UserDefaults properties for scoped hotkey settings observation.
+// Using @objc dynamic enables Combine's publisher(for:) key-path KVO without
+// listening to every UserDefaults write app-wide.
+extension UserDefaults {
+    @objc dynamic var globalHotkeyShortcut: String {
+        return string(forKey: "globalHotkeyShortcut") ?? "cmd+shift+g"
+    }
+    @objc dynamic var quickInputHotkeyShortcut: String {
+        return string(forKey: "quickInputHotkeyShortcut") ?? "cmd+shift+/"
+    }
+    @objc dynamic var quickInputHotkeyKeyCode: Int {
+        return integer(forKey: "quickInputHotkeyKeyCode")
+    }
+}
+
+// MARK: - Input Monitors
+
+extension AppDelegate {
+
+    func setupHotKey() {
+        guard !hasSetupHotKey else { return }
+        hasSetupHotKey = true
+
+        registerGlobalHotkeyMonitor()
+        registerQuickInputMonitor()
+        registerFnVMonitor()
+        registerCmdKMonitor()
+
+        globalHotkeyObserver = Publishers.Merge3(
+            UserDefaults.standard.publisher(for: \.globalHotkeyShortcut).map { _ in () },
+            UserDefaults.standard.publisher(for: \.quickInputHotkeyShortcut).map { _ in () },
+            UserDefaults.standard.publisher(for: \.quickInputHotkeyKeyCode).map { _ in () }
+        )
+        .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
+        .sink { [weak self] _ in
+            self?.registerGlobalHotkeyMonitor()
+            self?.registerQuickInputMonitor()
+        }
+    }
+
+    /// Registers a Carbon hotkey for Quick Input that intercepts system-wide,
+    /// before the frontmost app's menu system can consume it.
+    /// Reads the shortcut and key code from UserDefaults. Skips re-registration if unchanged.
+    func registerQuickInputMonitor() {
+        let shortcut = UserDefaults.standard.string(forKey: "quickInputHotkeyShortcut") ?? "cmd+shift+/"
+
+        if shortcut == lastRegisteredQuickInputHotkey { return }
+
+        // Tear down previous registration
+        if let ref = quickInputHotKeyRef {
+            UnregisterEventHotKey(ref)
+            quickInputHotKeyRef = nil
+        }
+        if let ref = quickInputEventHandlerRef {
+            RemoveEventHandler(ref)
+            quickInputEventHandlerRef = nil
+        }
+
+        let storedKeyCode = UserDefaults.standard.object(forKey: "quickInputHotkeyKeyCode") as? Int
+        let keyCode = UInt32(storedKeyCode ?? Int(kVK_ANSI_Slash))
+        let (modifierFlags, _) = ShortcutHelper.parseShortcut(shortcut)
+        let carbonMods = ShortcutHelper.carbonModifiers(from: modifierFlags)
+
+        // Install Carbon event handler for hotkey events
+        var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+        var handlerRef: EventHandlerRef?
+        InstallEventHandler(GetApplicationEventTarget(), quickInputHotKeyHandler, 1, &eventType, nil, &handlerRef)
+        quickInputEventHandlerRef = handlerRef
+
+        let hotKeyID = EventHotKeyID(signature: OSType(0x564C_4D51), id: 1) // "VLMQ"
+        var hotKeyRef: EventHotKeyRef?
+        let status = RegisterEventHotKey(
+            keyCode,
+            carbonMods,
+            hotKeyID,
+            GetApplicationEventTarget(),
+            0,
+            &hotKeyRef
+        )
+        if status == noErr {
+            quickInputHotKeyRef = hotKeyRef
+            log.info("Quick Input: Carbon hotkey \(ShortcutHelper.displayString(for: shortcut)) registered successfully")
+        } else {
+            log.error("Quick Input: Failed to register Carbon hotkey, status: \(status)")
+        }
+
+        lastRegisteredQuickInputHotkey = shortcut
+    }
+
+    /// Removes the Carbon hotkey and event handler registrations,
+    /// plus the Cmd+K local monitor.
+    func tearDownQuickInputMonitors() {
+        if let ref = quickInputHotKeyRef {
+            UnregisterEventHotKey(ref)
+            quickInputHotKeyRef = nil
+        }
+        if let ref = quickInputEventHandlerRef {
+            RemoveEventHandler(ref)
+            quickInputEventHandlerRef = nil
+        }
+        if let monitor = fnVGlobalMonitor {
+            NSEvent.removeMonitor(monitor)
+            fnVGlobalMonitor = nil
+        }
+        if let monitor = fnVLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            fnVLocalMonitor = nil
+        }
+        if let monitor = cmdKLocalMonitor {
+            NSEvent.removeMonitor(monitor)
+            cmdKLocalMonitor = nil
+        }
+    }
+
+    /// Registers Cmd+Shift+V as a global shortcut to open the quick input text field.
+    /// Uses NSEvent monitors (global + local).
+    func registerFnVMonitor() {
+        let handler: (NSEvent) -> NSEvent? = { [weak self] event in
+            // Cmd+Shift+V: keyCode 9 is kVK_ANSI_V
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            guard event.keyCode == 9,
+                  mods == [.command, .shift] else {
+                return event
+            }
+            Task { @MainActor in
+                guard self?.isBootstrapping != true else { return }
+                self?.toggleQuickInput(aboveDock: true)
+            }
+            return nil // consume the event
+        }
+
+        fnVGlobalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
+            _ = handler(event)
+        }
+        fnVLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+    }
+
+    /// Registers Cmd+K as a local shortcut to open the command palette.
+    /// Only active when the app is focused (local monitor, not global).
+    func registerCmdKMonitor() {
+        let handler: (NSEvent) -> NSEvent? = { [weak self] event in
+            // Cmd+K: keyCode 40 is kVK_ANSI_K
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            guard event.keyCode == 40,
+                  mods == [.command] else {
+                return event
+            }
+            Task { @MainActor in
+                guard self?.isBootstrapping != true else { return }
+                self?.toggleCommandPalette()
+            }
+            return nil // consume the event
+        }
+        cmdKLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
+    }
+
+    func toggleCommandPalette() {
+        if let window = commandPaletteWindow, window.isVisible {
+            window.dismiss()
+            return
+        }
+
+        let window = CommandPaletteWindow()
+
+        // Static actions
+        window.actions = [
+            CommandPaletteAction(id: "new-conversation", icon: "square.and.pencil", label: "New Conversation", shortcutHint: "\u{2318}N") { [weak self] in
+                self?.mainWindow?.threadManager.enterDraftMode()
+                self?.mainWindow?.windowState.selection = nil
+            },
+            CommandPaletteAction(id: "settings", icon: "gear", label: "Settings", shortcutHint: "\u{2318},") { [weak self] in
+                self?.mainWindow?.windowState.togglePanel(.settings)
+            },
+            CommandPaletteAction(id: "app-directory", icon: "square.grid.2x2", label: "App Directory", shortcutHint: nil) { [weak self] in
+                self?.mainWindow?.windowState.showAppsPanel()
+            },
+            CommandPaletteAction(id: "intelligence", icon: "brain.head.profile", label: "Intelligence", shortcutHint: nil) { [weak self] in
+                self?.mainWindow?.windowState.togglePanel(.intelligence)
+            },
+        ]
+
+        // Recent conversations from ThreadManager
+        if let threads = mainWindow?.threadManager.threads {
+            window.recentItems = threads
+                .filter { !$0.isArchived }
+                .sorted { $0.lastInteractedAt > $1.lastInteractedAt }
+                .prefix(5)
+                .map { CommandPaletteRecentItem(id: $0.id, title: $0.title, lastInteracted: $0.lastInteractedAt) }
+        }
+
+        window.onSelectConversation = { [weak self] threadId in
+            self?.mainWindow?.threadManager.selectThread(id: threadId)
+        }
+
+        // Wire runtime HTTP resolver for server search
+        window.runtimeHTTPResolver = {
+            let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
+                .flatMap(Int.init) ?? 7821
+            if let jwt = ActorTokenManager.getToken(), !jwt.isEmpty {
+                return ("http://localhost:\(port)", jwt)
+            }
+            guard let token = readHttpToken() else { return nil }
+            return ("http://localhost:\(port)", token)
+        }
+
+        window.show()
+        commandPaletteWindow = window
+    }
+
+    func toggleQuickInput(aboveDock: Bool = false, requestScreenPermission: Bool? = nil) {
+        if let window = quickInputWindow, window.isVisible {
+            window.dismiss()
+            return
+        }
+
+        // Auto-detect screen recording permission if not explicitly specified
+        let shouldShowPermissionPrompt = requestScreenPermission
+            ?? (PermissionManager.screenRecordingStatus() != .granted)
+
+        let window = QuickInputWindow()
+        window.onSubmit = { [weak self, weak window] message, imageData in
+            let notify = window?.notifyOnComplete ?? false
+            self?.handleQuickInputSubmit(message, imageData: imageData, notifyOnComplete: notify)
+        }
+        window.onSubmitToThread = { [weak self, weak window] message, imageData in
+            let notify = window?.notifyOnComplete ?? false
+            self?.handleQuickInputSubmitToThread(message, imageData: imageData, notifyOnComplete: notify)
+        }
+        window.onSelectThread = { [weak self] threadId in
+            self?.handleQuickInputSelectThread(threadId)
+        }
+        window.onMicrophoneToggle = { [weak self] in
+            self?.voiceInput?.toggleRecording()
+        }
+        // Provide the 3 most recent non-archived threads
+        if let threads = mainWindow?.threadManager.threads {
+            window.recentThreads = threads
+                .filter { !$0.isArchived }
+                .sorted { $0.lastInteractedAt > $1.lastInteractedAt }
+                .prefix(3)
+                .map { QuickInputThread(id: $0.id, title: $0.title) }
+        }
+        window.showScreenPermissionPrompt = shouldShowPermissionPrompt
+        if aboveDock {
+            window.showAboveDock()
+        } else {
+            window.show()
+        }
+        quickInputWindow = window
+    }
+
+    /// Starts screen region capture directly from the menu bar icon click.
+    /// After the user selects a region, the quick input bar appears near
+    /// the selection with the screenshot attached.
+    func startScreenCapture() {
+        guard PermissionManager.screenRecordingStatus() == .granted else {
+            PermissionManager.requestScreenRecordingAccess()
+            return
+        }
+
+        // Dismiss any existing quick input window
+        quickInputWindow?.dismiss()
+        quickInputWindow = nil
+
+        let selectionWindow = ScreenSelectionWindow()
+        selectionWindow.onComplete = { [weak self] imageData, selectionRect in
+            guard let self else { return }
+
+            let window = QuickInputWindow()
+            window.onSubmit = { [weak self, weak window] message, imgData in
+                let notify = window?.notifyOnComplete ?? false
+                self?.handleQuickInputSubmit(message, imageData: imgData, notifyOnComplete: notify)
+            }
+            window.onSubmitToThread = { [weak self, weak window] message, imgData in
+                let notify = window?.notifyOnComplete ?? false
+                self?.handleQuickInputSubmitToThread(message, imageData: imgData, notifyOnComplete: notify)
+            }
+            window.onSelectThread = { [weak self] threadId in
+                self?.handleQuickInputSelectThread(threadId)
+            }
+            window.onMicrophoneToggle = { [weak self] in
+                self?.voiceInput?.toggleRecording()
+            }
+            if let threads = self.mainWindow?.threadManager.threads {
+                window.recentThreads = threads
+                    .filter { !$0.isArchived }
+                    .sorted { $0.lastInteractedAt > $1.lastInteractedAt }
+                    .prefix(3)
+                    .map { QuickInputThread(id: $0.id, title: $0.title) }
+            }
+            window.setAttachment(imageData: imageData)
+            window.showNearRect(selectionRect)
+            self.quickInputWindow = window
+        }
+        selectionWindow.onCancel = { /* User cancelled — do nothing */ }
+        selectionWindow.show()
+    }
+
+    func handleQuickInputSubmit(_ message: String, imageData: Data?, notifyOnComplete: Bool) {
+        // Ensure mainWindow exists so we can get a ChatViewModel.
+        // Never show it — quick input is fire-and-forget.
+        ensureMainWindowExists()
+        guard let mainWindow else { return }
+        mainWindow.threadManager.createThread()
+        if let threadId = mainWindow.threadManager.activeThreadId {
+            mainWindow.windowState.selection = .thread(threadId)
+        }
+        guard let viewModel = mainWindow.activeViewModel else { return }
+
+        if notifyOnComplete {
+            setupQuickInputNotification(on: viewModel)
+        }
+
+        if let imageData {
+            viewModel.addAttachment(imageData: imageData, filename: "Screenshot.jpg")
+            viewModel.inputText = message
+            quickInputAttachmentCancellable = viewModel.attachmentManager.$isLoadingAttachment
+                .filter { !$0 }
+                .first()
+                .sink { [weak self] _ in
+                    viewModel.sendMessage()
+                    self?.quickInputAttachmentCancellable = nil
+                }
+        } else {
+            viewModel.inputText = message
+            viewModel.sendMessage()
+        }
+    }
+
+    func handleQuickInputSubmitToThread(_ message: String, imageData: Data?, notifyOnComplete: Bool) {
+        guard let mainWindow else { return }
+        if let viewModel = mainWindow.activeViewModel {
+            if notifyOnComplete {
+                setupQuickInputNotification(on: viewModel)
+            }
+            if let imageData {
+                viewModel.addAttachment(imageData: imageData, filename: "Screenshot.jpg")
+            }
+            viewModel.inputText = message
+            viewModel.sendMessage()
+        }
+    }
+
+    /// Sets a one-shot `onResponseComplete` callback on the view model to send a macOS notification.
+    func setupQuickInputNotification(on viewModel: ChatViewModel) {
+        let notificationService = services.activityNotificationService
+        viewModel.onResponseComplete = { [weak viewModel] summary in
+            // One-shot — clear the callback after firing
+            viewModel?.onResponseComplete = nil
+            Task {
+                await notificationService.notifyQuickInputComplete(summary: summary)
+            }
+        }
+    }
+
+    func handleQuickInputSelectThread(_ threadId: UUID) {
+        showMainWindow()
+        guard let mainWindow else { return }
+        mainWindow.threadManager.activeThreadId = threadId
+    }
+
+    /// Tears down and re-registers the global "Open Vellum" hotkey based on
+    /// the current `globalHotkeyShortcut` UserDefaults value. Skips
+    /// re-registration if the shortcut hasn't changed.
+    func registerGlobalHotkeyMonitor() {
+        let shortcut = UserDefaults.standard.string(forKey: "globalHotkeyShortcut") ?? "cmd+shift+g"
+
+        if shortcut == lastRegisteredGlobalHotkey { return }
+
+        if let existing = hotKeyMonitor {
+            NSEvent.removeMonitor(existing)
+            hotKeyMonitor = nil
+        }
+
+        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
+
+        // Use NSEvent global monitor instead of Carbon RegisterEventHotKey (HotKey package).
+        // Carbon hotkeys consume the event globally, preventing other apps from seeing the
+        // keystroke. NSEvent.addGlobalMonitorForEvents observes without consuming.
+        hotKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            let eventMods = event.modifierFlags.intersection(.deviceIndependentFlagsMask).subtracting(.numericPad)
+            guard eventMods == targetModifiers,
+                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else { return }
+            Task { @MainActor in
+                guard self?.isBootstrapping != true else { return }
+                self?.showMainWindow()
+            }
+        }
+
+        lastRegisteredGlobalHotkey = shortcut
+    }
+
+    func setupEscapeMonitor() {
+        escapeMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.keyCode == 53 { // Escape
+                Task { @MainActor in
+                    self?.startSessionTask?.cancel()
+                    self?.thinkingWindow?.close()
+                    self?.thinkingWindow = nil
+                    self?.currentSession?.cancel()
+                    self?.currentTextSession?.cancel()
+                    self?.ambientAgent.resume()
+                    self?.surfaceManager.dismissAll()
+                    self?.toolConfirmationNotificationService.dismissAll()
+                    self?.secretPromptManager.dismissAll()
+                }
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -10,35 +10,6 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppDelegate")
 
-/// Carbon event handler for the Quick Input hotkey (Cmd+Shift+/).
-/// Must be a free function because Carbon callbacks are C function pointers.
-private func quickInputHotKeyHandler(
-    _: EventHandlerCallRef?,
-    event: EventRef?,
-    _: UnsafeMutableRawPointer?
-) -> OSStatus {
-    guard let event else { return OSStatus(eventNotHandledErr) }
-
-    var hotKeyID = EventHotKeyID()
-    let status = GetEventParameter(
-        event,
-        EventParamName(kEventParamDirectObject),
-        EventParamType(typeEventHotKeyID),
-        nil,
-        MemoryLayout<EventHotKeyID>.size,
-        nil,
-        &hotKeyID
-    )
-    guard status == noErr, hotKeyID.id == 1 else { return OSStatus(eventNotHandledErr) }
-
-    Task { @MainActor in
-        guard let appDelegate = AppDelegate.shared,
-              !appDelegate.isBootstrapping else { return }
-        appDelegate.toggleQuickInput()
-    }
-    return noErr
-}
-
 @MainActor
 public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     /// Shared reference — `NSApp.delegate as? AppDelegate` fails under
@@ -52,8 +23,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var lastRegisteredQuickInputHotkey: String?
     var globalHotkeyObserver: AnyCancellable?
     var escapeMonitor: Any?
-    private var fnVGlobalMonitor: Any?
-    private var fnVLocalMonitor: Any?
+    var hasSetupHotKey = false
+    var fnVGlobalMonitor: Any?
+    var fnVLocalMonitor: Any?
     var overlayWindow: SessionOverlayWindow?
     var currentSession: ComputerUseSession?
     var currentTextSession: TextSession?
@@ -67,9 +39,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     private var voiceTranscriptionWindow: VoiceTranscriptionWindow?
     var thinkingWindow: ThinkingIndicatorWindow?
     var quickInputWindow: QuickInputWindow?
-    private var quickInputHotKeyRef: EventHotKeyRef?
-    private var quickInputEventHandlerRef: EventHandlerRef?
-    private var commandPaletteWindow: CommandPaletteWindow?
+    var quickInputHotKeyRef: EventHotKeyRef?
+    var quickInputEventHandlerRef: EventHandlerRef?
+    var commandPaletteWindow: CommandPaletteWindow?
     var cmdKLocalMonitor: Any?
     public let services = AppServices()
     let assistantCli = AssistantCli()
@@ -81,7 +53,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var daemonClient: DaemonClient { services.daemonClient }
     var ambientAgent: AmbientAgent { services.ambientAgent }
     var surfaceManager: SurfaceManager { services.surfaceManager }
-    private var secretPromptManager: SecretPromptManager { services.secretPromptManager }
+    var secretPromptManager: SecretPromptManager { services.secretPromptManager }
     var zoomManager: ZoomManager { services.zoomManager }
     var conversationZoomManager: ConversationZoomManager { services.conversationZoomManager }
 
@@ -120,7 +92,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     private var preVoiceInputText: String?
     var statusIconCancellable: AnyCancellable?
     var connectionStatusCancellable: AnyCancellable?
-    private var quickInputAttachmentCancellable: AnyCancellable?
+    var quickInputAttachmentCancellable: AnyCancellable?
     var conversationZoomEnabledCancellable: AnyCancellable?
     var conversationBadgeCancellable: AnyCancellable?
     /// Observable state for SwiftUI command group `.disabled()` modifiers.
@@ -532,398 +504,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 
         showMainWindow()
         return true
-    }
-
-    // MARK: - Hotkey
-
-    var hasSetupHotKey = false
-
-    private func setupHotKey() {
-        guard !hasSetupHotKey else { return }
-        hasSetupHotKey = true
-
-        registerGlobalHotkeyMonitor()
-        registerQuickInputMonitor()
-        registerFnVMonitor()
-        registerCmdKMonitor()
-
-        globalHotkeyObserver = NotificationCenter.default
-            .publisher(for: UserDefaults.didChangeNotification)
-            .receive(on: RunLoop.main)
-            .sink { [weak self] _ in
-                self?.registerGlobalHotkeyMonitor()
-                self?.registerQuickInputMonitor()
-            }
-    }
-
-    /// Registers a Carbon hotkey for Quick Input that intercepts system-wide,
-    /// before the frontmost app's menu system can consume it.
-    /// Reads the shortcut and key code from UserDefaults. Skips re-registration if unchanged.
-    private func registerQuickInputMonitor() {
-        let shortcut = UserDefaults.standard.string(forKey: "quickInputHotkeyShortcut") ?? "cmd+shift+/"
-
-        if shortcut == lastRegisteredQuickInputHotkey { return }
-
-        // Tear down previous registration
-        if let ref = quickInputHotKeyRef {
-            UnregisterEventHotKey(ref)
-            quickInputHotKeyRef = nil
-        }
-        if let ref = quickInputEventHandlerRef {
-            RemoveEventHandler(ref)
-            quickInputEventHandlerRef = nil
-        }
-
-        let storedKeyCode = UserDefaults.standard.object(forKey: "quickInputHotkeyKeyCode") as? Int
-        let keyCode = UInt32(storedKeyCode ?? Int(kVK_ANSI_Slash))
-        let (modifierFlags, _) = ShortcutHelper.parseShortcut(shortcut)
-        let carbonMods = ShortcutHelper.carbonModifiers(from: modifierFlags)
-
-        // Install Carbon event handler for hotkey events
-        var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
-        var handlerRef: EventHandlerRef?
-        InstallEventHandler(GetApplicationEventTarget(), quickInputHotKeyHandler, 1, &eventType, nil, &handlerRef)
-        quickInputEventHandlerRef = handlerRef
-
-        let hotKeyID = EventHotKeyID(signature: OSType(0x564C_4D51), id: 1) // "VLMQ"
-        var hotKeyRef: EventHotKeyRef?
-        let status = RegisterEventHotKey(
-            keyCode,
-            carbonMods,
-            hotKeyID,
-            GetApplicationEventTarget(),
-            0,
-            &hotKeyRef
-        )
-        if status == noErr {
-            quickInputHotKeyRef = hotKeyRef
-            log.info("Quick Input: Carbon hotkey \(ShortcutHelper.displayString(for: shortcut)) registered successfully")
-        } else {
-            log.error("Quick Input: Failed to register Carbon hotkey, status: \(status)")
-        }
-
-        lastRegisteredQuickInputHotkey = shortcut
-    }
-
-    /// Removes the Carbon hotkey and event handler registrations,
-    /// plus the Cmd+K local monitor.
-    func tearDownQuickInputMonitors() {
-        if let ref = quickInputHotKeyRef {
-            UnregisterEventHotKey(ref)
-            quickInputHotKeyRef = nil
-        }
-        if let ref = quickInputEventHandlerRef {
-            RemoveEventHandler(ref)
-            quickInputEventHandlerRef = nil
-        }
-        if let monitor = fnVGlobalMonitor {
-            NSEvent.removeMonitor(monitor)
-            fnVGlobalMonitor = nil
-        }
-        if let monitor = fnVLocalMonitor {
-            NSEvent.removeMonitor(monitor)
-            fnVLocalMonitor = nil
-        }
-        if let monitor = cmdKLocalMonitor {
-            NSEvent.removeMonitor(monitor)
-            cmdKLocalMonitor = nil
-        }
-    }
-
-    /// Registers Cmd+Shift+V as a global shortcut to open the quick input text field.
-    /// Uses NSEvent monitors (global + local).
-    private func registerFnVMonitor() {
-        let handler: (NSEvent) -> NSEvent? = { [weak self] event in
-            // Cmd+Shift+V: keyCode 9 is kVK_ANSI_V
-            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            guard event.keyCode == 9,
-                  mods == [.command, .shift] else {
-                return event
-            }
-            Task { @MainActor in
-                guard self?.isBootstrapping != true else { return }
-                self?.toggleQuickInput(aboveDock: true)
-            }
-            return nil // consume the event
-        }
-
-        fnVGlobalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
-            _ = handler(event)
-        }
-        fnVLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
-    }
-
-    /// Registers Cmd+K as a local shortcut to open the command palette.
-    /// Only active when the app is focused (local monitor, not global).
-    private func registerCmdKMonitor() {
-        let handler: (NSEvent) -> NSEvent? = { [weak self] event in
-            // Cmd+K: keyCode 40 is kVK_ANSI_K
-            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            guard event.keyCode == 40,
-                  mods == [.command] else {
-                return event
-            }
-            Task { @MainActor in
-                guard self?.isBootstrapping != true else { return }
-                self?.toggleCommandPalette()
-            }
-            return nil // consume the event
-        }
-        cmdKLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: handler)
-    }
-
-    func toggleCommandPalette() {
-        if let window = commandPaletteWindow, window.isVisible {
-            window.dismiss()
-            return
-        }
-
-        let window = CommandPaletteWindow()
-
-        // Static actions
-        window.actions = [
-            CommandPaletteAction(id: "new-conversation", icon: "square.and.pencil", label: "New Conversation", shortcutHint: "\u{2318}N") { [weak self] in
-                self?.mainWindow?.threadManager.enterDraftMode()
-                self?.mainWindow?.windowState.selection = nil
-            },
-            CommandPaletteAction(id: "settings", icon: "gear", label: "Settings", shortcutHint: "\u{2318},") { [weak self] in
-                self?.mainWindow?.windowState.togglePanel(.settings)
-            },
-            CommandPaletteAction(id: "app-directory", icon: "square.grid.2x2", label: "App Directory", shortcutHint: nil) { [weak self] in
-                self?.mainWindow?.windowState.showAppsPanel()
-            },
-            CommandPaletteAction(id: "intelligence", icon: "brain.head.profile", label: "Intelligence", shortcutHint: nil) { [weak self] in
-                self?.mainWindow?.windowState.togglePanel(.intelligence)
-            },
-        ]
-
-        // Recent conversations from ThreadManager
-        if let threads = mainWindow?.threadManager.threads {
-            window.recentItems = threads
-                .filter { !$0.isArchived }
-                .sorted { $0.lastInteractedAt > $1.lastInteractedAt }
-                .prefix(5)
-                .map { CommandPaletteRecentItem(id: $0.id, title: $0.title, lastInteracted: $0.lastInteractedAt) }
-        }
-
-        window.onSelectConversation = { [weak self] threadId in
-            self?.mainWindow?.threadManager.selectThread(id: threadId)
-        }
-
-        // Wire runtime HTTP resolver for server search
-        window.runtimeHTTPResolver = {
-            let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
-                .flatMap(Int.init) ?? 7821
-            if let jwt = ActorTokenManager.getToken(), !jwt.isEmpty {
-                return ("http://localhost:\(port)", jwt)
-            }
-            guard let token = readHttpToken() else { return nil }
-            return ("http://localhost:\(port)", token)
-        }
-
-        window.show()
-        commandPaletteWindow = window
-    }
-
-    func toggleQuickInput(aboveDock: Bool = false, requestScreenPermission: Bool? = nil) {
-        if let window = quickInputWindow, window.isVisible {
-            window.dismiss()
-            return
-        }
-
-        // Auto-detect screen recording permission if not explicitly specified
-        let shouldShowPermissionPrompt = requestScreenPermission
-            ?? (PermissionManager.screenRecordingStatus() != .granted)
-
-        let window = QuickInputWindow()
-        window.onSubmit = { [weak self, weak window] message, imageData in
-            let notify = window?.notifyOnComplete ?? false
-            self?.handleQuickInputSubmit(message, imageData: imageData, notifyOnComplete: notify)
-        }
-        window.onSubmitToThread = { [weak self, weak window] message, imageData in
-            let notify = window?.notifyOnComplete ?? false
-            self?.handleQuickInputSubmitToThread(message, imageData: imageData, notifyOnComplete: notify)
-        }
-        window.onSelectThread = { [weak self] threadId in
-            self?.handleQuickInputSelectThread(threadId)
-        }
-        window.onMicrophoneToggle = { [weak self] in
-            self?.voiceInput?.toggleRecording()
-        }
-        // Provide the 3 most recent non-archived threads
-        if let threads = mainWindow?.threadManager.threads {
-            window.recentThreads = threads
-                .filter { !$0.isArchived }
-                .sorted { $0.lastInteractedAt > $1.lastInteractedAt }
-                .prefix(3)
-                .map { QuickInputThread(id: $0.id, title: $0.title) }
-        }
-        window.showScreenPermissionPrompt = shouldShowPermissionPrompt
-        if aboveDock {
-            window.showAboveDock()
-        } else {
-            window.show()
-        }
-        quickInputWindow = window
-    }
-
-    /// Starts screen region capture directly from the menu bar icon click.
-    /// After the user selects a region, the quick input bar appears near
-    /// the selection with the screenshot attached.
-    func startScreenCapture() {
-        guard PermissionManager.screenRecordingStatus() == .granted else {
-            PermissionManager.requestScreenRecordingAccess()
-            return
-        }
-
-        // Dismiss any existing quick input window
-        quickInputWindow?.dismiss()
-        quickInputWindow = nil
-
-        let selectionWindow = ScreenSelectionWindow()
-        selectionWindow.onComplete = { [weak self] imageData, selectionRect in
-            guard let self else { return }
-
-            let window = QuickInputWindow()
-            window.onSubmit = { [weak self, weak window] message, imgData in
-                let notify = window?.notifyOnComplete ?? false
-                self?.handleQuickInputSubmit(message, imageData: imgData, notifyOnComplete: notify)
-            }
-            window.onSubmitToThread = { [weak self, weak window] message, imgData in
-                let notify = window?.notifyOnComplete ?? false
-                self?.handleQuickInputSubmitToThread(message, imageData: imgData, notifyOnComplete: notify)
-            }
-            window.onSelectThread = { [weak self] threadId in
-                self?.handleQuickInputSelectThread(threadId)
-            }
-            window.onMicrophoneToggle = { [weak self] in
-                self?.voiceInput?.toggleRecording()
-            }
-            if let threads = self.mainWindow?.threadManager.threads {
-                window.recentThreads = threads
-                    .filter { !$0.isArchived }
-                    .sorted { $0.lastInteractedAt > $1.lastInteractedAt }
-                    .prefix(3)
-                    .map { QuickInputThread(id: $0.id, title: $0.title) }
-            }
-            window.setAttachment(imageData: imageData)
-            window.showNearRect(selectionRect)
-            self.quickInputWindow = window
-        }
-        selectionWindow.onCancel = { /* User cancelled — do nothing */ }
-        selectionWindow.show()
-    }
-
-    private func handleQuickInputSubmit(_ message: String, imageData: Data?, notifyOnComplete: Bool) {
-        // Ensure mainWindow exists so we can get a ChatViewModel.
-        // Never show it — quick input is fire-and-forget.
-        ensureMainWindowExists()
-        guard let mainWindow else { return }
-        mainWindow.threadManager.createThread()
-        if let threadId = mainWindow.threadManager.activeThreadId {
-            mainWindow.windowState.selection = .thread(threadId)
-        }
-        guard let viewModel = mainWindow.activeViewModel else { return }
-
-        if notifyOnComplete {
-            setupQuickInputNotification(on: viewModel)
-        }
-
-        if let imageData {
-            viewModel.addAttachment(imageData: imageData, filename: "Screenshot.jpg")
-            viewModel.inputText = message
-            quickInputAttachmentCancellable = viewModel.attachmentManager.$isLoadingAttachment
-                .filter { !$0 }
-                .first()
-                .sink { [weak self] _ in
-                    viewModel.sendMessage()
-                    self?.quickInputAttachmentCancellable = nil
-                }
-        } else {
-            viewModel.inputText = message
-            viewModel.sendMessage()
-        }
-    }
-
-    private func handleQuickInputSubmitToThread(_ message: String, imageData: Data?, notifyOnComplete: Bool) {
-        guard let mainWindow else { return }
-        if let viewModel = mainWindow.activeViewModel {
-            if notifyOnComplete {
-                setupQuickInputNotification(on: viewModel)
-            }
-            if let imageData {
-                viewModel.addAttachment(imageData: imageData, filename: "Screenshot.jpg")
-            }
-            viewModel.inputText = message
-            viewModel.sendMessage()
-        }
-    }
-
-    /// Sets a one-shot `onResponseComplete` callback on the view model to send a macOS notification.
-    private func setupQuickInputNotification(on viewModel: ChatViewModel) {
-        let notificationService = services.activityNotificationService
-        viewModel.onResponseComplete = { [weak viewModel] summary in
-            // One-shot — clear the callback after firing
-            viewModel?.onResponseComplete = nil
-            Task {
-                await notificationService.notifyQuickInputComplete(summary: summary)
-            }
-        }
-    }
-
-    private func handleQuickInputSelectThread(_ threadId: UUID) {
-        showMainWindow()
-        guard let mainWindow else { return }
-        mainWindow.threadManager.activeThreadId = threadId
-    }
-
-    /// Tears down and re-registers the global "Open Vellum" hotkey based on
-    /// the current `globalHotkeyShortcut` UserDefaults value. Skips
-    /// re-registration if the shortcut hasn't changed.
-    private func registerGlobalHotkeyMonitor() {
-        let shortcut = UserDefaults.standard.string(forKey: "globalHotkeyShortcut") ?? "cmd+shift+g"
-
-        if shortcut == lastRegisteredGlobalHotkey { return }
-
-        if let existing = hotKeyMonitor {
-            NSEvent.removeMonitor(existing)
-            hotKeyMonitor = nil
-        }
-
-        let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)
-
-        // Use NSEvent global monitor instead of Carbon RegisterEventHotKey (HotKey package).
-        // Carbon hotkeys consume the event globally, preventing other apps from seeing the
-        // keystroke. NSEvent.addGlobalMonitorForEvents observes without consuming.
-        hotKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            let eventMods = event.modifierFlags.intersection(.deviceIndependentFlagsMask).subtracting(.numericPad)
-            guard eventMods == targetModifiers,
-                  event.charactersIgnoringModifiers?.lowercased() == targetKey.lowercased() else { return }
-            Task { @MainActor in
-                guard self?.isBootstrapping != true else { return }
-                self?.showMainWindow()
-            }
-        }
-
-        lastRegisteredGlobalHotkey = shortcut
-    }
-
-    private func setupEscapeMonitor() {
-        escapeMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            if event.keyCode == 53 { // Escape
-                Task { @MainActor in
-                    self?.startSessionTask?.cancel()
-                    self?.thinkingWindow?.close()
-                    self?.thinkingWindow = nil
-                    self?.currentSession?.cancel()
-                    self?.currentTextSession?.cancel()
-                    self?.ambientAgent.resume()
-                    self?.surfaceManager.dismissAll()
-                    self?.toolConfirmationNotificationService.dismissAll()
-                    self?.secretPromptManager.dismissAll()
-                }
-            }
-        }
     }
 
     // MARK: - Voice Input


### PR DESCRIPTION
## Summary
- Extracts all input monitor methods (hotkeys, quick input, command palette, escape monitor, screen capture) and the `quickInputHotKeyHandler` C function from AppDelegate.swift into `AppDelegate+InputMonitors.swift`
- Replaces broad `UserDefaults.didChangeNotification` observer with scoped KVO publishers using `@objc dynamic` computed properties on `UserDefaults`, following the pattern from `AlwaysOnAudioMonitor.swift`

### Bug fix — UserDefaults observer
**Before**: `setupHotKey()` subscribed to `UserDefaults.didChangeNotification`, which fires on every defaults write across the entire app — causing unnecessary hotkey re-registration on unrelated settings changes.
**After**: Uses `Publishers.Merge3` of scoped `publisher(for:)` observers on `globalHotkeyShortcut`, `quickInputHotkeyShortcut`, and `quickInputHotkeyKeyCode` with a 100ms debounce.

### Methods moved
- `quickInputHotKeyHandler` (free function)
- `setupHotKey()`, `registerGlobalHotkeyMonitor()`, `registerQuickInputMonitor()`
- `tearDownQuickInputMonitors()`, `registerFnVMonitor()`, `registerCmdKMonitor()`
- `toggleCommandPalette()`, `toggleQuickInput(aboveDock:requestScreenPermission:)`
- `startScreenCapture()`, `handleQuickInputSubmit`, `handleQuickInputSubmitToThread`
- `setupQuickInputNotification`, `handleQuickInputSelectThread`, `setupEscapeMonitor()`

Part of plan: appdelegate-refactor.md (PR 5 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
