### PR TITLE
Introduce managed-proxy context resolver for provider initialization

### DIFF
--- a/assistant/src/providers/managed-proxy/constants.ts
+++ b/assistant/src/providers/managed-proxy/constants.ts
@@ -1,0 +1,47 @@
+/**
+ * Provider metadata for managed proxy routing.
+ *
+ * Each managed-capable provider maps to a deterministic proxy base path
+ * used when routing LLM requests through the platform's managed proxy.
+ * Providers marked as non-managed (e.g. ollama) are excluded.
+ */
+
+export interface ManagedProviderMeta {
+  /** Provider identifier matching the registry name. */
+  name: string;
+  /** Whether this provider supports managed proxy routing. */
+  managed: boolean;
+  /** Proxy path segment appended to the platform base URL (only for managed providers). */
+  proxyPath?: string;
+}
+
+/**
+ * Explicit provider metadata for all known providers.
+ * Managed providers get a deterministic proxy path; non-managed providers
+ * are marked accordingly and have no proxy path.
+ */
+export const MANAGED_PROVIDER_META: Record<string, ManagedProviderMeta> = {
+  openai: { name: "openai", managed: true, proxyPath: "/v1/proxy/openai" },
+  anthropic: {
+    name: "anthropic",
+    managed: true,
+    proxyPath: "/v1/proxy/anthropic",
+  },
+  gemini: { name: "gemini", managed: true, proxyPath: "/v1/proxy/gemini" },
+  fireworks: {
+    name: "fireworks",
+    managed: true,
+    proxyPath: "/v1/proxy/fireworks",
+  },
+  openrouter: {
+    name: "openrouter",
+    managed: true,
+    proxyPath: "/v1/proxy/openrouter",
+  },
+  ollama: { name: "ollama", managed: false },
+};
+
+/** Provider names that support managed proxy routing. */
+export const MANAGED_PROVIDER_NAMES = Object.entries(MANAGED_PROVIDER_META)
+  .filter(([, meta]) => meta.managed)
+  .map(([name]) => name);

--- a/assistant/src/providers/managed-proxy/context.test.ts
+++ b/assistant/src/providers/managed-proxy/context.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Mock logger to suppress output
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Mutable state for env and secure key stubs
+let mockPlatformBaseUrl = "";
+let mockAssistantApiKey: string | null = null;
+
+mock.module("../../config/env.js", () => ({
+  getPlatformBaseUrl: () => mockPlatformBaseUrl,
+}));
+
+mock.module("../../security/secure-keys.js", () => ({
+  getSecureKey: (key: string) => {
+    if (key === "credential:vellum:assistant_api_key") {
+      return mockAssistantApiKey;
+    }
+    return null;
+  },
+}));
+
+import {
+  buildManagedBaseUrl,
+  hasManagedProxyPrereqs,
+  managedFallbackEnabledFor,
+  resolveManagedProxyContext,
+} from "./context.js";
+
+describe("resolveManagedProxyContext", () => {
+  beforeEach(() => {
+    mockPlatformBaseUrl = "";
+    mockAssistantApiKey = null;
+  });
+
+  test("returns disabled when platform URL is empty", () => {
+    mockPlatformBaseUrl = "";
+    mockAssistantApiKey = "sk-test-key";
+
+    const ctx = resolveManagedProxyContext();
+    expect(ctx.enabled).toBe(false);
+    expect(ctx.platformBaseUrl).toBe("");
+  });
+
+  test("returns disabled when assistant API key is missing", () => {
+    mockPlatformBaseUrl = "https://platform.example.com";
+    mockAssistantApiKey = null;
+
+    const ctx = resolveManagedProxyContext();
+    expect(ctx.enabled).toBe(false);
+    expect(ctx.assistantApiKey).toBe("");
+  });
+
+  test("returns disabled when both are missing", () => {
+    const ctx = resolveManagedProxyContext();
+    expect(ctx.enabled).toBe(false);
+  });
+
+  test("returns enabled when both platform URL and API key are present", () => {
+    mockPlatformBaseUrl = "https://platform.example.com/";
+    mockAssistantApiKey = "sk-test-key";
+
+    const ctx = resolveManagedProxyContext();
+    expect(ctx.enabled).toBe(true);
+    expect(ctx.platformBaseUrl).toBe("https://platform.example.com");
+    expect(ctx.assistantApiKey).toBe("sk-test-key");
+  });
+
+  test("strips trailing slashes from platform URL", () => {
+    mockPlatformBaseUrl = "https://platform.example.com///";
+    mockAssistantApiKey = "sk-test-key";
+
+    const ctx = resolveManagedProxyContext();
+    expect(ctx.platformBaseUrl).toBe("https://platform.example.com");
+  });
+});
+
+describe("hasManagedProxyPrereqs", () => {
+  beforeEach(() => {
+    mockPlatformBaseUrl = "";
+    mockAssistantApiKey = null;
+  });
+
+  test("returns false when prerequisites are missing", () => {
+    expect(hasManagedProxyPrereqs()).toBe(false);
+  });
+
+  test("returns true when prerequisites are satisfied", () => {
+    mockPlatformBaseUrl = "https://platform.example.com";
+    mockAssistantApiKey = "sk-test-key";
+    expect(hasManagedProxyPrereqs()).toBe(true);
+  });
+});
+
+describe("buildManagedBaseUrl", () => {
+  beforeEach(() => {
+    mockPlatformBaseUrl = "https://platform.example.com";
+    mockAssistantApiKey = "sk-test-key";
+  });
+
+  test("builds correct URL for managed providers", () => {
+    expect(buildManagedBaseUrl("openai")).toBe(
+      "https://platform.example.com/v1/proxy/openai",
+    );
+    expect(buildManagedBaseUrl("anthropic")).toBe(
+      "https://platform.example.com/v1/proxy/anthropic",
+    );
+    expect(buildManagedBaseUrl("gemini")).toBe(
+      "https://platform.example.com/v1/proxy/gemini",
+    );
+    expect(buildManagedBaseUrl("fireworks")).toBe(
+      "https://platform.example.com/v1/proxy/fireworks",
+    );
+    expect(buildManagedBaseUrl("openrouter")).toBe(
+      "https://platform.example.com/v1/proxy/openrouter",
+    );
+  });
+
+  test("returns undefined for non-managed provider (ollama)", () => {
+    expect(buildManagedBaseUrl("ollama")).toBeUndefined();
+  });
+
+  test("returns undefined for unknown provider", () => {
+    expect(buildManagedBaseUrl("unknown-provider")).toBeUndefined();
+  });
+
+  test("returns undefined when prerequisites are missing", () => {
+    mockPlatformBaseUrl = "";
+    mockAssistantApiKey = null;
+    expect(buildManagedBaseUrl("openai")).toBeUndefined();
+  });
+});
+
+describe("managedFallbackEnabledFor", () => {
+  beforeEach(() => {
+    mockPlatformBaseUrl = "https://platform.example.com";
+    mockAssistantApiKey = "sk-test-key";
+  });
+
+  test("returns true for managed providers with prerequisites", () => {
+    expect(managedFallbackEnabledFor("openai")).toBe(true);
+    expect(managedFallbackEnabledFor("anthropic")).toBe(true);
+  });
+
+  test("returns false for non-managed provider", () => {
+    expect(managedFallbackEnabledFor("ollama")).toBe(false);
+  });
+
+  test("returns false for unknown provider", () => {
+    expect(managedFallbackEnabledFor("unknown")).toBe(false);
+  });
+
+  test("returns false when prerequisites are missing", () => {
+    mockPlatformBaseUrl = "";
+    mockAssistantApiKey = null;
+    expect(managedFallbackEnabledFor("openai")).toBe(false);
+  });
+});

--- a/assistant/src/providers/managed-proxy/context.ts
+++ b/assistant/src/providers/managed-proxy/context.ts
@@ -1,0 +1,77 @@
+/**
+ * Managed proxy context resolver.
+ *
+ * Resolves the prerequisites for routing LLM provider requests through the
+ * platform's managed proxy: the platform base URL and an assistant API key
+ * stored as a secure credential.
+ *
+ * When both are present, providers can be initialized with a managed proxy
+ * base URL instead of calling the upstream provider directly.
+ */
+
+import { getPlatformBaseUrl } from "../../config/env.js";
+import { getSecureKey } from "../../security/secure-keys.js";
+import { MANAGED_PROVIDER_META } from "./constants.js";
+
+/** Storage key for the assistant API key credential. */
+const ASSISTANT_API_KEY_STORAGE_KEY = "credential:vellum:assistant_api_key";
+
+export interface ManagedProxyContext {
+  /** Whether managed proxy prerequisites are satisfied. */
+  enabled: boolean;
+  /** Platform base URL (without trailing slash), or empty string if unavailable. */
+  platformBaseUrl: string;
+  /** Assistant API key for authenticating with the managed proxy, or empty string if unavailable. */
+  assistantApiKey: string;
+}
+
+/**
+ * Resolve managed proxy context from environment and secure storage.
+ *
+ * Returns an enabled context only when both the platform base URL and
+ * the assistant API key are present. Otherwise returns a disabled context.
+ */
+export function resolveManagedProxyContext(): ManagedProxyContext {
+  const platformBaseUrl = getPlatformBaseUrl().replace(/\/+$/, "");
+  const assistantApiKey = getSecureKey(ASSISTANT_API_KEY_STORAGE_KEY) ?? "";
+
+  const enabled = !!platformBaseUrl && !!assistantApiKey;
+
+  return { enabled, platformBaseUrl, assistantApiKey };
+}
+
+/**
+ * Check whether managed proxy prerequisites are available.
+ * Shorthand for checking that both platform URL and assistant API key exist.
+ */
+export function hasManagedProxyPrereqs(): boolean {
+  return resolveManagedProxyContext().enabled;
+}
+
+/**
+ * Build the full managed proxy base URL for a given provider.
+ *
+ * Combines the platform base URL with the provider's deterministic proxy path.
+ * Returns undefined if the provider is not managed or prerequisites are missing.
+ */
+export function buildManagedBaseUrl(provider: string): string | undefined {
+  const meta = MANAGED_PROVIDER_META[provider];
+  if (!meta?.managed || !meta.proxyPath) return undefined;
+
+  const ctx = resolveManagedProxyContext();
+  if (!ctx.enabled) return undefined;
+
+  return `${ctx.platformBaseUrl}${meta.proxyPath}`;
+}
+
+/**
+ * Whether managed fallback is enabled for a given provider.
+ *
+ * Returns true when the provider supports managed proxy routing and
+ * all prerequisites (platform URL + assistant API key) are satisfied.
+ */
+export function managedFallbackEnabledFor(provider: string): boolean {
+  const meta = MANAGED_PROVIDER_META[provider];
+  if (!meta?.managed) return false;
+  return hasManagedProxyPrereqs();
+}


### PR DESCRIPTION
## Summary
- Add managed-proxy context utilities for resolving platform URL and assistant API key
- Define provider metadata constants for managed-capable providers (openai, anthropic, gemini, fireworks, openrouter) and mark ollama as non-managed
- Add helper predicates: hasManagedProxyPrereqs, buildManagedBaseUrl, managedFallbackEnabledFor
- Add unit tests for context resolution scenarios (empty/missing platform URL, missing assistant key, successful resolution)

Part of plan: managed-llm-proxy-billing.md (PR 7 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
