### PR TITLE
fix: use dynamic simulator destination in iOS build script

### DIFF
--- a/clients/ios/build.sh
+++ b/clients/ios/build.sh
@@ -85,13 +85,30 @@ else
     exit 1
 fi
 
+# ── Resolve simulator destination ────────────────────────────────────
+# Finds the first available iPhone simulator instead of hardcoding a
+# device name that may not exist on every Xcode version.
+resolve_simulator_destination() {
+    local sim_name
+    sim_name=$(xcrun simctl list devices available 2>/dev/null \
+        | grep -oE 'iPhone [^(]+' \
+        | head -1 \
+        | sed 's/[[:space:]]*$//')
+    if [ -n "$sim_name" ]; then
+        echo "platform=iOS Simulator,name=$sim_name"
+    else
+        echo "generic/platform=iOS Simulator"
+    fi
+}
+
 # ── Run command ───────────────────────────────────────────────────────
 if [ "$CMD" = "test" ]; then
-    echo "Running iOS tests..."
+    SIM_DEST=$(resolve_simulator_destination)
+    echo "Running iOS tests (destination: $SIM_DEST)..."
     xcodebuild test \
         -project "$PROJECT" \
         -scheme "$SCHEME" \
-        -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+        -destination "$SIM_DEST" \
         -configuration Debug \
         CODE_SIGNING_ALLOWED=NO
     exit $?
@@ -105,7 +122,7 @@ if [ "$CMD" = "build" ]; then
     xcodebuild build \
         -project "$PROJECT" \
         -scheme "$SCHEME" \
-        -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+        -destination 'generic/platform=iOS Simulator' \
         -configuration Debug \
         CODE_SIGNING_ALLOWED=NO \
         -derivedDataPath "$DIST_DIR/DerivedData" \


### PR DESCRIPTION
## Summary
- The iOS CI build fails because Xcode 26.2 doesn't ship with an "iPhone 16 Pro" simulator
- For debug builds: use `generic/platform=iOS Simulator` (just compiles, no specific runtime needed)
- For tests: dynamically resolve the first available iPhone simulator via `xcrun simctl list`

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22696738837/job/65804727164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
