### PR TITLE
fix: remove deprecated TWILIO_WSS_BASE_URL env plumbing

### DIFF
--- a/assistant/src/__tests__/twilio-config.test.ts
+++ b/assistant/src/__tests__/twilio-config.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 let mockSecureKeys: Record<string, string | null> = {};
 let mockPhoneNumberEnv: string | undefined;
-let mockWssBaseUrl: string | undefined;
 let mockLoadConfigResult: Record<string, unknown> = {};
 
 mock.module("../util/logger.js", () => ({
@@ -21,7 +20,6 @@ mock.module("../security/secure-keys.js", () => ({
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => true,
   getTwilioPhoneNumberEnv: () => mockPhoneNumberEnv,
-  getTwilioWssBaseUrl: () => mockWssBaseUrl,
 }));
 
 mock.module("../config/loader.js", () => ({
@@ -42,7 +40,6 @@ describe("twilio-config", () => {
       "credential:twilio:auth_token": "test_auth_token",
     };
     mockPhoneNumberEnv = undefined;
-    mockWssBaseUrl = undefined;
     mockLoadConfigResult = {
       sms: { phoneNumber: "+15551234567" },
     };

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -1,4 +1,4 @@
-import { getTwilioPhoneNumberEnv, getTwilioWssBaseUrl } from "../config/env.js";
+import { getTwilioPhoneNumberEnv } from "../config/env.js";
 import { loadConfig } from "../config/loader.js";
 import {
   getPublicBaseUrl,
@@ -43,14 +43,7 @@ export function getTwilioConfig(assistantId?: string): TwilioConfig {
   const phoneNumber = resolveTwilioPhoneNumber(config, assistantId);
   const webhookBaseUrl = getPublicBaseUrl(config);
 
-  // Always use the centralized relay URL derived from the public ingress base URL.
-  // TWILIO_WSS_BASE_URL is ignored.
   let wssBaseUrl: string;
-  if (getTwilioWssBaseUrl()) {
-    log.warn(
-      "TWILIO_WSS_BASE_URL env var is deprecated. Relay URL is derived from ingress.publicBaseUrl.",
-    );
-  }
   try {
     wssBaseUrl = getTwilioRelayUrl(config);
   } catch {

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -131,10 +131,6 @@ export function getTwilioUserPhoneNumber(): string | undefined {
   return str("TWILIO_USER_PHONE_NUMBER");
 }
 
-export function getTwilioWssBaseUrl(): string | undefined {
-  return str("TWILIO_WSS_BASE_URL");
-}
-
 export function isTwilioWebhookValidationDisabled(): boolean {
   // Intentionally strict: only exact "true" disables validation (not "1").
   // This is a security-sensitive bypass — we don't want environments that
@@ -210,12 +206,6 @@ export function validateEnv(): void {
   const httpPort = getRuntimeHttpPort();
   if (httpPort < 1 || httpPort > 65535) {
     throw new Error(`Invalid RUNTIME_HTTP_PORT: ${httpPort} (must be 1-65535)`);
-  }
-
-  if (getTwilioWssBaseUrl()) {
-    log.warn(
-      "TWILIO_WSS_BASE_URL env var is deprecated. Relay URL is now derived from ingress.publicBaseUrl.",
-    );
   }
 
   for (const warning of checkUnrecognizedEnvVars()) {


### PR DESCRIPTION
## Summary
- Remove `getTwilioWssBaseUrl` env getter and its deprecation warning in twilio-config
- The env var was already ignored; relay URL derives from `ingress.publicBaseUrl`

Part of plan: dead-code-cleanup.md (PR 7 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
