### PR TITLE
fix: address review feedback on PR #12733

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -16,6 +16,8 @@ struct ContactDetailView: View {
     @State private var isHoveringHeader = false
     @State private var verificationInProgress: String?
     @State private var verificationSuccessChannelId: String?
+    @State private var telegramBootstrapUrl: String?
+    @State private var telegramBootstrapChannelId: String?
 
     // Metadata editing state (accessed from ContactDetailView+EditableMetadata.swift)
     @State var isEditingRelationship = false
@@ -313,6 +315,36 @@ struct ContactDetailView: View {
                         .foregroundColor(VColor.success)
                 }
             }
+
+            // Telegram bootstrap: the guardian needs to open a deep link before
+            // a verification code can be delivered.
+            if telegramBootstrapChannelId == channel.id, let urlString = telegramBootstrapUrl, let url = URL(string: urlString) {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Ask your contact to open this link to start the Telegram chat:")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+
+                    Button {
+                        NSWorkspace.shared.open(url)
+                    } label: {
+                        HStack(spacing: VSpacing.xs) {
+                            Image(systemName: "arrow.up.right.square")
+                                .font(.system(size: 11))
+                            Text("Open Telegram")
+                                .font(VFont.caption)
+                        }
+                        .foregroundColor(VColor.link)
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        if hovering {
+                            NSCursor.pointingHand.push()
+                        } else {
+                            NSCursor.pop()
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -498,6 +530,8 @@ struct ContactDetailView: View {
         verificationInProgress = channel.id
         errorMessage = nil
         verificationSuccessChannelId = nil
+        telegramBootstrapUrl = nil
+        telegramBootstrapChannelId = nil
 
         Task {
             do {
@@ -506,12 +540,19 @@ struct ContactDetailView: View {
                     channelId: channel.id
                 )
                 if result?.ok == true {
-                    verificationSuccessChannelId = channel.id
-                    // Auto-clear the success message after 5 seconds
-                    Task {
-                        try? await Task.sleep(nanoseconds: 5_000_000_000)
-                        if verificationSuccessChannelId == channel.id {
-                            verificationSuccessChannelId = nil
+                    // Telegram bootstrap: ok is true but no code was sent yet —
+                    // the user needs to open the bootstrap URL first.
+                    if let bootstrapUrl = result?.telegramBootstrapUrl {
+                        telegramBootstrapUrl = bootstrapUrl
+                        telegramBootstrapChannelId = channel.id
+                    } else {
+                        verificationSuccessChannelId = channel.id
+                        // Auto-clear the success message after 5 seconds
+                        Task {
+                            try? await Task.sleep(nanoseconds: 5_000_000_000)
+                            if verificationSuccessChannelId == channel.id {
+                                verificationSuccessChannelId = nil
+                            }
                         }
                     }
                 } else {

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1147,14 +1147,23 @@ public final class HTTPTransport {
     // MARK: - Channel Verification
 
     /// Send a verification code to a contact's channel via the gateway.
-    func verifyContactChannel(contactId: String, channelId: String) async throws -> DaemonClient.ChannelVerificationResult? {
+    func verifyContactChannel(contactId: String, channelId: String, isRetry: Bool = false) async throws -> DaemonClient.ChannelVerificationResult? {
         guard let url = buildURL(for: .contactsChannelVerify(contactId: contactId, channelId: channelId)) else { return nil }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         applyAuth(&request)
         let (data, response) = try await URLSession.shared.data(for: request)
-        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else { return nil }
+        if let http = response as? HTTPURLResponse {
+            if http.statusCode == 401 && !isRetry {
+                let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                if case .success = refreshResult {
+                    return try await verifyContactChannel(contactId: contactId, channelId: channelId, isRetry: true)
+                }
+                return nil
+            }
+            guard (200...299).contains(http.statusCode) else { return nil }
+        }
         return try JSONDecoder().decode(DaemonClient.ChannelVerificationResult.self, from: data)
     }
 


### PR DESCRIPTION
## Summary
- Add 401 auth-refresh retry to HTTPTransport.verifyContactChannel, matching the pattern used by all other HTTP methods in the class
- Handle Telegram bootstrap responses in ContactDetailView: when verification returns ok=true with a telegramBootstrapUrl (sendCount=0), show the bootstrap deep link instead of falsely claiming a verification code was sent

## Test plan
- [ ] Verify channel verification works normally (non-Telegram) with expired session tokens — should auto-refresh and retry
- [ ] Verify Telegram bootstrap flow shows the deep link UI instead of success message
- [ ] Verify non-Telegram verification still shows success checkmark as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
