### PR TITLE
fix: drop idx_contacts_importance before dropping importance column

### DIFF
--- a/assistant/src/memory/migrations/134-contacts-notes-column.ts
+++ b/assistant/src/memory/migrations/134-contacts-notes-column.ts
@@ -57,6 +57,9 @@ export function migrateContactsNotesColumn(database: DrizzleDb): void {
       log.info({ migrated }, "Migrated contact metadata to notes field");
     }
 
+    // Drop indexes that reference columns we're about to remove
+    raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_contacts_importance`);
+
     raw.exec(/*sql*/ `ALTER TABLE contacts DROP COLUMN relationship`);
     raw.exec(/*sql*/ `ALTER TABLE contacts DROP COLUMN importance`);
     raw.exec(/*sql*/ `ALTER TABLE contacts DROP COLUMN response_expectation`);


### PR DESCRIPTION
## Summary
- Drop `idx_contacts_importance` index before dropping the `importance` column in migration 134 to avoid SQLite error
- The index was created in migration 105 and references the column being dropped, causing all tests that init the DB to fail

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22703114652/job/65824480429

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
