### PR TITLE
fix: resolve TS2345 type error in route-schema-guard test

### DIFF
--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -188,13 +188,14 @@ describe("route-schema sync guard", () => {
   test("HTTP methods for each path should match between routes and schema", () => {
     const routes = extractRoutesFromSource();
     const HTTP_METHODS = ["get", "post", "put", "patch", "delete"] as const;
+    type HttpMethod = (typeof HTTP_METHODS)[number];
 
     const mismatches: string[] = [];
 
     // Build a map of path → set of methods from the route table.
     // Routes without an explicit method match any method — skip those
     // since the guard can't know which methods they actually handle.
-    const routeMethodsByPath = new Map<string, Set<string>>();
+    const routeMethodsByPath = new Map<string, Set<HttpMethod>>();
     for (const route of routes) {
       if (EXCLUDED_FROM_SCHEMA.has(route.path)) continue;
       if (route.path === "/") continue; // catch-all
@@ -208,7 +209,7 @@ describe("route-schema sync guard", () => {
         methods = new Set();
         routeMethodsByPath.set(normalizedPath, methods);
       }
-      methods.add(route.method.toLowerCase());
+      methods.add(route.method.toLowerCase() as HttpMethod);
     }
 
     // For each path that has explicit methods in the route table,


### PR DESCRIPTION
## Summary
- Type `routeMethodsByPath` with the `HttpMethod` literal union instead of `string` to fix `Set.has()` type mismatch with the `as const` `HTTP_METHODS` array
- Adds a cast on `route.method.toLowerCase()` since `String.toLowerCase()` returns `string`

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22708793415/job/65841571081

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
