### PR TITLE
fix: check wait state dynamically in heartbeat timer and remove dead getHeartbeatMessage

### DIFF
--- a/assistant/src/calls/relay-access-wait.ts
+++ b/assistant/src/calls/relay-access-wait.ts
@@ -126,7 +126,7 @@ export function getHeartbeatMessage(
 // ── Heartbeat scheduling ─────────────────────────────────────────────
 
 export interface ScheduleNextHeartbeatParams {
-  accessRequestWaitActive: boolean;
+  isWaitActive: () => boolean;
   accessRequestWaitStartedAt: number;
   callSessionId: string;
   /** Called to get the current sequence number and advance it. */
@@ -146,7 +146,7 @@ export interface ScheduleNextHeartbeatParams {
 export function scheduleNextHeartbeat(
   params: ScheduleNextHeartbeatParams,
 ): ReturnType<typeof setTimeout> | null {
-  if (!params.accessRequestWaitActive) return null;
+  if (!params.isWaitActive()) return null;
 
   const elapsed = Date.now() - params.accessRequestWaitStartedAt;
   const initialWindow = getGuardianWaitUpdateInitialWindowMs();
@@ -164,7 +164,7 @@ export function scheduleNextHeartbeat(
         );
 
   return setTimeout(() => {
-    if (!params.accessRequestWaitActive) return;
+    if (!params.isWaitActive()) return;
 
     const seq = params.consumeSequence();
     const guardianLabel = params.resolveGuardianLabel();

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -56,7 +56,6 @@ import { finalizeCall } from "./finalize-call.js";
 import {
   classifyWaitUtterance,
   emitAccessRequestCallbackHandoff,
-  getHeartbeatMessage,
   scheduleNextHeartbeat,
 } from "./relay-access-wait.js";
 import { routeSetup } from "./relay-setup-router.js";
@@ -1661,14 +1660,9 @@ export class RelayConnection {
     }
   }
 
-  private getHeartbeatMessage(): string {
-    const seq = this.heartbeatSequence++;
-    return getHeartbeatMessage(seq, this.resolveGuardianLabel());
-  }
-
   private scheduleNextHeartbeat(): void {
     this.accessRequestHeartbeatTimer = scheduleNextHeartbeat({
-      accessRequestWaitActive: this.accessRequestWaitActive,
+      isWaitActive: () => this.accessRequestWaitActive,
       accessRequestWaitStartedAt: this.accessRequestWaitStartedAt,
       callSessionId: this.callSessionId,
       consumeSequence: () => this.heartbeatSequence++,


### PR DESCRIPTION
Address feedback on PR #12844: fix stale boolean capture in heartbeat callback and remove unused getHeartbeatMessage method.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
