### PR TITLE
fix: move touchContactInteraction after dedup check to prevent inflated stats

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -11,6 +11,7 @@ import {
   parseInterfaceId,
 } from "../../channels/types.js";
 import { getChannelPermissionProfile } from "../../config/channel-permission-profiles.js";
+import { touchContactInteraction } from "../../contacts/contacts-write.js";
 import type { TrustContext } from "../../daemon/session-runtime-assembly.js";
 import * as attachmentsStore from "../../memory/attachments-store.js";
 import * as channelDeliveryStore from "../../memory/channel-delivery-store.js";
@@ -300,6 +301,13 @@ export async function handleChannelInbound(
         eventId: result.eventId,
       });
     }
+  }
+
+  // Track contact interaction only for genuinely new messages (not webhook
+  // retries). This was previously in ACL enforcement which runs before dedup,
+  // causing retries to inflate interaction counts.
+  if (!result.duplicate && resolvedMember) {
+    touchContactInteraction(resolvedMember.contact.id);
   }
 
   // external_conversation_bindings is assistant-agnostic. Restrict writes to

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -8,10 +8,7 @@
  */
 import type { ChannelId } from "../../../channels/types.js";
 import { findContactChannel } from "../../../contacts/contact-store.js";
-import {
-  touchChannelLastSeen,
-  touchContactInteraction,
-} from "../../../contacts/contacts-write.js";
+import { touchChannelLastSeen } from "../../../contacts/contacts-write.js";
 import type {
   ChannelStatus,
   ContactChannel,
@@ -635,9 +632,12 @@ export async function enforceIngressAcl(
         };
       }
 
-      // 'allow' or 'escalate' — update last seen and continue
+      // 'allow' or 'escalate' — update last seen timestamp.
+      // touchContactInteraction is intentionally NOT called here because
+      // duplicate detection hasn't run yet. It's called in
+      // inbound-message-handler.ts after dedup so webhook retries don't
+      // inflate interaction counts.
       touchChannelLastSeen(resolvedMember.channel.id);
-      touchContactInteraction(resolvedMember.contact.id);
     }
   }
 


### PR DESCRIPTION
touchContactInteraction was running during ACL enforcement, before duplicate detection. This meant webhook retries for the same externalMessageId would increment interactionCount each time. Moved the call to after deduplication so only genuinely new messages update contact interaction stats.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
