### PR TITLE
fix: add emitContactChange to mergeContacts and remove redundant emissions

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -731,6 +731,7 @@ export function mergeContacts(
     tx.delete(contacts).where(eq(contacts.id, mergeId)).run();
   });
 
+  emitContactChange();
   return getContactInternal(keepId)!;
 }
 

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -109,7 +109,6 @@ export function createGuardianBinding(params: {
     updatedAt: now,
   };
 
-  emitContactChange();
   return result;
 }
 
@@ -203,8 +202,6 @@ export function upsertMember(params: {
     externalUserId: canonicalId ?? undefined,
     externalChatId: params.externalChatId,
   });
-
-  emitContactChange();
 
   if (contactResult) {
     return { contact: contactResult.contact, channel: contactResult.channel };


### PR DESCRIPTION
Addresses review feedback from PR #12701. Adds missing emitContactChange() call in mergeContacts so clients are notified after contact merges. Removes redundant emitContactChange() calls from createGuardianBinding and upsertMember in contacts-write.ts since upsertContact now emits internally.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
