### PR TITLE
fix: log reset failures in handleNewCommand instead of swallowing

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -455,6 +455,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
               text,
             );
           },
+          log,
         );
       }
 

--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -162,6 +162,7 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
           normalized.message.conversationExternalId,
           (text) =>
             sendSmsReply(config, params.From, text, routing.assistantId),
+          log,
         );
       }
 

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -204,6 +204,7 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
             async (text) => {
               await sendWhatsAppReply(config, from, text);
             },
+            log,
           );
         }
 

--- a/gateway/src/webhook-pipeline.ts
+++ b/gateway/src/webhook-pipeline.ts
@@ -51,13 +51,18 @@ export async function handleNewCommand(
   sourceChannel: ChannelId,
   conversationExternalId: string,
   sendReply: (text: string) => Promise<void>,
+  logger: Logger,
 ): Promise<{ handled: true }> {
   try {
     await resetConversation(config, sourceChannel, conversationExternalId);
     sendReply(NEW_COMMAND_SUCCESS).catch(() => {
       // fire-and-forget — callers log send failures at their own level
     });
-  } catch {
+  } catch (err) {
+    logger.error(
+      { err, conversationExternalId },
+      "Failed to reset conversation for /new command",
+    );
     sendReply(NEW_COMMAND_ERROR).catch(() => {
       // fire-and-forget
     });


### PR DESCRIPTION
Address Codex feedback on PR #12852: log /new reset failures for operational observability instead of silently swallowing the exception.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
