### PR TITLE
fix: guard sendMessageDeps before dereferencing in handleSendMessage

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -836,7 +836,7 @@ export class RuntimeHttpServer {
 
       ...conversationRouteDefinitions({
         interfacesDir: this.interfacesDir,
-        sendMessageDeps: this.sendMessageDeps!,
+        sendMessageDeps: this.sendMessageDeps,
         approvalConversationGenerator: this.approvalConversationGenerator,
         suggestionCache: this.suggestionCache,
         suggestionInFlight: this.suggestionInFlight,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -452,7 +452,7 @@ function makeHubPublisher(
 export async function handleSendMessage(
   req: Request,
   deps: {
-    sendMessageDeps: SendMessageDeps;
+    sendMessageDeps?: SendMessageDeps;
     approvalConversationGenerator?: ApprovalConversationGenerator;
   },
   authContext: AuthContext,
@@ -532,6 +532,13 @@ export async function handleSendMessage(
 
   const mapping = getOrCreateConversation(conversationKey);
 
+  if (!deps.sendMessageDeps) {
+    return httpError(
+      "SERVICE_UNAVAILABLE",
+      "Message processing is not available",
+      503,
+    );
+  }
   const smDeps = deps.sendMessageDeps;
   const session = await smDeps.getOrCreateSession(mapping.conversationId);
 
@@ -896,7 +903,7 @@ export function handleSearchConversations(url: URL): Response {
 
 export function conversationRouteDefinitions(deps: {
   interfacesDir: string | null;
-  sendMessageDeps: SendMessageDeps;
+  sendMessageDeps?: SendMessageDeps;
   approvalConversationGenerator?: ApprovalConversationGenerator;
   suggestionCache: Map<string, string>;
   suggestionInFlight: Map<string, Promise<string | null>>;


### PR DESCRIPTION
Address feedback on PR #12827: add null guard for sendMessageDeps instead of non-null assertion, returning 503 when unavailable. The processMessage/persistAndProcessMessage dead code was already cleaned up in the current codebase.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12864" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
