### PR TITLE
feat: add TypeScript type check to pre-push hook

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -46,3 +46,17 @@ If you need to bypass this check in exceptional cases:
 ```bash
 git commit --no-verify
 ```
+
+### pre-push
+
+Runs before pushing to catch issues that would fail CI.
+
+**What it checks:**
+
+1. **TypeScript type check** — Runs `tsc --noEmit` on `assistant/` when `.ts`/`.tsx` files changed. This backstops the pre-commit type check which is skipped in worktrees for performance.
+2. **Related tests** — Finds and runs test files matching changed source file stems using filename heuristics.
+
+**Bypass (not recommended):**
+```bash
+git push --no-verify
+```

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -71,6 +71,32 @@ fi
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
+# --- TypeScript type check for assistant/ ---
+# The pre-commit hook skips tsc in worktrees to keep commits fast (~20s cold).
+# Pre-push is the right place to catch cross-file type errors before they hit CI.
+ASSISTANT_TS_CHANGED=0
+while IFS= read -r file; do
+    if [[ "$file" == assistant/*.ts ]] || [[ "$file" == assistant/*.tsx ]]; then
+        ASSISTANT_TS_CHANGED=1
+        break
+    fi
+done <<< "$CHANGED_FILES"
+
+if [ $ASSISTANT_TS_CHANGED -eq 1 ]; then
+    echo ""
+    echo "🔍 Type-checking assistant/..."
+    if ! (cd "${REPO_ROOT}/assistant" && "$BUN" x tsc --noEmit) 2>&1; then
+        echo ""
+        echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+        echo -e "${RED}TypeScript type errors in assistant/ — push blocked${NC}"
+        echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+        echo ""
+        echo "Fix the type errors or push with --no-verify to skip."
+        exit 1
+    fi
+    echo -e "  ${GREEN}✅ Type check OK in assistant/${NC}"
+fi
+
 # Temp dir for capturing test output
 RESULTS_DIR="$(mktemp -d)"
 trap 'rm -rf "${RESULTS_DIR}"' EXIT


### PR DESCRIPTION
## Summary
- Add `tsc --noEmit` for `assistant/` to the pre-push hook, running when any `.ts`/`.tsx` files changed
- This backstops the pre-commit type check which is intentionally skipped in worktrees for performance
- Would have caught the 15 type errors in CI run [#22698034471](https://github.com/vellum-ai/vellum-assistant/actions/runs/22698034471) before they reached main
- Updated `.githooks/README.md` to document the pre-push hook

## Original prompt
yes add the type check to pre-push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
