### PR TITLE
fix: add managed-proxy context to getSecureKey guard allowlist

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -241,6 +241,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "schedule/integration-status.ts", // integration status checks for scheduled reports
       "daemon/handlers/oauth-connect.ts", // OAuth connect handler for integration setup
       "daemon/handlers/config-slack-channel.ts", // Slack channel config credential management
+      "providers/managed-proxy/context.ts", // managed proxy API key lookup for provider initialization
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary
- Add `providers/managed-proxy/context.ts` to the `ALLOWED_IMPORTERS` set in the credential security guard test
- Fixes CI failure from #12803 which introduced a new `getSecureKey` import without updating the allowlist

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22703688299/job/65826226033

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
