### PR TITLE
fix: remove unused showSpinner, clearLine, SPINNER_FRAMES from step-runner

### DIFF
--- a/cli/src/lib/step-runner.ts
+++ b/cli/src/lib/step-runner.ts
@@ -1,20 +1,5 @@
 import { spawn } from "child_process";
 
-const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-
-export function clearLine(): void {
-  process.stdout.write("\r\x1b[K");
-}
-
-export function showSpinner(name: string): NodeJS.Timeout {
-  let frameIndex = 0;
-  return setInterval(() => {
-    clearLine();
-    process.stdout.write(`  ${SPINNER_FRAMES[frameIndex]} ${name}...`);
-    frameIndex = (frameIndex + 1) % SPINNER_FRAMES.length;
-  }, 80);
-}
-
 export function exec(
   command: string,
   args: string[],


### PR DESCRIPTION
Address Devin feedback on PR #12814: remove dead code left behind after runSteps removal.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
