### PR TITLE
fix: resolve session token from correct instance dir when switching assistants

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -101,10 +101,11 @@ extension AppDelegate {
                 services.reconfigureDaemonClient(config: config)
                 log.info("Configured local HTTP transport (localHttpEnabled flag) on port \(port)")
             } else {
-                // Use the specific assistant's socket path so switching between
-                // local instances connects to the correct daemon.
+                // Use the specific assistant's socket path and instance dir so
+                // switching between local instances connects to the correct daemon
+                // and authenticates with the correct session token.
                 let socketPath = assistant?.socketPath ?? DaemonClient.resolveSocketPath()
-                let config = DaemonConfig(socketPath: socketPath)
+                let config = DaemonConfig(socketPath: socketPath, instanceDir: assistant?.instanceDir)
                 services.reconfigureDaemonClient(config: config)
             }
             return

--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -97,6 +97,10 @@ public struct DaemonConfig {
     /// Defaults to `.defaultLocal` which preserves existing behavior.
     public let transportMetadata: TransportMetadata
 
+    /// Instance directory for multi-instance support (e.g. `~/.vellum/instances/alice`).
+    /// When set, token resolution uses this directory instead of the lockfile's latest entry.
+    public let instanceDir: String?
+
     /// Feature-flag bearer token for authenticating PATCH /v1/feature-flags/:flagKey requests.
     /// On macOS this is read from `~/.vellum/feature-flag-token`.
     /// On iOS this is received during QR pairing and stored in the Keychain.
@@ -115,10 +119,11 @@ public struct DaemonConfig {
     }
 
     /// Convenience initializer for socket transport (backwards compatible).
-    public init(socketPath: String) {
+    public init(socketPath: String, instanceDir: String? = nil) {
         self.transport = .socket(path: socketPath)
         self.transportMetadata = .defaultLocal
-        self.featureFlagToken = readFeatureFlagToken()
+        self.instanceDir = instanceDir
+        self.featureFlagToken = instanceDir.map { readFeatureFlagToken(environment: ["BASE_DATA_DIR": $0]) } ?? readFeatureFlagToken()
     }
 
     public static var `default`: DaemonConfig {
@@ -126,9 +131,10 @@ public struct DaemonConfig {
     }
     #endif
 
-    public init(transport: Transport, transportMetadata: TransportMetadata = .defaultLocal, featureFlagToken: String? = nil) {
+    public init(transport: Transport, transportMetadata: TransportMetadata = .defaultLocal, instanceDir: String? = nil, featureFlagToken: String? = nil) {
         self.transport = transport
         self.transportMetadata = transportMetadata
+        self.instanceDir = instanceDir
         #if os(macOS)
         self.featureFlagToken = featureFlagToken ?? readFeatureFlagToken()
         #else

--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -30,7 +30,8 @@ extension DaemonClient {
         // The bearer token may be nil at config time (e.g. local daemon hasn't
         // written the token file yet), so resolve it lazily from disk here.
         if case .http(let baseURL, let bearerToken, let conversationKey) = config.transport {
-            let resolvedToken = bearerToken ?? readHttpToken()
+            let tokenEnv = config.instanceDir.map { ["BASE_DATA_DIR": $0] }
+            let resolvedToken = bearerToken ?? readHttpToken(environment: tokenEnv)
             try await connectHTTP(baseURL: baseURL, bearerToken: resolvedToken, conversationKey: conversationKey)
             return
         }
@@ -194,12 +195,14 @@ extension DaemonClient {
 
     #if os(macOS)
     func authenticate() async throws {
-        // Try session-token file first, then fall back to transport's configured authToken
+        // Try session-token file first, then fall back to transport's configured authToken.
+        // Use the config's instanceDir so multi-instance switches read the correct token.
+        let tokenEnv = config.instanceDir.map { ["BASE_DATA_DIR": $0] }
         let transportToken: String? = {
             if case .tcp(_, _, _, let t) = config.transport { return t }
             return nil
         }()
-        guard let token = readSessionToken() ?? transportToken else {
+        guard let token = readSessionToken(environment: tokenEnv) ?? transportToken else {
             throw AuthError.missingToken
         }
 


### PR DESCRIPTION
## Summary
- When switching between local assistant instances, `authenticate()` resolved the session token from the most recently hatched lockfile entry instead of the specific assistant being switched to
- This caused auth failure → session list never arrives → infinite loading in the UI
- Threads `instanceDir` through `DaemonConfig` so token resolution reads from the correct instance directory

## Changes
- **DaemonConfig.swift**: Added `instanceDir` property, threaded through all initializers
- **DaemonConnection.swift**: `authenticate()` and HTTP token resolution pass `instanceDir` as `BASE_DATA_DIR` to token read functions
- **AppDelegate+DaemonSetup.swift**: Passes `assistant?.instanceDir` when creating config for local assistants

## Test plan
- [ ] Hatch two local assistants
- [ ] Switch between them in the UI — both should load their own threads without infinite loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
