### PR TITLE
fix: remove stale index.lock in enrichment test helper

### DIFF
--- a/assistant/src/__tests__/commit-message-enrichment-service.test.ts
+++ b/assistant/src/__tests__/commit-message-enrichment-service.test.ts
@@ -86,6 +86,13 @@ describe("CommitEnrichmentService", () => {
   }
 
   async function createCommit(): Promise<string> {
+    // Remove stale index.lock left by async enrichment jobs that ran git
+    // commands concurrently in a previous test. Without this, git add -A
+    // can fail with "Unable to create index.lock: File exists".
+    const lockFile = join(testDir, ".git", "index.lock");
+    if (existsSync(lockFile)) {
+      rmSync(lockFile, { force: true });
+    }
     writeFileSync(join(testDir, `file-${Date.now()}.txt`), "content");
     await gitService.commitChanges("test commit");
     return await gitService.getHeadHash();


### PR DESCRIPTION
## Summary
- Add stale `index.lock` cleanup to the `createCommit()` test helper in `commit-message-enrichment-service.test.ts`
- Prevents flaky CI failures where async enrichment jobs from a previous test leave behind a lock file that causes `git add -A` to fail

## Original prompt
Fix these tests: https://github.com/vellum-ai/vellum-assistant/actions/runs/22705610791

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
