### PR TITLE
fix: use fd inheritance for daemon/gateway spawns to prevent SIGPIPE death

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -647,14 +647,18 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
         }
       }
 
+      // Use fd inheritance instead of pipes so the daemon's stdout/stderr
+      // survive after the parent (hatch) exits. Bun does not ignore SIGPIPE,
+      // so piped stdio would kill the daemon on its first write after the
+      // parent closes.
       const daemonLogFd = openLogFile("hatch.log");
       const child = spawn(daemonBinary, [], {
         cwd: dirname(daemonBinary),
         detached: true,
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio: ["ignore", daemonLogFd, daemonLogFd],
         env: daemonEnv,
       });
-      pipeToLogFile(child, daemonLogFd, "daemon");
+      if (typeof daemonLogFd === "number") closeSync(daemonLogFd);
       child.unref();
       const daemonPid = child.pid;
 
@@ -856,13 +860,15 @@ export async function startGateway(
       );
     }
 
+    // Use fd inheritance (not pipes) so the gateway survives after the
+    // hatch CLI exits — Bun does not ignore SIGPIPE.
     const gatewayLogFd = openLogFile("hatch.log");
     gateway = spawn(gatewayBinary, [], {
       detached: true,
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["ignore", gatewayLogFd, gatewayLogFd],
       env: gatewayEnv,
     });
-    pipeToLogFile(gateway, gatewayLogFd, "gateway");
+    if (typeof gatewayLogFd === "number") closeSync(gatewayLogFd);
   } else {
     // Source tree / bunx: resolve the gateway source directory and run via bun.
     const gatewayDir = resolveGatewayDir();
@@ -873,10 +879,10 @@ export async function startGateway(
     gateway = spawn("bun", bunArgs, {
       cwd: gatewayDir,
       detached: true,
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["ignore", gwLogFd, gwLogFd],
       env: gatewayEnv,
     });
-    pipeToLogFile(gateway, gwLogFd, "gateway");
+    if (typeof gwLogFd === "number") closeSync(gwLogFd);
     if (watch) {
       console.log("   Gateway started in watch mode (bun --watch)");
     }
@@ -935,5 +941,4 @@ export async function stopLocalProcesses(): Promise<void> {
 
   const gatewayPidFile = join(vellumDir, "gateway.pid");
   await stopProcessByPidFile(gatewayPidFile, "gateway");
-
 }


### PR DESCRIPTION
## Summary

- Fix daemon and gateway processes dying from SIGPIPE when the hatch CLI process exits
- Replace piped stdio (`["ignore", "pipe", "pipe"]` + `pipeToLogFile()`) with fd inheritance (`["ignore", logFd, logFd]`) at all three desktop/source spawn sites in `cli/src/lib/local.ts`
- This matches the pattern already used by `startDaemonFromSource` which had an explicit comment explaining the SIGPIPE issue

## Context

When the desktop app hatches locally, the daemon and gateway are spawned with piped stdio. When the hatch CLI process exits, the pipe read ends close, and the daemon/gateway get SIGPIPE on their next stdout/stderr write and die. Bun does not ignore SIGPIPE, unlike Node.js.

## Test plan

- [ ] Verify daemon and gateway survive after hatch CLI exits on desktop app
- [ ] Verify logs still appear in hatch.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
