### PR TITLE
fix: restrict isLoadingHistory setter to internal access

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -465,7 +465,7 @@ public final class ChatViewModel: ObservableObject {
 
     /// True while `populateFromHistory` is actively inserting messages.
     /// Observers can check this to avoid treating the history hydration as new activity.
-    public var isLoadingHistory: Bool = false
+    public internal(set) var isLoadingHistory: Bool = false
 
     // MARK: - Message Pagination
 


### PR DESCRIPTION
Restrict isLoadingHistory setter to internal(set) instead of fully public. The @testable import mechanism still allows test access without widening the production API.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
