### PR TITLE
feat: add updateContact HTTP method to DaemonClient for contact metadata editing

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1535,6 +1535,57 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(ContactsRequestMessage(action: "update_channel", channelId: channelId, status: status, policy: policy, reason: reason))
     }
 
+    /// Update a contact's metadata via the HTTP API (`POST /v1/contacts`).
+    /// Works for both local daemon (via httpPort) and managed (via httpTransport).
+    public func updateContact(
+        contactId: String,
+        displayName: String,
+        relationship: String? = nil,
+        importance: Double? = nil,
+        responseExpectation: String? = nil,
+        preferredTone: String? = nil
+    ) async throws -> ContactPayload? {
+        let baseURL: String
+        let bearerToken: String?
+
+        if let httpTransport {
+            baseURL = httpTransport.baseURL
+            bearerToken = httpTransport.bearerToken
+        } else if let local = resolveLocalDaemonHTTPEndpoint() {
+            baseURL = local.baseURL
+            bearerToken = local.bearerToken
+        } else {
+            return nil
+        }
+
+        guard let url = URL(string: "\(baseURL)/v1/contacts") else { return nil }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token = bearerToken, !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        var body: [String: Any] = ["id": contactId, "displayName": displayName]
+        if let relationship { body["relationship"] = relationship }
+        if let importance { body["importance"] = importance }
+        if let responseExpectation { body["responseExpectation"] = responseExpectation }
+        if let preferredTone { body["preferredTone"] = preferredTone }
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse,
+              (200...201).contains(http.statusCode) else { return nil }
+
+        struct UpsertResponse: Decodable {
+            let ok: Bool
+            let contact: ContactPayload
+        }
+        let decoded = try JSONDecoder().decode(UpsertResponse.self, from: data)
+        return decoded.contact
+    }
+
     // MARK: - Feature Flags
 
     /// A single assistant feature flag entry returned by `GET /v1/feature-flags`.

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -162,6 +162,7 @@ public final class HTTPTransport {
         case contactsList(limit: Int, role: String?)
         case contactsGet(id: String)
         case contactsChannelUpdate(channelId: String)
+        case contactsUpsert
     }
 
     /// Build a URL for the given endpoint using the current route mode.
@@ -250,6 +251,8 @@ public final class HTTPTransport {
         case .contactsChannelUpdate(let channelId):
             let encoded = channelId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? channelId
             return ("/v1/contacts/channels/\(encoded)", nil)
+        case .contactsUpsert:
+            return ("/v1/contacts", nil)
         }
     }
 
@@ -319,6 +322,8 @@ public final class HTTPTransport {
         case .contactsChannelUpdate(let channelId):
             let encoded = channelId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? channelId
             return ("\(prefix)/contacts/channels/\(encoded)/", nil)
+        case .contactsUpsert:
+            return ("\(prefix)/contacts/", nil)
         }
     }
 
@@ -1032,6 +1037,68 @@ public final class HTTPTransport {
     private struct HTTPContactResponse: Decodable {
         let ok: Bool
         let contact: ContactPayload?
+    }
+
+    /// Response wrapper for `POST /v1/contacts` (upsert).
+    private struct HTTPContactUpsertResponse: Decodable {
+        let ok: Bool
+        let contact: ContactPayload
+    }
+
+    /// Update a contact's metadata via `POST /v1/contacts`.
+    /// Emits a `contactsResponse` on success so the detail view can react.
+    func updateContact(
+        contactId: String,
+        displayName: String,
+        relationship: String? = nil,
+        importance: Double? = nil,
+        responseExpectation: String? = nil,
+        preferredTone: String? = nil,
+        isRetry: Bool = false
+    ) async {
+        guard let url = buildURL(for: .contactsUpsert) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        var body: [String: Any] = ["id": contactId, "displayName": displayName]
+        if let relationship { body["relationship"] = relationship }
+        if let importance { body["importance"] = importance }
+        if let responseExpectation { body["responseExpectation"] = responseExpectation }
+        if let preferredTone { body["preferredTone"] = preferredTone }
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        await updateContact(contactId: contactId, displayName: displayName, relationship: relationship, importance: importance, responseExpectation: responseExpectation, preferredTone: preferredTone, isRetry: true)
+                    }
+                    return
+                }
+                guard (200...201).contains(http.statusCode) else {
+                    log.error("HTTPTransport: update contact failed (\(http.statusCode))")
+                    onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: false, error: "HTTP \(http.statusCode)")))
+                    return
+                }
+            }
+
+            do {
+                let decoded = try decoder.decode(HTTPContactUpsertResponse.self, from: data)
+                onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: true, contact: decoded.contact)))
+            } catch {
+                log.error("HTTPTransport: failed to decode update contact response: \(error)")
+                onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: false, error: error.localizedDescription)))
+            }
+        } catch {
+            log.error("HTTPTransport: update contact error: \(error.localizedDescription)")
+            onMessage?(.contactsResponse(ContactsResponseMessage(type: "contacts_response", success: false, error: error.localizedDescription)))
+        }
     }
 
     // MARK: - Surface Actions


### PR DESCRIPTION
## Summary
- Add async updateContact method to DaemonClient that calls POST /v1/contacts via HTTP
- Support both local daemon (via resolveLocalDaemonHTTPEndpoint) and managed mode (via httpTransport)
- Add matching implementation in HTTPDaemonClient using buildURL/applyAuth pattern

Part of plan: contacts-ui-metadata-editing.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
