### PR TITLE
fix: always show Log Out in sidebar drawer menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -23,7 +23,6 @@ struct MainWindowView: View {
     /// so we can restore it when they exit instead of jumping to visibleThreads.first
     /// (which may be a pinned thread unrelated to what they were doing).
     @State private var preTemporaryChatThreadId: UUID?
-    @State private var hasSessionToken: Bool = false
 
     @AppStorage("sidebarExpanded") var sidebarExpanded: Bool = true
     @AppStorage("themePreference") private var themePreference: String = "system"
@@ -446,8 +445,7 @@ struct MainWindowView: View {
                             onLogOut: {
                                 sidebar.showPreferencesDrawer = false
                                 AppDelegate.shared?.performLogout()
-                            },
-                            showLogOut: hasSessionToken
+                            }
                         )
                         .frame(width: drawerWidth)
                         .offset(x: drawerX, y: -28)
@@ -503,7 +501,6 @@ struct MainWindowView: View {
                 windowState.persistentThreadId = activeId
             }
             daemonClient.startSSE()
-            hasSessionToken = SessionTokenManager.getToken() != nil
         }
         .onDisappear {
             copyThread.cancel()
@@ -520,9 +517,6 @@ struct MainWindowView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .apiKeyManagerDidChange)) { _ in
             windowState.refreshAPIKeyStatus(isConnected: daemonClient.isConnected)
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .sessionTokenDidChange)) { _ in
-            hasSessionToken = SessionTokenManager.getToken() != nil
         }
         .onReceive(daemonClient.$isConnected) { connected in
             windowState.refreshAPIKeyStatus(isConnected: connected)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -5,7 +5,6 @@ struct DrawerMenuView: View {
     let onSettings: () -> Void
     let onDebug: () -> Void
     let onLogOut: () -> Void
-    let showLogOut: Bool
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             DrawerThemeToggle()
@@ -22,12 +21,10 @@ struct DrawerMenuView: View {
 
             DrawerMenuItem(icon: "ladybug", label: "Debug", action: onDebug)
 
-            if showLogOut {
-                VColor.surfaceBorder.frame(height: 1)
-                    .padding(.vertical, VSpacing.xs)
+            VColor.surfaceBorder.frame(height: 1)
+                .padding(.vertical, VSpacing.xs)
 
-                DrawerMenuItem(icon: "rectangle.portrait.and.arrow.right", label: String(localized: "Log Out"), action: onLogOut)
-            }
+            DrawerMenuItem(icon: "rectangle.portrait.and.arrow.right", label: String(localized: "Log Out"), action: onLogOut)
         }
         .padding(.vertical, VSpacing.sm)
         .background(VColor.surfaceSubtle)


### PR DESCRIPTION
## Summary
- Remove the `showLogOut` / `hasSessionToken` gate so the Log Out button always appears in the sidebar preferences drawer
- Clean up the now-unused `hasSessionToken` state and its `sessionTokenDidChange` observer

## Original prompt
Oh interesting - let's make it show up regardless. Even if I'm in self-hosted mode I should be able to go back to the initial screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
