### PR TITLE
fix: handle empty filtered contacts card in ContactsListView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -149,7 +149,7 @@ struct ContactsListView: View {
                     .padding(VSpacing.lg)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .vCard(background: VColor.surfaceSubtle)
-            } else {
+            } else if !viewModel.otherContacts.isEmpty {
                 VStack(spacing: 0) {
                     ForEach(Array(viewModel.otherContacts.enumerated()), id: \.element.id) { index, contact in
                         if index > 0 {


### PR DESCRIPTION
When non-guardian contacts exist but are all filtered out by search, the contacts list rendered a blank card. This fixes the edge case by checking both the unfiltered existence and filtered emptiness.

Addresses feedback from PR #12896.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
