### PR TITLE
Track contact interaction stats on inbound voice calls

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -20,6 +20,7 @@ import {
 import {
   createGuardianBinding,
   revokeGuardianBinding,
+  touchContactInteraction,
   upsertMember,
 } from "../contacts/contacts-write.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
@@ -874,6 +875,10 @@ export class RelayConnection {
       }
 
       // Guardian and trusted-contact callers proceed normally.
+      if (actorTrust.memberRecord) {
+        touchContactInteraction(actorTrust.memberRecord.contact.id);
+      }
+
       // Update the controller's guardian context with the trust-resolved
       // context so downstream policy gates have accurate actor metadata.
       if (this.controller && actorTrust.trustClass !== "unknown") {


### PR DESCRIPTION
## Summary
- Wire `touchContactInteraction` into the voice call ACL success path in relay-server.ts
- Each inbound voice call from a recognized contact (guardian or trusted-contact) now increments `interactionCount` and updates `lastInteraction`
- Fires once per call connection, not per speech utterance

Part of plan: contact-interaction-stats.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
