### PR TITLE
fix: keep name editor open on save failure in ContactDetailView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -586,13 +586,19 @@ struct ContactDetailView: View {
         errorMessage = nil
 
         do {
-            if let updated = try await daemonClient?.updateContact(
+            guard let daemonClient else {
+                errorMessage = "Failed to update name"
+                return
+            }
+            if let updated = try await daemonClient.updateContact(
                 contactId: displayContact.id,
                 displayName: trimmed
             ) {
                 currentContact = updated
+                isEditingName = false
+            } else {
+                errorMessage = "Failed to update name"
             }
-            isEditingName = false
         } catch {
             errorMessage = "Failed to update name: \(error.localizedDescription)"
         }


### PR DESCRIPTION
Addresses review feedback from PR #12691. saveDisplayName() was unconditionally setting isEditingName=false, even when the save failed. Now only exits edit mode on success and shows an error on failure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
