### PR TITLE
memory: add policy helper for user-evidenced conflicts

### DIFF
--- a/assistant/src/__tests__/conflict-policy.test.ts
+++ b/assistant/src/__tests__/conflict-policy.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, test } from "bun:test";
 import {
   isConflictKindEligible,
   isConflictKindPairEligible,
+  isConflictUserEvidenced,
   isDurableInstructionStatement,
   isStatementConflictEligible,
   isTransientTrackingStatement,
+  isUserEvidencedVerificationState,
 } from "../memory/conflict-policy.js";
 
 describe("conflict-policy", () => {
@@ -188,6 +190,80 @@ describe("conflict-policy", () => {
       expect(
         isStatementConflictEligible("fact", "User works at Acme Corp"),
       ).toBe(true);
+    });
+  });
+
+  describe("isUserEvidencedVerificationState", () => {
+    test("accepts user_reported", () => {
+      expect(isUserEvidencedVerificationState("user_reported")).toBe(true);
+    });
+
+    test("accepts user_confirmed", () => {
+      expect(isUserEvidencedVerificationState("user_confirmed")).toBe(true);
+    });
+
+    test("accepts legacy_import", () => {
+      expect(isUserEvidencedVerificationState("legacy_import")).toBe(true);
+    });
+
+    test("rejects assistant_inferred", () => {
+      expect(isUserEvidencedVerificationState("assistant_inferred")).toBe(
+        false,
+      );
+    });
+
+    test("rejects unknown states", () => {
+      expect(isUserEvidencedVerificationState("")).toBe(false);
+      expect(isUserEvidencedVerificationState("auto_detected")).toBe(false);
+      expect(isUserEvidencedVerificationState("pending")).toBe(false);
+    });
+  });
+
+  describe("isConflictUserEvidenced", () => {
+    test("returns true when existing side is user-evidenced", () => {
+      expect(
+        isConflictUserEvidenced("user_reported", "assistant_inferred"),
+      ).toBe(true);
+      expect(
+        isConflictUserEvidenced("user_confirmed", "assistant_inferred"),
+      ).toBe(true);
+      expect(
+        isConflictUserEvidenced("legacy_import", "assistant_inferred"),
+      ).toBe(true);
+    });
+
+    test("returns true when candidate side is user-evidenced", () => {
+      expect(
+        isConflictUserEvidenced("assistant_inferred", "user_reported"),
+      ).toBe(true);
+      expect(
+        isConflictUserEvidenced("assistant_inferred", "user_confirmed"),
+      ).toBe(true);
+      expect(
+        isConflictUserEvidenced("assistant_inferred", "legacy_import"),
+      ).toBe(true);
+    });
+
+    test("returns true when both sides are user-evidenced", () => {
+      expect(isConflictUserEvidenced("user_reported", "user_confirmed")).toBe(
+        true,
+      );
+      expect(isConflictUserEvidenced("legacy_import", "user_reported")).toBe(
+        true,
+      );
+    });
+
+    test("returns false when neither side is user-evidenced", () => {
+      expect(
+        isConflictUserEvidenced("assistant_inferred", "assistant_inferred"),
+      ).toBe(false);
+    });
+
+    test("returns false for unknown states on both sides", () => {
+      expect(isConflictUserEvidenced("auto_detected", "pending")).toBe(false);
+      expect(
+        isConflictUserEvidenced("assistant_inferred", "auto_detected"),
+      ).toBe(false);
     });
   });
 });

--- a/assistant/src/memory/conflict-policy.ts
+++ b/assistant/src/memory/conflict-policy.ts
@@ -71,6 +71,40 @@ export function isDurableInstructionStatement(statement: string): boolean {
   return DURABLE_INSTRUCTION_CUES.test(statement);
 }
 
+// ── Verification-state provenance ──────────────────────────────────────
+
+// States indicating user involvement — either the user directly stated
+// the information, explicitly confirmed it, or it was bulk-imported from
+// a trusted external source the user chose to connect.
+const USER_EVIDENCED_STATES = new Set([
+  "user_reported",
+  "user_confirmed",
+  "legacy_import",
+]);
+
+/**
+ * Returns true when the verification state indicates user provenance
+ * (as opposed to purely assistant-inferred).
+ */
+export function isUserEvidencedVerificationState(state: string): boolean {
+  return USER_EVIDENCED_STATES.has(state);
+}
+
+/**
+ * Returns true when at least one side of a conflict pair has user-evidenced
+ * provenance. Assistant-inferred-only conflicts should not escalate into
+ * user-facing behavior.
+ */
+export function isConflictUserEvidenced(
+  existingState: string,
+  candidateState: string,
+): boolean {
+  return (
+    isUserEvidencedVerificationState(existingState) ||
+    isUserEvidencedVerificationState(candidateState)
+  );
+}
+
 /**
  * Returns true when a statement of the given kind is eligible to participate
  * in conflict detection at the statement level. This combines kind eligibility


### PR DESCRIPTION
## Summary
- Add isUserEvidencedVerificationState() helper for user_reported, user_confirmed, legacy_import states
- Add isConflictUserEvidenced() helper requiring at least one side to be user-evidenced
- Add comprehensive unit tests covering all verification-state combinations

Part of plan: no-user-facing-conflict-prompts.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
