### PR TITLE
fix: gate touchContactInteraction on trusted classes in voice call handler

### DIFF
--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -591,7 +591,11 @@ export class RelayConnection {
         this.startNameCapture(outcome.assistantId, outcome.fromNumber);
         return;
       case "guardian_verification":
-        if (resolved.actorTrust.memberRecord) {
+        if (
+          resolved.actorTrust.memberRecord &&
+          (resolved.actorTrust.trustClass === "guardian" ||
+            resolved.actorTrust.trustClass === "trusted_contact")
+        ) {
           touchContactInteraction(resolved.actorTrust.memberRecord.contact.id);
         }
         if (this.controller && resolved.actorTrust.trustClass !== "unknown") {
@@ -606,7 +610,11 @@ export class RelayConnection {
         return;
       case "normal_call":
         if (outcome.isInbound) {
-          if (resolved.actorTrust.memberRecord) {
+          if (
+            resolved.actorTrust.memberRecord &&
+            (resolved.actorTrust.trustClass === "guardian" ||
+              resolved.actorTrust.trustClass === "trusted_contact")
+          ) {
             touchContactInteraction(
               resolved.actorTrust.memberRecord.contact.id,
             );


### PR DESCRIPTION
touchContactInteraction was gated only on actorTrust.memberRecord presence, but resolveActorTrust can return a member record for non-active channels while classifying the caller as 'unknown'. Changed to only track interactions for guardian/trusted_contact trust classes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
