### PR TITLE
fix: make conversations join conditional on source/channel filters

### DIFF
--- a/assistant/src/memory/conversation-attention-store.ts
+++ b/assistant/src/memory/conversation-attention-store.ts
@@ -412,7 +412,7 @@ export function listConversationAttention(
     );
   }
 
-  const query = db
+  let query = db
     .select({
       conversationId: conversationAssistantAttentionState.conversationId,
       assistantId: conversationAssistantAttentionState.assistantId,
@@ -437,11 +437,16 @@ export function listConversationAttention(
       createdAt: conversationAssistantAttentionState.createdAt,
       updatedAt: conversationAssistantAttentionState.updatedAt,
     })
-    .from(conversationAssistantAttentionState)
-    .innerJoin(
+    .from(conversationAssistantAttentionState);
+
+  // Only join conversations table when filtering by source or sourceChannel
+  if (source || sourceChannel) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    query = (query as any).innerJoin(
       conversations,
       eq(conversationAssistantAttentionState.conversationId, conversations.id),
     );
+  }
 
   const rows = query
     .where(and(...conditions))


### PR DESCRIPTION
Address Codex feedback on PR #12838: restore conditional join in listConversationAttention to avoid unnecessary table lookups on the common unfiltered path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
