### PR TITLE
fix: remap parentSessionId in SSE session ID translation

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -544,6 +544,14 @@ public final class HTTPTransport {
                     of: "\"sessionId\": \"\(remoteId)\"",
                     with: "\"sessionId\": \"\(localId)\""
                 )
+                jsonString = jsonString.replacingOccurrences(
+                    of: "\"parentSessionId\":\"\(remoteId)\"",
+                    with: "\"parentSessionId\":\"\(localId)\""
+                )
+                jsonString = jsonString.replacingOccurrences(
+                    of: "\"parentSessionId\": \"\(remoteId)\"",
+                    with: "\"parentSessionId\": \"\(localId)\""
+                )
             }
         }
 


### PR DESCRIPTION
Extends the SSE session ID remapping in HTTPDaemonClient.parseSSEData to also handle parentSessionId, ensuring subagent events are correctly attributed in HTTP transport mode. Addresses Codex feedback on #12790.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
