### PR TITLE
fix: reorder contact routes to prevent :id from shadowing invite paths

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -102,7 +102,10 @@ import {
   startGuardianExpirySweep,
   stopGuardianExpirySweep,
 } from "./routes/channel-routes.js";
-import { contactRouteDefinitions } from "./routes/contact-routes.js";
+import {
+  contactCatchAllRouteDefinitions,
+  contactRouteDefinitions,
+} from "./routes/contact-routes.js";
 import { conversationAttentionRouteDefinitions } from "./routes/conversation-attention-routes.js";
 import { conversationRouteDefinitions } from "./routes/conversation-routes.js";
 import { debugRouteDefinitions } from "./routes/debug-routes.js";
@@ -847,9 +850,10 @@ export class RuntimeHttpServer {
       ...surfaceActionRouteDefinitions({ findSession: this.findSession }),
       ...guardianActionRouteDefinitions(),
 
-      // Invites must precede contacts/:id to avoid shadowing
-      ...inviteRouteDefinitions(),
       ...contactRouteDefinitions(),
+      ...inviteRouteDefinitions(),
+      // contacts/:id catch-all must follow invite routes to avoid shadowing
+      ...contactCatchAllRouteDefinitions(),
 
       ...integrationRouteDefinitions(),
       ...twilioRouteDefinitions(),

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -727,6 +727,16 @@ export function contactRouteDefinitions(): RouteDefinition[] {
           authContext.assistantId,
         ),
     },
+  ];
+}
+
+/**
+ * Catch-all `contacts/:id` route. Must be registered AFTER any routes that
+ * share the `contacts/` prefix (e.g. `inviteRouteDefinitions()`) to avoid
+ * the `:id` parameter matching literal sub-paths like "invites".
+ */
+export function contactCatchAllRouteDefinitions(): RouteDefinition[] {
+  return [
     {
       endpoint: "contacts/:id",
       method: "GET",


### PR DESCRIPTION
Address Devin feedback on PR #12851: extract contacts/:id into a separate contactCatchAllRouteDefinitions() function so it is always registered after invite routes, preventing the :id parameter from matching 'invites' as a value.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
