### PR TITLE
fix: migrate legacy permissions mode to workspace during config load

### DIFF
--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -56,6 +56,21 @@ function ensureMigratedDataDir(): void {
 }
 
 /**
+ * Migrate deprecated raw config values before Zod validation.
+ * This prevents `validateWithSchema` from silently dropping fields whose
+ * values were valid in older releases but have since been removed from the
+ * schema enum, which would cause a fallback to the default and silently
+ * change behavior on upgrade.
+ */
+function migrateRawConfig(raw: Record<string, unknown>): void {
+  const permissions = raw.permissions as Record<string, unknown> | undefined;
+  if (permissions?.mode === "legacy") {
+    permissions.mode = "workspace";
+    log.info('Migrated permissions.mode from "legacy" to "workspace".');
+  }
+}
+
+/**
  * Zod 4's .default({}) returns {} as output without running inner-schema
  * parsing, so nested object defaults are never applied. Re-parse the config
  * to cascade defaults through each nesting level.
@@ -226,6 +241,10 @@ export function loadConfig(): AssistantConfig {
         }
       }
     }
+
+    // Migrate removed config values before validation so existing configs
+    // don't silently change behavior when Zod drops unknown enum values.
+    migrateRawConfig(fileConfig);
 
     // Validate and apply defaults via Zod schema
     const config = validateWithSchema(fileConfig);


### PR DESCRIPTION
Address Codex feedback on PR #12816: handle config migration for removed legacy mode to prevent silent behavior change.

When permissions.mode was set to "legacy" in an existing config, removing it from the Zod enum caused validateWithSchema to silently drop the field and fall back to the "workspace" default. This adds an explicit pre-validation migration step that converts "legacy" to "workspace" with a log message, so the transition is intentional and visible rather than silent.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
