### PR TITLE
refactor: make invite transport a first-class channel adapter with explicit registration

### DIFF
--- a/assistant/src/__tests__/channel-invite-transport.test.ts
+++ b/assistant/src/__tests__/channel-invite-transport.test.ts
@@ -17,19 +17,19 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 
 import {
   _resetRegistry,
-  type ChannelInviteTransport,
+  type ChannelInviteAdapter,
+  getInviteAdapterRegistry,
   getTransport,
   registerTransport,
 } from "../runtime/channel-invite-transport.js";
-// Importing the Telegram module auto-registers the transport
-import { telegramInviteTransport } from "../runtime/channel-invite-transports/telegram.js";
+import { telegramInviteAdapter } from "../runtime/channel-invite-transports/telegram.js";
 
 describe("channel-invite-transport", () => {
   beforeEach(() => {
     _resetRegistry();
     mockBotUsername = "test_invite_bot";
     // Re-register after reset so Telegram tests work
-    registerTransport(telegramInviteTransport);
+    registerTransport(telegramInviteAdapter);
   });
 
   // =========================================================================
@@ -37,46 +37,58 @@ describe("channel-invite-transport", () => {
   // =========================================================================
 
   describe("registry", () => {
-    test("returns the Telegram transport for telegram channel", () => {
-      const transport = getTransport("telegram");
-      expect(transport).toBeDefined();
-      expect(transport!.channel).toBe("telegram");
+    test("returns the Telegram adapter for telegram channel", () => {
+      const adapter = getTransport("telegram");
+      expect(adapter).toBeDefined();
+      expect(adapter!.channel).toBe("telegram");
     });
 
     test("returns undefined for an unregistered channel", () => {
-      const transport = getTransport("sms");
-      expect(transport).toBeUndefined();
+      const adapter = getTransport("sms");
+      expect(adapter).toBeUndefined();
     });
 
-    test("overwrites a previously registered transport for the same channel", () => {
-      const custom: ChannelInviteTransport = {
+    test("overwrites a previously registered adapter for the same channel", () => {
+      const custom: ChannelInviteAdapter = {
         channel: "telegram",
-        buildShareableInvite: () => ({ url: "custom", displayText: "custom" }),
+        buildShareLink: () => ({ url: "custom", displayText: "custom" }),
         extractInboundToken: () => undefined,
       };
       registerTransport(custom);
-      const transport = getTransport("telegram");
+      const adapter = getTransport("telegram");
       expect(
-        transport!.buildShareableInvite({
+        adapter!.buildShareLink!({
           rawToken: "x",
           sourceChannel: "telegram",
         }).url,
       ).toBe("custom");
     });
 
-    test("_resetRegistry clears all transports", () => {
+    test("_resetRegistry clears all adapters", () => {
       _resetRegistry();
       expect(getTransport("telegram")).toBeUndefined();
+    });
+
+    test("getInviteAdapterRegistry returns the singleton registry", () => {
+      const registry = getInviteAdapterRegistry();
+      expect(registry.get("telegram")).toBeDefined();
+    });
+
+    test("registry.getAll returns all registered adapters", () => {
+      const registry = getInviteAdapterRegistry();
+      const all = registry.getAll();
+      expect(all.length).toBeGreaterThanOrEqual(1);
+      expect(all.some((a) => a.channel === "telegram")).toBe(true);
     });
   });
 
   // =========================================================================
-  // Telegram adapter — buildShareableInvite
+  // Telegram adapter — buildShareLink
   // =========================================================================
 
-  describe("telegram buildShareableInvite", () => {
+  describe("telegram buildShareLink", () => {
     test("produces a valid Telegram deep link", () => {
-      const result = telegramInviteTransport.buildShareableInvite!({
+      const result = telegramInviteAdapter.buildShareLink!({
         rawToken: "abc123_test-token",
         sourceChannel: "telegram",
       });
@@ -90,11 +102,11 @@ describe("channel-invite-transport", () => {
     });
 
     test("deep link is deterministic for the same token", () => {
-      const a = telegramInviteTransport.buildShareableInvite!({
+      const a = telegramInviteAdapter.buildShareLink!({
         rawToken: "tok1",
         sourceChannel: "telegram",
       });
-      const b = telegramInviteTransport.buildShareableInvite!({
+      const b = telegramInviteAdapter.buildShareLink!({
         rawToken: "tok1",
         sourceChannel: "telegram",
       });
@@ -104,7 +116,7 @@ describe("channel-invite-transport", () => {
 
     test("uses the configured bot username", () => {
       mockBotUsername = "my_custom_bot";
-      const result = telegramInviteTransport.buildShareableInvite!({
+      const result = telegramInviteAdapter.buildShareLink!({
         rawToken: "token",
         sourceChannel: "telegram",
       });
@@ -118,7 +130,7 @@ describe("channel-invite-transport", () => {
       delete process.env.TELEGRAM_BOT_USERNAME;
       try {
         expect(() =>
-          telegramInviteTransport.buildShareableInvite!({
+          telegramInviteAdapter.buildShareLink!({
             rawToken: "token",
             sourceChannel: "telegram",
           }),
@@ -133,7 +145,7 @@ describe("channel-invite-transport", () => {
       const prev = process.env.TELEGRAM_BOT_USERNAME;
       process.env.TELEGRAM_BOT_USERNAME = "env_bot";
       try {
-        const result = telegramInviteTransport.buildShareableInvite!({
+        const result = telegramInviteAdapter.buildShareLink!({
           rawToken: "token",
           sourceChannel: "telegram",
         });
@@ -154,7 +166,7 @@ describe("channel-invite-transport", () => {
 
   describe("telegram extractInboundToken", () => {
     test("extracts token from structured commandIntent", () => {
-      const token = telegramInviteTransport.extractInboundToken({
+      const token = telegramInviteAdapter.extractInboundToken!({
         commandIntent: { type: "start", payload: "iv_abc123" },
         content: "/start iv_abc123",
       });
@@ -162,7 +174,7 @@ describe("channel-invite-transport", () => {
     });
 
     test("extracts base64url token from commandIntent", () => {
-      const token = telegramInviteTransport.extractInboundToken({
+      const token = telegramInviteAdapter.extractInboundToken!({
         commandIntent: { type: "start", payload: "iv_YWJjMTIz-_test" },
         content: "/start iv_YWJjMTIz-_test",
       });
@@ -170,7 +182,7 @@ describe("channel-invite-transport", () => {
     });
 
     test("returns undefined when commandIntent has no payload", () => {
-      const token = telegramInviteTransport.extractInboundToken({
+      const token = telegramInviteAdapter.extractInboundToken!({
         commandIntent: { type: "start" },
         content: "/start",
       });
@@ -178,7 +190,7 @@ describe("channel-invite-transport", () => {
     });
 
     test("returns undefined when commandIntent payload has wrong prefix (gv_)", () => {
-      const token = telegramInviteTransport.extractInboundToken({
+      const token = telegramInviteAdapter.extractInboundToken!({
         commandIntent: { type: "start", payload: "gv_abc123" },
         content: "/start gv_abc123",
       });
@@ -186,7 +198,7 @@ describe("channel-invite-transport", () => {
     });
 
     test("returns undefined when commandIntent payload has no prefix", () => {
-      const token = telegramInviteTransport.extractInboundToken({
+      const token = telegramInviteAdapter.extractInboundToken!({
         commandIntent: { type: "start", payload: "abc123" },
         content: "/start abc123",
       });
@@ -194,7 +206,7 @@ describe("channel-invite-transport", () => {
     });
 
     test("returns undefined when commandIntent type is not start", () => {
-      const token = telegramInviteTransport.extractInboundToken({
+      const token = telegramInviteAdapter.extractInboundToken!({
         commandIntent: { type: "help", payload: "iv_abc123" },
         content: "/help iv_abc123",
       });
@@ -202,7 +214,7 @@ describe("channel-invite-transport", () => {
     });
 
     test("returns undefined when commandIntent payload is iv_ with empty token", () => {
-      const token = telegramInviteTransport.extractInboundToken({
+      const token = telegramInviteAdapter.extractInboundToken!({
         commandIntent: { type: "start", payload: "iv_" },
         content: "/start iv_",
       });
@@ -210,7 +222,7 @@ describe("channel-invite-transport", () => {
     });
 
     test("returns undefined when commandIntent payload is iv_ with whitespace-only token", () => {
-      const token = telegramInviteTransport.extractInboundToken({
+      const token = telegramInviteAdapter.extractInboundToken!({
         commandIntent: { type: "start", payload: "iv_   " },
         content: "/start iv_   ",
       });
@@ -218,49 +230,49 @@ describe("channel-invite-transport", () => {
     });
 
     test("extracts token from raw content fallback", () => {
-      const token = telegramInviteTransport.extractInboundToken({
+      const token = telegramInviteAdapter.extractInboundToken!({
         content: "/start iv_abc123",
       });
       expect(token).toBe("abc123");
     });
 
     test("extracts token from raw content with extra whitespace", () => {
-      const token = telegramInviteTransport.extractInboundToken({
+      const token = telegramInviteAdapter.extractInboundToken!({
         content: "/start   iv_token123",
       });
       expect(token).toBe("token123");
     });
 
     test("returns undefined for empty content", () => {
-      const token = telegramInviteTransport.extractInboundToken({
+      const token = telegramInviteAdapter.extractInboundToken!({
         content: "",
       });
       expect(token).toBeUndefined();
     });
 
     test("returns undefined for content without /start", () => {
-      const token = telegramInviteTransport.extractInboundToken({
+      const token = telegramInviteAdapter.extractInboundToken!({
         content: "hello world",
       });
       expect(token).toBeUndefined();
     });
 
     test("returns undefined for /start without iv_ prefix in content", () => {
-      const token = telegramInviteTransport.extractInboundToken({
+      const token = telegramInviteAdapter.extractInboundToken!({
         content: "/start gv_abc123",
       });
       expect(token).toBeUndefined();
     });
 
     test("returns undefined for malformed /start with only iv_ in content", () => {
-      const token = telegramInviteTransport.extractInboundToken({
+      const token = telegramInviteAdapter.extractInboundToken!({
         content: "/start iv_",
       });
       expect(token).toBeUndefined();
     });
 
     test("prefers commandIntent over raw content", () => {
-      const token = telegramInviteTransport.extractInboundToken({
+      const token = telegramInviteAdapter.extractInboundToken!({
         commandIntent: { type: "start", payload: "iv_from_intent" },
         content: "/start iv_from_content",
       });
@@ -269,7 +281,7 @@ describe("channel-invite-transport", () => {
 
     test("returns undefined when commandIntent rejects, even if content has token", () => {
       // commandIntent present but payload has wrong prefix
-      const token = telegramInviteTransport.extractInboundToken({
+      const token = telegramInviteAdapter.extractInboundToken!({
         commandIntent: { type: "start", payload: "gv_abc123" },
         content: "/start iv_valid_token",
       });

--- a/assistant/src/channels/config.ts
+++ b/assistant/src/channels/config.ts
@@ -1,5 +1,5 @@
 /**
- * Canonical per-channel notification policy registry.
+ * Canonical per-channel policy registry.
  *
  * Every ChannelId must have an entry here. The `satisfies` constraint
  * ensures that adding a new ChannelId to channels/types.ts will fail
@@ -13,11 +13,17 @@ export type ConversationStrategy =
   | "continue_existing_conversation"
   | "not_deliverable";
 
+export interface ChannelInvitePolicy {
+  /** Whether inbound invite code redemption is supported on this channel. */
+  codeRedemptionEnabled: boolean;
+}
+
 export interface ChannelNotificationPolicy {
   notification: {
     deliveryEnabled: boolean;
     conversationStrategy: ConversationStrategy;
   };
+  invite: ChannelInvitePolicy;
 }
 
 const CHANNEL_POLICIES = {
@@ -26,11 +32,17 @@ const CHANNEL_POLICIES = {
       deliveryEnabled: true,
       conversationStrategy: "start_new_conversation",
     },
+    invite: {
+      codeRedemptionEnabled: false,
+    },
   },
   telegram: {
     notification: {
       deliveryEnabled: true,
       conversationStrategy: "continue_existing_conversation",
+    },
+    invite: {
+      codeRedemptionEnabled: true,
     },
   },
   sms: {
@@ -38,11 +50,17 @@ const CHANNEL_POLICIES = {
       deliveryEnabled: true,
       conversationStrategy: "continue_existing_conversation",
     },
+    invite: {
+      codeRedemptionEnabled: true,
+    },
   },
   whatsapp: {
     notification: {
       deliveryEnabled: false,
       conversationStrategy: "continue_existing_conversation",
+    },
+    invite: {
+      codeRedemptionEnabled: false,
     },
   },
   slack: {
@@ -50,11 +68,17 @@ const CHANNEL_POLICIES = {
       deliveryEnabled: true,
       conversationStrategy: "continue_existing_conversation",
     },
+    invite: {
+      codeRedemptionEnabled: true,
+    },
   },
   email: {
     notification: {
       deliveryEnabled: false,
       conversationStrategy: "continue_existing_conversation",
+    },
+    invite: {
+      codeRedemptionEnabled: true,
     },
   },
   voice: {
@@ -62,12 +86,15 @@ const CHANNEL_POLICIES = {
       deliveryEnabled: false,
       conversationStrategy: "not_deliverable",
     },
+    invite: {
+      codeRedemptionEnabled: false,
+    },
   },
 } as const satisfies Record<ChannelId, ChannelNotificationPolicy>;
 
 export type ChannelPolicies = typeof CHANNEL_POLICIES;
 
-/** Returns the full notification policy for a channel. */
+/** Returns the full policy for a channel. */
 export function getChannelPolicy(
   channelId: ChannelId,
 ): ChannelNotificationPolicy {
@@ -96,4 +123,16 @@ export function getConversationStrategy(
   channelId: ChannelId,
 ): ConversationStrategy {
   return CHANNEL_POLICIES[channelId].notification.conversationStrategy;
+}
+
+/** Returns the invite policy for the given channel. */
+export function getChannelInvitePolicy(
+  channelId: ChannelId,
+): ChannelInvitePolicy {
+  return CHANNEL_POLICIES[channelId].invite;
+}
+
+/** Whether invite code redemption is enabled for the given channel. */
+export function isInviteCodeRedemptionEnabled(channelId: ChannelId): boolean {
+  return CHANNEL_POLICIES[channelId].invite.codeRedemptionEnabled;
 }

--- a/assistant/src/runtime/channel-invite-transport.ts
+++ b/assistant/src/runtime/channel-invite-transport.ts
@@ -1,13 +1,15 @@
 /**
- * Channel invite transport abstraction.
+ * Channel invite adapter abstraction.
  *
- * Defines a transport interface for building shareable invite links and
- * extracting inbound invite tokens from channel-specific payloads. Each
- * channel (Telegram, SMS, Slack, etc.) registers an adapter that knows
- * how to construct deep links and parse incoming tokens for that channel.
+ * Defines an adapter interface for building shareable invite links,
+ * extracting inbound invite tokens, and generating guardian instructions
+ * from channel-specific payloads. Each channel (Telegram, voice, etc.)
+ * registers an adapter that knows how to handle invite flows for that
+ * channel.
  *
- * The transport layer is intentionally thin: it handles URL construction
- * and token extraction only. Redemption logic lives in
+ * All methods are optional: a channel that only provides
+ * `buildGuardianInstruction` (e.g. SMS) is a valid adapter. The adapter
+ * layer is intentionally thin — redemption logic lives in
  * `invite-redemption-service.ts`.
  */
 
@@ -17,71 +19,142 @@ import type { ChannelId } from "../channels/types.js";
 // Types
 // ---------------------------------------------------------------------------
 
-export interface InviteSharePayload {
+export interface InviteShareLink {
   /** The full URL the recipient can open to redeem the invite. */
   url: string;
   /** Human-readable text suitable for display alongside the link. */
   displayText: string;
 }
 
-export interface ChannelInviteTransport {
-  /** The channel this transport handles. */
+export interface ChannelInviteAdapter {
+  /** The channel this adapter handles. */
   channel: ChannelId;
 
   /**
-   * Build a shareable invite payload (URL + display text) from a raw token.
-   *
-   * The raw token is the base64url-encoded secret returned by
-   * `invite-store.createInvite`. The transport wraps it in a
-   * channel-specific deep link so the recipient can redeem the invite
-   * by clicking/tapping the link.
+   * Build a channel-specific shareable link (e.g. Telegram deep link).
+   * Optional — not all channels support link-based invites.
    */
-  buildShareableInvite(params: {
+  buildShareLink?(params: {
     rawToken: string;
     sourceChannel: ChannelId;
-  }): InviteSharePayload;
+  }): InviteShareLink;
 
   /**
-   * Extract an invite token from an inbound channel message.
-   *
-   * Returns the raw token string (without the `iv_` prefix) if the
-   * message contains a valid invite token, or `undefined` otherwise.
+   * Extract a channel-specific invite token from an inbound message
+   * (e.g. Telegram `/start iv_<token>`). Optional — only needed for
+   * channels with link-based invites.
    */
-  extractInboundToken(params: {
+  extractInboundToken?(params: {
     commandIntent?: Record<string, unknown>;
     content: string;
     sourceMetadata?: Record<string, unknown>;
   }): string | undefined;
+
+  /**
+   * Build guardian instruction text for this channel. Optional — falls
+   * back to generic instruction if not implemented.
+   */
+  buildGuardianInstruction?(params: {
+    inviteCode: string;
+    contactName?: string;
+  }): string;
 }
+
+// ---------------------------------------------------------------------------
+// Backward-compatible type aliases
+// ---------------------------------------------------------------------------
+
+/** @deprecated Use `ChannelInviteAdapter` instead. */
+export type ChannelInviteTransport = ChannelInviteAdapter;
+
+/** @deprecated Use `InviteShareLink` instead. */
+export type InviteSharePayload = InviteShareLink;
 
 // ---------------------------------------------------------------------------
 // Registry
 // ---------------------------------------------------------------------------
 
-const registry = new Map<ChannelId, ChannelInviteTransport>();
+export class InviteAdapterRegistry {
+  private adapters = new Map<ChannelId, ChannelInviteAdapter>();
 
-/**
- * Register a channel invite transport. Overwrites any previously registered
- * transport for the same channel.
- */
-export function registerTransport(transport: ChannelInviteTransport): void {
-  registry.set(transport.channel, transport);
+  /**
+   * Register a channel invite adapter. Overwrites any previously
+   * registered adapter for the same channel.
+   */
+  register(adapter: ChannelInviteAdapter): void {
+    this.adapters.set(adapter.channel, adapter);
+  }
+
+  /**
+   * Look up the registered adapter for a channel. Returns `undefined`
+   * when no adapter has been registered for the given channel.
+   */
+  get(channel: ChannelId): ChannelInviteAdapter | undefined {
+    return this.adapters.get(channel);
+  }
+
+  /** Return all registered adapters. */
+  getAll(): ChannelInviteAdapter[] {
+    return Array.from(this.adapters.values());
+  }
+
+  /**
+   * Reset the registry. Intended for tests only.
+   * @internal
+   */
+  _reset(): void {
+    this.adapters.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton registry + backward-compatible free functions
+// ---------------------------------------------------------------------------
+
+import { telegramInviteAdapter } from "./channel-invite-transports/telegram.js";
+import { voiceInviteAdapter } from "./channel-invite-transports/voice.js";
+
+/** Create a registry instance with built-in adapters registered. */
+export function createInviteAdapterRegistry(): InviteAdapterRegistry {
+  const registry = new InviteAdapterRegistry();
+  registry.register(telegramInviteAdapter);
+  registry.register(voiceInviteAdapter);
+  return registry;
 }
 
 /**
- * Look up the registered transport for a channel. Returns `undefined` when
- * no transport has been registered for the given channel.
+ * Module-level singleton registry, created eagerly so callers that
+ * import the free functions continue to work without changes.
+ */
+const defaultRegistry = createInviteAdapterRegistry();
+
+/** Return the module-level singleton registry. */
+export function getInviteAdapterRegistry(): InviteAdapterRegistry {
+  return defaultRegistry;
+}
+
+/**
+ * Register a channel invite adapter on the default registry.
+ * @deprecated Prefer `getInviteAdapterRegistry().register(adapter)`.
+ */
+export function registerTransport(transport: ChannelInviteAdapter): void {
+  defaultRegistry.register(transport);
+}
+
+/**
+ * Look up the registered adapter for a channel on the default registry.
+ * @deprecated Prefer `getInviteAdapterRegistry().get(channel)`.
  */
 export function getTransport(
   channel: ChannelId,
-): ChannelInviteTransport | undefined {
-  return registry.get(channel);
+): ChannelInviteAdapter | undefined {
+  return defaultRegistry.get(channel);
 }
 
 /**
- * Reset the registry. Intended for tests only.
+ * Reset the default registry. Intended for tests only.
  * @internal
  */
 export function _resetRegistry(): void {
-  registry.clear();
+  defaultRegistry._reset();
 }

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -1,5 +1,5 @@
 /**
- * Telegram channel invite transport adapter.
+ * Telegram channel invite adapter.
  *
  * Builds `https://t.me/<botUsername>?start=iv_<token>` deep links and
  * extracts invite tokens from `/start iv_<token>` command payloads.
@@ -10,10 +10,9 @@
 
 import type { ChannelId } from "../../channels/types.js";
 import { getCredentialMetadata } from "../../tools/credentials/metadata-store.js";
-import {
-  type ChannelInviteTransport,
-  type InviteSharePayload,
-  registerTransport,
+import type {
+  ChannelInviteAdapter,
+  InviteShareLink,
 } from "../channel-invite-transport.js";
 
 // ---------------------------------------------------------------------------
@@ -44,16 +43,16 @@ function getTelegramBotUsername(): string | undefined {
 const INVITE_TOKEN_PREFIX = "iv_";
 
 // ---------------------------------------------------------------------------
-// Transport implementation
+// Adapter implementation
 // ---------------------------------------------------------------------------
 
-export const telegramInviteTransport: ChannelInviteTransport = {
+export const telegramInviteAdapter: ChannelInviteAdapter = {
   channel: "telegram" as ChannelId,
 
-  buildShareableInvite(params: {
+  buildShareLink(params: {
     rawToken: string;
     sourceChannel: ChannelId;
-  }): InviteSharePayload {
+  }): InviteShareLink {
     const botUsername = getTelegramBotUsername();
     if (!botUsername) {
       throw new Error(
@@ -105,7 +104,8 @@ export const telegramInviteTransport: ChannelInviteTransport = {
 };
 
 // ---------------------------------------------------------------------------
-// Auto-register on import
+// Backward-compatible alias
 // ---------------------------------------------------------------------------
 
-registerTransport(telegramInviteTransport);
+/** @deprecated Use `telegramInviteAdapter` instead. */
+export const telegramInviteTransport = telegramInviteAdapter;

--- a/assistant/src/runtime/channel-invite-transports/voice.ts
+++ b/assistant/src/runtime/channel-invite-transports/voice.ts
@@ -1,34 +1,33 @@
 /**
- * Voice channel invite transport adapter.
+ * Voice channel invite adapter.
  *
  * Voice invites are identity-bound: the invitee must call from a specific
  * phone number and enter a numeric code. Unlike Telegram invites, there is
  * no shareable deep link — the guardian relays the code and calling
  * instructions verbally or via another channel.
  *
- * The transport builds human-readable instruction text and provides a
+ * The adapter builds human-readable instruction text and provides a
  * no-op token extractor since voice invite redemption uses the dedicated
  * voice-code path rather than generic token extraction.
  */
 
 import type { ChannelId } from "../../channels/types.js";
-import {
-  type ChannelInviteTransport,
-  type InviteSharePayload,
-  registerTransport,
+import type {
+  ChannelInviteAdapter,
+  InviteShareLink,
 } from "../channel-invite-transport.js";
 
 // ---------------------------------------------------------------------------
-// Transport implementation
+// Adapter implementation
 // ---------------------------------------------------------------------------
 
-export const voiceInviteTransport: ChannelInviteTransport = {
+export const voiceInviteAdapter: ChannelInviteAdapter = {
   channel: "voice" as ChannelId,
 
-  buildShareableInvite(_params: {
+  buildShareLink(_params: {
     rawToken: string;
     sourceChannel: ChannelId;
-  }): InviteSharePayload {
+  }): InviteShareLink {
     // Voice invites do not produce a clickable URL. The "url" field contains
     // a placeholder — callers should use displayText for presentation.
     return {
@@ -52,7 +51,8 @@ export const voiceInviteTransport: ChannelInviteTransport = {
 };
 
 // ---------------------------------------------------------------------------
-// Auto-register on import
+// Backward-compatible alias
 // ---------------------------------------------------------------------------
 
-registerTransport(voiceInviteTransport);
+/** @deprecated Use `voiceInviteAdapter` instead. */
+export const voiceInviteTransport = voiceInviteAdapter;

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -20,15 +20,13 @@ import {
 } from "../memory/invite-store.js";
 import { isValidE164 } from "../util/phone.js";
 import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
-import { getTransport } from "./channel-invite-transport.js";
+import { getInviteAdapterRegistry } from "./channel-invite-transport.js";
 import {
   type InviteRedemptionOutcome,
   redeemInvite as redeemInviteTyped,
   redeemVoiceInviteCode as redeemVoiceInviteCodeTyped,
   type VoiceRedemptionOutcome,
 } from "./invite-redemption-service.js";
-
-import "./channel-invite-transports/telegram.js";
 
 // ---------------------------------------------------------------------------
 // Response shapes — used by both HTTP routes and IPC handlers
@@ -66,11 +64,11 @@ function buildSharePayload(
   rawToken?: string,
 ): InviteResponseData["share"] | undefined {
   if (!rawToken || !isChannelId(sourceChannel)) return undefined;
-  const transport = getTransport(sourceChannel);
-  if (!transport?.buildShareableInvite) return undefined;
+  const adapter = getInviteAdapterRegistry().get(sourceChannel);
+  if (!adapter?.buildShareLink) return undefined;
 
   try {
-    return transport.buildShareableInvite({
+    return adapter.buildShareLink({
       rawToken,
       sourceChannel,
     });

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -45,9 +45,6 @@ import { handleGuardianReplyIntercept } from "./inbound-stages/guardian-reply-in
 import { runSecretIngressCheck } from "./inbound-stages/secret-ingress-check.js";
 import { handleVerificationIntercept } from "./inbound-stages/verification-intercept.js";
 
-import "../channel-invite-transports/telegram.js";
-import "../channel-invite-transports/voice.js";
-
 const log = getLogger("runtime-http");
 
 export async function handleChannelInbound(

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -24,7 +24,7 @@ import {
   getPendingChallenge,
   resolveBootstrapToken,
 } from "../../channel-guardian-service.js";
-import { getTransport } from "../../channel-invite-transport.js";
+import { getInviteAdapterRegistry } from "../../channel-invite-transport.js";
 import { deliverChannelReply } from "../../gateway-client.js";
 import { redeemInvite } from "../../invite-redemption-service.js";
 import { getInviteRedemptionReply } from "../../invite-redemption-templates.js";
@@ -146,8 +146,8 @@ export async function enforceIngressAcl(
     !Array.isArray(rawCommandIntentForAcl)
       ? (rawCommandIntentForAcl as Record<string, unknown>)
       : undefined;
-  const inviteTransport = getTransport(sourceChannel);
-  const inviteToken = inviteTransport?.extractInboundToken({
+  const inviteAdapter = getInviteAdapterRegistry().get(sourceChannel);
+  const inviteToken = inviteAdapter?.extractInboundToken?.({
     commandIntent: commandIntentForAcl,
     content: trimmedContent,
     sourceMetadata,


### PR DESCRIPTION
## Summary
- Rename ChannelInviteTransport → ChannelInviteAdapter with all-optional methods (buildShareLink, extractInboundToken, buildGuardianInstruction)
- Replace side-effect import registration with explicit InviteAdapterRegistry factory pattern
- Add invite.codeRedemptionEnabled to channel config with satisfies enforcement
- Update Telegram and voice adapters and all callers

Part of plan: invite-ui-instructions.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
