### PR TITLE
Update phone-setup test case to handle Twilio account prompt

### DIFF
--- a/playwright/cases/phone-setup.md
+++ b/playwright/cases/phone-setup.md
@@ -14,7 +14,7 @@ Verify that we're able to configure everything needed for the assistant to be ab
 1. Launch the App
 2. Open a chat thread
 3. Send the message "Can you make phone calls for me?"
-4. Verify that the assistant responds in the affirmative that it is able to make phone calls, but that some initial setup is needed.
+4. Verify that the assistant responds in the affirmative that it is able to make phone calls, but that some initial setup is needed. If prompted, state that you already have a Twilio account.
 5. You should be asked to provider your Twilio Account SID, your Twilio Auth Token, and your ngrok Auth Token, all through new windows that pop open titled "Secure Credential."
 6. Verify that you were able to supply all three credentals through a secure window and were NOT encouraged to provide them conversationally through the chat interface.
 7. You should be asked what voice you want the assistant to have and be presented with a few options to choose from.


### PR DESCRIPTION
## Summary
- Update phone-setup Playwright test case step 4 to instruct the tester to state they already have a Twilio account if prompted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
