### PR TITLE
fix: always scan for orphaned processes during retire

### DIFF
--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -102,11 +102,11 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
     await stopProcessByPidFile(outboundProxyPidFile, "outbound-proxy");
   }
 
-  // If the PID file didn't track a running daemon, scan for orphaned
-  // daemon processes that may have been started without writing a PID.
-  if (!daemonStopped) {
-    await stopOrphanedDaemonProcesses();
-  }
+  // Always scan for orphaned daemon processes. The macOS desktop app can
+  // spawn daemon/gateway processes independently of the CLI's PID tracking,
+  // so even if we successfully killed the PID-file daemon there may be
+  // app-spawned processes still running.
+  await stopOrphanedDaemonProcesses();
 
   // For named instances (instanceDir under ~/.vellum/instances/<name>/),
   // archive and remove the entire instance directory. For default instances


### PR DESCRIPTION
The macOS desktop app spawns daemon/gateway processes that aren't tracked by the CLI's PID files. Previously, `retireLocal` only scanned for orphans when `daemonStopped` was false — meaning if it successfully killed the PID-file daemon, it skipped the orphan scan. This left app-spawned processes running after retire, showing up as orphans in `vellum ps`.

Fix: always run `stopOrphanedDaemonProcesses()` regardless of whether the PID-file daemon was found.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12767" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
