### PR TITLE
refactor: construct split ActorContext in callback and interception paths

### DIFF
--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -150,8 +150,10 @@ export interface ApplyGuardianDecisionParams {
   approval: GuardianApprovalRequest;
   /** The parsed decision (action + source + optional requestId). */
   decision: ApprovalDecisionResult;
-  /** Principal ID of the actor making the decision. */
+  /** Principal ID of the actor making the decision (undefined in callback/interception paths without JWT/auth context). */
   actorPrincipalId: string | undefined;
+  /** Channel-native external user ID of the deciding actor (Telegram user ID, phone, etc.). */
+  actorExternalUserId: string | undefined;
   /** Channel the decision arrived on. */
   actorChannel: ChannelId;
   /** Optional decision context passed to handleChannelDecision. */
@@ -181,6 +183,7 @@ export function applyGuardianDecision(
     approval,
     decision,
     actorPrincipalId,
+    actorExternalUserId,
     actorChannel,
     decisionContext,
   } = params;
@@ -222,22 +225,23 @@ export function applyGuardianDecision(
       : ("approved" as const);
   updateApprovalDecision(approval.id, {
     status: approvalStatus,
-    decidedByExternalUserId: actorPrincipalId,
+    decidedByExternalUserId: actorExternalUserId ?? actorPrincipalId,
   });
 
   // Mint a scoped grant when a guardian approves a tool-approval request.
-  // Skip when actorPrincipalId is undefined -- minting a grant without
+  // Skip when neither actor identity is available -- minting a grant without
   // a known guardian identity is meaningless (e.g. requester self-cancel).
+  const effectiveGuardianId = actorExternalUserId ?? actorPrincipalId;
   if (
     effectiveDecision.action !== "reject" &&
     matchedInfo &&
-    actorPrincipalId
+    effectiveGuardianId
   ) {
     tryMintToolApprovalGrant({
       approvalInfo: matchedInfo,
       approval,
       decisionChannel: actorChannel,
-      guardianExternalUserId: actorPrincipalId,
+      guardianExternalUserId: effectiveGuardianId,
     });
   }
 

--- a/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
@@ -297,7 +297,8 @@ async function handleCallbackDecision(params: {
   const result = applyGuardianDecision({
     approval: guardianApproval,
     decision: callbackDecision,
-    actorPrincipalId: actorExternalId,
+    actorPrincipalId: undefined, // Callback path — principal not available at this layer
+    actorExternalUserId: actorExternalId, // Channel-native ID (Telegram user ID, phone, etc.)
     actorChannel: sourceChannel,
   });
 
@@ -491,7 +492,8 @@ async function handleConversationalDecision(params: {
   const result = applyGuardianDecision({
     approval: targetApproval,
     decision: engineDecision,
-    actorPrincipalId: actorExternalId,
+    actorPrincipalId: undefined, // Callback path — principal not available at this layer
+    actorExternalUserId: actorExternalId, // Channel-native ID (Telegram user ID, phone, etc.)
     actorChannel: sourceChannel,
   });
 
@@ -675,7 +677,8 @@ async function handleLegacyDecision(params: {
     const result = applyGuardianDecision({
       approval: targetLegacyApproval,
       decision: legacyGuardianDecision,
-      actorPrincipalId: actorExternalId,
+      actorPrincipalId: undefined, // Callback path — principal not available at this layer
+      actorExternalUserId: actorExternalId, // Channel-native ID (Telegram user ID, phone, etc.)
       actorChannel: sourceChannel,
     });
 

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -232,7 +232,8 @@ export async function handleApprovalInterception(
             const cancelApplyResult = applyGuardianDecision({
               approval: guardianApprovalForRequest,
               decision: rejectDecision,
-              actorPrincipalId: actorExternalId,
+              actorPrincipalId: undefined, // Interception path — principal not available
+              actorExternalUserId: actorExternalId, // Channel-native ID
               actorChannel: sourceChannel,
             });
             if (cancelApplyResult.applied) {


### PR DESCRIPTION
## Summary
- Update all ActorContext construction in callback strategy (3 callsites) and approval interception (1 callsite) to use split fields
- Set `actorExternalUserId` to the channel-native ID, `actorPrincipalId` to `undefined` (callback path has no JWT/auth context)
- Add `actorExternalUserId` to `ApplyGuardianDecisionParams` interface and wire it through the primitive (decidedByExternalUserId, grant minting)

Part of plan: actorcontext-split-externaluserid.md (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
