### PR TITLE
fix: make sendMessageDeps required, remove legacy processMessage deps

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -424,22 +424,6 @@ export async function runDaemon(): Promise<void> {
           sourceChannel,
           sourceInterface,
         ),
-      persistAndProcessMessage: (
-        conversationId,
-        content,
-        attachmentIds,
-        options,
-        sourceChannel,
-        sourceInterface,
-      ) =>
-        server.persistAndProcessMessage(
-          conversationId,
-          content,
-          attachmentIds,
-          options,
-          sourceChannel,
-          sourceInterface,
-        ),
       interfacesDir: getInterfacesDir(),
       approvalCopyGenerator: createApprovalCopyGenerator(),
       approvalConversationGenerator: createApprovalConversationGenerator(),

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -229,7 +229,6 @@ export type {
   GuardianActionCopyGenerator,
   GuardianFollowUpConversationGenerator,
   MessageProcessor,
-  NonBlockingMessageProcessor,
   RuntimeAttachmentMetadata,
   RuntimeHttpServerOptions,
   RuntimeMessageSessionOptions,
@@ -242,7 +241,6 @@ import type {
   GuardianActionCopyGenerator,
   GuardianFollowUpConversationGenerator,
   MessageProcessor,
-  NonBlockingMessageProcessor,
   RuntimeHttpServerOptions,
   SendMessageDeps,
 } from "./http-types.js";
@@ -262,7 +260,6 @@ export class RuntimeHttpServer {
   /** Legacy shared secret for pairing routes (not used for delivery or auth). */
   private bearerToken: string | undefined;
   private processMessage?: MessageProcessor;
-  private persistAndProcessMessage?: NonBlockingMessageProcessor;
   private approvalCopyGenerator?: ApprovalCopyGenerator;
   private approvalConversationGenerator?: ApprovalConversationGenerator;
   private guardianActionCopyGenerator?: GuardianActionCopyGenerator;
@@ -291,7 +288,6 @@ export class RuntimeHttpServer {
     this.hostname = options.hostname ?? DEFAULT_HOSTNAME;
     this.bearerToken = options.bearerToken;
     this.processMessage = options.processMessage;
-    this.persistAndProcessMessage = options.persistAndProcessMessage;
     this.approvalCopyGenerator = options.approvalCopyGenerator;
     this.approvalConversationGenerator = options.approvalConversationGenerator;
     this.guardianActionCopyGenerator = options.guardianActionCopyGenerator;
@@ -996,9 +992,7 @@ export class RuntimeHttpServer {
           handleSendMessage(
             req,
             {
-              processMessage: this.processMessage,
-              persistAndProcessMessage: this.persistAndProcessMessage,
-              sendMessageDeps: this.sendMessageDeps,
+              sendMessageDeps: this.sendMessageDeps!,
               approvalConversationGenerator: this.approvalConversationGenerator,
             },
             authContext,

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -133,20 +133,6 @@ export type MessageProcessor = (
 ) => Promise<{ messageId: string }>;
 
 /**
- * Non-blocking message processor that persists the user message and
- * starts the agent loop in the background, returning the messageId
- * immediately.
- */
-export type NonBlockingMessageProcessor = (
-  conversationId: string,
-  content: string,
-  attachmentIds?: string[],
-  options?: RuntimeMessageSessionOptions,
-  sourceChannel?: ChannelId,
-  sourceInterface?: InterfaceId,
-) => Promise<{ messageId: string }>;
-
-/**
  * Dependencies for the POST /v1/messages handler.
  *
  * The handler needs direct access to the session so it can check busy state,
@@ -171,8 +157,6 @@ export interface RuntimeHttpServerOptions {
   /** Legacy shared secret for pairing routes (not used for delivery or auth). */
   bearerToken?: string;
   processMessage?: MessageProcessor;
-  /** Non-blocking processor for POST /messages (persists + fires agent loop). */
-  persistAndProcessMessage?: NonBlockingMessageProcessor;
   /** Root directory for interface files on disk. */
   interfacesDir?: string;
   /** Daemon-injected generator for approval copy (provider-backed). */

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -41,8 +41,6 @@ import { routeGuardianReply } from "../guardian-reply-router.js";
 import { httpError } from "../http-errors.js";
 import type {
   ApprovalConversationGenerator,
-  MessageProcessor,
-  NonBlockingMessageProcessor,
   RuntimeAttachmentMetadata,
   RuntimeMessagePayload,
   SendMessageDeps,
@@ -453,9 +451,7 @@ function makeHubPublisher(
 export async function handleSendMessage(
   req: Request,
   deps: {
-    processMessage?: MessageProcessor;
-    persistAndProcessMessage?: NonBlockingMessageProcessor;
-    sendMessageDeps?: SendMessageDeps;
+    sendMessageDeps: SendMessageDeps;
     approvalConversationGenerator?: ApprovalConversationGenerator;
   },
   authContext: AuthContext,
@@ -535,9 +531,7 @@ export async function handleSendMessage(
 
   const mapping = getOrCreateConversation(conversationKey);
 
-  // Always wired in production (constructed in lifecycle.ts); type will be
-  // tightened to non-optional in a follow-up.
-  const smDeps = deps.sendMessageDeps!;
+  const smDeps = deps.sendMessageDeps;
   const session = await smDeps.getOrCreateSession(mapping.conversationId);
 
   // Resolve guardian context from the AuthContext's actorPrincipalId.


### PR DESCRIPTION
## Summary
- Make `sendMessageDeps` required in HandleSendMessageDeps (was optional with non-null assertion)
- Remove `processMessage` and `persistAndProcessMessage` from deps type and all wiring

Part of plan: dead-code-cleanup.md (PR 11b of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
