### PR TITLE
feat: add Swift build check to pre-push hook when clients/ changes

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,11 +2,13 @@
 
 # Pre-push hook: run tests related to changed files before pushing.
 #
-# Uses a dependency graph (scripts/affected-tests.ts) to find test files
-# that transitively import changed source files. Falls back to filename
-# heuristics for guard tests and when the graph builder fails.
+# Checks:
+# 1. Swift build (clients/) — when .swift files changed
+# 2. TypeScript type check (assistant/) — when .ts/.tsx files changed
+# 3. Related test discovery and execution — via dependency graph + filename heuristics
 #
-# Skip with: git push --no-verify
+# Skip Swift build only: SKIP_SWIFT_BUILD=1 git push
+# Skip all hooks: git push --no-verify
 
 set -uo pipefail
 
@@ -23,6 +25,9 @@ PER_TEST_TIMEOUT="${PER_TEST_TIMEOUT:-60}"
 # Set PREPUSH_DEBUG=0 to suppress.
 PREPUSH_DEBUG="${PREPUSH_DEBUG:-1}"
 PREPUSH_START_EPOCH=""
+
+# Set SKIP_SWIFT_BUILD=1 to skip the Swift compilation check.
+SKIP_SWIFT_BUILD="${SKIP_SWIFT_BUILD:-0}"
 
 _debug_log() {
     if [ "$PREPUSH_DEBUG" != "1" ]; then return; fi
@@ -98,209 +103,246 @@ CHANGED_FILES=$(git diff --name-only --diff-filter=ACMR "$REMOTE_SHA"..HEAD -- '
 _changed_count=$(echo "$CHANGED_FILES" | grep -c . 2>/dev/null || echo 0)
 _debug_log "changed files: ${_changed_count}"
 
-if [ -z "$CHANGED_FILES" ]; then
+# Get changed Swift files separately (not included in the TS/JS diff above)
+SWIFT_CHANGED_FILES=$(git diff --name-only --diff-filter=ACMR "$REMOTE_SHA"..HEAD -- 'clients/*.swift' 'clients/**/*.swift' 2>/dev/null)
+_swift_count=$(echo "$SWIFT_CHANGED_FILES" | grep -c . 2>/dev/null || echo 0)
+_debug_log "changed Swift files: ${_swift_count}"
+
+if [ -z "$CHANGED_FILES" ] && [ -z "$SWIFT_CHANGED_FILES" ]; then
     exit 0
 fi
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-_debug_log "scanning for assistant/ TS changes"
-
-# --- TypeScript type check for assistant/ ---
-# The pre-commit hook skips tsc in worktrees to keep commits fast (~20s cold).
-# Pre-push is the right place to catch cross-file type errors before they hit CI.
-ASSISTANT_TS_CHANGED=0
-while IFS= read -r file; do
-    if [[ "$file" == assistant/*.ts ]] || [[ "$file" == assistant/*.tsx ]]; then
-        ASSISTANT_TS_CHANGED=1
-        break
-    fi
-done <<< "$CHANGED_FILES"
-
-if [ $ASSISTANT_TS_CHANGED -eq 1 ]; then
-    echo ""
-    echo "🔍 Type-checking assistant/..."
-    _debug_log "tsc --noEmit start"
-    if ! (cd "${REPO_ROOT}/assistant" && "$BUN" x tsc --noEmit) 2>&1; then
+# --- Swift build check for clients/ ---
+# Mirrors the TypeScript type check: when .swift files in clients/ changed,
+# verify the project compiles. Catches missing types, broken references, etc.
+# Works in worktrees (cold build is slower but still catches errors).
+if [ -n "$SWIFT_CHANGED_FILES" ] && [ "$SKIP_SWIFT_BUILD" != "1" ]; then
+    if ! command -v swift &>/dev/null; then
+        echo -e "${YELLOW}⚠️  swift not found — skipping Swift build check${NC}"
+    elif [ ! -f "${REPO_ROOT}/clients/Package.swift" ]; then
+        _debug_log "clients/Package.swift not found — skipping Swift build check"
+    else
         echo ""
-        echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-        echo -e "${RED}TypeScript type errors in assistant/ — push blocked${NC}"
-        echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-        echo ""
-        echo "Fix the type errors or push with --no-verify to skip."
-        _debug_log "tsc --noEmit done (FAILED)"
-        exit 1
+        echo "🔍 Building clients/ (Swift)..."
+        _debug_log "swift build start"
+        if ! (cd "${REPO_ROOT}/clients" && swift build --product vellum-assistant 2>&1); then
+            echo ""
+            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+            echo -e "${RED}Swift build errors in clients/ — push blocked${NC}"
+            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+            echo ""
+            echo "Fix the build errors or push with --no-verify to skip."
+            _debug_log "swift build done (FAILED)"
+            exit 1
+        fi
+        echo -e "  ${GREEN}✅ Swift build OK in clients/${NC}"
+        _debug_log "swift build done (passed)"
     fi
-    echo -e "  ${GREEN}✅ Type check OK in assistant/${NC}"
-    _debug_log "tsc --noEmit done (passed)"
 fi
 
-# Temp dir for capturing test output
-RESULTS_DIR="$(mktemp -d)"
-trap 'rm -rf "${RESULTS_DIR}"' EXIT
+if [ -n "$CHANGED_FILES" ]; then
+    _debug_log "scanning for assistant/ TS changes"
 
-# For each package, find test files that correspond to changed source files.
-#
-# Phase A: Use the dependency graph (scripts/affected-tests.ts) to discover
-# test files that transitively import the changed source files.
-#
-# Phase B: Supplement with filename heuristics to catch guard tests that use
-# readFileSync (invisible to the import graph). For a changed source file like
-# `src/foo/bar-baz.ts`, looks for `bar-baz.test.ts` or `bar-baz-*.test.ts`.
-
-PACKAGES=("assistant" "cli" "gateway")
-overall_exit=0
-
-for pkg in "${PACKAGES[@]}"; do
-    _debug_log "package scan: $pkg"
-    # Collect changed source files for this package (excluding test files)
-    pkg_changed=()
+    # --- TypeScript type check for assistant/ ---
+    # The pre-commit hook skips tsc in worktrees to keep commits fast (~20s cold).
+    # Pre-push is the right place to catch cross-file type errors before they hit CI.
+    ASSISTANT_TS_CHANGED=0
     while IFS= read -r file; do
-        if [[ "$file" == "$pkg/"* ]] && [[ ! "$file" =~ \.test\.(ts|tsx|js|jsx)$ ]] && [[ ! "$file" =~ /__tests__/ ]]; then
-            pkg_changed+=("$file")
+        if [[ "$file" == assistant/*.ts ]] || [[ "$file" == assistant/*.tsx ]]; then
+            ASSISTANT_TS_CHANGED=1
+            break
         fi
     done <<< "$CHANGED_FILES"
 
-    # Also collect changed test files directly (always run them)
-    pkg_test_changed=()
-    while IFS= read -r file; do
-        if [[ "$file" == "$pkg/"* ]] && [[ "$file" =~ \.test\.(ts|tsx|js|jsx)$ ]]; then
-            pkg_test_changed+=("$file")
+    if [ $ASSISTANT_TS_CHANGED -eq 1 ]; then
+        echo ""
+        echo "🔍 Type-checking assistant/..."
+        _debug_log "tsc --noEmit start"
+        if ! (cd "${REPO_ROOT}/assistant" && "$BUN" x tsc --noEmit) 2>&1; then
+            echo ""
+            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+            echo -e "${RED}TypeScript type errors in assistant/ — push blocked${NC}"
+            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+            echo ""
+            echo "Fix the type errors or push with --no-verify to skip."
+            _debug_log "tsc --noEmit done (FAILED)"
+            exit 1
         fi
-    done <<< "$CHANGED_FILES"
-
-    if [ ${#pkg_changed[@]} -eq 0 ] && [ ${#pkg_test_changed[@]} -eq 0 ]; then
-        continue
+        echo -e "  ${GREEN}✅ Type check OK in assistant/${NC}"
+        _debug_log "tsc --noEmit done (passed)"
     fi
 
-    # Find matching test files (deduplicated)
-    test_files=()
-    unset seen_tests 2>/dev/null || true
-    declare -A seen_tests
+    # Temp dir for capturing test output
+    RESULTS_DIR="$(mktemp -d)"
+    trap 'rm -rf "${RESULTS_DIR}"' EXIT
 
-    # Add directly changed test files
-    if [ ${#pkg_test_changed[@]} -gt 0 ]; then
-        for tf in "${pkg_test_changed[@]}"; do
-            abs_tf="${REPO_ROOT}/${tf}"
-            if [ -f "$abs_tf" ] && [ -z "${seen_tests[$abs_tf]:-}" ]; then
-                test_files+=("$abs_tf")
-                seen_tests["$abs_tf"]=1
+    # For each package, find test files that correspond to changed source files.
+    #
+    # Phase A: Use the dependency graph (scripts/affected-tests.ts) to discover
+    # test files that transitively import the changed source files.
+    #
+    # Phase B: Supplement with filename heuristics to catch guard tests that use
+    # readFileSync (invisible to the import graph). For a changed source file like
+    # `src/foo/bar-baz.ts`, looks for `bar-baz.test.ts` or `bar-baz-*.test.ts`.
+
+    PACKAGES=("assistant" "cli" "gateway")
+    overall_exit=0
+
+    for pkg in "${PACKAGES[@]}"; do
+        _debug_log "package scan: $pkg"
+        # Collect changed source files for this package (excluding test files)
+        pkg_changed=()
+        while IFS= read -r file; do
+            if [[ "$file" == "$pkg/"* ]] && [[ ! "$file" =~ \.test\.(ts|tsx|js|jsx)$ ]] && [[ ! "$file" =~ /__tests__/ ]]; then
+                pkg_changed+=("$file")
             fi
-        done
-    fi
+        done <<< "$CHANGED_FILES"
 
-    # Phase A: dependency graph lookup
-    _debug_log "$pkg: building dependency graph"
-    graph_test_files=()
-    if [ ${#pkg_changed[@]} -gt 0 ]; then
-        # Strip pkg/ prefix — script expects paths relative to pkg root
-        stripped_changed=()
-        for f in "${pkg_changed[@]}"; do
-            stripped_changed+=("${f#${pkg}/}")
-        done
-        graph_output=""
-        graph_output=$("$BUN" run "${REPO_ROOT}/scripts/affected-tests.ts" --pkg "$pkg" "${stripped_changed[@]}" 2>/dev/null)
-        graph_exit=$?
-        if [ $graph_exit -eq 0 ] && [ -n "$graph_output" ]; then
-            while IFS= read -r tf; do
-                abs_tf="${REPO_ROOT}/${pkg}/${tf}"
+        # Also collect changed test files directly (always run them)
+        pkg_test_changed=()
+        while IFS= read -r file; do
+            if [[ "$file" == "$pkg/"* ]] && [[ "$file" =~ \.test\.(ts|tsx|js|jsx)$ ]]; then
+                pkg_test_changed+=("$file")
+            fi
+        done <<< "$CHANGED_FILES"
+
+        if [ ${#pkg_changed[@]} -eq 0 ] && [ ${#pkg_test_changed[@]} -eq 0 ]; then
+            continue
+        fi
+
+        # Find matching test files (deduplicated)
+        test_files=()
+        unset seen_tests 2>/dev/null || true
+        declare -A seen_tests
+
+        # Add directly changed test files
+        if [ ${#pkg_test_changed[@]} -gt 0 ]; then
+            for tf in "${pkg_test_changed[@]}"; do
+                abs_tf="${REPO_ROOT}/${tf}"
                 if [ -f "$abs_tf" ] && [ -z "${seen_tests[$abs_tf]:-}" ]; then
-                    graph_test_files+=("$abs_tf")
+                    test_files+=("$abs_tf")
                     seen_tests["$abs_tf"]=1
                 fi
-            done <<< "$graph_output"
-            _debug_log "$pkg: dep graph found ${#graph_test_files[@]} affected test(s)"
-        else
-            _debug_log "$pkg: dep graph failed (exit=$graph_exit), falling back to filename heuristic"
+            done
         fi
-    fi
-    test_files+=("${graph_test_files[@]}")
 
-    # Phase B: filename heuristic (fallback + supplement for guard tests)
-    stems=()
-    if [ ${#pkg_changed[@]} -gt 0 ]; then
-        for file in "${pkg_changed[@]}"; do
-            base="$(basename "$file")"
-            stem="${base%.*}"
-            stems+=("$stem")
-        done
-    fi
-
-    if [ ${#stems[@]} -gt 0 ]; then
-        for stem in "${stems[@]}"; do
-            while IFS= read -r tf; do
-                if [ -n "$tf" ] && [ -z "${seen_tests[$tf]:-}" ]; then
-                    test_files+=("$tf")
-                    seen_tests["$tf"]=1
-                fi
-            done < <(
-                find "${REPO_ROOT}/${pkg}/src" -type f \( \
-                    -name "${stem}.test.ts" -o \
-                    -name "${stem}-*.test.ts" \
-                \) 2>/dev/null
-            )
-        done
-    fi
-
-    if [ ${#test_files[@]} -eq 0 ]; then
-        continue
-    fi
-
-    _debug_log "$pkg: discovered ${#test_files[@]} test file(s)"
-
-    echo ""
-    echo "🧪 Running ${#test_files[@]} related test(s) for ${pkg}/..."
-
-    # Run each test file in isolation (same pattern as the main test runner).
-    failed_files=()
-    for tf in "${test_files[@]}"; do
-        rel="${tf#${REPO_ROOT}/${pkg}/}"
-        base="$(basename "$tf")"
-        safe_name="$(echo "$rel" | tr "/" "_")"
-        out_file="${RESULTS_DIR}/${safe_name}.out"
-
-        _debug_log "$pkg: running $base"
-        if [ -n "$TIMEOUT_CMD" ]; then
-            (cd "${REPO_ROOT}/${pkg}" && "$TIMEOUT_CMD" -k 10 "$PER_TEST_TIMEOUT" "$BUN" test "$rel" > "$out_file" 2>&1)
-        else
-            (cd "${REPO_ROOT}/${pkg}" && "$BUN" test "$rel" > "$out_file" 2>&1)
+        # Phase A: dependency graph lookup
+        _debug_log "$pkg: building dependency graph"
+        graph_test_files=()
+        if [ ${#pkg_changed[@]} -gt 0 ]; then
+            # Strip pkg/ prefix — script expects paths relative to pkg root
+            stripped_changed=()
+            for f in "${pkg_changed[@]}"; do
+                stripped_changed+=("${f#${pkg}/}")
+            done
+            graph_output=""
+            graph_output=$("$BUN" run "${REPO_ROOT}/scripts/affected-tests.ts" --pkg "$pkg" "${stripped_changed[@]}" 2>/dev/null)
+            graph_exit=$?
+            if [ $graph_exit -eq 0 ] && [ -n "$graph_output" ]; then
+                while IFS= read -r tf; do
+                    abs_tf="${REPO_ROOT}/${pkg}/${tf}"
+                    if [ -f "$abs_tf" ] && [ -z "${seen_tests[$abs_tf]:-}" ]; then
+                        graph_test_files+=("$abs_tf")
+                        seen_tests["$abs_tf"]=1
+                    fi
+                done <<< "$graph_output"
+                _debug_log "$pkg: dep graph found ${#graph_test_files[@]} affected test(s)"
+            else
+                _debug_log "$pkg: dep graph failed (exit=$graph_exit), falling back to filename heuristic"
+            fi
         fi
-        exit_code=$?
+        test_files+=("${graph_test_files[@]}")
 
-        if [ -n "$TIMEOUT_CMD" ] && { [ $exit_code -eq 124 ] || [ $exit_code -eq 137 ]; }; then
-            echo -e "  ${RED}✗${NC} ${base} (killed after ${PER_TEST_TIMEOUT}s)"
-            failed_files+=("$tf")
-        elif [ $exit_code -ne 0 ]; then
-            echo -e "  ${RED}✗${NC} ${base}"
-            failed_files+=("$tf")
-        else
-            echo -e "  ${GREEN}✓${NC} ${base}"
+        # Phase B: filename heuristic (fallback + supplement for guard tests)
+        stems=()
+        if [ ${#pkg_changed[@]} -gt 0 ]; then
+            for file in "${pkg_changed[@]}"; do
+                base="$(basename "$file")"
+                stem="${base%.*}"
+                stems+=("$stem")
+            done
         fi
-        _debug_log "$pkg: finished $base (exit=$exit_code)"
-    done
 
-    if [ ${#failed_files[@]} -gt 0 ]; then
+        if [ ${#stems[@]} -gt 0 ]; then
+            for stem in "${stems[@]}"; do
+                while IFS= read -r tf; do
+                    if [ -n "$tf" ] && [ -z "${seen_tests[$tf]:-}" ]; then
+                        test_files+=("$tf")
+                        seen_tests["$tf"]=1
+                    fi
+                done < <(
+                    find "${REPO_ROOT}/${pkg}/src" -type f \( \
+                        -name "${stem}.test.ts" -o \
+                        -name "${stem}-*.test.ts" \
+                    \) 2>/dev/null
+                )
+            done
+        fi
+
+        if [ ${#test_files[@]} -eq 0 ]; then
+            continue
+        fi
+
+        _debug_log "$pkg: discovered ${#test_files[@]} test file(s)"
+
         echo ""
-        echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-        echo -e "${RED}Test failures in ${pkg}/ — push blocked${NC}"
-        echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-        echo ""
-        for tf in "${failed_files[@]}"; do
+        echo "🧪 Running ${#test_files[@]} related test(s) for ${pkg}/..."
+
+        # Run each test file in isolation (same pattern as the main test runner).
+        failed_files=()
+        for tf in "${test_files[@]}"; do
             rel="${tf#${REPO_ROOT}/${pkg}/}"
+            base="$(basename "$tf")"
             safe_name="$(echo "$rel" | tr "/" "_")"
             out_file="${RESULTS_DIR}/${safe_name}.out"
-            echo "──────────────────────────────────────────"
-            echo "FAIL: ${pkg}/${rel}"
-            echo "──────────────────────────────────────────"
-            cat "$out_file"
-            echo ""
-        done
-        echo "Fix the failing tests or push with --no-verify to skip."
-        overall_exit=1
-    else
-        echo -e "  ${GREEN}✅ All related tests pass in ${pkg}/${NC}"
-    fi
-done
 
-_debug_log "hook finished (exit=$overall_exit)"
-exit $overall_exit
+            _debug_log "$pkg: running $base"
+            if [ -n "$TIMEOUT_CMD" ]; then
+                (cd "${REPO_ROOT}/${pkg}" && "$TIMEOUT_CMD" -k 10 "$PER_TEST_TIMEOUT" "$BUN" test "$rel" > "$out_file" 2>&1)
+            else
+                (cd "${REPO_ROOT}/${pkg}" && "$BUN" test "$rel" > "$out_file" 2>&1)
+            fi
+            exit_code=$?
+
+            if [ -n "$TIMEOUT_CMD" ] && { [ $exit_code -eq 124 ] || [ $exit_code -eq 137 ]; }; then
+                echo -e "  ${RED}✗${NC} ${base} (killed after ${PER_TEST_TIMEOUT}s)"
+                failed_files+=("$tf")
+            elif [ $exit_code -ne 0 ]; then
+                echo -e "  ${RED}✗${NC} ${base}"
+                failed_files+=("$tf")
+            else
+                echo -e "  ${GREEN}✓${NC} ${base}"
+            fi
+            _debug_log "$pkg: finished $base (exit=$exit_code)"
+        done
+
+        if [ ${#failed_files[@]} -gt 0 ]; then
+            echo ""
+            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+            echo -e "${RED}Test failures in ${pkg}/ — push blocked${NC}"
+            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+            echo ""
+            for tf in "${failed_files[@]}"; do
+                rel="${tf#${REPO_ROOT}/${pkg}/}"
+                safe_name="$(echo "$rel" | tr "/" "_")"
+                out_file="${RESULTS_DIR}/${safe_name}.out"
+                echo "──────────────────────────────────────────"
+                echo "FAIL: ${pkg}/${rel}"
+                echo "──────────────────────────────────────────"
+                cat "$out_file"
+                echo ""
+            done
+            echo "Fix the failing tests or push with --no-verify to skip."
+            overall_exit=1
+        else
+            echo -e "  ${GREEN}✅ All related tests pass in ${pkg}/${NC}"
+        fi
+    done
+
+    _debug_log "hook finished (exit=$overall_exit)"
+    exit $overall_exit
+fi
+
+_debug_log "hook finished (exit=0)"


### PR DESCRIPTION
## Summary
- Add `swift build --product vellum-assistant` check when `.swift` files under `clients/` change
- Restructure early exit so Swift-only changes still trigger the check
- Add `SKIP_SWIFT_BUILD=1` env var to opt out; runs by default when applicable
- Gracefully skip if `swift` not found or `Package.swift` missing

Part of plan: prepush-swift-build-check.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)