### PR TITLE
refactor: update test helpers to use split ActorContext fields

### DIFF
--- a/assistant/src/__tests__/guardian-decision-primitive-canonical.test.ts
+++ b/assistant/src/__tests__/guardian-decision-primitive-canonical.test.ts
@@ -71,7 +71,8 @@ const TEST_PRINCIPAL_ID = "test-principal-id";
 
 function guardianActor(overrides: Partial<ActorContext> = {}): ActorContext {
   return {
-    externalUserId: "guardian-1",
+    actorPrincipalId: TEST_PRINCIPAL_ID,
+    actorExternalUserId: "guardian-1",
     channel: "telegram",
     guardianPrincipalId: TEST_PRINCIPAL_ID,
     ...overrides,
@@ -80,7 +81,8 @@ function guardianActor(overrides: Partial<ActorContext> = {}): ActorContext {
 
 function trustedActor(overrides: Partial<ActorContext> = {}): ActorContext {
   return {
-    externalUserId: undefined,
+    actorPrincipalId: TEST_PRINCIPAL_ID,
+    actorExternalUserId: undefined,
     channel: "desktop",
     guardianPrincipalId: TEST_PRINCIPAL_ID,
     ...overrides,
@@ -254,7 +256,7 @@ describe("applyCanonicalGuardianDecision", () => {
 
     expect(result.applied).toBe(true);
     if (!result.applied) return;
-    // No grant minted because trusted actor has no externalUserId
+    // No grant minted because trusted actor has no actorExternalUserId
     expect(result.grantMinted).toBe(false);
   });
 

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -94,7 +94,8 @@ const TEST_PRINCIPAL_ID = "test-principal-id";
 
 function guardianActor(overrides: Partial<ActorContext> = {}): ActorContext {
   return {
-    externalUserId: "guardian-1",
+    actorPrincipalId: TEST_PRINCIPAL_ID,
+    actorExternalUserId: "guardian-1",
     channel: "telegram",
     guardianPrincipalId: TEST_PRINCIPAL_ID,
     ...overrides,
@@ -103,7 +104,8 @@ function guardianActor(overrides: Partial<ActorContext> = {}): ActorContext {
 
 function trustedActor(overrides: Partial<ActorContext> = {}): ActorContext {
   return {
-    externalUserId: undefined,
+    actorPrincipalId: TEST_PRINCIPAL_ID,
+    actorExternalUserId: undefined,
     channel: "desktop",
     guardianPrincipalId: TEST_PRINCIPAL_ID,
     ...overrides,
@@ -1212,13 +1214,13 @@ describe("routing invariant: destination hints do not bypass tool_approval princ
     });
 
     // No pendingRequestIds passed — identity-based fallback uses
-    // actor.externalUserId which does not match any request's
+    // actor.actorExternalUserId which does not match any request's
     // guardianExternalUserId (since it's null).
     const result = await routeGuardianReply(
       replyCtx({
         messageText: "approve",
         channel: "telegram",
-        actor: guardianActor({ externalUserId: "guardian-tg-user" }),
+        actor: guardianActor({ actorExternalUserId: "guardian-tg-user" }),
         conversationId: "conv-guardian-chat",
         // pendingRequestIds: undefined — no delivery hints
         approvalConversationGenerator: undefined,


### PR DESCRIPTION
## Summary
- Update `guardianActor` and `trustedActor` test helpers in both canonical decision and routing invariant test files to use `actorPrincipalId` and `actorExternalUserId` instead of `externalUserId`
- Update comments and overrides referencing the old `externalUserId` field name
- DB column assertions (`decidedByExternalUserId`, `guardianExternalUserId`) are unchanged

## Original prompt
Implement PR 7 from the plan at .private/plans/actorcontext-split-externaluserid.md — "Update test helpers to use split ActorContext fields"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
