### PR TITLE
fix: move sendMessageDeps guard before getOrCreateConversation

### DIFF
--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -530,8 +530,6 @@ export async function handleSendMessage(
     }
   }
 
-  const mapping = getOrCreateConversation(conversationKey);
-
   if (!deps.sendMessageDeps) {
     return httpError(
       "SERVICE_UNAVAILABLE",
@@ -539,6 +537,8 @@ export async function handleSendMessage(
       503,
     );
   }
+
+  const mapping = getOrCreateConversation(conversationKey);
   const smDeps = deps.sendMessageDeps;
   const session = await smDeps.getOrCreateSession(mapping.conversationId);
 


### PR DESCRIPTION
Reorder the sendMessageDeps guard check to run before getOrCreateConversation, preventing orphaned conversation DB records when sendMessageDeps is undefined. Addresses Devin feedback on #12864.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
