### PR TITLE
fix: remove unused conversation and thread-mapping store exports

### DIFF
--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -54,27 +54,6 @@ export { ensureDisplayOrderMigration as ensureColumns } from "./conversation-dis
 // CRUD functions for display_order and is_pinned
 // ---------------------------------------------------------------------------
 
-export function getDisplayOrder(conversationId: string): number | null {
-  ensureDisplayOrderMigration();
-  const row = rawGet<{ display_order: number | null }>(
-    "SELECT display_order FROM conversations WHERE id = ?",
-    conversationId,
-  );
-  return row?.display_order ?? null;
-}
-
-export function setDisplayOrder(
-  conversationId: string,
-  order: number | null,
-): void {
-  ensureDisplayOrderMigration();
-  rawRun(
-    "UPDATE conversations SET display_order = ? WHERE id = ?",
-    order,
-    conversationId,
-  );
-}
-
 export function batchSetDisplayOrders(
   updates: Array<{
     id: string;
@@ -98,36 +77,6 @@ export function batchSetDisplayOrders(
     rawExec("ROLLBACK");
     throw err;
   }
-}
-
-export function setConversationPinned(
-  conversationId: string,
-  isPinned: boolean,
-): void {
-  ensureDisplayOrderMigration();
-  rawRun(
-    "UPDATE conversations SET is_pinned = ? WHERE id = ?",
-    isPinned ? 1 : 0,
-    conversationId,
-  );
-}
-
-export function getConversationDisplayMeta(conversationId: string): {
-  displayOrder: number | null;
-  isPinned: boolean;
-} {
-  ensureDisplayOrderMigration();
-  const row = rawGet<{
-    display_order: number | null;
-    is_pinned: number | null;
-  }>(
-    "SELECT display_order, is_pinned FROM conversations WHERE id = ?",
-    conversationId,
-  );
-  return {
-    displayOrder: row?.display_order ?? null,
-    isPinned: (row?.is_pinned ?? 0) === 1,
-  };
 }
 
 export function getDisplayMetaForConversations(

--- a/assistant/src/memory/slack-thread-store.ts
+++ b/assistant/src/memory/slack-thread-store.ts
@@ -33,31 +33,6 @@ const THREAD_TTL_MS = 24 * 60 * 60 * 1000;
 const MAX_MAPPINGS = 5_000;
 
 /**
- * Look up the Slack thread timestamp for a conversation.
- * Returns null if no active thread mapping exists or the mapping has expired.
- */
-export function getThreadTs(
-  conversationId: string,
-  channelId: string,
-): string | null {
-  const mapping = threadMappings.get(conversationId);
-  if (!mapping) return null;
-
-  // Must be for the same channel
-  if (mapping.channelId !== channelId) return null;
-
-  // Check TTL
-  if (Date.now() - mapping.lastUsedAt > THREAD_TTL_MS) {
-    threadMappings.delete(conversationId);
-    return null;
-  }
-
-  // Update last-used timestamp
-  mapping.lastUsedAt = Date.now();
-  return mapping.threadTs;
-}
-
-/**
  * Associate a conversation with a Slack thread. Called when:
  * - An inbound message arrives with a threadTs (from the gateway callback URL)
  * - The assistant creates a new thread for a channel conversation
@@ -85,41 +60,6 @@ export function setThreadTs(
   });
 
   log.debug({ conversationId, channelId, threadTs }, "Thread mapping created");
-}
-
-/**
- * Remove the thread mapping for a conversation.
- * Called when a conversation should start a fresh thread.
- */
-export function clearThreadTs(conversationId: string): void {
-  threadMappings.delete(conversationId);
-}
-
-/**
- * Get all active thread mappings for a channel.
- * Useful for diagnostics and the configure tool.
- */
-export function getChannelThreadMappings(
-  channelId: string,
-): Array<{ conversationId: string; threadTs: string; lastUsedAt: number }> {
-  const results: Array<{
-    conversationId: string;
-    threadTs: string;
-    lastUsedAt: number;
-  }> = [];
-
-  const now = Date.now();
-  for (const [convId, mapping] of threadMappings) {
-    if (mapping.channelId !== channelId) continue;
-    if (now - mapping.lastUsedAt > THREAD_TTL_MS) continue;
-    results.push({
-      conversationId: convId,
-      threadTs: mapping.threadTs,
-      lastUsedAt: mapping.lastUsedAt,
-    });
-  }
-
-  return results;
 }
 
 /**
@@ -175,13 +115,4 @@ function evictExpiredIfNeeded(): void {
       threadMappings.delete(convId);
     }
   }
-}
-
-// ── Test helpers ────────────────────────────────────────────────────
-
-/**
- * Clear all thread mappings. Used in tests for isolation.
- */
-export function resetAllThreadMappings(): void {
-  threadMappings.clear();
 }


### PR DESCRIPTION
## Summary
- Remove 8 unused exported functions from conversation-store and slack-thread-store
- Functions had zero callers in production or test code

Part of plan: dead-code-cleanup.md (PR 2 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
