### PR TITLE
M1: Cache preview images in the ChatMessage data model

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -27,6 +27,7 @@ struct ChatBubble: View {
     var isProcessingAfterTools: Bool = false
     /// Status text from the assistant activity state, forwarded for inline display.
     var processingStatusText: String?
+    var onPreviewImageUpdate: ((String, String) -> Void)? = nil
 
     @State private var appearance = AvatarAppearanceManager.shared
     @State private var isHovered = false
@@ -168,7 +169,7 @@ struct ChatBubble: View {
                         // Skip surfaces that are currently shown in the floating overlay
                         if !message.inlineSurfaces.isEmpty {
                             ForEach(message.inlineSurfaces.filter { $0.id != activeSurfaceId }) { surface in
-                                InlineSurfaceRouter(surface: surface, onAction: onSurfaceAction)
+                                InlineSurfaceRouter(surface: surface, onAction: onSurfaceAction, onPreviewImageUpdate: onPreviewImageUpdate)
                             }
                         }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -73,7 +73,7 @@ extension ChatBubble {
             case .surface(let i):
                 if i < message.inlineSurfaces.count,
                    message.inlineSurfaces[i].id != activeSurfaceId {
-                    InlineSurfaceRouter(surface: message.inlineSurfaces[i], onAction: onSurfaceAction)
+                    InlineSurfaceRouter(surface: message.inlineSurfaces[i], onAction: onSurfaceAction, onPreviewImageUpdate: onPreviewImageUpdate)
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -62,6 +62,7 @@ struct ChatView: View {
     var onSubagentTap: ((String) -> Void)?
     /// Called to rehydrate truncated message content on demand.
     var onRehydrateMessage: ((UUID) -> Void)?
+    var onPreviewImageUpdate: ((String, String) -> Void)? = nil
     @ObservedObject var subagentDetailStore: SubagentDetailStore
     /// Resolves the daemon HTTP port at call time so lazy-loaded video
     /// attachments always use the latest port after daemon restarts.
@@ -210,6 +211,7 @@ struct ChatView: View {
                             onAbortSubagent: onAbortSubagent,
                             onSubagentTap: onSubagentTap,
                             onRehydrateMessage: onRehydrateMessage,
+                            onPreviewImageUpdate: onPreviewImageUpdate,
                             subagentDetailStore: subagentDetailStore,
                             displayedMessageCount: displayedMessageCount,
                             hasMoreMessages: hasMoreMessages,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -37,6 +37,7 @@ struct MessageListView: View {
     var onSubagentTap: ((String) -> Void)?
     /// Called to rehydrate truncated message content on demand.
     var onRehydrateMessage: ((UUID) -> Void)?
+    var onPreviewImageUpdate: ((String, String) -> Void)? = nil
     @ObservedObject var subagentDetailStore: SubagentDetailStore
 
     // MARK: - Pagination
@@ -422,7 +423,8 @@ struct MessageListView: View {
                                 isLatestAssistantMessage: message.role == .assistant && message.id == latestAssistantId,
                                 isProcessingAfterTools: canInlineProcessing && message.id == latestAssistantId,
                                 processingStatusText: canInlineProcessing && message.id == latestAssistantId ? assistantStatusText : nil,
-                                activeSurfaceId: activeSurfaceId
+                                activeSurfaceId: activeSurfaceId,
+                                onPreviewImageUpdate: onPreviewImageUpdate
                             )
                                 .id(message.id)
                                 .transition(.opacity)

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -714,6 +714,9 @@ struct ActiveChatViewWrapper: View {
             onRehydrateMessage: { messageId in
                 viewModel.rehydrateMessage(id: messageId)
             },
+            onPreviewImageUpdate: { appId, base64 in
+                viewModel.updateSurfacePreviewImage(appId: appId, base64: base64)
+            },
             subagentDetailStore: viewModel.subagentDetailStore,
             resolveHttpPort: daemonClient.httpPortResolver,
             isHistoryLoaded: viewModel.isHistoryLoaded,

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -596,6 +596,19 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
+    /// Persist a captured preview image into the ChatMessage model so it survives thread switches.
+    public func updateSurfacePreviewImage(appId: String, base64: String) {
+        for msgIdx in messages.indices {
+            for surfIdx in messages[msgIdx].inlineSurfaces.indices {
+                if case .dynamicPage(var dpData) = messages[msgIdx].inlineSurfaces[surfIdx].data,
+                   dpData.appId == appId {
+                    dpData.preview?.previewImage = base64
+                    messages[msgIdx].inlineSurfaces[surfIdx].data = .dynamicPage(dpData)
+                }
+            }
+        }
+    }
+
     /// Handle a `message_content_response` from the daemon, updating the matching
     /// message with full (untruncated) text and tool call results.
     public func handleMessageContentResponse(_ response: IPCMessageContentResponse) {

--- a/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
@@ -9,6 +9,7 @@ struct InlineAppCreatedCard: View {
     let appId: String?
     let onOpenApp: () -> Void
     let onPinToHomebase: () -> Void
+    var onPreviewImageUpdate: ((String) -> Void)? = nil
 
     @Environment(\.colorScheme) private var colorScheme
     @State private var previewImage: String?
@@ -98,6 +99,7 @@ struct InlineAppCreatedCard: View {
                   notifAppId == appId,
                   let base64 = notification.userInfo?["previewImage"] as? String else { return }
             previewImage = base64
+            onPreviewImageUpdate?(base64)
         }
     }
 }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineSurfaceRouter.swift
@@ -4,13 +4,15 @@ import SwiftUI
 public struct InlineSurfaceRouter: View {
     public let surface: InlineSurfaceData
     public let onAction: (String, String, [String: AnyCodable]?) -> Void
+    public var onPreviewImageUpdate: ((String, String) -> Void)? = nil
 
     @State private var selectionPayload: [String: AnyCodable]?
     @State private var clickedActionLabel: String?
 
-    public init(surface: InlineSurfaceData, onAction: @escaping (String, String, [String: AnyCodable]?) -> Void) {
+    public init(surface: InlineSurfaceData, onAction: @escaping (String, String, [String: AnyCodable]?) -> Void, onPreviewImageUpdate: ((String, String) -> Void)? = nil) {
         self.surface = surface
         self.onAction = onAction
+        self.onPreviewImageUpdate = onPreviewImageUpdate
     }
 
     /// Whether the surface content handles its own header/chrome.
@@ -178,6 +180,11 @@ public struct InlineSurfaceRouter: View {
                                     "description": preview.description as Any,
                                 ]
                             )
+                        },
+                        onPreviewImageUpdate: { base64 in
+                            if let appId = data.appId {
+                                onPreviewImageUpdate?(appId, base64)
+                            }
                         }
                     )
                 } else {

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -314,7 +314,7 @@ public struct DynamicPageSurfaceData: Sendable, Equatable {
     public let height: Int?
     public let appId: String?
     public let appType: String?
-    public let preview: DynamicPagePreview?
+    public var preview: DynamicPagePreview?
     public let reloadGeneration: Int?
     public let status: String?
 


### PR DESCRIPTION
When InlineAppCreatedCard receives a preview image via NotificationCenter, propagate it back into the ChatMessage model so it persists across thread switches. Previously, preview images were stored in ephemeral @State and lost on every thread switch.

Changes:
- Add onPreviewImageUpdate callback chain: InlineAppCreatedCard → InlineSurfaceRouter → ChatBubble → MessageListView → ChatViewModel
- Add updateSurfacePreviewImage method to ChatViewModel
- Make necessary data model types mutable (DynamicPageSurfaceData.preview, etc.)

Closes #12731
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
