### PR TITLE
Remove dead markConflictAsked function

### DIFF
--- a/assistant/src/__tests__/conflict-store.test.ts
+++ b/assistant/src/__tests__/conflict-store.test.ts
@@ -33,7 +33,6 @@ import {
   getPendingConflictByPair,
   listPendingConflictDetails,
   listPendingConflicts,
-  markConflictAsked,
   resolveConflict,
 } from "../memory/conflict-store.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
@@ -222,22 +221,6 @@ describe("conflict-store", () => {
     expect(pendingDefault).toHaveLength(1);
     expect(pendingDefault[0].id).toBe(conflictA.id);
     expect(pendingDefault[0].status).toBe("pending_clarification");
-  });
-
-  test("markConflictAsked updates lastAskedAt", () => {
-    const pair = insertItemPair("asked");
-    const conflict = createOrUpdatePendingConflict({
-      scopeId: "default",
-      existingItemId: pair.existingItemId,
-      candidateItemId: pair.candidateItemId,
-      relationship: "ambiguous_contradiction",
-    });
-
-    const askedAt = 1_734_000_000_000;
-    expect(markConflictAsked(conflict.id, askedAt)).toBe(true);
-    const updated = getConflictById(conflict.id);
-    expect(updated?.lastAskedAt).toBe(askedAt);
-    expect(updated?.updatedAt).toBe(askedAt);
   });
 
   test("listPendingConflictDetails joins current statements and verification states", () => {

--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -278,7 +278,6 @@ mock.module("../memory/conflict-store.js", () => ({
     conflictScopeCalls.push(scopeId);
     return pendingConflicts;
   },
-  markConflictAsked: () => true,
   applyConflictResolution: () => true,
   resolveConflict: (
     id: string,

--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -228,7 +228,6 @@ mock.module("../context/window-manager.js", () => ({
 
 mock.module("../memory/conflict-store.js", () => ({
   listPendingConflictDetails: () => [],
-  markConflictAsked: () => true,
   applyConflictResolution: () => true,
 }));
 

--- a/assistant/src/__tests__/session-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/session-workspace-cache-state.test.ts
@@ -142,7 +142,6 @@ mock.module("../context/window-manager.js", () => ({
 
 mock.module("../memory/conflict-store.js", () => ({
   listPendingConflictDetails: () => [],
-  markConflictAsked: () => true,
   applyConflictResolution: () => true,
 }));
 

--- a/assistant/src/__tests__/session-workspace-injection.test.ts
+++ b/assistant/src/__tests__/session-workspace-injection.test.ts
@@ -181,7 +181,6 @@ mock.module("../context/window-manager.js", () => ({
 }));
 mock.module("../memory/conflict-store.js", () => ({
   listPendingConflictDetails: () => [],
-  markConflictAsked: () => true,
   applyConflictResolution: () => true,
 }));
 mock.module("../memory/clarification-resolver.js", () => ({

--- a/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
@@ -179,7 +179,6 @@ mock.module("../context/window-manager.js", () => ({
 }));
 mock.module("../memory/conflict-store.js", () => ({
   listPendingConflictDetails: () => [],
-  markConflictAsked: () => true,
   applyConflictResolution: () => true,
 }));
 mock.module("../memory/clarification-resolver.js", () => ({

--- a/assistant/src/memory/conflict-store.ts
+++ b/assistant/src/memory/conflict-store.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getDb, getSqlite, rawAll, rawChanges } from "./db.js";
+import { getDb, getSqlite, rawAll } from "./db.js";
 import { enqueueMemoryJob } from "./jobs-store.js";
 import { memoryItemConflicts, memoryItems } from "./schema.js";
 import { clampUnitInterval } from "./validation.js";
@@ -274,22 +274,6 @@ export function listPendingConflictDetails(
     existingVerificationState: row.existing_verification_state,
     candidateVerificationState: row.candidate_verification_state,
   }));
-}
-
-export function markConflictAsked(
-  conflictId: string,
-  askedAt = Date.now(),
-): boolean {
-  const db = getDb();
-  db.update(memoryItemConflicts)
-    .set({
-      lastAskedAt: askedAt,
-      updatedAt: askedAt,
-    })
-    .where(eq(memoryItemConflicts.id, conflictId))
-    .run();
-
-  return rawChanges() > 0;
 }
 
 export function resolveConflict(


### PR DESCRIPTION
## Summary
- Remove the unused `markConflictAsked()` function from `conflict-store.ts` and its now-unused `rawChanges` import
- Remove the dedicated test for `markConflictAsked` in `conflict-store.test.ts`
- Remove `markConflictAsked` mock references from 5 test files

The conflict gate is internal-only and never surfaces clarification prompts to users, so this function has no runtime call sites.

## Test plan
- [x] `bun test conflict-store.test.ts` passes (8/8)
- [x] `bun test session-conflict-gate.test.ts` passes (28/28)
- [x] `bunx tsc --noEmit` passes
- [x] No remaining references to `markConflictAsked` in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
