### PR TITLE
fix: address remaining review feedback on multi-local-assist

### DIFF
--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -244,7 +244,8 @@ async function getLocalProcesses(entry: AssistantEntry): Promise<TableRow[]> {
       name: "outbound-proxy",
       pgrepName: "outbound-proxy",
       port: PROXY_PORT,
-      pidFile: join(vellumDir, "outbound-proxy.pid"),
+      // Outbound proxy is a shared singleton — always use the global PID path
+      pidFile: join(homedir(), ".vellum", "outbound-proxy.pid"),
     },
     {
       name: "embed-worker",

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -72,9 +72,10 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   // Only stop it if no other local assistants still have a running daemon.
   const outboundProxyPidFile = join(homedir(), ".vellum", "outbound-proxy.pid");
   const otherLocalRunning = loadAllAssistants().some((other) => {
-    if (other.cloud !== "local" || !other.resources) return false;
+    if (other.cloud !== "local") return false;
     if (other.assistantId === name) return false;
-    return isProcessAlive(other.resources.pidFile).alive;
+    const otherRes = other.resources ?? defaultLocalResources();
+    return isProcessAlive(otherRes.pidFile).alive;
   });
   if (!otherLocalRunning) {
     await stopProcessByPidFile(outboundProxyPidFile, "outbound-proxy");

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -63,9 +63,10 @@ export async function sleep(): Promise<void> {
   // have a running daemon — the proxy is a global singleton shared by all
   // instances.
   const otherLocalRunning = loadAllAssistants().some((other) => {
-    if (other.cloud !== "local" || !other.resources) return false;
+    if (other.cloud !== "local") return false;
     if (other.assistantId === entry.assistantId) return false;
-    return isProcessAlive(other.resources.pidFile).alive;
+    const otherRes = other.resources ?? defaultLocalResources();
+    return isProcessAlive(otherRes.pidFile).alive;
   });
 
   if (otherLocalRunning) {

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -241,12 +241,21 @@ export async function allocateLocalResources(
   // to prevent binding collisions when both are woken.
   const reservedPorts: number[] = [];
   for (const entry of loadAllAssistants()) {
-    if (entry.cloud !== "local" || !entry.resources) continue;
-    reservedPorts.push(
-      entry.resources.daemonPort,
-      entry.resources.gatewayPort,
-      entry.resources.qdrantPort,
-    );
+    if (entry.cloud !== "local") continue;
+    if (entry.resources) {
+      reservedPorts.push(
+        entry.resources.daemonPort,
+        entry.resources.gatewayPort,
+        entry.resources.qdrantPort,
+      );
+    } else {
+      // Legacy entries without resources use the default ports
+      reservedPorts.push(
+        DEFAULT_DAEMON_PORT,
+        DEFAULT_GATEWAY_PORT,
+        DEFAULT_QDRANT_PORT,
+      );
+    }
   }
 
   // Allocate ports sequentially to avoid overlapping ranges assigning the

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -1155,6 +1155,7 @@ export async function stopLocalProcesses(
   const gatewayPidFile = join(vellumDir, "gateway.pid");
   await stopProcessByPidFile(gatewayPidFile, "gateway");
 
-  const outboundProxyPidFile = join(vellumDir, "outbound-proxy.pid");
+  // Outbound proxy is a shared singleton — always use the global PID path
+  const outboundProxyPidFile = join(homedir(), ".vellum", "outbound-proxy.pid");
   await stopProcessByPidFile(outboundProxyPidFile, "outbound-proxy");
 }


### PR DESCRIPTION
Addresses all unresolved review feedback on PR #12665:

1. Legacy entries in proxy liveness check (sleep.ts + retire.ts): fall back to defaultLocalResources() instead of skipping entries without resources
2. stopLocalProcesses (local.ts): use global ~/.vellum/outbound-proxy.pid path
3. ps.ts: use global outbound proxy PID path for consistent status reporting
4. allocateLocalResources (assistant-config.ts): reserve default ports for legacy entries to prevent port collisions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
