### PR TITLE
fix: forward Anthropic API key from UserDefaults to daemon on hatch

### DIFF
--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -796,6 +796,14 @@ final class AssistantCli {
             if let port = fullEnv["RUNTIME_HTTP_PORT"] ?? getenv("RUNTIME_HTTP_PORT").flatMap({ String(cString: $0) }) {
                 env["RUNTIME_HTTP_PORT"] = port
             }
+            // Fall back to UserDefaults for the Anthropic API key when
+            // it's not in the process environment (e.g. app launched from
+            // Finder, not a terminal with ANTHROPIC_API_KEY set).
+            if env["ANTHROPIC_API_KEY"] == nil,
+               let storedKey = UserDefaults.standard.string(forKey: "vellum_provider_anthropic"),
+               !storedKey.isEmpty {
+                env["ANTHROPIC_API_KEY"] = storedKey
+            }
             proc.environment = env
 
             try proc.run()


### PR DESCRIPTION
## Summary

- When the desktop app is launched from Finder, `ANTHROPIC_API_KEY` is not in the process environment, causing "No providers available" errors
- The onboarding flow stores the key in UserDefaults (`vellum_provider_anthropic`), but `hatch()` only forwarded it from the process env
- Added a fallback in `AssistantCli.hatch()` that reads the key from UserDefaults when it's missing from the environment

## Test plan

- [ ] Launch the app from Finder (not terminal) with an API key stored via onboarding — verify the daemon starts without "No providers available" errors
- [ ] Launch the app from a terminal with `ANTHROPIC_API_KEY` set — verify the env var takes precedence over UserDefaults
- [ ] Launch the app with neither env var nor UserDefaults key — verify no crash (key simply isn't set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
