### PR TITLE
Add 'Send Verification' button and verification state to contact detail channel rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -14,6 +14,8 @@ struct ContactDetailView: View {
     @State private var isEditingName = false
     @State private var editedName = ""
     @State private var isHoveringHeader = false
+    @State private var verificationInProgress: String?
+    @State private var verificationSuccessChannelId: String?
 
     // Metadata editing state (accessed from ContactDetailView+EditableMetadata.swift)
     @State var isEditingRelationship = false
@@ -224,51 +226,92 @@ struct ContactDetailView: View {
     private func channelActions(for channel: ContactChannelPayload) -> some View {
         // Disable ALL action buttons while any channel action is in-flight to
         // serialize updates and prevent response correlation mix-ups.
-        let anyActionInFlight = actionInProgress != nil
+        let anyActionInFlight = actionInProgress != nil || verificationInProgress != nil
         let isThisChannel = actionInProgress == channel.id
 
-        HStack(spacing: VSpacing.sm) {
-            switch channel.status {
-            case "revoked":
-                VButton(
-                    label: "Restore Access",
-                    style: .secondary,
-                    size: .medium,
-                    isDisabled: anyActionInFlight
-                ) {
-                    updateChannelStatus(channelId: channel.id, status: "active")
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.sm) {
+                switch channel.status {
+                case "revoked":
+                    VButton(
+                        label: "Restore Access",
+                        style: .secondary,
+                        size: .medium,
+                        isDisabled: anyActionInFlight
+                    ) {
+                        updateChannelStatus(channelId: channel.id, status: "active")
+                    }
+                case "blocked":
+                    VButton(
+                        label: "Restore Access",
+                        style: .secondary,
+                        size: .medium,
+                        isDisabled: anyActionInFlight
+                    ) {
+                        updateChannelStatus(channelId: channel.id, status: "active")
+                    }
+                case "unverified", "pending":
+                    VButton(
+                        label: "Send Verification",
+                        style: .primary,
+                        size: .medium,
+                        isDisabled: anyActionInFlight
+                    ) {
+                        initiateVerification(for: channel)
+                    }
+                    VButton(
+                        label: "Revoke Access",
+                        style: .danger,
+                        size: .medium,
+                        isDisabled: anyActionInFlight
+                    ) {
+                        updateChannelStatus(channelId: channel.id, status: "revoked")
+                    }
+                default:
+                    VButton(
+                        label: "Revoke Access",
+                        style: .danger,
+                        size: .medium,
+                        isDisabled: anyActionInFlight
+                    ) {
+                        updateChannelStatus(channelId: channel.id, status: "revoked")
+                    }
+                    VButton(
+                        label: "Block",
+                        style: .danger,
+                        size: .medium,
+                        isDisabled: anyActionInFlight
+                    ) {
+                        updateChannelStatus(channelId: channel.id, status: "blocked")
+                    }
                 }
-            case "blocked":
-                VButton(
-                    label: "Restore Access",
-                    style: .secondary,
-                    size: .medium,
-                    isDisabled: anyActionInFlight
-                ) {
-                    updateChannelStatus(channelId: channel.id, status: "active")
-                }
-            default:
-                VButton(
-                    label: "Revoke Access",
-                    style: .danger,
-                    size: .medium,
-                    isDisabled: anyActionInFlight
-                ) {
-                    updateChannelStatus(channelId: channel.id, status: "revoked")
-                }
-                VButton(
-                    label: "Block",
-                    style: .danger,
-                    size: .medium,
-                    isDisabled: anyActionInFlight
-                ) {
-                    updateChannelStatus(channelId: channel.id, status: "blocked")
+
+                if isThisChannel {
+                    ProgressView()
+                        .controlSize(.small)
                 }
             }
 
-            if isThisChannel {
-                ProgressView()
-                    .controlSize(.small)
+            // Verification feedback
+            if verificationInProgress == channel.id {
+                HStack(spacing: VSpacing.xs) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Sending verification code...")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                }
+            }
+
+            if verificationSuccessChannelId == channel.id {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(VColor.success)
+                        .font(.system(size: 12))
+                    Text("Verification code sent")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.success)
+                }
             }
         }
     }
@@ -450,6 +493,37 @@ struct ContactDetailView: View {
         }
     }
 
+    private func initiateVerification(for channel: ContactChannelPayload) {
+        guard let daemonClient, verificationInProgress == nil else { return }
+        verificationInProgress = channel.id
+        errorMessage = nil
+        verificationSuccessChannelId = nil
+
+        Task {
+            do {
+                let result = try await daemonClient.verifyContactChannel(
+                    contactId: displayContact.id,
+                    channelId: channel.id
+                )
+                if result?.ok == true {
+                    verificationSuccessChannelId = channel.id
+                    // Auto-clear the success message after 5 seconds
+                    Task {
+                        try? await Task.sleep(nanoseconds: 5_000_000_000)
+                        if verificationSuccessChannelId == channel.id {
+                            verificationSuccessChannelId = nil
+                        }
+                    }
+                } else {
+                    errorMessage = result?.error ?? "Failed to send verification"
+                }
+            } catch {
+                errorMessage = "Failed to send verification: \(error.localizedDescription)"
+            }
+            verificationInProgress = nil
+        }
+    }
+
     private func updateChannelStatus(channelId: String, status: String) {
         guard let daemonClient else { return }
         guard actionInProgress == nil else { return }
@@ -551,6 +625,14 @@ struct ContactDetailView: View {
                         status: "pending",
                         policy: "restrict",
                         lastSeenAt: Int(Date().timeIntervalSince1970 * 1000) - 7_200_000
+                    ),
+                    ContactChannelPayload(
+                        id: "ch-5",
+                        type: "whatsapp",
+                        address: "+1555987654",
+                        isPrimary: false,
+                        status: "unverified",
+                        policy: "allow"
                     )
                 ]
             )

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1520,6 +1520,16 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     // MARK: - Contacts Management
 
+    /// Response from the channel verification endpoint.
+    public struct ChannelVerificationResult: Decodable {
+        public let ok: Bool
+        public let verificationSessionId: String?
+        public let expiresAt: Int?
+        public let sendCount: Int?
+        public let telegramBootstrapUrl: String?
+        public let error: String?
+    }
+
     /// A channel to attach when creating a new contact.
     public struct NewContactChannel: Codable {
         public let type: String
@@ -1662,6 +1672,44 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
         let decoded = try JSONDecoder().decode(UpsertResponse.self, from: data)
         return decoded.contact
+    }
+
+    /// Send a verification code to a contact's channel via the gateway.
+    /// Routes through `HTTPTransport` when available. Falls back to the
+    /// local gateway (port 7830) for socket-based connections.
+    public func verifyContactChannel(
+        contactId: String,
+        channelId: String
+    ) async throws -> ChannelVerificationResult? {
+        if let httpTransport {
+            return try await httpTransport.verifyContactChannel(
+                contactId: contactId,
+                channelId: channelId
+            )
+        }
+
+        #if os(macOS)
+        let gatewayPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
+            .flatMap(Int.init) ?? 7830
+        let baseURL = "http://127.0.0.1:\(gatewayPort)"
+        #else
+        return nil
+        #endif
+
+        let cEncoded = contactId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? contactId
+        let chEncoded = channelId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? channelId
+        guard let url = URL(string: "\(baseURL)/v1/contacts/\(cEncoded)/channels/\(chEncoded)/verify") else { return nil }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token = readHttpToken(), !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse,
+              (200...299).contains(http.statusCode) else { return nil }
+        return try JSONDecoder().decode(ChannelVerificationResult.self, from: data)
     }
 
     // MARK: - Feature Flags

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -162,6 +162,7 @@ public final class HTTPTransport {
         case contactsList(limit: Int, role: String?)
         case contactsGet(id: String)
         case contactsChannelUpdate(channelId: String)
+        case contactsChannelVerify(contactId: String, channelId: String)
         case contactsUpsert
     }
 
@@ -251,6 +252,10 @@ public final class HTTPTransport {
         case .contactsChannelUpdate(let channelId):
             let encoded = channelId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? channelId
             return ("/v1/contacts/channels/\(encoded)", nil)
+        case .contactsChannelVerify(let contactId, let channelId):
+            let cEncoded = contactId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? contactId
+            let chEncoded = channelId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? channelId
+            return ("/v1/contacts/\(cEncoded)/channels/\(chEncoded)/verify", nil)
         case .contactsUpsert:
             return ("/v1/contacts", nil)
         }
@@ -322,6 +327,10 @@ public final class HTTPTransport {
         case .contactsChannelUpdate(let channelId):
             let encoded = channelId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? channelId
             return ("\(prefix)/contacts/channels/\(encoded)/", nil)
+        case .contactsChannelVerify(let contactId, let channelId):
+            let cEncoded = contactId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? contactId
+            let chEncoded = channelId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? channelId
+            return ("\(prefix)/contacts/\(cEncoded)/channels/\(chEncoded)/verify/", nil)
         case .contactsUpsert:
             return ("\(prefix)/contacts/", nil)
         }
@@ -1133,6 +1142,20 @@ public final class HTTPTransport {
 
         let decoded = try decoder.decode(HTTPContactUpsertResponse.self, from: data)
         return decoded.contact
+    }
+
+    // MARK: - Channel Verification
+
+    /// Send a verification code to a contact's channel via the gateway.
+    func verifyContactChannel(contactId: String, channelId: String) async throws -> ChannelVerificationResult? {
+        guard let url = buildURL(for: .contactsChannelVerify(contactId: contactId, channelId: channelId)) else { return nil }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else { return nil }
+        return try JSONDecoder().decode(ChannelVerificationResult.self, from: data)
     }
 
     // MARK: - Surface Actions


### PR DESCRIPTION
## Summary
- Add contactsChannelVerify endpoint and verifyContactChannel() to HTTPDaemonClient/DaemonClient
- Add ChannelVerificationResult struct for decoding verification responses
- Add 'Send Verification' button for unverified/pending channels in ContactDetailView
- Show spinner during verification and success/error feedback

Part of plan: add-contacts-verify.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
