### PR TITLE
fix: always enable managed bootstrap on re-login

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -35,7 +35,7 @@ extension AppDelegate {
             state: state,
             daemonClient: daemonClient,
             authManager: authManager,
-            managedBootstrapEnabled: isCurrentAssistantManaged,
+            managedBootstrapEnabled: true,
             onComplete: { [weak self] in
                 self?.proceedToApp()
             },


### PR DESCRIPTION
## Summary
- When re-logging in via the auth window, `managedBootstrapEnabled` was set to `isCurrentAssistantManaged` which is `false` for users with existing local assistants
- This caused the managed bootstrap to be skipped after sign-in, leaving the user on their local assistant instead of transitioning to a managed one
- Changed to always pass `managedBootstrapEnabled: true` so signing in always triggers the managed assistant bootstrap

## Original prompt
Fix managed bootstrap not running on re-login

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
