### PR TITLE
fix(macos): resolve instance-specific paths for multi-instance

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -276,9 +276,15 @@ extension AppDelegate {
     }
 
     /// Check whether the local gateway is healthy by hitting its /healthz endpoint.
-    /// Reads port from GATEWAY_PORT env var (default 7830) to match local.ts runtime behavior.
+    /// Reads gatewayPort from the lockfile's resources (multi-instance uses dynamic ports),
+    /// falling back to GATEWAY_PORT env var or default 7830.
     func isGatewayHealthy() async -> Bool {
-        let port = ProcessInfo.processInfo.environment["GATEWAY_PORT"] ?? "7830"
+        let port: String = {
+            if let gp = LockfileAssistant.loadLatest()?.gatewayPort {
+                return String(gp)
+            }
+            return ProcessInfo.processInfo.environment["GATEWAY_PORT"] ?? "7830"
+        }()
         guard let url = URL(string: "http://localhost:\(port)/healthz") else { return false }
         var request = URLRequest(url: url)
         request.timeoutInterval = 2

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -217,6 +217,8 @@ struct LockfileAssistant {
     let zone: String?
     let instanceId: String?
     let hatchedAt: String?
+    let gatewayPort: Int?
+    let socketPath: String?
 
     /// Whether this assistant is running remotely (not on the local machine).
     var isRemote: Bool {
@@ -285,6 +287,7 @@ struct LockfileAssistant {
 
         return sorted.compactMap { entry -> LockfileAssistant? in
             guard let assistantId = entry["assistantId"] as? String else { return nil }
+            let resources = entry["resources"] as? [String: Any]
             return LockfileAssistant(
                 assistantId: assistantId,
                 runtimeUrl: entry["runtimeUrl"] as? String,
@@ -294,7 +297,9 @@ struct LockfileAssistant {
                 region: entry["region"] as? String,
                 zone: entry["zone"] as? String,
                 instanceId: entry["instanceId"] as? String,
-                hatchedAt: entry["hatchedAt"] as? String
+                hatchedAt: entry["hatchedAt"] as? String,
+                gatewayPort: resources?["gatewayPort"] as? Int,
+                socketPath: resources?["socketPath"] as? String
             )
         }
     }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -27,20 +27,13 @@ func resolveSocketPath(environment: [String: String]? = nil) -> String {
         let trimmed = envPath.trimmingCharacters(in: .whitespacesAndNewlines)
         return expandHomePath(trimmed)
     }
-    if let baseDir = env["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines), !baseDir.isEmpty {
-        return expandHomePath(baseDir) + "/.vellum/vellum.sock"
-    }
-    return NSHomeDirectory() + "/.vellum/vellum.sock"
+    return resolveVellumDir(environment: environment) + "/vellum.sock"
 }
 
 /// Resolve the daemon session token path.
 /// Uses BASE_DATA_DIR when set to match daemon root resolution.
 func resolveSessionTokenPath(environment: [String: String]? = nil) -> String {
-    let env = environment ?? ProcessInfo.processInfo.environment
-    if let baseDir = env["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines), !baseDir.isEmpty {
-        return expandHomePath(baseDir) + "/.vellum/session-token"
-    }
-    return NSHomeDirectory() + "/.vellum/session-token"
+    return resolveVellumDir(environment: environment) + "/session-token"
 }
 
 /// Read the daemon session token from disk.
@@ -70,7 +63,33 @@ public func resolveVellumDir(environment: [String: String]? = nil) -> String {
         let resolved = baseDir == "~" ? NSHomeDirectory() : (baseDir.hasPrefix("~/") ? NSHomeDirectory() + "/" + String(baseDir.dropFirst(2)) : baseDir)
         return resolved + "/.vellum"
     }
+    // Check the lockfile for instance-specific directory (multi-instance support)
+    if let instanceDir = resolveInstanceDirFromLockfile() {
+        return instanceDir + "/.vellum"
+    }
     return NSHomeDirectory() + "/.vellum"
+}
+
+/// Read the instanceDir from the latest lockfile entry's resources.
+private func resolveInstanceDirFromLockfile() -> String? {
+    guard let json = LockfilePaths.read(),
+          let assistants = json["assistants"] as? [[String: Any]],
+          !assistants.isEmpty else {
+        return nil
+    }
+    // Find the most recently hatched entry
+    let sorted = assistants.sorted { a, b in
+        let dateA = a["hatchedAt"] as? String ?? ""
+        let dateB = b["hatchedAt"] as? String ?? ""
+        return dateA > dateB
+    }
+    guard let latest = sorted.first,
+          let resources = latest["resources"] as? [String: Any],
+          let instanceDir = resources["instanceDir"] as? String,
+          !instanceDir.isEmpty else {
+        return nil
+    }
+    return instanceDir
 }
 
 /// Resolve the runtime HTTP bearer token path.


### PR DESCRIPTION
## Summary
- macOS app's DaemonClient resolved all paths (socket, PID, tokens) to `~/.vellum/` by default, but multi-instance hatches create everything under `~/.vellum/instances/<name>/`
- This caused the bootstrap retry loop to think the daemon was dead (socket not found), spawning dozens of new instances endlessly
- `resolveVellumDir()` now checks the lockfile for the latest entry's `resources.instanceDir` before falling back to the default
- `isGatewayHealthy()` reads `gatewayPort` from lockfile resources instead of hardcoded port 7830
- `LockfileAssistant` now parses `gatewayPort` and `socketPath` from the `resources` field

## Test plan
- [x] Clean state: kill all processes, delete instances and lockfile
- [x] Launch macOS app from scratch — hatches single instance, no spawn loop
- [x] Process count stays at 4 (app, daemon, gateway, qdrant) after 45+ seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
