### PR TITLE
fix: restore touchContactInteraction and setTrustContext in relay setup router

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -591,6 +591,14 @@ export class RelayConnection {
         this.startNameCapture(outcome.assistantId, outcome.fromNumber);
         return;
       case "guardian_verification":
+        if (resolved.actorTrust.memberRecord) {
+          touchContactInteraction(resolved.actorTrust.memberRecord.contact.id);
+        }
+        if (this.controller && resolved.actorTrust.trustClass !== "unknown") {
+          this.controller.setTrustContext(
+            toTrustContext(resolved.actorTrust, msg.from),
+          );
+        }
         this.startInboundGuardianVerification(
           outcome.assistantId,
           outcome.fromNumber,


### PR DESCRIPTION
Address Devin feedback on PR #12846: ensure guardian_verification path calls touchContactInteraction and setTrustContext for known callers before entering verification, matching the behavior of the normal_call path and the pre-refactor code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
