### PR TITLE
test: add guard test ensuring gateway routes and OpenAPI schema stay in sync

### DIFF
--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -1,0 +1,214 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { buildSchema } from "../schema.js";
+
+/**
+ * Extracts route paths from the gateway index.ts source code.
+ *
+ * Routes are defined in two places:
+ * 1. The `routes` array (RouteDefinition[]) — matched by the router
+ * 2. Pre-router paths in the `fetch()` handler (healthz, readyz, schema, WS upgrades)
+ *
+ * We parse the source text rather than importing index.ts because it calls
+ * `main()` at module scope which starts the server.
+ */
+function extractRoutePathsFromSource(): string[] {
+  const src = readFileSync(
+    join(import.meta.dirname!, "..", "index.ts"),
+    "utf-8",
+  );
+
+  const paths = new Set<string>();
+
+  // Match string literal paths: `path: "/some/path"`
+  const stringPathRe = /path:\s*"([^"]+)"/g;
+  for (const m of src.matchAll(stringPathRe)) {
+    paths.add(m[1]);
+  }
+
+  // Match regex paths and convert to OpenAPI-style parameterized paths.
+  // Pattern: `path: /^\/v1\/contacts\/([^/]+)$/`
+  const regexPathRe = /path:\s*\/\^(.*?)\$\//g;
+  for (const m of src.matchAll(regexPathRe)) {
+    const converted = regexToOpenApiPath(m[1]);
+    if (converted) paths.add(converted);
+  }
+
+  // Pre-router paths matched via `url.pathname === "/..."` in the fetch handler
+  const preRouterRe = /url\.pathname\s*===\s*"([^"]+)"/g;
+  for (const m of src.matchAll(preRouterRe)) {
+    paths.add(m[1]);
+  }
+
+  return [...paths].sort();
+}
+
+/**
+ * Converts an escaped regex path to an OpenAPI-style path.
+ * e.g. `\/v1\/contacts\/([^/]+)` → `/v1/contacts/{id}`
+ *
+ * Each capture group `([^/]+)` is replaced with `{paramN}` where N is the
+ * 1-based index of the group.
+ */
+function regexToOpenApiPath(escaped: string): string | null {
+  // Unescape forward slashes
+  let path = escaped.replace(/\\\//g, "/");
+
+  // Replace capture groups with numbered params.
+  // Handles both `([^/]+)` (single segment) and `(.+)` (greedy) patterns.
+  let paramIndex = 0;
+  path = path.replace(/\(\[\^\/\]\+\)|\(\.\+\)/g, () => {
+    paramIndex++;
+    return `{param${paramIndex}}`;
+  });
+
+  // If there are remaining regex constructs we can't convert, skip
+  if (/[\\()\[\].*+?{}|^$]/.test(path.replace(/\{param\d+\}/g, ""))) {
+    return null;
+  }
+
+  return path;
+}
+
+// ── Routes that are intentionally undocumented in the OpenAPI schema ──
+// Each entry must have a comment explaining why it's excluded.
+const EXCLUDED_FROM_SCHEMA = new Set([
+  // Internal-only route, not reachable from the public internet
+  "/internal/telegram/reconcile",
+
+  // Duplicate webhook paths for Twilio call routing — the canonical
+  // paths under /webhooks/ are documented instead
+  "/v1/calls/twilio/voice-webhook",
+  "/v1/calls/twilio/status",
+  "/v1/calls/twilio/connect-action",
+  "/v1/calls/relay",
+
+  // Browser relay WebSocket upgrade — handled pre-router, not a REST endpoint
+  "/v1/browser-relay",
+
+  // Runtime proxy catch-all — documented as /{path} in the schema
+  "catch-all",
+]);
+
+// ── Schema paths that don't map to a discrete route definition ──
+// These are documented in the schema but correspond to pre-router logic
+// or catch-all behavior rather than an explicit route table entry.
+const SCHEMA_ONLY_PATHS = new Set([
+  // Served by the catch-all runtime proxy, not a dedicated route
+  "/{path}",
+]);
+
+describe("route-schema sync guard", () => {
+  const schema = buildSchema() as { paths: Record<string, unknown> };
+  const schemaPaths = new Set(Object.keys(schema.paths));
+  const routePaths = extractRoutePathsFromSource();
+
+  test("every route path should have a corresponding schema entry", () => {
+    const missing: string[] = [];
+
+    for (const routePath of routePaths) {
+      if (EXCLUDED_FROM_SCHEMA.has(routePath)) continue;
+
+      // The catch-all regex `/^\//` matches everything — it maps to /{path} in the schema
+      if (routePath === "/") continue;
+
+      // Normalize regex-extracted parameterized paths to match schema naming.
+      // Route regexes use positional params ({param1}, {param2}) while the
+      // schema uses semantic names. We check if any schema path matches
+      // structurally (same segments, params in same positions).
+      const matched = findMatchingSchemaPath(routePath, schemaPaths);
+      if (!matched) {
+        missing.push(routePath);
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+
+  test("every schema path should have a corresponding route", () => {
+    const orphaned: string[] = [];
+
+    for (const schemaPath of schemaPaths) {
+      if (SCHEMA_ONLY_PATHS.has(schemaPath)) continue;
+
+      const matched = findMatchingRoutePath(schemaPath, routePaths);
+      if (!matched) {
+        orphaned.push(schemaPath);
+      }
+    }
+
+    expect(orphaned).toEqual([]);
+  });
+
+  test("excluded routes list contains only paths that actually exist", () => {
+    // Catch-all is a special synthetic entry
+    const actualPaths = new Set(routePaths);
+    const stale = [...EXCLUDED_FROM_SCHEMA].filter(
+      (p) => p !== "catch-all" && !actualPaths.has(p),
+    );
+
+    expect(stale).toEqual([]);
+  });
+});
+
+/**
+ * Checks if a route path (possibly with {paramN} placeholders) matches
+ * any schema path (with semantic parameter names like {contactId}).
+ *
+ * Two paths match if they have the same number of segments and every
+ * non-parameter segment is identical.
+ */
+function findMatchingSchemaPath(
+  routePath: string,
+  schemaPaths: Set<string>,
+): boolean {
+  // Direct match
+  if (schemaPaths.has(routePath)) return true;
+
+  const routeSegments = routePath.split("/");
+
+  for (const schemaPath of schemaPaths) {
+    const schemaSegments = schemaPath.split("/");
+    if (routeSegments.length !== schemaSegments.length) continue;
+
+    const matches = routeSegments.every((seg, i) => {
+      if (seg === schemaSegments[i]) return true;
+      // Both are parameters
+      if (seg.startsWith("{") && schemaSegments[i].startsWith("{")) return true;
+      return false;
+    });
+
+    if (matches) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Checks if a schema path matches any route path, accounting for
+ * parameterized segments.
+ */
+function findMatchingRoutePath(
+  schemaPath: string,
+  routePaths: string[],
+): boolean {
+  if (routePaths.includes(schemaPath)) return true;
+
+  const schemaSegments = schemaPath.split("/");
+
+  for (const routePath of routePaths) {
+    const routeSegments = routePath.split("/");
+    if (schemaSegments.length !== routeSegments.length) continue;
+
+    const matches = schemaSegments.every((seg, i) => {
+      if (seg === routeSegments[i]) return true;
+      if (seg.startsWith("{") && routeSegments[i].startsWith("{")) return true;
+      return false;
+    });
+
+    if (matches) return true;
+  }
+
+  return false;
+}

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -116,6 +116,70 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/brain-graph": {
+        get: {
+          summary: "Brain graph data",
+          description:
+            "Authenticated gateway endpoint that retrieves the brain graph data structure from the assistant runtime.",
+          operationId: "brainGraph",
+          security: [{ BearerAuth: [] }],
+          responses: {
+            "200": { description: "Brain graph data returned" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/brain-graph-ui": {
+        get: {
+          summary: "Brain graph UI",
+          description:
+            "Authenticated gateway endpoint that serves the brain graph visualization UI from the assistant runtime.",
+          operationId: "brainGraphUI",
+          security: [{ BearerAuth: [] }],
+          responses: {
+            "200": {
+              description: "Brain graph UI HTML returned",
+              content: {
+                "text/html": { schema: { type: "string" } },
+              },
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/home-base-ui": {
+        get: {
+          summary: "Home base UI",
+          description:
+            "Authenticated gateway endpoint that serves the home base dashboard UI from the assistant runtime.",
+          operationId: "homeBaseUI",
+          security: [{ BearerAuth: [] }],
+          responses: {
+            "200": {
+              description: "Home base UI HTML returned",
+              content: {
+                "text/html": { schema: { type: "string" } },
+              },
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
       "/webhooks/telegram": {
         post: {
           summary: "Telegram webhook",
@@ -794,6 +858,68 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/pairing/register": {
+        post: {
+          summary: "Register pairing code",
+          description:
+            "Authenticated gateway endpoint that registers a new pairing code for device linking via the assistant runtime.",
+          operationId: "pairingRegister",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Pairing code registered" },
+            "400": { description: "Invalid request payload" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "502": { description: "Failed to reach assistant runtime" },
+          },
+        },
+      },
+      "/pairing/request": {
+        post: {
+          summary: "Request pairing",
+          description:
+            "Initiates a pairing request using a pairing code. Auth failures are tracked for rate limiting.",
+          operationId: "pairingRequest",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Pairing request accepted" },
+            "400": { description: "Invalid request payload" },
+            "401": { description: "Unauthorized" },
+            "403": { description: "Pairing code expired or invalid" },
+            "502": { description: "Failed to reach assistant runtime" },
+          },
+        },
+      },
+      "/pairing/status": {
+        get: {
+          summary: "Check pairing status",
+          description:
+            "Checks the current status of a pairing request. Auth failures are tracked for rate limiting.",
+          operationId: "pairingStatus",
+          responses: {
+            "200": { description: "Pairing status returned" },
+            "401": { description: "Unauthorized" },
+            "403": { description: "Pairing session not found" },
+            "502": { description: "Failed to reach assistant runtime" },
+          },
+        },
+      },
       "/v1/integrations/telegram/config": {
         get: {
           summary: "Get Telegram integration config",
@@ -1045,6 +1171,50 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/contacts/{contactId}/channels/{channelId}/verify": {
+        post: {
+          summary: "Verify a contact channel",
+          description:
+            "Authenticated gateway endpoint that initiates or completes verification of a contact's communication channel via the assistant runtime.",
+          operationId: "contactsChannelVerify",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "contactId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+            {
+              name: "channelId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Channel verification initiated or completed",
+            },
+            "400": { description: "Invalid request payload" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "404": { description: "Contact or channel not found" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
       "/v1/contacts/invites": {
         get: {
           summary: "List contacts invites",
@@ -1277,6 +1447,82 @@ export function buildSchema(): Record<string, unknown> {
             "503": { description: "Bearer token not configured" },
             "502": { description: "Failed to reach assistant runtime" },
             "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/integrations/guardian/vellum/bootstrap": {
+        post: {
+          summary: "Bootstrap Vellum guardian",
+          description:
+            "Authenticated gateway endpoint that bootstraps the Vellum guardian identity and binds it to the assistant runtime.",
+          operationId: "guardianVellumBootstrap",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Guardian bootstrapped" },
+            "400": { description: "Invalid request payload" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/integrations/guardian/revoke": {
+        post: {
+          summary: "Revoke guardian binding",
+          description:
+            "Authenticated gateway endpoint that revokes an existing guardian binding via the assistant runtime.",
+          operationId: "guardianRevoke",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Guardian binding revoked" },
+            "400": { description: "Invalid request payload" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/integrations/guardian/vellum/refresh": {
+        post: {
+          summary: "Refresh guardian access token",
+          description:
+            "Refreshes an expired guardian access token. Accepts expired JWTs (signature, audience, and policy epoch are still verified — only the expiration check is relaxed).",
+          operationId: "guardianVellumRefresh",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "New access token returned" },
+            "401": { description: "Unauthorized — invalid token" },
+            "502": { description: "Failed to reach assistant runtime" },
           },
         },
       },
@@ -1640,6 +1886,56 @@ export function buildSchema(): Record<string, unknown> {
             "503": { description: "Bearer token not configured" },
             "502": { description: "Failed to reach assistant runtime" },
             "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/feature-flags": {
+        get: {
+          summary: "List feature flags",
+          description:
+            "Scope-protected gateway endpoint that lists current feature flag values. Requires a bearer token with `feature_flags.read` scope.",
+          operationId: "featureFlagsGet",
+          security: [{ BearerAuth: [] }],
+          responses: {
+            "200": { description: "Feature flags returned" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "403": { description: "Insufficient scope" },
+          },
+        },
+      },
+      "/v1/feature-flags/{flagKey}": {
+        patch: {
+          summary: "Update a feature flag",
+          description:
+            "Scope-protected gateway endpoint that updates a single feature flag value. Requires a bearer token with `feature_flags.write` scope.",
+          operationId: "featureFlagsPatch",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "flagKey",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+              description: "The feature flag key to update.",
+            },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Feature flag updated" },
+            "400": { description: "Invalid flag key encoding" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "403": { description: "Insufficient scope" },
           },
         },
       },


### PR DESCRIPTION
## Summary
- Add a guard test that validates every gateway route has a corresponding OpenAPI schema entry and vice versa
- Prevents route/schema drift by failing CI when routes are added without documentation or schema entries reference non-existent routes
- Internal routes are explicitly excluded via an allowlist
- Fix existing drift: add missing schema entries for pairing, brain graph, home base UI, guardian bootstrap/revoke/refresh, contacts channel verify, and feature flags routes

Part of plan: code-quality-backlog.md (PR 4 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
