### PR TITLE
fix: shrink-wrap user chat bubbles to text content width

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -345,8 +345,9 @@ struct ChatBubble: View {
                             .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
                             .tint(isUser ? VColor.userBubbleText : VColor.accent)
                             .selectableText(!message.isStreaming)
-                            // Frame before fixedSize to bound horizontal measurement.
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                            // For assistant messages, fill available width for readability.
+                            // For user messages, let the bubble shrink-wrap to text width.
+                            .frame(maxWidth: isUser ? nil : .infinity, alignment: .leading)
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 } else if !message.attachments.isEmpty {


### PR DESCRIPTION
## Summary
- User chat bubbles were always stretching to full 520pt width regardless of text length
- Changed `.frame(maxWidth: .infinity)` to `.frame(maxWidth: isUser ? nil : .infinity)` so user bubbles shrink-wrap to content
- Assistant messages still fill available width for readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
