### PR TITLE
fix: prevent retire from destroying shared data directory

### DIFF
--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -52,6 +52,27 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   const legacyDir = entry.baseDataDir;
   const vellumDir = legacyDir ?? join(resources.instanceDir, ".vellum");
 
+  // Check whether another local assistant shares the same data directory.
+  // Legacy entries without `resources` all resolve to ~/.vellum/ — if we
+  // blindly kill processes and archive the directory, we'd destroy the
+  // other assistant's running daemon and data.
+  const otherSharesDir = loadAllAssistants().some((other) => {
+    if (other.cloud !== "local") return false;
+    if (other.assistantId === name) return false;
+    const otherVellumDir =
+      other.baseDataDir ??
+      join((other.resources ?? defaultLocalResources()).instanceDir, ".vellum");
+    return otherVellumDir === vellumDir;
+  });
+
+  if (otherSharesDir) {
+    console.log(
+      `   Skipping process stop and archive — another local assistant shares ${vellumDir}.`,
+    );
+    console.log("\u2705 Local instance retired (config entry removed only).");
+    return;
+  }
+
   // Stop daemon via PID file — prefer resources paths, but for legacy entries
   // with a custom baseDataDir, derive from that directory instead.
   const daemonPidFile = legacyDir


### PR DESCRIPTION
When two legacy local entries (without resources) both resolve to ~/.vellum/, retiring one would:
1. Kill the other's daemon (shared PID file)
2. Kill the other's gateway (shared gateway.pid)
3. Archive the entire shared ~/.vellum/ directory

This caused the user's running assistant to be destroyed when retiring a different legacy entry.

Fix: before stopping processes or archiving, check if another local assistant shares the same data directory. If so, skip destructive operations and only remove the lockfile entry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
