### PR TITLE
fix: replace as-any casts in Zod config schemas with typed defaults

### DIFF
--- a/assistant/src/config/agent-schema.ts
+++ b/assistant/src/config/agent-schema.ts
@@ -82,7 +82,7 @@ export const SwarmConfigSchema = z.object({
       coder: z.number().int().positive().optional(),
       reviewer: z.number().int().positive().optional(),
     })
-    .default({} as any),
+    .default({}),
   plannerModelIntent: z
     .enum(["latency-optimized", "quality-optimized", "vision-optimized"], {
       error: "swarm.plannerModelIntent must be a valid model intent",

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -201,7 +201,7 @@ export const AssistantConfigSchema = z
         z.string(),
         z.string({ error: "Each apiKeys value must be a string" }),
       )
-      .default({} as any),
+      .default({} as Record<string, string>),
     webSearchProvider: z
       .enum(VALID_WEB_SEARCH_PROVIDERS, {
         error: `webSearchProvider must be one of: ${VALID_WEB_SEARCH_PROVIDERS.join(
@@ -273,7 +273,7 @@ export const AssistantConfigSchema = z
         z.string(),
         z.boolean({ error: "featureFlags values must be booleans" }),
       )
-      .default({} as any),
+      .default({} as Record<string, boolean>),
     assistantFeatureFlagValues: z
       .record(
         z.string(),


### PR DESCRIPTION
## Summary
- Replace as-any casts in Zod schema defaults with properly typed alternatives
- Fixes 3 instances across schema.ts and agent-schema.ts

Part of plan: code-smell-remediation.md (PR 4 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
