### PR TITLE
feat: replace contact metadata fields with notes in Swift clients and macOS UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteActions.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteActions.swift
@@ -52,7 +52,7 @@ struct SearchResultSchedule: Identifiable, Decodable {
 struct SearchResultContact: Identifiable, Decodable {
     let id: String
     let displayName: String
-    let relationship: String?
+    let notes: String?
     let lastInteraction: Double?
 }
 

--- a/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteView.swift
+++ b/clients/macos/vellum-assistant/Features/CommandPalette/CommandPaletteView.swift
@@ -379,8 +379,8 @@ struct CommandPaletteView: View {
                     .foregroundColor(VColor.textPrimary)
                     .lineLimit(1)
 
-                if let relationship = contact.relationship, !relationship.isEmpty {
-                    Text(relationship)
+                if let notes = contact.notes, !notes.isEmpty {
+                    Text(notes.components(separatedBy: .newlines).first ?? notes)
                         .font(VFont.caption)
                         .foregroundColor(VColor.textMuted)
                         .lineLimit(1)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactCreateView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactCreateView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import VellumAssistantShared
 
 /// A form sheet for creating a new contact with a display name,
-/// optional relationship, and one initial channel (type + address).
+/// optional notes, and one initial channel (type + address).
 @MainActor
 struct ContactCreateView: View {
     var daemonClient: DaemonClient?
@@ -12,7 +12,7 @@ struct ContactCreateView: View {
     // MARK: - Form State
 
     @State private var displayName = ""
-    @State private var relationship = ""
+    @State private var notes = ""
     @State private var channelType = "telegram"
     @State private var channelAddress = ""
     @State private var isSubmitting = false
@@ -68,12 +68,12 @@ struct ContactCreateView: View {
                 VTextField(placeholder: "e.g. Alice Chen", text: $displayName)
             }
 
-            // Relationship (optional)
+            // Notes (optional)
             VStack(alignment: .leading, spacing: VSpacing.xs) {
-                Text("Relationship")
+                Text("Notes")
                     .font(VFont.inputLabel)
                     .foregroundColor(VColor.textSecondary)
-                VTextField(placeholder: "e.g. Colleague (optional)", text: $relationship)
+                VTextField(placeholder: "e.g. Colleague, prefers casual tone (optional)", text: $notes)
             }
 
             // Channel type picker
@@ -165,13 +165,13 @@ struct ContactCreateView: View {
             ),
         ]
 
-        let trimmedRelationship = relationship.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedNotes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
 
         Task {
             do {
                 let contact = try await daemonClient.createContact(
                     displayName: displayName.trimmingCharacters(in: .whitespacesAndNewlines),
-                    relationship: trimmedRelationship.isEmpty ? nil : trimmedRelationship,
+                    notes: trimmedNotes.isEmpty ? nil : trimmedNotes,
                     channels: channels
                 )
                 if let contact {

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView+EditableMetadata.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView+EditableMetadata.swift
@@ -5,183 +5,82 @@ import VellumAssistantShared
 
 extension ContactDetailView {
 
-    var editableRelationshipRow: some View {
-        EditableMetadataRow(
-            label: "Relationship",
-            value: displayContact.relationship,
-            isEditing: $isEditingRelationship,
-            editor: {
-                TextField("Relationship", text: $editedRelationship)
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-                    .textFieldStyle(.plain)
-                    .onSubmit { Task { await saveRelationship() } }
-            },
-            onStartEditing: {
-                editedRelationship = displayContact.relationship ?? ""
-            },
-            onCancel: {
-                isEditingRelationship = false
-            }
-        )
-    }
+    var editableNotesRow: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            HStack {
+                Text("Notes")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+                Spacer()
+                if isEditingNotes {
+                    HStack(spacing: VSpacing.sm) {
+                        Button {
+                            Task { await saveNotes() }
+                        } label: {
+                            Image(systemName: "checkmark")
+                                .foregroundColor(VColor.success)
+                                .font(.system(size: 12, weight: .semibold))
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Save notes")
 
-    var editableImportanceRow: some View {
-        HStack(spacing: VSpacing.sm) {
-            Text("Importance")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textSecondary)
-                .frame(width: 140, alignment: .leading)
-
-            if isEditingImportance {
-                HStack(spacing: VSpacing.sm) {
-                    VSlider(value: $editedImportance, range: 0...1, step: 0.1)
-                        .frame(maxWidth: 160)
-
-                    Text(String(format: "%.1f", editedImportance))
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
-                        .frame(width: 30, alignment: .trailing)
-
-                    Button {
-                        Task { await saveImportance() }
-                    } label: {
-                        Image(systemName: "checkmark")
-                            .foregroundColor(VColor.success)
-                            .font(.system(size: 12, weight: .semibold))
+                        Button {
+                            isEditingNotes = false
+                        } label: {
+                            Image(systemName: "xmark")
+                                .foregroundColor(VColor.textMuted)
+                                .font(.system(size: 12, weight: .semibold))
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Cancel editing")
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Save importance")
-
-                    Button {
-                        isEditingImportance = false
-                    } label: {
-                        Image(systemName: "xmark")
-                            .foregroundColor(VColor.textMuted)
-                            .font(.system(size: 12, weight: .semibold))
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Cancel editing")
                 }
-            } else {
-                Text(String(format: "%.1f", displayContact.importance))
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-                    .onTapGesture {
-                        editedImportance = displayContact.importance
-                        isEditingImportance = true
-                    }
             }
 
-            Spacer()
-        }
-    }
-
-    var editableResponseExpectationRow: some View {
-        HStack(spacing: VSpacing.sm) {
-            Text("Response expectation")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textSecondary)
-                .frame(width: 140, alignment: .leading)
-
-            if isEditingResponseExpectation {
-                HStack(spacing: VSpacing.sm) {
-                    Picker("", selection: $editedResponseExpectation) {
-                        Text("Immediate").tag("immediate")
-                        Text("Within hours").tag("within_hours")
-                        Text("Within a day").tag("within_day")
-                        Text("Flexible").tag("flexible")
-                        Divider()
-                        Text("Clear").tag("")
-                    }
-                    .labelsHidden()
-                    .pickerStyle(.menu)
-
-                    Button {
-                        Task { await saveResponseExpectation(editedResponseExpectation.isEmpty ? nil : editedResponseExpectation) }
-                    } label: {
-                        Image(systemName: "checkmark")
-                            .foregroundColor(VColor.success)
-                            .font(.system(size: 12, weight: .semibold))
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Save response expectation")
-
-                    Button {
-                        isEditingResponseExpectation = false
-                    } label: {
-                        Image(systemName: "xmark")
-                            .foregroundColor(VColor.textMuted)
-                            .font(.system(size: 12, weight: .semibold))
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Cancel editing")
-                }
-            } else if let expectation = displayContact.responseExpectation,
-                      !expectation.isEmpty {
-                Text(formatResponseExpectation(expectation))
+            if isEditingNotes {
+                TextEditor(text: $editedNotes)
                     .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: 80, maxHeight: 200)
+                    .padding(VSpacing.xs)
+                    .background(VColor.inputBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+            } else if let notes = displayContact.notes, !notes.isEmpty {
+                Text(notes)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .onTapGesture {
-                        editedResponseExpectation = expectation
-                        isEditingResponseExpectation = true
+                        editedNotes = notes
+                        isEditingNotes = true
                     }
             } else {
                 Button {
-                    editedResponseExpectation = ""
-                    isEditingResponseExpectation = true
+                    editedNotes = ""
+                    isEditingNotes = true
                 } label: {
-                    Text("+ Add")
+                    Text("+ Add notes")
                         .font(VFont.caption)
                         .foregroundColor(VColor.accent)
                 }
                 .buttonStyle(.plain)
             }
-
-            Spacer()
         }
-    }
-
-    var editablePreferredToneRow: some View {
-        EditableMetadataRow(
-            label: "Preferred tone",
-            value: displayContact.preferredTone,
-            isEditing: $isEditingPreferredTone,
-            formatValue: { capitalizeFirst($0) },
-            editor: {
-                TextField("Preferred tone", text: $editedPreferredTone)
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-                    .textFieldStyle(.plain)
-                    .onSubmit { Task { await savePreferredTone() } }
-            },
-            onStartEditing: {
-                editedPreferredTone = displayContact.preferredTone ?? ""
-            },
-            onCancel: {
-                isEditingPreferredTone = false
-            }
-        )
     }
 
     // MARK: - Metadata Save Functions
 
     /// Returns true on success so callers can conditionally dismiss their editor.
     func saveMetadataField(
-        relationship: String? = nil,
-        importance: Double? = nil,
-        responseExpectation: String? = nil,
-        preferredTone: String? = nil
+        notes: String? = nil
     ) async -> Bool {
         errorMessage = nil
         do {
             if let updated = try await daemonClient?.updateContact(
                 contactId: displayContact.id,
                 displayName: displayContact.displayName,
-                relationship: relationship,
-                importance: importance,
-                responseExpectation: responseExpectation,
-                preferredTone: preferredTone
+                notes: notes
             ) {
                 currentContact = updated
                 return true
@@ -193,33 +92,11 @@ extension ContactDetailView {
         }
     }
 
-    func saveRelationship() async {
-        let trimmed = editedRelationship.trimmingCharacters(in: .whitespacesAndNewlines)
-        let success = await saveMetadataField(relationship: trimmed)
+    func saveNotes() async {
+        let trimmed = editedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
+        let success = await saveMetadataField(notes: trimmed)
         if success {
-            isEditingRelationship = false
-        }
-    }
-
-    func saveImportance() async {
-        let success = await saveMetadataField(importance: editedImportance)
-        if success {
-            isEditingImportance = false
-        }
-    }
-
-    func saveResponseExpectation(_ value: String?) async {
-        let success = await saveMetadataField(responseExpectation: value ?? "")
-        if success {
-            isEditingResponseExpectation = false
-        }
-    }
-
-    func savePreferredTone() async {
-        let trimmed = editedPreferredTone.trimmingCharacters(in: .whitespacesAndNewlines)
-        let success = await saveMetadataField(preferredTone: trimmed)
-        if success {
-            isEditingPreferredTone = false
+            isEditingNotes = false
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -26,14 +26,8 @@ struct ContactDetailView: View {
     @State private var inviteCopiedType: String?
 
     // Metadata editing state (accessed from ContactDetailView+EditableMetadata.swift)
-    @State var isEditingRelationship = false
-    @State var editedRelationship = ""
-    @State var isEditingImportance = false
-    @State var editedImportance: Double = 0.5
-    @State var isEditingResponseExpectation = false
-    @State var editedResponseExpectation = ""
-    @State var isEditingPreferredTone = false
-    @State var editedPreferredTone = ""
+    @State var isEditingNotes = false
+    @State var editedNotes = ""
 
     var displayContact: ContactPayload {
         currentContact ?? contact
@@ -488,13 +482,7 @@ struct ContactDetailView: View {
                     value: formatContactType(displayContact.contactType)
                 )
 
-                editableRelationshipRow
-
-                editableImportanceRow
-
-                editableResponseExpectationRow
-
-                editablePreferredToneRow
+                editableNotesRow
 
                 metadataRow(
                     label: "Interactions",
@@ -536,26 +524,6 @@ struct ContactDetailView: View {
         default:
             return "Human"
         }
-    }
-
-    func formatResponseExpectation(_ value: String) -> String {
-        switch value {
-        case "immediate":
-            return "Immediate"
-        case "within_hours":
-            return "Within hours"
-        case "within_day":
-            return "Within a day"
-        case "flexible":
-            return "Flexible"
-        default:
-            return capitalizeFirst(value.replacingOccurrences(of: "_", with: " "))
-        }
-    }
-
-    func capitalizeFirst(_ value: String) -> String {
-        guard let first = value.first else { return value }
-        return first.uppercased() + value.dropFirst()
     }
 
     // MARK: - Helpers
@@ -749,10 +717,7 @@ struct ContactDetailView: View {
                 id: "contact-1",
                 displayName: "Alice Smith",
                 role: "contact",
-                relationship: "colleague",
-                importance: 0.8,
-                responseExpectation: "within_hours",
-                preferredTone: "casual",
+                notes: "Colleague, prefers casual tone. Responds within hours.",
                 contactType: "human",
                 lastInteraction: Date().timeIntervalSince1970 * 1000 - 3_600_000,
                 interactionCount: 42,

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -176,8 +176,8 @@ struct ContactsListView: View {
                         .foregroundColor(VColor.textPrimary)
                         .lineLimit(1)
 
-                    if let relationship = contact.relationship, !relationship.isEmpty {
-                        Text(relationship)
+                    if let notes = contact.notes, !notes.isEmpty {
+                        Text(notes.components(separatedBy: .newlines).first ?? notes)
                             .font(VFont.caption)
                             .foregroundColor(VColor.textSecondary)
                             .lineLimit(1)
@@ -328,8 +328,6 @@ struct ContactsListView: View {
                 id: "guardian-1",
                 displayName: "Noah",
                 role: "guardian",
-                relationship: nil,
-                importance: 1.0,
                 lastInteraction: Date().timeIntervalSince1970 * 1000,
                 interactionCount: 42,
                 channels: [
@@ -351,8 +349,7 @@ struct ContactsListView: View {
                 id: "contact-2",
                 displayName: "Alice Chen",
                 role: "contact",
-                relationship: "Colleague",
-                importance: 0.8,
+                notes: "Colleague",
                 lastInteraction: Date().timeIntervalSince1970 * 1000 - 86400000,
                 interactionCount: 15,
                 channels: [
@@ -366,8 +363,7 @@ struct ContactsListView: View {
                 id: "contact-3",
                 displayName: "Bob Williams",
                 role: "contact",
-                relationship: "Friend",
-                importance: 0.6,
+                notes: "Friend",
                 lastInteraction: nil,
                 interactionCount: 3,
                 channels: [

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1566,10 +1566,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     public func updateContact(
         contactId: String,
         displayName: String,
-        relationship: String? = nil,
-        importance: Double? = nil,
-        responseExpectation: String? = nil,
-        preferredTone: String? = nil
+        notes: String? = nil
     ) async throws -> ContactPayload? {
         // Delegate to HTTPTransport when active — it handles buildURL/applyAuth
         // for both runtimeFlat and platformAssistantProxy route modes.
@@ -1577,10 +1574,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             return try await httpTransport.updateContactAndReturn(
                 contactId: contactId,
                 displayName: displayName,
-                relationship: relationship,
-                importance: importance,
-                responseExpectation: responseExpectation,
-                preferredTone: preferredTone
+                notes: notes
             )
         }
 
@@ -1596,10 +1590,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
 
         var body: [String: Any] = ["id": contactId, "displayName": displayName]
-        if let relationship { body["relationship"] = relationship }
-        if let importance { body["importance"] = importance }
-        if let responseExpectation { body["responseExpectation"] = responseExpectation }
-        if let preferredTone { body["preferredTone"] = preferredTone }
+        if let notes { body["notes"] = notes }
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
@@ -1622,15 +1613,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// local daemon HTTP server for socket-based connections.
     public func createContact(
         displayName: String,
-        relationship: String? = nil,
-        importance: Double? = nil,
+        notes: String? = nil,
         channels: [NewContactChannel]? = nil
     ) async throws -> ContactPayload? {
         if let httpTransport {
             return try await httpTransport.createContactAndReturn(
                 displayName: displayName,
-                relationship: relationship,
-                importance: importance,
+                notes: notes,
                 channels: channels
             )
         }
@@ -1646,8 +1635,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
 
         var body: [String: Any] = ["displayName": displayName]
-        if let relationship { body["relationship"] = relationship }
-        if let importance { body["importance"] = importance }
+        if let notes { body["notes"] = notes }
         if let channels {
             body["channels"] = channels.map { ch -> [String: Any] in
                 ["type": ch.type, "address": ch.address, "isPrimary": ch.isPrimary]

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -866,23 +866,17 @@ public struct IPCContactPayload: Codable, Sendable {
     public let id: String
     public let displayName: String
     public let role: String
-    public let relationship: String?
-    public let importance: Double
-    public let responseExpectation: String?
-    public let preferredTone: String?
+    public let notes: String?
     public let contactType: String?
     public let lastInteraction: Double?
     public let interactionCount: Int
     public let channels: [IPCContactChannelPayload]
 
-    public init(id: String, displayName: String, role: String, relationship: String? = nil, importance: Double, responseExpectation: String? = nil, preferredTone: String? = nil, contactType: String? = nil, lastInteraction: Double? = nil, interactionCount: Int, channels: [IPCContactChannelPayload]) {
+    public init(id: String, displayName: String, role: String, notes: String? = nil, contactType: String? = nil, lastInteraction: Double? = nil, interactionCount: Int, channels: [IPCContactChannelPayload]) {
         self.id = id
         self.displayName = displayName
         self.role = role
-        self.relationship = relationship
-        self.importance = importance
-        self.responseExpectation = responseExpectation
-        self.preferredTone = preferredTone
+        self.notes = notes
         self.contactType = contactType
         self.lastInteraction = lastInteraction
         self.interactionCount = interactionCount

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1077,10 +1077,7 @@ public final class HTTPTransport {
     func updateContactAndReturn(
         contactId: String,
         displayName: String,
-        relationship: String? = nil,
-        importance: Double? = nil,
-        responseExpectation: String? = nil,
-        preferredTone: String? = nil,
+        notes: String? = nil,
         isRetry: Bool = false
     ) async throws -> ContactPayload? {
         guard let url = buildURL(for: .contactsUpsert) else { return nil }
@@ -1091,10 +1088,7 @@ public final class HTTPTransport {
         applyAuth(&request)
 
         var body: [String: Any] = ["id": contactId, "displayName": displayName]
-        if let relationship { body["relationship"] = relationship }
-        if let importance { body["importance"] = importance }
-        if let responseExpectation { body["responseExpectation"] = responseExpectation }
-        if let preferredTone { body["preferredTone"] = preferredTone }
+        if let notes { body["notes"] = notes }
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
         let (data, response) = try await URLSession.shared.data(for: request)
@@ -1103,7 +1097,7 @@ public final class HTTPTransport {
             if http.statusCode == 401 && !isRetry {
                 let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                 if case .success = refreshResult {
-                    return try await updateContactAndReturn(contactId: contactId, displayName: displayName, relationship: relationship, importance: importance, responseExpectation: responseExpectation, preferredTone: preferredTone, isRetry: true)
+                    return try await updateContactAndReturn(contactId: contactId, displayName: displayName, notes: notes, isRetry: true)
                 }
                 return nil
             }
@@ -1120,8 +1114,7 @@ public final class HTTPTransport {
     /// Omits the `id` field to trigger creation instead of update.
     func createContactAndReturn(
         displayName: String,
-        relationship: String? = nil,
-        importance: Double? = nil,
+        notes: String? = nil,
         channels: [DaemonClient.NewContactChannel]? = nil,
         isRetry: Bool = false
     ) async throws -> ContactPayload? {
@@ -1133,8 +1126,7 @@ public final class HTTPTransport {
         applyAuth(&request)
 
         var body: [String: Any] = ["displayName": displayName]
-        if let relationship { body["relationship"] = relationship }
-        if let importance { body["importance"] = importance }
+        if let notes { body["notes"] = notes }
         if let channels {
             body["channels"] = channels.map { ch -> [String: Any] in
                 ["type": ch.type, "address": ch.address, "isPrimary": ch.isPrimary]
@@ -1148,7 +1140,7 @@ public final class HTTPTransport {
             if http.statusCode == 401 && !isRetry {
                 let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                 if case .success = refreshResult {
-                    return try await createContactAndReturn(displayName: displayName, relationship: relationship, importance: importance, channels: channels, isRetry: true)
+                    return try await createContactAndReturn(displayName: displayName, notes: notes, channels: channels, isRetry: true)
                 }
                 return nil
             }


### PR DESCRIPTION
## Summary
- Regenerate IPC contract to reflect notes field replacing relationship, importance, responseExpectation, and preferredTone
- Update DaemonClient and HTTPDaemonClient to use single notes parameter instead of four metadata fields
- Update all macOS contact views (detail, create, list, command palette) to use notes
- Replace four separate editable metadata rows with a single notes text editor in ContactDetailView

Part of plan: contact-notes-field.md (PR 9 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
