### PR TITLE
fix: localUrl for loopback health checks + instance-aware Home path

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -70,7 +70,10 @@ function parseArgs(): ParsedArgs {
   }
 
   let runtimeUrl =
-    process.env.RUNTIME_URL || entry?.runtimeUrl || FALLBACK_RUNTIME_URL;
+    process.env.RUNTIME_URL ||
+    entry?.localUrl ||
+    entry?.runtimeUrl ||
+    FALLBACK_RUNTIME_URL;
   let assistantId =
     process.env.ASSISTANT_ID || entry?.assistantId || FALLBACK_ASSISTANT_ID;
   let bearerToken =

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -587,6 +587,8 @@ async function waitForDaemonReady(
 async function displayPairingQRCode(
   runtimeUrl: string,
   bearerToken: string | undefined,
+  /** External gateway URL for the QR payload. When omitted, runtimeUrl is used. */
+  externalGatewayUrl?: string,
 ): Promise<void> {
   try {
     const pairingRequestId = randomUUID();
@@ -613,7 +615,7 @@ async function displayPairingQRCode(
       body: JSON.stringify({
         pairingRequestId,
         pairingSecret,
-        gatewayUrl: runtimeUrl,
+        gatewayUrl: externalGatewayUrl ?? runtimeUrl,
       }),
     });
 
@@ -632,7 +634,7 @@ async function displayPairingQRCode(
       type: "vellum-daemon",
       v: 4,
       id: hostId,
-      g: runtimeUrl,
+      g: externalGatewayUrl ?? runtimeUrl,
       pairingRequestId,
       pairingSecret,
     });
@@ -758,6 +760,7 @@ async function hatchLocal(
   const localEntry: AssistantEntry = {
     assistantId: instanceName,
     runtimeUrl,
+    localUrl: `http://127.0.0.1:${resources.gatewayPort}`,
     baseDataDir,
     bearerToken,
     cloud: "local",
@@ -781,8 +784,11 @@ async function hatchLocal(
     console.log(`  Runtime: ${runtimeUrl}`);
     console.log("");
 
-    // Generate and display pairing QR code
-    await displayPairingQRCode(runtimeUrl, bearerToken);
+    // Use loopback for HTTP calls (health check + pairing register) since
+    // mDNS hostnames may not resolve on the local machine, but keep the
+    // external runtimeUrl in the QR payload so iOS devices can reach it.
+    const localGatewayUrl = `http://127.0.0.1:${resources.gatewayPort}`;
+    await displayPairingQRCode(localGatewayUrl, bearerToken, runtimeUrl);
   }
 }
 

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -413,7 +413,7 @@ async function listAllAssistants(): Promise<void> {
 
   await Promise.all(
     assistants.map(async (a, rowIndex) => {
-      const health = await checkHealth(a.runtimeUrl);
+      const health = await checkHealth(a.localUrl ?? a.runtimeUrl);
 
       const infoParts = [a.runtimeUrl];
       if (a.cloud) infoParts.push(`cloud: ${a.cloud}`);

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -43,6 +43,9 @@ export interface LocalInstanceResources {
 export interface AssistantEntry {
   assistantId: string;
   runtimeUrl: string;
+  /** Loopback URL for same-machine health checks (e.g. `http://127.0.0.1:7831`).
+   *  Avoids mDNS resolution issues when the machine checks its own gateway. */
+  localUrl?: string;
   baseDataDir?: string;
   bearerToken?: string;
   cloud: string;

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -219,6 +219,7 @@ struct LockfileAssistant {
     let hatchedAt: String?
     let gatewayPort: Int?
     let socketPath: String?
+    let instanceDir: String?
 
     /// Whether this assistant is running remotely (not on the local machine).
     var isRemote: Bool {
@@ -255,7 +256,8 @@ struct LockfileAssistant {
         case "vellum":
             return .vellum(runtimeUrl: runtimeUrl ?? "")
         default:
-            return .local(workspacePath: NSHomeDirectory() + "/.vellum/workspace")
+            let base = instanceDir ?? NSHomeDirectory()
+            return .local(workspacePath: base + "/.vellum/workspace")
         }
     }
 
@@ -299,7 +301,8 @@ struct LockfileAssistant {
                 instanceId: entry["instanceId"] as? String,
                 hatchedAt: entry["hatchedAt"] as? String,
                 gatewayPort: resources?["gatewayPort"] as? Int,
-                socketPath: resources?["socketPath"] as? String
+                socketPath: resources?["socketPath"] as? String,
+                instanceDir: resources?["instanceDir"] as? String
             )
         }
     }


### PR DESCRIPTION
## Summary
- Adds `localUrl` (`http://127.0.0.1:<port>`) to lockfile entries so same-machine health checks use loopback instead of mDNS hostnames that don't resolve locally
- `vellum ps` and `vellum client` prefer `localUrl` over `runtimeUrl` for local connections
- Hatch uses loopback for HTTP calls (health check + pairing register) while keeping mDNS URL in QR payload for iOS
- macOS UI "Home" path reads `instanceDir` from lockfile resources instead of hardcoding `~/.vellum/workspace`

## Test plan
- [ ] `vellum hatch local` writes `localUrl` to lockfile
- [ ] `vellum ps` no longer times out on mDNS hostname
- [ ] macOS UI shows instance-specific Home path

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
