### PR TITLE
fix: emit contacts_changed broadcast on contact upsert

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -213,6 +213,7 @@ export function upsertContact(params: {
         syncChannels(contactId, params.channels, now);
       }
 
+      emitContactChange();
       return { ...getContactInternal(contactId)!, created: false };
     }
   }
@@ -281,6 +282,7 @@ export function upsertContact(params: {
           .run();
 
         syncChannels(contactId, params.channels, now);
+        emitContactChange();
         return { ...getContactInternal(contactId)!, created: false };
       }
     }
@@ -311,6 +313,7 @@ export function upsertContact(params: {
     syncChannels(contactId, params.channels, now);
   }
 
+  emitContactChange();
   return { ...getContactInternal(contactId)!, created: true };
 }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contacts-ui-metadata-editing.md.

**Gap:** Missing broadcast signal from HTTP contact upsert
**What was expected:** contacts_changed broadcast emitted when contacts are updated via POST /v1/contacts
**What was found:** upsertContact() did not call emitContactChange(), so the sidebar didn't auto-refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
