### PR TITLE
feat: set importance=1.0 and relationship="guardian" on guardian contact creation

### DIFF
--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -78,6 +78,8 @@ export function createGuardianBinding(params: {
   upsertContact({
     displayName,
     role: "guardian",
+    importance: 1.0,
+    relationship: "guardian",
     principalId: params.guardianPrincipalId,
     assistantId: params.assistantId,
     channels: [


### PR DESCRIPTION
## Summary
- Set `importance: 1.0` on guardian contacts at creation time (previously defaulted to 0.5)
- Set `relationship: "guardian"` on guardian contacts at creation time (previously null)
- Applies to all guardian bindings (vellum bootstrap, Telegram/SMS channel verification)

Part of plan: guardian-contact-field-inference.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
