### PR TITLE
Backfill contact interaction stats from channel lastSeenAt data

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -33,6 +33,7 @@ import {
   createTasksAndWorkItemsTables,
   createWatchersAndLogsTables,
   migrateAssistantContactMetadata,
+  migrateBackfillContactInteractionStats,
   migrateBackfillGuardianPrincipalId,
   migrateCallSessionMode,
   migrateCanonicalGuardianDeliveriesDestinationIndex,
@@ -276,6 +277,9 @@ export function initializeDb(): void {
 
   // 37. Add contact_type to contacts and assistant_contact_metadata table
   migrateAssistantContactMetadata(database);
+
+  // 38. Backfill contact interaction stats from channel lastSeenAt
+  migrateBackfillContactInteractionStats(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/135-backfill-contact-interaction-stats.ts
+++ b/assistant/src/memory/migrations/135-backfill-contact-interaction-stats.ts
@@ -1,0 +1,31 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * Backfill contacts.last_interaction from the max lastSeenAt across each
+ * contact's channels. interactionCount cannot be reliably derived from
+ * existing data, so it stays at 0 and accumulates going forward.
+ */
+export function migrateBackfillContactInteractionStats(db: DrizzleDb): void {
+  withCrashRecovery(db, "backfill_contact_interaction_stats", () => {
+    db.run(/*sql*/ `
+      UPDATE contacts
+      SET last_interaction = (
+        SELECT MAX(last_seen_at)
+        FROM contact_channels
+        WHERE contact_id = contacts.id
+          AND last_seen_at IS NOT NULL
+      ),
+      updated_at = CASE
+        WHEN (SELECT MAX(last_seen_at) FROM contact_channels WHERE contact_id = contacts.id AND last_seen_at IS NOT NULL) IS NOT NULL
+        THEN (SELECT MAX(last_seen_at) FROM contact_channels WHERE contact_id = contacts.id AND last_seen_at IS NOT NULL)
+        ELSE updated_at
+      END
+      WHERE last_interaction IS NULL
+        AND EXISTS (
+          SELECT 1 FROM contact_channels
+          WHERE contact_id = contacts.id AND last_seen_at IS NOT NULL
+        )
+    `);
+  });
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -76,6 +76,7 @@ export { migrateDropLegacyMemberGuardianTables } from "./131-drop-legacy-member-
 export { migrateContactsAssistantId } from "./132-contacts-assistant-id.js";
 export { migrateAssistantContactMetadata } from "./133-assistant-contact-metadata.js";
 export { migrateContactsNotesColumn } from "./134-contacts-notes-column.js";
+export { migrateBackfillContactInteractionStats } from "./135-backfill-contact-interaction-stats.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,


### PR DESCRIPTION
## Summary
- Add migration `134-backfill-contact-interaction-stats.ts` that backfills `contacts.last_interaction` from the max `lastSeenAt` across each contact's channels
- Uses `withCrashRecovery` for idempotency — safe to re-run
- Single SQL UPDATE with correlated subqueries — no row-by-row iteration
- `interactionCount` stays at 0 and accumulates going forward

Part of plan: contact-interaction-stats.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
