### PR TITLE
refactor: rename `actorExternalUserId` to `actorPrincipalId` in legacy guardian decision params

### DIFF
--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -150,8 +150,8 @@ export interface ApplyGuardianDecisionParams {
   approval: GuardianApprovalRequest;
   /** The parsed decision (action + source + optional requestId). */
   decision: ApprovalDecisionResult;
-  /** External user ID of the actor making the decision. */
-  actorExternalUserId: string | undefined;
+  /** Principal ID of the actor making the decision. */
+  actorPrincipalId: string | undefined;
   /** Channel the decision arrived on. */
   actorChannel: ChannelId;
   /** Optional decision context passed to handleChannelDecision. */
@@ -180,7 +180,7 @@ export function applyGuardianDecision(
   const {
     approval,
     decision,
-    actorExternalUserId,
+    actorPrincipalId,
     actorChannel,
     decisionContext,
   } = params;
@@ -222,22 +222,22 @@ export function applyGuardianDecision(
       : ("approved" as const);
   updateApprovalDecision(approval.id, {
     status: approvalStatus,
-    decidedByExternalUserId: actorExternalUserId,
+    decidedByExternalUserId: actorPrincipalId,
   });
 
   // Mint a scoped grant when a guardian approves a tool-approval request.
-  // Skip when actorExternalUserId is undefined -- minting a grant without
+  // Skip when actorPrincipalId is undefined -- minting a grant without
   // a known guardian identity is meaningless (e.g. requester self-cancel).
   if (
     effectiveDecision.action !== "reject" &&
     matchedInfo &&
-    actorExternalUserId
+    actorPrincipalId
   ) {
     tryMintToolApprovalGrant({
       approvalInfo: matchedInfo,
       approval,
       decisionChannel: actorChannel,
-      guardianExternalUserId: actorExternalUserId,
+      guardianExternalUserId: actorPrincipalId,
     });
   }
 

--- a/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
@@ -297,7 +297,7 @@ async function handleCallbackDecision(params: {
   const result = applyGuardianDecision({
     approval: guardianApproval,
     decision: callbackDecision,
-    actorExternalUserId: actorExternalId,
+    actorPrincipalId: actorExternalId,
     actorChannel: sourceChannel,
   });
 
@@ -491,7 +491,7 @@ async function handleConversationalDecision(params: {
   const result = applyGuardianDecision({
     approval: targetApproval,
     decision: engineDecision,
-    actorExternalUserId: actorExternalId,
+    actorPrincipalId: actorExternalId,
     actorChannel: sourceChannel,
   });
 
@@ -675,7 +675,7 @@ async function handleLegacyDecision(params: {
     const result = applyGuardianDecision({
       approval: targetLegacyApproval,
       decision: legacyGuardianDecision,
-      actorExternalUserId: actorExternalId,
+      actorPrincipalId: actorExternalId,
       actorChannel: sourceChannel,
     });
 

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -232,7 +232,7 @@ export async function handleApprovalInterception(
             const cancelApplyResult = applyGuardianDecision({
               approval: guardianApprovalForRequest,
               decision: rejectDecision,
-              actorExternalUserId: actorExternalId,
+              actorPrincipalId: actorExternalId,
               actorChannel: sourceChannel,
             });
             if (cancelApplyResult.applied) {


### PR DESCRIPTION
## Summary
- Rename `actorExternalUserId` to `actorPrincipalId` in `ApplyGuardianDecisionParams` interface
- Update all references in `applyGuardianDecision()` function body (destructure, DB writes, grant minting)
- Update all four callsites in guardian-callback-strategy.ts and guardian-approval-interception.ts

Part of plan: rename-external-userid.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
