### PR TITLE
fix: add missing contacts notes column migration to db-init

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -42,6 +42,7 @@ import {
   migrateContactChannelsAccessFields,
   migrateContactChannelsTypeChatIdIndex,
   migrateContactsAssistantId,
+  migrateContactsNotesColumn,
   migrateContactsRolePrincipal,
   migrateConversationsThreadTypeIndex,
   migrateDropLegacyMemberGuardianTables,
@@ -278,7 +279,10 @@ export function initializeDb(): void {
   // 37. Add contact_type to contacts and assistant_contact_metadata table
   migrateAssistantContactMetadata(database);
 
-  // 38. Backfill contact interaction stats from channel lastSeenAt
+  // 38. Consolidate contact metadata columns into single notes field
+  migrateContactsNotesColumn(database);
+
+  // 39. Backfill contact interaction stats from channel lastSeenAt
   migrateBackfillContactInteractionStats(database);
 
   validateMigrationState(database);

--- a/assistant/src/memory/migrations/134-contacts-notes-column.ts
+++ b/assistant/src/memory/migrations/134-contacts-notes-column.ts
@@ -6,46 +6,60 @@ const log = getLogger("migration-134");
 export function migrateContactsNotesColumn(database: DrizzleDb): void {
   const raw = getSqliteFrom(database);
 
-  raw.exec(/*sql*/ `ALTER TABLE contacts ADD COLUMN notes TEXT`);
+  try {
+    raw.exec(/*sql*/ `ALTER TABLE contacts ADD COLUMN notes TEXT`);
+  } catch {
+    /* already exists */
+  }
 
-  const rows = raw
-    .query(
-      `SELECT id, relationship, importance, response_expectation, preferred_tone
+  // Check if legacy columns still exist before attempting backfill + drop
+  const cols = new Set(
+    (
+      raw.query(`PRAGMA table_info(contacts)`).all() as Array<{ name: string }>
+    ).map((c) => c.name),
+  );
+
+  if (cols.has("relationship")) {
+    const rows = raw
+      .query(
+        `SELECT id, relationship, importance, response_expectation, preferred_tone
        FROM contacts
        WHERE relationship IS NOT NULL
           OR importance != 0.5
           OR response_expectation IS NOT NULL
           OR preferred_tone IS NOT NULL`,
-    )
-    .all() as Array<{
-    id: string;
-    relationship: string | null;
-    importance: number;
-    response_expectation: string | null;
-    preferred_tone: string | null;
-  }>;
+      )
+      .all() as Array<{
+      id: string;
+      relationship: string | null;
+      importance: number;
+      response_expectation: string | null;
+      preferred_tone: string | null;
+    }>;
 
-  const update = raw.prepare(`UPDATE contacts SET notes = ? WHERE id = ?`);
+    const update = raw.prepare(`UPDATE contacts SET notes = ? WHERE id = ?`);
 
-  for (const row of rows) {
-    const parts: string[] = [];
-    if (row.relationship) parts.push(`Relationship: ${row.relationship}`);
-    if (row.importance !== 0.5) parts.push(`Importance: ${row.importance}`);
-    if (row.response_expectation)
-      parts.push(`Response expectation: ${row.response_expectation}`);
-    if (row.preferred_tone) parts.push(`Preferred tone: ${row.preferred_tone}`);
-    if (parts.length > 0) {
-      update.run(parts.join("\n"), row.id);
+    for (const row of rows) {
+      const parts: string[] = [];
+      if (row.relationship) parts.push(`Relationship: ${row.relationship}`);
+      if (row.importance !== 0.5) parts.push(`Importance: ${row.importance}`);
+      if (row.response_expectation)
+        parts.push(`Response expectation: ${row.response_expectation}`);
+      if (row.preferred_tone)
+        parts.push(`Preferred tone: ${row.preferred_tone}`);
+      if (parts.length > 0) {
+        update.run(parts.join("\n"), row.id);
+      }
     }
-  }
 
-  const migrated = rows.length;
-  if (migrated > 0) {
-    log.info({ migrated }, "Migrated contact metadata to notes field");
-  }
+    const migrated = rows.length;
+    if (migrated > 0) {
+      log.info({ migrated }, "Migrated contact metadata to notes field");
+    }
 
-  raw.exec(/*sql*/ `ALTER TABLE contacts DROP COLUMN relationship`);
-  raw.exec(/*sql*/ `ALTER TABLE contacts DROP COLUMN importance`);
-  raw.exec(/*sql*/ `ALTER TABLE contacts DROP COLUMN response_expectation`);
-  raw.exec(/*sql*/ `ALTER TABLE contacts DROP COLUMN preferred_tone`);
+    raw.exec(/*sql*/ `ALTER TABLE contacts DROP COLUMN relationship`);
+    raw.exec(/*sql*/ `ALTER TABLE contacts DROP COLUMN importance`);
+    raw.exec(/*sql*/ `ALTER TABLE contacts DROP COLUMN response_expectation`);
+    raw.exec(/*sql*/ `ALTER TABLE contacts DROP COLUMN preferred_tone`);
+  }
 }


### PR DESCRIPTION
## Summary
- Migration 134 (`migrateContactsNotesColumn`) was defined but never called in `db-init.ts`, causing `SQLiteError: table contacts has no column named notes` across 25 test files
- Added the migration call between steps 37 (assistant contact metadata) and 39 (backfill interaction stats)
- Made the migration idempotent (try/catch on ADD COLUMN, check column existence before backfill/drop)

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22701067937/job/65818052350

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
