### PR TITLE
fix: enforce restrictive permissions on existing session files

### DIFF
--- a/assistant/src/util/cookie-session.ts
+++ b/assistant/src/util/cookie-session.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -59,9 +60,12 @@ export function createSessionStore(providerKey: string): CookieSessionStore {
   function saveSession(session: CookieSession): void {
     const dir = getSessionDir();
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    writeFileSync(getSessionPath(), JSON.stringify(session, null, 2), {
+    const path = getSessionPath();
+    writeFileSync(path, JSON.stringify(session, null, 2), {
       mode: 0o600,
     });
+    // writeFileSync mode only applies to newly created files; enforce on existing ones too
+    chmodSync(path, 0o600);
   }
 
   function clearSession(): void {


### PR DESCRIPTION
Add chmodSync after writeFileSync to ensure 0o600 permissions on existing session.json files, not just newly created ones. Addresses Codex feedback on #12859.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
