### PR TITLE
fix: remove permissions.mode "legacy" from schema and checker

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -55,16 +55,16 @@ mock.module("../util/logger.js", () => ({
 }));
 
 // Mutable config object so tests can switch permissions.mode between
-// 'legacy', 'strict', and 'workspace' without re-registering the mock.
+// 'strict' and 'workspace' without re-registering the mock.
 interface TestConfig {
-  permissions: { mode: "legacy" | "strict" | "workspace" };
+  permissions: { mode: "strict" | "workspace" };
   skills: { load: { extraDirs: string[] } };
   sandbox: { enabled: boolean };
   [key: string]: unknown;
 }
 
 const testConfig: TestConfig = {
-  permissions: { mode: "legacy" },
+  permissions: { mode: "workspace" },
   skills: { load: { extraDirs: [] } },
   sandbox: { enabled: true },
 };
@@ -81,7 +81,6 @@ mock.module("../config/loader.js", () => ({
 }));
 
 import {
-  _resetLegacyDeprecationWarning,
   check,
   classifyRisk,
   generateAllowlistOptions,
@@ -169,11 +168,9 @@ describe("Permission Checker", () => {
   beforeEach(() => {
     // Reset trust-store state between tests
     clearCache();
-    // Reset permissions mode to legacy so existing tests are not affected
-    testConfig.permissions = { mode: "legacy" };
+    // Reset permissions mode to workspace (default) so existing tests are not affected
+    testConfig.permissions = { mode: "workspace" };
     testConfig.skills = { load: { extraDirs: [] } };
-    // Reset the one-time legacy deprecation warning flag and captured log calls
-    _resetLegacyDeprecationWarning();
     loggerWarnCalls.length = 0;
     try {
       rmSync(join(checkerTestDir, "protected", "trust.json"));
@@ -2565,7 +2562,7 @@ describe("Permission Checker", () => {
       });
 
       test("legacy mode: file_write to skill source still prompts as High risk", async () => {
-        testConfig.permissions.mode = "legacy";
+        testConfig.permissions.mode = "workspace";
         ensureSkillsDir();
         const skillPath = join(
           checkerTestDir,
@@ -3327,7 +3324,7 @@ describe("Permission Checker", () => {
     });
 
     test("skill_load auto-allows in legacy mode (backward compat)", async () => {
-      testConfig.permissions.mode = "legacy";
+      testConfig.permissions.mode = "workspace";
       const result = await check("skill_load", { skill: "any-skill" }, "/tmp");
       expect(result.decision).toBe("allow");
       // The default allow rule matches before the Low risk fallback
@@ -3850,7 +3847,7 @@ describe("Permission Checker", () => {
 
     describe("Invariant 6: user can set broad rules if they choose", () => {
       test("wildcard allow rule matches any command in legacy mode", async () => {
-        testConfig.permissions.mode = "legacy";
+        testConfig.permissions.mode = "workspace";
         addRule("bash", "*", "everywhere");
         const result = await check(
           "bash",
@@ -4203,7 +4200,7 @@ describe("Permission Checker", () => {
     }
 
     test("browser tools are auto-allowed in legacy mode", async () => {
-      testConfig.permissions = { mode: "legacy" };
+      testConfig.permissions = { mode: "workspace" };
       for (const toolName of browserToolNames) {
         const result = await check(toolName, {}, "/tmp");
         expect(result.decision).toBe("allow");
@@ -4218,7 +4215,7 @@ describe("Permission Checker", () => {
           expect(result.decision).toBe("allow");
         }
       } finally {
-        testConfig.permissions = { mode: "legacy" };
+        testConfig.permissions = { mode: "workspace" };
       }
     });
   });
@@ -4295,7 +4292,7 @@ describe("Permission Checker", () => {
 describe("bash network_mode=proxied — no special-casing", () => {
   beforeEach(() => {
     clearCache();
-    testConfig.permissions = { mode: "legacy" };
+    testConfig.permissions = { mode: "workspace" };
     testConfig.skills = { load: { extraDirs: [] } };
   });
 
@@ -4416,7 +4413,7 @@ describe("computer-use tool permission defaults", () => {
 describe("scope matching behavior", () => {
   beforeEach(() => {
     clearCache();
-    testConfig.permissions = { mode: "legacy" };
+    testConfig.permissions = { mode: "workspace" };
     try {
       rmSync(join(checkerTestDir, "protected", "trust.json"));
     } catch {
@@ -4562,7 +4559,7 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
   });
 
   afterEach(() => {
-    testConfig.permissions = { mode: "legacy" };
+    testConfig.permissions = { mode: "workspace" };
   });
 
   // ── workspace-scoped file operations auto-allow ──────────────────
@@ -4771,79 +4768,6 @@ describe("workspace mode — auto-allow workspace-scoped operations", () => {
   });
 });
 
-// ── legacy mode deprecation warning ─────────────────────────────────────
-
-describe("legacy mode — deprecation warning", () => {
-  beforeEach(() => {
-    clearCache();
-    _resetLegacyDeprecationWarning();
-    loggerWarnCalls.length = 0;
-    testConfig.permissions = { mode: "legacy" };
-    testConfig.skills = { load: { extraDirs: [] } };
-    try {
-      rmSync(join(checkerTestDir, "protected", "trust.json"));
-    } catch {
-      /* may not exist */
-    }
-  });
-
-  afterEach(() => {
-    testConfig.permissions = { mode: "legacy" };
-  });
-
-  test("emits deprecation warning on first check() call in legacy mode", async () => {
-    await check("file_read", { file_path: "/tmp/test.txt" }, "/tmp");
-    expect(loggerWarnCalls.some((m) => m.includes("deprecated"))).toBe(true);
-    expect(loggerWarnCalls.some((m) => m.includes("legacy"))).toBe(true);
-  });
-
-  test("deprecation warning fires only once per process", async () => {
-    await check("file_read", { file_path: "/tmp/a.txt" }, "/tmp");
-    const firstCount = loggerWarnCalls.filter((m) =>
-      m.includes("deprecated"),
-    ).length;
-    expect(firstCount).toBe(1);
-
-    await check("file_read", { file_path: "/tmp/b.txt" }, "/tmp");
-    const secondCount = loggerWarnCalls.filter((m) =>
-      m.includes("deprecated"),
-    ).length;
-    expect(secondCount).toBe(1);
-  });
-
-  test("no deprecation warning in workspace mode", async () => {
-    testConfig.permissions = { mode: "workspace" };
-    await check("file_read", { file_path: "/tmp/test.txt" }, "/tmp");
-    expect(loggerWarnCalls.some((m) => m.includes("deprecated"))).toBe(false);
-  });
-
-  test("no deprecation warning in strict mode", async () => {
-    testConfig.permissions = { mode: "strict" };
-    await check("file_read", { file_path: "/tmp/test.txt" }, "/tmp");
-    expect(loggerWarnCalls.some((m) => m.includes("deprecated"))).toBe(false);
-  });
-
-  test("legacy mode still produces correct decisions (low risk auto-allowed)", async () => {
-    const result = await check(
-      "file_read",
-      { file_path: "/tmp/test.txt" },
-      "/tmp",
-    );
-    expect(result.decision).toBe("allow");
-    expect(result.reason).toContain("Low risk");
-  });
-
-  test("legacy mode still prompts for medium risk", async () => {
-    const result = await check(
-      "file_write",
-      { file_path: "/tmp/test.txt" },
-      "/tmp",
-    );
-    expect(result.decision).toBe("prompt");
-    expect(result.reason).toContain("risk");
-  });
-});
-
 describe("shell command candidates wiring (PR 04)", () => {
   test("existing raw shell rule still matches", async () => {
     clearCache();
@@ -4896,7 +4820,7 @@ describe("integration regressions (PR 11)", () => {
       /* may not exist */
     }
     clearCache();
-    testConfig.permissions = { mode: "legacy" };
+    testConfig.permissions = { mode: "workspace" };
     testConfig.sandbox = { enabled: true };
   });
 

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -527,11 +527,12 @@ describe("AssistantConfigSchema", () => {
     expect(result.permissions.mode).toBe("strict");
   });
 
-  test("accepts explicit permissions.mode legacy", () => {
-    const result = AssistantConfigSchema.parse({
-      permissions: { mode: "legacy" },
-    });
-    expect(result.permissions.mode).toBe("legacy");
+  test("rejects permissions.mode legacy", () => {
+    expect(() =>
+      AssistantConfigSchema.parse({
+        permissions: { mode: "legacy" },
+      }),
+    ).toThrow();
   });
 
   test("accepts explicit permissions.mode workspace", () => {

--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 const VALID_SECRET_ACTIONS = ["redact", "warn", "block", "prompt"] as const;
-const VALID_PERMISSIONS_MODES = ["legacy", "strict", "workspace"] as const;
+const VALID_PERMISSIONS_MODES = ["strict", "workspace"] as const;
 const VALID_SMS_PROVIDERS = ["twilio"] as const;
 
 export const TimeoutConfigSchema = z.object({

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -15,7 +15,6 @@ import {
   looksLikePathOnlyInput,
 } from "../tools/network/url-safety.js";
 import { getTool } from "../tools/registry.js";
-import { getLogger } from "../util/logger.js";
 import {
   buildShellAllowlistOptions,
   buildShellCommandCandidates,
@@ -67,14 +66,6 @@ export function clearRiskCache(): void {
 // Invalidate risk cache whenever trust rules change so that risk decisions
 // referencing config-dependent checks (e.g. skill source paths) stay fresh.
 onRulesChanged(clearRiskCache);
-
-// Ensures the legacy mode deprecation warning fires at most once per process.
-let _legacyDeprecationWarned = false;
-
-/** @internal — exposed only for tests to reset the one-time warning flag. */
-export function _resetLegacyDeprecationWarning(): void {
-  _legacyDeprecationWarned = false;
-}
 
 // Low-risk shell programs that are read-only / informational
 const LOW_RISK_PROGRAMS = new Set([
@@ -787,13 +778,6 @@ export async function check(
   // agent new capabilities, so in strict mode users must approve each
   // skill load via an exact-version or wildcard trust rule.
   const permissionsMode = getConfig().permissions.mode;
-
-  if (permissionsMode === "legacy" && !_legacyDeprecationWarned) {
-    _legacyDeprecationWarned = true;
-    getLogger("checker").warn(
-      'Permissions mode "legacy" is deprecated and will be removed in a future release. Switch to "workspace" (default) or "strict".',
-    );
-  }
 
   if (permissionsMode === "strict" && !matchedRule) {
     return {


### PR DESCRIPTION
## Summary
- Remove "legacy" from VALID_PERMISSIONS_MODES enum in core-schema
- Remove all legacy-mode branches, deprecation warning flag, and reset function from checker
- Remove unused `getLogger` import from checker (dead code from removed deprecation warning)
- Update tests to remove legacy mode references and deprecation warning test block

Part of plan: dead-code-cleanup.md (PR 8a of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
