### PR TITLE
fix: show "+ Add Contact" affordance when only guardian exists

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -52,7 +52,7 @@ struct ContactsListView: View {
                 guardianSection(guardian)
             }
 
-            // Other contacts section — header + add button always visible
+            // Other contacts section (always show header + "+" button)
             otherContactsSection
 
             // Filtered-empty state (contacts exist but search yields nothing)
@@ -142,7 +142,14 @@ struct ContactsListView: View {
                 .accessibilityLabel("Add contact")
             }
 
-            if !viewModel.otherContacts.isEmpty {
+            if viewModel.otherContacts.isEmpty {
+                Text("No contacts yet. Tap + to add one.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .padding(VSpacing.lg)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .vCard(background: VColor.surfaceSubtle)
+            } else {
                 VStack(spacing: 0) {
                     ForEach(Array(viewModel.otherContacts.enumerated()), id: \.element.id) { index, contact in
                         if index > 0 {


### PR DESCRIPTION
## Summary
- Always show the "Contacts" section header with "+" button even when no non-guardian contacts exist
- When no contacts exist, show subtle empty state: "No contacts yet. Tap + to add one."
- Existing contact list behavior unchanged

Part of plan: contacts-add-and-all-channels.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
