### PR TITLE
fix: handle rejected WhatsApp messages correctly in webhook pipeline

### DIFF
--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -263,6 +263,13 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
           continue;
         }
 
+        // Rejected messages are processed successfully (ok: true) but should
+        // not be logged as "forwarded" — the rejection callback already handled them.
+        if (result.rejected) {
+          dedupCache.mark(whatsappMessageId);
+          continue;
+        }
+
         dedupCache.mark(whatsappMessageId);
         tlog.info(
           { status: "forwarded", whatsappMessageId },


### PR DESCRIPTION
Address feedback on PR #12855: prevent rejected WhatsApp messages from being logged as 'forwarded to runtime'. processInboundResult returns ok:true for rejected messages, so the caller must also check result.rejected before logging the forwarded success signal.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
