### PR TITLE
fix: restore touchContactInteraction for message edits

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -244,6 +244,13 @@ export async function handleChannelInbound(
 
   // ── Edit path: update existing message content, no new agent loop ──
   if (isEdit && sourceMessageId) {
+    // Edits don't go through recordInbound (no dedup concern), so it's safe
+    // to track the interaction here — ensures message edits from active
+    // members still increment interactionCount and update lastInteraction.
+    if (resolvedMember) {
+      touchContactInteraction(resolvedMember.contact.id);
+    }
+
     return handleEditIntercept({
       sourceChannel,
       conversationExternalId,


### PR DESCRIPTION
PR #12898 moved touchContactInteraction after dedup but the edit path returns before it. This adds a touchContactInteraction call in the edit path so message edits still track contact interactions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
