### PR TITLE
fix: remove deprecated sandbox_set IPC contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ bun run src/index.ts daemon start
 - Sandbox-scoped tools: `file_read`, `file_write`, `file_edit`, and `bash`.
 - Explicit host tools: `host_file_read`, `host_file_write`, `host_file_edit`, and `host_bash` (absolute host paths only for host file tools).
 - Host/computer-use prompts: `host_*` and `computer_use_*` (including `computer_use_request_control`) default to `ask` unless allowlisted/denylisted in trust rules.
-- Runtime override removal: CLI `--no-sandbox` is removed; legacy `sandbox_set` IPC messages are accepted but ignored (deprecated no-op).
+- Runtime override removal: CLI `--no-sandbox` is removed; the sandbox mode is always active.
 
 ### Sandbox Backend
 

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -883,7 +883,7 @@ graph LR
         C5["user_message<br/>text, attachments"]
         C6["confirmation_response<br/>decision"]
         C7["cancel / undo"]
-        C8["model_get / model_set<br/>sandbox_set (deprecated no-op)"]
+        C8["model_get / model_set"]
         C9["ping"]
         C10["ipc_blob_probe<br/>probeId, nonceSha256"]
         C11["work_items_list / work_item_get<br/>work_item_create / work_item_update<br/>work_item_complete / work_item_run_task<br/>(planned)"]

--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -145,13 +145,6 @@ exports[`IPC message snapshots ClientMessage types usage_request serializes to e
 }
 `;
 
-exports[`IPC message snapshots ClientMessage types sandbox_set serializes to expected JSON 1`] = `
-{
-  "enabled": true,
-  "type": "sandbox_set",
-}
-`;
-
 exports[`IPC message snapshots ClientMessage types cu_session_create serializes to expected JSON 1`] = `
 {
   "screenHeight": 1080,

--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -52,7 +52,6 @@ class MockSession {
     | { skipPreMessageRollback?: boolean; isInteractive?: boolean }
     | undefined;
   public updateClientHistory: Array<{ hasNoClient: boolean }> = [];
-  public setSandboxOverrideCalls = 0;
   private stale = false;
   private processing = false;
   public trustContext: Record<string, unknown> | null = null;
@@ -95,9 +94,7 @@ class MockSession {
     return this._currentSender;
   }
 
-  setSandboxOverride(): void {
-    this.setSandboxOverrideCalls += 1;
-  }
+  setSandboxOverride(): void {}
 
   isProcessing(): boolean {
     return this.processing;
@@ -431,21 +428,6 @@ describe("DaemonServer initial session hydration", () => {
     await internal.sendInitialSession(socket);
 
     expect(lastCreatedWorkingDir).toBe("/tmp/workspace");
-  });
-
-  test("ignores deprecated sandbox_set runtime override messages", async () => {
-    const server = new DaemonServer();
-    const internal = asDaemonServerTestAccess(server);
-    const { socket } = createFakeSocket();
-
-    await internal.sendInitialSession(socket);
-    const session = internal.sessions.get(conversation.id);
-    expect(session).toBeDefined();
-    expect(session!.setSandboxOverrideCalls).toBe(0);
-
-    internal.dispatchMessage({ type: "sandbox_set", enabled: false }, socket);
-
-    expect(session!.setSandboxOverrideCalls).toBe(0);
   });
 
   test("sendInitialSession includes threadType in session_info", async () => {

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -101,10 +101,6 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     type: "usage_request",
     sessionId: "sess-001",
   },
-  sandbox_set: {
-    type: "sandbox_set",
-    enabled: true,
-  },
   cu_session_create: {
     type: "cu_session_create",
     sessionId: "cu-sess-001",

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -60,7 +60,6 @@ import type {
   MessageContentRequest,
   RegenerateRequest,
   ReorderThreadsRequest,
-  SandboxSetRequest,
   SecretResponse,
   ServerMessage,
   SessionCreateRequest,
@@ -1823,17 +1822,6 @@ export function handleUsageRequest(
   });
 }
 
-export function handleSandboxSet(
-  msg: SandboxSetRequest,
-  _socket: net.Socket,
-  _ctx: HandlerContext,
-): void {
-  log.warn(
-    { enabled: msg.enabled },
-    "Received deprecated sandbox_set message. Runtime sandbox overrides are ignored.",
-  );
-}
-
 export function handleDeleteQueuedMessage(
   msg: DeleteQueuedMessage,
   socket: net.Socket,
@@ -1999,7 +1987,6 @@ export const sessionHandlers = defineHandlers({
   undo: handleUndo,
   regenerate: handleRegenerate,
   usage_request: handleUsageRequest,
-  sandbox_set: handleSandboxSet,
   conversation_search: handleConversationSearch,
   reorder_threads: handleReorderThreads,
 });

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -123,7 +123,6 @@
     "reorder_threads",
     "ride_shotgun_start",
     "ride_shotgun_stop",
-    "sandbox_set",
     "schedule_remove",
     "schedule_run_now",
     "schedule_toggle",

--- a/assistant/src/daemon/ipc-contract/sessions.ts
+++ b/assistant/src/daemon/ipc-contract/sessions.ts
@@ -141,11 +141,6 @@ export interface UsageRequest {
   sessionId: string;
 }
 
-export interface SandboxSetRequest {
-  type: "sandbox_set";
-  enabled: boolean;
-}
-
 export interface SessionsClearRequest {
   type: "sessions_clear";
 }
@@ -421,7 +416,6 @@ export type _SessionsClientMessages =
   | UndoRequest
   | RegenerateRequest
   | UsageRequest
-  | SandboxSetRequest
   | SessionListRequest
   | SessionCreateRequest
   | SessionSwitchRequest

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -3455,16 +3455,6 @@ public struct IPCRideShotgunStop: Codable, Sendable {
     }
 }
 
-public struct IPCSandboxSetRequest: Codable, Sendable {
-    public let type: String
-    public let enabled: Bool
-
-    public init(type: String, enabled: Bool) {
-        self.type = type
-        self.enabled = enabled
-    }
-}
-
 public struct IPCScheduleRemove: Codable, Sendable {
     public let type: String
     public let id: String


### PR DESCRIPTION
## Summary
- Remove the deprecated `sandbox_set` IPC message type, handler, contract entry, and all tests
- Clean up references in README.md and ARCHITECTURE.md

Part of plan: code-smell-remediation.md (PR 1 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
