### PR TITLE
feat: standardize nav item hover/active colors and heights

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1083,7 +1083,7 @@ private struct SettingsNavRow: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, VSpacing.md)
                 .padding(.vertical, VSpacing.sm)
-                .background(isSelected ? VColor.hoverOverlay.opacity(0.08) : (isHovered ? VColor.hoverOverlay.opacity(0.04) : Color.clear))
+                .background(isSelected ? VColor.navActive : (isHovered ? VColor.navHover : Color.clear))
                 .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
                 .contentShape(Rectangle())
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuItem.swift
@@ -34,7 +34,7 @@ struct DrawerMenuItem: View {
             }
             .padding(.horizontal, VSpacing.lg)
             .padding(.vertical, VSpacing.sm)
-            .background(isHovered ? VColor.hoverOverlay.opacity(0.06) : Color.clear)
+            .background(isHovered ? VColor.navHover : Color.clear)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift
@@ -38,7 +38,7 @@ struct SidebarPrimaryRow: View {
             .padding(.vertical, VSpacing.sm)
             .frame(maxWidth: .infinity, alignment: isExpanded ? .leading : .center)
             .background(
-                (isActive ? adaptiveColor(light: Moss._100, dark: Moss._700) : isHovered ? adaptiveColor(light: Moss._100, dark: Moss._700).opacity(0.5) : .clear)
+                (isActive ? VColor.navActive : isHovered ? VColor.navHover : .clear)
                     .animation(VAnimation.fast, value: isHovered)
             )
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))

--- a/clients/shared/DesignSystem/Core/Display/VListRow.swift
+++ b/clients/shared/DesignSystem/Core/Display/VListRow.swift
@@ -26,10 +26,10 @@ public struct VListRow<Content: View>: View {
 
     private var rowContent: some View {
         content()
-            .padding(.vertical, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
             .padding(.horizontal, VSpacing.lg)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(isHovered ? VColor.surfaceBorder.opacity(0.5) : .clear)
+            .background(isHovered ? VColor.navHover : .clear)
             .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
             .onHover { hovering in
                 isHovered = hovering


### PR DESCRIPTION
## Summary
- Align all list/nav components to use `VColor.navHover` (#E8E6DA) and `VColor.navActive` (#D4DFD0) for consistent hover/active states
- Reduce `VListRow` vertical padding from `VSpacing.md` (12pt) to `VSpacing.sm` (8pt) to match nav/thread items
- Update `SidebarPrimaryRow`, `DrawerMenuItem`, and `SettingsNavRow` to use the standardized nav tokens

## Test plan
- [ ] VListRow hover shows navHover color
- [ ] SidebarPrimaryRow active/hover matches thread items
- [ ] DrawerMenuItem hover uses navHover
- [ ] Settings nav sidebar uses navHover/navActive
- [ ] All items have consistent 8pt vertical padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
