### PR TITLE
fix: prefer JWT over http-token in resolveLocalDaemonHTTPEndpoint

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1320,9 +1320,20 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     /// Resolves the base URL and bearer token for the daemon's local HTTP server.
     /// Returns `nil` when no local HTTP port is configured.
+    ///
+    /// Prefers the JWT access token from `ActorTokenManager` (which carries
+    /// the scopes the daemon's JWT-only auth middleware expects) and falls back
+    /// to the file-based http-token for backwards compatibility.
     private func resolveLocalDaemonHTTPEndpoint() -> (baseURL: String, bearerToken: String?)? {
         guard let port = httpPort else { return nil }
         let baseURL = "http://localhost:\(port)"
+
+        // Prefer JWT — the daemon auth middleware requires JWTs.
+        if let jwt = ActorTokenManager.getToken(), !jwt.isEmpty {
+            return (baseURL, jwt)
+        }
+
+        // Legacy fallback: file-based shared-secret token.
         let tokenPath = resolveHttpTokenPath()
         let bearerToken: String?
         do {


### PR DESCRIPTION
## Summary
- `resolveLocalDaemonHTTPEndpoint()` was sending the plain file-based http-token (64-byte hex string) as the bearer token, but the daemon's auth middleware now only accepts JWTs — causing `POST /v1/contacts` (and other local fallback paths) to fail with 401 "malformed_token: expected 3 dot-separated parts"
- Now prefers `ActorTokenManager.getToken()` (JWT) when available, falling back to the file-based token for backwards compatibility
- Mirrors the pattern already used by `SettingsStore.buildDaemonRequest()` and `resolveFeatureFlagAuthToken()`

## Original prompt
it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
