### PR TITLE
fix: move gateway fallback code inside #if os(macOS) to fix iOS build

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1639,9 +1639,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         let gatewayPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
             .flatMap(Int.init) ?? 7830
         let baseURL = "http://127.0.0.1:\(gatewayPort)"
-        #else
-        return nil
-        #endif
 
         guard let url = URL(string: "\(baseURL)/v1/contacts") else { return nil }
         var request = URLRequest(url: url)
@@ -1672,6 +1669,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
         let decoded = try JSONDecoder().decode(UpsertResponse.self, from: data)
         return decoded.contact
+        #else
+        return nil
+        #endif
     }
 
     /// Send a verification code to a contact's channel via the gateway.
@@ -1692,9 +1692,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         let gatewayPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
             .flatMap(Int.init) ?? 7830
         let baseURL = "http://127.0.0.1:\(gatewayPort)"
-        #else
-        return nil
-        #endif
 
         let cEncoded = contactId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? contactId
         let chEncoded = channelId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? channelId
@@ -1710,6 +1707,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         guard let http = response as? HTTPURLResponse,
               (200...299).contains(http.statusCode) else { return nil }
         return try JSONDecoder().decode(ChannelVerificationResult.self, from: data)
+        #else
+        return nil
+        #endif
     }
 
     // MARK: - Feature Flags


### PR DESCRIPTION
## Summary
- `createContact` and `verifyContactChannel` in `DaemonClient.swift` defined `baseURL` inside `#if os(macOS)` but referenced it after `#endif`, causing a compile error on iOS simulator
- Moved the entire gateway fallback HTTP request code inside the `#if os(macOS)` block and placed `return nil` in the `#else` branch

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22699429480/job/65812995920

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
