### PR TITLE
refactor: extract shared webhook copy constants to gateway/src/webhook-copy.ts

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -19,6 +19,12 @@ import { downloadTelegramFile } from "../../telegram/download.js";
 import { normalizeTelegramUpdate } from "../../telegram/normalize.js";
 import { sendTelegramReply } from "../../telegram/send.js";
 import { verifyWebhookSecret } from "../../telegram/verify.js";
+import {
+  NEW_COMMAND_ERROR,
+  NEW_COMMAND_SUCCESS,
+  ROUTING_REJECTION_NOTICE,
+  SERVICE_UNAVAILABLE_ERROR,
+} from "../../webhook-copy.js";
 
 const log = getLogger("telegram-webhook");
 
@@ -382,7 +388,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
           );
           if (updateId !== undefined) dedupCache.unreserve(updateId);
           return Response.json(
-            { error: "Service temporarily unavailable" },
+            { error: SERVICE_UNAVAILABLE_ERROR },
             {
               status: 503,
               headers: { "Retry-After": String(err.retryAfterSecs) },
@@ -431,7 +437,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
           sendTelegramReply(
             config,
             normalized.message.conversationExternalId,
-            "\u26a0\ufe0f This message could not be routed to an assistant. Please check your gateway routing configuration.",
+            `\u26a0\ufe0f ${ROUTING_REJECTION_NOTICE}`,
           ).catch((err) => {
             tlog.error(
               { err, chatId: normalized.message.conversationExternalId },
@@ -449,7 +455,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
           sendTelegramReply(
             config,
             normalized.message.conversationExternalId,
-            "Starting a new conversation!",
+            NEW_COMMAND_SUCCESS,
           ).catch((err) => {
             tlog.error({ err }, "Failed to send /new confirmation");
           });
@@ -458,7 +464,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
           sendTelegramReply(
             config,
             normalized.message.conversationExternalId,
-            "Failed to reset conversation. Please try again.",
+            NEW_COMMAND_ERROR,
           ).catch((replyErr) => {
             tlog.error({ err: replyErr }, "Failed to send /new error reply");
           });
@@ -593,7 +599,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
           sendTelegramReply(
             config,
             chatId,
-            "\u26a0\ufe0f This message could not be routed to an assistant. Please check your gateway routing configuration.",
+            `\u26a0\ufe0f ${ROUTING_REJECTION_NOTICE}`,
           ).catch((err) => {
             tlog.error(
               { err, chatId },
@@ -666,7 +672,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
           );
         if (updateId !== undefined) dedupCache.unreserve(updateId);
         return Response.json(
-          { error: "Service temporarily unavailable" },
+          { error: SERVICE_UNAVAILABLE_ERROR },
           {
             status: 503,
             headers: { "Retry-After": String(err.retryAfterSecs) },

--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -17,6 +17,12 @@ import {
 import { sendSmsReply } from "../../twilio/send-sms.js";
 import { validateTwilioWebhookRequest } from "../../twilio/validate-webhook.js";
 import type { GatewayInboundEvent } from "../../types.js";
+import {
+  NEW_COMMAND_ERROR,
+  NEW_COMMAND_SUCCESS,
+  ROUTING_REJECTION_NOTICE,
+  SERVICE_UNAVAILABLE_ERROR,
+} from "../../webhook-copy.js";
 
 const log = getLogger("twilio-sms-webhook");
 
@@ -144,16 +150,14 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
           { from: params.From, reason: routing.reason },
           "Routing rejected /new command",
         );
-        sendSmsReply(
-          config,
-          params.From,
-          "This message could not be routed to an assistant. Please check your gateway routing configuration.",
-        ).catch((err) => {
-          tlog.error(
-            { err, to: params.From },
-            "Failed to send /new routing rejection notice",
-          );
-        });
+        sendSmsReply(config, params.From, ROUTING_REJECTION_NOTICE).catch(
+          (err) => {
+            tlog.error(
+              { err, to: params.From },
+              "Failed to send /new routing rejection notice",
+            );
+          },
+        );
       } else {
         try {
           await resetConversation(
@@ -164,7 +168,7 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
           sendSmsReply(
             config,
             params.From,
-            "Starting a new conversation!",
+            NEW_COMMAND_SUCCESS,
             routing.assistantId,
           ).catch((err) => {
             tlog.error({ err }, "Failed to send /new confirmation");
@@ -174,7 +178,7 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
           sendSmsReply(
             config,
             params.From,
-            "Failed to reset conversation. Please try again.",
+            NEW_COMMAND_ERROR,
             routing.assistantId,
           ).catch((replyErr) => {
             tlog.error({ err: replyErr }, "Failed to send /new error reply");
@@ -192,16 +196,14 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
         "Routing rejected inbound SMS",
       );
       if (rejectionLimiter.shouldSend(params.From)) {
-        sendSmsReply(
-          config,
-          params.From,
-          "This message could not be routed to an assistant. Please check your gateway routing configuration.",
-        ).catch((err) => {
-          tlog.error(
-            { err, to: params.From },
-            "Failed to send routing rejection notice",
-          );
-        });
+        sendSmsReply(config, params.From, ROUTING_REJECTION_NOTICE).catch(
+          (err) => {
+            tlog.error(
+              { err, to: params.From },
+              "Failed to send routing rejection notice",
+            );
+          },
+        );
       }
       dedupCache.mark(messageSid);
       return Response.json({ ok: true });
@@ -221,16 +223,14 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
           "Routing rejected inbound SMS",
         );
         if (rejectionLimiter.shouldSend(params.From)) {
-          sendSmsReply(
-            config,
-            params.From,
-            "This message could not be routed to an assistant. Please check your gateway routing configuration.",
-          ).catch((err) => {
-            tlog.error(
-              { err, to: params.From },
-              "Failed to send routing rejection notice",
-            );
-          });
+          sendSmsReply(config, params.From, ROUTING_REJECTION_NOTICE).catch(
+            (err) => {
+              tlog.error(
+                { err, to: params.From },
+                "Failed to send routing rejection notice",
+              );
+            },
+          );
         }
         dedupCache.mark(messageSid);
         return Response.json({ ok: true });
@@ -256,7 +256,7 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
         );
         dedupCache.unreserve(messageSid);
         return Response.json(
-          { error: "Service temporarily unavailable" },
+          { error: SERVICE_UNAVAILABLE_ERROR },
           {
             status: 503,
             headers: { "Retry-After": String(err.retryAfterSecs) },

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -17,6 +17,12 @@ import { markWhatsAppMessageRead } from "../../whatsapp/api.js";
 import { normalizeWhatsAppWebhook } from "../../whatsapp/normalize.js";
 import { sendWhatsAppReply } from "../../whatsapp/send.js";
 import { verifyWhatsAppWebhookSignature } from "../../whatsapp/verify.js";
+import {
+  NEW_COMMAND_ERROR,
+  NEW_COMMAND_SUCCESS,
+  ROUTING_REJECTION_NOTICE,
+  SERVICE_UNAVAILABLE_ERROR,
+} from "../../webhook-copy.js";
 
 const log = getLogger("whatsapp-webhook");
 
@@ -185,16 +191,14 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
             { from, reason: routing.reason },
             "Routing rejected /new command",
           );
-          sendWhatsAppReply(
-            config,
-            from,
-            "This message could not be routed to an assistant. Please check your gateway routing configuration.",
-          ).catch((err) => {
-            tlog.error(
-              { err, to: from },
-              "Failed to send /new routing rejection notice",
-            );
-          });
+          sendWhatsAppReply(config, from, ROUTING_REJECTION_NOTICE).catch(
+            (err) => {
+              tlog.error(
+                { err, to: from },
+                "Failed to send /new routing rejection notice",
+              );
+            },
+          );
         } else {
           try {
             await resetConversation(
@@ -202,22 +206,21 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
               event.sourceChannel,
               event.message.conversationExternalId,
             );
-            sendWhatsAppReply(
-              config,
-              from,
-              "Starting a new conversation!",
-            ).catch((err) => {
-              tlog.error({ err }, "Failed to send /new confirmation");
-            });
+            sendWhatsAppReply(config, from, NEW_COMMAND_SUCCESS).catch(
+              (err) => {
+                tlog.error({ err }, "Failed to send /new confirmation");
+              },
+            );
           } catch (err) {
             tlog.error({ err }, "Failed to reset conversation");
-            sendWhatsAppReply(
-              config,
-              from,
-              "Failed to reset conversation. Please try again.",
-            ).catch((replyErr) => {
-              tlog.error({ err: replyErr }, "Failed to send /new error reply");
-            });
+            sendWhatsAppReply(config, from, NEW_COMMAND_ERROR).catch(
+              (replyErr) => {
+                tlog.error(
+                  { err: replyErr },
+                  "Failed to send /new error reply",
+                );
+              },
+            );
           }
         }
 
@@ -231,16 +234,14 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
           "Routing rejected inbound WhatsApp message",
         );
         if (rejectionLimiter.shouldSend(from)) {
-          sendWhatsAppReply(
-            config,
-            from,
-            "This message could not be routed to an assistant. Please check your gateway routing configuration.",
-          ).catch((err) => {
-            tlog.error(
-              { err, to: from },
-              "Failed to send routing rejection notice",
-            );
-          });
+          sendWhatsAppReply(config, from, ROUTING_REJECTION_NOTICE).catch(
+            (err) => {
+              tlog.error(
+                { err, to: from },
+                "Failed to send routing rejection notice",
+              );
+            },
+          );
         }
         dedupCache.mark(whatsappMessageId);
         continue;
@@ -260,16 +261,14 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
             "Routing rejected inbound WhatsApp message",
           );
           if (rejectionLimiter.shouldSend(from)) {
-            sendWhatsAppReply(
-              config,
-              from,
-              "This message could not be routed to an assistant. Please check your gateway routing configuration.",
-            ).catch((err) => {
-              tlog.error(
-                { err, to: from },
-                "Failed to send routing rejection notice",
-              );
-            });
+            sendWhatsAppReply(config, from, ROUTING_REJECTION_NOTICE).catch(
+              (err) => {
+                tlog.error(
+                  { err, to: from },
+                  "Failed to send routing rejection notice",
+                );
+              },
+            );
           }
           dedupCache.mark(whatsappMessageId);
           continue;
@@ -298,7 +297,7 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
           );
           dedupCache.unreserve(whatsappMessageId);
           return Response.json(
-            { error: "Service temporarily unavailable" },
+            { error: SERVICE_UNAVAILABLE_ERROR },
             {
               status: 503,
               headers: { "Retry-After": String(err.retryAfterSecs) },

--- a/gateway/src/webhook-copy.ts
+++ b/gateway/src/webhook-copy.ts
@@ -1,0 +1,9 @@
+export const ROUTING_REJECTION_NOTICE =
+  "This message could not be routed to an assistant. Please check your gateway routing configuration.";
+
+export const NEW_COMMAND_SUCCESS = "Starting a new conversation!";
+
+export const NEW_COMMAND_ERROR =
+  "Failed to reset conversation. Please try again.";
+
+export const SERVICE_UNAVAILABLE_ERROR = "Service temporarily unavailable";


### PR DESCRIPTION
## Summary
- Extract duplicated string constants (routing rejection, /new command success/error, service unavailable) from twilio-sms-webhook.ts, telegram-webhook.ts, and whatsapp-webhook.ts into a shared gateway/src/webhook-copy.ts module
- All three webhook handlers now import and use the shared constants instead of inline strings

Part of plan: code-quality-backlog.md (PR 1 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
