### PR TITLE
fix: replace non-existent VColor.link with VColor.accent

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -420,7 +420,7 @@ struct ContactDetailView: View {
                             Text("Open Telegram")
                                 .font(VFont.caption)
                         }
-                        .foregroundColor(VColor.link)
+                        .foregroundColor(VColor.accent)
                     }
                     .buttonStyle(.plain)
                     .onHover { hovering in


### PR DESCRIPTION
## Summary
- `VColor.link` doesn't exist in the design system, causing a Swift compilation error on CI
- Replaced with `VColor.accent`, the correct semantic token for interactive/link-style elements

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22702963212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
