### PR TITLE
Use managed proxy fallback for OpenAI, Fireworks, and OpenRouter when user keys are absent

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -78,8 +78,10 @@ mock.module("openai", () => ({
 }));
 
 // Import after mocking
+import { FireworksProvider } from "../providers/fireworks/client.js";
 import { OllamaProvider } from "../providers/ollama/client.js";
 import { OpenAIProvider } from "../providers/openai/client.js";
+import { OpenRouterProvider } from "../providers/openrouter/client.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -841,6 +843,86 @@ describe("OpenAIProvider", () => {
           function: { name: "test", arguments: '{"x":1}' },
         },
       ],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Managed proxy initialization
+// ---------------------------------------------------------------------------
+
+describe("managed proxy initialization", () => {
+  beforeEach(() => {
+    lastConstructorOptions = null;
+  });
+
+  test("OpenAIProvider initializes with managed proxy base URL", () => {
+    const managed = new OpenAIProvider("ast-key-123", "gpt-4o", {
+      baseURL: "https://platform.example.com/v1/proxy/openai",
+    });
+
+    expect(managed.name).toBe("openai");
+    expect(lastConstructorOptions).toEqual({
+      apiKey: "ast-key-123",
+      baseURL: "https://platform.example.com/v1/proxy/openai",
+    });
+  });
+
+  test("OpenAIProvider without baseURL calls provider directly", () => {
+    new OpenAIProvider("sk-user-key", "gpt-4o");
+
+    expect(lastConstructorOptions).toEqual({
+      apiKey: "sk-user-key",
+      baseURL: undefined,
+    });
+  });
+
+  test("FireworksProvider initializes with managed proxy base URL", () => {
+    const managed = new FireworksProvider(
+      "ast-key-123",
+      "accounts/fireworks/models/llama-v3p1-70b-instruct",
+      {
+        baseURL: "https://platform.example.com/v1/proxy/fireworks",
+      },
+    );
+
+    expect(managed.name).toBe("fireworks");
+    expect(lastConstructorOptions).toEqual({
+      apiKey: "ast-key-123",
+      baseURL: "https://platform.example.com/v1/proxy/fireworks",
+    });
+  });
+
+  test("FireworksProvider without managed baseURL uses default Fireworks URL", () => {
+    new FireworksProvider(
+      "fw-user-key",
+      "accounts/fireworks/models/llama-v3p1-70b-instruct",
+    );
+
+    expect(lastConstructorOptions).toEqual({
+      apiKey: "fw-user-key",
+      baseURL: "https://api.fireworks.ai/inference/v1",
+    });
+  });
+
+  test("OpenRouterProvider initializes with managed proxy base URL", () => {
+    const managed = new OpenRouterProvider("ast-key-123", "openai/gpt-4o", {
+      baseURL: "https://platform.example.com/v1/proxy/openrouter",
+    });
+
+    expect(managed.name).toBe("openrouter");
+    expect(lastConstructorOptions).toEqual({
+      apiKey: "ast-key-123",
+      baseURL: "https://platform.example.com/v1/proxy/openrouter",
+    });
+  });
+
+  test("OpenRouterProvider without managed baseURL uses default OpenRouter URL", () => {
+    new OpenRouterProvider("or-user-key", "openai/gpt-4o");
+
+    expect(lastConstructorOptions).toEqual({
+      apiKey: "or-user-key",
+      baseURL: "https://openrouter.ai/api/v1",
     });
   });
 });

--- a/assistant/src/__tests__/provider-fail-open-selection.test.ts
+++ b/assistant/src/__tests__/provider-fail-open-selection.test.ts
@@ -1,8 +1,46 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock managed-proxy context so we can control managed fallback prereqs
+// ---------------------------------------------------------------------------
+let mockManagedEnabled = false;
+let mockPlatformBaseUrl = "";
+let mockAssistantApiKey = "";
+
+mock.module("../providers/managed-proxy/context.js", () => ({
+  resolveManagedProxyContext: () => ({
+    enabled: mockManagedEnabled,
+    platformBaseUrl: mockPlatformBaseUrl,
+    assistantApiKey: mockAssistantApiKey,
+  }),
+  hasManagedProxyPrereqs: () => mockManagedEnabled,
+  buildManagedBaseUrl: (provider: string) => {
+    if (!mockManagedEnabled) return undefined;
+    const paths: Record<string, string> = {
+      openai: "/v1/proxy/openai",
+      fireworks: "/v1/proxy/fireworks",
+      openrouter: "/v1/proxy/openrouter",
+    };
+    const path = paths[provider];
+    if (!path) return undefined;
+    return `${mockPlatformBaseUrl}${path}`;
+  },
+  managedFallbackEnabledFor: (provider: string) => {
+    if (!mockManagedEnabled) return false;
+    return [
+      "openai",
+      "fireworks",
+      "openrouter",
+      "anthropic",
+      "gemini",
+    ].includes(provider);
+  },
+}));
 
 import {
   getFailoverProvider,
   initializeProviders,
+  listProviders,
   resolveProviderSelection,
 } from "../providers/registry.js";
 
@@ -123,5 +161,113 @@ describe("getFailoverProvider (fail-open)", () => {
     const provider = getFailoverProvider("gemini", ["anthropic"]);
     // Should be a RetryProvider wrapping AnthropicProvider, not a FailoverProvider
     expect(provider.name).not.toBe("failover");
+  });
+});
+
+// -------------------------------------------------------------------------
+// Managed proxy fallback
+// -------------------------------------------------------------------------
+
+describe("managed proxy fallback", () => {
+  function enableManagedProxy() {
+    mockManagedEnabled = true;
+    mockPlatformBaseUrl = "https://platform.example.com";
+    mockAssistantApiKey = "ast-key-123";
+  }
+
+  function disableManagedProxy() {
+    mockManagedEnabled = false;
+    mockPlatformBaseUrl = "";
+    mockAssistantApiKey = "";
+  }
+
+  test("openai registered via managed fallback when no user key but proxy context is valid", () => {
+    enableManagedProxy();
+    try {
+      initializeProviders({
+        apiKeys: { anthropic: "test-key" },
+        provider: "anthropic",
+        model: "test-model",
+      });
+      const registered = listProviders();
+      expect(registered).toContain("openai");
+      expect(registered).toContain("fireworks");
+      expect(registered).toContain("openrouter");
+    } finally {
+      disableManagedProxy();
+    }
+  });
+
+  test("user key takes precedence over managed fallback", () => {
+    enableManagedProxy();
+    try {
+      initializeProviders({
+        apiKeys: { anthropic: "test-key", openai: "user-openai-key" },
+        provider: "anthropic",
+        model: "test-model",
+      });
+      // openai should be registered (via user key, not managed)
+      const registered = listProviders();
+      expect(registered).toContain("openai");
+      // fireworks/openrouter should also be registered via managed fallback
+      expect(registered).toContain("fireworks");
+      expect(registered).toContain("openrouter");
+    } finally {
+      disableManagedProxy();
+    }
+  });
+
+  test("managed fallback not activated when proxy context is disabled", () => {
+    disableManagedProxy();
+    initializeProviders({
+      apiKeys: { anthropic: "test-key" },
+      provider: "anthropic",
+      model: "test-model",
+    });
+    const registered = listProviders();
+    expect(registered).not.toContain("openai");
+    expect(registered).not.toContain("fireworks");
+    expect(registered).not.toContain("openrouter");
+  });
+
+  test("managed providers participate in failover selection", () => {
+    enableManagedProxy();
+    try {
+      initializeProviders({
+        apiKeys: { anthropic: "test-key" },
+        provider: "anthropic",
+        model: "test-model",
+      });
+      const selection = resolveProviderSelection("anthropic", [
+        "openai",
+        "fireworks",
+      ]);
+      expect(selection.availableProviders).toEqual([
+        "anthropic",
+        "openai",
+        "fireworks",
+      ]);
+      expect(selection.selectedPrimary).toBe("anthropic");
+      expect(selection.usedFallbackPrimary).toBe(false);
+    } finally {
+      disableManagedProxy();
+    }
+  });
+
+  test("managed provider selected as primary when configured primary unavailable", () => {
+    enableManagedProxy();
+    try {
+      // No anthropic key, no gemini key — only managed providers available
+      initializeProviders({
+        apiKeys: {},
+        provider: "openai",
+        model: "test-model",
+      });
+      const selection = resolveProviderSelection("openai", ["fireworks"]);
+      expect(selection.selectedPrimary).toBe("openai");
+      expect(selection.usedFallbackPrimary).toBe(false);
+    } finally {
+      disableManagedProxy();
+    }
   });
 });

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -4,6 +4,10 @@ import { AnthropicProvider } from "./anthropic/client.js";
 import { FailoverProvider, type ProviderHealthStatus } from "./failover.js";
 import { FireworksProvider } from "./fireworks/client.js";
 import { GeminiProvider } from "./gemini/client.js";
+import {
+  buildManagedBaseUrl,
+  resolveManagedProxyContext,
+} from "./managed-proxy/context.js";
 import { getProviderDefaultModel } from "./model-intents.js";
 import { OllamaProvider } from "./ollama/client.js";
 import { OpenAIProvider } from "./openai/client.js";
@@ -225,6 +229,23 @@ export function initializeProviders(config: ProvidersConfig): void {
         ),
       ),
     );
+  } else {
+    const managedBaseUrl = buildManagedBaseUrl("openai");
+    if (managedBaseUrl) {
+      const ctx = resolveManagedProxyContext();
+      const model = resolveModel(config, "openai");
+      registerProvider(
+        "openai",
+        new RetryProvider(
+          wrapWithLogfire(
+            new OpenAIProvider(ctx.assistantApiKey, model, {
+              baseURL: managedBaseUrl,
+              streamTimeoutMs,
+            }),
+          ),
+        ),
+      );
+    }
   }
   if (config.apiKeys.gemini) {
     const model = resolveModel(config, "gemini");
@@ -263,6 +284,23 @@ export function initializeProviders(config: ProvidersConfig): void {
         ),
       ),
     );
+  } else {
+    const managedBaseUrl = buildManagedBaseUrl("fireworks");
+    if (managedBaseUrl) {
+      const ctx = resolveManagedProxyContext();
+      const model = resolveModel(config, "fireworks");
+      registerProvider(
+        "fireworks",
+        new RetryProvider(
+          wrapWithLogfire(
+            new FireworksProvider(ctx.assistantApiKey, model, {
+              baseURL: managedBaseUrl,
+              streamTimeoutMs,
+            }),
+          ),
+        ),
+      );
+    }
   }
   if (config.apiKeys.openrouter) {
     const model = resolveModel(config, "openrouter");
@@ -276,5 +314,22 @@ export function initializeProviders(config: ProvidersConfig): void {
         ),
       ),
     );
+  } else {
+    const managedBaseUrl = buildManagedBaseUrl("openrouter");
+    if (managedBaseUrl) {
+      const ctx = resolveManagedProxyContext();
+      const model = resolveModel(config, "openrouter");
+      registerProvider(
+        "openrouter",
+        new RetryProvider(
+          wrapWithLogfire(
+            new OpenRouterProvider(ctx.assistantApiKey, model, {
+              baseURL: managedBaseUrl,
+              streamTimeoutMs,
+            }),
+          ),
+        ),
+      );
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Update provider init to use managed proxy base URL + assistant key when user keys are absent
- Preserve BYO key precedence — direct provider calls when user key exists
- Add tests for user-key precedence, managed fallback activation, and disabled state

Part of plan: managed-llm-proxy-billing.md (PR 8 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
