### PR TITLE
fix: exclude pre-auth route modules from guard-test policy scan

### DIFF
--- a/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
+++ b/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
@@ -56,7 +56,9 @@ describe("route policy coverage", () => {
     const routePolicySrc = readFileSync(routePolicyPath, "utf-8");
 
     // Collect all source files to scan for endpoint literals: http-server.ts
-    // plus every route module under routes/.
+    // plus every route module under routes/. Pre-auth route modules (those
+    // containing "pre-auth endpoint") are excluded because they are handled
+    // before JWT auth and are not composed into buildRouteTable().
     const allSources = [httpServerSrc];
     try {
       const routeFiles = execSync(`ls "${routeModulesDir}"/*.ts`, {
@@ -66,7 +68,9 @@ describe("route policy coverage", () => {
         .split("\n")
         .filter((f) => f.length > 0);
       for (const filePath of routeFiles) {
-        allSources.push(readFileSync(filePath, "utf-8"));
+        const src = readFileSync(filePath, "utf-8");
+        if (src.includes("pre-auth endpoint")) continue;
+        allSources.push(src);
       }
     } catch {
       // No route modules found — only inline routes will be covered.


### PR DESCRIPTION
The guard test scans all route modules under routes/ for endpoint literals, but pre-auth routes (guardian-bootstrap, guardian-refresh) are not part of the authenticated route table and should be excluded from the policy coverage check. Skips route files containing a 'pre-auth endpoint' marker comment, which both guardian pre-auth modules already have.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
