### PR TITLE
refactor: use shared webhook pipeline utilities in twilio-sms-webhook.ts

### DIFF
--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -10,19 +10,16 @@ import {
   isRejection,
 } from "../../routing/resolve-assistant.js";
 import type { RouteResult } from "../../routing/types.js";
-import {
-  CircuitBreakerOpenError,
-  resetConversation,
-} from "../../runtime/client.js";
 import { sendSmsReply } from "../../twilio/send-sms.js";
 import { validateTwilioWebhookRequest } from "../../twilio/validate-webhook.js";
 import type { GatewayInboundEvent } from "../../types.js";
+import { ROUTING_REJECTION_NOTICE } from "../../webhook-copy.js";
 import {
-  NEW_COMMAND_ERROR,
-  NEW_COMMAND_SUCCESS,
-  ROUTING_REJECTION_NOTICE,
-  SERVICE_UNAVAILABLE_ERROR,
-} from "../../webhook-copy.js";
+  handleCircuitBreakerError,
+  handleNewCommand,
+  isNewCommand,
+  processInboundResult,
+} from "../../webhook-pipeline.js";
 
 const log = getLogger("twilio-sms-webhook");
 
@@ -144,7 +141,7 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
     const normalized = normalizeSmsPayload(params);
 
     // --- /new intercept: reset conversation before it reaches the runtime ---
-    if (normalized.message.content.trim().toLowerCase() === "/new") {
+    if (isNewCommand(normalized.message.content)) {
       if (isRejection(routing)) {
         tlog.warn(
           { from: params.From, reason: routing.reason },
@@ -159,31 +156,13 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
           },
         );
       } else {
-        try {
-          await resetConversation(
-            config,
-            normalized.sourceChannel,
-            normalized.message.conversationExternalId,
-          );
-          sendSmsReply(
-            config,
-            params.From,
-            NEW_COMMAND_SUCCESS,
-            routing.assistantId,
-          ).catch((err) => {
-            tlog.error({ err }, "Failed to send /new confirmation");
-          });
-        } catch (err) {
-          tlog.error({ err }, "Failed to reset conversation");
-          sendSmsReply(
-            config,
-            params.From,
-            NEW_COMMAND_ERROR,
-            routing.assistantId,
-          ).catch((replyErr) => {
-            tlog.error({ err: replyErr }, "Failed to send /new error reply");
-          });
-        }
+        await handleNewCommand(
+          config,
+          normalized.sourceChannel,
+          normalized.message.conversationExternalId,
+          (text) =>
+            sendSmsReply(config, params.From, text, routing.assistantId),
+        );
       }
 
       dedupCache.mark(messageSid);
@@ -217,29 +196,34 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
         routingOverride: routing as RouteResult,
       });
 
-      if (result.rejected) {
-        tlog.warn(
-          { from: params.From, reason: result.rejectionReason },
-          "Routing rejected inbound SMS",
-        );
-        if (rejectionLimiter.shouldSend(params.From)) {
-          sendSmsReply(config, params.From, ROUTING_REJECTION_NOTICE).catch(
-            (err) => {
-              tlog.error(
-                { err, to: params.From },
-                "Failed to send routing rejection notice",
-              );
-            },
+      const outcome = processInboundResult(
+        result,
+        dedupCache,
+        messageSid,
+        () => {
+          tlog.warn(
+            { from: params.From, reason: result.rejectionReason },
+            "Routing rejected inbound SMS",
           );
-        }
-        dedupCache.mark(messageSid);
-        return Response.json({ ok: true });
-      }
+          if (rejectionLimiter.shouldSend(params.From)) {
+            sendSmsReply(config, params.From, ROUTING_REJECTION_NOTICE).catch(
+              (err) => {
+                tlog.error(
+                  { err, to: params.From },
+                  "Failed to send routing rejection notice",
+                );
+              },
+            );
+          }
+        },
+        tlog,
+      );
 
-      if (!result.forwarded) {
-        tlog.error({ messageSid }, "Failed to forward SMS to runtime");
-        dedupCache.unreserve(messageSid);
-        return Response.json({ error: "Internal error" }, { status: 500 });
+      if (!outcome.ok) {
+        return Response.json(
+          { error: "Internal error" },
+          { status: outcome.status },
+        );
       }
 
       // Mark as seen only after successful forwarding
@@ -249,20 +233,14 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
         "SMS forwarded to runtime",
       );
     } catch (err) {
-      if (err instanceof CircuitBreakerOpenError) {
-        tlog.warn(
-          { retryAfterSecs: err.retryAfterSecs },
-          "Circuit breaker open — returning 503",
-        );
-        dedupCache.unreserve(messageSid);
-        return Response.json(
-          { error: SERVICE_UNAVAILABLE_ERROR },
-          {
-            status: 503,
-            headers: { "Retry-After": String(err.retryAfterSecs) },
-          },
-        );
-      }
+      const cbResponse = handleCircuitBreakerError(
+        err,
+        dedupCache,
+        messageSid,
+        tlog,
+      );
+      if (cbResponse) return cbResponse;
+
       tlog.error({ err, messageSid }, "Failed to process inbound SMS");
       dedupCache.unreserve(messageSid);
       return Response.json({ error: "Internal error" }, { status: 500 });


### PR DESCRIPTION
## Summary
- Refactor twilio-sms-webhook.ts to use shared pipeline utilities from webhook-pipeline.ts
- Replace inline /new command handling with `isNewCommand()` + `handleNewCommand()`
- Replace inline circuit breaker catch block with `handleCircuitBreakerError()`
- Replace inline result rejection/forwarding checks with `processInboundResult()`
- Remove now-unused imports (CircuitBreakerOpenError, resetConversation, copy constants handled by pipeline)
- Twilio-specific logic (MMS intercept, phone routing, webhook validation) unchanged

Part of plan: code-quality-backlog.md (PR 8 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
