### PR TITLE
fix: use resolveLocalDaemonHTTPEndpoint for createContact fallback

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1619,7 +1619,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Omits the `id` field to trigger creation instead of update.
     /// Routes through `HTTPTransport` when available so that managed-mode
     /// URL paths and auth headers are applied correctly. Falls back to the
-    /// local gateway (port 7830) for socket-based connections.
+    /// local daemon HTTP server for socket-based connections.
     public func createContact(
         displayName: String,
         relationship: String? = nil,
@@ -1635,16 +1635,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             )
         }
 
-        #if os(macOS)
-        let gatewayPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
-            .flatMap(Int.init) ?? 7830
-        let baseURL = "http://127.0.0.1:\(gatewayPort)"
+        guard let local = resolveLocalDaemonHTTPEndpoint() else { return nil }
 
-        guard let url = URL(string: "\(baseURL)/v1/contacts") else { return nil }
+        guard let url = URL(string: "\(local.baseURL)/v1/contacts") else { return nil }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let token = readHttpToken(), !token.isEmpty {
+        if let token = local.bearerToken, !token.isEmpty {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 
@@ -1669,9 +1666,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
         let decoded = try JSONDecoder().decode(UpsertResponse.self, from: data)
         return decoded.contact
-        #else
-        return nil
-        #endif
     }
 
     /// Send a verification code to a contact's channel via the gateway.


### PR DESCRIPTION
## Summary
- Refactor createContact() gateway fallback to use resolveLocalDaemonHTTPEndpoint() instead of hardcoded gateway port 7830
- Matches the pattern used by sibling updateContact() method for consistency
- Fixes silent nil return when gateway is down but daemon HTTP server is available

Addresses feedback on #12726

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
