### PR TITLE
fix: update proxy path test assertion for runtime-proxy routes

### DIFF
--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -250,7 +250,7 @@ describe("managed proxy integration — constants integrity", () => {
       expect(meta).toBeDefined();
       expect(meta.managed).toBe(true);
       expect(meta.proxyPath).toBeTruthy();
-      expect(meta.proxyPath).toMatch(/^\/v1\/proxy\//);
+      expect(meta.proxyPath).toMatch(/^\/v1\/runtime-proxy\//);
     }
   });
 


### PR DESCRIPTION
## Summary
- Updated test assertion in `provider-managed-proxy-integration.test.ts` to expect `/v1/runtime-proxy/` prefix instead of `/v1/proxy/`, aligning with the route change in #12811

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22704064347

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
