### PR TITLE
feat: add 6-digit inviteCode and guardianInstruction to invite response

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -61,6 +61,7 @@ import {
   migrateNotificationDeliveryThreadDecision,
   migrateReminderRoutingIntent,
   migrateSchemaIndexesAndColumns,
+  migrateInviteCodeHashColumn,
   migrateVoiceInviteColumns,
   migrateVoiceInviteDisplayMetadata,
   recoverCrashedMigrations,
@@ -245,6 +246,9 @@ export function initializeDb(): void {
 
   // 27. Voice invite display metadata (friend_name, guardian_name) for personalized prompts
   migrateVoiceInviteDisplayMetadata(database);
+
+  // 27b. 6-digit invite code hash column for non-voice channel invite redemption
+  migrateInviteCodeHashColumn(database);
 
   // 28. Actor token records (hash-only actor token persistence)
   createActorTokenRecordsTable(database);

--- a/assistant/src/memory/invite-store.ts
+++ b/assistant/src/memory/invite-store.ts
@@ -38,6 +38,8 @@ export interface IngressInvite {
   expectedExternalUserId: string | null;
   voiceCodeHash: string | null;
   voiceCodeDigits: number | null;
+  // 6-digit invite code hash (null for voice invites which use voiceCodeHash)
+  inviteCodeHash: string | null;
   // Display metadata for personalized voice prompts (null for non-voice invites)
   friendName: string | null;
   guardianName: string | null;
@@ -84,6 +86,7 @@ function rowToInvite(
     expectedExternalUserId: row.expectedExternalUserId,
     voiceCodeHash: row.voiceCodeHash,
     voiceCodeDigits: row.voiceCodeDigits,
+    inviteCodeHash: row.inviteCodeHash,
     friendName: row.friendName,
     guardianName: row.guardianName,
     createdAt: row.createdAt,
@@ -106,6 +109,8 @@ export function createInvite(params: {
   expectedExternalUserId?: string;
   voiceCodeHash?: string;
   voiceCodeDigits?: number;
+  // 6-digit invite code hash (for non-voice invites)
+  inviteCodeHash?: string;
   friendName?: string;
   guardianName?: string;
 }): { invite: IngressInvite; rawToken: string } {
@@ -132,6 +137,7 @@ export function createInvite(params: {
     expectedExternalUserId: params.expectedExternalUserId ?? null,
     voiceCodeHash: params.voiceCodeHash ?? null,
     voiceCodeDigits: params.voiceCodeDigits ?? null,
+    inviteCodeHash: params.inviteCodeHash ?? null,
     friendName: params.friendName ?? null,
     guardianName: params.guardianName ?? null,
     createdAt: now,
@@ -345,4 +351,29 @@ export function findActiveVoiceInvites(params: {
     .all();
 
   return rows.map(rowToInvite);
+}
+
+// ---------------------------------------------------------------------------
+// findByInviteCodeHash
+// ---------------------------------------------------------------------------
+
+/**
+ * Find an active invite by its 6-digit invite code hash.
+ * Used by the channel-agnostic code redemption flow.
+ */
+export function findByInviteCodeHash(hash: string): IngressInvite | undefined {
+  const db = getDb();
+
+  const row = db
+    .select()
+    .from(assistantIngressInvites)
+    .where(
+      and(
+        eq(assistantIngressInvites.inviteCodeHash, hash),
+        eq(assistantIngressInvites.status, "active"),
+      ),
+    )
+    .get();
+
+  return row ? rowToInvite(row) : undefined;
 }

--- a/assistant/src/memory/migrations/040-invite-code-hash-column.ts
+++ b/assistant/src/memory/migrations/040-invite-code-hash-column.ts
@@ -1,0 +1,16 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Add invite_code_hash column to assistant_ingress_invites for 6-digit
+ * invite code redemption on non-voice channels. The column is nullable —
+ * voice invites use voice_code_hash instead.
+ */
+export function migrateInviteCodeHashColumn(database: DrizzleDb): void {
+  try {
+    database.run(
+      /*sql*/ `ALTER TABLE assistant_ingress_invites ADD COLUMN invite_code_hash TEXT`,
+    );
+  } catch {
+    /* already exists */
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -41,6 +41,7 @@ export { migrateNormalizePhoneIdentities } from "./036-normalize-phone-identitie
 export { migrateVoiceInviteColumns } from "./037-voice-invite-columns.js";
 export { createActorTokenRecordsTable } from "./038-actor-token-records.js";
 export { createActorRefreshTokenRecordsTable } from "./039-actor-refresh-token-records.js";
+export { migrateInviteCodeHashColumn } from "./040-invite-code-hash-column.js";
 export { createCoreTables } from "./100-core-tables.js";
 export { createWatchersAndLogsTables } from "./101-watchers-and-logs.js";
 export { addCoreColumns } from "./102-alter-table-columns.js";

--- a/assistant/src/memory/schema/contacts.ts
+++ b/assistant/src/memory/schema/contacts.ts
@@ -87,6 +87,8 @@ export const assistantIngressInvites = sqliteTable(
     expectedExternalUserId: text("expected_external_user_id"),
     voiceCodeHash: text("voice_code_hash"),
     voiceCodeDigits: integer("voice_code_digits"),
+    // 6-digit invite code hash (nullable — voice invites use voiceCodeHash instead)
+    inviteCodeHash: text("invite_code_hash"),
     // Display metadata for personalized voice prompts (nullable — non-voice invites leave these NULL)
     friendName: text("friend_name"),
     guardianName: text("guardian_name"),

--- a/assistant/src/runtime/channel-invite-transport.ts
+++ b/assistant/src/runtime/channel-invite-transport.ts
@@ -111,12 +111,14 @@ export class InviteAdapterRegistry {
 // Singleton registry + backward-compatible free functions
 // ---------------------------------------------------------------------------
 
+import { smsInviteAdapter } from "./channel-invite-transports/sms.js";
 import { telegramInviteAdapter } from "./channel-invite-transports/telegram.js";
 import { voiceInviteAdapter } from "./channel-invite-transports/voice.js";
 
 /** Create a registry instance with built-in adapters registered. */
 export function createInviteAdapterRegistry(): InviteAdapterRegistry {
   const registry = new InviteAdapterRegistry();
+  registry.register(smsInviteAdapter);
   registry.register(telegramInviteAdapter);
   registry.register(voiceInviteAdapter);
   return registry;

--- a/assistant/src/runtime/channel-invite-transports/sms.ts
+++ b/assistant/src/runtime/channel-invite-transports/sms.ts
@@ -1,0 +1,62 @@
+/**
+ * SMS channel invite adapter.
+ *
+ * Provides guardian instruction text that includes the assistant's Twilio
+ * phone number. SMS invites use the universal 6-digit code path for
+ * redemption, so this adapter only implements `buildGuardianInstruction` —
+ * no `buildShareLink` or `extractInboundToken` needed.
+ */
+
+import type { ChannelId } from "../../channels/types.js";
+import { getTwilioPhoneNumberEnv } from "../../config/env.js";
+import { loadRawConfig } from "../../config/loader.js";
+import { getSecureKey } from "../../security/secure-keys.js";
+import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
+
+// ---------------------------------------------------------------------------
+// Phone number resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the SMS phone number with canonical precedence:
+ * env override -> config sms.phoneNumber -> secure key fallback.
+ * Mirrors the resolution strategy in `channel-readiness-service.ts`.
+ */
+function resolveSmsPhoneNumber(): string | undefined {
+  try {
+    const raw = loadRawConfig();
+    const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
+    return (
+      getTwilioPhoneNumberEnv() ||
+      (smsConfig.phoneNumber as string) ||
+      getSecureKey("credential:twilio:phone_number") ||
+      undefined
+    );
+  } catch {
+    return (
+      getTwilioPhoneNumberEnv() ||
+      getSecureKey("credential:twilio:phone_number") ||
+      undefined
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Adapter implementation
+// ---------------------------------------------------------------------------
+
+export const smsInviteAdapter: ChannelInviteAdapter = {
+  channel: "sms" as ChannelId,
+
+  buildGuardianInstruction(params: {
+    inviteCode: string;
+    contactName?: string;
+  }): string {
+    const phoneNumber = resolveSmsPhoneNumber();
+    const contactLabel = params.contactName || "the contact";
+    if (!phoneNumber) {
+      return `Tell ${contactLabel} to text the assistant and provide the code ${params.inviteCode}.`;
+    }
+    return `Tell ${contactLabel} to text ${phoneNumber} and provide the code ${params.inviteCode}.`;
+  },
+};

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -67,6 +67,18 @@ export const telegramInviteAdapter: ChannelInviteAdapter = {
     };
   },
 
+  buildGuardianInstruction(params: {
+    inviteCode: string;
+    contactName?: string;
+  }): string {
+    const botUsername = getTelegramBotUsername();
+    const contactLabel = params.contactName || "the contact";
+    if (!botUsername) {
+      return `Tell ${contactLabel} to message the assistant on Telegram and provide the code ${params.inviteCode}.`;
+    }
+    return `Tell ${contactLabel} to message @${botUsername} on Telegram and provide the code ${params.inviteCode}.`;
+  },
+
   extractInboundToken(params: {
     commandIntent?: Record<string, unknown>;
     content: string;

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -52,6 +52,9 @@ export interface InviteResponseData {
   voiceCodeDigits?: number;
   friendName?: string;
   guardianName?: string;
+  // Non-voice invite fields (present only for non-voice invites)
+  inviteCode?: string;
+  guardianInstruction?: string;
   createdAt: number;
 }
 
@@ -81,7 +84,12 @@ function buildSharePayload(
 
 function inviteToResponse(
   inv: IngressInvite,
-  opts?: { rawToken?: string; voiceCode?: string },
+  opts?: {
+    rawToken?: string;
+    voiceCode?: string;
+    inviteCode?: string;
+    guardianInstruction?: string;
+  },
 ): InviteResponseData {
   const share = buildSharePayload(inv.sourceChannel, opts?.rawToken);
   return {
@@ -104,6 +112,10 @@ function inviteToResponse(
       : {}),
     ...(inv.friendName ? { friendName: inv.friendName } : {}),
     ...(inv.guardianName ? { guardianName: inv.guardianName } : {}),
+    ...(opts?.inviteCode ? { inviteCode: opts.inviteCode } : {}),
+    ...(opts?.guardianInstruction
+      ? { guardianInstruction: opts.guardianInstruction }
+      : {}),
     createdAt: inv.createdAt,
   };
 }
@@ -125,6 +137,8 @@ export function createIngressInvite(params: {
   note?: string;
   maxUses?: number;
   expiresInMs?: number;
+  // Contact display name for personalizing guardian instructions
+  contactName?: string;
   // Voice invite parameters
   expectedExternalUserId?: string;
   voiceCodeDigits?: number;
@@ -141,6 +155,12 @@ export function createIngressInvite(params: {
   let voiceCode: string | undefined;
   let voiceCodeHash: string | undefined;
   const isVoice = params.sourceChannel === "voice";
+
+  // For non-voice invites: generate a 6-digit invite code for guardian-mediated
+  // redemption. The plaintext code is returned once in the response; only the
+  // hash is persisted for later redemption lookup.
+  let inviteCode: string | undefined;
+  let inviteCodeHash: string | undefined;
 
   if (isVoice) {
     if (!params.expectedExternalUserId) {
@@ -167,6 +187,9 @@ export function createIngressInvite(params: {
     }
     voiceCode = generateVoiceCode(6);
     voiceCodeHash = hashVoiceCode(voiceCode);
+  } else {
+    inviteCode = generateVoiceCode(6);
+    inviteCodeHash = hashVoiceCode(inviteCode);
   }
 
   const { invite, rawToken } = createInvite({
@@ -182,8 +205,37 @@ export function createIngressInvite(params: {
           friendName: params.friendName,
           guardianName: params.guardianName,
         }
-      : {}),
+      : { inviteCodeHash }),
   });
+
+  // Build guardian instruction for non-voice invites
+  let guardianInstruction: string | undefined;
+  if (!isVoice && inviteCode) {
+    const channelId = isChannelId(params.sourceChannel)
+      ? params.sourceChannel
+      : undefined;
+    const adapter = channelId
+      ? getInviteAdapterRegistry().get(channelId)
+      : undefined;
+
+    if (adapter?.buildGuardianInstruction) {
+      try {
+        guardianInstruction = adapter.buildGuardianInstruction({
+          inviteCode,
+          contactName: params.contactName,
+        });
+      } catch {
+        // Fall through to generic instruction if adapter fails
+      }
+    }
+
+    if (!guardianInstruction) {
+      const contactLabel = params.contactName || "the contact";
+      const channelLabel = params.sourceChannel;
+      guardianInstruction = `Tell ${contactLabel} to contact the assistant on ${channelLabel} and provide the code ${inviteCode}.`;
+    }
+  }
+
   // Voice invites must not expose the token — callers must redeem via the
   // identity-bound voice code flow, not the generic token redemption path.
   return {
@@ -191,6 +243,8 @@ export function createIngressInvite(params: {
     data: inviteToResponse(invite, {
       rawToken: isVoice ? undefined : rawToken,
       voiceCode,
+      inviteCode,
+      guardianInstruction,
     }),
   };
 }


### PR DESCRIPTION
## Summary
- Add inviteCodeHash column to DB schema and invite store for 6-digit codes
- Generate 6-digit invite codes for all non-voice channels using existing voice code utility
- Add buildGuardianInstruction to Telegram and new SMS adapters for channel-specific instruction text
- Return inviteCode and guardianInstruction in invite API response with generic fallback

Part of plan: invite-ui-instructions.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12923" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
