### PR TITLE
refactor: extract shared webhook pipeline utilities (circuit breaker, result processing, /new command)

### DIFF
--- a/gateway/src/webhook-pipeline.ts
+++ b/gateway/src/webhook-pipeline.ts
@@ -1,0 +1,100 @@
+import type { Logger } from "pino";
+import type { ChannelId } from "./channels/types.js";
+import type { GatewayConfig } from "./config.js";
+import type { StringDedupCache } from "./dedup-cache.js";
+import type { InboundResult } from "./handlers/handle-inbound.js";
+import {
+  CircuitBreakerOpenError,
+  resetConversation,
+} from "./runtime/client.js";
+import {
+  NEW_COMMAND_ERROR,
+  NEW_COMMAND_SUCCESS,
+  SERVICE_UNAVAILABLE_ERROR,
+} from "./webhook-copy.js";
+
+/**
+ * If the error is a CircuitBreakerOpenError, logs a warning, unreserves the
+ * dedup cache entry, and returns a 503 response with Retry-After header.
+ * Returns null if the error is not a circuit breaker error.
+ */
+export function handleCircuitBreakerError(
+  err: unknown,
+  dedupCache: StringDedupCache,
+  cacheKey: string,
+  logger: Logger,
+): Response | null {
+  if (!(err instanceof CircuitBreakerOpenError)) return null;
+
+  logger.warn(
+    { retryAfterSecs: err.retryAfterSecs },
+    "Circuit breaker open — returning 503",
+  );
+  dedupCache.unreserve(cacheKey);
+  return Response.json(
+    { error: SERVICE_UNAVAILABLE_ERROR },
+    {
+      status: 503,
+      headers: { "Retry-After": String(err.retryAfterSecs) },
+    },
+  );
+}
+
+/**
+ * Handles the /new command flow: resets the conversation and sends a
+ * success or error reply via the provided callback.
+ * Returns `{ handled: true }` in all cases since both success and error
+ * are terminal for this message.
+ */
+export async function handleNewCommand(
+  config: GatewayConfig,
+  sourceChannel: ChannelId,
+  conversationExternalId: string,
+  sendReply: (text: string) => Promise<void>,
+): Promise<{ handled: true }> {
+  try {
+    await resetConversation(config, sourceChannel, conversationExternalId);
+    sendReply(NEW_COMMAND_SUCCESS).catch(() => {
+      // fire-and-forget — callers log send failures at their own level
+    });
+  } catch {
+    sendReply(NEW_COMMAND_ERROR).catch(() => {
+      // fire-and-forget
+    });
+  }
+  return { handled: true };
+}
+
+/**
+ * Processes the result of `handleInbound()`: checks for rejections
+ * (rate-limited notice via sendRejection callback) and forwarding failures
+ * (unreserve cache, log error).
+ * Returns `{ ok: true }` on success or `{ ok: false, status: number }` on failure.
+ */
+export function processInboundResult(
+  result: InboundResult,
+  dedupCache: StringDedupCache,
+  cacheKey: string,
+  sendRejection: () => void,
+  logger: Logger,
+): { ok: true } | { ok: false; status: number } {
+  if (result.rejected) {
+    sendRejection();
+    return { ok: true };
+  }
+
+  if (!result.forwarded) {
+    logger.error({ cacheKey }, "Failed to forward message to runtime");
+    dedupCache.unreserve(cacheKey);
+    return { ok: false, status: 500 };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Returns true if the message text is the /new command.
+ */
+export function isNewCommand(text: string): boolean {
+  return text.trim().toLowerCase() === "/new";
+}


### PR DESCRIPTION
## Summary
- Create gateway/src/webhook-pipeline.ts with four shared utilities: handleCircuitBreakerError, handleNewCommand, processInboundResult, isNewCommand
- All utilities are callback-parameterized with no channel-specific logic
- Prepares for PRs 8-10 which will refactor each webhook handler to use these utilities

Part of plan: code-quality-backlog.md (PR 6 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
