### PR TITLE
feat: use resolveUserReference for guardian displayName at bootstrap

### DIFF
--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -13,6 +13,7 @@ import { createHash } from "node:crypto";
 
 import { v4 as uuid } from "uuid";
 
+import { resolveUserReference } from "../../config/user-reference.js";
 import { findGuardianForChannel } from "../../contacts/contact-store.js";
 import { createGuardianBinding } from "../../contacts/contacts-write.js";
 import { getLogger } from "../../util/logger.js";
@@ -54,6 +55,7 @@ function ensureGuardianPrincipal(assistantId: string): {
 
   // Mint a new principal ID for the vellum channel
   const guardianPrincipalId = `vellum-principal-${uuid()}`;
+  const guardianDisplayName = resolveUserReference();
 
   createGuardianBinding({
     assistantId,
@@ -62,7 +64,10 @@ function ensureGuardianPrincipal(assistantId: string): {
     guardianDeliveryChatId: "local",
     guardianPrincipalId,
     verifiedVia: "bootstrap",
-    metadataJson: JSON.stringify({ bootstrappedAt: Date.now() }),
+    metadataJson: JSON.stringify({
+      bootstrappedAt: Date.now(),
+      displayName: guardianDisplayName,
+    }),
   });
 
   log.info(


### PR DESCRIPTION
## Summary
- Use `resolveUserReference()` to derive the guardian contact's displayName at bootstrap time
- Reads preferred name from USER.md (e.g. "Noa"), falls back to "my human" if unavailable
- Replaces the previous behavior of using the principalId UUID as the displayName

Part of plan: guardian-contact-field-inference.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
