### PR TITLE
daemon: remove memory conflict prompt emission and injection plumbing

### DIFF
--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -189,9 +189,7 @@ mock.module("../daemon/session-memory.js", () => ({
       latencyMs: 0,
     },
     dynamicProfile: { text: "" },
-    softConflictInstruction: null,
     recallInjectionStrategy: "prepend_user_block" as const,
-    conflictClarification: null,
   }),
 }));
 

--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -333,13 +333,12 @@ describe("applyRuntimeInjections with channelCapabilities", () => {
     };
 
     const result = applyRuntimeInjections(baseMessages, {
-      softConflictInstruction: "What is your name?",
       channelCapabilities: caps,
     });
 
     expect(result.length).toBe(1);
-    // softConflictInstruction appends, channelCapabilities prepends
-    expect(result[0].content.length).toBe(3);
+    // channelCapabilities prepends
+    expect(result[0].content.length).toBe(2);
   });
 });
 

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -453,50 +453,7 @@ export async function runAgentLoopImpl(
       onEvent,
     );
 
-    if (memoryResult.conflictClarification) {
-      const loopChannelMeta = {
-        ...provenanceFromTrustContext(ctx.trustContext),
-        userMessageChannel: capturedTurnChannelContext.userMessageChannel,
-        assistantMessageChannel:
-          capturedTurnChannelContext.assistantMessageChannel,
-        userMessageInterface: capturedTurnInterfaceContext.userMessageInterface,
-        assistantMessageInterface:
-          capturedTurnInterfaceContext.assistantMessageInterface,
-      };
-      const assistantMessage = createAssistantMessage(
-        memoryResult.conflictClarification,
-      );
-      await conversationStore.addMessage(
-        ctx.conversationId,
-        "assistant",
-        JSON.stringify(assistantMessage.content),
-        loopChannelMeta,
-      );
-      ctx.messages.push(assistantMessage);
-      onEvent({
-        type: "assistant_text_delta",
-        text: memoryResult.conflictClarification,
-        sessionId: ctx.conversationId,
-      });
-      ctx.traceEmitter.emit(
-        "message_complete",
-        "Conflict clarification requested (relevant)",
-        {
-          requestId: reqId,
-          status: "info",
-          attributes: { conflictGate: "relevant" },
-        },
-      );
-      onEvent({ type: "message_complete", sessionId: ctx.conversationId });
-      return;
-    }
-
-    const {
-      recall,
-      dynamicProfile,
-      softConflictInstruction,
-      recallInjectionStrategy,
-    } = memoryResult;
+    const { recall, dynamicProfile, recallInjectionStrategy } = memoryResult;
     runMessages = memoryResult.runMessages;
 
     // Build active surface context
@@ -585,7 +542,6 @@ export async function runAgentLoopImpl(
 
     // Shared injection options — reused whenever we need to re-inject after reduction.
     const injectionOpts = {
-      softConflictInstruction,
       activeSurface,
       workspaceTopLevelContext: ctx.workspaceTopLevelContext,
       channelCapabilities: ctx.channelCapabilities ?? null,

--- a/assistant/src/daemon/session-memory.ts
+++ b/assistant/src/daemon/session-memory.ts
@@ -24,7 +24,6 @@ export interface MemoryRecallResult {
   runMessages: Message[];
   recall: Awaited<ReturnType<typeof buildMemoryRecall>>;
   dynamicProfile: { text: string };
-  softConflictInstruction: string | null;
   recallInjectionStrategy: RecallInjectionStrategy;
 }
 
@@ -37,7 +36,7 @@ export interface MemoryPrepareContext {
   scopeId: string;
   includeDefaultFallback: boolean;
   trustClass: "guardian" | "trusted_contact" | "unknown";
-  /** When false (e.g. scheduled tasks), skip conflict clarification prompts. */
+  /** When false (e.g. scheduled tasks), skip conflict gate evaluation. */
   isInteractive?: boolean;
 }
 
@@ -64,7 +63,7 @@ export async function prepareMemoryContext(
   userMessageId: string,
   abortSignal: AbortSignal,
   onEvent: (msg: ServerMessage) => void,
-): Promise<MemoryRecallResult & { conflictClarification: string | null }> {
+): Promise<MemoryRecallResult> {
   // Provenance-based trust gating: untrusted actors skip all memory operations
   // (recall, dynamic profile, conflict gate) to prevent untrusted content from
   // influencing memory-augmented responses.
@@ -94,9 +93,7 @@ export async function prepareMemoryContext(
         topCandidates: [],
       } as Awaited<ReturnType<typeof buildMemoryRecall>>,
       dynamicProfile: { text: "" },
-      softConflictInstruction: null,
       recallInjectionStrategy: "prepend_user_block",
-      conflictClarification: null,
     };
   }
 
@@ -129,64 +126,24 @@ export async function prepareMemoryContext(
         topCandidates: [],
       } as Awaited<ReturnType<typeof buildMemoryRecall>>,
       dynamicProfile: { text: "" },
-      softConflictInstruction: null,
       recallInjectionStrategy: "prepend_user_block",
-      conflictClarification: null,
     };
   }
 
   const runtimeConfig = getConfig();
   const memoryEnabled = runtimeConfig.memory?.enabled !== false;
 
-  // Conflict gate — skip entirely for non-interactive sessions (scheduled tasks,
-  // work items) since there is no human to answer the clarification question.
+  // Conflict gate — evaluate for side effects (background resolution/dismissal)
+  // but do not return any user-facing payload. Non-interactive sessions skip
+  // entirely since there is no human context for conflict evaluation.
   const isInteractive = ctx.isInteractive !== false;
   const conflictConfig =
     memoryEnabled && isInteractive
       ? runtimeConfig.memory?.conflicts
       : undefined;
-  const conflictGateResult = conflictConfig
-    ? await ctx.conflictGate.evaluate(content, conflictConfig, ctx.scopeId)
-    : null;
-
-  if (conflictGateResult?.relevant) {
-    return {
-      runMessages: ctx.messages,
-      recall: {
-        enabled: false,
-        degraded: false,
-        injectedText: "",
-        lexicalHits: 0,
-        semanticHits: 0,
-        recencyHits: 0,
-        entityHits: 0,
-        relationSeedEntityCount: 0,
-        relationTraversedEdgeCount: 0,
-        relationNeighborEntityCount: 0,
-        relationExpandedItemCount: 0,
-        earlyTerminated: false,
-        mergedCount: 0,
-        selectedCount: 0,
-        rerankApplied: false,
-        injectedTokens: 0,
-        latencyMs: 0,
-        topCandidates: [],
-      } as Awaited<ReturnType<typeof buildMemoryRecall>>,
-      dynamicProfile: { text: "" },
-      softConflictInstruction: null,
-      recallInjectionStrategy: "prepend_user_block",
-      conflictClarification: [
-        conflictGateResult.question,
-        "",
-        "I need this clarification before I can give guidance that depends on that preference.",
-      ].join("\n"),
-    };
+  if (conflictConfig) {
+    await ctx.conflictGate.evaluate(content, conflictConfig, ctx.scopeId);
   }
-
-  const softConflictInstruction =
-    conflictGateResult && !conflictGateResult.relevant
-      ? conflictGateResult.question
-      : null;
 
   // Dynamic profile
   const profileConfig = memoryEnabled
@@ -312,8 +269,6 @@ export async function prepareMemoryContext(
     runMessages,
     recall,
     dynamicProfile,
-    softConflictInstruction,
     recallInjectionStrategy,
-    conflictClarification: null,
   };
 }

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -392,24 +392,6 @@ export interface ActiveSurfaceContext {
   appFiles?: string[];
 }
 
-/**
- * Append a memory-conflict clarification instruction to the last user message.
- */
-export function injectClarificationRequestIntoUserMessage(
-  message: Message,
-  question: string,
-): Message {
-  const instruction = [
-    "[Memory clarification request]",
-    `Ask this once in your response: ${question}`,
-    "After asking, continue helping with the current request.",
-  ].join("\n");
-  return {
-    ...message,
-    content: [...message.content, { type: "text", text: `\n\n${instruction}` }],
-  };
-}
-
 const MAX_CONTEXT_LENGTH = 100_000;
 
 function truncateHtml(html: string, budget: number): string {
@@ -1050,9 +1032,9 @@ export function stripInjectedContext(
  * - `'full'` (default): all injections are applied.
  * - `'minimal'`: only safety-critical context is injected (channel turn,
  *   interface turn, inbound actor, non-interactive marker, voice call
- *   control, channel capabilities, soft conflict). High-token optional
- *   blocks (workspace top-level, temporal, channel command, active surface)
- *   are skipped to reduce context pressure.
+ *   control, channel capabilities). High-token optional blocks (workspace
+ *   top-level, temporal, channel command, active surface) are skipped to
+ *   reduce context pressure.
  */
 export type InjectionMode = "full" | "minimal";
 
@@ -1065,7 +1047,6 @@ export type InjectionMode = "full" | "minimal";
 export function applyRuntimeInjections(
   runMessages: Message[],
   options: {
-    softConflictInstruction?: string | null;
     activeSurface?: ActiveSurfaceContext | null;
     workspaceTopLevelContext?: string | null;
     channelCapabilities?: ChannelCapabilities | null;
@@ -1109,19 +1090,6 @@ export function applyRuntimeInjections(
       result = [
         ...result.slice(0, -1),
         injectVoiceCallControlContext(userTail, options.voiceCallControlPrompt),
-      ];
-    }
-  }
-
-  if (options.softConflictInstruction) {
-    const userTail = result[result.length - 1];
-    if (userTail && userTail.role === "user") {
-      result = [
-        ...result.slice(0, -1),
-        injectClarificationRequestIntoUserMessage(
-          userTail,
-          options.softConflictInstruction,
-        ),
       ];
     }
   }


### PR DESCRIPTION
## Summary
- Remove user-facing conflict clarification payload returns from session-memory.ts
- Delete early-return branch in session-agent-loop.ts that emitted conflict clarification as assistant response
- Remove Memory clarification request injection helper and option plumbing from session-runtime-assembly.ts
- Update session-agent-loop.test.ts and session-runtime-assembly.test.ts mocks/types and assertions for new runtime contract

Part of plan: no-user-facing-conflict-prompts.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
