### PR TITLE
feat: parse inviteCode and guardianInstruction from invite response

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1676,10 +1676,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     public func createInvite(
         sourceChannel: String,
         note: String? = nil,
-        maxUses: Int? = nil
-    ) async throws -> (inviteId: String, token: String, shareUrl: String?)? {
+        maxUses: Int? = nil,
+        contactName: String? = nil
+    ) async throws -> (inviteId: String, token: String, shareUrl: String?, inviteCode: String?, guardianInstruction: String?)? {
         if let httpTransport {
-            return try await httpTransport.createInvite(sourceChannel: sourceChannel, note: note, maxUses: maxUses)
+            return try await httpTransport.createInvite(sourceChannel: sourceChannel, note: note, maxUses: maxUses, contactName: contactName)
         }
 
         #if os(macOS)
@@ -1689,6 +1690,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         var body: [String: Any] = ["sourceChannel": sourceChannel]
         if let note { body["note"] = note }
         if let maxUses { body["maxUses"] = maxUses }
+        if let contactName { body["contactName"] = contactName }
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
@@ -1703,6 +1705,8 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                 let id: String
                 let token: String?
                 let share: ShareData?
+                let inviteCode: String?
+                let guardianInstruction: String?
             }
             struct ShareData: Decodable {
                 let url: String
@@ -1711,7 +1715,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
         let decoded = try JSONDecoder().decode(CreateInviteResponse.self, from: data)
         guard let invite = decoded.invite, let token = invite.token else { return nil }
-        return (inviteId: invite.id, token: token, shareUrl: invite.share?.url)
+        return (inviteId: invite.id, token: token, shareUrl: invite.share?.url, inviteCode: invite.inviteCode, guardianInstruction: invite.guardianInstruction)
         #else
         return nil
         #endif

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1119,6 +1119,8 @@ public final class HTTPTransport {
             let token: String?
             let share: SharePayload?
             let status: String
+            let inviteCode: String?
+            let guardianInstruction: String?
         }
         struct SharePayload: Decodable {
             let url: String
@@ -1215,8 +1217,9 @@ public final class HTTPTransport {
         sourceChannel: String,
         note: String? = nil,
         maxUses: Int? = nil,
+        contactName: String? = nil,
         isRetry: Bool = false
-    ) async throws -> (inviteId: String, token: String, shareUrl: String?)? {
+    ) async throws -> (inviteId: String, token: String, shareUrl: String?, inviteCode: String?, guardianInstruction: String?)? {
         guard let url = buildURL(for: .contactsInvitesCreate) else { return nil }
 
         var request = URLRequest(url: url)
@@ -1227,6 +1230,7 @@ public final class HTTPTransport {
         var body: [String: Any] = ["sourceChannel": sourceChannel]
         if let note { body["note"] = note }
         if let maxUses { body["maxUses"] = maxUses }
+        if let contactName { body["contactName"] = contactName }
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
         let (data, response) = try await URLSession.shared.data(for: request)
@@ -1235,7 +1239,7 @@ public final class HTTPTransport {
             if http.statusCode == 401 && !isRetry {
                 let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
                 if case .success = refreshResult {
-                    return try await createInvite(sourceChannel: sourceChannel, note: note, maxUses: maxUses, isRetry: true)
+                    return try await createInvite(sourceChannel: sourceChannel, note: note, maxUses: maxUses, contactName: contactName, isRetry: true)
                 }
                 return nil
             }
@@ -1244,7 +1248,7 @@ public final class HTTPTransport {
 
         let decoded = try decoder.decode(HTTPCreateInviteResponse.self, from: data)
         guard let invite = decoded.invite, let token = invite.token else { return nil }
-        return (inviteId: invite.id, token: token, shareUrl: invite.share?.url)
+        return (inviteId: invite.id, token: token, shareUrl: invite.share?.url, inviteCode: invite.inviteCode, guardianInstruction: invite.guardianInstruction)
     }
 
     // MARK: - Channel Verification


### PR DESCRIPTION
## Summary
- Add inviteCode and guardianInstruction fields to HTTPCreateInviteResponse.InvitePayload
- Add contactName parameter to createInvite method for personalized instructions
- Return new fields in createInvite result tuple

Part of plan: invite-ui-instructions.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
