### PR TITLE
fix: pass GATEWAY_PORT to daemon in multi-instance mode

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -219,6 +219,7 @@ async function startDaemonFromSource(
   if (resources) {
     env.BASE_DATA_DIR = resources.instanceDir;
     env.RUNTIME_HTTP_PORT = String(resources.daemonPort);
+    env.GATEWAY_PORT = String(resources.gatewayPort);
     env.VELLUM_DAEMON_SOCKET = resources.socketPath;
     env.QDRANT_HTTP_PORT = String(resources.qdrantPort);
     delete env.QDRANT_URL;
@@ -308,6 +309,7 @@ async function startDaemonWatchFromSource(
   if (resources) {
     env.BASE_DATA_DIR = resources.instanceDir;
     env.RUNTIME_HTTP_PORT = String(resources.daemonPort);
+    env.GATEWAY_PORT = String(resources.gatewayPort);
     env.VELLUM_DAEMON_SOCKET = resources.socketPath;
     env.QDRANT_HTTP_PORT = String(resources.qdrantPort);
     delete env.QDRANT_URL;
@@ -714,6 +716,7 @@ export async function startLocalDaemon(
       if (resources) {
         daemonEnv.BASE_DATA_DIR = resources.instanceDir;
         daemonEnv.RUNTIME_HTTP_PORT = String(resources.daemonPort);
+        daemonEnv.GATEWAY_PORT = String(resources.gatewayPort);
         daemonEnv.VELLUM_DAEMON_SOCKET = resources.socketPath;
         daemonEnv.QDRANT_HTTP_PORT = String(resources.qdrantPort);
         delete daemonEnv.QDRANT_URL;


### PR DESCRIPTION
## Summary
- Pass `GATEWAY_PORT` env var to the daemon process when spawning multi-instance assistants
- Without this, the daemon defaults to 7830 and reports the wrong gateway URL to the macOS app via IPC (`localGatewayTarget`), causing the UI to show port 7830 instead of the actual allocated port (e.g. 7832)
- Fixed in all 3 daemon spawn paths in `local.ts`

## Test plan
- [ ] Hatch a new local assistant, verify UI shows the correct gateway port
- [ ] `vellum ps` and macOS Settings > Gateway should show the same port

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
