### PR TITLE
Track contact interaction stats on inbound channel messages

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -8,7 +8,10 @@
  */
 import type { ChannelId } from "../../../channels/types.js";
 import { findContactChannel } from "../../../contacts/contact-store.js";
-import { touchChannelLastSeen } from "../../../contacts/contacts-write.js";
+import {
+  touchChannelLastSeen,
+  touchContactInteraction,
+} from "../../../contacts/contacts-write.js";
 import type {
   ChannelStatus,
   ContactChannel,
@@ -634,6 +637,7 @@ export async function enforceIngressAcl(
 
       // 'allow' or 'escalate' — update last seen and continue
       touchChannelLastSeen(resolvedMember.channel.id);
+      touchContactInteraction(resolvedMember.contact.id);
     }
   }
 


### PR DESCRIPTION
## Summary
- Wire `touchContactInteraction` into ACL enforcement alongside existing `touchChannelLastSeen`
- Every inbound text/chat message that passes ACL now increments the sender contact's `interactionCount` and updates `lastInteraction`

Part of plan: contact-interaction-stats.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
