### PR TITLE
fix: remove unused CLI exports (fetchFirewallRules, listAssistantInstances, sshCommand, runSteps)

### DIFF
--- a/cli/src/lib/gcp.ts
+++ b/cli/src/lib/gcp.ts
@@ -198,58 +198,6 @@ export async function syncFirewallRules(
   }
 }
 
-export async function fetchFirewallRules(
-  project: string,
-  tag: string,
-): Promise<string> {
-  const output = await execOutput("gcloud", [
-    "compute",
-    "firewall-rules",
-    "list",
-    `--project=${project}`,
-    "--format=json",
-  ]);
-  const rules = JSON.parse(output) as Array<{ targetTags?: string[] }>;
-  const filtered = rules.filter((r) => r.targetTags?.includes(tag));
-  return JSON.stringify(filtered, null, 2);
-}
-
-export interface GcpInstance {
-  name: string;
-  zone: string;
-  externalIp: string | null;
-  species: string | null;
-}
-
-export async function listAssistantInstances(
-  project: string,
-): Promise<GcpInstance[]> {
-  const output = await execOutput("gcloud", [
-    "compute",
-    "instances",
-    "list",
-    `--project=${project}`,
-    "--filter=labels.vellum-assistant=true",
-    "--format=json(name,zone,networkInterfaces[0].accessConfigs[0].natIP,labels)",
-  ]);
-  const parsed = JSON.parse(output) as Array<{
-    name: string;
-    zone: string;
-    networkInterfaces?: Array<{ accessConfigs?: Array<{ natIP?: string }> }>;
-    labels?: Record<string, string>;
-  }>;
-  return parsed.map((inst) => {
-    const zoneParts = (inst.zone ?? "").split("/");
-    return {
-      name: inst.name,
-      zone: zoneParts[zoneParts.length - 1] || "",
-      externalIp:
-        inst.networkInterfaces?.[0]?.accessConfigs?.[0]?.natIP ?? null,
-      species: inst.labels?.species ?? null,
-    };
-  });
-}
-
 export async function instanceExists(
   instanceName: string,
   project: string,
@@ -279,27 +227,6 @@ export async function instanceExists(
     }
     throw error;
   }
-}
-
-export async function sshCommand(
-  instanceName: string,
-  project: string,
-  zone: string,
-  command: string,
-): Promise<string> {
-  return execOutput("gcloud", [
-    "compute",
-    "ssh",
-    instanceName,
-    `--project=${project}`,
-    `--zone=${zone}`,
-    "--quiet",
-    "--ssh-flag=-o StrictHostKeyChecking=no",
-    "--ssh-flag=-o UserKnownHostsFile=/dev/null",
-    "--ssh-flag=-o ConnectTimeout=5",
-    "--ssh-flag=-o LogLevel=ERROR",
-    `--command=${command}`,
-  ]);
 }
 
 export async function fetchAndDisplayStartupLogs(

--- a/cli/src/lib/step-runner.ts
+++ b/cli/src/lib/step-runner.ts
@@ -2,11 +2,6 @@ import { spawn } from "child_process";
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
-interface Step {
-  name: string;
-  run: () => Promise<void>;
-}
-
 export function clearLine(): void {
   process.stdout.write("\r\x1b[K");
 }
@@ -18,27 +13,6 @@ export function showSpinner(name: string): NodeJS.Timeout {
     process.stdout.write(`  ${SPINNER_FRAMES[frameIndex]} ${name}...`);
     frameIndex = (frameIndex + 1) % SPINNER_FRAMES.length;
   }, 80);
-}
-
-export async function runSteps(steps: Step[]): Promise<void> {
-  for (let i = 0; i < steps.length; i++) {
-    const step = steps[i];
-    const label = `[${i + 1}/${steps.length}] ${step.name}`;
-
-    const spinner = showSpinner(label);
-
-    try {
-      await step.run();
-      clearInterval(spinner);
-      clearLine();
-      console.log(`  ✔ ${label}`);
-    } catch (error) {
-      clearInterval(spinner);
-      clearLine();
-      console.log(`  ✖ ${label}`);
-      throw error;
-    }
-  }
 }
 
 export function exec(


### PR DESCRIPTION
## Summary
- Remove 4 unused exported functions from CLI lib modules (gcp.ts, step-runner.ts)
- Remove `GcpInstance` interface that was only used by the deleted `listAssistantInstances`
- Remove `Step` interface that was only used by the deleted `runSteps`
- All have zero callers anywhere in the codebase

Part of plan: dead-code-cleanup.md (PR 6 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
