### PR TITLE
docs: document `ActorContext.externalUserId` mixed semantics and migration path

### DIFF
--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -42,7 +42,16 @@ const log = getLogger("guardian-request-resolvers");
 
 /** Actor context for the entity making the decision. */
 export interface ActorContext {
-  /** External user ID of the deciding actor (undefined for desktop actors). */
+  /**
+   * Identity of the deciding actor. Mixed semantics depending on entry path:
+   * - HTTP/IPC path (desktop): this is a principal ID (same as guardianPrincipalId)
+   * - Callback/conversational path (channel): this is a channel-native ID (Telegram user ID, E.164 phone, etc.)
+   *
+   * TODO: Split into two distinct fields — `actorPrincipalId` for auth identity
+   * and `actorChannelUserId` for channel-native identity — to eliminate the ambiguity.
+   * The `ProcessGuardianDecisionParams` and `ApplyGuardianDecisionParams` have already
+   * been renamed to `actorPrincipalId` as a first step.
+   */
   externalUserId: string | undefined;
   /** Channel the decision arrived on. */
   channel: string;


### PR DESCRIPTION
## Summary
- Update JSDoc on `ActorContext.externalUserId` to document its mixed semantics (principal ID vs channel-native ID depending on entry path)
- Add TODO comment describing the next migration step: splitting into `actorPrincipalId` and `actorChannelUserId`

Part of plan: rename-external-userid.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
