### PR TITLE
fix: set WKNavigationDelegate before loadHTMLString to prevent race condition

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/OffscreenPreviewCapture.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/OffscreenPreviewCapture.swift
@@ -32,12 +32,12 @@ enum OffscreenPreviewCapture {
         window.contentView = webView
 
         // Load the HTML and wait for navigation to finish.
-        webView.loadHTMLString(html, baseURL: nil)
         let didLoad = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
             let delegate = NavigationDelegate(continuation: continuation)
             webView.navigationDelegate = delegate
             // Hold a reference so ARC doesn't deallocate the delegate before it fires.
             objc_setAssociatedObject(webView, "navDelegate", delegate, .OBJC_ASSOCIATION_RETAIN)
+            webView.loadHTMLString(html, baseURL: nil)
         }
 
         guard didLoad else {


### PR DESCRIPTION
## Summary
- Reorder delegate assignment in `OffscreenPreviewCapture.capture(html:)` to happen before `loadHTMLString` call
- Prevents a race condition where navigation completes before the delegate is attached, causing the `CheckedContinuation` to never resume and hanging the preview capture task indefinitely

## Test plan
- [ ] Verify preview capture still works correctly in the app
- [ ] Confirm no hangs during preview generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
