### PR TITLE
fix: mock workspace git in session-conflict-gate test

### DIFF
--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -71,6 +71,16 @@ mock.module("../util/platform.js", () => ({
   getDataDir: () => "/tmp",
 }));
 
+mock.module("../workspace/turn-commit.js", () => ({
+  commitTurnChanges: async () => {},
+}));
+
+mock.module("../workspace/git-service.js", () => ({
+  getWorkspaceGitService: () => ({
+    ensureInitialized: async () => {},
+  }),
+}));
+
 mock.module("../memory/guardian-action-store.js", () => ({
   getPendingDeliveryByConversation: () => null,
   getGuardianActionRequest: () => null,


### PR DESCRIPTION
## Summary
- `session-conflict-gate.test.ts` uses `/tmp` as the workspace dir but didn't mock workspace git operations
- On CI, `git add -A` in `/tmp` picks up system directories and other test artifacts, causing fatal git errors that cascade into assertion failures
- Added `turn-commit.js` and `git-service.js` mocks matching `session-agent-loop.test.ts`

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22697179225/job/65806115774

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12681" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
