### PR TITLE
fix: use specific socket path when switching local assistants

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -101,8 +101,11 @@ extension AppDelegate {
                 services.reconfigureDaemonClient(config: config)
                 log.info("Configured local HTTP transport (localHttpEnabled flag) on port \(port)")
             } else {
-                // Reset to default socket transport in case the previous assistant used HTTP.
-                services.reconfigureDaemonClient(config: .default)
+                // Use the specific assistant's socket path so switching between
+                // local instances connects to the correct daemon.
+                let socketPath = assistant?.socketPath ?? DaemonClient.resolveSocketPath()
+                let config = DaemonConfig(socketPath: socketPath)
+                services.reconfigureDaemonClient(config: config)
             }
             return
         }


### PR DESCRIPTION
## Summary
- When switching between local assistants in the macOS UI picker, the DaemonClient was using `DaemonConfig.default` which resolves the socket path from the most recently hatched lockfile entry
- This caused both assistants to connect to the same daemon, showing identical threads regardless of which assistant was selected
- Now reads the specific assistant's `socketPath` from lockfile resources so each instance connects to its own daemon

## Test plan
- [ ] Hatch two local assistants, switch between them in the UI, verify different threads appear

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
