### PR TITLE
fix: remove unused gateway exports (scopes, token-service, db, channel asserts)

### DIFF
--- a/gateway/src/auth/scopes.ts
+++ b/gateway/src/auth/scopes.ts
@@ -6,7 +6,7 @@
  * policy decision, not a runtime configuration.
  */
 
-import type { AuthContext, Scope, ScopeProfile } from "./types.js";
+import type { Scope, ScopeProfile } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Profile -> scope mapping
@@ -47,14 +47,4 @@ const PROFILE_SCOPES: Record<ScopeProfile, ReadonlySet<Scope>> = {
 /** Resolve a scope profile name to its set of granted scopes. */
 export function resolveScopeProfile(profile: ScopeProfile): ReadonlySet<Scope> {
   return PROFILE_SCOPES[profile];
-}
-
-/** Check whether the auth context includes a specific scope. */
-export function hasScope(ctx: AuthContext, scope: Scope): boolean {
-  return ctx.scopes.has(scope);
-}
-
-/** Check whether the auth context includes all of the given scopes. */
-export function hasAllScopes(ctx: AuthContext, ...scopes: Scope[]): boolean {
-  return scopes.every((s) => ctx.scopes.has(s));
 }

--- a/gateway/src/auth/token-service.ts
+++ b/gateway/src/auth/token-service.ts
@@ -6,12 +6,7 @@
  * ~/.vellum/protected/actor-token-signing-key.
  */
 
-import {
-  createHash,
-  createHmac,
-  randomBytes,
-  timingSafeEqual,
-} from "node:crypto";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import {
   chmodSync,
   existsSync,
@@ -79,16 +74,6 @@ export function loadOrCreateSigningKey(): Buffer {
  */
 export function initSigningKey(key: Buffer): void {
   signingKey = key;
-}
-
-/**
- * Check whether the signing key has been initialized.
- *
- * Useful for test setup code that needs to ensure initSigningKey()
- * has been called before minting tokens.
- */
-export function isSigningKeyInitialized(): boolean {
-  return signingKey !== null;
 }
 
 function getSigningKey(): Buffer {
@@ -217,12 +202,4 @@ export function verifyToken(
   }
 
   return { ok: true, claims };
-}
-
-// ---------------------------------------------------------------------------
-// Hash
-// ---------------------------------------------------------------------------
-
-export function hashToken(token: string): string {
-  return createHash("sha256").update(token).digest("hex");
 }

--- a/gateway/src/channels/types.ts
+++ b/gateway/src/channels/types.ts
@@ -21,15 +21,6 @@ export function parseChannelId(value: unknown): ChannelId | null {
   return isChannelId(value) ? value : null;
 }
 
-export function assertChannelId(value: unknown, field: string): ChannelId {
-  if (!isChannelId(value)) {
-    throw new Error(
-      `Invalid channel ID for ${field}: ${String(value)}. Valid values: ${CHANNEL_IDS.join(", ")}`,
-    );
-  }
-  return value;
-}
-
 export const INTERFACE_IDS = [
   "macos",
   "ios",
@@ -54,15 +45,6 @@ export function isInterfaceId(value: unknown): value is InterfaceId {
 
 export function parseInterfaceId(value: unknown): InterfaceId | null {
   return isInterfaceId(value) ? value : null;
-}
-
-export function assertInterfaceId(value: unknown, field: string): InterfaceId {
-  if (!isInterfaceId(value)) {
-    throw new Error(
-      `Invalid interface ID for ${field}: ${String(value)}. Valid values: ${INTERFACE_IDS.join(", ")}`,
-    );
-  }
-  return value;
 }
 
 export interface TurnInterfaceContext {

--- a/gateway/src/db/connection.ts
+++ b/gateway/src/db/connection.ts
@@ -42,11 +42,3 @@ function migrate(db: Database): void {
     )
   `);
 }
-
-/** Reset the singleton — used by tests. */
-export function resetGatewayDb(): void {
-  if (db) {
-    db.close();
-    db = null;
-  }
-}


### PR DESCRIPTION
## Summary
- Remove 7 unused exported functions from gateway auth, db, and channel modules
- All have zero callers in production code (gateway uses different patterns internally)

Part of plan: dead-code-cleanup.md (PR 5 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
