### PR TITLE
fix: route DaemonClient.updateContact through HTTPTransport for managed assistant compat

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1536,7 +1536,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     }
 
     /// Update a contact's metadata via the HTTP API (`POST /v1/contacts`).
-    /// Works for both local daemon (via httpPort) and managed (via httpTransport).
+    /// Routes through `HTTPTransport` when available so that managed-mode
+    /// URL paths (`/v1/assistants/{id}/contacts/`) and auth headers
+    /// (`X-Session-Token`) are applied correctly. Falls back to the local
+    /// daemon HTTP server for socket-based connections.
     public func updateContact(
         contactId: String,
         displayName: String,
@@ -1545,24 +1548,27 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         responseExpectation: String? = nil,
         preferredTone: String? = nil
     ) async throws -> ContactPayload? {
-        let baseURL: String
-        let bearerToken: String?
-
+        // Delegate to HTTPTransport when active — it handles buildURL/applyAuth
+        // for both runtimeFlat and platformAssistantProxy route modes.
         if let httpTransport {
-            baseURL = httpTransport.baseURL
-            bearerToken = httpTransport.bearerToken
-        } else if let local = resolveLocalDaemonHTTPEndpoint() {
-            baseURL = local.baseURL
-            bearerToken = local.bearerToken
-        } else {
-            return nil
+            return try await httpTransport.updateContactAndReturn(
+                contactId: contactId,
+                displayName: displayName,
+                relationship: relationship,
+                importance: importance,
+                responseExpectation: responseExpectation,
+                preferredTone: preferredTone
+            )
         }
 
-        guard let url = URL(string: "\(baseURL)/v1/contacts") else { return nil }
+        // Local daemon path: direct HTTP call using the runtime server port.
+        guard let local = resolveLocalDaemonHTTPEndpoint() else { return nil }
+
+        guard let url = URL(string: "\(local.baseURL)/v1/contacts") else { return nil }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let token = bearerToken, !token.isEmpty {
+        if let token = local.bearerToken, !token.isEmpty {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1045,6 +1045,51 @@ public final class HTTPTransport {
         let contact: ContactPayload
     }
 
+    /// Update a contact's metadata via `POST /v1/contacts` and return the updated payload.
+    /// Routes through `buildURL`/`applyAuth` so managed-mode URL paths and auth headers
+    /// are applied correctly.
+    func updateContactAndReturn(
+        contactId: String,
+        displayName: String,
+        relationship: String? = nil,
+        importance: Double? = nil,
+        responseExpectation: String? = nil,
+        preferredTone: String? = nil,
+        isRetry: Bool = false
+    ) async throws -> ContactPayload? {
+        guard let url = buildURL(for: .contactsUpsert) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        var body: [String: Any] = ["id": contactId, "displayName": displayName]
+        if let relationship { body["relationship"] = relationship }
+        if let importance { body["importance"] = importance }
+        if let responseExpectation { body["responseExpectation"] = responseExpectation }
+        if let preferredTone { body["preferredTone"] = preferredTone }
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        if let http = response as? HTTPURLResponse {
+            if http.statusCode == 401 && !isRetry {
+                let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                if case .success = refreshResult {
+                    return try await updateContactAndReturn(contactId: contactId, displayName: displayName, relationship: relationship, importance: importance, responseExpectation: responseExpectation, preferredTone: preferredTone, isRetry: true)
+                }
+                return nil
+            }
+            guard (200...201).contains(http.statusCode) else {
+                return nil
+            }
+        }
+
+        let decoded = try decoder.decode(HTTPContactUpsertResponse.self, from: data)
+        return decoded.contact
+    }
+
     /// Update a contact's metadata via `POST /v1/contacts`.
     /// Emits a `contactsResponse` on success so the detail view can react.
     func updateContact(


### PR DESCRIPTION
Addresses review feedback from PR #12689. The updateContact method was bypassing HTTPTransport.buildURL/applyAuth and hardcoding /v1/contacts with bearer auth, breaking managed assistants with platformAssistantProxy routing and sessionToken auth. Now routes through HTTPTransport like other HTTP methods.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
