### PR TITLE
fix: remove unused clearRecallCache and clearHomeBaseAppLink exports

### DIFF
--- a/assistant/src/home-base/app-link-store.ts
+++ b/assistant/src/home-base/app-link-store.ts
@@ -76,10 +76,3 @@ export function setHomeBaseAppLink(
     updatedAt: now,
   };
 }
-
-export function clearHomeBaseAppLink(): void {
-  const db = getDb();
-  db.delete(homeBaseAppLinks)
-    .where(eq(homeBaseAppLinks.id, HOME_BASE_LINK_ID))
-    .run();
-}

--- a/assistant/src/memory/recall-cache.ts
+++ b/assistant/src/memory/recall-cache.ts
@@ -115,8 +115,3 @@ export function setCachedRecall(
 
   _cache.set(key, { version: _version, createdAt: Date.now(), result });
 }
-
-/** Clear the entire cache (useful for testing). */
-export function clearRecallCache(): void {
-  _cache.clear();
-}


### PR DESCRIPTION
## Summary
- Remove `clearRecallCache` from recall-cache.ts (zero callers)
- Remove `clearHomeBaseAppLink` from app-link-store.ts (zero callers)

Part of plan: dead-code-cleanup.md (PR 10 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
