### PR TITLE
fix: preserve full module exports in managed-proxy test mocks

### DIFF
--- a/assistant/src/__tests__/provider-fail-open-selection.test.ts
+++ b/assistant/src/__tests__/provider-fail-open-selection.test.ts
@@ -9,11 +9,15 @@ import { describe, expect, mock, test } from "bun:test";
 let mockPlatformBaseUrl = "";
 let mockAssistantApiKey = "";
 
+const actualEnv = await import("../config/env.js");
 mock.module("../config/env.js", () => ({
+  ...actualEnv,
   getPlatformBaseUrl: () => mockPlatformBaseUrl,
 }));
 
+const actualSecureKeys = await import("../security/secure-keys.js");
 mock.module("../security/secure-keys.js", () => ({
+  ...actualSecureKeys,
   getSecureKey: (key: string) => {
     if (key === "credential:vellum:assistant_api_key") {
       return mockAssistantApiKey || null;


### PR DESCRIPTION
Address Codex feedback on PR #12817: spread original module exports when mocking env and secure-keys modules to prevent test bleed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
