### PR TITLE
fix: update remaining ActorContext call sites to use actorExternalUserId

### DIFF
--- a/assistant/src/__tests__/tool-grant-request-escalation.test.ts
+++ b/assistant/src/__tests__/tool-grant-request-escalation.test.ts
@@ -177,7 +177,8 @@ function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
 
 function guardianActor(overrides: Partial<ActorContext> = {}): ActorContext {
   return {
-    externalUserId: "guardian-1",
+    actorPrincipalId: "test-principal-id",
+    actorExternalUserId: "guardian-1",
     channel: "telegram",
     guardianPrincipalId: "test-principal-id",
     ...overrides,

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -237,7 +237,8 @@ function makeToolContext(overrides: Partial<ToolContext> = {}): ToolContext {
 
 function guardianActor(overrides: Partial<ActorContext> = {}): ActorContext {
   return {
-    externalUserId: "guardian-1",
+    actorPrincipalId: "test-principal-id",
+    actorExternalUserId: "guardian-1",
     channel: "telegram",
     guardianPrincipalId: "test-principal-id",
     ...overrides,

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -895,7 +895,8 @@ export async function handleUserMessage(
             messageText: messageText.trim(),
             channel: ipcChannel,
             actor: {
-              externalUserId: localCtx.guardianExternalUserId,
+              actorPrincipalId: localCtx.guardianPrincipalId ?? undefined,
+              actorExternalUserId: localCtx.guardianExternalUserId,
               channel: ipcChannel,
               guardianPrincipalId: localCtx.guardianPrincipalId ?? undefined,
             },

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -541,7 +541,9 @@ export async function processMessage(
       messageText: trimmedContent,
       channel: "vellum",
       actor: {
-        externalUserId: session.trustContext?.guardianExternalUserId,
+        actorPrincipalId:
+          session.trustContext?.guardianPrincipalId ?? undefined,
+        actorExternalUserId: session.trustContext?.guardianExternalUserId,
         channel: "vellum",
         guardianPrincipalId:
           session.trustContext?.guardianPrincipalId ?? undefined,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -124,7 +124,8 @@ async function tryConsumeCanonicalGuardianReply(params: {
     messageText: trimmedContent,
     channel: sourceChannel,
     actor: {
-      externalUserId: verifiedActorExternalUserId,
+      actorPrincipalId: verifiedActorPrincipalId,
+      actorExternalUserId: verifiedActorExternalUserId,
       channel: sourceChannel,
       guardianPrincipalId: verifiedActorPrincipalId,
     },

--- a/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
@@ -129,7 +129,8 @@ export async function handleGuardianReplyIntercept(
     messageText: trimmedContent,
     channel: sourceChannel,
     actor: {
-      externalUserId: canonicalSenderId ?? rawSenderId!,
+      actorPrincipalId: guardianPrincipalId ?? undefined,
+      actorExternalUserId: canonicalSenderId ?? rawSenderId!,
       channel: sourceChannel,
       guardianPrincipalId: guardianPrincipalId ?? undefined,
     },


### PR DESCRIPTION
## Summary
- Rename `externalUserId` to `actorExternalUserId` and add missing `actorPrincipalId` in all remaining `ActorContext` construction sites (conversation-routes, sessions handler, session-process, guardian-reply-intercept)
- Fix `guardianActor()` test helpers in tool-grant-request-escalation and trusted-contact-inline-approval-integration tests to use the new field names
- Fixes type check errors and test failures where `decidedByExternalUserId` was null

## Original prompt
fix CI in https://github.com/vellum-ai/vellum-assistant/actions/runs/22698111286

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
