### PR TITLE
memory: include verification state in pending conflict detail query

### DIFF
--- a/assistant/src/__tests__/conflict-store.test.ts
+++ b/assistant/src/__tests__/conflict-store.test.ts
@@ -60,6 +60,10 @@ function resetTables() {
 function insertItemPair(
   suffix: string,
   scopeId = "default",
+  opts?: {
+    existingVerificationState?: string;
+    candidateVerificationState?: string;
+  },
 ): { existingItemId: string; candidateItemId: string } {
   const db = getDb();
   const now = Date.now();
@@ -76,7 +80,8 @@ function insertItemPair(
         confidence: 0.8,
         importance: 0.5,
         fingerprint: `fp-existing-${suffix}`,
-        verificationState: "assistant_inferred",
+        verificationState:
+          opts?.existingVerificationState ?? "assistant_inferred",
         scopeId,
         firstSeenAt: now,
         lastSeenAt: now,
@@ -90,7 +95,8 @@ function insertItemPair(
         confidence: 0.8,
         importance: 0.5,
         fingerprint: `fp-candidate-${suffix}`,
-        verificationState: "assistant_inferred",
+        verificationState:
+          opts?.candidateVerificationState ?? "assistant_inferred",
         scopeId,
         firstSeenAt: now,
         lastSeenAt: now,
@@ -234,8 +240,11 @@ describe("conflict-store", () => {
     expect(updated?.updatedAt).toBe(askedAt);
   });
 
-  test("listPendingConflictDetails joins current statements", () => {
-    const pair = insertItemPair("details", "workspace-a");
+  test("listPendingConflictDetails joins current statements and verification states", () => {
+    const pair = insertItemPair("details", "workspace-a", {
+      existingVerificationState: "user_confirmed",
+      candidateVerificationState: "assistant_inferred",
+    });
     createOrUpdatePendingConflict({
       scopeId: "workspace-a",
       existingItemId: pair.existingItemId,
@@ -250,6 +259,8 @@ describe("conflict-store", () => {
     expect(details[0].candidateStatement).toBe("Candidate statement details");
     expect(details[0].existingKind).toBe("fact");
     expect(details[0].candidateKind).toBe("fact");
+    expect(details[0].existingVerificationState).toBe("user_confirmed");
+    expect(details[0].candidateVerificationState).toBe("assistant_inferred");
   });
 
   test("applyConflictResolution keeps candidate and resolves conflict row", () => {

--- a/assistant/src/memory/conflict-store.ts
+++ b/assistant/src/memory/conflict-store.ts
@@ -57,6 +57,8 @@ export interface PendingConflictDetail extends MemoryItemConflict {
   candidateStatement: string;
   existingKind: string;
   candidateKind: string;
+  existingVerificationState: string;
+  candidateVerificationState: string;
 }
 
 export type ConflictResolutionAction =
@@ -210,6 +212,8 @@ export function listPendingConflictDetails(
     candidate_statement: string;
     existing_kind: string;
     candidate_kind: string;
+    existing_verification_state: string;
+    candidate_verification_state: string;
   }
   const cursorClause = cursor
     ? `AND (c.created_at > ? OR (c.created_at = ? AND c.id > ?))`
@@ -235,7 +239,9 @@ export function listPendingConflictDetails(
       existing_item.statement AS existing_statement,
       candidate_item.statement AS candidate_statement,
       existing_item.kind AS existing_kind,
-      candidate_item.kind AS candidate_kind
+      candidate_item.kind AS candidate_kind,
+      existing_item.verification_state AS existing_verification_state,
+      candidate_item.verification_state AS candidate_verification_state
     FROM memory_item_conflicts c
     INNER JOIN memory_items existing_item ON existing_item.id = c.existing_item_id
     INNER JOIN memory_items candidate_item ON candidate_item.id = c.candidate_item_id
@@ -265,6 +271,8 @@ export function listPendingConflictDetails(
     candidateStatement: row.candidate_statement,
     existingKind: row.existing_kind,
     candidateKind: row.candidate_kind,
+    existingVerificationState: row.existing_verification_state,
+    candidateVerificationState: row.candidate_verification_state,
   }));
 }
 


### PR DESCRIPTION
## Summary
- Extend PendingConflictDetail with existingVerificationState and candidateVerificationState fields
- Update listPendingConflictDetails SQL query to join verification_state from both existing and candidate items
- Update unit tests to assert both verification-state fields are present and correct

Part of plan: no-user-facing-conflict-prompts.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
