### PR TITLE
feat: add Unbind button to disable keyboard shortcuts in settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAppearanceTab.swift
@@ -114,8 +114,15 @@ struct SettingsAppearanceTab: View {
                             stopRecording()
                         }
                     } else {
-                        VButton(label: "Record", style: .outlined) {
-                            startRecording()
+                        HStack(spacing: VSpacing.sm) {
+                            VButton(label: "Record", style: .outlined) {
+                                startRecording()
+                            }
+                            if !store.globalHotkeyShortcut.isEmpty {
+                                VButton(label: "Unbind", style: .outlined) {
+                                    store.globalHotkeyShortcut = ""
+                                }
+                            }
                         }
                     }
                 }
@@ -147,8 +154,16 @@ struct SettingsAppearanceTab: View {
                             stopRecording()
                         }
                     } else {
-                        VButton(label: "Record", style: .outlined) {
-                            startRecordingQuickInput()
+                        HStack(spacing: VSpacing.sm) {
+                            VButton(label: "Record", style: .outlined) {
+                                startRecordingQuickInput()
+                            }
+                            if !store.quickInputHotkeyShortcut.isEmpty {
+                                VButton(label: "Unbind", style: .outlined) {
+                                    store.quickInputHotkeyShortcut = ""
+                                    store.quickInputHotkeyKeyCode = 0
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Add Unbind button next to Record for both Open Vellum and Quick Input hotkey rows
- When unbound, pill shows 'None' and only Record button is visible to re-enable
- Clicking Unbind clears the shortcut to empty string, immediately disabling the hotkey

Part of plan: unbind-shortcuts.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
