### PR TITLE
feat: replace contact metadata fields with notes in CLI and docs

### DIFF
--- a/assistant/docs/runbook-trusted-contacts.md
+++ b/assistant/docs/runbook-trusted-contacts.md
@@ -62,10 +62,7 @@ Response shape:
     {
       "id": "uuid",
       "displayName": "Alice",
-      "relationship": "friend",
-      "importance": 0.5,
-      "responseExpectation": null,
-      "preferredTone": null,
+      "notes": null,
       "lastInteraction": 1700000000000,
       "interactionCount": 12,
       "createdAt": 1699000000000,

--- a/cli/src/commands/contacts.ts
+++ b/cli/src/commands/contacts.ts
@@ -82,10 +82,7 @@ interface ContactChannel {
 interface Contact {
   id: string;
   displayName: string;
-  relationship: string | null;
-  importance: number;
-  responseExpectation: string | null;
-  preferredTone: string | null;
+  notes: string | null;
   lastInteraction: number | null;
   interactionCount: number;
   channels: ContactChannel[];
@@ -109,10 +106,7 @@ function formatContact(c: Contact): string {
   const lines = [
     `  ID:           ${c.id}`,
     `  Name:         ${c.displayName}`,
-    `  Relationship: ${c.relationship ?? "(none)"}`,
-    `  Importance:   ${c.importance.toFixed(2)}`,
-    `  Response:     ${c.responseExpectation ?? "(none)"}`,
-    `  Tone:         ${c.preferredTone ?? "(none)"}`,
+    `  Notes:        ${c.notes ?? "(none)"}`,
     `  Interactions: ${c.interactionCount}`,
   ];
   if (c.lastInteraction) {


### PR DESCRIPTION
## Summary
- Update CLI contacts command to display notes instead of four old fields
- Update runbook-trusted-contacts.md examples to use notes

Part of plan: contact-notes-field.md (PR 10 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
