### PR TITLE
fix: verify routing source in managed proxy credential-precedence tests

### DIFF
--- a/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-managed-proxy-integration.test.ts
@@ -23,7 +23,11 @@ mock.module("../security/secure-keys.js", () => ({
   },
 }));
 
-import { initializeProviders, listProviders } from "../providers/registry.js";
+import {
+  getProviderRoutingSource,
+  initializeProviders,
+  listProviders,
+} from "../providers/registry.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -72,7 +76,7 @@ beforeEach(() => {
 describe("managed proxy integration — credential precedence", () => {
   describe("user keys present → providers use direct connections (not proxy)", () => {
     test.each(MANAGED_PROVIDERS)(
-      "%s registers when user key is provided regardless of managed context",
+      "%s routes via user-key when user key is provided regardless of managed context",
       (provider: string) => {
         enableManagedProxy();
         initializeProviders({
@@ -81,10 +85,11 @@ describe("managed proxy integration — credential precedence", () => {
           model: "test-model",
         });
         expect(listProviders()).toContain(provider);
+        expect(getProviderRoutingSource(provider)).toBe("user-key");
       },
     );
 
-    test("all five managed providers register with user keys", () => {
+    test("all five managed providers route via user-key with user keys", () => {
       enableManagedProxy();
       initializeProviders({
         apiKeys: userKeysFor(...MANAGED_PROVIDERS),
@@ -94,10 +99,11 @@ describe("managed proxy integration — credential precedence", () => {
       const registered = listProviders();
       for (const p of MANAGED_PROVIDERS) {
         expect(registered).toContain(p);
+        expect(getProviderRoutingSource(p)).toBe("user-key");
       }
     });
 
-    test("user keys still work when managed context is disabled", () => {
+    test("user keys still route via user-key when managed context is disabled", () => {
       disableManagedProxy();
       initializeProviders({
         apiKeys: userKeysFor(...MANAGED_PROVIDERS),
@@ -107,13 +113,14 @@ describe("managed proxy integration — credential precedence", () => {
       const registered = listProviders();
       for (const p of MANAGED_PROVIDERS) {
         expect(registered).toContain(p);
+        expect(getProviderRoutingSource(p)).toBe("user-key");
       }
     });
   });
 
   describe("user keys absent + managed context available → providers use managed proxy", () => {
     test.each(MANAGED_PROVIDERS)(
-      "%s registers via managed fallback when no user key",
+      "%s routes via managed-proxy when no user key",
       (provider: string) => {
         enableManagedProxy();
         initializeProviders({
@@ -123,10 +130,11 @@ describe("managed proxy integration — credential precedence", () => {
           model: "test-model",
         });
         expect(listProviders()).toContain(provider);
+        expect(getProviderRoutingSource(provider)).toBe("managed-proxy");
       },
     );
 
-    test("all five managed providers register via managed fallback simultaneously", () => {
+    test("all five managed providers route via managed-proxy simultaneously", () => {
       enableManagedProxy();
       initializeProviders({
         apiKeys: {},
@@ -136,6 +144,7 @@ describe("managed proxy integration — credential precedence", () => {
       const registered = listProviders();
       for (const p of MANAGED_PROVIDERS) {
         expect(registered).toContain(p);
+        expect(getProviderRoutingSource(p)).toBe("managed-proxy");
       }
     });
   });
@@ -151,6 +160,7 @@ describe("managed proxy integration — credential precedence", () => {
           model: "test-model",
         });
         expect(listProviders()).not.toContain(provider);
+        expect(getProviderRoutingSource(provider)).toBeUndefined();
       },
     );
 
@@ -166,7 +176,7 @@ describe("managed proxy integration — credential precedence", () => {
   });
 
   describe("mixed: some user keys + managed fallback fills gaps", () => {
-    test("user key for anthropic, managed fallback fills remaining four", () => {
+    test("user key for anthropic routes direct, managed fallback fills remaining four via proxy", () => {
       enableManagedProxy();
       initializeProviders({
         apiKeys: userKeysFor("anthropic"),
@@ -175,13 +185,14 @@ describe("managed proxy integration — credential precedence", () => {
       });
       const registered = listProviders();
       expect(registered).toContain("anthropic");
-      expect(registered).toContain("openai");
-      expect(registered).toContain("gemini");
-      expect(registered).toContain("fireworks");
-      expect(registered).toContain("openrouter");
+      expect(getProviderRoutingSource("anthropic")).toBe("user-key");
+      for (const p of ["openai", "gemini", "fireworks", "openrouter"]) {
+        expect(registered).toContain(p);
+        expect(getProviderRoutingSource(p)).toBe("managed-proxy");
+      }
     });
 
-    test("user key for openai, managed fallback fills remaining four", () => {
+    test("user key for openai routes direct, managed fallback fills remaining four via proxy", () => {
       enableManagedProxy();
       initializeProviders({
         apiKeys: userKeysFor("openai"),
@@ -189,8 +200,11 @@ describe("managed proxy integration — credential precedence", () => {
         model: "test-model",
       });
       const registered = listProviders();
-      for (const p of MANAGED_PROVIDERS) {
+      expect(registered).toContain("openai");
+      expect(getProviderRoutingSource("openai")).toBe("user-key");
+      for (const p of ["anthropic", "gemini", "fireworks", "openrouter"]) {
         expect(registered).toContain(p);
+        expect(getProviderRoutingSource(p)).toBe("managed-proxy");
       }
     });
   });

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -16,6 +16,7 @@ import { RetryProvider } from "./retry.js";
 import type { Provider } from "./types.js";
 
 const providers = new Map<string, Provider>();
+const routingSources = new Map<string, "user-key" | "managed-proxy">();
 let cachedFailoverProvider: FailoverProvider | null = null;
 let cachedFailoverKey: string | null = null;
 
@@ -121,6 +122,12 @@ export function listProviders(): string[] {
   return Array.from(providers.keys());
 }
 
+export function getProviderRoutingSource(
+  name: string,
+): "user-key" | "managed-proxy" | undefined {
+  return routingSources.get(name);
+}
+
 /**
  * Return the default model for a given provider name.
  * Falls back to the Anthropic default if the provider name is unknown.
@@ -199,6 +206,7 @@ export function getProviderDebugStatus(
 
 export function initializeProviders(config: ProvidersConfig): void {
   providers.clear();
+  routingSources.clear();
   cachedFailoverProvider = null;
   cachedFailoverKey = null;
 
@@ -218,6 +226,7 @@ export function initializeProviders(config: ProvidersConfig): void {
         ),
       ),
     );
+    routingSources.set("anthropic", "user-key");
   } else {
     // No user Anthropic key — try managed proxy fallback
     const managedBaseUrl = buildManagedBaseUrl("anthropic");
@@ -237,6 +246,7 @@ export function initializeProviders(config: ProvidersConfig): void {
           ),
         ),
       );
+      routingSources.set("anthropic", "managed-proxy");
     }
   }
   if (config.apiKeys.openai) {
@@ -249,6 +259,7 @@ export function initializeProviders(config: ProvidersConfig): void {
         ),
       ),
     );
+    routingSources.set("openai", "user-key");
   } else {
     const managedBaseUrl = buildManagedBaseUrl("openai");
     if (managedBaseUrl) {
@@ -265,6 +276,7 @@ export function initializeProviders(config: ProvidersConfig): void {
           ),
         ),
       );
+      routingSources.set("openai", "managed-proxy");
     }
   }
   if (config.apiKeys.gemini) {
@@ -277,6 +289,7 @@ export function initializeProviders(config: ProvidersConfig): void {
         ),
       ),
     );
+    routingSources.set("gemini", "user-key");
   } else {
     // No user Gemini key — try managed proxy fallback
     const managedBaseUrl = buildManagedBaseUrl("gemini");
@@ -294,6 +307,7 @@ export function initializeProviders(config: ProvidersConfig): void {
           ),
         ),
       );
+      routingSources.set("gemini", "managed-proxy");
     }
   }
   if (config.provider === "ollama" || config.apiKeys.ollama) {
@@ -309,6 +323,7 @@ export function initializeProviders(config: ProvidersConfig): void {
         ),
       ),
     );
+    routingSources.set("ollama", "user-key");
   }
   if (config.apiKeys.fireworks) {
     const model = resolveModel(config, "fireworks");
@@ -322,6 +337,7 @@ export function initializeProviders(config: ProvidersConfig): void {
         ),
       ),
     );
+    routingSources.set("fireworks", "user-key");
   } else {
     const managedBaseUrl = buildManagedBaseUrl("fireworks");
     if (managedBaseUrl) {
@@ -338,6 +354,7 @@ export function initializeProviders(config: ProvidersConfig): void {
           ),
         ),
       );
+      routingSources.set("fireworks", "managed-proxy");
     }
   }
   if (config.apiKeys.openrouter) {
@@ -352,6 +369,7 @@ export function initializeProviders(config: ProvidersConfig): void {
         ),
       ),
     );
+    routingSources.set("openrouter", "user-key");
   } else {
     const managedBaseUrl = buildManagedBaseUrl("openrouter");
     if (managedBaseUrl) {
@@ -368,6 +386,7 @@ export function initializeProviders(config: ProvidersConfig): void {
           ),
         ),
       );
+      routingSources.set("openrouter", "managed-proxy");
     }
   }
 }


### PR DESCRIPTION
Address Codex feedback on PR #12808: enhance credential-precedence tests to verify routing source (user-key vs managed-proxy), not just provider presence. Adds getProviderRoutingSource() to the provider registry and updates all credential-precedence test assertions to check routing source.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
