### PR TITLE
fix: persist org ID and fix managed proxy healthz path

### DIFF
--- a/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/ManagedAssistantBootstrapService.swift
@@ -63,6 +63,7 @@ public final class ManagedAssistantBootstrapService {
                 throw ManagedBootstrapError.serverError(statusCode: 0, detail: "No organizations found for this account")
             }
             organizationId = firstOrg.id
+            UserDefaults.standard.set(organizationId, forKey: "connectedOrganizationId")
             log.info("Resolved organization: \(organizationId, privacy: .public)")
         } catch let error as PlatformAPIError {
             throw mapPlatformError(error)

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -254,17 +254,14 @@ public final class HTTPTransport {
     }
 
     /// Builds paths for the platform assistant proxy layout
-    /// (e.g. /v1/assistants/{id}/health, /v1/assistants/{id}/messages/).
+    /// (e.g. /v1/assistants/{id}/healthz/, /v1/assistants/{id}/messages/).
     /// Trailing slashes match the Django URL convention.
     private func buildPlatformProxyPath(for endpoint: Endpoint, assistantId: String) -> (path: String, query: String?) {
         let prefix = "/v1/assistants/\(assistantId)"
 
         switch endpoint {
         case .healthz:
-            // Use /health (no trailing slash) so the gateway proxy rewrites to
-            // /v1/health, which the runtime serves. /healthz is a root-level
-            // endpoint that doesn't exist under /v1/.
-            return ("\(prefix)/health", nil)
+            return ("\(prefix)/healthz/", nil)
         case .events(let conversationKey):
             let encoded = conversationKey.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? conversationKey
             return ("\(prefix)/events/", "conversationKey=\(encoded)")
@@ -1697,6 +1694,9 @@ public final class HTTPTransport {
         case .sessionToken:
             if let token = SessionTokenManager.getToken() {
                 request.setValue(token, forHTTPHeaderField: "X-Session-Token")
+            }
+            if let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
+                request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
             }
         }
     }


### PR DESCRIPTION
## Summary
- Persist the resolved organization ID to UserDefaults during managed bootstrap so it's available for subsequent API calls
- Attach `Vellum-Organization-Id` header on all session-token-authenticated platform requests
- Fix the healthz proxy path from `/health` (no trailing slash) to `/healthz/` to match the platform's Django URL convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12670" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
