### PR TITLE
fix: remove unused verifyBearerToken, parseMcpToolName, memoryToolDefinitions

### DIFF
--- a/assistant/src/runtime/middleware/auth.ts
+++ b/assistant/src/runtime/middleware/auth.ts
@@ -3,18 +3,6 @@
  * and gateway-origin verification.
  */
 
-import { timingSafeEqual } from "node:crypto";
-
-/**
- * Constant-time comparison of two bearer tokens to prevent timing attacks.
- */
-export function verifyBearerToken(provided: string, expected: string): boolean {
-  const a = Buffer.from(provided);
-  const b = Buffer.from(expected);
-  if (a.length !== b.length) return false;
-  return timingSafeEqual(a, b);
-}
-
 /**
  * Check if a hostname is a loopback address.
  */

--- a/assistant/src/tools/mcp/mcp-tool-factory.ts
+++ b/assistant/src/tools/mcp/mcp-tool-factory.ts
@@ -18,23 +18,6 @@ export function mcpToolName(serverId: string, toolName: string): string {
   return `mcp__${serverId}__${toolName}`;
 }
 
-/**
- * Parse a namespaced MCP tool name back into serverId and original tool name.
- * Returns null if the name doesn't match the MCP naming convention.
- */
-export function parseMcpToolName(
-  name: string,
-): { serverId: string; toolName: string } | null {
-  if (!name.startsWith("mcp__")) return null;
-  const prefixRemoved = name.slice(5); // remove 'mcp__'
-  const firstSep = prefixRemoved.indexOf("__");
-  if (firstSep === -1) return null;
-  return {
-    serverId: prefixRemoved.slice(0, firstSep),
-    toolName: prefixRemoved.slice(firstSep + 2),
-  };
-}
-
 export interface McpToolMetadata {
   name: string;
   description: string;

--- a/assistant/src/tools/memory/definitions.ts
+++ b/assistant/src/tools/memory/definitions.ts
@@ -93,9 +93,3 @@ export const memoryUpdateDefinition: ToolDefinition = {
     required: ["memory_id", "statement"],
   },
 };
-
-export const memoryToolDefinitions: ToolDefinition[] = [
-  memorySearchDefinition,
-  memorySaveDefinition,
-  memoryUpdateDefinition,
-];


### PR DESCRIPTION
## Summary
- Remove `verifyBearerToken` from auth middleware (never integrated into request validation)
- Remove `parseMcpToolName` from MCP tool factory (inverse of `mcpToolName`, never called)
- Remove `memoryToolDefinitions` array export (individual definitions are used directly)

Part of plan: dead-code-cleanup.md (PR 4 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12820" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
