### PR TITLE
fix: move Keychain I/O out of view body and localize Log Out string

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -23,6 +23,7 @@ struct MainWindowView: View {
     /// so we can restore it when they exit instead of jumping to visibleThreads.first
     /// (which may be a pinned thread unrelated to what they were doing).
     @State private var preTemporaryChatThreadId: UUID?
+    @State private var hasSessionToken: Bool = false
 
     @AppStorage("sidebarExpanded") var sidebarExpanded: Bool = true
     @AppStorage("themePreference") private var themePreference: String = "system"
@@ -446,7 +447,7 @@ struct MainWindowView: View {
                                 sidebar.showPreferencesDrawer = false
                                 AppDelegate.shared?.performLogout()
                             },
-                            showLogOut: SessionTokenManager.getToken() != nil
+                            showLogOut: hasSessionToken
                         )
                         .frame(width: drawerWidth)
                         .offset(x: drawerX, y: -28)
@@ -502,6 +503,7 @@ struct MainWindowView: View {
                 windowState.persistentThreadId = activeId
             }
             daemonClient.startSSE()
+            hasSessionToken = SessionTokenManager.getToken() != nil
         }
         .onDisappear {
             copyThread.cancel()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -26,7 +26,7 @@ struct DrawerMenuView: View {
                 VColor.surfaceBorder.frame(height: 1)
                     .padding(.vertical, VSpacing.xs)
 
-                DrawerMenuItem(icon: "rectangle.portrait.and.arrow.right", label: "Log Out", action: onLogOut)
+                DrawerMenuItem(icon: "rectangle.portrait.and.arrow.right", label: String(localized: "Log Out"), action: onLogOut)
             }
         }
         .padding(.vertical, VSpacing.sm)


### PR DESCRIPTION
Move SessionTokenManager.getToken() call out of SwiftUI view body into @State property updated via onAppear. Localize 'Log Out' string with String(localized:).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
