### PR TITLE
fix: replace onChange auto-save with explicit Save button for response expectation picker

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView+EditableMetadata.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView+EditableMetadata.swift
@@ -96,11 +96,16 @@ extension ContactDetailView {
                     }
                     .labelsHidden()
                     .pickerStyle(.menu)
-                    .onChange(of: editedResponseExpectation) { _, newValue in
-                        let currentValue = displayContact.responseExpectation ?? ""
-                        guard newValue != currentValue else { return }
-                        Task { await saveResponseExpectation(newValue.isEmpty ? nil : newValue) }
+
+                    Button {
+                        Task { await saveResponseExpectation(editedResponseExpectation.isEmpty ? nil : editedResponseExpectation) }
+                    } label: {
+                        Image(systemName: "checkmark")
+                            .foregroundColor(VColor.success)
+                            .font(.system(size: 12, weight: .semibold))
                     }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Save response expectation")
 
                     Button {
                         isEditingResponseExpectation = false


### PR DESCRIPTION
Replace the onChange-based auto-save on the response expectation picker with an explicit Save button (checkmark), matching the importance row pattern. This fixes two issues: (1) the stale-state guard that compared against displayContact.responseExpectation could persist wrong values under slow network, and (2) the user couldn't retry a failed save for the same value since onChange only fires on value change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
