### PR TITLE
fix: normalize Telegram destination for rate limiting in contact verification

### DIFF
--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -45,6 +45,7 @@ import {
   deliverVerificationTelegram,
   DESTINATION_RATE_WINDOW_MS,
   MAX_SENDS_PER_DESTINATION_WINDOW,
+  normalizeTelegramDestination,
 } from "../guardian-outbound-actions.js";
 import {
   composeVerificationSlack,
@@ -517,10 +518,17 @@ export async function handleVerifyContactChannel(
     );
   }
 
+  // Normalize Telegram destinations so rate-limit lookups are consistent with
+  // guardian-outbound-actions (strips leading '@', lowercases handles).
+  const effectiveDestination =
+    verificationChannel === "telegram"
+      ? normalizeTelegramDestination(destination)
+      : destination;
+
   // Rate limit check
   const recentSendCount = countRecentSendsToDestination(
     verificationChannel,
-    destination,
+    effectiveDestination,
     DESTINATION_RATE_WINDOW_MS,
   );
   if (recentSendCount >= MAX_SENDS_PER_DESTINATION_WINDOW) {
@@ -582,7 +590,7 @@ export async function handleVerifyContactChannel(
         expectedChatId: channel.externalChatId,
         expectedExternalUserId: channel.externalUserId ?? undefined,
         identityBindingStatus: "bound",
-        destinationAddress: destination,
+        destinationAddress: effectiveDestination,
         verificationPurpose: "trusted_contact",
       });
 
@@ -630,7 +638,7 @@ export async function handleVerifyContactChannel(
       assistantId,
       channel: verificationChannel,
       identityBindingStatus: "pending_bootstrap",
-      destinationAddress: destination,
+      destinationAddress: effectiveDestination,
       bootstrapTokenHash,
       verificationPurpose: "trusted_contact",
     });
@@ -649,6 +657,18 @@ export async function handleVerifyContactChannel(
   // --- Slack verification ---
   if (verificationChannel === "slack") {
     const slackUserId = channel.externalUserId ?? destination;
+
+    // Only claim identity is bound when we have at least one platform identifier
+    const hasIdentityBinding = Boolean(
+      channel.externalUserId || channel.externalChatId,
+    );
+    if (!hasIdentityBinding) {
+      return httpError(
+        "BAD_REQUEST",
+        "Slack verification requires an externalUserId or externalChatId for identity binding",
+        400,
+      );
+    }
 
     const sessionResult = createOutboundSession({
       assistantId,


### PR DESCRIPTION
## Summary
- Import and use normalizeTelegramDestination for Telegram channels in contact verification flow
- Normalize destination before rate-limit checks and in session creation for consistency with guardian-outbound-actions
- Prevents double rate-limit windows (10+10 instead of 10) for the same Telegram user
- Require identity binding (externalUserId or externalChatId) for Slack verification sessions

Addresses feedback on #12729

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
