### PR TITLE
fix: target Save button explicitly in fill-secure-credential fallback

### DIFF
--- a/playwright/agent/tools/fill-secure-credential.ts
+++ b/playwright/agent/tools/fill-secure-credential.ts
@@ -68,7 +68,7 @@ export async function execute(
   // 1. Finds the Secure Credential panel window (scans all windows for "Secure Credential" header, smallest match wins)
   // 2. Finds the text field via `entire contents` (reliable regardless of nesting)
   // 3. Types the env var value
-  // 4. Clicks Save (last button in the panel, or by accessibility identifier)
+  // 4. Clicks Save (by accessibility identifier, or by name "Save")
   //
   // The panel's actual hierarchy is:
   //   window > group > scroll area > text field
@@ -142,8 +142,7 @@ tell application "System Events"
     delay 0.3
 
     -- Click the Save button.
-    -- The Save button is the last button in the panel content.
-    -- We search entire contents and pick the last button (Cancel comes first, Save last).
+    -- We search entire contents for a button with the accessibility identifier or name "Save".
     set clickedSave to false
 
     -- Strategy 1: Find button by accessibility identifier
@@ -157,20 +156,19 @@ tell application "System Events"
       end try
     end repeat
 
-    -- Strategy 2: Click the last button in the panel (Save is always last)
+    -- Strategy 2: Find button by name/title "Save"
     if not clickedSave then
-      set lastBtn to missing value
       repeat with elem in allElems
         try
           if class of elem is button then
-            set lastBtn to elem
+            if name of elem is "Save" or title of elem is "Save" then
+              click elem
+              set clickedSave to true
+              exit repeat
+            end if
           end if
         end try
       end repeat
-      if lastBtn is not missing value then
-        click lastBtn
-        set clickedSave to true
-      end if
     end if
 
     if not clickedSave then


### PR DESCRIPTION
Addresses Codex review feedback on #12911. The fallback button selection in fill_secure_credential now explicitly looks for a button named 'Save' instead of blindly picking the last button, which could incorrectly click 'Send Once (not saved)' when allowOneTimeSend is enabled.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
