### PR TITLE
feat: display all channel types in contact detail, showing missing ones as "Not set up"

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -5,6 +5,8 @@ import VellumAssistantShared
 /// verification status, action buttons, and metadata.
 @MainActor
 struct ContactDetailView: View {
+    private static let allChannelTypes = ["telegram", "sms", "email", "voice", "slack"]
+
     let contact: ContactPayload
     var daemonClient: DaemonClient?
 
@@ -142,14 +144,32 @@ struct ContactDetailView: View {
                 .font(VFont.sectionTitle)
                 .foregroundColor(VColor.textPrimary)
 
-            if displayContact.channels.isEmpty {
-                Text("No channels configured")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-                    .padding(VSpacing.lg)
-            } else {
-                ForEach(displayContact.channels) { channel in
-                    channelRow(channel)
+            let channelsByType = Dictionary(
+                grouping: displayContact.channels,
+                by: { $0.type }
+            )
+            let extraChannels = displayContact.channels.filter { !Self.allChannelTypes.contains($0.type) }
+            let totalRows = Self.allChannelTypes.count + extraChannels.count
+
+            ForEach(Array(Self.allChannelTypes.enumerated()), id: \.element) { index, type in
+                if let channels = channelsByType[type] {
+                    ForEach(channels) { channel in
+                        channelRow(channel)
+                    }
+                } else {
+                    unconfiguredChannelRow(type: type)
+                }
+
+                if index < totalRows - 1 {
+                    Divider().background(VColor.divider)
+                }
+            }
+
+            ForEach(Array(extraChannels.enumerated()), id: \.element.id) { index, channel in
+                channelRow(channel)
+
+                if Self.allChannelTypes.count + index < totalRows - 1 {
+                    Divider().background(VColor.divider)
                 }
             }
 
@@ -215,10 +235,26 @@ struct ContactDetailView: View {
             if displayContact.role != "guardian" {
                 channelActions(for: channel)
             }
+        }
+    }
 
-            if channel.id != displayContact.channels.last?.id {
-                Divider().background(VColor.divider)
-            }
+    @ViewBuilder
+    private func unconfiguredChannelRow(type: String) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            Image(systemName: channelIcon(for: type))
+                .foregroundColor(VColor.textSecondary)
+                .font(.system(size: 14))
+                .frame(width: 20, alignment: .center)
+
+            Text(channelLabel(for: type))
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+
+            Spacer()
+
+            Text("Not set up")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
         }
     }
 
@@ -449,6 +485,17 @@ struct ContactDetailView: View {
             return "bubble.left.fill"
         default:
             return "globe"
+        }
+    }
+
+    private func channelLabel(for type: String) -> String {
+        switch type {
+        case "telegram": return "Telegram"
+        case "sms": return "SMS"
+        case "email": return "Email"
+        case "voice": return "Voice"
+        case "slack": return "Slack"
+        default: return type.capitalized
         }
     }
 


### PR DESCRIPTION
## Summary
- Iterate over all known channel types (Telegram, SMS, Email, Voice, Slack) in ContactDetailView channels section
- Show existing contact channels with full status/actions as before
- Show unconfigured channels as "Not set up" rows with muted styling
- Append any extra channel types not in the known list at the bottom

Part of plan: contacts-add-and-all-channels.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
