### PR TITLE
M1: add vellum credentials CLI command

### DIFF
--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+type ExecuteCall = {
+  input: Record<string, unknown>;
+  context: Record<string, unknown>;
+};
+
+const executeCalls: ExecuteCall[] = [];
+let nextResult: { content: string; isError: boolean } = {
+  content: "ok",
+  isError: false,
+};
+const secureValues = new Map<string, string>();
+const infoLogs: string[] = [];
+const errorLogs: string[] = [];
+
+mock.module("../tools/credentials/vault.js", () => ({
+  credentialStoreTool: {
+    execute: async (
+      input: Record<string, unknown>,
+      context: Record<string, unknown>,
+    ) => {
+      executeCalls.push({ input, context });
+      return nextResult;
+    },
+  },
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKey: (key: string) => secureValues.get(key),
+}));
+
+mock.module("../util/logger.js", () => ({
+  getCliLogger: () => ({
+    info: (message: string) => {
+      infoLogs.push(String(message));
+    },
+    error: (message: string) => {
+      errorLogs.push(String(message));
+    },
+  }),
+}));
+
+const { registerCredentialsCommand } = await import("../cli/credentials.js");
+
+async function runCli(
+  args: string[],
+): Promise<{ stdout: string; exitCode: number }> {
+  const program = new Command();
+  registerCredentialsCommand(program);
+
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  const stdoutChunks: string[] = [];
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  const priorExitCode = process.exitCode;
+  process.exitCode = 0;
+  let exitCode = 0;
+  try {
+    await program.parseAsync(["node", "vellum", ...args]);
+    exitCode = process.exitCode ?? 0;
+  } finally {
+    process.stdout.write = originalWrite;
+    process.exitCode = priorExitCode;
+  }
+
+  return {
+    stdout: stdoutChunks.join(""),
+    exitCode,
+  };
+}
+
+describe("vellum credentials CLI", () => {
+  beforeEach(() => {
+    executeCalls.length = 0;
+    nextResult = { content: "ok", isError: false };
+    secureValues.clear();
+    infoLogs.length = 0;
+    errorLogs.length = 0;
+    process.exitCode = 0;
+  });
+
+  test("list delegates to credential_store list action", async () => {
+    nextResult = { content: "[]", isError: false };
+
+    const result = await runCli(["credentials", "list"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("[]\n");
+    expect(executeCalls).toHaveLength(1);
+    expect(executeCalls[0]?.input).toEqual({ action: "list" });
+  });
+
+  test("set forwards policy options to store action", async () => {
+    nextResult = {
+      content: "Stored credential for twilio/auth_token.",
+      isError: false,
+    };
+
+    const result = await runCli([
+      "credentials",
+      "set",
+      "twilio",
+      "auth_token",
+      "secret-value",
+      "--allowed-tool",
+      "bash",
+      "--allowed-domain",
+      "api.twilio.com",
+      "--usage-description",
+      "Twilio auth token",
+      "--alias",
+      "twilio-primary",
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(executeCalls).toHaveLength(1);
+    expect(executeCalls[0]?.input).toMatchObject({
+      action: "store",
+      service: "twilio",
+      field: "auth_token",
+      value: "secret-value",
+      allowed_tools: ["bash"],
+      allowed_domains: ["api.twilio.com"],
+      usage_description: "Twilio auth token",
+      alias: "twilio-primary",
+    });
+    expect(executeCalls[0]?.context.trustClass).toBe("guardian");
+  });
+
+  test("get prints redacted credential output", async () => {
+    secureValues.set("credential:ngrok:authtoken", "token-123");
+
+    const result = await runCli([
+      "credentials",
+      "get",
+      "ngrok",
+      "authtoken",
+      "--redacted",
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("[REDACTED length=9]\n");
+  });
+
+  test("oauth2-connect parses repeated scope and extra params", async () => {
+    nextResult = { content: "Connected", isError: false };
+
+    const result = await runCli([
+      "credentials",
+      "oauth2-connect",
+      "gmail",
+      "--scope",
+      "openid",
+      "--scope",
+      "email",
+      "--extra-param",
+      "prompt=consent",
+      "--extra-param",
+      "access_type=offline",
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(executeCalls).toHaveLength(1);
+    expect(executeCalls[0]?.input).toMatchObject({
+      action: "oauth2_connect",
+      service: "gmail",
+      scopes: ["openid", "email"],
+      extra_params: {
+        prompt: "consent",
+        access_type: "offline",
+      },
+    });
+  });
+
+  test("oauth2-connect reports invalid extra-param input", async () => {
+    const result = await runCli([
+      "credentials",
+      "oauth2-connect",
+      "gmail",
+      "--extra-param",
+      "invalid-value",
+    ]);
+
+    expect(result.exitCode).toBe(1);
+    expect(executeCalls).toHaveLength(0);
+    expect(errorLogs[0]).toContain("Invalid --extra-param");
+  });
+});

--- a/assistant/src/cli/credentials.ts
+++ b/assistant/src/cli/credentials.ts
@@ -1,0 +1,418 @@
+import type { Command } from "commander";
+
+import { getSecureKey } from "../security/secure-keys.js";
+import { credentialStoreTool } from "../tools/credentials/vault.js";
+import { getCliLogger } from "../util/logger.js";
+
+const log = getCliLogger("cli");
+
+type CredentialPolicyOptions = {
+  allowedTool?: string[];
+  allowedDomain?: string[];
+  usageDescription?: string;
+  alias?: string;
+};
+
+type CredentialPromptOptions = CredentialPolicyOptions & {
+  label?: string;
+  description?: string;
+  placeholder?: string;
+  value?: string;
+};
+
+type CredentialOauthOptions = CredentialPolicyOptions & {
+  clientId?: string;
+  clientSecret?: string;
+  authUrl?: string;
+  tokenUrl?: string;
+  scope?: string[];
+  extraParam?: string[];
+  userinfoUrl?: string;
+  tokenEndpointAuthMethod?: "client_secret_basic" | "client_secret_post";
+};
+
+type CredentialGetOptions = {
+  redacted?: boolean;
+};
+
+function collectOption(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+function buildPolicyInput(
+  opts: CredentialPolicyOptions,
+): Record<string, unknown> {
+  const input: Record<string, unknown> = {};
+  if (opts.allowedTool && opts.allowedTool.length > 0) {
+    input.allowed_tools = opts.allowedTool;
+  }
+  if (opts.allowedDomain && opts.allowedDomain.length > 0) {
+    input.allowed_domains = opts.allowedDomain;
+  }
+  if (opts.usageDescription) {
+    input.usage_description = opts.usageDescription;
+  }
+  if (opts.alias) {
+    input.alias = opts.alias;
+  }
+  return input;
+}
+
+function parseExtraParams(
+  extraParamOptions: string[] | undefined,
+): Record<string, string> | undefined {
+  if (!extraParamOptions || extraParamOptions.length === 0) {
+    return undefined;
+  }
+  const extraParams: Record<string, string> = {};
+  for (const pair of extraParamOptions) {
+    const idx = pair.indexOf("=");
+    if (idx <= 0 || idx === pair.length - 1) {
+      throw new Error(
+        `Invalid --extra-param "${pair}". Use key=value (for example prompt=consent).`,
+      );
+    }
+    const key = pair.slice(0, idx).trim();
+    const value = pair.slice(idx + 1).trim();
+    if (!key || !value) {
+      throw new Error(
+        `Invalid --extra-param "${pair}". Use key=value (for example prompt=consent).`,
+      );
+    }
+    extraParams[key] = value;
+  }
+  return extraParams;
+}
+
+async function runCredentialAction(
+  input: Record<string, unknown>,
+  contextOverrides: Record<string, unknown> = {},
+): Promise<void> {
+  const result = await credentialStoreTool.execute(input, {
+    workingDir: process.cwd(),
+    sessionId: "cli",
+    conversationId: "cli",
+    trustClass: "guardian",
+    ...contextOverrides,
+  });
+  if (result.isError) {
+    log.error(result.content);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (input.action === "list" || input.action === "describe") {
+    process.stdout.write(`${result.content}\n`);
+    return;
+  }
+
+  log.info(result.content);
+}
+
+async function readStdinSecret(): Promise<string> {
+  let data = "";
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) {
+    data += chunk;
+  }
+  return data.trim();
+}
+
+async function readSecretFromTty(prompt: string): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    const stdin = process.stdin;
+    const stdout = process.stdout;
+
+    if (!stdin.isTTY) {
+      reject(new Error("stdin is not interactive"));
+      return;
+    }
+
+    const restore = () => {
+      stdin.off("data", onData);
+      stdin.setRawMode?.(false);
+      stdin.pause();
+    };
+
+    const onData = (chunk: string | Buffer): void => {
+      const data = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+
+      for (const ch of data) {
+        if (ch === "\u0003") {
+          restore();
+          reject(new Error("Credential prompt cancelled by user"));
+          return;
+        }
+        if (ch === "\r" || ch === "\n") {
+          stdout.write("\n");
+          const value = secret;
+          restore();
+          resolve(value);
+          return;
+        }
+        if (ch === "\u007f" || ch === "\b") {
+          if (secret.length > 0) {
+            secret = secret.slice(0, -1);
+          }
+          continue;
+        }
+        secret += ch;
+      }
+    };
+
+    let secret = "";
+    stdout.write(prompt);
+    stdin.resume();
+    stdin.setRawMode?.(true);
+    stdin.setEncoding("utf8");
+    stdin.on("data", onData);
+  });
+}
+
+async function resolvePromptValue(
+  service: string,
+  field: string,
+  valueArg?: string,
+): Promise<string> {
+  if (typeof valueArg === "string" && valueArg.length > 0) {
+    return valueArg;
+  }
+  if (!process.stdin.isTTY) {
+    return await readStdinSecret();
+  }
+  return await readSecretFromTty(`Enter secret for ${service}/${field}: `);
+}
+
+function redactValue(value: string): string {
+  return `[REDACTED length=${value.length}]`;
+}
+
+export function registerCredentialsCommand(program: Command): void {
+  const credentials = program
+    .command("credentials")
+    .description("Manage secure credentials for services and integrations");
+
+  credentials
+    .command("list")
+    .description("List stored credentials")
+    .alias("ls")
+    .action(async () => {
+      await runCredentialAction({ action: "list" });
+    });
+
+  const registerStoreCommand = (
+    commandName: string,
+    description: string,
+  ): void => {
+    credentials
+      .command(`${commandName} <service> <field> <value>`)
+      .description(description)
+      .option(
+        "--allowed-tool <tool>",
+        "Tool allowed to use this credential (repeat for multiple tools)",
+        collectOption,
+        [],
+      )
+      .option(
+        "--allowed-domain <domain>",
+        "Domain allowed to use this credential (repeat for multiple domains)",
+        collectOption,
+        [],
+      )
+      .option(
+        "--usage-description <description>",
+        "Human-readable purpose for the credential",
+      )
+      .option("--alias <alias>", "Human-friendly alias for this credential")
+      .action(
+        async (
+          service: string,
+          field: string,
+          value: string,
+          opts: CredentialPolicyOptions,
+        ) => {
+          await runCredentialAction({
+            action: "store",
+            service,
+            field,
+            value,
+            ...buildPolicyInput(opts),
+          });
+        },
+      );
+  };
+
+  registerStoreCommand("set", "Store a credential value");
+  registerStoreCommand("store", 'Alias for "credentials set"');
+
+  credentials
+    .command("get <service> <field>")
+    .description("Read a stored credential value")
+    .option(
+      "--redacted",
+      "Print redacted metadata instead of the raw secret value",
+    )
+    .action(
+      (service: string, field: string, opts: CredentialGetOptions = {}) => {
+        const key = `credential:${service}:${field}`;
+        const value = getSecureKey(key);
+        if (!value) {
+          log.error(`Credential not found for ${service}/${field}`);
+          process.exitCode = 1;
+          return;
+        }
+        process.stdout.write(`${opts.redacted ? redactValue(value) : value}\n`);
+      },
+    );
+
+  credentials
+    .command("delete <service> <field>")
+    .description("Delete a stored credential")
+    .alias("remove")
+    .action(async (service: string, field: string) => {
+      await runCredentialAction({ action: "delete", service, field });
+    });
+
+  credentials
+    .command("prompt <service> <field>")
+    .description(
+      "Prompt for a credential value (reads from hidden TTY input or stdin)",
+    )
+    .option("--label <label>", "Prompt label shown to the user")
+    .option("--description <description>", "Prompt description")
+    .option("--placeholder <placeholder>", "Prompt placeholder")
+    .option("--value <value>", "Credential value (for non-interactive usage)")
+    .option(
+      "--allowed-tool <tool>",
+      "Tool allowed to use this credential (repeat for multiple tools)",
+      collectOption,
+      [],
+    )
+    .option(
+      "--allowed-domain <domain>",
+      "Domain allowed to use this credential (repeat for multiple domains)",
+      collectOption,
+      [],
+    )
+    .option(
+      "--usage-description <description>",
+      "Human-readable purpose for the credential",
+    )
+    .action(
+      async (
+        service: string,
+        field: string,
+        opts: CredentialPromptOptions = {},
+      ) => {
+        const value = await resolvePromptValue(service, field, opts.value);
+        if (!value) {
+          log.error(
+            "No credential value provided. Pass --value, pipe via stdin, or enter a value interactively.",
+          );
+          process.exitCode = 1;
+          return;
+        }
+        await runCredentialAction(
+          {
+            action: "prompt",
+            service,
+            field,
+            label: opts.label,
+            description: opts.description,
+            placeholder: opts.placeholder,
+            ...buildPolicyInput(opts),
+          },
+          {
+            requestSecret: async () => ({
+              value,
+              delivery: "store",
+            }),
+          },
+        );
+      },
+    );
+
+  credentials
+    .command("describe <service>")
+    .description("Describe OAuth setup metadata for a service")
+    .action(async (service: string) => {
+      await runCredentialAction({ action: "describe", service });
+    });
+
+  credentials
+    .command("oauth2-connect <service>")
+    .alias("oauth2_connect")
+    .description("Run OAuth2 connect flow for a service")
+    .option("--client-id <clientId>", "OAuth client ID")
+    .option("--client-secret <clientSecret>", "OAuth client secret")
+    .option("--auth-url <url>", "OAuth authorization endpoint")
+    .option("--token-url <url>", "OAuth token endpoint")
+    .option(
+      "--scope <scope>",
+      "OAuth scope to request (repeat for multiple scopes)",
+      collectOption,
+      [],
+    )
+    .option(
+      "--extra-param <key=value>",
+      "Additional OAuth authorization query parameter",
+      collectOption,
+      [],
+    )
+    .option("--userinfo-url <url>", "OAuth userinfo endpoint")
+    .option(
+      "--token-endpoint-auth-method <method>",
+      "Token endpoint auth method: client_secret_basic or client_secret_post",
+    )
+    .option(
+      "--allowed-tool <tool>",
+      "Tool allowed to use resulting credentials (repeat for multiple tools)",
+      collectOption,
+      [],
+    )
+    .option(
+      "--allowed-domain <domain>",
+      "Domain allowed to use resulting credentials (repeat for multiple domains)",
+      collectOption,
+      [],
+    )
+    .option(
+      "--usage-description <description>",
+      "Human-readable purpose for the resulting credentials",
+    )
+    .action(
+      async (
+        service: string,
+        opts: CredentialOauthOptions = {},
+      ): Promise<void> => {
+        let extraParams: Record<string, string> | undefined;
+        try {
+          extraParams = parseExtraParams(opts.extraParam);
+        } catch (err) {
+          log.error(err instanceof Error ? err.message : String(err));
+          process.exitCode = 1;
+          return;
+        }
+
+        await runCredentialAction(
+          {
+            action: "oauth2_connect",
+            service,
+            client_id: opts.clientId,
+            client_secret: opts.clientSecret,
+            auth_url: opts.authUrl,
+            token_url: opts.tokenUrl,
+            scopes:
+              opts.scope && opts.scope.length > 0 ? opts.scope : undefined,
+            extra_params: extraParams,
+            userinfo_url: opts.userinfoUrl,
+            token_endpoint_auth_method: opts.tokenEndpointAuthMethod,
+            ...buildPolicyInput(opts),
+          },
+          {
+            isInteractive: false,
+          },
+        );
+      },
+    );
+}

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -22,6 +22,7 @@ import {
   registerDoctorCommand,
   registerSessionsCommand,
 } from "./cli/core-commands.js";
+import { registerCredentialsCommand } from "./cli/credentials.js";
 import { registerEmailCommand } from "./cli/email.js";
 import { registerInfluencerCommand } from "./cli/influencer.js";
 import {
@@ -42,6 +43,7 @@ registerDefaultAction(program);
 registerDevCommand(program);
 registerSessionsCommand(program);
 registerConfigCommand(program);
+registerCredentialsCommand(program);
 registerKeysCommand(program);
 registerTrustCommand(program);
 registerMemoryCommand(program);


### PR DESCRIPTION
## Summary
- add a first-class `vellum credentials` CLI command with credential vault actions (list/set/store/get/delete/prompt/describe/oauth2-connect)
- wire the new command into the main CLI entrypoint
- add dedicated CLI tests for action dispatch, policy option forwarding, redacted get output, and oauth2 option parsing

## Testing
- export PATH="/Users/aaronlevin/.bun/bin:/Users/aaronlevin/.codex/tmp/arg0/codex-arg0nSORuM:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/aaronlevin/.bun/bin:/Users/aaronlevin/google-cloud-sdk/bin:/Users/aaronlevin/.composio:/Users/aaronlevin/.composio:/Users/aaronlevin/.antigravity/antigravity/bin:/Users/aaronlevin/.codeium/windsurf/bin:/Users/aaronlevin/.local/bin:/Users/aaronlevin/.local/share/uv/python/bin:/Users/aaronlevin/.bun/bin:/Users/aaronlevin/Library/pnpm:/Library/Frameworks/Python.framework/Versions/3.12/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/aaronlevin/.cargo/bin:/Applications/Ghostty.app/Contents/MacOS:/Applications/Visual Studio Code.app/Contents/Resources/app/bin" && cd assistant && bun test src/__tests__/credentials-cli.test.ts
- export PATH="/Users/aaronlevin/.bun/bin:/Users/aaronlevin/.codex/tmp/arg0/codex-arg0nSORuM:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/aaronlevin/.bun/bin:/Users/aaronlevin/google-cloud-sdk/bin:/Users/aaronlevin/.composio:/Users/aaronlevin/.composio:/Users/aaronlevin/.antigravity/antigravity/bin:/Users/aaronlevin/.codeium/windsurf/bin:/Users/aaronlevin/.local/bin:/Users/aaronlevin/.local/share/uv/python/bin:/Users/aaronlevin/.bun/bin:/Users/aaronlevin/Library/pnpm:/Library/Frameworks/Python.framework/Versions/3.12/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/aaronlevin/.cargo/bin:/Applications/Ghostty.app/Contents/MacOS:/Applications/Visual Studio Code.app/Contents/Resources/app/bin" && cd assistant && bunx tsc --noEmit

Closes #12708
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
