### PR TITLE
fix: address review feedback on PR #12737

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -288,7 +288,10 @@ if [ -n "$CHANGED_FILES" ]; then
                 _debug_log "$pkg: dep graph failed (exit=$graph_exit), falling back to filename heuristic"
             fi
         fi
-        test_files+=("${graph_test_files[@]}")
+        # Guard for bash 3.2 compatibility (empty array + set -u)
+        if [ ${#graph_test_files[@]} -gt 0 ]; then
+            test_files+=("${graph_test_files[@]}")
+        fi
 
         # Phase B: filename heuristic (fallback + supplement for guard tests)
         stems=()

--- a/assistant/src/contacts/types.ts
+++ b/assistant/src/contacts/types.ts
@@ -38,6 +38,13 @@ export interface Contact {
   updatedAt: number;
   role: ContactRole;
   contactType: ContactType;
+  /**
+   * Internal auth identity (e.g. "vellum-principal-<uuid>"). Only meaningful
+   * for guardian contacts — it ties the contact record to the auth layer so
+   * the system can verify "this API caller IS this guardian" via JWT
+   * actorPrincipalId. Always null for non-guardian contacts, which are
+   * identified by channel address instead.
+   */
   principalId: string | null;
   assistantId: string | null;
 }


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #12737
- Guard empty `graph_test_files` array expansion under `set -u` for bash 3.2 compatibility on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
