### PR TITLE
refactor: extract voice input and wake-word into AppDelegate+Voice.swift

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
@@ -1,0 +1,198 @@
+import AppKit
+import Combine
+import VellumAssistantShared
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "AppDelegate")
+
+// MARK: - Voice Input & Wake Word
+
+extension AppDelegate {
+
+    func setupVoiceInput() {
+        voiceInput = VoiceInputManager()
+        voiceInput?.onTranscription = { [weak self] text in
+            self?.voiceTranscriptionWindow?.close()
+            self?.voiceTranscriptionWindow = nil
+
+            // Capture prefix before clearing — it was saved when partials started
+            let savedPrefix = (self?.preVoiceInputText ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            self?.preVoiceInputText = nil
+
+            // PTT uses priority-based routing because it's a one-shot dictation: the user
+            // speaks a single utterance and expects it to go to whatever surface is currently
+            // focused. This differs from wake word, which binds to a specific ChatViewModel at
+            // activation time for continuous conversational mode (see VoiceModeManager.handleSilenceDetected).
+            // Priority 0: Route to quick input bar if visible
+            if let quickInput = self?.quickInputWindow, quickInput.isVisible {
+                quickInput.setVoiceText(text)
+                return
+            }
+
+            // Priority 1: Route to main window ChatView if in the foreground
+            if NSApp.isActive,
+               let mainWindow = self?.mainWindow, mainWindow.isVisible,
+               let viewModel = mainWindow.activeViewModel {
+                // Append transcribed text to any existing input — let the user send manually
+                viewModel.inputText = savedPrefix.isEmpty ? text : "\(savedPrefix) \(text)"
+                return
+            }
+
+            // Priority 2: Route to active TextResponseWindow conversation
+            if let textSession = self?.currentTextSession, textSession.state == .ready {
+                textSession.sendFollowUp(text: text)
+                self?.textResponseWindow?.updatePartialTranscription("")
+                return
+            }
+
+            // Priority 3: Fall back to creating a new session
+            self?.startSession(task: text, source: "voice")
+        }
+        voiceInput?.onPartialTranscription = { [weak self] text in
+            // Skip if recording already stopped (late callback from speech recognizer)
+            guard self?.voiceInput?.isRecording == true else { return }
+
+            // Priority 0: Route partial text to quick input bar if visible
+            if let quickInput = self?.quickInputWindow, quickInput.isVisible {
+                quickInput.setVoiceText(text)
+                return
+            }
+
+            // Priority 1: Route partial text to main window ChatView input if in the foreground
+            if NSApp.isActive,
+               let mainWindow = self?.mainWindow, mainWindow.isVisible,
+               let viewModel = mainWindow.activeViewModel {
+                // Capture existing text on first partial so we can prepend it
+                if self?.preVoiceInputText == nil {
+                    self?.preVoiceInputText = viewModel.inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+                let prefix = self?.preVoiceInputText ?? ""
+                viewModel.inputText = prefix.isEmpty ? text : "\(prefix) \(text)"
+                return
+            }
+
+            // Priority 2: Route to active TextResponseWindow conversation
+            if let textSession = self?.currentTextSession, textSession.state == .ready {
+                self?.textResponseWindow?.updatePartialTranscription(text)
+            }
+        }
+        voiceInput?.daemonClient = daemonClient
+        voiceInput?.onActionModeTriggered = { [weak self] text in
+            guard let self else { return }
+            log.info("Action mode triggered from voice dictation — submitting task")
+            self.startSession(task: text, source: TaskSubmission.voiceActionSource)
+        }
+        voiceInput?.onRecordingStateChanged = { [weak self] isRecording in
+            // Check if main window is actively in the foreground (not just existing behind other apps)
+            let mainWindowActive = NSApp.isActive && (self?.mainWindow?.isVisible ?? false)
+            // If there's an active conversation in ready state, route recording state there
+            let hasActiveConvo = self?.currentTextSession?.state == .ready
+
+            // Sync recording state: clear on the view model that started recording
+            // to avoid stale isRecording when the user switches threads mid-recording.
+            if isRecording {
+                self?.recordingViewModel = self?.mainWindow?.activeViewModel
+            }
+            if let vm = self?.recordingViewModel {
+                vm.isRecording = isRecording
+            }
+            if !isRecording {
+                self?.recordingViewModel = nil
+            }
+
+            // Sync recording state to the quick input bar
+            self?.quickInputWindow?.setRecordingState(isRecording)
+
+            if isRecording {
+                self?.statusItem.button?.image = NSImage(
+                    systemSymbolName: "mic.fill",
+                    accessibilityDescription: "Vellum"
+                )
+                let quickInputActive = self?.quickInputWindow?.isVisible ?? false
+                let isDictation = self?.voiceInput?.currentMode == .dictation
+                if !mainWindowActive && !hasActiveConvo && !quickInputActive && !isDictation {
+                    let window = VoiceTranscriptionWindow(
+                        voiceModeManager: self?.mainWindow?.voiceModeManager
+                    )
+                    window.show()
+                    self?.voiceTranscriptionWindow = window
+                }
+                self?.textResponseWindow?.updateRecordingState(true)
+            } else {
+                self?.voiceTranscriptionWindow?.close()
+                self?.voiceTranscriptionWindow = nil
+                self?.updateMenuBarIcon()
+                self?.textResponseWindow?.updateRecordingState(false)
+            }
+        }
+        voiceInput?.start()
+
+        // Restart key monitors when the activation key is changed remotely via IPC
+        NotificationCenter.default.addObserver(
+            forName: .activationKeyChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.voiceInput?.restartKeyMonitors()
+            }
+        }
+    }
+
+    // MARK: - Wake Word Coordinator
+
+    func setupWakeWordCoordinator() {
+        guard let mainWindow else {
+            log.warning("Cannot set up wake word coordinator — main window not available")
+            return
+        }
+
+        let keyword = UserDefaults.standard.string(forKey: "wakeWordKeyword") ?? "computer"
+        let engine = SpeechWakeWordEngine(keyword: keyword)
+        let audioMonitor = AlwaysOnAudioMonitor(engine: engine)
+
+        let coordinator = WakeWordCoordinator(
+            audioMonitor: audioMonitor,
+            voiceModeManager: mainWindow.voiceModeManager,
+            threadManager: mainWindow.threadManager,
+            voiceInputManager: voiceInput
+        )
+
+        // Show a toast when the wake word engine hits a persistent error
+        // (e.g. Dictation disabled at the OS level).
+        wakeWordErrorCancellable = audioMonitor.$persistentErrorMessage
+            .compactMap { $0 }
+            .sink { [weak self] message in
+                self?.mainWindow?.windowState.showToast(
+                    message: message,
+                    style: .warning,
+                    primaryAction: VToastAction(label: "Open Settings") {
+                        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.keyboard?Dictation") {
+                            NSWorkspace.shared.open(url)
+                        }
+                    }
+                )
+            }
+
+        if UserDefaults.standard.bool(forKey: "wakeWordEnabled") {
+            audioMonitor.startMonitoring()
+        }
+
+        coordinator.markReady()
+        wakeWordCoordinator = coordinator
+    }
+
+    // MARK: - Ambient Agent
+
+    func setupAmbientAgent() {
+        ambientAgent.appDelegate = self
+        ambientAgent.daemonClient = daemonClient
+        // Ride Shotgun disabled — re-enable when the feature has a clearer value prop
+        // ambientAgent.setupRideShotgun()
+    }
+
+    func updateMenuBarIcon() {
+        guard statusItem != nil, let button = statusItem.button else { return }
+        configureMenuBarIcon(button)
+    }
+}

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -64,7 +64,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var textResponseWindow: TextResponseWindow?
     var voiceInput: VoiceInputManager?
     var wakeWordCoordinator: WakeWordCoordinator?
-    private var voiceTranscriptionWindow: VoiceTranscriptionWindow?
+    var wakeWordErrorCancellable: AnyCancellable?
+    var voiceTranscriptionWindow: VoiceTranscriptionWindow?
     var thinkingWindow: ThinkingIndicatorWindow?
     var quickInputWindow: QuickInputWindow?
     private var quickInputHotKeyRef: EventHotKeyRef?
@@ -114,10 +115,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var galleryWindow: ComponentGalleryWindow?
     #endif
     var windowObserver: Any?
-    private weak var recordingViewModel: ChatViewModel?
+    weak var recordingViewModel: ChatViewModel?
     /// Text that was in the chat input before PTT voice recording started,
     /// so we can prepend it to partial/final transcriptions instead of overwriting.
-    private var preVoiceInputText: String?
+    var preVoiceInputText: String?
     var statusIconCancellable: AnyCancellable?
     var connectionStatusCancellable: AnyCancellable?
     private var quickInputAttachmentCancellable: AnyCancellable?
@@ -927,195 +928,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     }
 
     // MARK: - Voice Input
-
-    private func setupVoiceInput() {
-        voiceInput = VoiceInputManager()
-        voiceInput?.onTranscription = { [weak self] text in
-            self?.voiceTranscriptionWindow?.close()
-            self?.voiceTranscriptionWindow = nil
-
-            // Capture prefix before clearing — it was saved when partials started
-            let savedPrefix = (self?.preVoiceInputText ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-            self?.preVoiceInputText = nil
-
-            // PTT uses priority-based routing because it's a one-shot dictation: the user
-            // speaks a single utterance and expects it to go to whatever surface is currently
-            // focused. This differs from wake word, which binds to a specific ChatViewModel at
-            // activation time for continuous conversational mode (see VoiceModeManager.handleSilenceDetected).
-            // Priority 0: Route to quick input bar if visible
-            if let quickInput = self?.quickInputWindow, quickInput.isVisible {
-                quickInput.setVoiceText(text)
-                return
-            }
-
-            // Priority 1: Route to main window ChatView if in the foreground
-            if NSApp.isActive,
-               let mainWindow = self?.mainWindow, mainWindow.isVisible,
-               let viewModel = mainWindow.activeViewModel {
-                // Append transcribed text to any existing input — let the user send manually
-                viewModel.inputText = savedPrefix.isEmpty ? text : "\(savedPrefix) \(text)"
-                return
-            }
-
-            // Priority 2: Route to active TextResponseWindow conversation
-            if let textSession = self?.currentTextSession, textSession.state == .ready {
-                textSession.sendFollowUp(text: text)
-                self?.textResponseWindow?.updatePartialTranscription("")
-                return
-            }
-
-            // Priority 3: Fall back to creating a new session
-            self?.startSession(task: text, source: "voice")
-        }
-        voiceInput?.onPartialTranscription = { [weak self] text in
-            // Skip if recording already stopped (late callback from speech recognizer)
-            guard self?.voiceInput?.isRecording == true else { return }
-
-            // Priority 0: Route partial text to quick input bar if visible
-            if let quickInput = self?.quickInputWindow, quickInput.isVisible {
-                quickInput.setVoiceText(text)
-                return
-            }
-
-            // Priority 1: Route partial text to main window ChatView input if in the foreground
-            if NSApp.isActive,
-               let mainWindow = self?.mainWindow, mainWindow.isVisible,
-               let viewModel = mainWindow.activeViewModel {
-                // Capture existing text on first partial so we can prepend it
-                if self?.preVoiceInputText == nil {
-                    self?.preVoiceInputText = viewModel.inputText.trimmingCharacters(in: .whitespacesAndNewlines)
-                }
-                let prefix = self?.preVoiceInputText ?? ""
-                viewModel.inputText = prefix.isEmpty ? text : "\(prefix) \(text)"
-                return
-            }
-
-            // Priority 2: Route to active TextResponseWindow conversation
-            if let textSession = self?.currentTextSession, textSession.state == .ready {
-                self?.textResponseWindow?.updatePartialTranscription(text)
-            }
-        }
-        voiceInput?.daemonClient = daemonClient
-        voiceInput?.onActionModeTriggered = { [weak self] text in
-            guard let self else { return }
-            log.info("Action mode triggered from voice dictation — submitting task")
-            self.startSession(task: text, source: TaskSubmission.voiceActionSource)
-        }
-        voiceInput?.onRecordingStateChanged = { [weak self] isRecording in
-            // Check if main window is actively in the foreground (not just existing behind other apps)
-            let mainWindowActive = NSApp.isActive && (self?.mainWindow?.isVisible ?? false)
-            // If there's an active conversation in ready state, route recording state there
-            let hasActiveConvo = self?.currentTextSession?.state == .ready
-
-            // Sync recording state: clear on the view model that started recording
-            // to avoid stale isRecording when the user switches threads mid-recording.
-            if isRecording {
-                self?.recordingViewModel = self?.mainWindow?.activeViewModel
-            }
-            if let vm = self?.recordingViewModel {
-                vm.isRecording = isRecording
-            }
-            if !isRecording {
-                self?.recordingViewModel = nil
-            }
-
-            // Sync recording state to the quick input bar
-            self?.quickInputWindow?.setRecordingState(isRecording)
-
-            if isRecording {
-                self?.statusItem.button?.image = NSImage(
-                    systemSymbolName: "mic.fill",
-                    accessibilityDescription: "Vellum"
-                )
-                let quickInputActive = self?.quickInputWindow?.isVisible ?? false
-                let isDictation = self?.voiceInput?.currentMode == .dictation
-                if !mainWindowActive && !hasActiveConvo && !quickInputActive && !isDictation {
-                    let window = VoiceTranscriptionWindow(
-                        voiceModeManager: self?.mainWindow?.voiceModeManager
-                    )
-                    window.show()
-                    self?.voiceTranscriptionWindow = window
-                }
-                self?.textResponseWindow?.updateRecordingState(true)
-            } else {
-                self?.voiceTranscriptionWindow?.close()
-                self?.voiceTranscriptionWindow = nil
-                self?.updateMenuBarIcon()
-                self?.textResponseWindow?.updateRecordingState(false)
-            }
-        }
-        voiceInput?.start()
-
-        // Restart key monitors when the activation key is changed remotely via IPC
-        NotificationCenter.default.addObserver(
-            forName: .activationKeyChanged,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
-                self?.voiceInput?.restartKeyMonitors()
-            }
-        }
-    }
-
-    // MARK: - Wake Word Coordinator
-
-    var wakeWordErrorCancellable: AnyCancellable?
-
-    func setupWakeWordCoordinator() {
-        guard let mainWindow else {
-            log.warning("Cannot set up wake word coordinator — main window not available")
-            return
-        }
-
-        let keyword = UserDefaults.standard.string(forKey: "wakeWordKeyword") ?? "computer"
-        let engine = SpeechWakeWordEngine(keyword: keyword)
-        let audioMonitor = AlwaysOnAudioMonitor(engine: engine)
-
-        let coordinator = WakeWordCoordinator(
-            audioMonitor: audioMonitor,
-            voiceModeManager: mainWindow.voiceModeManager,
-            threadManager: mainWindow.threadManager,
-            voiceInputManager: voiceInput
-        )
-
-        // Show a toast when the wake word engine hits a persistent error
-        // (e.g. Dictation disabled at the OS level).
-        wakeWordErrorCancellable = audioMonitor.$persistentErrorMessage
-            .compactMap { $0 }
-            .sink { [weak self] message in
-                self?.mainWindow?.windowState.showToast(
-                    message: message,
-                    style: .warning,
-                    primaryAction: VToastAction(label: "Open Settings") {
-                        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.keyboard?Dictation") {
-                            NSWorkspace.shared.open(url)
-                        }
-                    }
-                )
-            }
-
-        if UserDefaults.standard.bool(forKey: "wakeWordEnabled") {
-            audioMonitor.startMonitoring()
-        }
-
-        coordinator.markReady()
-        wakeWordCoordinator = coordinator
-    }
-
-    // MARK: - Ambient Agent
-
-    func setupAmbientAgent() {
-        ambientAgent.appDelegate = self
-        ambientAgent.daemonClient = daemonClient
-        // Ride Shotgun disabled — re-enable when the feature has a clearer value prop
-        // ambientAgent.setupRideShotgun()
-    }
-
-    func updateMenuBarIcon() {
-        guard statusItem != nil, let button = statusItem.button else { return }
-        configureMenuBarIcon(button)
-    }
 
     @objc func replayOnboarding() {
         guard onboardingWindow == nil else { return }


### PR DESCRIPTION
## Summary
- Extracts voice input and wake-word methods from AppDelegate.swift into `AppDelegate+Voice.swift`
- Pure mechanical move with zero logic changes

### Methods moved
- `setupVoiceInput()` (~129 lines — PTT activation, transcription routing)
- `setupWakeWordCoordinator()` (~40 lines)
- `setupAmbientAgent()`
- `updateMenuBarIcon()`

### Access-level widenings (private → internal)
- `voiceTranscriptionWindow`, `preVoiceInputText`, `recordingViewModel` (others already widened in earlier PRs)
- Moved `wakeWordErrorCancellable` declaration from inline to properties section

Part of plan: appdelegate-refactor.md (PR 6 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
