### PR TITLE
fix: replace 'daemon' with 'assistant' in user-facing disconnected status

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegateTypes.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegateTypes.swift
@@ -11,7 +11,7 @@ enum AssistantStatus {
         case .idle: return "Assistant is idle"
         case .thinking: return "Assistant is thinking..."
         case .error(let msg): return "Error: \(msg)"
-        case .disconnected: return "Disconnected from daemon"
+        case .disconnected: return "Disconnected from assistant"
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes user-facing menu string `"Disconnected from daemon"` → `"Disconnected from assistant"` in `AppDelegateTypes.swift`
- Pre-existing violation of AGENTS.md terminology rule that was carried forward during the AppDelegate refactor

Addresses review feedback on https://github.com/vellum-ai/vellum-assistant/pull/12646

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
