### PR TITLE
fix(macos): use lockfile gateway port instead of hardcoded 7830

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -276,15 +276,9 @@ extension AppDelegate {
     }
 
     /// Check whether the local gateway is healthy by hitting its /healthz endpoint.
-    /// Reads gatewayPort from the lockfile's resources (multi-instance uses dynamic ports),
-    /// falling back to GATEWAY_PORT env var or default 7830.
+    /// Port resolution: env var > lockfile > default 7830.
     func isGatewayHealthy() async -> Bool {
-        let port: String = {
-            if let gp = LockfileAssistant.loadLatest()?.gatewayPort {
-                return String(gp)
-            }
-            return ProcessInfo.processInfo.environment["GATEWAY_PORT"] ?? "7830"
-        }()
+        let port = LockfilePaths.resolveGatewayPort()
         guard let url = URL(string: "http://localhost:\(port)/healthz") else { return false }
         var request = URLRequest(url: url)
         request.timeoutInterval = 2

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -562,12 +562,9 @@ struct InlineVideoAttachmentView: View {
     }
 }
 
-/// Resolve the local gateway base URL from the GATEWAY_PORT env var (default 7830).
+/// Resolve the local gateway base URL: env var > lockfile > default 7830.
 private func resolveGatewayBaseUrl() -> String {
-    let envPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
-        ?? getenv("GATEWAY_PORT").flatMap({ String(cString: $0) })
-    let port = envPort.flatMap(Int.init) ?? 7830
-    return "http://127.0.0.1:\(port)"
+    "http://127.0.0.1:\(LockfilePaths.resolveGatewayPort())"
 }
 
 /// Fetch raw attachment bytes via the gateway's runtime proxy.

--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -5,7 +5,7 @@ import VellumAssistantShared
 /// Displays a QR code containing the v4 connection payload for iOS pairing.
 ///
 /// v4 payload:
-/// `{"type":"vellum-daemon","v":4,"id":"<mac-hash>","g":"<gateway-url>","pairingRequestId":"<uuid>","pairingSecret":"<32-byte-hex>","localLanUrl":"http://<lan-ip>:7830"}`
+/// `{"type":"vellum-daemon","v":4,"id":"<mac-hash>","g":"<gateway-url>","pairingRequestId":"<uuid>","pairingSecret":"<32-byte-hex>","localLanUrl":"http://<lan-ip>:<gateway-port>"}`
 ///
 /// Key differences from v3:
 /// - No bearer token in QR code (secured by pairing secret + Mac approval)
@@ -180,13 +180,9 @@ struct PairingQRCodeSheet: View {
 
     // MARK: - Registration
 
-    /// Resolve the local gateway base URL. Prefers `GATEWAY_PORT` env var,
-    /// falls back to the default gateway port 7830.
+    /// Resolve the local gateway base URL: env var > lockfile > default 7830.
     private var resolvedGatewayBaseUrl: String {
-        let envPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
-            ?? getenv("GATEWAY_PORT").flatMap({ String(cString: $0) })
-        let port = envPort.flatMap(Int.init) ?? 7830
-        return "http://127.0.0.1:\(port)"
+        "http://127.0.0.1:\(LockfilePaths.resolveGatewayPort())"
     }
 
     private func registerWithDaemon() {
@@ -293,7 +289,7 @@ struct PairingQRCodeSheet: View {
 
     private func computeLocalLanUrl() -> String? {
         guard let lanIP = LANIPHelper.currentLANAddress() else { return nil }
-        return "http://\(lanIP):7830"
+        return "http://\(lanIP):\(LockfilePaths.resolveGatewayPort())"
     }
 
     // MARK: - QR Generation

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -229,8 +229,9 @@ public final class SettingsStore: ObservableObject {
 
     @Published var ingressEnabled: Bool = false
     @Published var ingressPublicBaseUrl: String = ""
-    /// Read-only gateway target derived from daemon config (GATEWAY_PORT env var, default 7830).
-    @Published var localGatewayTarget: String = "http://127.0.0.1:7830"
+    /// Read-only gateway target derived from daemon config.
+    /// Initial value reads env var > lockfile > default 7830; updated by IPC.
+    @Published var localGatewayTarget: String = "http://127.0.0.1:\(LockfilePaths.resolveGatewayPort())"
 
     /// Set to `true` once the first ingress config IPC response arrives, so the
     /// view layer can defer diagnostics until the real config values are available.
@@ -1251,8 +1252,7 @@ public final class SettingsStore: ObservableObject {
             return (httpTransport.baseURL, httpTransport.bearerToken)
         }
         // Local mode: call the gateway directly.
-        let gatewayPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
-            .flatMap(Int.init) ?? 7830
+        let gatewayPort = LockfilePaths.resolveGatewayPort()
         let baseURL = "http://127.0.0.1:\(gatewayPort)"
         let bearerToken = readHttpToken()
         return (baseURL, bearerToken)
@@ -2264,10 +2264,10 @@ public final class SettingsStore: ObservableObject {
         readHttpToken() ?? ""
     }
 
-    /// LAN pairing URL for the gateway (port 7830), or nil if no LAN IP available.
+    /// LAN pairing URL for the gateway, or nil if no LAN IP available.
     var lanPairingUrl: String? {
         guard let ip = LANIPHelper.currentLANAddress() else { return nil }
-        return "http://\(ip):7830"
+        return "http://\(ip):\(LockfilePaths.resolveGatewayPort())"
     }
 
     // MARK: - Dev Mode Actions

--- a/clients/shared/Utilities/LockfilePaths.swift
+++ b/clients/shared/Utilities/LockfilePaths.swift
@@ -31,4 +31,23 @@ public enum LockfilePaths {
         }
         return nil
     }
+
+    /// Resolve the local gateway port: env var > lockfile > default 7830.
+    public static func resolveGatewayPort() -> Int {
+        if let envPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
+            ?? getenv("GATEWAY_PORT").flatMap({ String(cString: $0) }),
+           let port = Int(envPort) {
+            return port
+        }
+        if let json = read(),
+           let assistants = json["assistants"] as? [[String: Any]],
+           let latest = assistants.max(by: {
+               ($0["hatchedAt"] as? String ?? "") < ($1["hatchedAt"] as? String ?? "")
+           }),
+           let resources = latest["resources"] as? [String: Any],
+           let port = resources["gatewayPort"] as? Int {
+            return port
+        }
+        return 7830
+    }
 }


### PR DESCRIPTION
## Summary
- Added `LockfilePaths.resolveGatewayPort()` shared helper: env var > lockfile `resources.gatewayPort` > default 7830
- Replaced all 6 hardcoded 7830 references across the macOS app (SettingsStore, PairingQRCodeSheet, InlineVideoAttachmentView, AppDelegate)
- The Settings UI "Local Gateway Target" now shows the actual port from the lockfile instead of always showing 7830

## Test plan
- [x] Builds clean
- [x] With instance on port 7831, Settings should show `http://127.0.0.1:7831` instead of `:7830`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
