### PR TITLE
feat: unify search icon and shortcut tag into single button

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -313,15 +313,19 @@ struct MainWindowView: View {
                     }
                 }
 
-                HStack(spacing: 0) {
-                    VIconButton(label: "Search", icon: "magnifyingglass", iconOnly: true, tooltip: "Search (\u{2318}K)") {
-                        AppDelegate.shared?.toggleCommandPalette()
+                Button {
+                    AppDelegate.shared?.toggleCommandPalette()
+                } label: {
+                    HStack(spacing: VSpacing.xs) {
+                        Image(systemName: "magnifyingglass")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400))
+                        VShortcutTag("\u{2318}K")
                     }
-
-                    VShortcutTag("\u{2318}K") {
-                        AppDelegate.shared?.toggleCommandPalette()
-                    }
+                    .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
+                .help("Search (\u{2318}K)")
             }
             Spacer()
             PTTKeyIndicator {

--- a/clients/shared/DesignSystem/Core/Feedback/VShortcutTag.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VShortcutTag.swift
@@ -7,48 +7,58 @@ import AppKit
 public struct VShortcutTag: View {
     public let text: String
     public var icon: String? = nil
-    public let action: () -> Void
+    public var action: (() -> Void)? = nil
 
     @State private var isHovered = false
 
     private let tagColor = Color(hex: 0xA1A096)
     private let borderColor = Color(hex: 0xE8E6DA)
 
-    public init(_ text: String, icon: String? = nil, action: @escaping () -> Void = {}) {
+    public init(_ text: String, icon: String? = nil, action: (() -> Void)? = nil) {
         self.text = text
         self.icon = icon
         self.action = action
     }
 
-    public var body: some View {
-        Button(action: action) {
-            HStack(spacing: VSpacing.xs) {
-                if let icon {
-                    Image(systemName: icon)
-                        .font(.system(size: 11, weight: .medium))
-                }
-                Text(text)
-                    .font(VFont.caption)
+    private var tagContent: some View {
+        HStack(spacing: VSpacing.xs) {
+            if let icon {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .medium))
             }
-            .foregroundColor(tagColor)
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xs)
-            .background(
-                Capsule()
-                    .strokeBorder(isHovered ? tagColor.opacity(0.5) : borderColor, lineWidth: 1)
-            )
+            Text(text)
+                .font(VFont.caption)
         }
-        .buttonStyle(.plain)
-        #if os(macOS)
-        .onHover { hovering in
-            isHovered = hovering
-            if hovering { NSCursor.pointingHand.set() }
-            else { NSCursor.arrow.set() }
+        .foregroundColor(tagColor)
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
+        .background(
+            Capsule()
+                .strokeBorder(isHovered ? tagColor.opacity(0.5) : borderColor, lineWidth: 1)
+        )
+    }
+
+    public var body: some View {
+        if let action {
+            Button(action: action) {
+                tagContent
+            }
+            .buttonStyle(.plain)
+            #if os(macOS)
+            .onHover { hovering in
+                isHovered = hovering
+                if hovering { NSCursor.pointingHand.set() }
+                else { NSCursor.arrow.set() }
+            }
+            #else
+            .onHover { isHovered = $0 }
+            #endif
+            .accessibilityLabel(text)
+        } else {
+            tagContent
+                .allowsHitTesting(false)
+                .accessibilityLabel(text)
         }
-        #else
-        .onHover { isHovered = $0 }
-        #endif
-        .accessibilityLabel(text)
     }
 }
 


### PR DESCRIPTION
## Summary
- Unified the search magnifying glass icon and ⌘K shortcut tag into a single clickable button in the top bar
- Search icon now uses the standard green icon color (`adaptiveColor(light: 0x537D53, dark: Forest._400)`)
- Refactored `VShortcutTag` to support display-only mode (optional action parameter)
- Added `.contentShape(Rectangle())` so the entire button area is clickable

## Test plan
- [ ] Verify the search icon + ⌘K tag in the top bar acts as one clickable button
- [ ] Verify clicking anywhere on the combined element opens the command palette
- [ ] Verify hover cursor changes to pointer over the entire area
- [ ] Verify VShortcutTag without an action renders as display-only (no hover effects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
