### PR TITLE
fix: pass trace-enriched tlog to handleNewCommand in webhook handlers

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -455,7 +455,7 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
               text,
             );
           },
-          log,
+          tlog,
         );
       }
 

--- a/gateway/src/http/routes/twilio-sms-webhook.ts
+++ b/gateway/src/http/routes/twilio-sms-webhook.ts
@@ -162,7 +162,7 @@ export function createTwilioSmsWebhookHandler(config: GatewayConfig) {
           normalized.message.conversationExternalId,
           (text) =>
             sendSmsReply(config, params.From, text, routing.assistantId),
-          log,
+          tlog,
         );
       }
 

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -204,7 +204,7 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
             async (text) => {
               await sendWhatsAppReply(config, from, text);
             },
-            log,
+            tlog,
           );
         }
 


### PR DESCRIPTION
Replace module-level log with tlog in handleNewCommand calls across telegram, twilio-sms, and whatsapp webhook handlers to preserve traceId correlation. Addresses Devin feedback on #12863.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
