### PR TITLE
fix: fall back to file token when keychain token is empty in buildLocalRequest

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1357,8 +1357,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         request.httpMethod = method
         request.timeoutInterval = timeout
 
-        let token = tokenOverride
-            ?? ActorTokenManager.getToken()
+        let token = tokenOverride.flatMap { $0.isEmpty ? nil : $0 }
+            ?? ActorTokenManager.getToken().flatMap { $0.isEmpty ? nil : $0 }
             ?? readHttpToken()
         if let token, !token.isEmpty {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
@@ -1389,7 +1389,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             bearerToken = httpTransport.bearerToken
         } else if let gatewayBaseURL {
             baseURL = gatewayBaseURL
-            bearerToken = ActorTokenManager.getToken() ?? readHttpToken()
+            bearerToken = ActorTokenManager.getToken().flatMap { $0.isEmpty ? nil : $0 } ?? readHttpToken()
         } else {
             return nil
         }


### PR DESCRIPTION
Addresses Codex review feedback on #12914. The buildLocalRequest token resolution now correctly falls through to readHttpToken() when ActorTokenManager.getToken() returns an empty string, matching the previous behavior of resolveLocalDaemonHTTPEndpoint().
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
