### PR TITLE
fix: include previewImage in DynamicPagePreview equality check

### DIFF
--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -296,6 +296,7 @@ public struct DynamicPagePreview: Sendable, Equatable {
               lhs.subtitle == rhs.subtitle,
               lhs.description == rhs.description,
               lhs.icon == rhs.icon,
+              lhs.previewImage == rhs.previewImage,
               lhs.context == rhs.context else { return false }
         switch (lhs.metrics, rhs.metrics) {
         case (.none, .none):


### PR DESCRIPTION
Add previewImage to DynamicPagePreview's custom Equatable implementation. The field was omitted, making preview image mutations invisible to SwiftUI diffing and Combine's removeDuplicates. From Devin review on #12742.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
