### PR TITLE
Add pre-push hook to run related tests for changed files

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+# Pre-push hook: run tests related to changed files before pushing.
+#
+# For each package (assistant, cli, gateway), finds source files that changed
+# between HEAD and the remote tracking branch, then matches them to co-located
+# test files using filename heuristics. Runs matched tests in isolation so
+# failures surface fast.
+#
+# Skip with: git push --no-verify
+
+set -uo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+BUN="${BUN:-$(command -v bun 2>/dev/null || echo "$HOME/.bun/bin/bun")}"
+
+if [ ! -x "$BUN" ]; then
+    echo -e "${YELLOW}⚠️  bun not found — skipping pre-push tests${NC}"
+    exit 0
+fi
+
+# Determine the merge base to diff against.
+# stdin provides lines of: <local ref> <local sha> <remote ref> <remote sha>
+# We use the remote sha to find changed files. If the remote sha is all zeros
+# (new branch), diff against origin/main.
+REMOTE_SHA=""
+while read -r _ local_sha _ remote_sha; do
+    if [[ "$remote_sha" =~ ^0+$ ]]; then
+        REMOTE_SHA="$(git merge-base "$local_sha" origin/main 2>/dev/null || echo "")"
+    else
+        REMOTE_SHA="$remote_sha"
+    fi
+    break
+done
+
+if [ -z "$REMOTE_SHA" ]; then
+    echo -e "${YELLOW}⚠️  Could not determine remote base — skipping pre-push tests${NC}"
+    exit 0
+fi
+
+# Get all changed files (source files only, not deleted)
+CHANGED_FILES=$(git diff --name-only --diff-filter=ACMR "$REMOTE_SHA"..HEAD -- '*.ts' '*.tsx' '*.js' '*.jsx' '*.mjs' 2>/dev/null)
+
+if [ -z "$CHANGED_FILES" ]; then
+    exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Temp dir for capturing test output
+RESULTS_DIR="$(mktemp -d)"
+trap 'rm -rf "${RESULTS_DIR}"' EXIT
+
+# For each package, find test files that correspond to changed source files.
+#
+# Heuristic: for a changed source file like `src/foo/bar-baz.ts`, look for
+# test files matching `**/bar-baz*.test.ts` anywhere under the package's src/.
+# This catches:
+#   - src/__tests__/bar-baz.test.ts          (exact match)
+#   - src/__tests__/bar-baz-edge.test.ts     (prefix match)
+#   - src/foo/__tests__/bar-baz.test.ts      (co-located)
+
+PACKAGES=("assistant" "cli" "gateway")
+overall_exit=0
+
+for pkg in "${PACKAGES[@]}"; do
+    # Collect changed source files for this package (excluding test files)
+    pkg_changed=()
+    while IFS= read -r file; do
+        if [[ "$file" == "$pkg/"* ]] && [[ ! "$file" =~ \.test\.(ts|tsx|js|jsx)$ ]] && [[ ! "$file" =~ /__tests__/ ]]; then
+            pkg_changed+=("$file")
+        fi
+    done <<< "$CHANGED_FILES"
+
+    # Also collect changed test files directly (always run them)
+    pkg_test_changed=()
+    while IFS= read -r file; do
+        if [[ "$file" == "$pkg/"* ]] && [[ "$file" =~ \.test\.(ts|tsx|js|jsx)$ ]]; then
+            pkg_test_changed+=("$file")
+        fi
+    done <<< "$CHANGED_FILES"
+
+    if [ ${#pkg_changed[@]} -eq 0 ] && [ ${#pkg_test_changed[@]} -eq 0 ]; then
+        continue
+    fi
+
+    # Build a list of basename stems from changed source files
+    stems=()
+    for file in "${pkg_changed[@]}"; do
+        base="$(basename "$file")"
+        stem="${base%.*}"
+        stems+=("$stem")
+    done
+
+    # Find matching test files (deduplicated)
+    test_files=()
+    unset seen_tests 2>/dev/null || true
+    declare -A seen_tests
+
+    # Add directly changed test files
+    for tf in "${pkg_test_changed[@]}"; do
+        abs_tf="${REPO_ROOT}/${tf}"
+        if [ -f "$abs_tf" ] && [ -z "${seen_tests[$abs_tf]:-}" ]; then
+            test_files+=("$abs_tf")
+            seen_tests["$abs_tf"]=1
+        fi
+    done
+
+    # Search for test files matching source file stems
+    for stem in "${stems[@]}"; do
+        while IFS= read -r tf; do
+            if [ -n "$tf" ] && [ -z "${seen_tests[$tf]:-}" ]; then
+                test_files+=("$tf")
+                seen_tests["$tf"]=1
+            fi
+        done < <(find "${REPO_ROOT}/${pkg}/src" -type f -name "${stem}*.test.ts" 2>/dev/null)
+    done
+
+    if [ ${#test_files[@]} -eq 0 ]; then
+        continue
+    fi
+
+    echo ""
+    echo "🧪 Running ${#test_files[@]} related test(s) for ${pkg}/..."
+
+    # Run each test file in isolation (same pattern as the main test runner).
+    failed_files=()
+    for tf in "${test_files[@]}"; do
+        rel="${tf#${REPO_ROOT}/${pkg}/}"
+        base="$(basename "$tf")"
+        safe_name="$(echo "$rel" | tr "/" "_")"
+        out_file="${RESULTS_DIR}/${safe_name}.out"
+
+        (cd "${REPO_ROOT}/${pkg}" && "$BUN" test "$rel" > "$out_file" 2>&1)
+        exit_code=$?
+
+        if [ $exit_code -ne 0 ]; then
+            echo -e "  ${RED}✗${NC} ${base}"
+            failed_files+=("$tf")
+        else
+            echo -e "  ${GREEN}✓${NC} ${base}"
+        fi
+    done
+
+    if [ ${#failed_files[@]} -gt 0 ]; then
+        echo ""
+        echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+        echo -e "${RED}Test failures in ${pkg}/ — push blocked${NC}"
+        echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+        echo ""
+        for tf in "${failed_files[@]}"; do
+            rel="${tf#${REPO_ROOT}/${pkg}/}"
+            safe_name="$(echo "$rel" | tr "/" "_")"
+            out_file="${RESULTS_DIR}/${safe_name}.out"
+            echo "──────────────────────────────────────────"
+            echo "FAIL: ${pkg}/${rel}"
+            echo "──────────────────────────────────────────"
+            cat "$out_file"
+            echo ""
+        done
+        echo "Fix the failing tests or push with --no-verify to skip."
+        overall_exit=1
+    else
+        echo -e "  ${GREEN}✅ All related tests pass in ${pkg}/${NC}"
+    fi
+done
+
+exit $overall_exit


### PR DESCRIPTION
## Summary
- Add a `pre-push` git hook that detects changed source files, maps them to test files via filename heuristic, and runs them before allowing the push
- Covers all three packages (assistant, cli, gateway) with isolated per-file test execution
- Skippable with `git push --no-verify`

## Original prompt
it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
