### PR TITLE
fix: use unfiltered contacts for empty state check in ContactsListView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -142,7 +142,7 @@ struct ContactsListView: View {
                 .accessibilityLabel("Add contact")
             }
 
-            if viewModel.otherContacts.isEmpty {
+            if !viewModel.hasNonGuardianContacts {
                 Text("No contacts yet. Tap + to add one.")
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsViewModel.swift
@@ -57,6 +57,13 @@ final class ContactsViewModel: ObservableObject {
         filteredContacts.filter { $0.role != "guardian" }
     }
 
+    /// Whether any non-guardian contacts exist in the unfiltered list.
+    /// Used for empty-state checks so search filtering doesn't
+    /// incorrectly trigger the "No contacts yet" message.
+    var hasNonGuardianContacts: Bool {
+        contacts.contains { $0.role != "guardian" }
+    }
+
     // MARK: - Actions
 
     /// Request the list of contacts from the daemon.


### PR DESCRIPTION
The empty state in otherContactsSection was checking viewModel.otherContacts.isEmpty, but otherContacts is derived from the search-filtered filteredContacts. This caused the 'No contacts yet' message to appear incorrectly when a search filtered out all non-guardian contacts. Changed to check the unfiltered contacts list instead.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
