### PR TITLE
feat: support disabled (empty) shortcuts in ShortcutHelper and hotkey registration

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -40,10 +40,16 @@ func quickInputHotKeyHandler(
 // listening to every UserDefaults write app-wide.
 extension UserDefaults {
     @objc dynamic var globalHotkeyShortcut: String {
-        return string(forKey: "globalHotkeyShortcut") ?? "cmd+shift+g"
+        if UserDefaults.standard.object(forKey: "globalHotkeyShortcut") == nil {
+            return "cmd+shift+g"
+        }
+        return string(forKey: "globalHotkeyShortcut") ?? ""
     }
     @objc dynamic var quickInputHotkeyShortcut: String {
-        return string(forKey: "quickInputHotkeyShortcut") ?? "cmd+shift+/"
+        if UserDefaults.standard.object(forKey: "quickInputHotkeyShortcut") == nil {
+            return "cmd+shift+/"
+        }
+        return string(forKey: "quickInputHotkeyShortcut") ?? ""
     }
     @objc dynamic var quickInputHotkeyKeyCode: Int {
         return integer(forKey: "quickInputHotkeyKeyCode")
@@ -91,6 +97,12 @@ extension AppDelegate {
         if let ref = quickInputEventHandlerRef {
             RemoveEventHandler(ref)
             quickInputEventHandlerRef = nil
+        }
+
+        guard !shortcut.isEmpty else {
+            lastRegisteredQuickInputHotkey = shortcut
+            log.info("Quick Input: hotkey disabled")
+            return
         }
 
         let storedKeyCode = UserDefaults.standard.object(forKey: "quickInputHotkeyKeyCode") as? Int
@@ -407,6 +419,12 @@ extension AppDelegate {
         if let existing = hotKeyMonitor {
             NSEvent.removeMonitor(existing)
             hotKeyMonitor = nil
+        }
+
+        guard !shortcut.isEmpty else {
+            lastRegisteredGlobalHotkey = shortcut
+            log.info("Open Vellum: hotkey disabled")
+            return
         }
 
         let (targetModifiers, targetKey) = ShortcutHelper.parseShortcut(shortcut)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -345,8 +345,16 @@ public final class SettingsStore: ObservableObject {
 
         self.cmdEnterToSend = UserDefaults.standard.object(forKey: "cmdEnterToSend") as? Bool ?? false
 
-        self.globalHotkeyShortcut = UserDefaults.standard.string(forKey: "globalHotkeyShortcut") ?? "cmd+shift+g"
-        self.quickInputHotkeyShortcut = UserDefaults.standard.string(forKey: "quickInputHotkeyShortcut") ?? "cmd+shift+/"
+        if UserDefaults.standard.object(forKey: "globalHotkeyShortcut") == nil {
+            self.globalHotkeyShortcut = "cmd+shift+g"
+        } else {
+            self.globalHotkeyShortcut = UserDefaults.standard.string(forKey: "globalHotkeyShortcut") ?? ""
+        }
+        if UserDefaults.standard.object(forKey: "quickInputHotkeyShortcut") == nil {
+            self.quickInputHotkeyShortcut = "cmd+shift+/"
+        } else {
+            self.quickInputHotkeyShortcut = UserDefaults.standard.string(forKey: "quickInputHotkeyShortcut") ?? ""
+        }
         let storedQIKeyCode = UserDefaults.standard.object(forKey: "quickInputHotkeyKeyCode") as? Int
         self.quickInputHotkeyKeyCode = storedQIKeyCode ?? kVK_ANSI_Slash
 

--- a/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/ShortcutHelper.swift
@@ -8,6 +8,7 @@ enum ShortcutHelper {
     /// Converts a shortcut string like "cmd+shift+space" to a human-readable
     /// display string like "Command Shift Space".
     static func displayString(for shortcut: String) -> String {
+        guard !shortcut.isEmpty else { return "None" }
         let parts = shortcut.lowercased().split(separator: "+").map(String.init)
         return parts.map { displayToken($0) }.joined(separator: " ")
     }
@@ -15,6 +16,7 @@ enum ShortcutHelper {
     /// Parses a shortcut string into modifier flags and a key string suitable
     /// for matching against `NSEvent.charactersIgnoringModifiers`.
     static func parseShortcut(_ shortcut: String) -> (NSEvent.ModifierFlags, String) {
+        guard !shortcut.isEmpty else { return ([], "") }
         let parts = shortcut.lowercased().split(separator: "+").map(String.init)
         var modifiers: NSEvent.ModifierFlags = []
         var key = ""


### PR DESCRIPTION
## Summary
- Add empty-string handling to ShortcutHelper.displayString() and parseShortcut() to support disabled shortcuts
- Update hotkey registration in AppDelegate+InputMonitors to skip registration when shortcut is empty
- Fix UserDefaults KVO extension and SettingsStore init to preserve intentionally-empty shortcut values

Part of plan: unbind-shortcuts.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
