### PR TITLE
fix: remove unused notification-store exports

### DIFF
--- a/assistant/src/notifications/decisions-store.ts
+++ b/assistant/src/notifications/decisions-store.ts
@@ -7,10 +7,10 @@
  * were routed.
  */
 
-import { and, desc, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 import { getDb } from "../memory/db.js";
-import { notificationDecisions, notificationEvents } from "../memory/schema.js";
+import { notificationDecisions } from "../memory/schema.js";
 
 export interface NotificationDecisionRow {
   id: string;
@@ -23,23 +23,6 @@ export interface NotificationDecisionRow {
   promptVersion: string | null;
   validationResults: string | null; // JSON
   createdAt: number;
-}
-
-function rowToDecision(
-  row: typeof notificationDecisions.$inferSelect,
-): NotificationDecisionRow {
-  return {
-    id: row.id,
-    notificationEventId: row.notificationEventId,
-    shouldNotify: row.shouldNotify === 1,
-    selectedChannels: row.selectedChannels,
-    reasoningSummary: row.reasoningSummary,
-    confidence: row.confidence,
-    fallbackUsed: row.fallbackUsed === 1,
-    promptVersion: row.promptVersion,
-    validationResults: row.validationResults,
-    createdAt: row.createdAt,
-  };
 }
 
 export interface CreateDecisionParams {
@@ -110,90 +93,4 @@ export function updateDecision(id: string, params: UpdateDecisionParams): void {
     .set(updates)
     .where(eq(notificationDecisions.id, id))
     .run();
-}
-
-/** Fetch a single decision by ID. */
-export function getDecisionById(id: string): NotificationDecisionRow | null {
-  const db = getDb();
-  const row = db
-    .select()
-    .from(notificationDecisions)
-    .where(eq(notificationDecisions.id, id))
-    .get();
-  if (!row) return null;
-  return rowToDecision(row);
-}
-
-/** Fetch a decision by its parent event ID. */
-export function getDecisionByEventId(
-  eventId: string,
-): NotificationDecisionRow | null {
-  const db = getDb();
-  const row = db
-    .select()
-    .from(notificationDecisions)
-    .where(eq(notificationDecisions.notificationEventId, eventId))
-    .get();
-  if (!row) return null;
-  return rowToDecision(row);
-}
-
-export interface ListDecisionsFilters {
-  shouldNotify?: boolean;
-  limit?: number;
-}
-
-/** List decisions for an assistant with optional filters. */
-export function listDecisions(
-  assistantId: string,
-  filters?: ListDecisionsFilters,
-): NotificationDecisionRow[] {
-  const db = getDb();
-
-  // Join through notificationEvents to filter by assistantId
-  const conditions = [eq(notificationEvents.assistantId, assistantId)];
-
-  if (filters?.shouldNotify !== undefined) {
-    conditions.push(
-      eq(notificationDecisions.shouldNotify, filters.shouldNotify ? 1 : 0),
-    );
-  }
-
-  const limit = filters?.limit ?? 50;
-
-  const rows = db
-    .select({
-      id: notificationDecisions.id,
-      notificationEventId: notificationDecisions.notificationEventId,
-      shouldNotify: notificationDecisions.shouldNotify,
-      selectedChannels: notificationDecisions.selectedChannels,
-      reasoningSummary: notificationDecisions.reasoningSummary,
-      confidence: notificationDecisions.confidence,
-      fallbackUsed: notificationDecisions.fallbackUsed,
-      promptVersion: notificationDecisions.promptVersion,
-      validationResults: notificationDecisions.validationResults,
-      createdAt: notificationDecisions.createdAt,
-    })
-    .from(notificationDecisions)
-    .innerJoin(
-      notificationEvents,
-      eq(notificationDecisions.notificationEventId, notificationEvents.id),
-    )
-    .where(and(...conditions))
-    .orderBy(desc(notificationDecisions.createdAt))
-    .limit(limit)
-    .all();
-
-  return rows.map((row) => ({
-    id: row.id,
-    notificationEventId: row.notificationEventId,
-    shouldNotify: row.shouldNotify === 1,
-    selectedChannels: row.selectedChannels,
-    reasoningSummary: row.reasoningSummary,
-    confidence: row.confidence,
-    fallbackUsed: row.fallbackUsed === 1,
-    promptVersion: row.promptVersion,
-    validationResults: row.validationResults,
-    createdAt: row.createdAt,
-  }));
 }

--- a/assistant/src/notifications/deliveries-store.ts
+++ b/assistant/src/notifications/deliveries-store.ts
@@ -202,17 +202,6 @@ export function updateDeliveryClientOutcome(
   return rawChanges() > 0;
 }
 
-/** List all delivery records for a given notification decision. */
-export function listDeliveries(decisionId: string): NotificationDeliveryRow[] {
-  const db = getDb();
-  const rows = db
-    .select()
-    .from(notificationDeliveries)
-    .where(eq(notificationDeliveries.notificationDecisionId, decisionId))
-    .all();
-  return rows.map(rowToDelivery);
-}
-
 /** Check whether a delivery already exists for a given decision+channel pair. */
 export function findDeliveryByDecisionAndChannel(
   decisionId: string,

--- a/assistant/src/notifications/preferences-store.ts
+++ b/assistant/src/notifications/preferences-store.ts
@@ -10,7 +10,7 @@
 import { desc, eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getDb, rawChanges } from "../memory/db.js";
+import { getDb } from "../memory/db.js";
 import { notificationPreferences } from "../memory/schema.js";
 
 // ── Row type ────────────────────────────────────────────────────────────
@@ -94,61 +94,4 @@ export function listPreferences(
     .all();
 
   return rows.map(rowToPreference);
-}
-
-// ── Update ──────────────────────────────────────────────────────────────
-
-export interface UpdatePreferenceParams {
-  preferenceText?: string;
-  appliesWhen?: AppliesWhenConditions;
-  priority?: number;
-}
-
-export function updatePreference(
-  id: string,
-  params: UpdatePreferenceParams,
-): boolean {
-  const db = getDb();
-  const now = Date.now();
-
-  const updates: Record<string, unknown> = { updatedAt: now };
-  if (params.preferenceText !== undefined)
-    updates.preferenceText = params.preferenceText;
-  if (params.appliesWhen !== undefined)
-    updates.appliesWhenJson = JSON.stringify(params.appliesWhen);
-  if (params.priority !== undefined) updates.priority = params.priority;
-
-  db.update(notificationPreferences)
-    .set(updates)
-    .where(eq(notificationPreferences.id, id))
-    .run();
-
-  return rawChanges() > 0;
-}
-
-// ── Delete ──────────────────────────────────────────────────────────────
-
-export function deletePreference(id: string): boolean {
-  const db = getDb();
-
-  db.delete(notificationPreferences)
-    .where(eq(notificationPreferences.id, id))
-    .run();
-
-  return rawChanges() > 0;
-}
-
-// ── Get by ID ───────────────────────────────────────────────────────────
-
-export function getPreferenceById(
-  id: string,
-): NotificationPreferenceRow | null {
-  const db = getDb();
-  const row = db
-    .select()
-    .from(notificationPreferences)
-    .where(eq(notificationPreferences.id, id))
-    .get();
-  if (!row) return null;
-  return rowToPreference(row);
 }


### PR DESCRIPTION
## Summary
- Remove 7 unused exported functions from notification store modules (decisions-store, deliveries-store, preferences-store)
- These functions have zero callers in production or test code

Part of plan: dead-code-cleanup.md (PR 1 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
