### PR TITLE
fix: preserve parenthesized simulator names in iOS build script

### DIFF
--- a/clients/ios/build.sh
+++ b/clients/ios/build.sh
@@ -90,11 +90,14 @@ fi
 # device name that may not exist on every Xcode version.
 resolve_simulator_destination() {
     local sim_name
-    # Extract the device name from lines like "    iPhone 16 Pro (UUID) (Booted)"
-    # The regex captures everything between leading whitespace and the first " (".
+    # Extract the device name from lines like:
+    #   "    iPhone 16 Pro (XXXXXXXX-XXXX-...) (Shutdown)"
+    #   "    iPhone SE (3rd generation) (XXXXXXXX-XXXX-...) (Shutdown)"
+    # Strip the UUID parenthetical and any trailing state like (Booted)/(Shutdown),
+    # but preserve parenthesized model qualifiers like "(3rd generation)".
     sim_name=$(xcrun simctl list devices available 2>/dev/null \
         | grep 'iPhone' \
-        | sed -n 's/^[[:space:]]*\(iPhone[^(]*\) (.*/\1/p' \
+        | sed -n 's/^[[:space:]]*\(iPhone.*\) ([0-9A-Fa-f]\{8\}-.*$/\1/p' \
         | sed 's/[[:space:]]*$//' \
         | head -1 || true)
     if [ -n "$sim_name" ]; then


### PR DESCRIPTION
Fixes regex in resolve_simulator_destination() to preserve parenthesized model qualifiers like '(3rd generation)' in device names, while still stripping UUID and state parentheticals. Addresses Codex feedback on #12789.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
