### PR TITLE
M2: Eagerly request app previews when surfaces arrive

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1389,6 +1389,17 @@ extension ChatViewModel {
                 messages.append(newMsg)
             }
 
+            // Eagerly request preview for app surfaces that don't have one yet
+            if case .dynamicPage(let dpData) = surface.data,
+               let appId = dpData.appId,
+               dpData.preview?.previewImage == nil {
+                NotificationCenter.default.post(
+                    name: Notification.Name("MainWindow.requestAppPreview"),
+                    object: nil,
+                    userInfo: ["appId": appId]
+                )
+            }
+
         case .uiSurfaceUndoResult(let msg):
             guard belongsToSession(msg.sessionId) else { return }
             surfaceUndoCount = msg.remainingUndos

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1392,6 +1392,7 @@ extension ChatViewModel {
             // Eagerly request preview for app surfaces that don't have one yet
             if case .dynamicPage(let dpData) = surface.data,
                let appId = dpData.appId,
+               dpData.preview != nil,
                dpData.preview?.previewImage == nil {
                 NotificationCenter.default.post(
                     name: Notification.Name("MainWindow.requestAppPreview"),

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -284,6 +284,7 @@ public final class ChatViewModel: ObservableObject {
         }
     }
     private var reconnectObserver: NSObjectProtocol?
+    private var appPreviewCapturedObserver: NSObjectProtocol?
     /// Debounces rapid-fire daemon reconnect notifications so only one history
     /// reload is triggered per reconnect burst (500ms settle window).
     private var reconnectDebounceTask: Task<Void, Never>?
@@ -882,6 +883,20 @@ public final class ChatViewModel: ObservableObject {
                 } else {
                     self?.needsOfflineFlush = true
                 }
+            }
+        }
+
+        // Listen for captured app preview images and persist them into the
+        // ChatMessage model so they survive thread switches and history reloads.
+        appPreviewCapturedObserver = NotificationCenter.default.addObserver(
+            forName: Notification.Name("MainWindow.appPreviewImageCaptured"),
+            object: nil,
+            queue: nil
+        ) { [weak self] notification in
+            guard let appId = notification.userInfo?["appId"] as? String,
+                  let base64 = notification.userInfo?["previewImage"] as? String else { return }
+            Task { @MainActor [weak self] in
+                self?.updateSurfacePreviewImage(appId: appId, base64: base64)
             }
         }
 
@@ -2390,6 +2405,9 @@ public final class ChatViewModel: ObservableObject {
         reconnectDebounceTask?.cancel()
         memoryPressureSource?.cancel()
         if let observer = reconnectObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = appPreviewCapturedObserver {
             NotificationCenter.default.removeObserver(observer)
         }
     }

--- a/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
@@ -85,6 +85,15 @@ struct InlineAppCreatedCard: View {
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .onAppear {
             previewImage = preview.previewImage
+            // Fallback request for history-loaded surfaces that didn't go
+            // through the uiSurfaceShow IPC handler (app restart, reconnect).
+            if previewImage == nil, let appId = appId {
+                NotificationCenter.default.post(
+                    name: Notification.Name("MainWindow.requestAppPreview"),
+                    object: nil,
+                    userInfo: ["appId": appId]
+                )
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: Notification.Name("MainWindow.appPreviewImageCaptured"))) { notification in
             guard let notifAppId = notification.userInfo?["appId"] as? String,

--- a/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
+++ b/clients/shared/Features/Chat/InlineWidgets/InlineAppCreatedCard.swift
@@ -85,14 +85,6 @@ struct InlineAppCreatedCard: View {
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .onAppear {
             previewImage = preview.previewImage
-            // If no preview image yet, request one from the daemon
-            if previewImage == nil, let appId = appId {
-                NotificationCenter.default.post(
-                    name: Notification.Name("MainWindow.requestAppPreview"),
-                    object: nil,
-                    userInfo: ["appId": appId]
-                )
-            }
         }
         .onReceive(NotificationCenter.default.publisher(for: Notification.Name("MainWindow.appPreviewImageCaptured"))) { notification in
             guard let notifAppId = notification.userInfo?["appId"] as? String,


### PR DESCRIPTION
Fire requestAppPreview immediately when uiSurfaceShow processes an app surface with no preview image, instead of waiting for InlineAppCreatedCard.onAppear. Also subscribe to appPreviewImageCaptured in ChatViewModel to automatically update the model when previews arrive.

Changes:
- Add eager requestAppPreview post in uiSurfaceShow handler
- Subscribe to appPreviewImageCaptured in ChatViewModel to call updateSurfacePreviewImage

Closes #12732
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
