### PR TITLE
memory: sanitize pending conflict question text for non-user-facing storage

### DIFF
--- a/assistant/src/__tests__/contradiction-checker.test.ts
+++ b/assistant/src/__tests__/contradiction-checker.test.ts
@@ -201,7 +201,11 @@ describe("checkContradictions", () => {
     expect(conflicts[0].existingItemId).toBe("item-existing-ambiguous");
     expect(conflicts[0].candidateItemId).toBe("item-candidate-ambiguous");
     expect(conflicts[0].relationship).toBe("ambiguous_contradiction");
-    expect(conflicts[0].clarificationQuestion).toContain(
+    expect(conflicts[0].clarificationQuestion).toContain("Pending conflict:");
+    expect(conflicts[0].clarificationQuestion).not.toContain(
+      "I have conflicting notes",
+    );
+    expect(conflicts[0].clarificationQuestion).not.toContain(
       "Which one is correct?",
     );
   });

--- a/assistant/src/memory/contradiction-checker.ts
+++ b/assistant/src/memory/contradiction-checker.ts
@@ -502,7 +502,7 @@ function buildClarificationQuestion(
 ): string {
   const normalize = (input: string): string =>
     truncate(input.replace(/\s+/g, " ").trim(), 180, "");
-  return `I have conflicting notes: "${normalize(
+  return `Pending conflict: "${normalize(
     existingStatement,
-  )}" vs "${normalize(candidateStatement)}". Which one is correct?`;
+  )}" vs "${normalize(candidateStatement)}"`;
 }


### PR DESCRIPTION
## Summary
- Replace first-person question phrasing in buildClarificationQuestion() with neutral internal wording
- Keep truncation/normalization behavior unchanged
- Update tests to assert generated text no longer contains conversational phrasing

Part of plan: no-user-facing-conflict-prompts.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
