### PR TITLE
refactor: update access request resolver to use `actorExternalUserId`

### DIFF
--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -351,7 +351,7 @@ const accessRequestResolver: GuardianRequestResolver = {
       request.requesterChatId ?? request.requesterExternalUserId ?? "";
     const requesterLabel =
       requesterExternalUserId || requesterChatId || "the requester";
-    const decidedByExternalUserId = ctx.actor.externalUserId ?? "";
+    const decidedByExternalUserId = ctx.actor.actorExternalUserId ?? "";
     const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
     const desktopDeliverUrl = resolveDeliverCallbackUrlForChannel(channel);
     const desktopBearerToken = mintDaemonDeliveryToken();


### PR DESCRIPTION
## Summary
- Update `accessRequestResolver` to use `ctx.actor.actorExternalUserId` instead of `ctx.actor.externalUserId` for notification payloads

Part of plan: actorcontext-split-externaluserid.md (PR 5 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
