### PR TITLE
chore: remove triageResults table definition (only consumer was deleted triage engine)

### DIFF
--- a/assistant/src/memory/schema.ts
+++ b/assistant/src/memory/schema.ts
@@ -468,20 +468,6 @@ export const assistantContactMetadata = sqliteTable(
   },
 );
 
-// ── Triage Results ───────────────────────────────────────────────────
-
-export const triageResults = sqliteTable("triage_results", {
-  id: text("id").primaryKey(),
-  channel: text("channel").notNull(),
-  sender: text("sender").notNull(),
-  category: text("category").notNull(),
-  confidence: real("confidence").notNull(),
-  suggestedAction: text("suggested_action").notNull(),
-  matchedPlaybookIds: text("matched_playbook_ids"), // JSON array of playbook memory item IDs
-  messageId: text("message_id"), // optional external message identifier
-  createdAt: integer("created_at").notNull(),
-});
-
 // ── Follow-ups ──────────────────────────────────────────────────────
 
 export const followups = sqliteTable("followups", {


### PR DESCRIPTION
## Summary
- Remove the triageResults sqliteTable definition from assistant/src/memory/schema.ts
- The only consumer (triage-engine.ts) was deleted in PR 2
- No other module imports triageResults

Part of plan: contact-context-injection.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12748" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
