### PR TITLE
refactor: rename `externalUserId` to `actorPrincipalId` in guardian decision service params

### DIFF
--- a/assistant/src/daemon/handlers/guardian-actions.ts
+++ b/assistant/src/daemon/handlers/guardian-actions.ts
@@ -38,7 +38,7 @@ export const guardianActionsHandlers = defineHandlers({
         conversationId: msg.conversationId,
         channel: "vellum",
         actorContext: {
-          externalUserId: localTrustCtx.guardianExternalUserId,
+          actorPrincipalId: localTrustCtx.guardianExternalUserId,
           guardianPrincipalId: localTrustCtx.guardianPrincipalId ?? undefined,
         },
       });

--- a/assistant/src/runtime/guardian-action-service.ts
+++ b/assistant/src/runtime/guardian-action-service.ts
@@ -36,7 +36,7 @@ export interface ProcessGuardianDecisionParams {
   conversationId?: string;
   channel: string; // e.g. "vellum"
   actorContext: {
-    externalUserId: string | undefined;
+    actorPrincipalId: string | undefined;
     guardianPrincipalId: string | undefined;
   };
 }
@@ -96,7 +96,7 @@ export async function processGuardianDecision(
     requestId,
     action: action as ApprovalAction,
     actorContext: {
-      externalUserId: actorContext.externalUserId,
+      externalUserId: actorContext.actorPrincipalId,
       channel,
       guardianPrincipalId: actorContext.guardianPrincipalId,
     },

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -96,7 +96,7 @@ export async function handleGuardianActionDecision(
     conversationId,
     channel: "vellum",
     actorContext: {
-      externalUserId: authContext.actorPrincipalId ?? undefined,
+      actorPrincipalId: authContext.actorPrincipalId ?? undefined,
       guardianPrincipalId: authContext.actorPrincipalId ?? undefined,
     },
   });


### PR DESCRIPTION
## Summary
- Rename `externalUserId` to `actorPrincipalId` in `ProcessGuardianDecisionParams.actorContext` to accurately reflect that this field always contains a principal ID
- Update both HTTP and IPC callsites to pass the renamed field
- Preserve backward compatibility by mapping `actorPrincipalId` to `ActorContext.externalUserId` in the service function

Part of plan: rename-external-userid.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
