### PR TITLE
Add Anthropic managed proxy fallback with preserved streaming/tool behavior

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -8,6 +8,7 @@ import type { Message, ToolDefinition } from "../providers/types.js";
 
 let lastStreamParams: Record<string, unknown> | null = null;
 let _lastStreamOptions: Record<string, unknown> | null = null;
+let lastConstructorArgs: Record<string, unknown> | null = null;
 
 const fakeResponse = {
   content: [{ type: "text", text: "Hello" }],
@@ -33,7 +34,9 @@ class FakeAPIError extends Error {
 mock.module("@anthropic-ai/sdk", () => ({
   default: class MockAnthropic {
     static APIError = FakeAPIError;
-    constructor() {}
+    constructor(args: Record<string, unknown>) {
+      lastConstructorArgs = { ...args };
+    }
     messages = {
       stream: (
         params: Record<string, unknown>,
@@ -127,6 +130,7 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
   beforeEach(() => {
     lastStreamParams = null;
     _lastStreamOptions = null;
+    lastConstructorArgs = null;
     provider = new AnthropicProvider("sk-ant-test", "claude-sonnet-4-6");
   });
 
@@ -933,5 +937,86 @@ describe("AnthropicProvider — Cache-Control Characterization", () => {
     // Turn 3: cache on last block only
     expect(userMsgs[2].content[0].cache_control).toBeUndefined();
     expect(userMsgs[2].content[1].cache_control).toEqual({ type: "ephemeral" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — Managed Proxy Fallback
+// ---------------------------------------------------------------------------
+
+describe("AnthropicProvider — Managed Proxy Fallback", () => {
+  beforeEach(() => {
+    lastStreamParams = null;
+    _lastStreamOptions = null;
+    lastConstructorArgs = null;
+  });
+
+  test("constructor passes baseURL to Anthropic SDK when provided", () => {
+    new AnthropicProvider("managed-key", "claude-sonnet-4-6", {
+      baseURL: "https://platform.example.com/v1/proxy/anthropic",
+    });
+
+    expect(lastConstructorArgs).not.toBeNull();
+    expect(lastConstructorArgs!.apiKey).toBe("managed-key");
+    expect(lastConstructorArgs!.baseURL).toBe(
+      "https://platform.example.com/v1/proxy/anthropic",
+    );
+  });
+
+  test("constructor does not set baseURL when option is omitted", () => {
+    new AnthropicProvider("sk-ant-user-key", "claude-sonnet-4-6");
+
+    expect(lastConstructorArgs).not.toBeNull();
+    expect(lastConstructorArgs!.apiKey).toBe("sk-ant-user-key");
+    expect(lastConstructorArgs!.baseURL).toBeUndefined();
+  });
+
+  test("managed mode provider preserves tool-pairing behavior", async () => {
+    const provider = new AnthropicProvider("managed-key", "claude-sonnet-4-6", {
+      baseURL: "https://platform.example.com/v1/proxy/anthropic",
+    });
+
+    const messages: Message[] = [
+      userMsg("Read file"),
+      toolUseMsg("tu_1", "file_read"),
+      toolResultMsg("tu_1", "file contents"),
+    ];
+    await provider.sendMessage(messages);
+
+    const sent = lastStreamParams!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; tool_use_id?: string }>;
+    }>;
+
+    expect(sent).toHaveLength(3);
+    const toolResults = sent[2].content.filter((b) => b.type === "tool_result");
+    expect(toolResults).toHaveLength(1);
+    expect(toolResults[0].tool_use_id).toBe("tu_1");
+  });
+
+  test("managed mode provider preserves cache-control behavior", async () => {
+    const provider = new AnthropicProvider("managed-key", "claude-sonnet-4-6", {
+      baseURL: "https://platform.example.com/v1/proxy/anthropic",
+    });
+
+    await provider.sendMessage(
+      [userMsg("Hi")],
+      sampleTools,
+      "You are helpful.",
+    );
+
+    // System prompt cache control
+    const system = lastStreamParams!.system as Array<{
+      cache_control?: { type: string };
+    }>;
+    expect(system[0].cache_control).toEqual({ type: "ephemeral" });
+
+    // Last tool cache control
+    const tools = lastStreamParams!.tools as Array<{
+      cache_control?: { type: string };
+    }>;
+    expect(tools[tools.length - 1].cache_control).toEqual({
+      type: "ephemeral",
+    });
   });
 });

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -401,9 +401,13 @@ export class AnthropicProvider implements Provider {
   constructor(
     apiKey: string,
     model: string,
-    options: { useNativeWebSearch?: boolean; streamTimeoutMs?: number } = {},
+    options: {
+      useNativeWebSearch?: boolean;
+      streamTimeoutMs?: number;
+      baseURL?: string;
+    } = {},
   ) {
-    this.client = new Anthropic({ apiKey });
+    this.client = new Anthropic({ apiKey, baseURL: options.baseURL });
     // Models ending in "-fast" use the beta fast-mode API
     this.fastMode = model.endsWith("-fast");
     this.model = this.fastMode ? model.slice(0, -"-fast".length) : model;

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -4,6 +4,10 @@ import { AnthropicProvider } from "./anthropic/client.js";
 import { FailoverProvider, type ProviderHealthStatus } from "./failover.js";
 import { FireworksProvider } from "./fireworks/client.js";
 import { GeminiProvider } from "./gemini/client.js";
+import {
+  buildManagedBaseUrl,
+  resolveManagedProxyContext,
+} from "./managed-proxy/context.js";
 import { getProviderDefaultModel } from "./model-intents.js";
 import { OllamaProvider } from "./ollama/client.js";
 import { OpenAIProvider } from "./openai/client.js";
@@ -214,6 +218,26 @@ export function initializeProviders(config: ProvidersConfig): void {
         ),
       ),
     );
+  } else {
+    // No user Anthropic key — try managed proxy fallback
+    const managedBaseUrl = buildManagedBaseUrl("anthropic");
+    if (managedBaseUrl) {
+      const ctx = resolveManagedProxyContext();
+      const model = resolveModel(config, "anthropic");
+      registerProvider(
+        "anthropic",
+        new RetryProvider(
+          wrapWithLogfire(
+            new AnthropicProvider(ctx.assistantApiKey, model, {
+              useNativeWebSearch:
+                config.webSearchProvider === "anthropic-native",
+              streamTimeoutMs,
+              baseURL: managedBaseUrl,
+            }),
+          ),
+        ),
+      );
+    }
   }
   if (config.apiKeys.openai) {
     const model = resolveModel(config, "openai");


### PR DESCRIPTION
## Summary
- Extend AnthropicProvider to accept base URL override for managed fallback mode
- Preserve user-key-first behavior in registry initialization
- Keep existing tool-pairing and cache-control behavior unchanged
- Add tests for managed mode transport options and behavioral regressions

Part of plan: managed-llm-proxy-billing.md (PR 9 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
