### PR TITLE
refactor: update canonical decision primitive to use split ActorContext fields

### DIFF
--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -507,7 +507,7 @@ export async function applyCanonicalGuardianDecision(
   const resolved = resolveCanonicalGuardianRequest(requestId, "pending", {
     status: targetStatus,
     answerText: userText,
-    decidedByExternalUserId: actorContext.externalUserId,
+    decidedByExternalUserId: actorContext.actorExternalUserId,
     decidedByPrincipalId: actorContext.guardianPrincipalId,
   });
 
@@ -574,7 +574,7 @@ export async function applyCanonicalGuardianDecision(
       request: resolved,
       actorChannel: actorContext.channel,
       guardianExternalUserId:
-        actorContext.externalUserId ??
+        actorContext.actorExternalUserId ??
         resolved.guardianExternalUserId ??
         undefined,
     });


### PR DESCRIPTION
## Summary
- Update CAS resolve call to use `actorContext.actorExternalUserId` for `decidedByExternalUserId` column
- Update grant minting to use `actorContext.actorExternalUserId` for `guardianExternalUserId` parameter

Part of plan: actorcontext-split-externaluserid.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
