### PR TITLE
fix: clear connectedOrganizationId on logout and assistant switch

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -190,6 +190,8 @@ extension AppDelegate {
 
         // 4. Persist the new assistant selection
         UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")
+        // Clear stale org ID so the next bootstrap re-resolves it for the new assistant
+        UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
         assistant.writeToWorkspaceConfig()
 
         // Clear stale actor token for the previous assistant
@@ -270,6 +272,7 @@ extension AppDelegate {
         OnboardingState.clearPersistedState()
         UserDefaults.standard.removeObject(forKey: "bootstrapState")
         UserDefaults.standard.removeObject(forKey: "connectedAssistantId")
+        UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
         UserDefaults.standard.removeObject(forKey: "lastActivePanel")
 
         // Kill the daemon process so ensureDaemonRunning() actually spawns

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -154,6 +154,7 @@ public final class AuthManager {
             log.error("Logout request failed: \(error.localizedDescription)")
         }
         await SessionTokenManager.deleteTokenAsync()
+        UserDefaults.standard.removeObject(forKey: "connectedOrganizationId")
         state = .unauthenticated
         errorMessage = nil
     }


### PR DESCRIPTION
Clear connectedOrganizationId from UserDefaults during logout (both AuthManager.logout and performRetireAsync) and when switching assistants, preventing stale org headers when signing in with a different account or switching to a different managed assistant.

Addresses feedback from PR #12670.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
