### PR TITLE
fix: route SettingsStore HTTP requests through platform for managed assistants

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -970,38 +970,61 @@ public final class SettingsStore: ObservableObject {
 
     // MARK: - Slack Channel Actions (HTTP-first)
 
-    /// Resolves the runtime HTTP base URL and bearer token for direct HTTP calls.
+    /// Builds an authenticated URLRequest for the daemon's runtime HTTP server (local mode)
+    /// or the platform assistant proxy (managed mode).
     ///
-    /// Uses the JWT access token from ActorTokenManager (issued via guardian bootstrap)
-    /// as the primary auth credential. Falls back to the legacy `~/.vellum/http-token`
-    /// hex string only during the brief bootstrap window before the first JWT is issued.
-    ///
-    /// The daemon's auth middleware requires JWT format (3 dot-separated parts) — the
-    /// legacy hex token will be rejected with 401 if the JWT path isn't available yet.
-    /// This matches the auth pattern used by HTTPDaemonClient and the Twilio endpoints.
-    private func resolveRuntimeHTTP() -> (baseURL: String, token: String)? {
+    /// - Local: `http://localhost:{port}/{path}` with `Authorization: Bearer {jwt}`
+    /// - Managed: `{platformBaseURL}/v1/assistants/{id}/{path}/` with `X-Session-Token` + `Vellum-Organization-Id`
+    private func buildDaemonRequest(path: String, method: String) -> URLRequest? {
+        let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+        let assistant = connectedId.flatMap { LockfileAssistant.loadByName($0) }
+        if let assistant, assistant.isManaged {
+            let baseURL = assistant.runtimeUrl ?? AuthService.shared.baseURL
+            // Django URL convention: trailing slash
+            let trailingSlash = path.hasSuffix("/") ? "" : "/"
+            guard let url = URL(string: "\(baseURL)/v1/assistants/\(assistant.assistantId)/\(path)\(trailingSlash)") else { return nil }
+            var request = URLRequest(url: url)
+            request.httpMethod = method
+            request.timeoutInterval = 5
+            if let token = SessionTokenManager.getToken() {
+                request.setValue(token, forHTTPHeaderField: "X-Session-Token")
+            }
+            if let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
+                request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
+            }
+            return request
+        }
+
+        // Local mode: direct to daemon runtime HTTP server
         let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
             .flatMap(Int.init) ?? 7821
-        // Prefer JWT from guardian bootstrap (same pattern as HTTPDaemonClient line 1504)
+        let token: String
         if let jwt = ActorTokenManager.getToken(), !jwt.isEmpty {
-            return ("http://localhost:\(port)", jwt)
+            token = jwt
+        } else if let httpToken = readHttpToken() {
+            token = httpToken
+        } else {
+            return nil
         }
-        // Fallback to legacy http-token for pre-bootstrap window
-        guard let token = readHttpToken() else { return nil }
-        return ("http://localhost:\(port)", token)
+        guard let url = URL(string: "http://localhost:\(port)/\(path)") else { return nil }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.timeoutInterval = 5
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        return request
+    }
+
+    /// Whether the daemon HTTP endpoint is reachable (for tombstone replay gating).
+    private func isDaemonHTTPAvailable() -> Bool {
+        return buildDaemonRequest(path: "v1/secrets", method: "GET") != nil
     }
 
     // MARK: - Daemon Key Sync (HTTP)
 
     /// Notify the daemon that an API key was set, so it updates its encrypted store.
     private func syncKeyToDaemon(provider: String, value: String) {
-        guard let http = resolveRuntimeHTTP() else { return }
-        guard let url = URL(string: "\(http.baseURL)/v1/secrets") else { return }
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        guard var request = buildDaemonRequest(path: "v1/secrets", method: "POST") else { return }
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 5
         let body: [String: String] = ["type": "api_key", "name": provider, "value": value]
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
         Task.detached {
@@ -1037,7 +1060,7 @@ public final class SettingsStore: ObservableObject {
         guard !tombstones.isEmpty else { return }
         // Bail out early if the HTTP endpoint is unavailable — preserve all tombstones
         // for the next reconnect attempt.
-        guard resolveRuntimeHTTP() != nil else { return }
+        guard isDaemonHTTPAvailable() else { return }
         var remaining: [[String: String]] = []
         for entry in tombstones {
             guard let type = entry["type"], let name = entry["name"] else { continue }
@@ -1062,13 +1085,8 @@ public final class SettingsStore: ObservableObject {
     /// Returns true if the HTTP endpoint was available and the request was dispatched.
     @discardableResult
     private func deleteKeyFromDaemon(provider: String) -> Bool {
-        guard let http = resolveRuntimeHTTP() else { return false }
-        guard let url = URL(string: "\(http.baseURL)/v1/secrets") else { return false }
-        var request = URLRequest(url: url)
-        request.httpMethod = "DELETE"
-        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        guard var request = buildDaemonRequest(path: "v1/secrets", method: "DELETE") else { return false }
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 5
         let body: [String: String] = ["type": "api_key", "name": provider]
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
         Task.detached {
@@ -1079,13 +1097,8 @@ public final class SettingsStore: ObservableObject {
 
     /// Notify the daemon that a credential was set (type: "credential", name: "service:field").
     private func syncCredentialToDaemon(name: String, value: String) {
-        guard let http = resolveRuntimeHTTP() else { return }
-        guard let url = URL(string: "\(http.baseURL)/v1/secrets") else { return }
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        guard var request = buildDaemonRequest(path: "v1/secrets", method: "POST") else { return }
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 5
         let body: [String: String] = ["type": "credential", "name": name, "value": value]
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
         Task.detached {
@@ -1097,13 +1110,8 @@ public final class SettingsStore: ObservableObject {
     /// Returns true if the HTTP endpoint was available and the request was dispatched.
     @discardableResult
     private func deleteCredentialFromDaemon(name: String) -> Bool {
-        guard let http = resolveRuntimeHTTP() else { return false }
-        guard let url = URL(string: "\(http.baseURL)/v1/secrets") else { return false }
-        var request = URLRequest(url: url)
-        request.httpMethod = "DELETE"
-        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        guard var request = buildDaemonRequest(path: "v1/secrets", method: "DELETE") else { return false }
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 5
         let body: [String: String] = ["type": "credential", "name": name]
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
         Task.detached {
@@ -1137,11 +1145,7 @@ public final class SettingsStore: ObservableObject {
     }
 
     func fetchSlackChannelConfig() {
-        guard let http = resolveRuntimeHTTP() else { return }
-        guard let url = URL(string: "\(http.baseURL)/v1/integrations/slack/channel/config") else { return }
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        guard var request = buildDaemonRequest(path: "v1/integrations/slack/channel/config", method: "GET") else { return }
         request.timeoutInterval = 10
         Task {
             do {
@@ -1175,17 +1179,10 @@ public final class SettingsStore: ObservableObject {
         guard !trimmedBot.isEmpty, !trimmedApp.isEmpty else { return }
         slackChannelSaveInProgress = true
         slackChannelError = nil
-        guard let http = resolveRuntimeHTTP() else {
+        guard var request = buildDaemonRequest(path: "v1/integrations/slack/channel/config", method: "POST") else {
             slackChannelSaveInProgress = false
             return
         }
-        guard let url = URL(string: "\(http.baseURL)/v1/integrations/slack/channel/config") else {
-            slackChannelSaveInProgress = false
-            return
-        }
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = 10
         let body: [String: String] = ["botToken": trimmedBot, "appToken": trimmedApp]
@@ -1226,11 +1223,7 @@ public final class SettingsStore: ObservableObject {
 
     func clearSlackChannelConfig() {
         slackChannelError = nil
-        guard let http = resolveRuntimeHTTP() else { return }
-        guard let url = URL(string: "\(http.baseURL)/v1/integrations/slack/channel/config") else { return }
-        var request = URLRequest(url: url)
-        request.httpMethod = "DELETE"
-        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        guard var request = buildDaemonRequest(path: "v1/integrations/slack/channel/config", method: "DELETE") else { return }
         request.timeoutInterval = 10
         Task {
             do {
@@ -1599,11 +1592,14 @@ public final class SettingsStore: ObservableObject {
     // MARK: - Approved Ingress Contacts Actions
 
     func refreshTelegramApprovedMembers() {
-        guard let http = resolveRuntimeHTTP() else { return }
-        guard let url = URL(string: "\(http.baseURL)/v1/contacts?channelType=telegram") else { return }
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        guard var request = buildDaemonRequest(path: "v1/contacts", method: "GET") else { return }
+        // Append query parameter — buildDaemonRequest already set the base URL
+        if let url = request.url, var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+            var items = components.queryItems ?? []
+            items.append(URLQueryItem(name: "channelType", value: "telegram"))
+            components.queryItems = items
+            request.url = components.url
+        }
         request.timeoutInterval = 10
         telegramApprovedMembersLoading = true
         telegramApprovedMembersError = nil
@@ -1653,12 +1649,7 @@ public final class SettingsStore: ObservableObject {
     }
 
     func revokeTelegramApprovedMember(memberId: String) {
-        guard let http = resolveRuntimeHTTP() else { return }
-        // memberId is now a channelId — revoke via PATCH /v1/contacts/channels/:channelId
-        guard let url = URL(string: "\(http.baseURL)/v1/contacts/channels/\(memberId)") else { return }
-        var request = URLRequest(url: url)
-        request.httpMethod = "PATCH"
-        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        guard var request = buildDaemonRequest(path: "v1/contacts/channels/\(memberId)", method: "PATCH") else { return }
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try? JSONSerialization.data(withJSONObject: ["status": "revoked"])
         request.timeoutInterval = 10
@@ -1684,11 +1675,13 @@ public final class SettingsStore: ObservableObject {
     }
 
     func refreshSlackApprovedMembers() {
-        guard let http = resolveRuntimeHTTP() else { return }
-        guard let url = URL(string: "\(http.baseURL)/v1/contacts?channelType=slack") else { return }
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        guard var request = buildDaemonRequest(path: "v1/contacts", method: "GET") else { return }
+        if let url = request.url, var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+            var items = components.queryItems ?? []
+            items.append(URLQueryItem(name: "channelType", value: "slack"))
+            components.queryItems = items
+            request.url = components.url
+        }
         request.timeoutInterval = 10
         slackApprovedMembersLoading = true
         slackApprovedMembersError = nil
@@ -1738,11 +1731,7 @@ public final class SettingsStore: ObservableObject {
     }
 
     func revokeSlackApprovedMember(memberId: String) {
-        guard let http = resolveRuntimeHTTP() else { return }
-        guard let url = URL(string: "\(http.baseURL)/v1/contacts/channels/\(memberId)") else { return }
-        var request = URLRequest(url: url)
-        request.httpMethod = "PATCH"
-        request.setValue("Bearer \(http.token)", forHTTPHeaderField: "Authorization")
+        guard var request = buildDaemonRequest(path: "v1/contacts/channels/\(memberId)", method: "PATCH") else { return }
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try? JSONSerialization.data(withJSONObject: ["status": "revoked"])
         request.timeoutInterval = 10


### PR DESCRIPTION
## Summary
- `resolveRuntimeHTTP()` always returned `localhost:7821` with a bearer JWT, which doesn't exist for managed assistants (causing "malformed_token: expected 3 dot-separated parts" errors)
- Replaced with `buildDaemonRequest()` that detects managed mode from the lockfile and routes through the platform proxy (`/v1/assistants/{id}/...`) with `X-Session-Token` + `Vellum-Organization-Id` headers
- All 10+ callers updated: secret sync/delete, credential sync/delete, Slack channel config, Telegram/Slack approved member management

## Original prompt
Fix SettingsStore sending wrong auth for managed assistants

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
