### PR TITLE
refactor: migrate Amazon session to shared cookie-session primitive

### DIFF
--- a/assistant/src/amazon/session.ts
+++ b/assistant/src/amazon/session.ts
@@ -1,110 +1,49 @@
 /**
  * Amazon session persistence.
- * Stores/loads auth cookies from a recording or manual login.
+ * Delegates cookie CRUD to the shared cookie-session primitive;
+ * keeps Amazon-specific cookie validation and CSRF extraction.
  */
 
 import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
-import { join } from "node:path";
+  type CookieSession,
+  createSessionStore,
+  importFromRecordingBase,
+} from "../util/cookie-session.js";
 
-import type {
-  ExtractedCredential,
-  SessionRecording,
-} from "../tools/browser/network-recording-types.js";
-import { getDataDir } from "../util/platform.js";
+export type AmazonSession = CookieSession;
 
-export interface AmazonSession {
-  cookies: ExtractedCredential[];
-  importedAt: string;
-  recordingId?: string;
-}
+const store = createSessionStore("amazon");
 
-function getSessionDir(): string {
-  return join(getDataDir(), "amazon");
-}
-
-function getSessionPath(): string {
-  return join(getSessionDir(), "session.json");
-}
-
-export function loadSession(): AmazonSession | null {
-  const path = getSessionPath();
-  if (!existsSync(path)) return null;
-  try {
-    return JSON.parse(readFileSync(path, "utf-8")) as AmazonSession;
-  } catch {
-    return null;
-  }
-}
-
-export function saveSession(session: AmazonSession): void {
-  const dir = getSessionDir();
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  writeFileSync(getSessionPath(), JSON.stringify(session, null, 2));
-}
-
-export function clearSession(): void {
-  const path = getSessionPath();
-  if (existsSync(path)) {
-    unlinkSync(path);
-  }
-}
+export const { loadSession, saveSession, clearSession, getCookieHeader } =
+  store;
 
 /**
  * Import cookies from a Ride Shotgun recording file.
  * Validates that the recording contains Amazon's required auth cookies.
  */
 export function importFromRecording(recordingPath: string): AmazonSession {
-  if (!existsSync(recordingPath)) {
-    throw new Error(`Recording not found: ${recordingPath}`);
-  }
-  const recording = JSON.parse(
-    readFileSync(recordingPath, "utf-8"),
-  ) as SessionRecording;
-  if (!recording.cookies?.length) {
-    throw new Error("Recording contains no cookies");
-  }
-
-  const cookieNames = new Set(recording.cookies.map((c) => c.name));
-
-  if (!cookieNames.has("session-id")) {
-    throw new Error(
-      "Recording is missing required Amazon cookie: session-id. " +
-        "Make sure you are logged in to Amazon.",
-    );
-  }
-  if (!cookieNames.has("ubid-main")) {
-    throw new Error(
-      "Recording is missing required Amazon cookie: ubid-main. " +
-        "Make sure you are logged in to Amazon.",
-    );
-  }
-  if (!cookieNames.has("at-main") && !cookieNames.has("x-main")) {
-    throw new Error(
-      "Recording is missing required Amazon auth cookie (at-main or x-main). " +
-        "Make sure you are fully logged in to Amazon.",
-    );
-  }
-
-  const session: AmazonSession = {
-    cookies: recording.cookies,
-    importedAt: new Date().toISOString(),
-    recordingId: recording.id,
-  };
+  const session = importFromRecordingBase(recordingPath, (cookieNames) => {
+    if (!cookieNames.has("session-id")) {
+      throw new Error(
+        "Recording is missing required Amazon cookie: session-id. " +
+          "Make sure you are logged in to Amazon.",
+      );
+    }
+    if (!cookieNames.has("ubid-main")) {
+      throw new Error(
+        "Recording is missing required Amazon cookie: ubid-main. " +
+          "Make sure you are logged in to Amazon.",
+      );
+    }
+    if (!cookieNames.has("at-main") && !cookieNames.has("x-main")) {
+      throw new Error(
+        "Recording is missing required Amazon auth cookie (at-main or x-main). " +
+          "Make sure you are fully logged in to Amazon.",
+      );
+    }
+  });
   saveSession(session);
   return session;
-}
-
-/**
- * Build a Cookie header string from the session.
- */
-export function getCookieHeader(session: AmazonSession): string {
-  return session.cookies.map((c) => `${c.name}=${c.value}`).join("; ");
 }
 
 /**


### PR DESCRIPTION
## Summary
- Migrate `amazon/session.ts` to use shared `cookie-session.ts` primitive
- Replace duplicated CRUD/cookie-header logic with `createSessionStore("amazon")`
- Keep Amazon-specific cookie validation and CSRF extraction

Part of plan: dead-code-cleanup.md (PR 12b of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
