### PR TITLE
docs: update Conventions to show file-scoped bun test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Bun + TypeScript monorepo with multiple packages:
 
 - **Bun PATH**: Run `export PATH="$HOME/.bun/bin:$PATH"` before any bun/bunx commands.
 - **Imports**: All imports use `.js` extensions (NodeNext module resolution).
-- **Package manager**: Use `bun install` for dependencies, `bun test` for tests, `bunx tsc --noEmit` for type-checking.
+- **Package manager**: Use `bun install` for dependencies, `bun test <file>` for tests (always scope to specific files), `bunx tsc --noEmit` for type-checking.
 - **Install dependencies**: `cd assistant && bun install` (each package has its own `bun.lock`).
 
 ## Development


### PR DESCRIPTION
## Summary
- Update the package manager convention to show `bun test <file>` instead of bare `bun test`
- Reinforces the file-scoping requirement from the new Testing section

## Original prompt
Update Conventions section (line 17) in AGENTS.md to scope bun test to specific files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12839" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
