### PR TITLE
fix: remove deprecated cron_expression and reminder_cron_id aliases

### DIFF
--- a/assistant/src/__tests__/followup-tools.test.ts
+++ b/assistant/src/__tests__/followup-tools.test.ts
@@ -122,36 +122,6 @@ describe("followup_create tool", () => {
     expect(result.content).toContain("Reminder schedule: sched-abc");
   });
 
-  test("creates a follow-up with deprecated reminder_cron_id alias", async () => {
-    const result = await executeFollowupCreate(
-      {
-        channel: "email",
-        thread_id: "thread-789",
-        reminder_cron_id: "cron-abc",
-      },
-      ctx,
-    );
-
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain("Reminder schedule: cron-abc");
-  });
-
-  test("reminder_schedule_id takes precedence over reminder_cron_id", async () => {
-    const result = await executeFollowupCreate(
-      {
-        channel: "email",
-        thread_id: "thread-prio",
-        reminder_schedule_id: "sched-wins",
-        reminder_cron_id: "cron-loses",
-      },
-      ctx,
-    );
-
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain("Reminder schedule: sched-wins");
-    expect(result.content).not.toContain("cron-loses");
-  });
-
   test("rejects missing channel", async () => {
     const result = await executeFollowupCreate(
       {

--- a/assistant/src/__tests__/recurrence-types.test.ts
+++ b/assistant/src/__tests__/recurrence-types.test.ts
@@ -66,21 +66,6 @@ describe("normalizeScheduleSyntax", () => {
     });
   });
 
-  test("falls back to legacyCronExpression", () => {
-    const result = normalizeScheduleSyntax({
-      legacyCronExpression: "0 9 * * *",
-    });
-    expect(result).toEqual({ syntax: "cron", expression: "0 9 * * *" });
-  });
-
-  test("honors explicit syntax hint in legacyCronExpression fallback", () => {
-    const result = normalizeScheduleSyntax({
-      syntax: "rrule",
-      legacyCronExpression: "0 9 * * *",
-    });
-    expect(result).toEqual({ syntax: "rrule", expression: "0 9 * * *" });
-  });
-
   test("returns null when nothing is provided", () => {
     expect(normalizeScheduleSyntax({})).toBeNull();
   });

--- a/assistant/src/__tests__/schedule-tools.test.ts
+++ b/assistant/src/__tests__/schedule-tools.test.ts
@@ -76,7 +76,7 @@ describe("schedule_create tool", () => {
     const result = await executeScheduleCreate(
       {
         name: "Daily standup",
-        cron_expression: "0 9 * * 1-5",
+        expression: "0 9 * * 1-5",
         message: "Time for standup!",
       },
       ctx,
@@ -93,7 +93,7 @@ describe("schedule_create tool", () => {
     const result = await executeScheduleCreate(
       {
         name: "Paused job",
-        cron_expression: "0 12 * * *",
+        expression: "0 12 * * *",
         message: "Noon check",
         enabled: false,
       },
@@ -108,7 +108,7 @@ describe("schedule_create tool", () => {
     const result = await executeScheduleCreate(
       {
         name: "LA morning",
-        cron_expression: "0 8 * * *",
+        expression: "0 8 * * *",
         message: "Good morning LA",
         timezone: "America/Los_Angeles",
       },
@@ -122,7 +122,7 @@ describe("schedule_create tool", () => {
   test("rejects missing name", async () => {
     const result = await executeScheduleCreate(
       {
-        cron_expression: "0 9 * * *",
+        expression: "0 9 * * *",
         message: "test",
       },
       ctx,
@@ -142,16 +142,14 @@ describe("schedule_create tool", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content).toContain(
-      "expression (or cron_expression) is required",
-    );
+    expect(result.content).toContain("expression is required");
   });
 
   test("rejects missing message", async () => {
     const result = await executeScheduleCreate(
       {
         name: "Test",
-        cron_expression: "0 9 * * *",
+        expression: "0 9 * * *",
       },
       ctx,
     );
@@ -164,7 +162,8 @@ describe("schedule_create tool", () => {
     const result = await executeScheduleCreate(
       {
         name: "Bad cron",
-        cron_expression: "not-a-cron",
+        syntax: "cron",
+        expression: "not-a-cron",
         message: "test",
       },
       ctx,
@@ -194,7 +193,7 @@ describe("schedule_list tool", () => {
     await executeScheduleCreate(
       {
         name: "Job Alpha",
-        cron_expression: "0 9 * * *",
+        expression: "0 9 * * *",
         message: "Alpha",
       },
       ctx,
@@ -202,7 +201,7 @@ describe("schedule_list tool", () => {
     await executeScheduleCreate(
       {
         name: "Job Beta",
-        cron_expression: "0 17 * * *",
+        expression: "0 17 * * *",
         message: "Beta",
       },
       ctx,
@@ -220,7 +219,7 @@ describe("schedule_list tool", () => {
     await executeScheduleCreate(
       {
         name: "Enabled Job",
-        cron_expression: "0 9 * * *",
+        expression: "0 9 * * *",
         message: "enabled",
       },
       ctx,
@@ -228,7 +227,7 @@ describe("schedule_list tool", () => {
     await executeScheduleCreate(
       {
         name: "Disabled Job",
-        cron_expression: "0 17 * * *",
+        expression: "0 17 * * *",
         message: "disabled",
         enabled: false,
       },
@@ -246,7 +245,7 @@ describe("schedule_list tool", () => {
     await executeScheduleCreate(
       {
         name: "Detail Job",
-        cron_expression: "30 14 * * *",
+        expression: "30 14 * * *",
         message: "Afternoon check",
       },
       ctx,
@@ -286,7 +285,7 @@ describe("schedule_update tool", () => {
     await executeScheduleCreate(
       {
         name: "Old Name",
-        cron_expression: "0 9 * * *",
+        expression: "0 9 * * *",
         message: "test",
       },
       ctx,
@@ -312,7 +311,7 @@ describe("schedule_update tool", () => {
     await executeScheduleCreate(
       {
         name: "Timing Test",
-        cron_expression: "0 9 * * *",
+        expression: "0 9 * * *",
         message: "test",
       },
       ctx,
@@ -324,7 +323,7 @@ describe("schedule_update tool", () => {
     const result = await executeScheduleUpdate(
       {
         job_id: row.id,
-        cron_expression: "0 17 * * *",
+        expression: "0 17 * * *",
       },
       ctx,
     );
@@ -337,7 +336,7 @@ describe("schedule_update tool", () => {
     await executeScheduleCreate(
       {
         name: "Disable Me",
-        cron_expression: "0 9 * * *",
+        expression: "0 9 * * *",
         message: "test",
       },
       ctx,
@@ -370,7 +369,7 @@ describe("schedule_update tool", () => {
     await executeScheduleCreate(
       {
         name: "No Update",
-        cron_expression: "0 9 * * *",
+        expression: "0 9 * * *",
         message: "test",
       },
       ctx,
@@ -402,7 +401,7 @@ describe("schedule_update tool", () => {
     await executeScheduleCreate(
       {
         name: "Bad Update",
-        cron_expression: "0 9 * * *",
+        expression: "0 9 * * *",
         message: "test",
       },
       ctx,
@@ -414,7 +413,8 @@ describe("schedule_update tool", () => {
     const result = await executeScheduleUpdate(
       {
         job_id: row.id,
-        cron_expression: "invalid",
+        syntax: "cron",
+        expression: "invalid",
       },
       ctx,
     );
@@ -430,22 +430,6 @@ describe("schedule_create with RRULE", () => {
   beforeEach(() => {
     getRawDb().run("DELETE FROM cron_runs");
     getRawDb().run("DELETE FROM cron_jobs");
-  });
-
-  test("creates a schedule with legacy cron_expression", async () => {
-    const result = await executeScheduleCreate(
-      {
-        name: "Legacy cron",
-        cron_expression: "0 9 * * 1-5",
-        message: "Legacy test",
-      },
-      ctx,
-    );
-
-    expect(result.isError).toBe(false);
-    expect(result.content).toContain("Schedule created successfully");
-    expect(result.content).toContain("Syntax: cron");
-    expect(result.content).toContain("Every weekday at 9:00 AM");
   });
 
   test("creates a schedule with RRULE syntax + expression", async () => {
@@ -507,7 +491,7 @@ describe("schedule_update with RRULE", () => {
     await executeScheduleCreate(
       {
         name: "Cron to RRULE",
-        cron_expression: "0 9 * * *",
+        expression: "0 9 * * *",
         message: "test",
       },
       ctx,
@@ -535,7 +519,7 @@ describe("schedule_update with RRULE", () => {
     await executeScheduleCreate(
       {
         name: "Auto-detect on update",
-        cron_expression: "0 9 * * *",
+        expression: "0 9 * * *",
         message: "test",
       },
       ctx,
@@ -561,7 +545,7 @@ describe("schedule_update with RRULE", () => {
     await executeScheduleCreate(
       {
         name: "Cron auto-detect",
-        cron_expression: "0 9 * * *",
+        expression: "0 9 * * *",
         message: "test",
       },
       ctx,
@@ -593,7 +577,7 @@ describe("schedule_list with RRULE", () => {
     await executeScheduleCreate(
       {
         name: "Cron Job",
-        cron_expression: "0 9 * * 1-5",
+        expression: "0 9 * * 1-5",
         message: "Cron test",
       },
       ctx,
@@ -750,7 +734,7 @@ describe("schedule_update with RRULE set", () => {
     await executeScheduleCreate(
       {
         name: "Cron to set",
-        cron_expression: "0 9 * * *",
+        expression: "0 9 * * *",
         message: "test",
       },
       ctx,
@@ -784,7 +768,7 @@ describe("schedule_update with RRULE set", () => {
     await executeScheduleCreate(
       {
         name: "Bad set update",
-        cron_expression: "0 9 * * *",
+        expression: "0 9 * * *",
         message: "test",
       },
       ctx,
@@ -928,7 +912,7 @@ describe("schedule_delete tool", () => {
     await executeScheduleCreate(
       {
         name: "Delete Me",
-        cron_expression: "0 9 * * *",
+        expression: "0 9 * * *",
         message: "test",
       },
       ctx,

--- a/assistant/src/config/bundled-skills/followups/TOOLS.json
+++ b/assistant/src/config/bundled-skills/followups/TOOLS.json
@@ -29,10 +29,6 @@
             "type": "string",
             "description": "Optional recurrence schedule ID to fire a reminder when overdue"
           },
-          "reminder_cron_id": {
-            "type": "string",
-            "description": "Deprecated alias for reminder_schedule_id. Use reminder_schedule_id instead."
-          },
           "reason": {
             "type": "string",
             "description": "Brief non-technical explanation of why this tool is being called"

--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -63,7 +63,7 @@ Exclusions (EXDATE, EXRULE) always take precedence over inclusions (RRULE, RDATE
 
 ## Tool Input
 
-Use `syntax` + `expression` to specify the schedule type explicitly, or just `expression` to auto-detect. The legacy `cron_expression` field is still accepted as a cron alias.
+Use `syntax` + `expression` to specify the schedule type explicitly, or just `expression` to auto-detect.
 
 ## Lifecycle
 

--- a/assistant/src/config/bundled-skills/schedule/TOOLS.json
+++ b/assistant/src/config/bundled-skills/schedule/TOOLS.json
@@ -20,11 +20,7 @@
           },
           "expression": {
             "type": "string",
-            "description": "Canonical schedule expression (cron or RRULE). Preferred over cron_expression."
-          },
-          "cron_expression": {
-            "type": "string",
-            "description": "Deprecated alias for expression with cron syntax. Use expression + syntax instead."
+            "description": "Schedule expression (cron or RRULE)"
           },
           "timezone": {
             "type": "string",
@@ -97,11 +93,7 @@
           },
           "expression": {
             "type": "string",
-            "description": "New schedule expression (cron or RRULE). Preferred over cron_expression."
-          },
-          "cron_expression": {
-            "type": "string",
-            "description": "Deprecated alias for expression with cron syntax. Use expression + syntax instead."
+            "description": "New schedule expression (cron or RRULE)"
           },
           "timezone": {
             "type": "string",

--- a/assistant/src/schedule/recurrence-types.ts
+++ b/assistant/src/schedule/recurrence-types.ts
@@ -34,13 +34,11 @@ export function detectScheduleSyntax(
  * Resolution order:
  * 1. If explicit `syntax` is provided, use it
  * 2. If `expression` is provided, auto-detect from expression
- * 3. If `legacyCronExpression` is provided, treat as cron
- * 4. Return null if nothing resolved
+ * 3. Return null if nothing resolved
  */
 export function normalizeScheduleSyntax(input: {
   syntax?: ScheduleSyntax;
   expression?: string;
-  legacyCronExpression?: string;
 }): { syntax: ScheduleSyntax; expression: string } | null {
   // Explicit syntax + expression
   if (input.syntax && input.expression) {
@@ -58,14 +56,6 @@ export function normalizeScheduleSyntax(input: {
       return { syntax: input.syntax, expression: input.expression };
     }
     return null;
-  }
-
-  // Legacy cron_expression fallback
-  if (input.legacyCronExpression) {
-    return {
-      syntax: input.syntax ?? "cron",
-      expression: input.legacyCronExpression,
-    };
   }
 
   return null;

--- a/assistant/src/tools/followups/followup_create.ts
+++ b/assistant/src/tools/followups/followup_create.ts
@@ -51,9 +51,7 @@ export async function executeFollowupCreate(
   const expectedResponseHours = input.expected_response_hours as
     | number
     | undefined;
-  // Canonical: reminder_schedule_id; deprecated alias: reminder_cron_id
-  const reminderScheduleId = (input.reminder_schedule_id ??
-    input.reminder_cron_id) as string | undefined;
+  const reminderScheduleId = input.reminder_schedule_id as string | undefined;
 
   // Validate contact exists if provided
   if (contactId) {

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -31,16 +31,14 @@ export async function executeScheduleCreate(
     };
   }
 
-  // Resolve syntax and expression from new or legacy fields
   const resolved = normalizeScheduleSyntax({
     syntax: input.syntax as "cron" | "rrule" | undefined,
     expression: input.expression as string | undefined,
-    legacyCronExpression: input.cron_expression as string | undefined,
   });
 
   if (!resolved) {
     return {
-      content: "Error: expression (or cron_expression) is required",
+      content: "Error: expression is required",
       isError: true,
     };
   }

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -27,13 +27,10 @@ export async function executeScheduleUpdate(
   if (input.enabled !== undefined) updates.enabled = input.enabled;
 
   // Auto-detect syntax when expression changes without explicit syntax
-  const hasExpression =
-    input.expression !== undefined || input.cron_expression !== undefined;
-  if (hasExpression || input.syntax !== undefined) {
+  if (input.expression !== undefined || input.syntax !== undefined) {
     const resolved = normalizeScheduleSyntax({
       syntax: input.syntax as "cron" | "rrule" | undefined,
       expression: input.expression as string | undefined,
-      legacyCronExpression: input.cron_expression as string | undefined,
     });
     if (resolved) {
       updates.syntax = resolved.syntax;
@@ -42,8 +39,6 @@ export async function executeScheduleUpdate(
       updates.expression = input.expression;
       const detected = detectScheduleSyntax(input.expression as string);
       if (detected) updates.syntax = detected;
-    } else if (input.cron_expression !== undefined) {
-      updates.cronExpression = input.cron_expression;
     }
     // When only syntax is provided (no expression), normalizeScheduleSyntax returns null
     // but we still need to persist the explicit syntax value.


### PR DESCRIPTION
## Summary
- Remove `cron_expression` deprecated alias from schedule TOOLS.json and runtime
- Remove `reminder_cron_id` deprecated alias from followups TOOLS.json and runtime
- Simplify `normalizeScheduleSyntax` to only accept canonical fields
- Update tests to use canonical `expression` field instead of deprecated aliases

Part of plan: dead-code-cleanup.md (PR 9 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
