### PR TITLE
refactor: add route definition array exports to runtime route modules

### DIFF
--- a/assistant/src/runtime/routes/app-routes.ts
+++ b/assistant/src/runtime/routes/app-routes.ts
@@ -12,6 +12,7 @@ import { getApp } from "../../memory/app-store.js";
 import * as sharedAppLinksStore from "../../memory/shared-app-links-store.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 
 const log = getLogger("runtime-http");
 
@@ -198,4 +199,36 @@ export function handleDeleteSharedApp(shareToken: string): Response {
     return httpError("NOT_FOUND", "Shared app not found", 404);
   }
   return Response.json({ success: true });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function appRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "apps/share",
+      method: "POST",
+      handler: async ({ req }) => handleShareApp(req),
+    },
+    {
+      endpoint: "apps/shared/:token/metadata",
+      method: "GET",
+      policyKey: "apps/shared/metadata",
+      handler: ({ params }) => handleGetSharedAppMetadata(params.token),
+    },
+    {
+      endpoint: "apps/shared/:token",
+      method: "GET",
+      policyKey: "apps/shared",
+      handler: ({ params }) => handleDownloadSharedApp(params.token),
+    },
+    {
+      endpoint: "apps/shared/:token",
+      method: "DELETE",
+      policyKey: "apps/shared",
+      handler: ({ params }) => handleDeleteSharedApp(params.token),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -16,6 +16,7 @@ import { getLogger } from "../../util/logger.js";
 import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
 import type { AuthContext } from "../auth/types.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 import * as pendingInteractions from "../pending-interactions.js";
 
 const log = getLogger("approval-routes");
@@ -316,4 +317,35 @@ export function handleListPendingInteractions(
         }
       : null,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function approvalRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "confirm",
+      method: "POST",
+      handler: async ({ req, authContext }) => handleConfirm(req, authContext),
+    },
+    {
+      endpoint: "secret",
+      method: "POST",
+      handler: async ({ req, authContext }) => handleSecret(req, authContext),
+    },
+    {
+      endpoint: "trust-rules",
+      method: "POST",
+      handler: async ({ req, authContext }) =>
+        handleTrustRule(req, authContext),
+    },
+    {
+      endpoint: "pending-interactions",
+      method: "GET",
+      handler: ({ url, authContext }) =>
+        handleListPendingInteractions(url, authContext),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -10,6 +10,7 @@ import {
   validateAttachmentUpload,
 } from "../../memory/attachments-store.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 
 /** 30 MB — base64-encoded 20 MB attachment ≈ 27 MB plus JSON wrapper overhead. */
 const MAX_UPLOAD_BODY_BYTES = 30 * 1024 * 1024;
@@ -219,4 +220,35 @@ export function handleGetAttachmentContent(
       "Accept-Ranges": "bytes",
     },
   });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function attachmentRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "attachments",
+      method: "POST",
+      handler: async ({ req }) => handleUploadAttachment(req),
+    },
+    {
+      endpoint: "attachments",
+      method: "DELETE",
+      handler: async ({ req }) => handleDeleteAttachment(req),
+    },
+    {
+      endpoint: "attachments/:id/content",
+      method: "GET",
+      policyKey: "attachments/content",
+      handler: ({ req, params }) => handleGetAttachmentContent(params.id, req),
+    },
+    {
+      endpoint: "attachments/:id",
+      method: "GET",
+      policyKey: "attachments",
+      handler: ({ params }) => handleGetAttachment(params.id),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/brain-graph-routes.ts
+++ b/assistant/src/runtime/routes/brain-graph-routes.ts
@@ -17,6 +17,7 @@ import {
   memoryItems,
 } from "../../memory/schema.js";
 import { resolveBundledDir } from "../../util/bundled-asset.js";
+import type { RouteDefinition } from "../http-router.js";
 
 function getLobeRegion(entityType: string): string {
   switch (entityType) {
@@ -235,4 +236,30 @@ export function handleServeBrainGraphUI(bearerToken?: string): Response {
       { status: 500 },
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function brainGraphRouteDefinitions(deps: {
+  mintUiPageToken: () => string;
+}): RouteDefinition[] {
+  return [
+    {
+      endpoint: "brain-graph",
+      method: "GET",
+      handler: () => handleGetBrainGraph(),
+    },
+    {
+      endpoint: "brain-graph-ui",
+      method: "GET",
+      handler: () => handleServeBrainGraphUI(deps.mintUiPageToken()),
+    },
+    {
+      endpoint: "home-base-ui",
+      method: "GET",
+      handler: () => handleServeHomeBaseUI(deps.mintUiPageToken()),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/call-routes.ts
+++ b/assistant/src/runtime/routes/call-routes.ts
@@ -19,6 +19,7 @@ import { getConfig } from "../../config/loader.js";
 import { VALID_CALLER_IDENTITY_MODES } from "../../config/schema.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { httpError, httpErrorCodeFromStatus } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 
 // ── Idempotency cache ─────────────────────────────────────────────────────────
 // Stores serialized 201 responses keyed by idempotencyKey for 5 minutes so
@@ -274,4 +275,44 @@ export async function handleInstructionCall(
   }
 
   return Response.json({ ok: true });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function callRouteDefinitions(deps: {
+  assistantId: string;
+}): RouteDefinition[] {
+  return [
+    {
+      endpoint: "calls/start",
+      method: "POST",
+      handler: async ({ req }) => handleStartCall(req, deps.assistantId),
+    },
+    {
+      endpoint: "calls/:id/cancel",
+      method: "POST",
+      policyKey: "calls/cancel",
+      handler: async ({ req, params }) => handleCancelCall(req, params.id),
+    },
+    {
+      endpoint: "calls/:id/answer",
+      method: "POST",
+      policyKey: "calls/answer",
+      handler: async ({ req, params }) => handleAnswerCall(req, params.id),
+    },
+    {
+      endpoint: "calls/:id/instruction",
+      method: "POST",
+      policyKey: "calls/instruction",
+      handler: async ({ req, params }) => handleInstructionCall(req, params.id),
+    },
+    {
+      endpoint: "calls/:id",
+      method: "GET",
+      policyKey: "calls",
+      handler: ({ params }) => handleGetCallStatus(params.id),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/channel-readiness-routes.ts
+++ b/assistant/src/runtime/routes/channel-readiness-routes.ts
@@ -7,6 +7,7 @@
 
 import type { ChannelId } from "../../channels/types.js";
 import { getReadinessService } from "../../daemon/handlers/config-channels.js";
+import type { RouteDefinition } from "../http-router.js";
 
 /**
  * GET /v1/channels/readiness
@@ -74,4 +75,23 @@ export async function handleRefreshChannelReadiness(
       remoteChecks: s.remoteChecks,
     })),
   });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function channelReadinessRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "channels/readiness",
+      method: "GET",
+      handler: async ({ url }) => handleGetChannelReadiness(url),
+    },
+    {
+      endpoint: "channels/readiness/refresh",
+      method: "POST",
+      handler: async ({ req }) => handleRefreshChannelReadiness(req),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -7,6 +7,25 @@
  * - channel-delivery-routes.ts — delivery ack, dead letters, reply delivery
  * - channel-guardian-routes.ts — guardian approval interception, expiry sweep
  */
+
+import type { RouteDefinition } from "../http-router.js";
+import type {
+  ApprovalConversationGenerator,
+  ApprovalCopyGenerator,
+  GuardianActionCopyGenerator,
+  GuardianFollowUpConversationGenerator,
+  MessageProcessor,
+} from "../http-types.js";
+import {
+  handleChannelDeliveryAck as _handleChannelDeliveryAck,
+  handleListDeadLetters as _handleListDeadLetters,
+  handleReplayDeadLetters as _handleReplayDeadLetters,
+} from "./channel-delivery-routes.js";
+import {
+  handleChannelInbound as _handleChannelInbound,
+  handleDeleteConversation as _handleDeleteConversation,
+} from "./channel-inbound-routes.js";
+
 export {
   handleChannelDeliveryAck,
   handleListDeadLetters,
@@ -25,3 +44,54 @@ export {
   _setTestPollMaxWait,
   type DenialReason,
 } from "./channel-route-shared.js";
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function channelRouteDefinitions(deps: {
+  assistantId: string;
+  processMessage?: MessageProcessor;
+  approvalCopyGenerator?: ApprovalCopyGenerator;
+  approvalConversationGenerator?: ApprovalConversationGenerator;
+  guardianActionCopyGenerator?: GuardianActionCopyGenerator;
+  guardianFollowUpConversationGenerator?: GuardianFollowUpConversationGenerator;
+}): RouteDefinition[] {
+  return [
+    {
+      endpoint: "channels/conversation",
+      method: "DELETE",
+      handler: async ({ req }) =>
+        _handleDeleteConversation(req, deps.assistantId),
+    },
+    {
+      endpoint: "channels/inbound",
+      method: "POST",
+      handler: async ({ req }) =>
+        _handleChannelInbound(
+          req,
+          deps.processMessage,
+          deps.assistantId,
+          deps.approvalCopyGenerator,
+          deps.approvalConversationGenerator,
+          deps.guardianActionCopyGenerator,
+          deps.guardianFollowUpConversationGenerator,
+        ),
+    },
+    {
+      endpoint: "channels/delivery-ack",
+      method: "POST",
+      handler: async ({ req }) => _handleChannelDeliveryAck(req),
+    },
+    {
+      endpoint: "channels/dead-letters",
+      method: "GET",
+      handler: () => _handleListDeadLetters(),
+    },
+    {
+      endpoint: "channels/replay",
+      method: "POST",
+      handler: async ({ req }) => _handleReplayDeadLetters(req),
+    },
+  ];
+}

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -54,6 +54,7 @@ import {
   GUARDIAN_VERIFY_TEMPLATE_KEYS,
 } from "../guardian-verification-templates.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 
 const VALID_CONTACT_TYPES: readonly ContactType[] = ["human", "assistant"];
 const VALID_ASSISTANT_SPECIES: readonly AssistantSpecies[] = [
@@ -682,4 +683,56 @@ export async function handleVerifyContactChannel(
     `Verification is not supported for channel type "${channel.type}"`,
     400,
   );
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function contactRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "contacts",
+      method: "GET",
+      handler: ({ url, authContext }) =>
+        handleListContacts(url, authContext.assistantId),
+    },
+    {
+      endpoint: "contacts",
+      method: "POST",
+      handler: async ({ req, authContext }) =>
+        handleUpsertContact(req, authContext.assistantId),
+    },
+    {
+      endpoint: "contacts/merge",
+      method: "POST",
+      handler: async ({ req, authContext }) =>
+        handleMergeContacts(req, authContext.assistantId),
+    },
+    {
+      endpoint: "contacts/channels/:id",
+      method: "PATCH",
+      policyKey: "contacts/channels",
+      handler: async ({ req, params, authContext }) =>
+        handleUpdateContactChannel(req, params.id, authContext.assistantId),
+    },
+    {
+      endpoint: "contacts/:contactId/channels/:channelId/verify",
+      method: "POST",
+      policyKey: "contacts/channels",
+      handler: async ({ params, authContext }) =>
+        handleVerifyContactChannel(
+          params.contactId,
+          params.channelId,
+          authContext.assistantId,
+        ),
+    },
+    {
+      endpoint: "contacts/:id",
+      method: "GET",
+      policyKey: "contacts",
+      handler: ({ params, authContext }) =>
+        handleGetContact(params.id, authContext.assistantId),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/conversation-attention-routes.ts
+++ b/assistant/src/runtime/routes/conversation-attention-routes.ts
@@ -12,6 +12,7 @@ import * as conversationStore from "../../memory/conversation-store.js";
 import { truncate } from "../../util/truncate.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 
 export function handleListConversationAttention(url: URL): Response {
   const stateParam = url.searchParams.get("state") ?? "all";
@@ -123,4 +124,18 @@ export function handleListConversationAttention(url: URL): Response {
     conversations: results,
     hasMore,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function conversationAttentionRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "conversations/attention",
+      method: "GET",
+      handler: ({ url }) => handleListConversationAttention(url),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -39,6 +39,7 @@ import type { AuthContext } from "../auth/types.js";
 import { bridgeConfirmationRequestToGuardian } from "../confirmation-request-guardian-bridge.js";
 import { routeGuardianReply } from "../guardian-reply-router.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 import type {
   ApprovalConversationGenerator,
   RuntimeAttachmentMetadata,
@@ -887,4 +888,51 @@ export function handleSearchConversations(url: URL): Response {
   });
 
   return Response.json({ query, results });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function conversationRouteDefinitions(deps: {
+  interfacesDir: string | null;
+  sendMessageDeps: SendMessageDeps;
+  approvalConversationGenerator?: ApprovalConversationGenerator;
+  suggestionCache: Map<string, string>;
+  suggestionInFlight: Map<string, Promise<string | null>>;
+}): RouteDefinition[] {
+  return [
+    {
+      endpoint: "messages",
+      method: "GET",
+      handler: ({ url }) => handleListMessages(url, deps.interfacesDir),
+    },
+    {
+      endpoint: "messages",
+      method: "POST",
+      handler: async ({ req, authContext }) =>
+        handleSendMessage(
+          req,
+          {
+            sendMessageDeps: deps.sendMessageDeps,
+            approvalConversationGenerator: deps.approvalConversationGenerator,
+          },
+          authContext,
+        ),
+    },
+    {
+      endpoint: "search",
+      method: "GET",
+      handler: ({ url }) => handleSearchConversations(url),
+    },
+    {
+      endpoint: "suggestion",
+      method: "GET",
+      handler: async ({ url }) =>
+        handleGetSuggestion(url, {
+          suggestionCache: deps.suggestionCache,
+          suggestionInFlight: deps.suggestionInFlight,
+        }),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/debug-routes.ts
+++ b/assistant/src/runtime/routes/debug-routes.ts
@@ -11,6 +11,7 @@ import { getMemoryJobCounts } from "../../memory/jobs-store.js";
 import { getProviderDebugStatus } from "../../providers/registry.js";
 import { countSchedules } from "../../schedule/schedule-store.js";
 import { getDbPath } from "../../util/platform.js";
+import type { RouteDefinition } from "../http-router.js";
 
 /** Process start time — used to calculate uptime. */
 const startedAt = Date.now();
@@ -72,4 +73,18 @@ export function handleDebug(): Response {
     },
     timestamp: new Date(now).toISOString(),
   });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function debugRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "debug",
+      method: "GET",
+      handler: () => handleDebug(),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -20,6 +20,7 @@ import {
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import type { AuthContext } from "../auth/types.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 
 /** Keep-alive comment sent to idle clients every 30 s by default. */
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -193,4 +194,19 @@ export function handleSubscribeAssistantEvents(
       Connection: "keep-alive",
     },
   });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function eventsRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "events",
+      method: "GET",
+      handler: ({ req, url, authContext }) =>
+        handleSubscribeAssistantEvents(req, url, { authContext }),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/global-search-routes.ts
+++ b/assistant/src/runtime/routes/global-search-routes.ts
@@ -21,6 +21,7 @@ import { listSchedules } from "../../schedule/schedule-store.js";
 import { getLogger } from "../../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 
 const log = getLogger("global-search");
 
@@ -263,4 +264,18 @@ export async function handleGlobalSearch(url: URL): Promise<Response> {
 
   const response: GlobalSearchResponse = { query, results };
   return Response.json(response);
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function globalSearchRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "search/global",
+      method: "GET",
+      handler: async ({ url }) => handleGlobalSearch(url),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/guardian-action-routes.ts
+++ b/assistant/src/runtime/routes/guardian-action-routes.ts
@@ -21,6 +21,7 @@ import { processGuardianDecision } from "../guardian-action-service.js";
 import type { GuardianDecisionPrompt } from "../guardian-decision-types.js";
 import { buildDecisionActions } from "../guardian-decision-types.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 
 // ---------------------------------------------------------------------------
 // GET /v1/guardian-actions/pending?conversationId=...
@@ -236,4 +237,25 @@ function buildKindAwareQuestionText(req: CanonicalGuardianRequest): string {
   }
 
   return baseText;
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function guardianActionRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "guardian-actions/pending",
+      method: "GET",
+      handler: ({ url, authContext }) =>
+        handleGuardianActionsPending(url, authContext),
+    },
+    {
+      endpoint: "guardian-actions/decision",
+      method: "POST",
+      handler: async ({ req, authContext }) =>
+        handleGuardianActionDecision(req, authContext),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -20,6 +20,7 @@ import { getLogger } from "../../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { mintCredentialPair } from "../auth/credential-service.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 
 /** Bun server shape needed for requestIP -- avoids importing the full Bun type. */
 type ServerWithRequestIP = {
@@ -158,4 +159,23 @@ export async function handleGuardianBootstrap(
     log.error({ err }, "Guardian bootstrap failed");
     return httpError("INTERNAL_ERROR", "Internal server error", 500);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Guardian bootstrap is a pre-auth endpoint (handled before JWT auth in
+ * http-server.ts), so these definitions are exported for completeness but
+ * are not added to the authenticated route table.
+ */
+export function guardianBootstrapRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "integrations/guardian/vellum/bootstrap",
+      method: "POST",
+      handler: async ({ req, server }) => handleGuardianBootstrap(req, server),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/guardian-refresh-routes.ts
+++ b/assistant/src/runtime/routes/guardian-refresh-routes.ts
@@ -8,6 +8,7 @@
 import { getLogger } from "../../util/logger.js";
 import { rotateCredentials } from "../auth/credential-service.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 
 const log = getLogger("guardian-refresh");
 
@@ -71,4 +72,23 @@ export async function handleGuardianRefresh(req: Request): Promise<Response> {
     log.error({ err }, "Guardian refresh failed");
     return httpError("INTERNAL_ERROR", "Internal server error", 500);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Guardian refresh is a pre-auth endpoint (handled before JWT auth in
+ * http-server.ts), so these definitions are exported for completeness but
+ * are not added to the authenticated route table.
+ */
+export function guardianRefreshRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "integrations/guardian/vellum/refresh",
+      method: "POST",
+      handler: async ({ req }) => handleGuardianRefresh(req),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import { getBaseDataDir } from "../../config/env-registry.js";
 import { getWorkspacePromptPath, readLockfile } from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 
 interface DiskSpaceInfo {
   path: string;
@@ -230,4 +231,23 @@ export function handleGetIdentity(): Response {
     createdAt,
     originSystem,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function identityRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "health",
+      method: "GET",
+      handler: () => handleHealth(),
+    },
+    {
+      endpoint: "identity",
+      method: "GET",
+      handler: () => handleGetIdentity(),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -48,6 +48,7 @@ import {
   startOutbound,
 } from "../guardian-outbound-actions.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 import { guardianVerificationLimiter } from "../verification-rate-limiter.js";
 
 /**
@@ -295,4 +296,86 @@ export async function handleCancelOutbound(req: Request): Promise<Response> {
   });
   const status = result.success ? 200 : 400;
   return Response.json(result, { status });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function integrationRouteDefinitions(): RouteDefinition[] {
+  return [
+    // Telegram
+    {
+      endpoint: "integrations/telegram/config",
+      method: "GET",
+      handler: () => handleGetTelegramConfig(),
+    },
+    {
+      endpoint: "integrations/telegram/config",
+      method: "POST",
+      handler: async ({ req }) => handleSetTelegramConfig(req),
+    },
+    {
+      endpoint: "integrations/telegram/config",
+      method: "DELETE",
+      handler: async () => handleClearTelegramConfig(),
+    },
+    {
+      endpoint: "integrations/telegram/commands",
+      method: "POST",
+      handler: async ({ req }) => handleSetTelegramCommands(req),
+    },
+    {
+      endpoint: "integrations/telegram/setup",
+      method: "POST",
+      handler: async ({ req }) => handleSetupTelegram(req),
+    },
+    // Slack
+    {
+      endpoint: "integrations/slack/channel/config",
+      method: "GET",
+      handler: () => handleGetSlackChannelConfig(),
+    },
+    {
+      endpoint: "integrations/slack/channel/config",
+      method: "POST",
+      handler: async ({ req }) => handleSetSlackChannelConfig(req),
+    },
+    {
+      endpoint: "integrations/slack/channel/config",
+      method: "DELETE",
+      handler: () => handleClearSlackChannelConfig(),
+    },
+    // Guardian
+    {
+      endpoint: "integrations/guardian/challenge",
+      method: "POST",
+      handler: async ({ req }) => handleCreateGuardianChallenge(req),
+    },
+    {
+      endpoint: "integrations/guardian/status",
+      method: "GET",
+      handler: ({ url }) => handleGetGuardianStatus(url),
+    },
+    {
+      endpoint: "integrations/guardian/revoke",
+      method: "POST",
+      handler: async ({ req }) => handleRevokeGuardian(req),
+    },
+    {
+      endpoint: "integrations/guardian/outbound/start",
+      method: "POST",
+      handler: async ({ req }) => handleStartOutbound(req),
+    },
+    {
+      endpoint: "integrations/guardian/outbound/resend",
+      method: "POST",
+      handler: async ({ req }) => handleResendOutbound(req),
+    },
+    {
+      endpoint: "integrations/guardian/outbound/cancel",
+      method: "POST",
+      handler: async ({ req }) => handleCancelOutbound(req),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/invite-routes.ts
+++ b/assistant/src/runtime/routes/invite-routes.ts
@@ -8,6 +8,7 @@
  *   POST   /v1/contacts/invites/redeem — redeem an invite (token or voice code)
  */
 
+import type { RouteDefinition } from "../http-router.js";
 import {
   createIngressInvite,
   listIngressInvites,
@@ -137,4 +138,34 @@ export async function handleRedeemInvite(req: Request): Promise<Response> {
     return Response.json({ ok: false, error: result.error }, { status: 400 });
   }
   return Response.json({ ok: true, invite: result.data });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function inviteRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "contacts/invites",
+      method: "GET",
+      handler: ({ url }) => handleListInvites(url),
+    },
+    {
+      endpoint: "contacts/invites",
+      method: "POST",
+      handler: async ({ req }) => handleCreateInvite(req),
+    },
+    {
+      endpoint: "contacts/invites/redeem",
+      method: "POST",
+      handler: async ({ req }) => handleRedeemInvite(req),
+    },
+    {
+      endpoint: "contacts/invites/:id",
+      method: "DELETE",
+      policyKey: "contacts/invites",
+      handler: ({ params }) => handleRevokeInvite(params.id),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -18,6 +18,7 @@ import { resetDb } from "../../memory/db-connection.js";
 import { getLogger } from "../../util/logger.js";
 import { getDbPath, getWorkspaceConfigPath } from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 import { buildExportVBundle } from "../migrations/vbundle-builder.js";
 import {
   analyzeImport,
@@ -431,4 +432,33 @@ export async function handleMigrationImport(req: Request): Promise<Response> {
       500,
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function migrationRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "migrations/validate",
+      method: "POST",
+      handler: async ({ req }) => handleMigrationValidate(req),
+    },
+    {
+      endpoint: "migrations/export",
+      method: "POST",
+      handler: async ({ req }) => handleMigrationExport(req),
+    },
+    {
+      endpoint: "migrations/import-preflight",
+      method: "POST",
+      handler: async ({ req }) => handleMigrationImportPreflight(req),
+    },
+    {
+      endpoint: "migrations/import",
+      method: "POST",
+      handler: async ({ req }) => handleMigrationImport(req),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/pairing-routes.ts
+++ b/assistant/src/runtime/routes/pairing-routes.ts
@@ -14,6 +14,7 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { mintCredentialPair } from "../auth/credential-service.js";
 import { ensureVellumGuardianBinding } from "../guardian-vellum-migration.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 
 const log = getLogger("runtime-http");
 
@@ -403,4 +404,21 @@ export function handlePairingStatus(
   }
 
   return Response.json({ status: entry.status });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function pairingRouteDefinitions(deps: {
+  pairingContext: PairingHandlerContext;
+}): RouteDefinition[] {
+  return [
+    {
+      endpoint: "pairing/register",
+      method: "POST",
+      handler: async ({ req }) =>
+        handlePairingRegister(req, deps.pairingContext),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -12,6 +12,7 @@ import {
 } from "../../tools/credentials/metadata-store.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 
 const log = getLogger("runtime-http");
 
@@ -169,4 +170,23 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
     log.error({ err, type, name }, "Failed to delete secret via HTTP");
     return httpError("INTERNAL_ERROR", message, 500);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function secretRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "secrets",
+      method: "POST",
+      handler: async ({ req }) => handleAddSecret(req),
+    },
+    {
+      endpoint: "secrets",
+      method: "DELETE",
+      handler: async ({ req }) => handleDeleteSecret(req),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -6,6 +6,7 @@
  */
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 
 const log = getLogger("surface-action-routes");
 
@@ -73,4 +74,29 @@ export async function handleSurfaceAction(
     );
     return httpError("INTERNAL_ERROR", "Failed to handle surface action", 500);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function surfaceActionRouteDefinitions(deps: {
+  findSession?: SessionLookup;
+}): RouteDefinition[] {
+  return [
+    {
+      endpoint: "surface-actions",
+      method: "POST",
+      handler: async ({ req }) => {
+        if (!deps.findSession) {
+          return httpError(
+            "NOT_IMPLEMENTED",
+            "Surface actions not available",
+            501,
+          );
+        }
+        return handleSurfaceAction(req, deps.findSession);
+      },
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/trust-rules-routes.ts
+++ b/assistant/src/runtime/routes/trust-rules-routes.ts
@@ -13,6 +13,7 @@ import {
 } from "../../permissions/trust-store.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
 
 const log = getLogger("trust-rules-routes");
 
@@ -150,4 +151,34 @@ export async function handleUpdateTrustRuleManage(
     log.error({ err, id }, "Failed to update trust rule via HTTP");
     return httpError("INTERNAL_ERROR", "Failed to update trust rule", 500);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function trustRulesRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "trust-rules/manage",
+      method: "GET",
+      handler: () => handleListTrustRules(),
+    },
+    {
+      endpoint: "trust-rules/manage",
+      method: "POST",
+      handler: async ({ req }) => handleAddTrustRuleManage(req),
+    },
+    {
+      endpoint: "trust-rules/manage/:id",
+      method: "DELETE",
+      handler: ({ params }) => handleRemoveTrustRuleManage(params.id),
+    },
+    {
+      endpoint: "trust-rules/manage/:id",
+      method: "PATCH",
+      handler: async ({ req, params }) =>
+        handleUpdateTrustRuleManage(req, params.id),
+    },
+  ];
 }

--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -46,6 +46,7 @@ import {
   upsertCredentialMetadata,
 } from "../../tools/credentials/metadata-store.js";
 import { mintDaemonDeliveryToken } from "../auth/token-service.js";
+import type { RouteDefinition } from "../http-router.js";
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -1125,4 +1126,82 @@ export async function handleSmsDoctor(): Promise<Response> {
       actionItems,
     },
   });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function twilioRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "integrations/twilio/config",
+      method: "GET",
+      handler: () => handleGetTwilioConfig(),
+    },
+    {
+      endpoint: "integrations/twilio/credentials",
+      method: "POST",
+      handler: async ({ req }) => handleSetTwilioCredentials(req),
+    },
+    {
+      endpoint: "integrations/twilio/credentials",
+      method: "DELETE",
+      handler: () => handleClearTwilioCredentials(),
+    },
+    {
+      endpoint: "integrations/twilio/numbers",
+      method: "GET",
+      handler: async () => handleListTwilioNumbers(),
+    },
+    {
+      endpoint: "integrations/twilio/numbers/provision",
+      method: "POST",
+      handler: async ({ req }) => handleProvisionTwilioNumber(req),
+    },
+    {
+      endpoint: "integrations/twilio/numbers/assign",
+      method: "POST",
+      handler: async ({ req }) => handleAssignTwilioNumber(req),
+    },
+    {
+      endpoint: "integrations/twilio/numbers/release",
+      method: "POST",
+      handler: async ({ req }) => handleReleaseTwilioNumber(req),
+    },
+    {
+      endpoint: "integrations/twilio/sms/compliance",
+      method: "GET",
+      handler: async () => handleGetSmsCompliance(),
+    },
+    {
+      endpoint: "integrations/twilio/sms/compliance/tollfree",
+      method: "POST",
+      handler: async ({ req }) => handleSubmitTollfreeVerification(req),
+    },
+    {
+      endpoint: "integrations/twilio/sms/compliance/tollfree/:sid",
+      method: "PATCH",
+      policyKey: "integrations/twilio/sms/compliance/tollfree",
+      handler: async ({ req, params }) =>
+        handleUpdateTollfreeVerification(req, params.sid),
+    },
+    {
+      endpoint: "integrations/twilio/sms/compliance/tollfree/:sid",
+      method: "DELETE",
+      policyKey: "integrations/twilio/sms/compliance/tollfree",
+      handler: async ({ params }) =>
+        handleDeleteTollfreeVerification(params.sid),
+    },
+    {
+      endpoint: "integrations/twilio/sms/test",
+      method: "POST",
+      handler: async ({ req }) => handleSmsSendTest(req),
+    },
+    {
+      endpoint: "integrations/twilio/sms/doctor",
+      method: "POST",
+      handler: async () => handleSmsDoctor(),
+    },
+  ];
 }


### PR DESCRIPTION
## Summary

- Add a `*RouteDefinitions()` function to each of the 25 route modules under `assistant/src/runtime/routes/`, returning `RouteDefinition[]` arrays that mirror the inline definitions currently in `buildRouteTable()`.
- This is a purely additive change — `http-server.ts` is untouched. A follow-up PR will wire these exports into `buildRouteTable()` to eliminate the inline duplication.
- Barrel file `channel-routes.ts` uses aliased imports so the local function body can reference the re-exported handlers.

## Test plan
- [x] `bunx tsc --noEmit` passes with no new type errors
- [x] Prettier and ESLint pass
- [x] No changes to `http-server.ts` — existing route table is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
