### PR TITLE
Add touchContactInteraction function for atomic contact stats update

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -1030,6 +1030,23 @@ export function updateChannelLastSeenById(channelId: string): void {
     .run();
 }
 
+/**
+ * Atomically increment interactionCount and set lastInteraction on a contact.
+ * Optimized for the hot path — single UPDATE with no prior SELECT.
+ */
+export function updateContactInteraction(contactId: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.update(contacts)
+    .set({
+      lastInteraction: now,
+      interactionCount: sql`${contacts.interactionCount} + 1`,
+      updatedAt: now,
+    })
+    .where(eq(contacts.id, contactId))
+    .run();
+}
+
 // ── Assistant Contact Metadata ──────────────────────────────────────
 
 function parseAssistantMetadata(

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -19,6 +19,7 @@ import {
   getContactInternal,
   updateChannelLastSeenById,
   updateChannelStatus,
+  updateContactInteraction,
   upsertContact,
 } from "./contact-store.js";
 import type {
@@ -282,5 +283,17 @@ export function touchChannelLastSeen(channelId: string): void {
     updateChannelLastSeenById(channelId);
   } catch (err) {
     log.warn({ err }, "Failed to update channel lastSeenAt");
+  }
+}
+
+/**
+ * Increment the interaction count and update lastInteraction on a contact.
+ * Expects a plain contact UUID (Contact.id).
+ */
+export function touchContactInteraction(contactId: string): void {
+  try {
+    updateContactInteraction(contactId);
+  } catch (err) {
+    log.warn({ err }, "Failed to update contact interaction stats");
   }
 }


### PR DESCRIPTION
## Summary
- Add `updateContactInteraction` to contact-store.ts — single atomic UPDATE that increments `interactionCount` and sets `lastInteraction` on a contact by primary key
- Add `touchContactInteraction` wrapper to contacts-write.ts with error swallowing (matches `touchChannelLastSeen` pattern)

Part of plan: contact-interaction-stats.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
