### PR TITLE
Multi-local assistant support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,14 @@ Judgement calls affecting user experience should be made by the assistant throug
 
 "Daemon" is an internal implementation detail. In all user-facing text — CLI output, error messages, help strings, SKILL.md instructions that would be relayed to users, README documentation, and UI strings — use **"assistant"** instead of "daemon". Internal code (variable names, class names, file paths, log messages, comments explaining architecture) may continue using "daemon" since users don't see those. When in doubt, ask: "Would a user ever read this?" If yes, say "assistant".
 
+## Multi-Instance Path Invariant
+
+When the daemon runs with `BASE_DATA_DIR` set to an instance directory (e.g. `~/.vellum/instances/alice/`), `getRootDir()` resolves to `join(BASE_DATA_DIR, ".vellum")`. All CLI and daemon code that references instance-scoped files must use `join(instanceDir, ".vellum", ...)` — never assume the root is `~/.vellum/` directly. This ensures socket paths, PID files, tokens, and config are correctly scoped per instance.
+
+## Qdrant Port Override
+
+Use `QDRANT_HTTP_PORT` (not `QDRANT_URL`) when allocating per-instance Qdrant ports. Setting `QDRANT_URL` triggers QdrantManager's external/remote mode which bypasses the local managed Qdrant lifecycle (download, start, health checks). The CLI deletes `QDRANT_URL` from the environment when spawning instance daemons to ensure local Qdrant management is used.
+
 ## Memory Conflict Handling — Internal Only
 
 Memory conflicts must never surface as user-facing clarification prompts. The conflict gate evaluates and resolves conflicts internally without producing any user-visible output — no injected instructions, no clarification questions, no blocking the user's request. The response path always continues answering the user. If you add or modify conflict-related code, verify that `ConflictGate.evaluate()` returns `void` (not a user-facing string), that no conflict text is emitted into the agent loop's message stream, and that `session-runtime-assembly.ts` does not inject conflict instructions. Guard tests: `session-conflict-gate.test.ts`, `session-agent-loop.test.ts`, `memory-lifecycle-e2e.test.ts`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,6 +32,112 @@ This file is the cross-system architecture index. Detailed designs live in domai
 - **Assistant feature flags** control skill availability at runtime. The canonical key format is `feature_flags.<flagId>.enabled`; the legacy `skills.<id>.enabled` format is no longer supported. All declared flags live in the unified registry at `meta/feature-flags/feature-flag-registry.json`, scoped by `scope` (`assistant` or `macos`). Labels come from the registry. Bundled copies exist at `assistant/src/config/feature-flag-registry.json` and `gateway/src/feature-flag-registry.json`. The gateway owns the `/v1/feature-flags` REST API (see [`gateway/ARCHITECTURE.md`](gateway/ARCHITECTURE.md)); the daemon resolves effective flag state via the assistant feature-flag resolver (see [`assistant/ARCHITECTURE.md`](assistant/ARCHITECTURE.md)). When a flag is OFF, the corresponding skill is excluded from all exposure surfaces: client skill lists, system prompt catalog, `skill_load`, runtime tool projection, and included child skills. Guard tests enforce that all flag keys in code use the canonical format and that all referenced flags are declared in the unified registry.
 - **Context overflow resilience**: The session loop implements a deterministic overflow convergence pipeline that recovers from context-too-large failures without surfacing errors to users. A preflight budget check catches overflow before provider calls; a tiered reducer (forced compaction, tool-result truncation, media stubbing, injection downgrade) iteratively shrinks the payload; and an overflow policy resolver gates latest-turn compression behind user approval for interactive sessions. Non-interactive sessions auto-compress; denied compression produces a graceful assistant explanation message (not a `session_error`). Config lives under `contextWindow.overflowRecovery`. See [`assistant/ARCHITECTURE.md`](assistant/ARCHITECTURE.md#context-overflow-recovery) for the full design and [`assistant/docs/architecture/memory.md`](assistant/docs/architecture/memory.md#context-compaction-and-overflow-recovery-interaction) for compaction interaction details.
 
+## Multi-Local Instance Isolation
+
+Multiple local assistant instances can run side-by-side on the same machine, each fully isolated. This enables development, testing, or running multiple assistants concurrently without conflicts.
+
+### Instance Directory Layout
+
+Each named instance gets its own directory tree under `~/.vellum/instances/<name>/`:
+
+```
+~/.vellum.lock.json                    # Global lockfile (all entries + activeAssistant)
+~/.vellum/
+├── instances/
+│   ├── alice/                     # Instance root (= BASE_DATA_DIR for this daemon)
+│   │   └── .vellum/              # Runtime dir (getRootDir() resolves here)
+│   │       ├── vellum.sock       # Unix domain socket
+│   │       ├── vellum.pid        # Daemon PID
+│   │       ├── gateway.pid       # Gateway PID
+│   │       ├── outbound-proxy.pid
+│   │       ├── http-token        # Bearer token for gateway auth
+│   │       ├── session-token
+│   │       └── workspace/
+│   │           ├── config.json
+│   │           ├── data/
+│   │           │   ├── db/assistant.db
+│   │           │   ├── qdrant/
+│   │           │   └── logs/
+│   │           └── skills/
+│   └── bob/
+│       └── .vellum/
+│           └── ...               # Same structure as alice
+└── ...                           # Legacy single-instance files (default instance)
+```
+
+The legacy single-instance layout (`~/.vellum/` directly) continues to work as the default. Named instances are created via `vellum hatch --name <name>` (the `--name` flag triggers multi-instance isolation).
+
+### Isolation Model
+
+Each instance gets its own:
+- **`BASE_DATA_DIR`**: Set to the instance directory (e.g. `~/.vellum/instances/alice/`). The daemon appends `.vellum` to this to derive `getRootDir()`, so all runtime files land under the instance.
+- **Daemon port** (`RUNTIME_HTTP_PORT`): Allocated by scanning from base port 7821.
+- **Gateway port** (`GATEWAY_PORT`): Allocated by scanning from base port 7830.
+- **Qdrant port** (`QDRANT_HTTP_PORT`): Allocated by scanning from base port 6333.
+- **Unix socket**: `<instanceDir>/.vellum/vellum.sock`
+- **PID file**: `<instanceDir>/.vellum/vellum.pid`
+- **SQLite database, logs, memory indices**: All under `<instanceDir>/.vellum/workspace/data/`
+
+### Port Allocation
+
+Ports are allocated sequentially by `allocateLocalResources()` in `cli/src/lib/assistant-config.ts`:
+
+1. Scan from `DEFAULT_DAEMON_PORT` (7821) upward to find the first available port.
+2. Scan from `DEFAULT_GATEWAY_PORT` (7830) upward, excluding the daemon port.
+3. Scan from `DEFAULT_QDRANT_PORT` (6333) upward, excluding both previously allocated ports.
+
+Availability is checked via TCP connect probe. Each scan range spans up to 100 ports. Allocated ports are persisted in the lockfile `resources` field so `wake`/`sleep` can restart instances on the same ports.
+
+### Lockfile Schema
+
+The global lockfile (`~/.vellum.lock.json`) tracks all instances:
+
+```jsonc
+{
+  "assistants": [
+    {
+      "assistantId": "alice",
+      "runtimeUrl": "http://localhost:7821",
+      "cloud": "local",
+      "hatchedAt": "2026-03-04T...",
+      "resources": {                    // Present for local multi-instance entries
+        "instanceDir": "~/.vellum/instances/alice",
+        "daemonPort": 7821,
+        "gatewayPort": 7830,
+        "qdrantPort": 6333,
+        "socketPath": "~/.vellum/instances/alice/.vellum/vellum.sock",
+        "pidFile": "~/.vellum/instances/alice/.vellum/vellum.pid"
+      }
+    },
+    {
+      "assistantId": "bob",
+      "runtimeUrl": "http://localhost:7822",
+      "cloud": "local",
+      "resources": { ... }
+    }
+  ],
+  "activeAssistant": "alice"           // Set by `vellum use <name>`
+}
+```
+
+- `resources` (`LocalInstanceResources`): Present on local entries in multi-instance setups. Legacy single-instance entries without `resources` are normalized to default paths at runtime.
+- `activeAssistant`: Determines which instance CLI commands target by default.
+- Remote assistants (`cloud: "gcp"`, `"aws"`, etc.) are unaffected and have no `resources` field.
+
+### Active Assistant Targeting
+
+CLI commands resolve which instance to target via `resolveTargetAssistant()`:
+
+1. **Explicit name argument** — `vellum sleep alice`
+2. **Active assistant** — set via `vellum use <name>`, stored as `activeAssistant` in lockfile
+3. **Sole local assistant** — when exactly one local instance exists
+
+`wake` and `sleep` guard against targeting remote assistants (they exit with an error for non-`local` entries).
+
+### Mixed Local/Remote
+
+The lockfile can contain both local and remote entries. Remote entries (cloud providers) carry connection metadata (`runtimeUrl`, `bearerToken`, etc.) but no `resources`. `wake` and `sleep` only operate on local instances (they error for remote entries). `retire` works on both local and remote instances, using cloud-specific teardown for GCP/AWS/custom entries.
+
 ## System Overview
 
 ```mermaid

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -158,6 +158,10 @@ export function getQdrantUrlEnv(): string | undefined {
   return str("QDRANT_URL");
 }
 
+export function getQdrantHttpPortEnv(): number | undefined {
+  return int("QDRANT_HTTP_PORT");
+}
+
 // ── Ollama ───────────────────────────────────────────────────────────────────
 
 export function getOllamaBaseUrlEnv(): string | undefined {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -10,6 +10,7 @@ import { TwilioConversationRelayProvider } from "../calls/twilio-provider.js";
 import { setVoiceBridgeDeps } from "../calls/voice-session-bridge.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import {
+  getQdrantHttpPortEnv,
   getQdrantUrlEnv,
   getRuntimeHttpHost,
   getRuntimeHttpPort,
@@ -250,7 +251,13 @@ export async function runDaemon(): Promise<void> {
     log.info("Daemon startup: DaemonServer started");
 
     // Initialize Qdrant vector store — non-fatal so the daemon stays up without it
-    const qdrantUrl = getQdrantUrlEnv() || config.memory.qdrant.url;
+    // Prefer QDRANT_HTTP_PORT (locally-spawned Qdrant on a specific port) over
+    // QDRANT_URL (external Qdrant instance) so the CLI can set the port without
+    // triggering QdrantManager's external mode which skips local process spawn.
+    const qdrantHttpPort = getQdrantHttpPortEnv();
+    const qdrantUrl = qdrantHttpPort
+      ? `http://127.0.0.1:${qdrantHttpPort}`
+      : getQdrantUrlEnv() || config.memory.qdrant.url;
     log.info({ qdrantUrl }, "Daemon startup: initializing Qdrant");
     const qdrantManager = new QdrantManager({ url: qdrantUrl });
     try {

--- a/assistant/src/runtime/assistant-scope.ts
+++ b/assistant/src/runtime/assistant-scope.ts
@@ -6,5 +6,10 @@
  * gateway and platform layers (hatch, invite links, etc.). Daemon code
  * should never derive scoping decisions from externally-provided assistant
  * IDs — use this constant instead.
+ *
+ * Multi-instance invariant: each daemon process is single-tenant within
+ * its own BASE_DATA_DIR. The fixed "self" value works across multiple
+ * local instances because each instance has isolated storage — there is
+ * no cross-instance data sharing that would require disambiguating IDs.
  */
 export const DAEMON_INTERNAL_ASSISTANT_ID = "self" as const;

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -85,6 +85,11 @@ export function readLockfile(): Record<string, unknown> | null {
  * inbound call path resolves phone numbers to config keys (typically
  * "self"). This function maps any known lockfile assistant ID to "self"
  * so both sides use a consistent DB key.
+ *
+ * Multi-instance safety: each daemon process runs with a scoped
+ * BASE_DATA_DIR, so readLockfile() only sees the lockfile for this
+ * instance. The mapping to "self" is correct because each daemon is
+ * single-tenant — it only manages its own instance's data.
  */
 export function normalizeAssistantId(assistantId: string): string {
   if (assistantId === "self") return "self";

--- a/cli/src/__tests__/multi-local.test.ts
+++ b/cli/src/__tests__/multi-local.test.ts
@@ -1,0 +1,275 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Create a temp directory that acts as a fake home, so allocateLocalResources()
+// and defaultLocalResources() never touch the real ~/.vellum directory.
+const testDir = mkdtempSync(join(tmpdir(), "cli-multi-local-test-"));
+process.env.BASE_DATA_DIR = testDir;
+
+// Mock homedir() to return testDir — this isolates allocateLocalResources()
+// which uses homedir() directly for instance directory creation.
+const realOs = await import("node:os");
+mock.module("node:os", () => ({
+  ...realOs,
+  homedir: () => testDir,
+}));
+// Also mock the bare "os" specifier since assistant-config.ts uses `from "os"`
+mock.module("os", () => ({
+  ...realOs,
+  homedir: () => testDir,
+}));
+
+// Mock probePort so we control which ports appear in-use without touching the network
+const probePortMock = mock<(port: number, host?: string) => Promise<boolean>>(
+  () => Promise.resolve(false),
+);
+mock.module("../lib/port-probe.js", () => ({
+  probePort: probePortMock,
+}));
+
+import {
+  allocateLocalResources,
+  defaultLocalResources,
+  resolveTargetAssistant,
+  setActiveAssistant,
+  getActiveAssistant,
+  removeAssistantEntry,
+  saveAssistantEntry,
+  type AssistantEntry,
+} from "../lib/assistant-config.js";
+import { DEFAULT_DAEMON_PORT } from "../lib/constants.js";
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true });
+  delete process.env.BASE_DATA_DIR;
+});
+
+function writeLockfile(data: unknown): void {
+  writeFileSync(
+    join(testDir, ".vellum.lock.json"),
+    JSON.stringify(data, null, 2),
+  );
+}
+
+function readLockfileRaw(): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(join(testDir, ".vellum.lock.json"), "utf-8"),
+  ) as Record<string, unknown>;
+}
+
+const makeEntry = (
+  id: string,
+  cloud = "local",
+  extra?: Partial<AssistantEntry>,
+): AssistantEntry => ({
+  assistantId: id,
+  runtimeUrl: `http://localhost:${DEFAULT_DAEMON_PORT}`,
+  cloud,
+  ...extra,
+});
+
+function resetLockfile(): void {
+  try {
+    rmSync(join(testDir, ".vellum.lock.json"));
+  } catch {
+    // file may not exist
+  }
+  try {
+    rmSync(join(testDir, ".vellum.lockfile.json"));
+  } catch {
+    // file may not exist
+  }
+}
+
+describe("multi-local", () => {
+  beforeEach(() => {
+    resetLockfile();
+    probePortMock.mockReset();
+    probePortMock.mockImplementation(() => Promise.resolve(false));
+  });
+
+  describe("allocateLocalResources() produces non-conflicting ports", () => {
+    test("two instances get distinct ports and dirs when first instance ports are occupied", async () => {
+      // After the first allocation grabs its ports, simulate those ports
+      // being in-use so the second allocation must pick different ones.
+      const a = await allocateLocalResources("instance-a");
+      const occupiedPorts = new Set([
+        a.daemonPort,
+        a.gatewayPort,
+        a.qdrantPort,
+      ]);
+      probePortMock.mockImplementation((port: number) =>
+        Promise.resolve(occupiedPorts.has(port)),
+      );
+
+      const b = await allocateLocalResources("instance-b");
+
+      // All six ports must be unique across both instances
+      const allPorts = [
+        a.daemonPort,
+        a.gatewayPort,
+        a.qdrantPort,
+        b.daemonPort,
+        b.gatewayPort,
+        b.qdrantPort,
+      ];
+      expect(new Set(allPorts).size).toBe(6);
+
+      // Instance dirs must be distinct
+      expect(a.instanceDir).not.toBe(b.instanceDir);
+      expect(a.instanceDir).toContain("instance-a");
+      expect(b.instanceDir).toContain("instance-b");
+    });
+
+    test("skips ports that probePort reports as in-use", async () => {
+      // Simulate the default ports being occupied
+      const portsInUse = new Set([
+        DEFAULT_DAEMON_PORT,
+        DEFAULT_DAEMON_PORT + 1,
+      ]);
+      probePortMock.mockImplementation((port: number) =>
+        Promise.resolve(portsInUse.has(port)),
+      );
+
+      const res = await allocateLocalResources("probe-test");
+      expect(res.daemonPort).toBeGreaterThan(DEFAULT_DAEMON_PORT + 1);
+      expect(portsInUse.has(res.daemonPort)).toBe(false);
+    });
+  });
+
+  describe("defaultLocalResources() returns legacy paths", () => {
+    test("instanceDir is homedir", () => {
+      const res = defaultLocalResources();
+      expect(res.instanceDir).toBe(testDir);
+    });
+
+    test("daemonPort is DEFAULT_DAEMON_PORT", () => {
+      const res = defaultLocalResources();
+      expect(res.daemonPort).toBe(DEFAULT_DAEMON_PORT);
+    });
+  });
+
+  describe("resolveTargetAssistant() priority chain", () => {
+    test("explicit name returns that entry", () => {
+      writeLockfile({
+        assistants: [makeEntry("alpha"), makeEntry("beta")],
+      });
+      const result = resolveTargetAssistant("beta");
+      expect(result.assistantId).toBe("beta");
+    });
+
+    test("active assistant set returns the active entry", () => {
+      writeLockfile({
+        assistants: [makeEntry("alpha"), makeEntry("beta")],
+        activeAssistant: "alpha",
+      });
+      const result = resolveTargetAssistant();
+      expect(result.assistantId).toBe("alpha");
+    });
+
+    test("sole local assistant returns it", () => {
+      writeLockfile({
+        assistants: [makeEntry("only-one")],
+      });
+      const result = resolveTargetAssistant();
+      expect(result.assistantId).toBe("only-one");
+    });
+
+    test("multiple local assistants and no active throws with guidance", () => {
+      writeLockfile({
+        assistants: [makeEntry("x"), makeEntry("y")],
+      });
+      // resolveTargetAssistant calls process.exit(1) on ambiguity
+      const mockExit = mock(() => {
+        throw new Error("process.exit called");
+      });
+      const origExit = process.exit;
+      process.exit = mockExit as unknown as typeof process.exit;
+      try {
+        expect(() => resolveTargetAssistant()).toThrow("process.exit called");
+        expect(mockExit).toHaveBeenCalledWith(1);
+      } finally {
+        process.exit = origExit;
+      }
+    });
+
+    test("no local assistants throws", () => {
+      writeLockfile({ assistants: [] });
+      const mockExit = mock(() => {
+        throw new Error("process.exit called");
+      });
+      const origExit = process.exit;
+      process.exit = mockExit as unknown as typeof process.exit;
+      try {
+        expect(() => resolveTargetAssistant()).toThrow("process.exit called");
+        expect(mockExit).toHaveBeenCalledWith(1);
+      } finally {
+        process.exit = origExit;
+      }
+    });
+  });
+
+  describe("setActiveAssistant() / getActiveAssistant() round-trip", () => {
+    test("set active, read it back", () => {
+      writeLockfile({ assistants: [makeEntry("my-assistant")] });
+      setActiveAssistant("my-assistant");
+      expect(getActiveAssistant()).toBe("my-assistant");
+    });
+
+    test("lockfile is updated on disk", () => {
+      writeLockfile({ assistants: [makeEntry("disk-check")] });
+      setActiveAssistant("disk-check");
+      const raw = readLockfileRaw();
+      expect(raw.activeAssistant).toBe("disk-check");
+    });
+  });
+
+  describe("removeAssistantEntry() clears matching activeAssistant", () => {
+    test("set active to foo, remove foo, verify active is null", () => {
+      writeLockfile({
+        assistants: [makeEntry("foo"), makeEntry("bar")],
+        activeAssistant: "foo",
+      });
+      removeAssistantEntry("foo");
+      expect(getActiveAssistant()).toBeNull();
+    });
+
+    test("set active to foo, remove bar, verify active is still foo", () => {
+      writeLockfile({
+        assistants: [makeEntry("foo"), makeEntry("bar")],
+        activeAssistant: "foo",
+      });
+      removeAssistantEntry("bar");
+      expect(getActiveAssistant()).toBe("foo");
+    });
+  });
+
+  describe("remote non-regression", () => {
+    test("resolveTargetAssistant works with remote entries", () => {
+      writeLockfile({
+        assistants: [
+          makeEntry("my-remote", "gcp", {
+            runtimeUrl: "http://10.0.0.1:7821",
+          }),
+        ],
+        activeAssistant: "my-remote",
+      });
+      const result = resolveTargetAssistant();
+      expect(result.assistantId).toBe("my-remote");
+      expect(result.cloud).toBe("gcp");
+    });
+
+    test("remote entries don't get resources applied", () => {
+      const remoteEntry = makeEntry("cloud-box", "aws", {
+        runtimeUrl: "http://10.0.0.2:7821",
+      });
+      writeLockfile({ assistants: [remoteEntry] });
+      // Save and reload to verify resources are not injected
+      saveAssistantEntry(remoteEntry);
+      const result = resolveTargetAssistant("cloud-box");
+      expect(result.resources).toBeUndefined();
+    });
+  });
+});

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -67,7 +67,10 @@ function parseArgs(): ParsedArgs {
   }
 
   let runtimeUrl =
-    process.env.RUNTIME_URL || entry?.runtimeUrl || FALLBACK_RUNTIME_URL;
+    process.env.RUNTIME_URL ||
+    entry?.localUrl ||
+    entry?.runtimeUrl ||
+    FALLBACK_RUNTIME_URL;
   let assistantId =
     process.env.ASSISTANT_ID || entry?.assistantId || FALLBACK_ASSISTANT_ID;
   const bearerToken =

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -1,5 +1,6 @@
 import {
   findAssistantByName,
+  getActiveAssistant,
   loadLatestAssistant,
 } from "../lib/assistant-config";
 import { GATEWAY_PORT, type Species } from "../lib/constants";
@@ -45,12 +46,24 @@ function parseArgs(): ParsedArgs {
     }
   }
 
-  const entry = positionalName
-    ? findAssistantByName(positionalName)
-    : loadLatestAssistant();
-  if (positionalName && !entry) {
-    console.error(`No assistant instance found with name '${positionalName}'.`);
-    process.exit(1);
+  let entry: ReturnType<typeof findAssistantByName>;
+  if (positionalName) {
+    entry = findAssistantByName(positionalName);
+    if (!entry) {
+      console.error(
+        `No assistant instance found with name '${positionalName}'.`,
+      );
+      process.exit(1);
+    }
+  } else if (process.env.RUNTIME_URL) {
+    // Explicit env var — skip assistant resolution, will use env values below
+    entry = loadLatestAssistant();
+  } else {
+    // Respect active assistant when set, otherwise fall back to latest
+    // for backward compatibility with remote-only setups.
+    const active = getActiveAssistant();
+    const activeEntry = active ? findAssistantByName(active) : null;
+    entry = activeEntry ?? loadLatestAssistant();
   }
 
   let runtimeUrl =

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -726,98 +726,72 @@ async function hatchLocal(
   }
 
   const baseDataDir = join(resources.instanceDir, ".vellum");
-  const isFirstLocal = localAssistants.length === 0;
 
   console.log(`🥚 Hatching local assistant: ${instanceName}`);
   console.log(`   Species: ${species}`);
   console.log("");
 
-  // Subsequent assistants are registered but not started — the user can wake
-  // them explicitly via the toggle or `vellum wake`. The first assistant is
-  // always started immediately since there's nothing running yet.
-  if (isFirstLocal || restart) {
-    await startLocalDaemon(watch, resources);
+  await startLocalDaemon(watch, resources);
 
-    let runtimeUrl: string;
-    try {
-      runtimeUrl = await startGateway(instanceName, watch, resources);
-    } catch (error) {
-      // Gateway failed — stop the daemon we just started so we don't leave
-      // orphaned processes with no lock file entry.
-      console.error(
-        `\n❌ Gateway startup failed — stopping assistant to avoid orphaned processes.`,
-      );
-      await stopLocalProcesses(resources);
-      throw error;
+  let runtimeUrl: string;
+  try {
+    runtimeUrl = await startGateway(instanceName, watch, resources);
+  } catch (error) {
+    // Gateway failed — stop the daemon we just started so we don't leave
+    // orphaned processes with no lock file entry.
+    console.error(
+      `\n❌ Gateway startup failed — stopping assistant to avoid orphaned processes.`,
+    );
+    await stopLocalProcesses(resources);
+    throw error;
+  }
+
+  await startOutboundProxy(watch);
+
+  // Read the bearer token (JWT) written by the daemon so the CLI can
+  // with the gateway (which requires auth by default). The daemon writes under
+  // getRootDir() which resolves to <instanceDir>/.vellum/.
+  let bearerToken: string | undefined;
+  try {
+    const tokenPath = join(resources.instanceDir, ".vellum", "http-token");
+    const token = readFileSync(tokenPath, "utf-8").trim();
+    if (token) bearerToken = token;
+  } catch {
+    // Token file may not exist if daemon started without HTTP server
+  }
+
+  const localEntry: AssistantEntry = {
+    assistantId: instanceName,
+    runtimeUrl,
+    localUrl: `http://127.0.0.1:${resources.gatewayPort}`,
+    baseDataDir,
+    bearerToken,
+    cloud: "local",
+    species,
+    hatchedAt: new Date().toISOString(),
+    resources,
+  };
+  if (!daemonOnly && !restart) {
+    saveAssistantEntry(localEntry);
+    syncConfigToLockfile();
+
+    if (process.env.VELLUM_DESKTOP_APP) {
+      installCLISymlink();
     }
 
-    await startOutboundProxy(watch);
+    console.log("");
+    console.log(`✅ Local assistant hatched!`);
+    console.log("");
+    console.log("Instance details:");
+    console.log(`  Name: ${instanceName}`);
+    console.log(`  Runtime: ${runtimeUrl}`);
+    console.log("");
 
-    // Read the bearer token (JWT) written by the daemon so the CLI can
-    // authenticate with the gateway. The daemon writes under
-    // getRootDir() which resolves to <instanceDir>/.vellum/.
-    let bearerToken: string | undefined;
-    try {
-      const tokenPath = join(resources.instanceDir, ".vellum", "http-token");
-      const token = readFileSync(tokenPath, "utf-8").trim();
-      if (token) bearerToken = token;
-    } catch {
-      // Token file may not exist if daemon started without HTTP server
-    }
-
-    const localEntry: AssistantEntry = {
-      assistantId: instanceName,
-      runtimeUrl,
-      localUrl: `http://127.0.0.1:${resources.gatewayPort}`,
-      baseDataDir,
-      bearerToken,
-      cloud: "local",
-      species,
-      hatchedAt: new Date().toISOString(),
-      resources,
-    };
-    if (!daemonOnly && !restart) {
-      saveAssistantEntry(localEntry);
-      syncConfigToLockfile();
-
-      if (process.env.VELLUM_DESKTOP_APP) {
-        installCLISymlink();
-      }
-
-      console.log("");
-      console.log(`✅ Local assistant hatched!`);
-      console.log("");
-      console.log("Instance details:");
-      console.log(`  Name: ${instanceName}`);
-      console.log(`  Runtime: ${runtimeUrl}`);
-      console.log("");
-
-      // Use loopback for HTTP calls (health check + pairing register) since
-      // mDNS hostnames may not resolve on the local machine, but keep the
-      // external runtimeUrl in the QR payload so iOS devices can reach it.
-      const localGatewayUrl = `http://127.0.0.1:${resources.gatewayPort}`;
-      await displayPairingQRCode(localGatewayUrl, bearerToken, runtimeUrl);
-    }
-  } else {
-    // Register the new assistant without starting it. It will be woken on demand.
-    const localEntry: AssistantEntry = {
-      assistantId: instanceName,
-      runtimeUrl: `http://localhost:${resources.gatewayPort}`,
-      localUrl: `http://127.0.0.1:${resources.gatewayPort}`,
-      baseDataDir,
-      cloud: "local",
-      species,
-      hatchedAt: new Date().toISOString(),
-      resources,
-    };
-    if (!daemonOnly) {
-      saveAssistantEntry(localEntry);
-      syncConfigToLockfile();
-
-      console.log(`✅ Local assistant registered: ${instanceName}`);
-      console.log(`   Wake it with: vellum wake ${instanceName}`);
-      console.log("");
-    }
+    // Use loopback for HTTP calls (health check + pairing register) since
+    // mDNS hostnames may not resolve on the local machine, but keep the
+    // external runtimeUrl in the QR payload so iOS devices can reach it.
+    const localGatewayUrl = `http://127.0.0.1:${resources.gatewayPort}`;
+    await displayPairingQRCode(localGatewayUrl, bearerToken, runtimeUrl);
   }
 }
 

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -22,6 +22,7 @@ import cliPkg from "../../package.json";
 import { buildOpenclawStartupScript } from "../adapters/openclaw";
 import {
   allocateLocalResources,
+  defaultLocalResources,
   findAssistantByName,
   loadAllAssistants,
   saveAssistantEntry,
@@ -715,6 +716,9 @@ async function hatchLocal(
   const existingEntry = findAssistantByName(instanceName);
   if (existingEntry?.cloud === "local" && existingEntry.resources) {
     resources = existingEntry.resources;
+  } else if (restart && existingEntry?.cloud === "local") {
+    // Legacy entry without resources — use default paths to match existing layout
+    resources = defaultLocalResources();
   } else {
     resources = await allocateLocalResources(instanceName);
   }

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -726,72 +726,98 @@ async function hatchLocal(
   }
 
   const baseDataDir = join(resources.instanceDir, ".vellum");
+  const isFirstLocal = localAssistants.length === 0;
 
   console.log(`🥚 Hatching local assistant: ${instanceName}`);
   console.log(`   Species: ${species}`);
   console.log("");
 
-  await startLocalDaemon(watch, resources);
+  // Subsequent assistants are registered but not started — the user can wake
+  // them explicitly via the toggle or `vellum wake`. The first assistant is
+  // always started immediately since there's nothing running yet.
+  if (isFirstLocal || restart) {
+    await startLocalDaemon(watch, resources);
 
-  let runtimeUrl: string;
-  try {
-    runtimeUrl = await startGateway(instanceName, watch, resources);
-  } catch (error) {
-    // Gateway failed — stop the daemon we just started so we don't leave
-    // orphaned processes with no lock file entry.
-    console.error(
-      `\n❌ Gateway startup failed — stopping assistant to avoid orphaned processes.`,
-    );
-    await stopLocalProcesses(resources);
-    throw error;
-  }
-
-  await startOutboundProxy(watch);
-
-  // Read the bearer token (JWT) written by the daemon so the CLI can
-  // authenticate with the gateway. The daemon writes under
-  // getRootDir() which resolves to <instanceDir>/.vellum/.
-  let bearerToken: string | undefined;
-  try {
-    const tokenPath = join(resources.instanceDir, ".vellum", "http-token");
-    const token = readFileSync(tokenPath, "utf-8").trim();
-    if (token) bearerToken = token;
-  } catch {
-    // Token file may not exist if daemon started without HTTP server
-  }
-
-  const localEntry: AssistantEntry = {
-    assistantId: instanceName,
-    runtimeUrl,
-    localUrl: `http://127.0.0.1:${resources.gatewayPort}`,
-    baseDataDir,
-    bearerToken,
-    cloud: "local",
-    species,
-    hatchedAt: new Date().toISOString(),
-    resources,
-  };
-  if (!daemonOnly && !restart) {
-    saveAssistantEntry(localEntry);
-    syncConfigToLockfile();
-
-    if (process.env.VELLUM_DESKTOP_APP) {
-      installCLISymlink();
+    let runtimeUrl: string;
+    try {
+      runtimeUrl = await startGateway(instanceName, watch, resources);
+    } catch (error) {
+      // Gateway failed — stop the daemon we just started so we don't leave
+      // orphaned processes with no lock file entry.
+      console.error(
+        `\n❌ Gateway startup failed — stopping assistant to avoid orphaned processes.`,
+      );
+      await stopLocalProcesses(resources);
+      throw error;
     }
 
-    console.log("");
-    console.log(`✅ Local assistant hatched!`);
-    console.log("");
-    console.log("Instance details:");
-    console.log(`  Name: ${instanceName}`);
-    console.log(`  Runtime: ${runtimeUrl}`);
-    console.log("");
+    await startOutboundProxy(watch);
 
-    // Use loopback for HTTP calls (health check + pairing register) since
-    // mDNS hostnames may not resolve on the local machine, but keep the
-    // external runtimeUrl in the QR payload so iOS devices can reach it.
-    const localGatewayUrl = `http://127.0.0.1:${resources.gatewayPort}`;
-    await displayPairingQRCode(localGatewayUrl, bearerToken, runtimeUrl);
+    // Read the bearer token (JWT) written by the daemon so the CLI can
+    // authenticate with the gateway. The daemon writes under
+    // getRootDir() which resolves to <instanceDir>/.vellum/.
+    let bearerToken: string | undefined;
+    try {
+      const tokenPath = join(resources.instanceDir, ".vellum", "http-token");
+      const token = readFileSync(tokenPath, "utf-8").trim();
+      if (token) bearerToken = token;
+    } catch {
+      // Token file may not exist if daemon started without HTTP server
+    }
+
+    const localEntry: AssistantEntry = {
+      assistantId: instanceName,
+      runtimeUrl,
+      localUrl: `http://127.0.0.1:${resources.gatewayPort}`,
+      baseDataDir,
+      bearerToken,
+      cloud: "local",
+      species,
+      hatchedAt: new Date().toISOString(),
+      resources,
+    };
+    if (!daemonOnly && !restart) {
+      saveAssistantEntry(localEntry);
+      syncConfigToLockfile();
+
+      if (process.env.VELLUM_DESKTOP_APP) {
+        installCLISymlink();
+      }
+
+      console.log("");
+      console.log(`✅ Local assistant hatched!`);
+      console.log("");
+      console.log("Instance details:");
+      console.log(`  Name: ${instanceName}`);
+      console.log(`  Runtime: ${runtimeUrl}`);
+      console.log("");
+
+      // Use loopback for HTTP calls (health check + pairing register) since
+      // mDNS hostnames may not resolve on the local machine, but keep the
+      // external runtimeUrl in the QR payload so iOS devices can reach it.
+      const localGatewayUrl = `http://127.0.0.1:${resources.gatewayPort}`;
+      await displayPairingQRCode(localGatewayUrl, bearerToken, runtimeUrl);
+    }
+  } else {
+    // Register the new assistant without starting it. It will be woken on demand.
+    const localEntry: AssistantEntry = {
+      assistantId: instanceName,
+      runtimeUrl: `http://localhost:${resources.gatewayPort}`,
+      localUrl: `http://127.0.0.1:${resources.gatewayPort}`,
+      baseDataDir,
+      cloud: "local",
+      species,
+      hatchedAt: new Date().toISOString(),
+      resources,
+    };
+    if (!daemonOnly) {
+      saveAssistantEntry(localEntry);
+      syncConfigToLockfile();
+
+      console.log(`✅ Local assistant registered: ${instanceName}`);
+      console.log(`   Wake it with: vellum wake ${instanceName}`);
+      console.log("");
+    }
   }
 }
 

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -588,6 +588,8 @@ async function waitForDaemonReady(
 async function displayPairingQRCode(
   runtimeUrl: string,
   bearerToken: string | undefined,
+  /** External gateway URL for the QR payload. When omitted, runtimeUrl is used. */
+  externalGatewayUrl?: string,
 ): Promise<void> {
   try {
     const pairingRequestId = randomUUID();
@@ -614,7 +616,7 @@ async function displayPairingQRCode(
       body: JSON.stringify({
         pairingRequestId,
         pairingSecret,
-        gatewayUrl: runtimeUrl,
+        gatewayUrl: externalGatewayUrl ?? runtimeUrl,
       }),
     });
 
@@ -633,7 +635,7 @@ async function displayPairingQRCode(
       type: "vellum-daemon",
       v: 4,
       id: hostId,
-      g: runtimeUrl,
+      g: externalGatewayUrl ?? runtimeUrl,
       pairingRequestId,
       pairingSecret,
     });
@@ -761,6 +763,7 @@ async function hatchLocal(
   const localEntry: AssistantEntry = {
     assistantId: instanceName,
     runtimeUrl,
+    localUrl: `http://127.0.0.1:${resources.gatewayPort}`,
     baseDataDir,
     bearerToken,
     cloud: "local",
@@ -784,8 +787,11 @@ async function hatchLocal(
     console.log(`  Runtime: ${runtimeUrl}`);
     console.log("");
 
-    // Generate and display pairing QR code
-    await displayPairingQRCode(runtimeUrl, bearerToken);
+    // Use loopback for HTTP calls (health check + pairing register) since
+    // mDNS hostnames may not resolve on the local machine, but keep the
+    // external runtimeUrl in the QR payload so iOS devices can reach it.
+    const localGatewayUrl = `http://127.0.0.1:${resources.gatewayPort}`;
+    await displayPairingQRCode(localGatewayUrl, bearerToken, runtimeUrl);
   }
 }
 

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -740,7 +740,7 @@ async function hatchLocal(
     throw error;
   }
 
-  await startOutboundProxy(watch, resources);
+  await startOutboundProxy(watch);
 
   // Read the bearer token (JWT) written by the daemon so the CLI can
   // authenticate with the gateway. The daemon writes under

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -21,14 +21,18 @@ import cliPkg from "../../package.json";
 
 import { buildOpenclawStartupScript } from "../adapters/openclaw";
 import {
+  allocateLocalResources,
+  findAssistantByName,
   loadAllAssistants,
   saveAssistantEntry,
   syncConfigToLockfile,
 } from "../lib/assistant-config";
-import type { AssistantEntry } from "../lib/assistant-config";
+import type {
+  AssistantEntry,
+  LocalInstanceResources,
+} from "../lib/assistant-config";
 import { hatchAws } from "../lib/aws";
 import {
-  GATEWAY_PORT,
   SPECIES_CONFIG,
   VALID_REMOTE_HOSTS,
   VALID_SPECIES,
@@ -39,9 +43,9 @@ import type { PollResult, WatchHatchingResult } from "../lib/gcp";
 import {
   startLocalDaemon,
   startGateway,
+  startOutboundProxy,
   stopLocalProcesses,
 } from "../lib/local";
-import { probePort } from "../lib/port-probe";
 import { isProcessAlive } from "../lib/process";
 import { generateRandomSuffix } from "../lib/random-name";
 import { validateAssistantName } from "../lib/retire-archive";
@@ -703,64 +707,48 @@ async function hatchLocal(
       );
       await stopLocalProcesses();
     }
-
-    // Verify required ports are available before starting any services.
-    // Only check when no local assistants exist — if there are existing local
-    // assistants, their daemon/gateway/qdrant legitimately own these ports.
-    const RUNTIME_HTTP_PORT = Number(process.env.RUNTIME_HTTP_PORT) || 7821;
-    const QDRANT_PORT = 6333;
-    const requiredPorts = [
-      { name: "daemon", port: RUNTIME_HTTP_PORT },
-      { name: "gateway", port: GATEWAY_PORT },
-      { name: "qdrant", port: QDRANT_PORT },
-    ];
-    const conflicts: string[] = [];
-    await Promise.all(
-      requiredPorts.map(async ({ name, port }) => {
-        if (await probePort(port)) {
-          conflicts.push(`  - Port ${port} (${name}) is already in use`);
-        }
-      }),
-    );
-    if (conflicts.length > 0) {
-      throw new Error(
-        `Cannot hatch — required ports are already in use:\n${conflicts.join("\n")}\n\n` +
-          "Stop the conflicting processes or use environment variables to configure alternative ports " +
-          "(RUNTIME_HTTP_PORT, GATEWAY_PORT).",
-      );
-    }
   }
 
-  const baseDataDir = join(
-    process.env.BASE_DATA_DIR?.trim() ||
-      (process.env.HOME ?? userInfo().homedir),
-    ".vellum",
-  );
+  // Reuse existing resources if re-hatching with --name that matches a known
+  // local assistant, otherwise allocate fresh per-instance ports and directories.
+  let resources: LocalInstanceResources;
+  const existingEntry = findAssistantByName(instanceName);
+  if (existingEntry?.cloud === "local" && existingEntry.resources) {
+    resources = existingEntry.resources;
+  } else {
+    resources = await allocateLocalResources(instanceName);
+  }
+
+  const baseDataDir = join(resources.instanceDir, ".vellum");
 
   console.log(`🥚 Hatching local assistant: ${instanceName}`);
   console.log(`   Species: ${species}`);
   console.log("");
 
-  await startLocalDaemon(watch);
+  await startLocalDaemon(watch, resources);
 
   let runtimeUrl: string;
   try {
-    runtimeUrl = await startGateway(instanceName, watch);
+    runtimeUrl = await startGateway(instanceName, watch, resources);
   } catch (error) {
     // Gateway failed — stop the daemon we just started so we don't leave
     // orphaned processes with no lock file entry.
     console.error(
       `\n❌ Gateway startup failed — stopping assistant to avoid orphaned processes.`,
     );
-    await stopLocalProcesses();
+    await stopLocalProcesses(resources);
     throw error;
   }
 
+  await startOutboundProxy(watch, resources);
+
   // Read the bearer token (JWT) written by the daemon so the CLI can
-  // authenticate with the gateway.
+  // authenticate with the gateway. The daemon writes under
+  // getRootDir() which resolves to <instanceDir>/.vellum/.
   let bearerToken: string | undefined;
   try {
-    const token = readFileSync(join(baseDataDir, "http-token"), "utf-8").trim();
+    const tokenPath = join(resources.instanceDir, ".vellum", "http-token");
+    const token = readFileSync(tokenPath, "utf-8").trim();
     if (token) bearerToken = token;
   } catch {
     // Token file may not exist if daemon started without HTTP server
@@ -774,6 +762,7 @@ async function hatchLocal(
     cloud: "local",
     species,
     hatchedAt: new Date().toISOString(),
+    resources,
   };
   if (!daemonOnly && !restart) {
     saveAssistantEntry(localEntry);

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -44,7 +44,6 @@ import type { PollResult, WatchHatchingResult } from "../lib/gcp";
 import {
   startLocalDaemon,
   startGateway,
-  startOutboundProxy,
   stopLocalProcesses,
 } from "../lib/local";
 import { isProcessAlive } from "../lib/process";
@@ -745,8 +744,6 @@ async function hatchLocal(
     await stopLocalProcesses(resources);
     throw error;
   }
-
-  await startOutboundProxy(watch);
 
   // Read the bearer token (JWT) written by the daemon so the CLI can
   // with the gateway (which requires auth by default). The daemon writes under

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -412,7 +412,7 @@ async function listAllAssistants(): Promise<void> {
 
   await Promise.all(
     assistants.map(async (a, rowIndex) => {
-      const health = await checkHealth(a.runtimeUrl, a.bearerToken);
+      const health = await checkHealth(a.localUrl ?? a.runtimeUrl, a.bearerToken);
 
       const infoParts = [a.runtimeUrl];
       if (a.cloud) infoParts.push(`cloud: ${a.cloud}`);

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -218,6 +218,7 @@ function formatDetectionInfo(proc: DetectedProcess): string {
 async function getLocalProcesses(entry: AssistantEntry): Promise<TableRow[]> {
   const resources = entry.resources ?? defaultLocalResources();
   const vellumDir = join(resources.instanceDir, ".vellum");
+  const PROXY_PORT = Number(process.env.PROXY_PORT) || 7829;
 
   const specs: ProcessSpec[] = [
     {
@@ -237,6 +238,13 @@ async function getLocalProcesses(entry: AssistantEntry): Promise<TableRow[]> {
       pgrepName: "vellum-gateway",
       port: resources.gatewayPort,
       pidFile: join(vellumDir, "gateway.pid"),
+    },
+    {
+      name: "outbound-proxy",
+      pgrepName: "outbound-proxy",
+      port: PROXY_PORT,
+      // Outbound proxy is a shared singleton — always use the global PID path
+      pidFile: join(homedir(), ".vellum", "outbound-proxy.pid"),
     },
     {
       name: "embed-worker",

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -412,7 +412,25 @@ async function listAllAssistants(): Promise<void> {
 
   await Promise.all(
     assistants.map(async (a, rowIndex) => {
-      const health = await checkHealth(a.localUrl ?? a.runtimeUrl, a.bearerToken);
+      // For local assistants, check if the daemon process is alive before
+      // hitting the health endpoint. If the PID file is missing or the
+      // process isn't running, the assistant is sleeping — skip the
+      // network health check to avoid a misleading "unreachable" status.
+      let health: { status: string; detail: string | null };
+      const resources =
+        a.resources ??
+        (a.cloud === "local" ? defaultLocalResources() : undefined);
+      if (a.cloud === "local" && resources) {
+        const pid = readPidFile(resources.pidFile);
+        const alive = pid !== null && isProcessAlive(pid);
+        if (!alive) {
+          health = { status: "sleeping", detail: null };
+        } else {
+          health = await checkHealth(a.localUrl ?? a.runtimeUrl, a.bearerToken);
+        }
+      } else {
+        health = await checkHealth(a.localUrl ?? a.runtimeUrl, a.bearerToken);
+      }
 
       const infoParts = [a.runtimeUrl];
       if (a.cloud) infoParts.push(`cloud: ${a.cloud}`);

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -218,7 +218,6 @@ function formatDetectionInfo(proc: DetectedProcess): string {
 async function getLocalProcesses(entry: AssistantEntry): Promise<TableRow[]> {
   const resources = entry.resources ?? defaultLocalResources();
   const vellumDir = join(resources.instanceDir, ".vellum");
-  const PROXY_PORT = Number(process.env.PROXY_PORT) || 7829;
 
   const specs: ProcessSpec[] = [
     {
@@ -238,13 +237,6 @@ async function getLocalProcesses(entry: AssistantEntry): Promise<TableRow[]> {
       pgrepName: "vellum-gateway",
       port: resources.gatewayPort,
       pidFile: join(vellumDir, "gateway.pid"),
-    },
-    {
-      name: "outbound-proxy",
-      pgrepName: "outbound-proxy",
-      port: PROXY_PORT,
-      // Outbound proxy is a shared singleton — always use the global PID path
-      pidFile: join(homedir(), ".vellum", "outbound-proxy.pid"),
     },
     {
       name: "embed-worker",

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -3,19 +3,17 @@ import { homedir } from "os";
 import { join } from "path";
 
 import {
+  defaultLocalResources,
   findAssistantByName,
+  getActiveAssistant,
   loadAllAssistants,
   type AssistantEntry,
 } from "../lib/assistant-config";
-import { GATEWAY_PORT } from "../lib/constants";
 import { checkHealth } from "../lib/health-check";
 import { pgrepExact } from "../lib/pgrep";
 import { probePort } from "../lib/port-probe";
 import { withStatusEmoji } from "../lib/status-emoji";
 import { execOutput } from "../lib/step-runner";
-
-const RUNTIME_HTTP_PORT = Number(process.env.RUNTIME_HTTP_PORT) || 7821;
-const QDRANT_PORT = 6333;
 
 // ── Table formatting helpers ────────────────────────────────────
 
@@ -218,25 +216,26 @@ function formatDetectionInfo(proc: DetectedProcess): string {
 }
 
 async function getLocalProcesses(entry: AssistantEntry): Promise<TableRow[]> {
-  const vellumDir = entry.baseDataDir ?? join(homedir(), ".vellum");
+  const resources = entry.resources ?? defaultLocalResources();
+  const vellumDir = join(resources.instanceDir, ".vellum");
 
   const specs: ProcessSpec[] = [
     {
       name: "assistant",
       pgrepName: "vellum-daemon",
-      port: RUNTIME_HTTP_PORT,
-      pidFile: join(vellumDir, "vellum.pid"),
+      port: resources.daemonPort,
+      pidFile: resources.pidFile,
     },
     {
       name: "qdrant",
       pgrepName: "qdrant",
-      port: QDRANT_PORT,
+      port: resources.qdrantPort,
       pidFile: join(vellumDir, "workspace", "data", "qdrant", "qdrant.pid"),
     },
     {
       name: "gateway",
       pgrepName: "vellum-gateway",
-      port: GATEWAY_PORT,
+      port: resources.gatewayPort,
       pidFile: join(vellumDir, "gateway.pid"),
     },
     {
@@ -355,6 +354,7 @@ async function detectOrphanedProcesses(): Promise<OrphanedProcess[]> {
 
 async function listAllAssistants(): Promise<void> {
   const assistants = loadAllAssistants();
+  const activeId = getActiveAssistant();
 
   if (assistants.length === 0) {
     console.log("No assistants found.");
@@ -381,9 +381,10 @@ async function listAllAssistants(): Promise<void> {
     const infoParts = [a.runtimeUrl];
     if (a.cloud) infoParts.push(`cloud: ${a.cloud}`);
     if (a.species) infoParts.push(`species: ${a.species}`);
+    const prefix = a.assistantId === activeId ? "* " : "  ";
 
     return {
-      name: a.assistantId,
+      name: prefix + a.assistantId,
       status: withStatusEmoji("checking..."),
       info: infoParts.join(" | "),
     };
@@ -410,8 +411,9 @@ async function listAllAssistants(): Promise<void> {
       if (a.species) infoParts.push(`species: ${a.species}`);
       if (health.detail) infoParts.push(health.detail);
 
+      const prefix = a.assistantId === activeId ? "* " : "  ";
       const updatedRow: TableRow = {
-        name: a.assistantId,
+        name: prefix + a.assistantId,
         status: withStatusEmoji(health.status),
         info: infoParts.join(" | "),
       };

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -6,12 +6,14 @@ import { basename, dirname, join } from "path";
 import {
   defaultLocalResources,
   findAssistantByName,
+  loadAllAssistants,
   removeAssistantEntry,
 } from "../lib/assistant-config";
 import type { AssistantEntry } from "../lib/assistant-config";
 import { retireInstance as retireAwsInstance } from "../lib/aws";
 import { retireInstance as retireGcpInstance } from "../lib/gcp";
 import {
+  isProcessAlive,
   stopOrphanedDaemonProcesses,
   stopProcessByPidFile,
 } from "../lib/process";
@@ -66,6 +68,18 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   // configurable drain window (GATEWAY_SHUTDOWN_DRAIN_MS, default 5s) before it exits.
   const gatewayPidFile = join(vellumDir, "gateway.pid");
   await stopProcessByPidFile(gatewayPidFile, "gateway", undefined, 7000);
+
+  // Outbound proxy is a shared singleton — always use the global PID path.
+  // Only stop it if no other local assistants still have a running daemon.
+  const outboundProxyPidFile = join(homedir(), ".vellum", "outbound-proxy.pid");
+  const otherLocalRunning = loadAllAssistants().some((other) => {
+    if (other.cloud !== "local" || !other.resources) return false;
+    if (other.assistantId === name) return false;
+    return isProcessAlive(other.resources.pidFile).alive;
+  });
+  if (!otherLocalRunning) {
+    await stopProcessByPidFile(outboundProxyPidFile, "outbound-proxy");
+  }
 
   // If the PID file didn't track a running daemon, scan for orphaned
   // daemon processes that may have been started without writing a PID.

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -103,11 +103,11 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
     await stopProcessByPidFile(outboundProxyPidFile, "outbound-proxy");
   }
 
-  // If the PID file didn't track a running daemon, scan for orphaned
-  // daemon processes that may have been started without writing a PID.
-  if (!daemonStopped) {
-    await stopOrphanedDaemonProcesses();
-  }
+  // Always scan for orphaned daemon processes. The macOS desktop app can
+  // spawn daemon/gateway processes independently of the CLI's PID tracking,
+  // so even if we successfully killed the PID-file daemon there may be
+  // app-spawned processes still running.
+  await stopOrphanedDaemonProcesses();
 
   // For named instances (instanceDir under ~/.vellum/instances/<name>/),
   // archive and remove the entire instance directory. For default instances

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -4,6 +4,7 @@ import { homedir } from "os";
 import { basename, dirname, join } from "path";
 
 import {
+  defaultLocalResources,
   findAssistantByName,
   removeAssistantEntry,
 } from "../lib/assistant-config";
@@ -40,18 +41,23 @@ function extractHostFromUrl(url: string): string {
   }
 }
 
-function getBaseDir(): string {
-  return process.env.BASE_DATA_DIR?.trim() || homedir();
-}
-
 async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   console.log("\u{1F5D1}\ufe0f  Stopping local assistant...\n");
 
-  const vellumDir = join(getBaseDir(), ".vellum");
+  // Use entry resources when available; for legacy entries, derive paths
+  // from baseDataDir (which may differ from homedir if BASE_DATA_DIR was set).
+  const resources = entry.resources ?? defaultLocalResources();
+  const legacyDir = entry.baseDataDir;
+  const vellumDir = legacyDir ?? join(resources.instanceDir, ".vellum");
 
-  // Stop daemon via PID file
-  const daemonPidFile = join(vellumDir, "vellum.pid");
-  const socketFile = join(vellumDir, "vellum.sock");
+  // Stop daemon via PID file — prefer resources paths, but for legacy entries
+  // with a custom baseDataDir, derive from that directory instead.
+  const daemonPidFile = legacyDir
+    ? join(legacyDir, "vellum.pid")
+    : resources.pidFile;
+  const socketFile = legacyDir
+    ? join(legacyDir, "vellum.sock")
+    : resources.socketPath;
   const daemonStopped = await stopProcessByPidFile(daemonPidFile, "daemon", [
     socketFile,
   ]);
@@ -67,14 +73,23 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
     await stopOrphanedDaemonProcesses();
   }
 
+  // For named instances (instanceDir under ~/.vellum/instances/<name>/),
+  // archive and remove the entire instance directory. For default instances
+  // (instanceDir is homedir), archive only the .vellum subdirectory.
+  const instancesBase = join(homedir(), ".vellum", "instances");
+  const isNamedInstance = resources.instanceDir.startsWith(instancesBase + "/");
+  const dirToArchive = isNamedInstance ? resources.instanceDir : vellumDir;
+
   // Move the data directory out of the way so the path is immediately available
   // for the next hatch, then kick off the tar archive in the background.
   const archivePath = getArchivePath(name);
   const metadataPath = getMetadataPath(name);
   const stagingDir = `${archivePath}.staging`;
 
-  if (!existsSync(vellumDir)) {
-    console.log(`   No data directory at ${vellumDir} — nothing to archive.`);
+  if (!existsSync(dirToArchive)) {
+    console.log(
+      `   No data directory at ${dirToArchive} — nothing to archive.`,
+    );
     console.log("\u2705 Local instance retired.");
     return;
   }
@@ -83,10 +98,10 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   mkdirSync(dirname(stagingDir), { recursive: true });
 
   try {
-    renameSync(vellumDir, stagingDir);
+    renameSync(dirToArchive, stagingDir);
   } catch (err) {
     console.warn(
-      `⚠️  Failed to move ${vellumDir}: ${err instanceof Error ? err.message : err}`,
+      `⚠️  Failed to move ${dirToArchive}: ${err instanceof Error ? err.message : err}`,
     );
     console.warn("Skipping archive.");
     console.log("\u2705 Local instance retired.");

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -73,9 +73,10 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   // Only stop it if no other local assistants still have a running daemon.
   const outboundProxyPidFile = join(homedir(), ".vellum", "outbound-proxy.pid");
   const otherLocalRunning = loadAllAssistants().some((other) => {
-    if (other.cloud !== "local" || !other.resources) return false;
+    if (other.cloud !== "local") return false;
     if (other.assistantId === name) return false;
-    return isProcessAlive(other.resources.pidFile).alive;
+    const otherRes = other.resources ?? defaultLocalResources();
+    return isProcessAlive(otherRes.pidFile).alive;
   });
   if (!otherLocalRunning) {
     await stopProcessByPidFile(outboundProxyPidFile, "outbound-proxy");

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -52,6 +52,27 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   const legacyDir = entry.baseDataDir;
   const vellumDir = legacyDir ?? join(resources.instanceDir, ".vellum");
 
+  // Check whether another local assistant shares the same data directory.
+  // Legacy entries without `resources` all resolve to ~/.vellum/ — if we
+  // blindly kill processes and archive the directory, we'd destroy the
+  // other assistant's running daemon and data.
+  const otherSharesDir = loadAllAssistants().some((other) => {
+    if (other.cloud !== "local") return false;
+    if (other.assistantId === name) return false;
+    const otherVellumDir =
+      other.baseDataDir ??
+      join((other.resources ?? defaultLocalResources()).instanceDir, ".vellum");
+    return otherVellumDir === vellumDir;
+  });
+
+  if (otherSharesDir) {
+    console.log(
+      `   Skipping process stop and archive — another local assistant shares ${vellumDir}.`,
+    );
+    console.log("\u2705 Local instance retired (config entry removed only).");
+    return;
+  }
+
   // Stop daemon via PID file — prefer resources paths, but for legacy entries
   // with a custom baseDataDir, derive from that directory instead.
   const daemonPidFile = legacyDir

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -109,11 +109,10 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
     await stopOrphanedDaemonProcesses();
   }
 
-  // For named instances (instanceDir under ~/.vellum/instances/<name>/),
-  // archive and remove the entire instance directory. For default instances
+  // For named instances (instanceDir differs from homedir), archive and
+  // remove the entire instance directory. For the default instance
   // (instanceDir is homedir), archive only the .vellum subdirectory.
-  const instancesBase = join(homedir(), ".vellum", "instances");
-  const isNamedInstance = resources.instanceDir.startsWith(instancesBase + "/");
+  const isNamedInstance = resources.instanceDir !== homedir();
   const dirToArchive = isNamedInstance ? resources.instanceDir : vellumDir;
 
   // Move the data directory out of the way so the path is immediately available

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -103,11 +103,11 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
     await stopProcessByPidFile(outboundProxyPidFile, "outbound-proxy");
   }
 
-  // Always scan for orphaned daemon processes. The macOS desktop app can
-  // spawn daemon/gateway processes independently of the CLI's PID tracking,
-  // so even if we successfully killed the PID-file daemon there may be
-  // app-spawned processes still running.
-  await stopOrphanedDaemonProcesses();
+  // If the PID file didn't track a running daemon, scan for orphaned
+  // daemon processes that may have been started without writing a PID.
+  if (!daemonStopped) {
+    await stopOrphanedDaemonProcesses();
+  }
 
   // For named instances (instanceDir under ~/.vellum/instances/<name>/),
   // archive and remove the entire instance directory. For default instances

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -13,7 +13,6 @@ import type { AssistantEntry } from "../lib/assistant-config";
 import { retireInstance as retireAwsInstance } from "../lib/aws";
 import { retireInstance as retireGcpInstance } from "../lib/gcp";
 import {
-  isProcessAlive,
   stopOrphanedDaemonProcesses,
   stopProcessByPidFile,
 } from "../lib/process";
@@ -89,19 +88,6 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   // configurable drain window (GATEWAY_SHUTDOWN_DRAIN_MS, default 5s) before it exits.
   const gatewayPidFile = join(vellumDir, "gateway.pid");
   await stopProcessByPidFile(gatewayPidFile, "gateway", undefined, 7000);
-
-  // Outbound proxy is a shared singleton — always use the global PID path.
-  // Only stop it if no other local assistants still have a running daemon.
-  const outboundProxyPidFile = join(homedir(), ".vellum", "outbound-proxy.pid");
-  const otherLocalRunning = loadAllAssistants().some((other) => {
-    if (other.cloud !== "local") return false;
-    if (other.assistantId === name) return false;
-    const otherRes = other.resources ?? defaultLocalResources();
-    return isProcessAlive(otherRes.pidFile).alive;
-  });
-  if (!otherLocalRunning) {
-    await stopProcessByPidFile(outboundProxyPidFile, "outbound-proxy");
-  }
 
   // If the PID file didn't track a running daemon, scan for orphaned
   // daemon processes that may have been started without writing a PID.

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -1,19 +1,17 @@
-import { homedir } from "os";
 import { join } from "path";
 
 import {
   defaultLocalResources,
-  loadAllAssistants,
   resolveTargetAssistant,
 } from "../lib/assistant-config.js";
-import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
+import { stopProcessByPidFile } from "../lib/process";
 
 export async function sleep(): Promise<void> {
   const args = process.argv.slice(3);
   if (args.includes("--help") || args.includes("-h")) {
     console.log("Usage: vellum sleep [<name>]");
     console.log("");
-    console.log("Stop the assistant, gateway, and outbound-proxy processes.");
+    console.log("Stop the assistant and gateway processes.");
     console.log("");
     console.log("Arguments:");
     console.log(
@@ -38,8 +36,6 @@ export async function sleep(): Promise<void> {
   const socketFile = resources.socketPath;
   const vellumDir = join(resources.instanceDir, ".vellum");
   const gatewayPidFile = join(vellumDir, "gateway.pid");
-  // Outbound proxy is a shared singleton — always use the global PID path
-  const outboundProxyPidFile = join(homedir(), ".vellum", "outbound-proxy.pid");
 
   // Stop daemon
   const daemonStopped = await stopProcessByPidFile(daemonPidFile, "daemon", [
@@ -63,29 +59,5 @@ export async function sleep(): Promise<void> {
     console.log("Gateway is not running.");
   } else {
     console.log("Gateway stopped.");
-  }
-
-  // Only stop the shared outbound proxy if no other local assistants still
-  // have a running daemon — the proxy is a global singleton shared by all
-  // instances.
-  const otherLocalRunning = loadAllAssistants().some((other) => {
-    if (other.cloud !== "local") return false;
-    if (other.assistantId === entry.assistantId) return false;
-    const otherRes = other.resources ?? defaultLocalResources();
-    return isProcessAlive(otherRes.pidFile).alive;
-  });
-
-  if (otherLocalRunning) {
-    console.log("Outbound proxy left running (other local instances active).");
-  } else {
-    const outboundProxyStopped = await stopProcessByPidFile(
-      outboundProxyPidFile,
-      "outbound-proxy",
-    );
-    if (!outboundProxyStopped) {
-      console.log("Outbound proxy is not running.");
-    } else {
-      console.log("Outbound proxy stopped.");
-    }
   }
 }

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -1,3 +1,4 @@
+import { homedir } from "os";
 import { join } from "path";
 
 import {
@@ -36,6 +37,8 @@ export async function sleep(): Promise<void> {
   const socketFile = resources.socketPath;
   const vellumDir = join(resources.instanceDir, ".vellum");
   const gatewayPidFile = join(vellumDir, "gateway.pid");
+  // Outbound proxy is a shared singleton — always use the global PID path
+  const outboundProxyPidFile = join(homedir(), ".vellum", "outbound-proxy.pid");
 
   // Stop daemon
   const daemonStopped = await stopProcessByPidFile(daemonPidFile, "daemon", [
@@ -61,4 +64,14 @@ export async function sleep(): Promise<void> {
     console.log("Gateway stopped.");
   }
 
+  // Stop outbound proxy
+  const outboundProxyStopped = await stopProcessByPidFile(
+    outboundProxyPidFile,
+    "outbound-proxy",
+  );
+  if (!outboundProxyStopped) {
+    console.log("Outbound proxy is not running.");
+  } else {
+    console.log("Outbound proxy stopped.");
+  }
 }

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -69,9 +69,10 @@ export async function sleep(): Promise<void> {
   // have a running daemon — the proxy is a global singleton shared by all
   // instances.
   const otherLocalRunning = loadAllAssistants().some((other) => {
-    if (other.cloud !== "local" || !other.resources) return false;
+    if (other.cloud !== "local") return false;
     if (other.assistantId === entry.assistantId) return false;
-    return isProcessAlive(other.resources.pidFile).alive;
+    const otherRes = other.resources ?? defaultLocalResources();
+    return isProcessAlive(otherRes.pidFile).alive;
   });
 
   if (otherLocalRunning) {

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -1,20 +1,40 @@
-import { homedir } from "os";
 import { join } from "path";
 
+import {
+  defaultLocalResources,
+  resolveTargetAssistant,
+} from "../lib/assistant-config.js";
 import { stopProcessByPidFile } from "../lib/process";
 
 export async function sleep(): Promise<void> {
   const args = process.argv.slice(3);
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum sleep");
+    console.log("Usage: vellum sleep [<name>]");
     console.log("");
-    console.log("Stop the assistant and gateway processes.");
+    console.log("Stop the assistant, gateway, and outbound-proxy processes.");
+    console.log("");
+    console.log("Arguments:");
+    console.log(
+      "  <name>    Name of the assistant to stop (default: active or only local)",
+    );
     process.exit(0);
   }
 
-  const vellumDir = join(homedir(), ".vellum");
-  const daemonPidFile = join(vellumDir, "vellum.pid");
-  const socketFile = join(vellumDir, "vellum.sock");
+  const nameArg = args.find((a) => !a.startsWith("-"));
+  const entry = resolveTargetAssistant(nameArg);
+
+  if (entry.cloud && entry.cloud !== "local") {
+    console.error(
+      `Error: 'vellum sleep' only works with local assistants. '${entry.assistantId}' is a ${entry.cloud} instance.`,
+    );
+    process.exit(1);
+  }
+
+  const resources = entry.resources ?? defaultLocalResources();
+
+  const daemonPidFile = resources.pidFile;
+  const socketFile = resources.socketPath;
+  const vellumDir = join(resources.instanceDir, ".vellum");
   const gatewayPidFile = join(vellumDir, "gateway.pid");
 
   // Stop daemon

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -3,9 +3,10 @@ import { join } from "path";
 
 import {
   defaultLocalResources,
+  loadAllAssistants,
   resolveTargetAssistant,
 } from "../lib/assistant-config.js";
-import { stopProcessByPidFile } from "../lib/process";
+import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
 
 export async function sleep(): Promise<void> {
   const args = process.argv.slice(3);
@@ -64,14 +65,26 @@ export async function sleep(): Promise<void> {
     console.log("Gateway stopped.");
   }
 
-  // Stop outbound proxy
-  const outboundProxyStopped = await stopProcessByPidFile(
-    outboundProxyPidFile,
-    "outbound-proxy",
-  );
-  if (!outboundProxyStopped) {
-    console.log("Outbound proxy is not running.");
+  // Only stop the shared outbound proxy if no other local assistants still
+  // have a running daemon — the proxy is a global singleton shared by all
+  // instances.
+  const otherLocalRunning = loadAllAssistants().some((other) => {
+    if (other.cloud !== "local" || !other.resources) return false;
+    if (other.assistantId === entry.assistantId) return false;
+    return isProcessAlive(other.resources.pidFile).alive;
+  });
+
+  if (otherLocalRunning) {
+    console.log("Outbound proxy left running (other local instances active).");
   } else {
-    console.log("Outbound proxy stopped.");
+    const outboundProxyStopped = await stopProcessByPidFile(
+      outboundProxyPidFile,
+      "outbound-proxy",
+    );
+    if (!outboundProxyStopped) {
+      console.log("Outbound proxy is not running.");
+    } else {
+      console.log("Outbound proxy stopped.");
+    }
   }
 }

--- a/cli/src/commands/use.ts
+++ b/cli/src/commands/use.ts
@@ -1,0 +1,44 @@
+import {
+  findAssistantByName,
+  getActiveAssistant,
+  setActiveAssistant,
+} from "../lib/assistant-config.js";
+
+export async function use(): Promise<void> {
+  const args = process.argv.slice(3);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log("Usage: vellum use [<name>]");
+    console.log("");
+    console.log("Set the active assistant for commands.");
+    console.log("");
+    console.log("Arguments:");
+    console.log("  <name>    Name of the assistant to make active");
+    console.log("");
+    console.log(
+      "When called without a name, prints the current active assistant.",
+    );
+    process.exit(0);
+  }
+
+  const name = args.find((a) => !a.startsWith("-"));
+
+  if (!name) {
+    const active = getActiveAssistant();
+    if (active) {
+      console.log(`Active assistant: ${active}`);
+    } else {
+      console.log("No active assistant set.");
+    }
+    return;
+  }
+
+  const entry = findAssistantByName(name);
+  if (!entry) {
+    console.error(`No assistant found with name '${name}'.`);
+    process.exit(1);
+  }
+
+  setActiveAssistant(name);
+  console.log(`Active assistant set to '${name}'.`);
+}

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -77,8 +77,8 @@ export async function wake(): Promise<void> {
     await startLocalDaemon(watch, resources);
   }
 
-  // Start gateway (non-desktop only)
-  if (!process.env.VELLUM_DESKTOP_APP) {
+  // Start gateway
+  {
     const vellumDir = join(resources.instanceDir, ".vellum");
     const gatewayPidFile = join(vellumDir, "gateway.pid");
     const { alive, pid } = isProcessAlive(gatewayPidFile);

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -1,5 +1,4 @@
 import { existsSync, readFileSync } from "fs";
-import { homedir } from "os";
 import { join } from "path";
 
 import {
@@ -7,11 +6,7 @@ import {
   resolveTargetAssistant,
 } from "../lib/assistant-config.js";
 import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
-import {
-  startLocalDaemon,
-  startGateway,
-  startOutboundProxy,
-} from "../lib/local";
+import { startLocalDaemon, startGateway } from "../lib/local";
 
 export async function wake(): Promise<void> {
   const args = process.argv.slice(3);
@@ -97,20 +92,6 @@ export async function wake(): Promise<void> {
       await startGateway(undefined, watch, resources);
     }
   }
-
-  // Start outbound proxy — shared singleton using global PID file so
-  // multiple local instances share a single proxy on the default ports.
-  const globalVellumDir = join(homedir(), ".vellum");
-  const outboundProxyPidFile = join(globalVellumDir, "outbound-proxy.pid");
-  const outboundProxyStatus = isProcessAlive(outboundProxyPidFile);
-  if (outboundProxyStatus.alive && watch) {
-    // Restart in watch mode
-    console.log(
-      `Outbound proxy running (pid ${outboundProxyStatus.pid}) — restarting in watch mode...`,
-    );
-    await stopProcessByPidFile(outboundProxyPidFile, "outbound-proxy");
-  }
-  await startOutboundProxy(watch);
 
   console.log("Wake complete.");
 }

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
 import { join } from "path";
 
 import {
@@ -97,8 +98,19 @@ export async function wake(): Promise<void> {
     }
   }
 
-  // Start outbound proxy
-  await startOutboundProxy(watch, resources);
+  // Start outbound proxy — shared singleton using global PID file so
+  // multiple local instances share a single proxy on the default ports.
+  const globalVellumDir = join(homedir(), ".vellum");
+  const outboundProxyPidFile = join(globalVellumDir, "outbound-proxy.pid");
+  const outboundProxyStatus = isProcessAlive(outboundProxyPidFile);
+  if (outboundProxyStatus.alive && watch) {
+    // Restart in watch mode
+    console.log(
+      `Outbound proxy running (pid ${outboundProxyStatus.pid}) — restarting in watch mode...`,
+    );
+    await stopProcessByPidFile(outboundProxyPidFile, "outbound-proxy");
+  }
+  await startOutboundProxy(watch);
 
   console.log("Wake complete.");
 }

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -1,17 +1,28 @@
 import { existsSync, readFileSync } from "fs";
-import { homedir } from "os";
 import { join } from "path";
 
-import { loadAllAssistants } from "../lib/assistant-config";
+import {
+  defaultLocalResources,
+  resolveTargetAssistant,
+} from "../lib/assistant-config.js";
 import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
-import { startLocalDaemon, startGateway } from "../lib/local";
+import {
+  startLocalDaemon,
+  startGateway,
+  startOutboundProxy,
+} from "../lib/local";
 
 export async function wake(): Promise<void> {
   const args = process.argv.slice(3);
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum wake [options]");
+    console.log("Usage: vellum wake [<name>] [options]");
     console.log("");
     console.log("Start the assistant and gateway processes.");
+    console.log("");
+    console.log("Arguments:");
+    console.log(
+      "  <name>    Name of the assistant to start (default: active or only local)",
+    );
     console.log("");
     console.log("Options:");
     console.log(
@@ -21,19 +32,20 @@ export async function wake(): Promise<void> {
   }
 
   const watch = args.includes("--watch");
+  const nameArg = args.find((a) => !a.startsWith("-"));
+  const entry = resolveTargetAssistant(nameArg);
 
-  const assistants = loadAllAssistants();
-  const hasLocal = assistants.some((a) => a.cloud === "local");
-  if (!hasLocal) {
+  if (entry.cloud && entry.cloud !== "local") {
     console.error(
-      "Error: No local assistant found in lock file. Run 'vellum hatch local' first.",
+      `Error: 'vellum wake' only works with local assistants. '${entry.assistantId}' is a ${entry.cloud} instance.`,
     );
     process.exit(1);
   }
 
-  const vellumDir = join(homedir(), ".vellum");
-  const pidFile = join(vellumDir, "vellum.pid");
-  const socketFile = join(vellumDir, "vellum.sock");
+  const resources = entry.resources ?? defaultLocalResources();
+
+  const pidFile = resources.pidFile;
+  const socketFile = resources.socketPath;
 
   // Check if daemon is already running
   let daemonRunning = false;
@@ -61,11 +73,12 @@ export async function wake(): Promise<void> {
   }
 
   if (!daemonRunning) {
-    await startLocalDaemon(watch);
+    await startLocalDaemon(watch, resources);
   }
 
   // Start gateway (non-desktop only)
   if (!process.env.VELLUM_DESKTOP_APP) {
+    const vellumDir = join(resources.instanceDir, ".vellum");
     const gatewayPidFile = join(vellumDir, "gateway.pid");
     const { alive, pid } = isProcessAlive(gatewayPidFile);
     if (alive) {
@@ -75,14 +88,17 @@ export async function wake(): Promise<void> {
           `Gateway running (pid ${pid}) — restarting in watch mode...`,
         );
         await stopProcessByPidFile(gatewayPidFile, "gateway");
-        await startGateway(undefined, watch);
+        await startGateway(undefined, watch, resources);
       } else {
         console.log(`Gateway already running (pid ${pid}).`);
       }
     } else {
-      await startGateway(undefined, watch);
+      await startGateway(undefined, watch, resources);
     }
   }
 
-  console.log("✅ Wake complete.");
+  // Start outbound proxy
+  await startOutboundProxy(watch, resources);
+
+  console.log("Wake complete.");
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -12,6 +12,7 @@ import { skills } from "./commands/skills";
 import { sleep } from "./commands/sleep";
 import { ssh } from "./commands/ssh";
 import { tunnel } from "./commands/tunnel";
+import { use } from "./commands/use";
 import { wake } from "./commands/wake";
 
 const commands = {
@@ -27,6 +28,7 @@ const commands = {
   sleep,
   ssh,
   tunnel,
+  use,
   wake,
   whoami,
 } as const;
@@ -60,6 +62,7 @@ async function main() {
     console.log("  sleep    Stop the assistant process");
     console.log("  ssh      SSH into a remote assistant instance");
     console.log("  tunnel   Create a tunnel for a locally hosted assistant");
+    console.log("  use      Set the active assistant for commands");
     console.log("  wake     Start the assistant and gateway");
     console.log("  whoami   Show current logged-in user");
     process.exit(0);

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -225,13 +225,31 @@ export async function allocateLocalResources(
   const instanceDir = join(homedir(), ".vellum", "instances", instanceName);
   mkdirSync(instanceDir, { recursive: true });
 
+  // Collect ports already assigned to other local instances in the lockfile.
+  // Even if those instances are stopped, we must avoid reusing their ports
+  // to prevent binding collisions when both are woken.
+  const reservedPorts: number[] = [];
+  for (const entry of loadAllAssistants()) {
+    if (entry.cloud !== "local" || !entry.resources) continue;
+    reservedPorts.push(
+      entry.resources.daemonPort,
+      entry.resources.gatewayPort,
+      entry.resources.qdrantPort,
+    );
+  }
+
   // Allocate ports sequentially to avoid overlapping ranges assigning the
   // same port to multiple services (e.g. daemon 7821-7920 overlaps gateway 7830-7929).
-  const daemonPort = await findAvailablePort(DEFAULT_DAEMON_PORT);
+  const daemonPort = await findAvailablePort(
+    DEFAULT_DAEMON_PORT,
+    reservedPorts,
+  );
   const gatewayPort = await findAvailablePort(DEFAULT_GATEWAY_PORT, [
+    ...reservedPorts,
     daemonPort,
   ]);
   const qdrantPort = await findAvailablePort(DEFAULT_QDRANT_PORT, [
+    ...reservedPorts,
     daemonPort,
     gatewayPort,
   ]);

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -15,17 +15,28 @@ import { probePort } from "./port-probe.js";
  * side-by-side without conflicts.
  */
 export interface LocalInstanceResources {
-  /** Root directory for this instance (e.g. ~/.vellum/instances/<name>/) */
+  /**
+   * Instance-specific data root. For named instances this is
+   * `~/.vellum/instances/<name>/`; the daemon's working directory
+   * (`.vellum/`) lives inside it (e.g. `~/.vellum/instances/<name>/.vellum/`).
+   * Distinct from `AssistantEntry.baseDataDir`, which is a legacy field from
+   * the pre-multi-instance layout kept for backward compatibility.
+   */
   instanceDir: string;
-  /** HTTP port for the daemon runtime server */
+  /**
+   * Allocated port for process management — detecting conflicts, displaying
+   * status, and waking/sleeping. Overlaps with `AssistantEntry.runtimeUrl`
+   * (which is the full URL clients connect to) but kept separately so
+   * lifecycle commands can reason about port numbers directly.
+   */
   daemonPort: number;
   /** HTTP port for the gateway */
   gatewayPort: number;
   /** HTTP port for the Qdrant vector store */
   qdrantPort: number;
-  /** Path to the Unix domain socket */
+  /** Absolute path to the Unix domain socket for IPC */
   socketPath: string;
-  /** Path to the daemon PID file */
+  /** Absolute path to the daemon PID file used for process lifecycle */
   pidFile: string;
 }
 

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -43,6 +43,9 @@ export interface LocalInstanceResources {
 export interface AssistantEntry {
   assistantId: string;
   runtimeUrl: string;
+  /** Loopback URL for same-machine health checks (e.g. `http://127.0.0.1:7831`).
+   *  Avoids mDNS resolution issues when the machine checks its own gateway. */
+  localUrl?: string;
   baseDataDir?: string;
   bearerToken?: string;
   cloud: string;

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -1,6 +1,33 @@
-import { existsSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
+
+import {
+  DEFAULT_DAEMON_PORT,
+  DEFAULT_GATEWAY_PORT,
+  DEFAULT_QDRANT_PORT,
+} from "./constants.js";
+import { probePort } from "./port-probe.js";
+
+/**
+ * Per-instance resource paths and ports. Each local assistant instance gets
+ * its own directory tree, ports, and socket so multiple instances can run
+ * side-by-side without conflicts.
+ */
+export interface LocalInstanceResources {
+  /** Root directory for this instance (e.g. ~/.vellum/instances/<name>/) */
+  instanceDir: string;
+  /** HTTP port for the daemon runtime server */
+  daemonPort: number;
+  /** HTTP port for the gateway */
+  gatewayPort: number;
+  /** HTTP port for the Qdrant vector store */
+  qdrantPort: number;
+  /** Path to the Unix domain socket */
+  socketPath: string;
+  /** Path to the daemon PID file */
+  pidFile: string;
+}
 
 export interface AssistantEntry {
   assistantId: string;
@@ -16,6 +43,8 @@ export interface AssistantEntry {
   sshUser?: string;
   zone?: string;
   hatchedAt?: string;
+  /** Per-instance resource config. Present for local entries in multi-instance setups. */
+  resources?: LocalInstanceResources;
 }
 
 interface LockfileData {
@@ -105,6 +134,90 @@ export function saveAssistantEntry(entry: AssistantEntry): void {
   );
   entries.unshift(entry);
   writeAssistants(entries);
+}
+
+/**
+ * Scan upward from `basePort` to find an available port. A port is considered
+ * available when `probePort()` returns false (nothing listening). Scans up to
+ * 100 ports above the base before giving up.
+ */
+async function findAvailablePort(
+  basePort: number,
+  excludedPorts: number[] = [],
+): Promise<number> {
+  const maxOffset = 100;
+  for (let offset = 0; offset < maxOffset; offset++) {
+    const port = basePort + offset;
+    if (excludedPorts.includes(port)) continue;
+    const inUse = await probePort(port);
+    if (!inUse) return port;
+  }
+  throw new Error(
+    `Could not find an available port scanning from ${basePort} to ${basePort + maxOffset - 1}`,
+  );
+}
+
+/**
+ * Allocate an isolated set of resources for a named local instance.
+ * Creates the instance directory at ~/.vellum/instances/<name>/ and finds
+ * available ports for the daemon, gateway, and Qdrant.
+ */
+export async function allocateLocalResources(
+  instanceName: string,
+): Promise<LocalInstanceResources> {
+  const instanceDir = join(homedir(), ".vellum", "instances", instanceName);
+  mkdirSync(instanceDir, { recursive: true });
+
+  // Allocate ports sequentially to avoid overlapping ranges assigning the
+  // same port to multiple services (e.g. daemon 7821-7920 overlaps gateway 7830-7929).
+  const daemonPort = await findAvailablePort(DEFAULT_DAEMON_PORT);
+  const gatewayPort = await findAvailablePort(DEFAULT_GATEWAY_PORT, [
+    daemonPort,
+  ]);
+  const qdrantPort = await findAvailablePort(DEFAULT_QDRANT_PORT, [
+    daemonPort,
+    gatewayPort,
+  ]);
+
+  return {
+    instanceDir,
+    daemonPort,
+    gatewayPort,
+    qdrantPort,
+    socketPath: join(instanceDir, ".vellum", "vellum.sock"),
+    pidFile: join(instanceDir, ".vellum", "vellum.pid"),
+  };
+}
+
+/**
+ * Return default resources representing the legacy single-instance layout.
+ * Used to normalize existing lockfile entries so callers can treat all local
+ * entries uniformly.
+ */
+export function defaultLocalResources(): LocalInstanceResources {
+  const vellumDir = join(homedir(), ".vellum");
+  return {
+    instanceDir: homedir(),
+    daemonPort: DEFAULT_DAEMON_PORT,
+    gatewayPort: DEFAULT_GATEWAY_PORT,
+    qdrantPort: DEFAULT_QDRANT_PORT,
+    socketPath: join(vellumDir, "vellum.sock"),
+    pidFile: join(vellumDir, "vellum.pid"),
+  };
+}
+
+/**
+ * Normalize existing lockfile entries so local entries include resource fields.
+ * Remote entries are left untouched. Returns a new array (does not mutate input).
+ */
+export function normalizeExistingEntryResources(
+  entries: AssistantEntry[],
+): AssistantEntry[] {
+  return entries.map((entry) => {
+    if (entry.cloud !== "local") return entry;
+    if (entry.resources) return entry;
+    return { ...entry, resources: defaultLocalResources() };
+  });
 }
 
 /**

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -16,7 +16,10 @@ import { probePort } from "./port-probe.js";
  */
 export interface LocalInstanceResources {
   /**
-   * Instance-specific data root (e.g. `~/.vellum/instances/<name>/`).
+   * Instance-specific data root. The first local assistant uses `~` (workspace
+   * at `~/.vellum`); subsequent assistants use
+   * `~/.local/share/vellum/assistants/<name>/` (workspace at
+   * `~/.local/share/vellum/assistants/<name>/.vellum`).
    * The daemon's `.vellum/` directory lives inside it. Equivalent to
    * `AssistantEntry.baseDataDir` minus the trailing `/.vellum` suffix —
    * `baseDataDir` is kept on the flat entry for legacy lockfile compat.
@@ -225,13 +228,27 @@ async function findAvailablePort(
 
 /**
  * Allocate an isolated set of resources for a named local instance.
- * Creates the instance directory at ~/.vellum/instances/<name>/ and finds
- * available ports for the daemon, gateway, and Qdrant.
+ * The first local assistant gets `instanceDir = ~` with default ports (same as
+ * legacy single-instance layout). Subsequent assistants are placed under
+ * `~/.local/share/vellum/assistants/<name>/` with scanned ports.
  */
 export async function allocateLocalResources(
   instanceName: string,
 ): Promise<LocalInstanceResources> {
-  const instanceDir = join(homedir(), ".vellum", "instances", instanceName);
+  // First local assistant gets the home directory — identical to legacy layout.
+  const existingLocals = loadAllAssistants().filter((e) => e.cloud === "local");
+  if (existingLocals.length === 0) {
+    return defaultLocalResources();
+  }
+
+  const instanceDir = join(
+    homedir(),
+    ".local",
+    "share",
+    "vellum",
+    "assistants",
+    instanceName,
+  );
   mkdirSync(instanceDir, { recursive: true });
 
   // Collect ports already assigned to other local instances in the lockfile.

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -49,6 +49,7 @@ export interface AssistantEntry {
 
 interface LockfileData {
   assistants?: AssistantEntry[];
+  activeAssistant?: string;
   platformBaseUrl?: string;
   [key: string]: unknown;
 }
@@ -120,12 +121,68 @@ export function findAssistantByName(name: string): AssistantEntry | null {
 }
 
 export function removeAssistantEntry(assistantId: string): void {
-  const entries = readAssistants();
-  writeAssistants(entries.filter((e) => e.assistantId !== assistantId));
+  const data = readLockfile();
+  const entries = (data.assistants ?? []).filter(
+    (e: AssistantEntry) => e.assistantId !== assistantId,
+  );
+  data.assistants = entries;
+  // Clear active assistant if it matches the removed entry
+  if (data.activeAssistant === assistantId) {
+    delete data.activeAssistant;
+  }
+  writeLockfile(data);
 }
 
 export function loadAllAssistants(): AssistantEntry[] {
   return readAssistants();
+}
+
+export function getActiveAssistant(): string | null {
+  const data = readLockfile();
+  return data.activeAssistant ?? null;
+}
+
+export function setActiveAssistant(assistantId: string): void {
+  const data = readLockfile();
+  data.activeAssistant = assistantId;
+  writeLockfile(data);
+}
+
+/**
+ * Resolve which assistant to target for a command. Priority:
+ * 1. Explicit name argument
+ * 2. Active assistant set via `vellum use`
+ * 3. Sole local assistant (when exactly one exists)
+ */
+export function resolveTargetAssistant(nameArg?: string): AssistantEntry {
+  if (nameArg) {
+    const entry = findAssistantByName(nameArg);
+    if (!entry) {
+      console.error(`No assistant found with name '${nameArg}'.`);
+      process.exit(1);
+    }
+    return entry;
+  }
+
+  const active = getActiveAssistant();
+  if (active) {
+    const entry = findAssistantByName(active);
+    if (entry) return entry;
+    // Active assistant no longer exists in lockfile — fall through
+  }
+
+  const all = readAssistants();
+  const locals = all.filter((e) => e.cloud === "local");
+  if (locals.length === 1) return locals[0];
+
+  if (locals.length === 0) {
+    console.error("No local assistant found. Run 'vellum hatch local' first.");
+  } else {
+    console.error(
+      `Multiple assistants found. Set an active assistant with 'vellum use <name>'.`,
+    );
+  }
+  process.exit(1);
 }
 
 export function saveAssistantEntry(entry: AssistantEntry): void {

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -16,19 +16,13 @@ import { probePort } from "./port-probe.js";
  */
 export interface LocalInstanceResources {
   /**
-   * Instance-specific data root. For named instances this is
-   * `~/.vellum/instances/<name>/`; the daemon's working directory
-   * (`.vellum/`) lives inside it (e.g. `~/.vellum/instances/<name>/.vellum/`).
-   * Distinct from `AssistantEntry.baseDataDir`, which is a legacy field from
-   * the pre-multi-instance layout kept for backward compatibility.
+   * Instance-specific data root (e.g. `~/.vellum/instances/<name>/`).
+   * The daemon's `.vellum/` directory lives inside it. Equivalent to
+   * `AssistantEntry.baseDataDir` minus the trailing `/.vellum` suffix —
+   * `baseDataDir` is kept on the flat entry for legacy lockfile compat.
    */
   instanceDir: string;
-  /**
-   * Allocated port for process management — detecting conflicts, displaying
-   * status, and waking/sleeping. Overlaps with `AssistantEntry.runtimeUrl`
-   * (which is the full URL clients connect to) but kept separately so
-   * lifecycle commands can reason about port numbers directly.
-   */
+  /** HTTP port for the daemon runtime server */
   daemonPort: number;
   /** HTTP port for the gateway */
   gatewayPort: number;
@@ -36,7 +30,7 @@ export interface LocalInstanceResources {
   qdrantPort: number;
   /** Absolute path to the Unix domain socket for IPC */
   socketPath: string;
-  /** Absolute path to the daemon PID file used for process lifecycle */
+  /** Absolute path to the daemon PID file */
   pidFile: string;
 }
 
@@ -46,6 +40,7 @@ export interface AssistantEntry {
   /** Loopback URL for same-machine health checks (e.g. `http://127.0.0.1:7831`).
    *  Avoids mDNS resolution issues when the machine checks its own gateway. */
   localUrl?: string;
+  /** @deprecated Use `resources.instanceDir` for multi-instance entries. Legacy equivalent of `join(instanceDir, ".vellum")`. */
   baseDataDir?: string;
   bearerToken?: string;
   cloud: string;

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -241,12 +241,21 @@ export async function allocateLocalResources(
   // to prevent binding collisions when both are woken.
   const reservedPorts: number[] = [];
   for (const entry of loadAllAssistants()) {
-    if (entry.cloud !== "local" || !entry.resources) continue;
-    reservedPorts.push(
-      entry.resources.daemonPort,
-      entry.resources.gatewayPort,
-      entry.resources.qdrantPort,
-    );
+    if (entry.cloud !== "local") continue;
+    if (entry.resources) {
+      reservedPorts.push(
+        entry.resources.daemonPort,
+        entry.resources.gatewayPort,
+        entry.resources.qdrantPort,
+      );
+    } else {
+      // Legacy entries without resources use the default ports
+      reservedPorts.push(
+        DEFAULT_DAEMON_PORT,
+        DEFAULT_GATEWAY_PORT,
+        DEFAULT_QDRANT_PORT,
+      );
+    }
   }
 
   // Allocate ports sequentially to avoid overlapping ranges assigning the

--- a/cli/src/lib/constants.ts
+++ b/cli/src/lib/constants.ts
@@ -2,6 +2,12 @@ export const FIREWALL_TAG = "vellum-assistant";
 export const GATEWAY_PORT = process.env.GATEWAY_PORT
   ? Number(process.env.GATEWAY_PORT)
   : 7830;
+
+/** Default ports used as scan start points for multi-instance allocation. */
+export const DEFAULT_DAEMON_PORT = 7821;
+export const DEFAULT_GATEWAY_PORT = 7830;
+export const DEFAULT_QDRANT_PORT = 6333;
+
 export const VALID_REMOTE_HOSTS = ["local", "gcp", "aws", "custom"] as const;
 export type RemoteHost = (typeof VALID_REMOTE_HOSTS)[number];
 export const VALID_SPECIES = ["openclaw", "vellum"] as const;

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -277,6 +277,8 @@ async function startDaemonFromSource(
     env.BASE_DATA_DIR = resources.instanceDir;
     env.RUNTIME_HTTP_PORT = String(resources.daemonPort);
     env.VELLUM_DAEMON_SOCKET = resources.socketPath;
+    env.QDRANT_HTTP_PORT = String(resources.qdrantPort);
+    delete env.QDRANT_URL;
   }
 
   // Use fd inheritance instead of pipes so the daemon's stdout/stderr survive
@@ -365,6 +367,8 @@ async function startDaemonWatchFromSource(
     env.BASE_DATA_DIR = resources.instanceDir;
     env.RUNTIME_HTTP_PORT = String(resources.daemonPort);
     env.VELLUM_DAEMON_SOCKET = resources.socketPath;
+    env.QDRANT_HTTP_PORT = String(resources.qdrantPort);
+    delete env.QDRANT_URL;
   }
 
   const daemonLogFd = openLogFile("hatch.log");
@@ -725,6 +729,8 @@ export async function startLocalDaemon(
       for (const key of [
         "ANTHROPIC_API_KEY",
         "BASE_DATA_DIR",
+        "QDRANT_HTTP_PORT",
+        "QDRANT_URL",
         "RUNTIME_HTTP_PORT",
         "VELLUM_DAEMON_TCP_PORT",
         "VELLUM_DAEMON_TCP_HOST",
@@ -746,6 +752,8 @@ export async function startLocalDaemon(
         daemonEnv.BASE_DATA_DIR = resources.instanceDir;
         daemonEnv.RUNTIME_HTTP_PORT = String(resources.daemonPort);
         daemonEnv.VELLUM_DAEMON_SOCKET = resources.socketPath;
+        daemonEnv.QDRANT_HTTP_PORT = String(resources.qdrantPort);
+        delete daemonEnv.QDRANT_URL;
       }
 
       // Use fd inheritance instead of pipes so the daemon's stdout/stderr

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -12,7 +12,11 @@ import { createConnection } from "net";
 import { homedir, hostname, networkInterfaces, platform } from "os";
 import { dirname, join } from "path";
 
-import { loadLatestAssistant } from "./assistant-config.js";
+import {
+  defaultLocalResources,
+  loadLatestAssistant,
+  type LocalInstanceResources,
+} from "./assistant-config.js";
 import { GATEWAY_PORT } from "./constants.js";
 import { stopProcessByPidFile } from "./process.js";
 import { openLogFile, pipeToLogFile } from "./xdg-log.js";
@@ -210,14 +214,20 @@ function resolveDaemonMainPath(assistantIndex: string): string {
   return join(dirname(assistantIndex), "daemon", "main.ts");
 }
 
-async function startDaemonFromSource(assistantIndex: string): Promise<void> {
+async function startDaemonFromSource(
+  assistantIndex: string,
+  resources?: LocalInstanceResources,
+): Promise<void> {
   const daemonMainPath = resolveDaemonMainPath(assistantIndex);
 
-  const vellumDir = join(homedir(), ".vellum");
-  mkdirSync(vellumDir, { recursive: true });
+  const defaults = defaultLocalResources();
+  const res = resources ?? defaults;
+  // Ensure the directory containing PID/socket files exists. For named
+  // instances this is instanceDir/.vellum/ (matching daemon's getRootDir()).
+  mkdirSync(dirname(res.pidFile), { recursive: true });
 
-  const pidFile = join(vellumDir, "vellum.pid");
-  const socketFile = join(vellumDir, "vellum.sock");
+  const pidFile = res.pidFile;
+  const socketFile = res.socketPath;
 
   // --- Lifecycle guard: prevent split-brain daemon state ---
   if (existsSync(pidFile)) {
@@ -263,6 +273,11 @@ async function startDaemonFromSource(assistantIndex: string): Promise<void> {
     env.VELLUM_DAEMON_TCP_ENABLED =
       process.env.VELLUM_DAEMON_TCP_ENABLED || "1";
   }
+  if (resources) {
+    env.BASE_DATA_DIR = resources.instanceDir;
+    env.RUNTIME_HTTP_PORT = String(resources.daemonPort);
+    env.VELLUM_DAEMON_SOCKET = resources.socketPath;
+  }
 
   // Use fd inheritance instead of pipes so the daemon's stdout/stderr survive
   // after the parent (hatch) exits. Bun does not ignore SIGPIPE, so piped
@@ -287,17 +302,19 @@ async function startDaemonFromSource(assistantIndex: string): Promise<void> {
 // assistant-side equivalent.
 async function startDaemonWatchFromSource(
   assistantIndex: string,
+  resources?: LocalInstanceResources,
 ): Promise<void> {
   const mainPath = resolveDaemonMainPath(assistantIndex);
   if (!existsSync(mainPath)) {
     throw new Error(`Daemon main.ts not found at ${mainPath}`);
   }
 
-  const vellumDir = join(homedir(), ".vellum");
-  mkdirSync(vellumDir, { recursive: true });
+  const defaults = defaultLocalResources();
+  const res = resources ?? defaults;
+  mkdirSync(dirname(res.pidFile), { recursive: true });
 
-  const pidFile = join(vellumDir, "vellum.pid");
-  const socketFile = join(vellumDir, "vellum.sock");
+  const pidFile = res.pidFile;
+  const socketFile = res.socketPath;
 
   // --- Lifecycle guard: prevent split-brain daemon state ---
   // If a daemon is already running, skip spawning a new one.
@@ -344,6 +361,11 @@ async function startDaemonWatchFromSource(
     RUNTIME_HTTP_PORT: process.env.RUNTIME_HTTP_PORT || "7821",
     VELLUM_DEV: "1",
   };
+  if (resources) {
+    env.BASE_DATA_DIR = resources.instanceDir;
+    env.RUNTIME_HTTP_PORT = String(resources.daemonPort);
+    env.VELLUM_DAEMON_SOCKET = resources.socketPath;
+  }
 
   const daemonLogFd = openLogFile("hatch.log");
   const child = spawn("bun", ["--watch", "run", mainPath], {
@@ -478,7 +500,8 @@ function isSocketResponsive(
   });
 }
 
-async function discoverPublicUrl(): Promise<string | undefined> {
+async function discoverPublicUrl(port?: number): Promise<string | undefined> {
+  const effectivePort = port ?? GATEWAY_PORT;
   const cloud = process.env.VELLUM_CLOUD;
 
   let externalIp: string | undefined;
@@ -516,7 +539,7 @@ async function discoverPublicUrl(): Promise<string | undefined> {
 
     if (externalIp) {
       console.log(`   Discovered external IP: ${externalIp}`);
-      return `http://${externalIp}:${GATEWAY_PORT}`;
+      return `http://${externalIp}:${effectivePort}`;
     }
   }
 
@@ -527,18 +550,18 @@ async function discoverPublicUrl(): Promise<string | undefined> {
     const localHostname = getMacLocalHostname();
     if (localHostname) {
       console.log(`   Discovered macOS local hostname: ${localHostname}`);
-      return `http://${localHostname}:${GATEWAY_PORT}`;
+      return `http://${localHostname}:${effectivePort}`;
     }
   }
 
   const lanIp = getLocalLanIPv4();
   if (lanIp) {
     console.log(`   Discovered LAN IP: ${lanIp}`);
-    return `http://${lanIp}:${GATEWAY_PORT}`;
+    return `http://${lanIp}:${effectivePort}`;
   }
 
   // Final fallback to localhost when no LAN address could be discovered.
-  return `http://localhost:${GATEWAY_PORT}`;
+  return `http://localhost:${effectivePort}`;
 }
 
 /**
@@ -607,7 +630,10 @@ function getLocalLanIPv4(): string | undefined {
 // It should eventually converge with
 // assistant/src/daemon/daemon-control.ts::startDaemon which is the
 // assistant-side equivalent.
-export async function startLocalDaemon(watch: boolean = false): Promise<void> {
+export async function startLocalDaemon(
+  watch: boolean = false,
+  resources?: LocalInstanceResources,
+): Promise<void> {
   if (process.env.VELLUM_DESKTOP_APP && !watch) {
     // When running inside the desktop app, the CLI owns the daemon lifecycle.
     // Find the vellum-daemon binary adjacent to the CLI binary.
@@ -621,9 +647,10 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
       );
     }
 
-    const vellumDir = join(homedir(), ".vellum");
-    const pidFile = join(vellumDir, "vellum.pid");
-    const socketFile = join(vellumDir, "vellum.sock");
+    const defaults = defaultLocalResources();
+    const res = resources ?? defaults;
+    const pidFile = res.pidFile;
+    const socketFile = res.socketPath;
 
     // If a daemon is already running, skip spawning a new one.
     // This prevents cascading kill→restart cycles when multiple callers
@@ -679,8 +706,8 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
       // Ensure bun is available for runtime features (browser, skills install)
       ensureBunInstalled();
 
-      // Ensure ~/.vellum/ exists for PID/socket files
-      mkdirSync(vellumDir, { recursive: true });
+      // Ensure the directory containing PID/socket files exists
+      mkdirSync(dirname(pidFile), { recursive: true });
 
       // Build a minimal environment for the daemon. When launched from the
       // macOS app the CLI inherits a huge environment (XPC_SERVICE_NAME,
@@ -712,6 +739,13 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
         if (process.env[key]) {
           daemonEnv[key] = process.env[key]!;
         }
+      }
+      // When running a named instance, override env so the daemon resolves
+      // all paths under the instance directory and listens on its own port.
+      if (resources) {
+        daemonEnv.BASE_DATA_DIR = resources.instanceDir;
+        daemonEnv.RUNTIME_HTTP_PORT = String(resources.daemonPort);
+        daemonEnv.VELLUM_DAEMON_SOCKET = resources.socketPath;
       }
 
       // Use fd inheritance instead of pipes so the daemon's stdout/stderr
@@ -758,9 +792,9 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
         // Kill the bundled daemon to avoid two processes competing for the same socket/port
         await stopProcessByPidFile(pidFile, "bundled daemon", [socketFile]);
         if (watch) {
-          await startDaemonWatchFromSource(assistantIndex);
+          await startDaemonWatchFromSource(assistantIndex, resources);
         } else {
-          await startDaemonFromSource(assistantIndex);
+          await startDaemonFromSource(assistantIndex, resources);
         }
         socketReady = await waitForSocketFile(socketFile, 60000);
       }
@@ -783,12 +817,13 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
           "  Ensure the daemon binary is bundled alongside the CLI, or run from the source tree.",
       );
     }
-    if (watch) {
-      await startDaemonWatchFromSource(assistantIndex);
+    const defaults = defaultLocalResources();
+    const res = resources ?? defaults;
 
-      const vellumDir = join(homedir(), ".vellum");
-      const socketFile = join(vellumDir, "vellum.sock");
-      const socketReady = await waitForSocketFile(socketFile, 60000);
+    if (watch) {
+      await startDaemonWatchFromSource(assistantIndex, resources);
+
+      const socketReady = await waitForSocketFile(res.socketPath, 60000);
       if (socketReady) {
         console.log("   Assistant socket ready\n");
       } else {
@@ -797,11 +832,9 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
         );
       }
     } else {
-      await startDaemonFromSource(assistantIndex);
+      await startDaemonFromSource(assistantIndex, resources);
 
-      const vellumDir = join(homedir(), ".vellum");
-      const socketFile = join(vellumDir, "vellum.sock");
-      const socketReady = await waitForSocketFile(socketFile, 60000);
+      const socketReady = await waitForSocketFile(res.socketPath, 60000);
       if (socketReady) {
         console.log("   Assistant socket ready\n");
       } else {
@@ -816,8 +849,11 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
 export async function startGateway(
   assistantId?: string,
   watch: boolean = false,
+  resources?: LocalInstanceResources,
 ): Promise<string> {
-  const publicUrl = await discoverPublicUrl();
+  const effectiveGatewayPort = resources?.gatewayPort ?? GATEWAY_PORT;
+
+  const publicUrl = await discoverPublicUrl(effectiveGatewayPort);
   if (publicUrl) {
     console.log(`   Public URL: ${publicUrl}`);
   }
@@ -831,11 +867,82 @@ export async function startGateway(
     process.env.GATEWAY_DEFAULT_ASSISTANT_ID ||
     loadLatestAssistant()?.assistantId;
 
+  // Read the bearer token so the gateway can authenticate proxied requests
+  // (e.g. from paired iOS devices). Respect VELLUM_HTTP_TOKEN_PATH and
+  // BASE_DATA_DIR for consistency with gateway/config.ts and the daemon.
+  // When resources are provided, the token lives under the instance directory.
+  const httpTokenPath =
+    process.env.VELLUM_HTTP_TOKEN_PATH ??
+    (resources
+      ? join(resources.instanceDir, ".vellum", "http-token")
+      : join(
+          process.env.BASE_DATA_DIR?.trim() || homedir(),
+          ".vellum",
+          "http-token",
+        ));
+  let runtimeProxyBearerToken: string | undefined;
+  try {
+    const tok = readFileSync(httpTokenPath, "utf-8").trim();
+    if (tok) runtimeProxyBearerToken = tok;
+  } catch {
+    // Token file doesn't exist yet — daemon hasn't written it.
+  }
+
+  // If no token is available (first startup — daemon hasn't written it yet),
+  // poll for the file to appear. On fresh installs the daemon may take 60s+
+  // for Qdrant download, migrations, and first-time init. Starting the
+  // gateway without auth is a security risk since the config is loaded once
+  // at startup and never reloads, so we fail rather than silently disabling auth.
+  if (!runtimeProxyBearerToken) {
+    console.log("   Waiting for bearer token file...");
+    const maxWait = 60000;
+    const pollInterval = 500;
+    const start = Date.now();
+    const pidFile =
+      resources?.pidFile ??
+      join(
+        process.env.BASE_DATA_DIR?.trim() || homedir(),
+        ".vellum",
+        "vellum.pid",
+      );
+    while (Date.now() - start < maxWait) {
+      await new Promise((r) => setTimeout(r, pollInterval));
+      try {
+        const tok = readFileSync(httpTokenPath, "utf-8").trim();
+        if (tok) {
+          runtimeProxyBearerToken = tok;
+          break;
+        }
+      } catch {
+        // File still doesn't exist, keep polling.
+      }
+      // Check if the daemon process is still alive — no point waiting if it crashed
+      try {
+        const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+        if (pid) process.kill(pid, 0); // throws if process doesn't exist
+      } catch {
+        break; // daemon process is gone
+      }
+    }
+  }
+
+  if (!runtimeProxyBearerToken) {
+    throw new Error(
+      `Bearer token file not found at ${httpTokenPath} after 60s.\n` +
+        "  The gateway cannot start without authentication — this would leave the proxy permanently unauthenticated.\n" +
+        "  Ensure the daemon is running and has written the token file, or set VELLUM_HTTP_TOKEN_PATH to the correct path.",
+  );
+  }
+  const effectiveDaemonPort =
+    resources?.daemonPort ?? Number(process.env.RUNTIME_HTTP_PORT || "7821");
+
   const gatewayEnv: Record<string, string> = {
     ...(process.env as Record<string, string>),
     GATEWAY_RUNTIME_PROXY_ENABLED: "true",
     GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "true",
-    RUNTIME_HTTP_PORT: process.env.RUNTIME_HTTP_PORT || "7821",
+    RUNTIME_PROXY_BEARER_TOKEN: runtimeProxyBearerToken,
+    RUNTIME_HTTP_PORT: String(effectiveDaemonPort),
+    GATEWAY_PORT: String(effectiveGatewayPort),
     // Skip the drain window for locally-launched gateways — there is no load
     // balancer draining connections, so waiting serves no purpose and causes
     // `vellum sleep` to SIGKILL the gateway when the CLI timeout is shorter
@@ -908,11 +1015,13 @@ export async function startGateway(
   gateway.unref();
 
   if (gateway.pid) {
-    const vellumDir = join(homedir(), ".vellum");
-    writeFileSync(join(vellumDir, "gateway.pid"), String(gateway.pid), "utf-8");
+    const gwPidDir = resources
+      ? join(resources.instanceDir, ".vellum")
+      : join(homedir(), ".vellum");
+    writeFileSync(join(gwPidDir, "gateway.pid"), String(gateway.pid), "utf-8");
   }
 
-  const gatewayUrl = publicUrl || `http://localhost:${GATEWAY_PORT}`;
+  const gatewayUrl = publicUrl || `http://localhost:${effectiveGatewayPort}`;
 
   // Wait for the gateway to be responsive before returning. Without this,
   // callers (e.g. displayPairingQRCode) may try to connect before the HTTP
@@ -922,9 +1031,12 @@ export async function startGateway(
   let ready = false;
   while (Date.now() - start < timeoutMs) {
     try {
-      const res = await fetch(`http://localhost:${GATEWAY_PORT}/healthz`, {
-        signal: AbortSignal.timeout(2000),
-      });
+      const res = await fetch(
+        `http://localhost:${effectiveGatewayPort}/healthz`,
+        {
+          signal: AbortSignal.timeout(2000),
+        },
+      );
       if (res.ok) {
         ready = true;
         break;
@@ -945,15 +1057,145 @@ export async function startGateway(
   return gatewayUrl;
 }
 
+export async function startOutboundProxy(
+  watch: boolean = false,
+  resources?: LocalInstanceResources,
+): Promise<void> {
+  const proxyDir = resolveOutboundProxyDir();
+  if (!proxyDir) {
+    console.log("   ⚠️  Outbound proxy not found — skipping");
+    return;
+  }
+
+  console.log("🔒 Starting outbound proxy...");
+
+  const vellumDir = resources
+    ? join(resources.instanceDir, ".vellum")
+    : join(homedir(), ".vellum");
+  mkdirSync(vellumDir, { recursive: true });
+
+  const pidFile = join(vellumDir, "outbound-proxy.pid");
+
+  // Check if already running
+  if (existsSync(pidFile)) {
+    try {
+      const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+      if (!isNaN(pid)) {
+        try {
+          process.kill(pid, 0);
+          console.log(`   Outbound proxy already running (pid ${pid})\n`);
+          return;
+        } catch {
+          try {
+            unlinkSync(pidFile);
+          } catch {}
+        }
+      }
+    } catch {}
+  }
+
+  const proxyEnv: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+    PROXY_PORT: process.env.PROXY_PORT || "7829",
+    PROXY_HEALTH_PORT: process.env.PROXY_HEALTH_PORT || "7828",
+  };
+
+  const proxyLogFd = openLogFile("hatch.log");
+
+  let proxy;
+  if (process.env.VELLUM_DESKTOP_APP && !watch) {
+    const proxyBinary = join(
+      dirname(process.execPath),
+      "vellum-outbound-proxy",
+    );
+    if (!existsSync(proxyBinary)) {
+      console.log(
+        "   ⚠️  Outbound proxy binary not found — falling back to source",
+      );
+      const bunArgs = watch
+        ? ["--watch", "run", "src/main.ts"]
+        : ["run", "src/main.ts"];
+      proxy = spawn("bun", bunArgs, {
+        cwd: proxyDir,
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: proxyEnv,
+      });
+    } else {
+      proxy = spawn(proxyBinary, [], {
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: proxyEnv,
+      });
+    }
+  } else {
+    const bunArgs = watch
+      ? ["--watch", "run", "src/main.ts"]
+      : ["run", "src/main.ts"];
+    proxy = spawn("bun", bunArgs, {
+      cwd: proxyDir,
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: proxyEnv,
+    });
+  }
+
+  pipeToLogFile(proxy, proxyLogFd, "outbound-proxy");
+  proxy.unref();
+
+  if (proxy.pid) {
+    writeFileSync(pidFile, String(proxy.pid), "utf-8");
+  }
+
+  if (watch) {
+    console.log("   Outbound proxy started in watch mode (bun --watch)");
+  }
+
+  // Wait for the health endpoint to respond
+  const healthPort = Number(process.env.PROXY_HEALTH_PORT) || 7828;
+  const start = Date.now();
+  const timeoutMs = 15000;
+  let ready = false;
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(`http://localhost:${healthPort}/healthz`, {
+        signal: AbortSignal.timeout(2000),
+      });
+      if (res.ok) {
+        ready = true;
+        break;
+      }
+    } catch {
+      // Not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+
+  if (!ready) {
+    console.warn(
+      "   ⚠️  Outbound proxy started but health check did not respond within 15s",
+    );
+  }
+
+  console.log("✅ Outbound proxy started\n");
+}
+
 /**
- * Stop any locally-running daemon and gateway processes and clean up
- * PID/socket files. Called when hatch fails partway through so we don't
- * leave orphaned processes with no lock file entry.
+ * Stop any locally-running daemon, gateway, and outbound-proxy processes
+ * and clean up PID/socket files. Called when hatch fails partway through
+ * so we don't leave orphaned processes with no lock file entry.
+ *
+ * When `resources` is provided, uses instance-specific paths instead of
+ * the default ~/.vellum/ paths.
  */
-export async function stopLocalProcesses(): Promise<void> {
-  const vellumDir = join(homedir(), ".vellum");
-  const daemonPidFile = join(vellumDir, "vellum.pid");
-  const socketFile = join(vellumDir, "vellum.sock");
+export async function stopLocalProcesses(
+  resources?: LocalInstanceResources,
+): Promise<void> {
+  const vellumDir = resources
+    ? join(resources.instanceDir, ".vellum")
+    : join(homedir(), ".vellum");
+  const daemonPidFile = resources?.pidFile ?? join(vellumDir, "vellum.pid");
+  const socketFile = resources?.socketPath ?? join(vellumDir, "vellum.sock");
   await stopProcessByPidFile(daemonPidFile, "daemon", [socketFile]);
 
   const gatewayPidFile = join(vellumDir, "gateway.pid");

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -963,6 +963,9 @@ export async function startGateway(
     // than the drain window.  Respect an explicit env override.
     GATEWAY_SHUTDOWN_DRAIN_MS: process.env.GATEWAY_SHUTDOWN_DRAIN_MS || "0",
     ...(watch ? { VELLUM_DEV: "1" } : {}),
+    // Set BASE_DATA_DIR so the gateway loads the correct signing key and
+    // credentials for this instance (mirrors the daemon env setup).
+    ...(resources ? { BASE_DATA_DIR: resources.instanceDir } : {}),
   };
 
   if (process.env.GATEWAY_UNMAPPED_POLICY) {

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -945,7 +945,7 @@ export async function startGateway(
       `Bearer token file not found at ${httpTokenPath} after 60s.\n` +
         "  The gateway cannot start without authentication — this would leave the proxy permanently unauthenticated.\n" +
         "  Ensure the daemon is running and has written the token file, or set VELLUM_HTTP_TOKEN_PATH to the correct path.",
-  );
+    );
   }
   const effectiveDaemonPort =
     resources?.daemonPort ?? Number(process.env.RUNTIME_HTTP_PORT || "7821");
@@ -1073,131 +1073,8 @@ export async function startGateway(
   return gatewayUrl;
 }
 
-export async function startOutboundProxy(
-  watch: boolean = false,
-  resources?: LocalInstanceResources,
-): Promise<void> {
-  const proxyDir = resolveOutboundProxyDir();
-  if (!proxyDir) {
-    console.log("   ⚠️  Outbound proxy not found — skipping");
-    return;
-  }
-
-  console.log("🔒 Starting outbound proxy...");
-
-  const vellumDir = resources
-    ? join(resources.instanceDir, ".vellum")
-    : join(homedir(), ".vellum");
-  mkdirSync(vellumDir, { recursive: true });
-
-  const pidFile = join(vellumDir, "outbound-proxy.pid");
-
-  // Check if already running
-  if (existsSync(pidFile)) {
-    try {
-      const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
-      if (!isNaN(pid)) {
-        try {
-          process.kill(pid, 0);
-          console.log(`   Outbound proxy already running (pid ${pid})\n`);
-          return;
-        } catch {
-          try {
-            unlinkSync(pidFile);
-          } catch {}
-        }
-      }
-    } catch {}
-  }
-
-  const proxyEnv: Record<string, string> = {
-    ...(process.env as Record<string, string>),
-    PROXY_PORT: process.env.PROXY_PORT || "7829",
-    PROXY_HEALTH_PORT: process.env.PROXY_HEALTH_PORT || "7828",
-  };
-
-  const proxyLogFd = openLogFile("hatch.log");
-
-  let proxy;
-  if (process.env.VELLUM_DESKTOP_APP && !watch) {
-    const proxyBinary = join(
-      dirname(process.execPath),
-      "vellum-outbound-proxy",
-    );
-    if (!existsSync(proxyBinary)) {
-      console.log(
-        "   ⚠️  Outbound proxy binary not found — falling back to source",
-      );
-      const bunArgs = watch
-        ? ["--watch", "run", "src/main.ts"]
-        : ["run", "src/main.ts"];
-      proxy = spawn("bun", bunArgs, {
-        cwd: proxyDir,
-        detached: true,
-        stdio: ["ignore", "pipe", "pipe"],
-        env: proxyEnv,
-      });
-    } else {
-      proxy = spawn(proxyBinary, [], {
-        detached: true,
-        stdio: ["ignore", "pipe", "pipe"],
-        env: proxyEnv,
-      });
-    }
-  } else {
-    const bunArgs = watch
-      ? ["--watch", "run", "src/main.ts"]
-      : ["run", "src/main.ts"];
-    proxy = spawn("bun", bunArgs, {
-      cwd: proxyDir,
-      detached: true,
-      stdio: ["ignore", "pipe", "pipe"],
-      env: proxyEnv,
-    });
-  }
-
-  pipeToLogFile(proxy, proxyLogFd, "outbound-proxy");
-  proxy.unref();
-
-  if (proxy.pid) {
-    writeFileSync(pidFile, String(proxy.pid), "utf-8");
-  }
-
-  if (watch) {
-    console.log("   Outbound proxy started in watch mode (bun --watch)");
-  }
-
-  // Wait for the health endpoint to respond
-  const healthPort = Number(process.env.PROXY_HEALTH_PORT) || 7828;
-  const start = Date.now();
-  const timeoutMs = 15000;
-  let ready = false;
-  while (Date.now() - start < timeoutMs) {
-    try {
-      const res = await fetch(`http://localhost:${healthPort}/healthz`, {
-        signal: AbortSignal.timeout(2000),
-      });
-      if (res.ok) {
-        ready = true;
-        break;
-      }
-    } catch {
-      // Not ready yet
-    }
-    await new Promise((r) => setTimeout(r, 250));
-  }
-
-  if (!ready) {
-    console.warn(
-      "   ⚠️  Outbound proxy started but health check did not respond within 15s",
-    );
-  }
-
-  console.log("✅ Outbound proxy started\n");
-}
-
 /**
- * Stop any locally-running daemon, gateway, and outbound-proxy processes
+ * Stop any locally-running daemon and gateway processes
  * and clean up PID/socket files. Called when hatch fails partway through
  * so we don't leave orphaned processes with no lock file entry.
  *
@@ -1216,8 +1093,4 @@ export async function stopLocalProcesses(
 
   const gatewayPidFile = join(vellumDir, "gateway.pid");
   await stopProcessByPidFile(gatewayPidFile, "gateway", undefined, 7000);
-
-  // Outbound proxy is a shared singleton — always use the global PID path
-  const outboundProxyPidFile = join(homedir(), ".vellum", "outbound-proxy.pid");
-  await stopProcessByPidFile(outboundProxyPidFile, "outbound-proxy");
 }

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -432,9 +432,12 @@ function normalizeIngressUrl(value: unknown): string | undefined {
   return normalized || undefined;
 }
 
-function readWorkspaceIngressPublicBaseUrl(): string | undefined {
+function readWorkspaceIngressPublicBaseUrl(
+  instanceDir?: string,
+): string | undefined {
   const baseDataDir =
-    process.env.BASE_DATA_DIR?.trim() || (process.env.HOME ?? homedir());
+    instanceDir ??
+    (process.env.BASE_DATA_DIR?.trim() || (process.env.HOME ?? homedir()));
   const workspaceConfigPath = join(
     baseDataDir,
     ".vellum",
@@ -968,7 +971,9 @@ export async function startGateway(
   if (resolvedAssistantId) {
     gatewayEnv.GATEWAY_DEFAULT_ASSISTANT_ID = resolvedAssistantId;
   }
-  const workspaceIngressPublicBaseUrl = readWorkspaceIngressPublicBaseUrl();
+  const workspaceIngressPublicBaseUrl = readWorkspaceIngressPublicBaseUrl(
+    resources?.instanceDir,
+  );
   const ingressPublicBaseUrl =
     workspaceIngressPublicBaseUrl ??
     normalizeIngressUrl(process.env.INGRESS_PUBLIC_BASE_URL) ??

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -1213,4 +1213,8 @@ export async function stopLocalProcesses(
 
   const gatewayPidFile = join(vellumDir, "gateway.pid");
   await stopProcessByPidFile(gatewayPidFile, "gateway", undefined, 7000);
+
+  // Outbound proxy is a shared singleton — always use the global PID path
+  const outboundProxyPidFile = join(homedir(), ".vellum", "outbound-proxy.pid");
+  await stopProcessByPidFile(outboundProxyPidFile, "outbound-proxy");
 }

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -276,6 +276,7 @@ async function startDaemonFromSource(
   if (resources) {
     env.BASE_DATA_DIR = resources.instanceDir;
     env.RUNTIME_HTTP_PORT = String(resources.daemonPort);
+    env.GATEWAY_PORT = String(resources.gatewayPort);
     env.VELLUM_DAEMON_SOCKET = resources.socketPath;
     env.QDRANT_HTTP_PORT = String(resources.qdrantPort);
     delete env.QDRANT_URL;
@@ -366,6 +367,7 @@ async function startDaemonWatchFromSource(
   if (resources) {
     env.BASE_DATA_DIR = resources.instanceDir;
     env.RUNTIME_HTTP_PORT = String(resources.daemonPort);
+    env.GATEWAY_PORT = String(resources.gatewayPort);
     env.VELLUM_DAEMON_SOCKET = resources.socketPath;
     env.QDRANT_HTTP_PORT = String(resources.qdrantPort);
     delete env.QDRANT_URL;
@@ -754,6 +756,7 @@ export async function startLocalDaemon(
       if (resources) {
         daemonEnv.BASE_DATA_DIR = resources.instanceDir;
         daemonEnv.RUNTIME_HTTP_PORT = String(resources.daemonPort);
+        daemonEnv.GATEWAY_PORT = String(resources.gatewayPort);
         daemonEnv.VELLUM_DAEMON_SOCKET = resources.socketPath;
         daemonEnv.QDRANT_HTTP_PORT = String(resources.qdrantPort);
         delete daemonEnv.QDRANT_URL;

--- a/cli/src/lib/status-emoji.ts
+++ b/cli/src/lib/status-emoji.ts
@@ -6,6 +6,9 @@ export function statusEmoji(status: string): string {
   if (s.startsWith("error") || s === "unreachable" || s.startsWith("exited")) {
     return "🔴";
   }
+  if (s === "sleeping") {
+    return "💤";
+  }
   return "🟡";
 }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -175,8 +175,9 @@ extension AppDelegate {
         recordingManager.forceStop()
         recordingHUDWindow?.dismiss()
 
-        // 3. Stop daemon processes and disconnect transport
-        assistantCli.stop()
+        // 3. Disconnect transport — leave the old daemon running so it stays
+        //    awake and can be switched back to without a cold start.
+        assistantCli.stopMonitoring()
         daemonClient.disconnect()
         // Close and recreate the main window to reset thread/session state
         mainWindow?.close()

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -100,8 +100,11 @@ extension AppDelegate {
                 services.reconfigureDaemonClient(config: config)
                 log.info("Configured local HTTP transport (localHttpEnabled flag) on port \(port)")
             } else {
-                // Reset to default socket transport in case the previous assistant used HTTP.
-                services.reconfigureDaemonClient(config: .default)
+                // Use the specific assistant's socket path so switching between
+                // local instances connects to the correct daemon.
+                let socketPath = assistant?.socketPath ?? DaemonClient.resolveSocketPath()
+                let config = DaemonConfig(socketPath: socketPath)
+                services.reconfigureDaemonClient(config: config)
             }
             return
         }

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -100,10 +100,11 @@ extension AppDelegate {
                 services.reconfigureDaemonClient(config: config)
                 log.info("Configured local HTTP transport (localHttpEnabled flag) on port \(port)")
             } else {
-                // Use the specific assistant's socket path so switching between
-                // local instances connects to the correct daemon.
+                // Use the specific assistant's socket path and instance dir so
+                // switching between local instances connects to the correct daemon
+                // and authenticates with the correct session token.
                 let socketPath = assistant?.socketPath ?? DaemonClient.resolveSocketPath()
-                let config = DaemonConfig(socketPath: socketPath)
+                let config = DaemonConfig(socketPath: socketPath, instanceDir: assistant?.instanceDir)
                 services.reconfigureDaemonClient(config: config)
             }
             return

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -276,9 +276,15 @@ extension AppDelegate {
     }
 
     /// Check whether the local gateway is healthy by hitting its /healthz endpoint.
-    /// Reads port from GATEWAY_PORT env var (default 7830) to match local.ts runtime behavior.
+    /// Reads gatewayPort from the lockfile's resources (multi-instance uses dynamic ports),
+    /// falling back to GATEWAY_PORT env var or default 7830.
     func isGatewayHealthy() async -> Bool {
-        let port = ProcessInfo.processInfo.environment["GATEWAY_PORT"] ?? "7830"
+        let port: String = {
+            if let gp = LockfileAssistant.loadLatest()?.gatewayPort {
+                return String(gp)
+            }
+            return ProcessInfo.processInfo.environment["GATEWAY_PORT"] ?? "7830"
+        }()
         guard let url = URL(string: "http://localhost:\(port)/healthz") else { return false }
         var request = URLRequest(url: url)
         request.timeoutInterval = 2

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -276,15 +276,9 @@ extension AppDelegate {
     }
 
     /// Check whether the local gateway is healthy by hitting its /healthz endpoint.
-    /// Reads gatewayPort from the lockfile's resources (multi-instance uses dynamic ports),
-    /// falling back to GATEWAY_PORT env var or default 7830.
+    /// Port resolution: env var > lockfile > default 7830.
     func isGatewayHealthy() async -> Bool {
-        let port: String = {
-            if let gp = LockfileAssistant.loadLatest()?.gatewayPort {
-                return String(gp)
-            }
-            return ProcessInfo.processInfo.environment["GATEWAY_PORT"] ?? "7830"
-        }()
+        let port = LockfilePaths.resolveGatewayPort()
         guard let url = URL(string: "http://localhost:\(port)/healthz") else { return false }
         var request = URLRequest(url: url)
         request.timeoutInterval = 2

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -372,6 +372,40 @@ final class AssistantCli {
         isRestarting = false
     }
 
+    /// Wake a specific assistant's daemon via the CLI.
+    func wake(name: String) async throws {
+        guard let binaryURL = cliBinaryURL else {
+            log.info("No bundled CLI binary found — skipping wake (dev mode)")
+            return
+        }
+
+        log.info("Running wake via CLI for '\(name, privacy: .private)'")
+        let (_, stderr, status) = try await runCLI(binaryURL: binaryURL, arguments: ["wake", name])
+
+        if status != 0 {
+            log.error("CLI wake failed with exit code \(status, privacy: .public): \(stderr, privacy: .private)")
+            throw CLIError.executionFailed(stderr)
+        }
+        log.info("CLI wake completed successfully for '\(name, privacy: .private)'")
+    }
+
+    /// Sleep a specific assistant's daemon via the CLI.
+    func sleep(name: String) async throws {
+        guard let binaryURL = cliBinaryURL else {
+            log.info("No bundled CLI binary found — skipping sleep (dev mode)")
+            return
+        }
+
+        log.info("Running sleep via CLI for '\(name, privacy: .private)'")
+        let (_, stderr, status) = try await runCLI(binaryURL: binaryURL, arguments: ["sleep", name])
+
+        if status != 0 {
+            log.error("CLI sleep failed with exit code \(status, privacy: .public): \(stderr, privacy: .private)")
+            throw CLIError.executionFailed(stderr)
+        }
+        log.info("CLI sleep completed successfully for '\(name, privacy: .private)'")
+    }
+
     // MARK: - Remote Hatch (pass-through to CLI)
 
     struct RemoteHatchConfig {

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -562,12 +562,9 @@ struct InlineVideoAttachmentView: View {
     }
 }
 
-/// Resolve the local gateway base URL from the GATEWAY_PORT env var (default 7830).
+/// Resolve the local gateway base URL: env var > lockfile > default 7830.
 private func resolveGatewayBaseUrl() -> String {
-    let envPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
-        ?? getenv("GATEWAY_PORT").flatMap({ String(cString: $0) })
-    let port = envPort.flatMap(Int.init) ?? 7830
-    return "http://127.0.0.1:\(port)"
+    "http://127.0.0.1:\(LockfilePaths.resolveGatewayPort())"
 }
 
 /// Fetch raw attachment bytes via the gateway's runtime proxy.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -241,6 +241,8 @@ struct LockfileAssistant {
     let zone: String?
     let instanceId: String?
     let hatchedAt: String?
+    let gatewayPort: Int?
+    let socketPath: String?
 
     /// Whether this assistant is running remotely (not on the local machine).
     var isRemote: Bool {
@@ -309,6 +311,7 @@ struct LockfileAssistant {
 
         return sorted.compactMap { entry -> LockfileAssistant? in
             guard let assistantId = entry["assistantId"] as? String else { return nil }
+            let resources = entry["resources"] as? [String: Any]
             return LockfileAssistant(
                 assistantId: assistantId,
                 runtimeUrl: entry["runtimeUrl"] as? String,
@@ -318,7 +321,9 @@ struct LockfileAssistant {
                 region: entry["region"] as? String,
                 zone: entry["zone"] as? String,
                 instanceId: entry["instanceId"] as? String,
-                hatchedAt: entry["hatchedAt"] as? String
+                hatchedAt: entry["hatchedAt"] as? String,
+                gatewayPort: resources?["gatewayPort"] as? Int,
+                socketPath: resources?["socketPath"] as? String
             )
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -243,6 +243,7 @@ struct LockfileAssistant {
     let hatchedAt: String?
     let gatewayPort: Int?
     let socketPath: String?
+    let instanceDir: String?
 
     /// Whether this assistant is running remotely (not on the local machine).
     var isRemote: Bool {
@@ -279,7 +280,8 @@ struct LockfileAssistant {
         case "vellum":
             return .vellum(runtimeUrl: runtimeUrl ?? "")
         default:
-            return .local(workspacePath: NSHomeDirectory() + "/.vellum/workspace")
+            let base = instanceDir ?? NSHomeDirectory()
+            return .local(workspacePath: base + "/.vellum/workspace")
         }
     }
 
@@ -323,7 +325,8 @@ struct LockfileAssistant {
                 instanceId: entry["instanceId"] as? String,
                 hatchedAt: entry["hatchedAt"] as? String,
                 gatewayPort: resources?["gatewayPort"] as? Int,
-                socketPath: resources?["socketPath"] as? String
+                socketPath: resources?["socketPath"] as? String,
+                instanceDir: resources?["instanceDir"] as? String
             )
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -5,7 +5,7 @@ import VellumAssistantShared
 /// Displays a QR code containing the v4 connection payload for iOS pairing.
 ///
 /// v4 payload:
-/// `{"type":"vellum-daemon","v":4,"id":"<mac-hash>","g":"<gateway-url>","pairingRequestId":"<uuid>","pairingSecret":"<32-byte-hex>","localLanUrl":"http://<lan-ip>:7830"}`
+/// `{"type":"vellum-daemon","v":4,"id":"<mac-hash>","g":"<gateway-url>","pairingRequestId":"<uuid>","pairingSecret":"<32-byte-hex>","localLanUrl":"http://<lan-ip>:<gateway-port>"}`
 ///
 /// Key differences from v3:
 /// - No bearer token in QR code (secured by pairing secret + Mac approval)
@@ -180,13 +180,9 @@ struct PairingQRCodeSheet: View {
 
     // MARK: - Registration
 
-    /// Resolve the local gateway base URL. Prefers `GATEWAY_PORT` env var,
-    /// falls back to the default gateway port 7830.
+    /// Resolve the local gateway base URL: env var > lockfile > default 7830.
     private var resolvedGatewayBaseUrl: String {
-        let envPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
-            ?? getenv("GATEWAY_PORT").flatMap({ String(cString: $0) })
-        let port = envPort.flatMap(Int.init) ?? 7830
-        return "http://127.0.0.1:\(port)"
+        "http://127.0.0.1:\(LockfilePaths.resolveGatewayPort())"
     }
 
     private func registerWithDaemon() {
@@ -283,7 +279,7 @@ struct PairingQRCodeSheet: View {
 
     private func computeLocalLanUrl() -> String? {
         guard let lanIP = LANIPHelper.currentLANAddress() else { return nil }
-        return "http://\(lanIP):7830"
+        return "http://\(lanIP):\(LockfilePaths.resolveGatewayPort())"
     }
 
     // MARK: - QR Generation

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -340,8 +340,6 @@ struct SettingsAccountTab: View {
         if assistant.isRemote { return true }
         // Mid-transition — prevent double-toggle
         if transitioningStates.contains(assistant.assistantId) { return true }
-        // Can't sleep the currently active assistant
-        if assistant.assistantId == selectedAssistantId && (awakeStates[assistant.assistantId] ?? false) { return true }
         return false
     }
 
@@ -369,6 +367,16 @@ struct SettingsAccountTab: View {
                     try await cli.sleep(name: assistant.assistantId)
                 }
                 awakeStates[assistant.assistantId] = awake
+                // If we just slept the active assistant, auto-switch to
+                // another awake one so the app stays connected.
+                if !awake && assistant.assistantId == selectedAssistantId {
+                    if let next = lockfileAssistants.first(where: {
+                        $0.assistantId != assistant.assistantId && (awakeStates[$0.assistantId] ?? false)
+                    }) {
+                        switchToAssistant(next)
+                        selectedAssistantId = next.assistantId
+                    }
+                }
             } catch {
                 // On failure, re-check actual state
                 let env: [String: String]? = assistant.instanceDir.map { ["BASE_DATA_DIR": $0] }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -26,6 +26,10 @@ struct SettingsAccountTab: View {
     @State private var isHatchFlagEnabled: Bool = true
     @State private var isLoadingHatchFlag: Bool = false
 
+    // -- Wake/sleep toggle state --
+    @State private var awakeStates: [String: Bool] = [:]
+    @State private var transitioningStates: Set<String> = []
+
     /// Whether the hatch new assistant feature flag is enabled.
     /// Defaults to `true` until the gateway responds. Once the gateway response
     /// arrives, this reflects the value of `feature_flags.hatch-new-assistant.enabled`.
@@ -47,6 +51,7 @@ struct SettingsAccountTab: View {
             platformUrlText = store.platformBaseUrl
             lockfileAssistants = LockfileAssistant.loadAll()
             selectedAssistantId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
+            refreshAwakeStates()
             identity = IdentityInfo.load()
             if identity == nil,
                let assistant = lockfileAssistants.first(where: { $0.assistantId == selectedAssistantId }),
@@ -261,7 +266,7 @@ struct SettingsAccountTab: View {
     private var switchAssistantSection: some View {
         if lockfileAssistants.count > 1 {
             VStack(alignment: .leading, spacing: VSpacing.md) {
-                Text("Switch Assistant")
+                Text("Assistants")
                     .font(VFont.sectionTitle)
                     .foregroundColor(VColor.textPrimary)
 
@@ -276,26 +281,100 @@ struct SettingsAccountTab: View {
                                 .foregroundColor(VColor.textMuted)
                         }
                         Spacer()
+                        if transitioningStates.contains(assistant.assistantId) {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
                         VToggle(isOn: Binding(
-                            get: { assistant.assistantId == selectedAssistantId },
+                            get: { awakeStates[assistant.assistantId] ?? false },
                             set: { isOn in
-                                if isOn { switchToAssistant(assistant) }
+                                toggleAwakeState(assistant: assistant, awake: isOn)
                             }
                         ))
+                        .disabled(toggleDisabled(for: assistant))
                     }
                     .padding(.vertical, VSpacing.xs)
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        if assistant.assistantId != selectedAssistantId {
-                            switchToAssistant(assistant)
+                }
+
+                Divider().background(VColor.surfaceBorder)
+
+                HStack {
+                    Text("Active")
+                        .font(VFont.inputLabel)
+                        .foregroundColor(VColor.textSecondary)
+                    Spacer()
+                    Picker("", selection: $selectedAssistantId) {
+                        ForEach(awakeAssistants, id: \.assistantId) { assistant in
+                            Text(assistant.assistantId).tag(assistant.assistantId)
                         }
                     }
+                    .labelsHidden()
+                    .frame(maxWidth: 200)
                 }
             }
             .padding(VSpacing.lg)
             .frame(maxWidth: .infinity, alignment: .leading)
             .vCard(background: VColor.surfaceSubtle)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .onChange(of: selectedAssistantId) { oldValue, newValue in
+                // Skip if reverting to current or unchanged
+                let currentId = UserDefaults.standard.string(forKey: "connectedAssistantId") ?? ""
+                guard newValue != currentId, newValue != oldValue else { return }
+                guard let assistant = lockfileAssistants.first(where: { $0.assistantId == newValue }) else { return }
+                // Only switch if the selected assistant is awake
+                guard awakeStates[assistant.assistantId] == true else {
+                    selectedAssistantId = currentId
+                    return
+                }
+                switchToAssistant(assistant)
+            }
+        }
+    }
+
+    private var awakeAssistants: [LockfileAssistant] {
+        lockfileAssistants.filter { awakeStates[$0.assistantId] ?? false }
+    }
+
+    private func toggleDisabled(for assistant: LockfileAssistant) -> Bool {
+        // Remote assistants are always awake — can't toggle
+        if assistant.isRemote { return true }
+        // Mid-transition — prevent double-toggle
+        if transitioningStates.contains(assistant.assistantId) { return true }
+        // Can't sleep the currently active assistant
+        if assistant.assistantId == selectedAssistantId && (awakeStates[assistant.assistantId] ?? false) { return true }
+        return false
+    }
+
+    private func refreshAwakeStates() {
+        for assistant in lockfileAssistants {
+            if assistant.isRemote {
+                awakeStates[assistant.assistantId] = true
+            } else {
+                let env: [String: String]? = assistant.instanceDir.map { ["BASE_DATA_DIR": $0] }
+                awakeStates[assistant.assistantId] = DaemonClient.isDaemonProcessAlive(environment: env)
+            }
+        }
+    }
+
+    private func toggleAwakeState(assistant: LockfileAssistant, awake: Bool) {
+        guard !assistant.isRemote else { return }
+        guard let cli = AppDelegate.shared?.assistantCli else { return }
+
+        transitioningStates.insert(assistant.assistantId)
+        Task {
+            do {
+                if awake {
+                    try await cli.wake(name: assistant.assistantId)
+                } else {
+                    try await cli.sleep(name: assistant.assistantId)
+                }
+                awakeStates[assistant.assistantId] = awake
+            } catch {
+                // On failure, re-check actual state
+                let env: [String: String]? = assistant.instanceDir.map { ["BASE_DATA_DIR": $0] }
+                awakeStates[assistant.assistantId] = DaemonClient.isDaemonProcessAlive(environment: env)
+            }
+            transitioningStates.remove(assistant.assistantId)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2288,16 +2288,7 @@ public final class SettingsStore: ObservableObject {
         ingressPublicBaseUrl
     }
 
-<<<<<<< HEAD
-    /// LAN pairing URL for the gateway (port 7830), or nil if no LAN IP available.
-=======
-    /// Bearer token for iOS pairing.
-    var resolvedIosBearerToken: String {
-        readHttpToken() ?? ""
-    }
-
     /// LAN pairing URL for the gateway, or nil if no LAN IP available.
->>>>>>> d1c54ffa8 (fix(macos): use lockfile gateway port instead of hardcoded 7830 (#12781))
     var lanPairingUrl: String? {
         guard let ip = LANIPHelper.currentLANAddress() else { return nil }
         return "http://\(ip):\(LockfilePaths.resolveGatewayPort())"

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -229,8 +229,9 @@ public final class SettingsStore: ObservableObject {
 
     @Published var ingressEnabled: Bool = false
     @Published var ingressPublicBaseUrl: String = ""
-    /// Read-only gateway target derived from daemon config (GATEWAY_PORT env var, default 7830).
-    @Published var localGatewayTarget: String = "http://127.0.0.1:7830"
+    /// Read-only gateway target derived from daemon config.
+    /// Initial value reads env var > lockfile > default 7830; updated by IPC.
+    @Published var localGatewayTarget: String = "http://127.0.0.1:\(LockfilePaths.resolveGatewayPort())"
 
     /// Set to `true` once the first ingress config IPC response arrives, so the
     /// view layer can defer diagnostics until the real config values are available.
@@ -1284,8 +1285,7 @@ public final class SettingsStore: ObservableObject {
             return (httpTransport.baseURL, httpTransport.bearerToken)
         }
         // Local mode: call the gateway directly.
-        let gatewayPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
-            .flatMap(Int.init) ?? 7830
+        let gatewayPort = LockfilePaths.resolveGatewayPort()
         let baseURL = "http://127.0.0.1:\(gatewayPort)"
         let bearerToken = ActorTokenManager.getToken()
         return (baseURL, bearerToken)
@@ -2288,10 +2288,19 @@ public final class SettingsStore: ObservableObject {
         ingressPublicBaseUrl
     }
 
+<<<<<<< HEAD
     /// LAN pairing URL for the gateway (port 7830), or nil if no LAN IP available.
+=======
+    /// Bearer token for iOS pairing.
+    var resolvedIosBearerToken: String {
+        readHttpToken() ?? ""
+    }
+
+    /// LAN pairing URL for the gateway, or nil if no LAN IP available.
+>>>>>>> d1c54ffa8 (fix(macos): use lockfile gateway port instead of hardcoded 7830 (#12781))
     var lanPairingUrl: String? {
         guard let ip = LANIPHelper.currentLANAddress() else { return nil }
-        return "http://\(ip):7830"
+        return "http://\(ip):\(LockfilePaths.resolveGatewayPort())"
     }
 
     // MARK: - Dev Mode Actions

--- a/clients/macos/vellum-assistantTests/LockfileAssistantManagedTests.swift
+++ b/clients/macos/vellum-assistantTests/LockfileAssistantManagedTests.swift
@@ -171,7 +171,10 @@ final class LockfileAssistantManagedTests: XCTestCase {
             region: nil,
             zone: nil,
             instanceId: nil,
-            hatchedAt: "2024-01-01T00:00:00Z"
+            hatchedAt: "2024-01-01T00:00:00Z",
+            gatewayPort: nil,
+            socketPath: nil,
+            instanceDir: nil
         )
         XCTAssertTrue(assistant.isManaged)
     }
@@ -186,7 +189,10 @@ final class LockfileAssistantManagedTests: XCTestCase {
             region: nil,
             zone: nil,
             instanceId: nil,
-            hatchedAt: nil
+            hatchedAt: nil,
+            gatewayPort: nil,
+            socketPath: nil,
+            instanceDir: nil
         )
         XCTAssertFalse(assistant.isManaged)
     }
@@ -201,7 +207,10 @@ final class LockfileAssistantManagedTests: XCTestCase {
             region: nil,
             zone: "us-central1-a",
             instanceId: "inst-1",
-            hatchedAt: nil
+            hatchedAt: nil,
+            gatewayPort: nil,
+            socketPath: nil,
+            instanceDir: nil
         )
         XCTAssertFalse(assistant.isManaged)
     }
@@ -216,7 +225,10 @@ final class LockfileAssistantManagedTests: XCTestCase {
             region: nil,
             zone: nil,
             instanceId: nil,
-            hatchedAt: nil
+            hatchedAt: nil,
+            gatewayPort: nil,
+            socketPath: nil,
+            instanceDir: nil
         )
         XCTAssertTrue(assistant.isManaged, "isManaged should be case-insensitive")
     }
@@ -233,7 +245,10 @@ final class LockfileAssistantManagedTests: XCTestCase {
             region: nil,
             zone: nil,
             instanceId: nil,
-            hatchedAt: nil
+            hatchedAt: nil,
+            gatewayPort: nil,
+            socketPath: nil,
+            instanceDir: nil
         )
         XCTAssertFalse(assistant.isRemote)
     }
@@ -248,7 +263,10 @@ final class LockfileAssistantManagedTests: XCTestCase {
             region: nil,
             zone: nil,
             instanceId: nil,
-            hatchedAt: nil
+            hatchedAt: nil,
+            gatewayPort: nil,
+            socketPath: nil,
+            instanceDir: nil
         )
         XCTAssertTrue(assistant.isRemote)
     }
@@ -263,7 +281,10 @@ final class LockfileAssistantManagedTests: XCTestCase {
             region: nil,
             zone: nil,
             instanceId: nil,
-            hatchedAt: nil
+            hatchedAt: nil,
+            gatewayPort: nil,
+            socketPath: nil,
+            instanceDir: nil
         )
         XCTAssertTrue(assistant.isRemote)
     }
@@ -280,7 +301,10 @@ final class LockfileAssistantManagedTests: XCTestCase {
             region: nil,
             zone: nil,
             instanceId: nil,
-            hatchedAt: nil
+            hatchedAt: nil,
+            gatewayPort: nil,
+            socketPath: nil,
+            instanceDir: nil
         )
         if case .vellum(let runtimeUrl) = assistant.home {
             XCTAssertEqual(runtimeUrl, "https://platform.vellum.ai")

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -33,20 +33,13 @@ func resolveSocketPath(environment: [String: String]? = nil) -> String {
         let trimmed = envPath.trimmingCharacters(in: .whitespacesAndNewlines)
         return expandHomePath(trimmed)
     }
-    if let baseDir = env["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines), !baseDir.isEmpty {
-        return expandHomePath(baseDir) + "/.vellum/vellum.sock"
-    }
-    return NSHomeDirectory() + "/.vellum/vellum.sock"
+    return resolveVellumDir(environment: environment) + "/vellum.sock"
 }
 
 /// Resolve the daemon session token path.
 /// Uses BASE_DATA_DIR when set to match daemon root resolution.
 func resolveSessionTokenPath(environment: [String: String]? = nil) -> String {
-    let env = environment ?? ProcessInfo.processInfo.environment
-    if let baseDir = env["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines), !baseDir.isEmpty {
-        return expandHomePath(baseDir) + "/.vellum/session-token"
-    }
-    return NSHomeDirectory() + "/.vellum/session-token"
+    return resolveVellumDir(environment: environment) + "/session-token"
 }
 
 /// Read the daemon session token from disk.
@@ -76,7 +69,40 @@ public func resolveVellumDir(environment: [String: String]? = nil) -> String {
         let resolved = baseDir == "~" ? NSHomeDirectory() : (baseDir.hasPrefix("~/") ? NSHomeDirectory() + "/" + String(baseDir.dropFirst(2)) : baseDir)
         return resolved + "/.vellum"
     }
+    // Check the lockfile for instance-specific directory (multi-instance support)
+    if let instanceDir = resolveInstanceDirFromLockfile() {
+        return instanceDir + "/.vellum"
+    }
     return NSHomeDirectory() + "/.vellum"
+}
+
+/// Read the instanceDir from the latest lockfile entry's resources.
+private func resolveInstanceDirFromLockfile() -> String? {
+    guard let json = LockfilePaths.read(),
+          let assistants = json["assistants"] as? [[String: Any]],
+          !assistants.isEmpty else {
+        return nil
+    }
+    // Find the most recently hatched entry
+    let sorted = assistants.sorted { a, b in
+        let dateA = a["hatchedAt"] as? String ?? ""
+        let dateB = b["hatchedAt"] as? String ?? ""
+        return dateA > dateB
+    }
+    guard let latest = sorted.first,
+          let resources = latest["resources"] as? [String: Any],
+          let instanceDir = resources["instanceDir"] as? String,
+          !instanceDir.isEmpty else {
+        return nil
+    }
+    return instanceDir
+}
+
+/// Resolve the runtime HTTP bearer token path.
+/// Uses BASE_DATA_DIR when set to match daemon root resolution.
+/// Available on all platforms since HTTP transport is used on both macOS and iOS.
+public func resolveHttpTokenPath(environment: [String: String]? = nil) -> String {
+    return resolveVellumDir(environment: environment) + "/http-token"
 }
 
 /// Resolve the feature-flag bearer token path.

--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -97,6 +97,10 @@ public struct DaemonConfig {
     /// Defaults to `.defaultLocal` which preserves existing behavior.
     public let transportMetadata: TransportMetadata
 
+    /// Instance directory for multi-instance support (e.g. `~/.vellum/instances/alice`).
+    /// When set, token resolution uses this directory instead of the lockfile's latest entry.
+    public let instanceDir: String?
+
     /// Feature-flag bearer token for authenticating PATCH /v1/feature-flags/:flagKey requests.
     /// On macOS this is read from `~/.vellum/feature-flag-token`.
     /// On iOS this is received during QR pairing and stored in the Keychain.
@@ -115,10 +119,11 @@ public struct DaemonConfig {
     }
 
     /// Convenience initializer for socket transport (backwards compatible).
-    public init(socketPath: String) {
+    public init(socketPath: String, instanceDir: String? = nil) {
         self.transport = .socket(path: socketPath)
         self.transportMetadata = .defaultLocal
-        self.featureFlagToken = readFeatureFlagToken()
+        self.instanceDir = instanceDir
+        self.featureFlagToken = instanceDir.map { readFeatureFlagToken(environment: ["BASE_DATA_DIR": $0]) } ?? readFeatureFlagToken()
     }
 
     public static var `default`: DaemonConfig {
@@ -126,9 +131,10 @@ public struct DaemonConfig {
     }
     #endif
 
-    public init(transport: Transport, transportMetadata: TransportMetadata = .defaultLocal, featureFlagToken: String? = nil) {
+    public init(transport: Transport, transportMetadata: TransportMetadata = .defaultLocal, instanceDir: String? = nil, featureFlagToken: String? = nil) {
         self.transport = transport
         self.transportMetadata = transportMetadata
+        self.instanceDir = instanceDir
         #if os(macOS)
         self.featureFlagToken = featureFlagToken ?? readFeatureFlagToken()
         #else

--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -33,7 +33,7 @@ extension DaemonClient {
         // started after a previous bootstrap carry the persisted JWT.
         if case .http(let baseURL, let bearerToken, let conversationKey) = config.transport {
             let tokenEnv = config.instanceDir.map { ["BASE_DATA_DIR": $0] }
-            let resolvedToken = bearerToken ?? readHttpToken(environment: tokenEnv)
+            let resolvedToken = bearerToken ?? (try? String(contentsOfFile: resolveHttpTokenPath(environment: tokenEnv), encoding: .utf8)).map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             try await connectHTTP(baseURL: baseURL, bearerToken: resolvedToken, conversationKey: conversationKey)
             return
         }

--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -32,8 +32,8 @@ extension DaemonClient {
         // Resolve lazily from ActorTokenManager (Keychain) so connections
         // started after a previous bootstrap carry the persisted JWT.
         if case .http(let baseURL, let bearerToken, let conversationKey) = config.transport {
-            let resolvedToken = bearerToken
-                ?? ActorTokenManager.getToken().flatMap { $0.isEmpty ? nil : $0 }
+            let tokenEnv = config.instanceDir.map { ["BASE_DATA_DIR": $0] }
+            let resolvedToken = bearerToken ?? readHttpToken(environment: tokenEnv)
             try await connectHTTP(baseURL: baseURL, bearerToken: resolvedToken, conversationKey: conversationKey)
             return
         }
@@ -197,12 +197,14 @@ extension DaemonClient {
 
     #if os(macOS)
     func authenticate() async throws {
-        // Try session-token file first, then fall back to transport's configured authToken
+        // Try session-token file first, then fall back to transport's configured authToken.
+        // Use the config's instanceDir so multi-instance switches read the correct token.
+        let tokenEnv = config.instanceDir.map { ["BASE_DATA_DIR": $0] }
         let transportToken: String? = {
             if case .tcp(_, _, _, let t) = config.transport { return t }
             return nil
         }()
-        guard let token = readSessionToken() ?? transportToken else {
+        guard let token = readSessionToken(environment: tokenEnv) ?? transportToken else {
             throw AuthError.missingToken
         }
 

--- a/clients/shared/Utilities/LockfilePaths.swift
+++ b/clients/shared/Utilities/LockfilePaths.swift
@@ -31,4 +31,23 @@ public enum LockfilePaths {
         }
         return nil
     }
+
+    /// Resolve the local gateway port: env var > lockfile > default 7830.
+    public static func resolveGatewayPort() -> Int {
+        if let envPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
+            ?? getenv("GATEWAY_PORT").flatMap({ String(cString: $0) }),
+           let port = Int(envPort) {
+            return port
+        }
+        if let json = read(),
+           let assistants = json["assistants"] as? [[String: Any]],
+           let latest = assistants.max(by: {
+               ($0["hatchedAt"] as? String ?? "") < ($1["hatchedAt"] as? String ?? "")
+           }),
+           let resources = latest["resources"] as? [String: Any],
+           let port = resources["gatewayPort"] as? Int {
+            return port
+        }
+        return 7830
+    }
 }

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -132,6 +132,10 @@ export async function loadConfig(): Promise<GatewayConfig> {
   const telegramApiBaseUrl =
     process.env.TELEGRAM_API_BASE_URL || "https://api.telegram.org";
 
+  // Port-based routing: each gateway instance reads RUNTIME_HTTP_PORT to
+  // discover its co-located daemon's HTTP port. In multi-instance setups,
+  // the CLI passes a per-instance daemon port so each gateway proxies to
+  // the correct daemon process (see cli/src/lib/local.ts startGateway).
   const runtimePort = process.env.RUNTIME_HTTP_PORT || "7821";
   const assistantRuntimeBaseUrl =
     process.env.ASSISTANT_RUNTIME_BASE_URL || `http://localhost:${runtimePort}`;


### PR DESCRIPTION
## Summary
Adds support for running multiple local assistant instances side-by-side, each with isolated data directories, ports, sockets, and Qdrant databases. Users can switch between instances with `vellum use <name>`.

## Changes
- **M1 (#12615)**: Instance isolation contract — `LocalInstanceResources` type, `allocateLocalResources()`, per-instance ports/paths in `local.ts`
- **M2 (#12630)**: Qdrant isolation — `QDRANT_HTTP_PORT` env var for per-instance Qdrant without triggering external mode
- **M3 (#12635)**: Wire into hatch — `hatchLocal()` calls `allocateLocalResources()` and saves resources to lockfile
- **M4 (#12639)**: Active-assistant targeting — `vellum use <name>`, `resolveTargetAssistant()`, updated wake/sleep/ps/client
- **M5 (#12644)**: Instance-scoped retire — `retireLocal()` uses instance resources for PID/socket/data paths
- **M6 (#12650)**: Identity/routing verification — documented multi-instance invariants (single-tenant daemon, port-based gateway routing)
- **M7 (#12652)**: Regression tests — 15 tests for resource allocation, target resolution, lockfile persistence, remote non-regression
- **M8 (#12661)**: Architecture docs — instance directory layout, isolation model, port allocation, active assistant targeting

## Milestone PRs (merged into feature branch)
- #12615: M1: Instance isolation contract
- #12630: M2: Qdrant isolation
- #12635: M3: Wire into hatch
- #12639: M4: Active-assistant targeting model
- #12644: M5: Instance-scoped retire
- #12650: M6: Identity/routing verification
- #12652: M7: Regression tests
- #12661: M8: Architecture docs

## Project issue
Closes #12604

## Test plan
- [ ] `vellum hatch --name alice` creates instance under `~/.vellum/instances/alice/`
- [ ] `vellum hatch --name bob` creates second instance with different ports
- [ ] `vellum use alice` sets active assistant
- [ ] `vellum wake` starts alice's processes
- [ ] `vellum sleep` stops only alice's processes
- [ ] `vellum ps` shows active indicator for alice
- [ ] `vellum client` connects to alice
- [ ] `vellum retire alice` stops and archives only alice
- [ ] Remote assistants unaffected by multi-local features

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
