### PR TITLE
refactor: update guardian-action-service ActorContext bridge to use split fields

### DIFF
--- a/assistant/src/runtime/guardian-action-service.ts
+++ b/assistant/src/runtime/guardian-action-service.ts
@@ -96,7 +96,8 @@ export async function processGuardianDecision(
     requestId,
     action: action as ApprovalAction,
     actorContext: {
-      externalUserId: actorContext.actorPrincipalId,
+      actorPrincipalId: actorContext.actorPrincipalId,
+      actorExternalUserId: undefined, // Desktop/IPC path — no channel-native ID
       channel,
       guardianPrincipalId: actorContext.guardianPrincipalId,
     },


### PR DESCRIPTION
## Summary
- Update the ActorContext bridge in `processGuardianDecision` to use the new split fields
- Map `actorPrincipalId` through from service params, set `actorExternalUserId` to `undefined` (desktop/IPC path has no channel-native ID)

Part of plan: actorcontext-split-externaluserid.md (PR 3 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12695" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
