### PR TITLE
fix: prefer JWT over http-token in SettingsStore and AppDelegate+Bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -412,7 +412,7 @@ extension AppDelegate {
                         bearerToken = httpTransport.bearerToken
                     } else if let port = self.daemonClient.httpPort {
                         baseURL = "http://localhost:\(port)"
-                        bearerToken = readHttpToken()
+                        bearerToken = ActorTokenManager.getToken() ?? readHttpToken()
                     } else {
                         continue
                     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1257,7 +1257,7 @@ public final class SettingsStore: ObservableObject {
         let gatewayPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
             .flatMap(Int.init) ?? 7830
         let baseURL = "http://127.0.0.1:\(gatewayPort)"
-        let bearerToken = readHttpToken()
+        let bearerToken = ActorTokenManager.getToken() ?? readHttpToken()
         return (baseURL, bearerToken)
     }
 


### PR DESCRIPTION
## Summary
- Fix `resolveTwilioHTTPEndpoint()` in SettingsStore to prefer JWT from `ActorTokenManager.getToken()` over file-based `readHttpToken()`
- Fix proactive refresh loop in AppDelegate+Bootstrap to prefer JWT over file-based token

Part of plan: centralize-http-auth-token.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
