### PR TITLE
fix: pre-push debug log macOS date fallback

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -30,10 +30,11 @@ _debug_log() {
     local now
     if command -v gdate &>/dev/null; then
         now=$(gdate +%s%3N)
-    elif date +%s%3N &>/dev/null 2>&1; then
-        now=$(date +%s%3N)
     else
-        now=$(( $(date +%s) * 1000 ))
+        now=$(date +%s%3N 2>/dev/null)
+        if [[ ! "$now" =~ ^[0-9]+$ ]]; then
+            now=$(( $(date +%s) * 1000 ))
+        fi
     fi
     if [ -z "$PREPUSH_START_EPOCH" ]; then
         PREPUSH_START_EPOCH="$now"


### PR DESCRIPTION
## Summary
- Fix arithmetic error on macOS without `gdate`: `date +%s%3N` exits 0 but produces `1772676453N` (literal N)
- Validate `date +%s%3N` output is purely numeric before using it; fall back to second-precision if not

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
