### PR TITLE
fix: address invite button review feedback from PR #12773

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -21,7 +21,7 @@ struct ContactDetailView: View {
     @State private var telegramBootstrapUrl: String?
     @State private var telegramBootstrapChannelId: String?
     @State private var inviteInProgress: String?
-    @State private var inviteResult: (type: String, token: String)?
+    @State private var inviteResult: (type: String, token: String, shareUrl: String?)?
     @State private var inviteError: String?
     @State private var inviteCopiedType: String?
 
@@ -267,7 +267,9 @@ struct ContactDetailView: View {
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)
 
-                if displayContact.role != "guardian" {
+                // Voice invites require additional fields (phone number, friend/guardian
+                // names) that aren't available in this context, so hide the button.
+                if displayContact.role != "guardian" && type != "voice" {
                     if inviteInProgress == type {
                         ProgressView()
                             .controlSize(.small)
@@ -286,12 +288,12 @@ struct ContactDetailView: View {
 
             if inviteResult?.type == type {
                 HStack(spacing: VSpacing.sm) {
-                    let token = inviteResult!.token
-                    let truncated = token.count > 20
-                        ? String(token.prefix(20)) + "..."
-                        : token
+                    let shareableText = inviteResult!.shareUrl ?? inviteResult!.token
+                    let truncated = shareableText.count > 20
+                        ? String(shareableText.prefix(20)) + "..."
+                        : shareableText
                     Text(truncated)
-                        .font(.system(.caption, design: .monospaced))
+                        .font(VFont.monoSmall)
                         .foregroundColor(VColor.textSecondary)
 
                     VButton(
@@ -301,10 +303,11 @@ struct ContactDetailView: View {
                         size: .medium
                     ) {
                         NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(token, forType: .string)
+                        NSPasteboard.general.setString(shareableText, forType: .string)
                         inviteCopiedType = type
                         Task {
                             try? await Task.sleep(nanoseconds: 2_000_000_000)
+                            guard !Task.isCancelled else { return }
                             if inviteCopiedType == type {
                                 inviteCopiedType = nil
                             }
@@ -652,7 +655,7 @@ struct ContactDetailView: View {
                     sourceChannel: type,
                     note: "Invite for \(displayContact.displayName)"
                 ) {
-                    inviteResult = (type: type, token: result.token)
+                    inviteResult = (type: type, token: result.token, shareUrl: result.shareUrl)
                 } else {
                     inviteError = "Failed to create invite"
                 }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1663,7 +1663,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         sourceChannel: String,
         note: String? = nil,
         maxUses: Int? = nil
-    ) async throws -> (inviteId: String, token: String)? {
+    ) async throws -> (inviteId: String, token: String, shareUrl: String?)? {
         if let httpTransport {
             return try await httpTransport.createInvite(sourceChannel: sourceChannel, note: note, maxUses: maxUses)
         }
@@ -1697,11 +1697,16 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             struct InviteData: Decodable {
                 let id: String
                 let token: String?
+                let share: ShareData?
+            }
+            struct ShareData: Decodable {
+                let url: String
+                let displayText: String
             }
         }
         let decoded = try JSONDecoder().decode(CreateInviteResponse.self, from: data)
         guard let invite = decoded.invite, let token = invite.token else { return nil }
-        return (inviteId: invite.id, token: token)
+        return (inviteId: invite.id, token: token, shareUrl: invite.share?.url)
         #else
         return nil
         #endif

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1117,7 +1117,12 @@ public final class HTTPTransport {
             let id: String
             let sourceChannel: String
             let token: String?
+            let share: SharePayload?
             let status: String
+        }
+        struct SharePayload: Decodable {
+            let url: String
+            let displayText: String
         }
     }
 
@@ -1211,7 +1216,7 @@ public final class HTTPTransport {
         note: String? = nil,
         maxUses: Int? = nil,
         isRetry: Bool = false
-    ) async throws -> (inviteId: String, token: String)? {
+    ) async throws -> (inviteId: String, token: String, shareUrl: String?)? {
         guard let url = buildURL(for: .contactsInvitesCreate) else { return nil }
 
         var request = URLRequest(url: url)
@@ -1239,7 +1244,7 @@ public final class HTTPTransport {
 
         let decoded = try decoder.decode(HTTPCreateInviteResponse.self, from: data)
         guard let invite = decoded.invite, let token = invite.token else { return nil }
-        return (inviteId: invite.id, token: token)
+        return (inviteId: invite.id, token: token, shareUrl: invite.share?.url)
     }
 
     // MARK: - Channel Verification


### PR DESCRIPTION
## Summary
- Hide Invite button for voice channels (voice invites need additional fields not available here)
- Use transport-specific shareable link instead of raw token for invite copying
- Replace raw font literal with VFont.monoSmall design token
- Add Task.isCancelled guard after Task.sleep in copied-label reset timer

Addresses feedback from PR #12773.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
