### PR TITLE
fix: align proxy paths with Django runtime-proxy route

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -953,13 +953,13 @@ describe("AnthropicProvider — Managed Proxy Fallback", () => {
 
   test("constructor passes baseURL to Anthropic SDK when provided", () => {
     new AnthropicProvider("managed-key", "claude-sonnet-4-6", {
-      baseURL: "https://platform.example.com/v1/proxy/anthropic",
+      baseURL: "https://platform.example.com/v1/runtime-proxy/anthropic",
     });
 
     expect(lastConstructorArgs).not.toBeNull();
     expect(lastConstructorArgs!.apiKey).toBe("managed-key");
     expect(lastConstructorArgs!.baseURL).toBe(
-      "https://platform.example.com/v1/proxy/anthropic",
+      "https://platform.example.com/v1/runtime-proxy/anthropic",
     );
   });
 
@@ -973,7 +973,7 @@ describe("AnthropicProvider — Managed Proxy Fallback", () => {
 
   test("managed mode provider preserves tool-pairing behavior", async () => {
     const provider = new AnthropicProvider("managed-key", "claude-sonnet-4-6", {
-      baseURL: "https://platform.example.com/v1/proxy/anthropic",
+      baseURL: "https://platform.example.com/v1/runtime-proxy/anthropic",
     });
 
     const messages: Message[] = [
@@ -996,7 +996,7 @@ describe("AnthropicProvider — Managed Proxy Fallback", () => {
 
   test("managed mode provider preserves cache-control behavior", async () => {
     const provider = new AnthropicProvider("managed-key", "claude-sonnet-4-6", {
-      baseURL: "https://platform.example.com/v1/proxy/anthropic",
+      baseURL: "https://platform.example.com/v1/runtime-proxy/anthropic",
     });
 
     await provider.sendMessage(

--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -741,12 +741,12 @@ describe("GeminiProvider", () => {
 
   test("sets httpOptions.baseUrl when managedBaseUrl is provided", () => {
     new GeminiProvider("managed-key", "gemini-3-flash", {
-      managedBaseUrl: "https://platform.example.com/v1/proxy/gemini",
+      managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
     });
     expect(lastConstructorOpts).toEqual({
       apiKey: "managed-key",
       httpOptions: {
-        baseUrl: "https://platform.example.com/v1/proxy/gemini",
+        baseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
       },
     });
   });
@@ -756,7 +756,7 @@ describe("GeminiProvider", () => {
       "managed-key",
       "gemini-3-flash",
       {
-        managedBaseUrl: "https://platform.example.com/v1/proxy/gemini",
+        managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
       },
     );
 
@@ -781,7 +781,7 @@ describe("GeminiProvider", () => {
       "managed-key",
       "gemini-3-flash",
       {
-        managedBaseUrl: "https://platform.example.com/v1/proxy/gemini",
+        managedBaseUrl: "https://platform.example.com/v1/runtime-proxy/gemini",
       },
     );
 

--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -858,13 +858,13 @@ describe("managed proxy initialization", () => {
 
   test("OpenAIProvider initializes with managed proxy base URL", () => {
     const managed = new OpenAIProvider("ast-key-123", "gpt-4o", {
-      baseURL: "https://platform.example.com/v1/proxy/openai",
+      baseURL: "https://platform.example.com/v1/runtime-proxy/openai",
     });
 
     expect(managed.name).toBe("openai");
     expect(lastConstructorOptions).toEqual({
       apiKey: "ast-key-123",
-      baseURL: "https://platform.example.com/v1/proxy/openai",
+      baseURL: "https://platform.example.com/v1/runtime-proxy/openai",
     });
   });
 
@@ -882,14 +882,14 @@ describe("managed proxy initialization", () => {
       "ast-key-123",
       "accounts/fireworks/models/llama-v3p1-70b-instruct",
       {
-        baseURL: "https://platform.example.com/v1/proxy/fireworks",
+        baseURL: "https://platform.example.com/v1/runtime-proxy/fireworks",
       },
     );
 
     expect(managed.name).toBe("fireworks");
     expect(lastConstructorOptions).toEqual({
       apiKey: "ast-key-123",
-      baseURL: "https://platform.example.com/v1/proxy/fireworks",
+      baseURL: "https://platform.example.com/v1/runtime-proxy/fireworks",
     });
   });
 
@@ -907,13 +907,13 @@ describe("managed proxy initialization", () => {
 
   test("OpenRouterProvider initializes with managed proxy base URL", () => {
     const managed = new OpenRouterProvider("ast-key-123", "openai/gpt-4o", {
-      baseURL: "https://platform.example.com/v1/proxy/openrouter",
+      baseURL: "https://platform.example.com/v1/runtime-proxy/openrouter",
     });
 
     expect(managed.name).toBe("openrouter");
     expect(lastConstructorOptions).toEqual({
       apiKey: "ast-key-123",
-      baseURL: "https://platform.example.com/v1/proxy/openrouter",
+      baseURL: "https://platform.example.com/v1/runtime-proxy/openrouter",
     });
   });
 

--- a/assistant/src/__tests__/provider-fail-open-selection.test.ts
+++ b/assistant/src/__tests__/provider-fail-open-selection.test.ts
@@ -17,9 +17,9 @@ mock.module("../providers/managed-proxy/context.js", () => ({
   buildManagedBaseUrl: (provider: string) => {
     if (!mockManagedEnabled) return undefined;
     const paths: Record<string, string> = {
-      openai: "/v1/proxy/openai",
-      fireworks: "/v1/proxy/fireworks",
-      openrouter: "/v1/proxy/openrouter",
+      openai: "/v1/runtime-proxy/openai",
+      fireworks: "/v1/runtime-proxy/fireworks",
+      openrouter: "/v1/runtime-proxy/openrouter",
     };
     const path = paths[provider];
     if (!path) return undefined;

--- a/assistant/src/providers/managed-proxy/constants.ts
+++ b/assistant/src/providers/managed-proxy/constants.ts
@@ -21,22 +21,30 @@ export interface ManagedProviderMeta {
  * are marked accordingly and have no proxy path.
  */
 export const MANAGED_PROVIDER_META: Record<string, ManagedProviderMeta> = {
-  openai: { name: "openai", managed: true, proxyPath: "/v1/proxy/openai" },
+  openai: {
+    name: "openai",
+    managed: true,
+    proxyPath: "/v1/runtime-proxy/openai",
+  },
   anthropic: {
     name: "anthropic",
     managed: true,
-    proxyPath: "/v1/proxy/anthropic",
+    proxyPath: "/v1/runtime-proxy/anthropic",
   },
-  gemini: { name: "gemini", managed: true, proxyPath: "/v1/proxy/gemini" },
+  gemini: {
+    name: "gemini",
+    managed: true,
+    proxyPath: "/v1/runtime-proxy/gemini",
+  },
   fireworks: {
     name: "fireworks",
     managed: true,
-    proxyPath: "/v1/proxy/fireworks",
+    proxyPath: "/v1/runtime-proxy/fireworks",
   },
   openrouter: {
     name: "openrouter",
     managed: true,
-    proxyPath: "/v1/proxy/openrouter",
+    proxyPath: "/v1/runtime-proxy/openrouter",
   },
   ollama: { name: "ollama", managed: false },
 };

--- a/assistant/src/providers/managed-proxy/context.test.ts
+++ b/assistant/src/providers/managed-proxy/context.test.ts
@@ -105,19 +105,19 @@ describe("buildManagedBaseUrl", () => {
 
   test("builds correct URL for managed providers", () => {
     expect(buildManagedBaseUrl("openai")).toBe(
-      "https://platform.example.com/v1/proxy/openai",
+      "https://platform.example.com/v1/runtime-proxy/openai",
     );
     expect(buildManagedBaseUrl("anthropic")).toBe(
-      "https://platform.example.com/v1/proxy/anthropic",
+      "https://platform.example.com/v1/runtime-proxy/anthropic",
     );
     expect(buildManagedBaseUrl("gemini")).toBe(
-      "https://platform.example.com/v1/proxy/gemini",
+      "https://platform.example.com/v1/runtime-proxy/gemini",
     );
     expect(buildManagedBaseUrl("fireworks")).toBe(
-      "https://platform.example.com/v1/proxy/fireworks",
+      "https://platform.example.com/v1/runtime-proxy/fireworks",
     );
     expect(buildManagedBaseUrl("openrouter")).toBe(
-      "https://platform.example.com/v1/proxy/openrouter",
+      "https://platform.example.com/v1/runtime-proxy/openrouter",
     );
   });
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for managed-llm-proxy-billing.md.

**Gap:** Proxy route mismatch between assistant and Django
**What was expected:** Proxy paths matching Django's /v1/runtime-proxy/{provider}/{path}
**What was found:** Constants used /v1/proxy/{provider} instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12811" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
