### PR TITLE
fix: stabilize chat scroll during sidebar expand in app-edit mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -92,6 +92,7 @@ struct ChatView: View {
     @State private var isDropTargeted = false
     @State private var editorContentHeight: CGFloat = 20
     @State private var isComposerExpanded = false
+    @State private var containerWidth: CGFloat = 0
 
     private var isEmptyState: Bool {
         messages.isEmpty && isHistoryLoaded
@@ -217,7 +218,8 @@ struct ChatView: View {
                             loadPreviousMessagePage: loadPreviousMessagePage,
                             threadId: threadId,
                             anchorMessageId: $anchorMessageId,
-                            isNearBottom: $isNearBottom
+                            isNearBottom: $isNearBottom,
+                            containerWidth: containerWidth
                         )
                         .safeAreaInset(edge: .bottom) {
                             Color.clear.frame(height: composerReservedHeight)
@@ -284,6 +286,12 @@ struct ChatView: View {
                 chatBackground
             }
             .background(VColor.chatBackground)
+            .background(
+                GeometryReader { geo in
+                    Color.clear.preference(key: ChatContainerWidthKey.self, value: geo.size.width)
+                }
+            )
+            .onPreferenceChange(ChatContainerWidthKey.self) { containerWidth = $0 }
 
             // Drop target overlay
             if isDropTargeted {
@@ -661,3 +669,12 @@ private struct ChatViewPreviewWrapper: View {
     }
 }
 #endif
+
+/// Propagates the chat container's measured width up to ChatView so it can
+/// forward it to MessageListView for resize-aware scroll stabilization.
+private struct ChatContainerWidthKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -55,6 +55,9 @@ struct MessageListView: View {
     /// Used by notification deep links to anchor the view to a specific message.
     @Binding var anchorMessageId: UUID?
     @Binding var isNearBottom: Bool
+    /// Measured width of the chat container, used to detect sidebar/split resizes
+    /// and stabilize scroll position during layout width changes.
+    var containerWidth: CGFloat = 0
     @Environment(\.conversationZoomScale) private var conversationZoomScale
     @AppStorage("hasEverSentMessage") private var hasEverSentMessage: Bool = false
     @AppStorage("completedConversationCount") private var completedConversationCount: Int = 0
@@ -104,6 +107,11 @@ struct MessageListView: View {
     /// regardless of whether messages.count changes. This covers the edge
     /// case where pagination stalls without adding/removing messages.
     @State private var anchorTimeoutTask: Task<Void, Never>?
+    /// Last container width that triggered a resize scroll handler, used to
+    /// detect meaningful width changes (>20pt) and avoid sub-pixel jitter.
+    @State private var lastHandledContainerWidth: CGFloat = 0
+    /// In-flight resize scroll stabilization task; cancelled on each new resize.
+    @State private var resizeScrollTask: Task<Void, Never>?
 
     /// The subset of messages actually shown, honoring the pagination window.
     private var visibleMessages: [ChatMessage] {
@@ -599,6 +607,8 @@ struct MessageListView: View {
                 suppressScrollbarDuringThreadSwitch = false
                 anchorTimeoutTask?.cancel()
                 anchorTimeoutTask = nil
+                resizeScrollTask?.cancel()
+                resizeScrollTask = nil
             }
             .onChange(of: isSending) {
                 if isSending {
@@ -692,17 +702,51 @@ struct MessageListView: View {
                 }
                 // When mid-scroll, do nothing — let SwiftUI handle the text reflow naturally.
             }
+            .onChange(of: containerWidth) {
+                // Ignore sub-pixel jitter and initial zero value
+                guard containerWidth > 0, abs(containerWidth - lastHandledContainerWidth) > 20 else { return }
+                lastHandledContainerWidth = containerWidth
+
+                // Cancel competing scroll tasks to prevent jitter during resize
+                scrollDebounceTask?.cancel()
+                scrollDebounceTask = nil
+                resizeScrollTask?.cancel()
+
+                resizeScrollTask = Task { @MainActor in
+                    // Temporarily suppress bottom auto-scroll so streaming/message-count
+                    // handlers don't fight with the resize stabilization.
+                    isSuppressingBottomScroll = true
+                    defer {
+                        if !Task.isCancelled {
+                            isSuppressingBottomScroll = false
+                            resizeScrollTask = nil
+                        }
+                    }
+                    // Wait for layout to settle (~100ms ≈ 6 frames)
+                    try? await Task.sleep(nanoseconds: 100_000_000)
+                    guard !Task.isCancelled else { return }
+
+                    if isNearBottom {
+                        // Pin to bottom without animation to avoid visual bounce
+                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                    }
+                    // If not near bottom, preserve viewport — no forced scroll.
+                }
+            }
             .onChange(of: threadId) {
                 // Keep the underlying NSScrollView instance stable across thread
                 // switches (prevents default-scroller flash), and reset view-local
                 // scroll state explicitly instead of remounting the whole view.
                 scrollDebounceTask?.cancel()
                 scrollDebounceTask = nil
+                resizeScrollTask?.cancel()
+                resizeScrollTask = nil
                 isPaginationInFlight = false
                 isSuppressingBottomScroll = false
                 isNearBottom = true
                 anchorIsVisible = true
                 hasReceivedScrollEvent = false
+                lastHandledContainerWidth = containerWidth
                 hoverExitDebounceTask?.cancel()
                 hoverExitDebounceTask = nil
                 anchorTimeoutTask?.cancel()

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -726,11 +726,13 @@ struct MessageListView: View {
                     try? await Task.sleep(nanoseconds: 100_000_000)
                     guard !Task.isCancelled else { return }
 
-                    if isNearBottom {
-                        // Pin to bottom without animation to avoid visual bounce
+                    if isNearBottom && anchorMessageId == nil {
+                        // Pin to bottom without animation to avoid visual bounce.
+                        // Skip when an anchor is pending (deep-link / notification)
+                        // to avoid yanking the viewport away from the target message.
                         proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
                     }
-                    // If not near bottom, preserve viewport — no forced scroll.
+                    // If not near bottom or anchor is set, preserve viewport.
                 }
             }
             .onChange(of: threadId) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -404,10 +404,12 @@ struct MainWindowView: View {
                     HStack(spacing: 16) {
                         if !isSettingsOpen {
                             sidebarView
+                                .animation(VAnimation.panel, value: sidebarExpanded)
                         }
 
                         chatContentView(geometry: geometry)
                             .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+                            .animation(nil, value: sidebarExpanded)
                             .overlay {
                                 if showDaemonLoading {
                                     DaemonLoadingChatSkeleton()
@@ -416,7 +418,6 @@ struct MainWindowView: View {
                             }
                     }
                     .padding(16)
-                    .animation(VAnimation.panel, value: sidebarExpanded)
                 }
                 .overlay {
                     // Click-outside-to-dismiss background for preferences drawer

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -169,6 +169,41 @@ extension MainWindowView {
         }
     }
 
+    // MARK: - Split-Width Helpers
+
+    /// Computes a clamped panel-width binding for split layouts, accounting for
+    /// sidebar consumption and enforcing min main/panel constraints on both
+    /// get and set paths so persisted values stay valid across resizes.
+    func clampedPanelWidth(geometry: GeometryProxy) -> Binding<Double> {
+        // Sidebar sits in the HStack and consumes real width.
+        // When settings is open the sidebar is hidden.
+        let settingsOpen: Bool = {
+            if case .panel(.settings) = windowState.selection { return true }
+            return false
+        }()
+        let sidebarWidth: CGFloat = settingsOpen ? 0 : (sidebarExpanded ? sidebarExpandedWidth : sidebarCollapsedWidth)
+        let hstackSpacing: CGFloat = 16
+        let outerPadding: CGFloat = 32 // 16 left + 16 right
+        let windowWidth: Double = Double(geometry.size.width) / zoomManager.zoomLevel
+        let availableWidth: Double = windowWidth - Double(sidebarWidth) - Double(hstackSpacing) - Double(outerPadding)
+
+        let minPanel: Double = 300
+        let minMain: Double = 300
+        // VSplitView internals: leading padding (xs=4) + divider (8) = 12
+        let dividerBudget: Double = Double(VSpacing.xs) + 12
+        let maxPanel = max(availableWidth - minMain - dividerBudget, minPanel)
+
+        return Binding<Double>(
+            get: {
+                let raw = appPanelWidth > 0 ? appPanelWidth : availableWidth * 0.7
+                return min(max(raw, minPanel), maxPanel)
+            },
+            set: {
+                appPanelWidth = min(max($0, minPanel), maxPanel)
+            }
+        )
+    }
+
     @ViewBuilder
     func chatContentView(geometry: GeometryProxy) -> some View {
         switch windowState.selection {
@@ -206,14 +241,8 @@ extension MainWindowView {
             // VSplitView: ChatView (left) + workspace (right)
             if let surface = windowState.activeDynamicParsedSurface,
                case .dynamicPage(let dpData) = surface.data {
-                // Compute content area width (sidebar is an overlay, doesn't reduce content width)
-                let contentWidth = Double(geometry.size.width) / zoomManager.zoomLevel - Double(VSpacing.sm)
-                let effectiveWidth = Binding<Double>(
-                    get: { appPanelWidth > 0 ? appPanelWidth : contentWidth * 0.7 },
-                    set: { appPanelWidth = $0 }
-                )
                 VSplitView(
-                    panelWidth: effectiveWidth,
+                    panelWidth: clampedPanelWidth(geometry: geometry),
                     showPanel: true,
                     main: {
                         chatView
@@ -230,13 +259,8 @@ extension MainWindowView {
             if panelType == .directory {
                 if isAppChatOpen {
                     // VSplitView: ChatView (left) + Home Base (right)
-                    let contentWidth = Double(geometry.size.width) / zoomManager.zoomLevel - Double(VSpacing.sm)
-                    let effectiveWidth = Binding<Double>(
-                        get: { appPanelWidth > 0 ? appPanelWidth : contentWidth * 0.7 },
-                        set: { appPanelWidth = $0 }
-                    )
                     VSplitView(
-                        panelWidth: effectiveWidth,
+                        panelWidth: clampedPanelWidth(geometry: geometry),
                         showPanel: true,
                         main: {
                             chatView
@@ -331,13 +355,8 @@ extension MainWindowView {
                 )
             } else if isAppChatOpen {
                 // Split view: chat (left) + panel (right)
-                let contentWidth = Double(geometry.size.width) / zoomManager.zoomLevel - Double(VSpacing.sm)
-                let effectiveWidth = Binding<Double>(
-                    get: { appPanelWidth > 0 ? appPanelWidth : contentWidth * 0.7 },
-                    set: { appPanelWidth = $0 }
-                )
                 VSplitView(
-                    panelWidth: effectiveWidth,
+                    panelWidth: clampedPanelWidth(geometry: geometry),
                     showPanel: true,
                     main: {
                         chatView

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -187,19 +187,22 @@ extension MainWindowView {
         let windowWidth: Double = Double(geometry.size.width) / zoomManager.zoomLevel
         let availableWidth: Double = windowWidth - Double(sidebarWidth) - Double(hstackSpacing) - Double(outerPadding)
 
-        let minPanel: Double = 300
-        let minMain: Double = 300
+        let preferredMinPanel: Double = 300
+        let preferredMinMain: Double = 300
         // VSplitView internals: leading padding (xs=4) + divider (8) = 12
         let dividerBudget: Double = Double(VSpacing.xs) + 12
-        let maxPanel = max(availableWidth - minMain - dividerBudget, minPanel)
+        let maxPanel: Double = availableWidth - preferredMinMain - dividerBudget
+        // When the window is too narrow, allow the panel to shrink below the
+        // preferred minimum so the main pane isn't crushed below its minimum.
+        let effectiveMinPanel: Double = min(preferredMinPanel, max(maxPanel, 100))
 
         return Binding<Double>(
             get: {
                 let raw = appPanelWidth > 0 ? appPanelWidth : availableWidth * 0.7
-                return min(max(raw, minPanel), maxPanel)
+                return min(max(raw, effectiveMinPanel), max(maxPanel, effectiveMinPanel))
             },
             set: {
-                appPanelWidth = min(max($0, minPanel), maxPanel)
+                appPanelWidth = min(max($0, effectiveMinPanel), max(maxPanel, effectiveMinPanel))
             }
         )
     }


### PR DESCRIPTION
## Summary
- Add `clampedPanelWidth` helper in PanelCoordinator that accounts for sidebar width consumption and clamps persisted `appPanelWidth` on both get/set paths (replaces 3 duplicated blocks)
- Scope sidebar animation to the sidebar view only, preventing frame-by-frame spring reflow on the chat/workspace container
- Add resize-aware scroll stabilization in MessageListView: detects meaningful container width changes (>20pt), suppresses competing auto-scroll during layout settle, and pins to bottom only when already near bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
