### PR TITLE
fix: prefer JWT over http-token in remaining gateway/runtime HTTP callers

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1368,7 +1368,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             bearerToken = httpTransport.bearerToken
         } else if let gatewayBaseURL {
             baseURL = gatewayBaseURL
-            bearerToken = readHttpToken()
+            bearerToken = ActorTokenManager.getToken() ?? readHttpToken()
         } else {
             return nil
         }
@@ -1688,7 +1688,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let token = readHttpToken(), !token.isEmpty {
+        if let token = ActorTokenManager.getToken() ?? readHttpToken(), !token.isEmpty {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 
@@ -1748,7 +1748,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let token = readHttpToken(), !token.isEmpty {
+        if let token = ActorTokenManager.getToken() ?? readHttpToken(), !token.isEmpty {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 
@@ -1835,12 +1835,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         let flags: [AssistantFeatureFlag]
     }
 
-    /// Resolve the runtime bearer token from either `httpTransport` or the on-disk token file.
+    /// Resolve the runtime bearer token from either `httpTransport`, the JWT access token, or the on-disk token file.
     /// Returns `nil` when no runtime token is available.
     private func resolveRuntimeBearerToken() -> String? {
         if let httpTransport = self.httpTransport, let bt = httpTransport.bearerToken, !bt.isEmpty {
             return bt
         }
+        if let jwt = ActorTokenManager.getToken(), !jwt.isEmpty { return jwt }
         return readHttpToken()
     }
 


### PR DESCRIPTION
## Summary
- `createInvite()`, `verifyContactChannel()`, `fetchIntegrationsStatus()`, and `resolveRuntimeBearerToken()` all sent the plain file-based http-token (64-byte hex) as the bearer token to the gateway/daemon, which now require JWTs
- Added `ActorTokenManager.getToken()` as the preferred token source in all four callers, falling back to `readHttpToken()` for backwards compatibility
- Companion to #12904 which fixed the same issue in `resolveLocalDaemonHTTPEndpoint()`

## Original prompt
Fix remaining readHttpToken() callers that send plain hex tokens to JWT-only endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
