### PR TITLE
fix: add user-evidenced dismissal check to background conflict handler

### DIFF
--- a/assistant/src/memory/job-handlers/conflict.ts
+++ b/assistant/src/memory/job-handlers/conflict.ts
@@ -4,12 +4,14 @@ import type { AssistantConfig } from "../../config/types.js";
 import { getLogger } from "../../util/logger.js";
 import { resolveConflictClarification } from "../clarification-resolver.js";
 import {
+  areStatementsCoherent,
   computeConflictRelevance,
   looksLikeClarificationReply,
   shouldAttemptConflictResolution,
 } from "../conflict-intent.js";
 import {
   isConflictKindPairEligible,
+  isConflictUserEvidenced,
   isStatementConflictEligible,
 } from "../conflict-policy.js";
 import {
@@ -81,6 +83,28 @@ export async function resolvePendingConflictsForMessageJob(
       resolveConflict(conflict.id, {
         status: "dismissed",
         resolutionNote: "Dismissed by conflict policy (transient/non-durable).",
+      });
+    } else if (
+      !isConflictUserEvidenced(
+        conflict.existingVerificationState,
+        conflict.candidateVerificationState,
+      )
+    ) {
+      resolveConflict(conflict.id, {
+        status: "dismissed",
+        resolutionNote:
+          "Dismissed by conflict policy (no user-evidenced provenance).",
+      });
+    } else if (
+      !areStatementsCoherent(
+        conflict.existingStatement,
+        conflict.candidateStatement,
+      )
+    ) {
+      resolveConflict(conflict.id, {
+        status: "dismissed",
+        resolutionNote:
+          "Dismissed by conflict policy (incoherent — zero statement overlap).",
       });
     }
   }


### PR DESCRIPTION
Mirror the interactive conflict gate's dismissal logic in the background job handler. Dismiss conflicts where neither side has user-evidenced provenance, and dismiss incoherent conflicts with zero statement overlap, consistent with session-conflict-gate.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
