### PR TITLE
refactor: remove readHttpToken() fallbacks from macOS app files

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -412,7 +412,7 @@ extension AppDelegate {
                         bearerToken = httpTransport.bearerToken
                     } else if let port = self.daemonClient.httpPort {
                         baseURL = "http://localhost:\(port)"
-                        bearerToken = ActorTokenManager.getToken() ?? readHttpToken()
+                        bearerToken = ActorTokenManager.getToken()
                     } else {
                         continue
                     }

--- a/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+InputMonitors.swift
@@ -245,11 +245,8 @@ extension AppDelegate {
         window.runtimeHTTPResolver = {
             let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
                 .flatMap(Int.init) ?? 7821
-            if let jwt = ActorTokenManager.getToken(), !jwt.isEmpty {
-                return ("http://localhost:\(port)", jwt)
-            }
-            guard let token = readHttpToken() else { return nil }
-            return ("http://localhost:\(port)", token)
+            guard let jwt = ActorTokenManager.getToken(), !jwt.isEmpty else { return nil }
+            return ("http://localhost:\(port)", jwt)
         }
 
         window.show()

--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -572,17 +572,7 @@ private func resolveGatewayBaseUrl() -> String {
 
 /// Fetch raw attachment bytes via the gateway's runtime proxy.
 private func fetchAttachmentContent(gatewayBaseUrl: String, attachmentId: String) async throws -> Data {
-    let tokenBase: String
-    if let baseDir = ProcessInfo.processInfo.environment["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines),
-       !baseDir.isEmpty {
-        tokenBase = baseDir
-    } else {
-        tokenBase = NSHomeDirectory()
-    }
-    let tokenPath = tokenBase + "/.vellum/http-token"
-    guard let tokenData = try? Data(contentsOf: URL(fileURLWithPath: tokenPath)),
-          let token = String(data: tokenData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
-          !token.isEmpty else {
+    guard let token = ActorTokenManager.getToken(), !token.isEmpty else {
         throw URLError(.userAuthenticationRequired)
     }
     let url = URL(string: "\(gatewayBaseUrl)/v1/attachments/\(attachmentId)/content")!

--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -241,11 +241,7 @@ struct PairingQRCodeSheet: View {
 
     /// Shared HTTP request logic for pairing registration.
     private func performRegistrationRequest(gatewayBaseUrl: String, requestId: String, secret: String) async -> Result<Void, RegistrationRequestError> {
-        let tokenPath = resolveHttpTokenPath()
-        let bearerToken: String? = {
-            guard let path = tokenPath else { return nil }
-            return try? String(contentsOfFile: path, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
-        }()
+        let bearerToken = ActorTokenManager.getToken()
 
         let url = URL(string: "\(gatewayBaseUrl)/pairing/register")!
 
@@ -281,14 +277,6 @@ struct PairingQRCodeSheet: View {
         } catch {
             return .failure(RegistrationRequestError(message: "Could not reach daemon: \(error.localizedDescription)"))
         }
-    }
-
-    private func resolveHttpTokenPath() -> String? {
-        if let envPath = ProcessInfo.processInfo.environment["VELLUM_HTTP_TOKEN_PATH"], !envPath.isEmpty {
-            return envPath
-        }
-        let base = ProcessInfo.processInfo.environment["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? NSHomeDirectory()
-        return "\(base)/.vellum/http-token"
     }
 
     private func computeLocalLanUrl() -> String? {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1000,14 +1000,7 @@ public final class SettingsStore: ObservableObject {
         // Local mode: direct to daemon runtime HTTP server
         let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
             .flatMap(Int.init) ?? 7821
-        let token: String
-        if let jwt = ActorTokenManager.getToken(), !jwt.isEmpty {
-            token = jwt
-        } else if let httpToken = readHttpToken() {
-            token = httpToken
-        } else {
-            return nil
-        }
+        guard let token = ActorTokenManager.getToken(), !token.isEmpty else { return nil }
         guard let url = URL(string: "http://localhost:\(port)/\(path)") else { return nil }
         var request = URLRequest(url: url)
         request.httpMethod = method
@@ -1257,7 +1250,7 @@ public final class SettingsStore: ObservableObject {
         let gatewayPort = ProcessInfo.processInfo.environment["GATEWAY_PORT"]
             .flatMap(Int.init) ?? 7830
         let baseURL = "http://127.0.0.1:\(gatewayPort)"
-        let bearerToken = ActorTokenManager.getToken() ?? readHttpToken()
+        let bearerToken = ActorTokenManager.getToken()
         return (baseURL, bearerToken)
     }
 


### PR DESCRIPTION
## Summary
- Remove `readHttpToken()` fallbacks from AppDelegate+Bootstrap, AppDelegate+InputMonitors, and SettingsStore
- Update PairingQRCodeSheet to use JWT instead of file-based token, remove local `resolveHttpTokenPath()`
- Update InlineVideoAttachmentView to use JWT instead of reading http-token file

Part of plan: remove-http-token.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
