### PR TITLE
fix: workspace mode permission checker tests

### DIFF
--- a/assistant/src/__tests__/checker.test.ts
+++ b/assistant/src/__tests__/checker.test.ts
@@ -681,10 +681,20 @@ describe("Permission Checker", () => {
       expect(result.decision).toBe("allow");
     });
 
-    test("file_write with no rule → prompt", async () => {
+    test("file_write within workspace with no rule → auto-allowed in workspace mode", async () => {
       const result = await check(
         "file_write",
         { path: "/tmp/file.txt" },
+        "/tmp",
+      );
+      expect(result.decision).toBe("allow");
+      expect(result.reason).toContain("workspace-scoped");
+    });
+
+    test("file_write outside workspace with no rule → prompt", async () => {
+      const result = await check(
+        "file_write",
+        { path: "/etc/some-file.txt" },
         "/tmp",
       );
       expect(result.decision).toBe("prompt");
@@ -1351,12 +1361,10 @@ describe("Permission Checker", () => {
     });
 
     test("core tool (no origin) still follows risk-based fallback", async () => {
-      // file_read is a core tool with Low risk → should auto-allow as before
-      const result = await check(
-        "file_read",
-        { path: "/tmp/test.txt" },
-        "/tmp",
-      );
+      // file_read is a core tool with Low risk — in workspace mode,
+      // workspace-scoped invocations are auto-allowed before risk fallback.
+      // Use a path outside the workspace to test the risk-based fallback.
+      const result = await check("file_read", { path: "/etc/hosts" }, "/tmp");
       expect(result.decision).toBe("allow");
       expect(result.reason).toContain("Low risk");
     });
@@ -1485,7 +1493,8 @@ describe("Permission Checker", () => {
 
     test("file_write of non-workspace file is not auto-allowed", async () => {
       const otherPath = join(checkerTestDir, "workspace", "OTHER.md");
-      const result = await check("file_write", { path: otherPath }, "/tmp");
+      // Use a workingDir that doesn't contain the path so it's not workspace-scoped
+      const result = await check("file_write", { path: otherPath }, "/home");
       // Medium risk with no matching allow rule → prompt
       expect(result.decision).toBe("prompt");
     });
@@ -4453,6 +4462,8 @@ describe("scope matching behavior", () => {
   });
 
   test("project-scoped rule does NOT match invocations from sibling directory", async () => {
+    // Use strict mode to test rule-matching isolation without workspace auto-allow
+    testConfig.permissions.mode = "strict";
     const projectDir = "/home/user/my-project";
     // Use a broad pattern that matches any file, scoped to the project
     addRule("file_write", "file_write:*", projectDir);
@@ -4467,6 +4478,8 @@ describe("scope matching behavior", () => {
   });
 
   test("project-scoped rule does NOT match invocations from parent directory", async () => {
+    // Use strict mode to test rule-matching isolation without workspace auto-allow
+    testConfig.permissions.mode = "strict";
     const projectDir = "/home/user/my-project";
     addRule("file_write", "file_write:*", projectDir);
 
@@ -4480,6 +4493,8 @@ describe("scope matching behavior", () => {
   });
 
   test("project-scoped rule does NOT match directory with shared prefix", async () => {
+    // Use strict mode to test rule-matching isolation without workspace auto-allow
+    testConfig.permissions.mode = "strict";
     // A rule for /home/user/project should NOT match /home/user/project-evil
     // (directory-boundary enforcement in matchesScope)
     const projectDir = "/home/user/project";

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -788,7 +788,12 @@ export async function check(
 
   // Workspace mode: auto-allow workspace-scoped operations that don't have
   // an explicit rule. Non-workspace operations fall through to risk-based policy.
-  if (permissionsMode === "workspace" && !matchedRule) {
+  // High-risk operations always require approval regardless of scope.
+  if (
+    permissionsMode === "workspace" &&
+    !matchedRule &&
+    risk !== RiskLevel.High
+  ) {
     // When sandbox is disabled, bash runs on the host — don't auto-allow
     const sandboxEnabled = getConfig().sandbox.enabled;
     if (toolName === "bash" && !sandboxEnabled) {


### PR DESCRIPTION
## Summary
- Fix bug where workspace mode auto-allowed High-risk operations (e.g., writing to skill directories) by adding `risk !== RiskLevel.High` guard
- Update test expectations broken by the legacy→workspace mode migration: tests that check rule-matching isolation now use strict mode, and tests for risk-based fallback use paths outside the workspace root

## Original prompt
Fix these tests: https://github.com/vellum-ai/vellum-assistant/actions/runs/22704758747/job/65829367995

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
