### PR TITLE
test: update contact tool tests for notes field

### DIFF
--- a/assistant/src/__tests__/contacts-tools.test.ts
+++ b/assistant/src/__tests__/contacts-tools.test.ts
@@ -140,17 +140,14 @@ describe("contact_upsert tool", () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Created contact");
     expect(result.content).toContain("Alice");
-    expect(result.content).toContain("Importance: 0.50");
   });
 
   test("creates a contact with all fields", async () => {
     const result = await executeContactUpsert(
       {
         display_name: "Bob",
-        relationship: "colleague",
-        importance: 0.8,
-        response_expectation: "within_hours",
-        preferred_tone: "professional",
+        notes:
+          "Colleague at Acme Corp, prefers professional tone, responds within hours",
         channels: [
           { type: "email", address: "bob@example.com", is_primary: true },
           { type: "slack", address: "@bob" },
@@ -161,10 +158,7 @@ describe("contact_upsert tool", () => {
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Bob");
-    expect(result.content).toContain("colleague");
-    expect(result.content).toContain("0.80");
-    expect(result.content).toContain("within_hours");
-    expect(result.content).toContain("professional");
+    expect(result.content).toContain("Notes: Colleague at Acme Corp");
     expect(result.content).toContain("email: bob@example.com");
     expect(result.content).toContain("slack: @bob");
   });
@@ -185,7 +179,7 @@ describe("contact_upsert tool", () => {
       {
         id: contactId,
         display_name: "Charlie Updated",
-        importance: 0.9,
+        notes: "Updated notes for Charlie",
       },
       ctx,
     );
@@ -193,7 +187,7 @@ describe("contact_upsert tool", () => {
     expect(updateResult.isError).toBe(false);
     expect(updateResult.content).toContain("Updated contact");
     expect(updateResult.content).toContain("Charlie Updated");
-    expect(updateResult.content).toContain("0.90");
+    expect(updateResult.content).toContain("Notes: Updated notes for Charlie");
   });
 
   test("auto-matches by channel address on create", async () => {
@@ -239,36 +233,6 @@ describe("contact_upsert tool", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain("display_name is required");
   });
-
-  test("rejects importance out of range", async () => {
-    const result = await executeContactUpsert(
-      {
-        display_name: "Test",
-        importance: 1.5,
-      },
-      ctx,
-    );
-
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain(
-      "importance must be a number between 0 and 1",
-    );
-  });
-
-  test("rejects negative importance", async () => {
-    const result = await executeContactUpsert(
-      {
-        display_name: "Test",
-        importance: -0.1,
-      },
-      ctx,
-    );
-
-    expect(result.isError).toBe(true);
-    expect(result.content).toContain(
-      "importance must be a number between 0 and 1",
-    );
-  });
 });
 
 // ── contact_search ──────────────────────────────────────────────────
@@ -303,23 +267,6 @@ describe("contact_search tool", () => {
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Charlie");
-  });
-
-  test("searches by relationship", async () => {
-    await executeContactUpsert(
-      { display_name: "Diana", relationship: "friend" },
-      ctx,
-    );
-    await executeContactUpsert(
-      { display_name: "Eve", relationship: "colleague" },
-      ctx,
-    );
-
-    const result = await executeContactSearch({ relationship: "friend" }, ctx);
-
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain("Diana");
-    expect(result.content).not.toContain("Eve");
   });
 
   test("returns no results message when nothing matches", async () => {
@@ -380,7 +327,7 @@ describe("contact_merge tool", () => {
     const r1 = await executeContactUpsert(
       {
         display_name: "Alice (Email)",
-        importance: 0.7,
+        notes: "Prefers email",
         channels: [{ type: "email", address: "alice@example.com" }],
       },
       ctx,
@@ -388,7 +335,7 @@ describe("contact_merge tool", () => {
     const r2 = await executeContactUpsert(
       {
         display_name: "Alice (Slack)",
-        importance: 0.9,
+        notes: "Active on Slack",
         channels: [{ type: "slack", address: "@alice" }],
       },
       ctx,
@@ -407,7 +354,7 @@ describe("contact_merge tool", () => {
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Merged");
-    expect(result.content).toContain("Importance: 0.90"); // takes higher importance
+    expect(result.content).toContain("Notes: Prefers email\nActive on Slack"); // concatenated notes
     expect(result.content).toContain("email: alice@example.com");
     expect(result.content).toContain("slack: @alice");
 


### PR DESCRIPTION
## Summary
- Update contact tool tests to use notes field instead of relationship/importance/responseExpectation/preferredTone
- Remove tests for importance validation (no longer applicable)
- Remove tests for relationship search filter (no longer applicable)
- Update merge test assertions for notes concatenation

Part of plan: contact-notes-field.md (PR 8 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
