### PR TITLE
fix: yield main actor in iOS attachment test to prevent CI timeout

### DIFF
--- a/clients/ios/Tests/AttachmentFlowIOSTests.swift
+++ b/clients/ios/Tests/AttachmentFlowIOSTests.swift
@@ -162,22 +162,27 @@ final class AttachmentFlowIOSTests: XCTestCase {
 
     // MARK: - Image Attachment via Raw Data
 
-    func testAddAttachmentFromImageData() {
-        // Create a minimal valid PNG
+    func testAddAttachmentFromImageData() async throws {
         let pngData = makeMinimalPNGData()
 
         viewModel.addAttachment(imageData: pngData, filename: "Screenshot.png")
 
-        // addAttachment(imageData:) processes the image asynchronously via Task,
-        // so wait for the attachment to appear.
-        let appeared = XCTNSPredicateExpectation(
-            predicate: NSPredicate { _, _ in self.viewModel.pendingAttachments.count == 1 },
-            object: nil
-        )
-        wait(for: [appeared], timeout: 5)
+        // addAttachment(imageData:) processes the image asynchronously via a
+        // MainActor Task. Yield the main actor so the continuation can run —
+        // XCTNSPredicateExpectation's wait(for:) pumps the run loop but doesn't
+        // yield the cooperative executor, causing the Task to never complete.
+        for _ in 0..<50 {
+            if !viewModel.pendingAttachments.isEmpty { break }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
 
-        XCTAssertEqual(viewModel.pendingAttachments[0].filename, "Screenshot.png")
-        XCTAssertEqual(viewModel.pendingAttachments[0].mimeType, "image/png")
+        XCTAssertEqual(viewModel.pendingAttachments.count, 1)
+        guard let first = viewModel.pendingAttachments.first else {
+            XCTFail("Expected one pending attachment")
+            return
+        }
+        XCTAssertEqual(first.filename, "Screenshot.png")
+        XCTAssertEqual(first.mimeType, "image/png")
     }
 
     func testAddAttachmentFromImageDataRespectsMaxAttachments() {


### PR DESCRIPTION
## Summary
- Convert `testAddAttachmentFromImageData` from `XCTNSPredicateExpectation` + `wait(for:)` to an `async` test with `Task.sleep` polling
- `wait(for:timeout:)` pumps the run loop but doesn't yield the Swift cooperative executor, so the MainActor `Task` inside `addAttachment(imageData:)` can never run its continuation — the attachment never appears, the predicate times out, and `pendingAttachments[0]` crashes with index out of range
- The async test properly yields the main actor between polls, allowing the Task to complete

## Original prompt
fix this ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22705443571/job/65831388060

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12880" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
