### PR TITLE
fix: observe sessionTokenDidChange to keep Log Out button in sync

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -521,6 +521,9 @@ struct MainWindowView: View {
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .sessionTokenDidChange)) { _ in
+            hasSessionToken = SessionTokenManager.getToken() != nil
+        }
         .onReceive(daemonClient.$isConnected) { connected in
             windowState.refreshAPIKeyStatus(isConnected: connected)
 


### PR DESCRIPTION
## Summary
- Adds an `.onReceive` handler for `.sessionTokenDidChange` notification in `MainWindowView` to keep `hasSessionToken` reactive
- Ensures the Log Out button visibility updates when the session token changes after initial `.onAppear`
- Mirrors the existing pattern used for `.apiKeyManagerDidChange`

Addresses Codex and Devin feedback on #12791.

## Test plan
- [ ] Verify Log Out button appears/disappears when session token changes
- [ ] Verify no regression in existing `.onAppear` initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
