### PR TITLE
fix: scope bun test command in Development section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ cd assistant && bun install
 # Type-check
 cd assistant && bunx tsc --noEmit
 
-# Run tests
-cd assistant && bun test
+# Run tests (always scope to specific files)
+cd assistant && bun test src/path/to/changed.test.ts
 
 # Lint
 cd assistant && bun run lint


### PR DESCRIPTION
## Summary
- Update the Development section's test command to show file-scoped usage instead of bare `bun test`
- Prevents subagents from running the full 700+ test suite and hanging

## Original prompt
Update Development section test command (line 29-30) in AGENTS.md to scope bun test to specific files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
