### PR TITLE
fix: clean up stale git index.lock between enrichment tests

### DIFF
--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -51,6 +51,14 @@ describe("CommitEnrichmentService", () => {
       /* ignore */
     }
     _resetEnrichmentService();
+
+    // Remove stale index.lock left by async enrichment jobs that ran git
+    // commands concurrently. Without this, the next test's createCommit()
+    // can fail with "Unable to create index.lock: File exists".
+    const lockFile = join(testDir, ".git", "index.lock");
+    if (existsSync(lockFile)) {
+      rmSync(lockFile, { force: true });
+    }
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary
- Add stale `index.lock` cleanup in `afterEach` for the commit-message-enrichment-service tests
- Prevents flaky CI failures where async enrichment jobs leave behind lock files that cause subsequent `git add -A` calls to fail

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22703802732/job/65826578543

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
