### PR TITLE
fix: strip v1/ prefix from managed proxy URLs in SettingsStore

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -980,9 +980,11 @@ public final class SettingsStore: ObservableObject {
         let assistant = connectedId.flatMap { LockfileAssistant.loadByName($0) }
         if let assistant, assistant.isManaged {
             let baseURL = assistant.runtimeUrl ?? AuthService.shared.baseURL
+            // Strip "v1/" prefix — the platform proxy already namespaces under /v1/assistants/{id}/
+            let proxyPath = path.hasPrefix("v1/") ? String(path.dropFirst(3)) : path
             // Django URL convention: trailing slash
-            let trailingSlash = path.hasSuffix("/") ? "" : "/"
-            guard let url = URL(string: "\(baseURL)/v1/assistants/\(assistant.assistantId)/\(path)\(trailingSlash)") else { return nil }
+            let trailingSlash = proxyPath.hasSuffix("/") ? "" : "/"
+            guard let url = URL(string: "\(baseURL)/v1/assistants/\(assistant.assistantId)/\(proxyPath)\(trailingSlash)") else { return nil }
             var request = URLRequest(url: url)
             request.httpMethod = method
             request.timeoutInterval = 5


### PR DESCRIPTION
## Summary
- `buildDaemonRequest()` callers pass `v1/secrets` as the path, but in managed mode the URL already has `/v1/assistants/{id}/`, creating `/v1/assistants/{id}/v1/secrets/` which returns 404
- Strip the `v1/` prefix in managed mode so paths resolve correctly (e.g. `/v1/assistants/{id}/secrets/`)

## Original prompt
Fix double v1/ prefix in managed proxy URLs causing 404 on secrets sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
