### PR TITLE
fix: distinguish rejected messages from forwarded in processInboundResult

### DIFF
--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -227,12 +227,13 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
         );
       }
 
-      // Mark as seen only after successful forwarding
       dedupCache.mark(messageSid);
-      tlog.info(
-        { status: "forwarded", messageSid },
-        "SMS forwarded to runtime",
-      );
+      if (!outcome.rejected) {
+        tlog.info(
+          { status: "forwarded", messageSid },
+          "SMS forwarded to runtime",
+        );
+      }
     } catch (err) {
       const cbResponse = handleCircuitBreakerError(
         err,

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -264,10 +264,12 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
         }
 
         dedupCache.mark(whatsappMessageId);
-        tlog.info(
-          { status: "forwarded", whatsappMessageId },
-          "WhatsApp message forwarded to runtime",
-        );
+        if (!processed.rejected) {
+          tlog.info(
+            { status: "forwarded", whatsappMessageId },
+            "WhatsApp message forwarded to runtime",
+          );
+        }
       } catch (err) {
         const cbResponse = handleCircuitBreakerError(
           err,

--- a/gateway/src/webhook-pipeline.ts
+++ b/gateway/src/webhook-pipeline.ts
@@ -74,7 +74,9 @@ export async function handleNewCommand(
  * Processes the result of `handleInbound()`: checks for rejections
  * (rate-limited notice via sendRejection callback) and forwarding failures
  * (unreserve cache, log error).
- * Returns `{ ok: true }` on success or `{ ok: false, status: number }` on failure.
+ * Returns `{ ok: true, rejected: false }` on successful forwarding,
+ * `{ ok: true, rejected: true }` when rejected (rate-limited), or
+ * `{ ok: false, status: number }` on failure.
  */
 export function processInboundResult(
   result: InboundResult,
@@ -82,10 +84,10 @@ export function processInboundResult(
   cacheKey: string,
   sendRejection: () => void,
   logger: Logger,
-): { ok: true } | { ok: false; status: number } {
+): { ok: true; rejected: boolean } | { ok: false; status: number } {
   if (result.rejected) {
     sendRejection();
-    return { ok: true };
+    return { ok: true, rejected: true };
   }
 
   if (!result.forwarded) {
@@ -94,7 +96,7 @@ export function processInboundResult(
     return { ok: false, status: 500 };
   }
 
-  return { ok: true };
+  return { ok: true, rejected: false };
 }
 
 /**


### PR DESCRIPTION
Address feedback on PR #12854: processInboundResult now returns a discriminated `rejected` field so callers can distinguish rejection from successful forwarding. Both twilio-sms-webhook and whatsapp-webhook now skip the 'forwarded to runtime' log for rejected messages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
