### PR TITLE
refactor: update guardian reply router to use `actorExternalUserId`

### DIFF
--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -209,14 +209,14 @@ function findPendingCanonicalRequests(
   }
 
   // Query by guardian identity when available
-  if (actor.externalUserId) {
+  if (actor.actorExternalUserId) {
     return listCanonicalGuardianRequests({
       status: "pending",
-      guardianExternalUserId: actor.externalUserId,
+      guardianExternalUserId: actor.actorExternalUserId,
     });
   }
 
-  // Actors without an externalUserId: scope by conversationId so the NL
+  // Actors without an actorExternalUserId: scope by conversationId so the NL
   // path can discover pending requests bound to this conversation.
   // Include guardianPrincipalId filter when available so the guardian only
   // sees requests they are authorized to act on.
@@ -230,7 +230,7 @@ function findPendingCanonicalRequests(
     });
   }
 
-  // Actors with a guardianPrincipalId but no externalUserId or
+  // Actors with a guardianPrincipalId but no actorExternalUserId or
   // conversationId: query by principal so desktop sessions can still
   // discover pending guardian work via their bound principal.
   if (actor.guardianPrincipalId) {


### PR DESCRIPTION
## Summary
- Update `resolvePendingGuardianRequests` to use `actor.actorExternalUserId` instead of `actor.externalUserId`
- Update related comments to reference the new field name

Part of plan: actorcontext-split-externaluserid.md (PR 4 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
