### PR TITLE
fix: qualify ChannelVerificationResult type in HTTPTransport

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1147,7 +1147,7 @@ public final class HTTPTransport {
     // MARK: - Channel Verification
 
     /// Send a verification code to a contact's channel via the gateway.
-    func verifyContactChannel(contactId: String, channelId: String) async throws -> ChannelVerificationResult? {
+    func verifyContactChannel(contactId: String, channelId: String) async throws -> DaemonClient.ChannelVerificationResult? {
         guard let url = buildURL(for: .contactsChannelVerify(contactId: contactId, channelId: channelId)) else { return nil }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -1155,7 +1155,7 @@ public final class HTTPTransport {
         applyAuth(&request)
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else { return nil }
-        return try JSONDecoder().decode(ChannelVerificationResult.self, from: data)
+        return try JSONDecoder().decode(DaemonClient.ChannelVerificationResult.self, from: data)
     }
 
     // MARK: - Surface Actions


### PR DESCRIPTION
## Summary
- `ChannelVerificationResult` is nested inside `DaemonClient` but was referenced unqualified in `HTTPTransport`, causing a Swift compilation error
- Qualify both references as `DaemonClient.ChannelVerificationResult`

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22699302727/job/65812613223

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
