### PR TITLE
fix: add MIGRATION_REGISTRY entry for backfill_contact_interaction_stats

### DIFF
--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -122,6 +122,12 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Enforce NOT NULL on channel_guardian_bindings.guardian_principal_id after backfill",
   },
+  {
+    key: "backfill_contact_interaction_stats",
+    version: 17,
+    description:
+      "Backfill contacts.last_interaction from the max lastSeenAt across each contact's channels",
+  },
 ];
 
 export interface MigrationValidationResult {


### PR DESCRIPTION
Migration 135 uses withCrashRecovery with checkpoint key 'backfill_contact_interaction_stats' but was missing a corresponding MIGRATION_REGISTRY entry. Added the registry entry with version 17 to enable dependency ordering validation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
