### PR TITLE
docs: add JSDoc to Contact.principalId explaining guardian-only auth semantics

### DIFF
--- a/assistant/src/contacts/types.ts
+++ b/assistant/src/contacts/types.ts
@@ -38,6 +38,13 @@ export interface Contact {
   updatedAt: number;
   role: ContactRole;
   contactType: ContactType;
+  /**
+   * Internal auth identity (e.g. "vellum-principal-<uuid>"). Only meaningful
+   * for guardian contacts — it ties the contact record to the auth layer so
+   * the system can verify "this API caller IS this guardian" via JWT
+   * actorPrincipalId. Always null for non-guardian contacts, which are
+   * identified by channel address instead.
+   */
   principalId: string | null;
   assistantId: string | null;
 }


### PR DESCRIPTION
## Summary
- Add JSDoc comment to `principalId` on the `Contact` interface clarifying it's a guardian-only auth identity field
- Documents that it holds a `vellum-principal-<uuid>` value, ties to JWT `actorPrincipalId`, and is always null for non-guardian contacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
