### PR TITLE
fix: serialize writeNote through mutex to prevent git index.lock race

### DIFF
--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -42,10 +42,6 @@ describe("CommitEnrichmentService", () => {
   beforeEach(() => {
     _resetGitServiceRegistry();
     _resetEnrichmentService();
-    // Previous tests' enrichment jobs may leave a stale index.lock if
-    // the git process exits but the lock file isn't flushed before the
-    // next test runs git operations in the shared testDir.
-    rmSync(join(testDir, ".git", "index.lock"), { force: true });
   });
 
   afterEach(async () => {

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -871,10 +871,12 @@ export class WorkspaceGitService {
     noteContent: string,
     signal?: AbortSignal,
   ): Promise<void> {
-    await this.execGit(
-      ["notes", "--ref=vellum", "add", "-f", "-m", noteContent, commitHash],
-      { signal },
-    );
+    await this.mutex.withLock(async () => {
+      await this.execGit(
+        ["notes", "--ref=vellum", "add", "-f", "-m", noteContent, commitHash],
+        { signal },
+      );
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
- `writeNote()` in `git-service.ts` was calling `execGit()` without acquiring the per-workspace mutex, allowing `git notes add` to race with `git add`/`git commit` for `.git/index.lock`
- Wrapped `writeNote` in `mutex.withLock()` to serialize all git operations on the same workspace
- Removed the stale `index.lock` cleanup workaround from the enrichment service test's `beforeEach`

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22700087999

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
