### PR TITLE
fix: scope bun test --grep example in AGENTS.md Testing section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ The full test suite is large and will hang or timeout if run unscoped. **Never r
 
 - After making changes, run only the tests relevant to what you changed:
   `cd assistant && bun test src/path/to/file.test.ts`
-- To run tests matching a pattern: `cd assistant && bun test --grep "pattern"`
+- To run tests matching a pattern: `cd assistant && bun test src/path/to/file.test.ts --grep "pattern"`
 - Use `bunx tsc --noEmit` for full-project type-checking instead of running all tests.
 
 ## Keep the README up to date


### PR DESCRIPTION
Address Codex feedback on PR #12835: add file path to grep example to prevent unscoped test discovery.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
