### PR TITLE
docs: add Testing section warning against unscoped bun test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,15 @@ cd assistant && bun test src/path/to/changed.test.ts
 cd assistant && bun run lint
 ```
 
+## Testing
+
+The full test suite is large and will hang or timeout if run unscoped. **Never run `bun test` without specifying file paths.**
+
+- After making changes, run only the tests relevant to what you changed:
+  `cd assistant && bun test src/path/to/file.test.ts`
+- To run tests matching a pattern: `cd assistant && bun test --grep "pattern"`
+- Use `bunx tsc --noEmit` for full-project type-checking instead of running all tests.
+
 ## Keep the README up to date
 
 Whenever you modify, add, or remove a slash command in `.claude/commands/`, you MUST update `README.md` to reflect the change. The README's "Slash Commands" section should always match the current set of commands. Update the TLDR description if the command's purpose changed, add new entries for new commands, and remove entries for deleted commands.


### PR DESCRIPTION
## Summary
- Add a dedicated Testing section to AGENTS.md after the Development section
- Explicitly warns that the full test suite will hang if run without file paths
- Provides examples of scoped test commands and pattern matching

## Original prompt
Add a new Testing section after the Development section in AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
