### PR TITLE
feat: add vellum CLI to assistant docker image

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -22,9 +22,6 @@ COPY package.json bun.lock ./
 # Install dependencies
 RUN bun install --frozen-lockfile
 
-# Install vellum CLI globally
-RUN bun install -g @vellumai/cli
-
 # Final stage
 FROM debian:trixie@sha256:3615a749858a1cba49b408fb49c37093db813321355a9ab7c1f9f4836341e9db AS runner
 
@@ -50,8 +47,9 @@ RUN apt-get update && apt-get install -y \
 COPY --from=builder /root/.bun/bin/bun /usr/local/bin/bun
 RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx
 
-# Copy vellum CLI from builder
-COPY --from=builder /root/.bun/bin/vellum /usr/local/bin/vellum
+# Install vellum CLI globally into /usr/local so the binary and its package
+# files are co-located and the launcher resolves correctly at runtime
+RUN BUN_INSTALL=/usr/local bun install -g @vellumai/cli
 
 # Create non-root user that also has sudo access so it can like install stuff
 RUN groupadd --system --gid 1001 assistant && \

--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -22,6 +22,9 @@ COPY package.json bun.lock ./
 # Install dependencies
 RUN bun install --frozen-lockfile
 
+# Install vellum CLI globally
+RUN bun install -g @vellumai/cli
+
 # Final stage
 FROM debian:trixie@sha256:3615a749858a1cba49b408fb49c37093db813321355a9ab7c1f9f4836341e9db AS runner
 
@@ -46,6 +49,9 @@ RUN apt-get update && apt-get install -y \
 # Copy bun binary from builder instead of re-installing
 COPY --from=builder /root/.bun/bin/bun /usr/local/bin/bun
 RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx
+
+# Copy vellum CLI from builder
+COPY --from=builder /root/.bun/bin/vellum /usr/local/bin/vellum
 
 # Create non-root user that also has sudo access so it can like install stuff
 RUN groupadd --system --gid 1001 assistant && \


### PR DESCRIPTION
## Summary
- Installs `@vellumai/cli` globally in the builder stage via `bun install -g`
- Copies the resulting `vellum` binary from builder to `/usr/local/bin/vellum` in the runner stage, alongside the existing bun binary
- Avoids a runtime network fetch; keeps the CLI at the version current at image build time

## Original prompt
We need to put vellum cli onto the assistant docker image, I think the best way might be to copy direct to the dockerfile but we could also do an bun install of the latest the choice is up to you

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
