### PR TITLE
fix: resolve managed-proxy test non-hermiticity

### DIFF
--- a/assistant/src/__tests__/managed-proxy-context.test.ts
+++ b/assistant/src/__tests__/managed-proxy-context.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // Mock logger to suppress output
-mock.module("../../util/logger.js", () => ({
+mock.module("../util/logger.js", () => ({
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
@@ -12,11 +12,11 @@ mock.module("../../util/logger.js", () => ({
 let mockPlatformBaseUrl = "";
 let mockAssistantApiKey: string | null = null;
 
-mock.module("../../config/env.js", () => ({
+mock.module("../config/env.js", () => ({
   getPlatformBaseUrl: () => mockPlatformBaseUrl,
 }));
 
-mock.module("../../security/secure-keys.js", () => ({
+mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (key: string) => {
     if (key === "credential:vellum:assistant_api_key") {
       return mockAssistantApiKey;
@@ -30,7 +30,7 @@ import {
   hasManagedProxyPrereqs,
   managedFallbackEnabledFor,
   resolveManagedProxyContext,
-} from "./context.js";
+} from "../providers/managed-proxy/context.js";
 
 describe("resolveManagedProxyContext", () => {
   beforeEach(() => {

--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -3,29 +3,23 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { MANAGED_PROVIDER_META } from "../providers/managed-proxy/constants.js";
 
 // ---------------------------------------------------------------------------
-// Mock managed-proxy context so we can control managed fallback prereqs
+// Mock the underlying dependencies that the real context module relies on.
+// This avoids mocking the context module directly and prevents mock conflicts
+// with context.test.ts (which also mocks these same underlying deps).
 // ---------------------------------------------------------------------------
-let mockManagedEnabled = false;
 let mockPlatformBaseUrl = "";
-let mockAssistantApiKey = "";
+let mockAssistantApiKey: string | null = null;
 
-mock.module("../providers/managed-proxy/context.js", () => ({
-  resolveManagedProxyContext: () => ({
-    enabled: mockManagedEnabled,
-    platformBaseUrl: mockPlatformBaseUrl,
-    assistantApiKey: mockAssistantApiKey,
-  }),
-  hasManagedProxyPrereqs: () => mockManagedEnabled,
-  buildManagedBaseUrl: (provider: string) => {
-    if (!mockManagedEnabled) return undefined;
-    const meta = MANAGED_PROVIDER_META[provider];
-    if (!meta?.managed || !meta.proxyPath) return undefined;
-    return `${mockPlatformBaseUrl}${meta.proxyPath}`;
-  },
-  managedFallbackEnabledFor: (provider: string) => {
-    if (!mockManagedEnabled) return false;
-    const meta = MANAGED_PROVIDER_META[provider];
-    return !!meta?.managed;
+mock.module("../config/env.js", () => ({
+  getPlatformBaseUrl: () => mockPlatformBaseUrl,
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKey: (key: string) => {
+    if (key === "credential:vellum:assistant_api_key") {
+      return mockAssistantApiKey;
+    }
+    return null;
   },
 }));
 
@@ -47,15 +41,13 @@ const MANAGED_PROVIDERS: string[] = [
 ];
 
 function enableManagedProxy() {
-  mockManagedEnabled = true;
   mockPlatformBaseUrl = PLATFORM_BASE;
   mockAssistantApiKey = MANAGED_API_KEY;
 }
 
 function disableManagedProxy() {
-  mockManagedEnabled = false;
   mockPlatformBaseUrl = "";
-  mockAssistantApiKey = "";
+  mockAssistantApiKey = null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Move context.test.ts into src/__tests__/ so it runs in CI
- Refactor integration test to mock underlying deps (env.js, secure-keys.js) instead of the whole context module
- Both test files can now run together without mock contamination

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
