### PR TITLE
fix: add dividers between multiple channels of the same type in contact detail

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -153,8 +153,12 @@ struct ContactDetailView: View {
 
             ForEach(Array(Self.allChannelTypes.enumerated()), id: \.element) { index, type in
                 if let channels = channelsByType[type] {
-                    ForEach(channels) { channel in
+                    ForEach(Array(channels.enumerated()), id: \.element.id) { channelIndex, channel in
                         channelRow(channel)
+
+                        if channelIndex < channels.count - 1 {
+                            Divider().background(VColor.divider)
+                        }
                     }
                 } else {
                     unconfiguredChannelRow(type: type)


### PR DESCRIPTION
When a contact had multiple channels of the same type, there were no dividers between them. Added dividers between individual channels within each type group for proper visual separation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
