### PR TITLE
fix: parse side-effect imports in affected-tests dependency scanner

### DIFF
--- a/scripts/affected-tests.ts
+++ b/scripts/affected-tests.ts
@@ -54,7 +54,9 @@ if (changedFiles.length === 0) {
 // Phase 1 — Scan source files and extract imports
 // ---------------------------------------------------------------------------
 
-const importRegex = /(?:from|mock\.module\()\s*["']([^"']+)["']/g;
+const importRegex =
+  /(?:from|mock\.module\()\s*["']([^"']+)["']/g;
+const sideEffectImportRegex = /\bimport\s+["']([^"']+)["']/g;
 
 const glob = new Bun.Glob("src/**/*.{ts,tsx}");
 
@@ -107,12 +109,28 @@ const entries = await Promise.all(
     const dir = path.dirname(absPath);
 
     let match: RegExpExecArray | null;
-    importRegex.lastIndex = 0;
-    // We need a fresh regex per file since we reuse the same regex object
+    // We need fresh regexes per file since we reuse the same regex objects
     const re = new RegExp(importRegex.source, importRegex.flags);
+    const sideEffectRe = new RegExp(
+      sideEffectImportRegex.source,
+      sideEffectImportRegex.flags,
+    );
+
+    // Match standard imports (from "…") and mock.module("…")
     while ((match = re.exec(text)) !== null) {
       const specifier = match[1];
-      // Only resolve relative specifiers
+      if (!specifier.startsWith("./") && !specifier.startsWith("../")) {
+        continue;
+      }
+      const resolved = resolveSpecifier(dir, specifier);
+      if (resolved) {
+        imports.add(resolved);
+      }
+    }
+
+    // Match side-effect imports: import "./foo.js"
+    while ((match = sideEffectRe.exec(text)) !== null) {
+      const specifier = match[1];
       if (!specifier.startsWith("./") && !specifier.startsWith("../")) {
         continue;
       }


### PR DESCRIPTION
## Summary
- Add regex pattern to match side-effect imports (e.g., import "./foo.js") in dependency graph builder
- Ensures tests that depend on side-effect-imported modules are correctly discovered
- Prevents regressions from slipping through pre-push test selection

Addresses feedback on #12735

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
