### PR TITLE
fix: reject deprecated reminder_cron_id and cron_expression fields

### DIFF
--- a/assistant/src/tools/followups/followup_create.ts
+++ b/assistant/src/tools/followups/followup_create.ts
@@ -47,6 +47,14 @@ export async function executeFollowupCreate(
     };
   }
 
+  if (input.reminder_cron_id !== undefined) {
+    return {
+      content:
+        'Error: "reminder_cron_id" is deprecated. Use "reminder_schedule_id" instead.',
+      isError: true,
+    };
+  }
+
   const contactId = input.contact_id as string | undefined;
   const expectedResponseHours = input.expected_response_hours as
     | number

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -20,6 +20,14 @@ export async function executeScheduleUpdate(
     return { content: "Error: job_id is required", isError: true };
   }
 
+  if (input.cron_expression !== undefined) {
+    return {
+      content:
+        'Error: "cron_expression" is deprecated. Use "expression" instead.',
+      isError: true,
+    };
+  }
+
   const updates: Record<string, unknown> = {};
   if (input.name !== undefined) updates.name = input.name;
   if (input.timezone !== undefined) updates.timezone = input.timezone;


### PR DESCRIPTION
Address feedback on PR #12825: error on deprecated field names instead of silently ignoring them.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
