### PR TITLE
feat: channel-agnostic 6-digit invite code redemption in ACL enforcement

### DIFF
--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -13,6 +13,7 @@ import { upsertMember } from "../contacts/contacts-write.js";
 import { getSqlite } from "../memory/db.js";
 import {
   findActiveVoiceInvites,
+  findByInviteCodeHash,
   findByTokenHash,
   hashToken,
   markInviteExpired,
@@ -401,6 +402,204 @@ export function redeemVoiceInviteCode(params: {
     ok: true,
     type: "redeemed",
     memberId: memberId!,
+    inviteId: invite.id,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// redeemInviteByCode
+// ---------------------------------------------------------------------------
+
+/**
+ * Redeem an invite using a 6-digit invite code (channel-agnostic).
+ *
+ * Unlike token-based redemption which uses deep links, code redemption works
+ * by intercepting bare 6-digit messages on channels with codeRedemptionEnabled.
+ * The code is hashed and looked up via `findByInviteCodeHash`.
+ *
+ * Validation: active status, not expired, uses remaining, channel match.
+ * On success: upserts/reactivates a member with status 'active', policy 'allow'.
+ */
+export function redeemInviteByCode(params: {
+  code: string;
+  sourceChannel: string;
+  externalUserId?: string;
+  externalChatId?: string;
+  displayName?: string;
+  username?: string;
+  assistantId?: string;
+}): InviteRedemptionOutcome {
+  const {
+    code,
+    sourceChannel,
+    externalUserId,
+    externalChatId,
+    displayName,
+    username,
+    assistantId,
+  } = params;
+
+  if (!externalUserId && !externalChatId) {
+    return { ok: false, reason: "missing_identity" };
+  }
+
+  const codeHash = hashVoiceCode(code);
+  const invite = findByInviteCodeHash(codeHash);
+
+  if (!invite) {
+    return { ok: false, reason: "invalid_token" };
+  }
+
+  if (invite.status !== "active") {
+    const mapped = STORE_ERROR_TO_REASON[`invite_${invite.status}`];
+    if (mapped) return mapped;
+    return { ok: false, reason: "invalid_token" };
+  }
+
+  if (invite.expiresAt <= Date.now()) {
+    markInviteExpired(invite.id);
+    return { ok: false, reason: "expired" };
+  }
+
+  if (invite.useCount >= invite.maxUses) {
+    return { ok: false, reason: "max_uses_reached" };
+  }
+
+  // Enforce channel match: the invite must belong to the channel the caller
+  // is redeeming from.
+  if (sourceChannel !== invite.sourceChannel) {
+    return { ok: false, reason: "channel_mismatch" };
+  }
+
+  // Code is valid — now safe to check existing membership without leaking
+  // membership status to callers with bogus codes.
+  const canonicalUserId = externalUserId
+    ? (canonicalizeInboundIdentity(
+        sourceChannel as ChannelId,
+        externalUserId,
+      ) ?? externalUserId)
+    : undefined;
+  const contactResult = findContactChannel({
+    channelType: sourceChannel,
+    externalUserId: canonicalUserId,
+    externalChatId: externalChatId,
+  });
+  const existingChannel = contactResult?.channel ?? null;
+  const existingContact = contactResult?.contact ?? null;
+
+  if (existingChannel && existingChannel.status === "active") {
+    return { ok: true, type: "already_member", memberId: existingChannel.id };
+  }
+
+  // Blocked members cannot bypass the guardian's explicit block via invite
+  // codes. Return the same generic failure as an invalid token to avoid
+  // leaking membership status to the caller.
+  if (existingChannel && existingChannel.status === "blocked") {
+    return { ok: false, reason: "invalid_token" };
+  }
+
+  // Inactive member reactivation: reactivate via upsertMember and consume
+  // an invite use atomically.
+  if (existingChannel) {
+    const STALE_INVITE_REACTIVATE = Symbol("stale_invite_reactivate");
+    const canonicalMemberId = existingChannel.externalUserId
+      ? canonicalizeInboundIdentity(
+          sourceChannel as ChannelId,
+          existingChannel.externalUserId,
+        )
+      : null;
+    const canonicalCallerId = externalUserId
+      ? canonicalizeInboundIdentity(sourceChannel as ChannelId, externalUserId)
+      : null;
+    const memberMatchesSender = !!(
+      canonicalMemberId &&
+      canonicalCallerId &&
+      canonicalMemberId === canonicalCallerId
+    );
+    const preservedDisplayName =
+      memberMatchesSender && existingContact?.displayName?.trim().length
+        ? existingContact.displayName
+        : displayName;
+
+    let reactivated: ReturnType<typeof upsertMember> | undefined;
+    try {
+      getSqlite()
+        .transaction(() => {
+          reactivated = upsertMember({
+            assistantId: assistantId ?? invite.assistantId,
+            sourceChannel,
+            externalUserId,
+            externalChatId,
+            displayName: preservedDisplayName,
+            username,
+            status: "active",
+            policy: "allow",
+            inviteId: invite.id,
+          });
+
+          const recorded = recordInviteUse({
+            inviteId: invite.id,
+            externalUserId,
+            externalChatId,
+          });
+
+          if (!recorded) throw STALE_INVITE_REACTIVATE;
+        })
+        .immediate();
+    } catch (err) {
+      if (err === STALE_INVITE_REACTIVATE) {
+        return { ok: false, reason: "invalid_token" };
+      }
+      throw err;
+    }
+
+    return {
+      ok: true,
+      type: "redeemed",
+      memberId: reactivated!.channel.id,
+      inviteId: invite.id,
+    };
+  }
+
+  // Fresh member creation: upsert into contacts tables and consume an invite
+  // use atomically.
+  const STALE_INVITE_FRESH = Symbol("stale_invite_fresh");
+  let freshResult: ReturnType<typeof upsertMember> | undefined;
+  try {
+    getSqlite()
+      .transaction(() => {
+        freshResult = upsertMember({
+          assistantId: assistantId ?? invite.assistantId,
+          sourceChannel,
+          externalUserId,
+          externalChatId,
+          displayName,
+          username,
+          status: "active",
+          policy: "allow",
+          inviteId: invite.id,
+        });
+
+        const recorded = recordInviteUse({
+          inviteId: invite.id,
+          externalUserId,
+          externalChatId,
+        });
+
+        if (!recorded) throw STALE_INVITE_FRESH;
+      })
+      .immediate();
+  } catch (err) {
+    if (err === STALE_INVITE_FRESH) {
+      return { ok: false, reason: "invalid_token" };
+    }
+    throw err;
+  }
+
+  return {
+    ok: true,
+    type: "redeemed",
+    memberId: freshResult!.channel.id,
     inviteId: invite.id,
   };
 }

--- a/assistant/src/runtime/invite-redemption-templates.ts
+++ b/assistant/src/runtime/invite-redemption-templates.ts
@@ -13,13 +13,13 @@ import type { InviteRedemptionOutcome } from "./invite-redemption-service.js";
 // ---------------------------------------------------------------------------
 
 export const INVITE_REPLY_TEMPLATES = {
-  redeemed: "Welcome! You've been granted access via invite link.",
+  redeemed: "Welcome! You've been granted access.",
   already_member: "You already have access.",
-  invalid_token: "This invite link is no longer valid.",
-  expired: "This invite link is no longer valid.",
-  revoked: "This invite link is no longer valid.",
-  max_uses_reached: "This invite link is no longer valid.",
-  channel_mismatch: "This invite link is not valid for this channel.",
+  invalid_token: "This invite is no longer valid.",
+  expired: "This invite is no longer valid.",
+  revoked: "This invite is no longer valid.",
+  max_uses_reached: "This invite is no longer valid.",
+  channel_mismatch: "This invite is not valid for this channel.",
   missing_identity:
     "Unable to process this invite. Please contact the person who shared it.",
   generic_failure:

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -6,6 +6,7 @@
  * Extracted from inbound-message-handler.ts to keep the top-level handler
  * focused on orchestration.
  */
+import { isInviteCodeRedemptionEnabled } from "../../../channels/config.js";
 import type { ChannelId } from "../../../channels/types.js";
 import { findContactChannel } from "../../../contacts/contact-store.js";
 import { touchChannelLastSeen } from "../../../contacts/contacts-write.js";
@@ -26,7 +27,10 @@ import {
 } from "../../channel-guardian-service.js";
 import { getInviteAdapterRegistry } from "../../channel-invite-transport.js";
 import { deliverChannelReply } from "../../gateway-client.js";
-import { redeemInvite } from "../../invite-redemption-service.js";
+import {
+  redeemInvite,
+  redeemInviteByCode,
+} from "../../invite-redemption-service.js";
 import { getInviteRedemptionReply } from "../../invite-redemption-templates.js";
 
 const log = getLogger("runtime-http");
@@ -253,6 +257,32 @@ export async function enforceIngressAcl(
           };
       }
 
+      // ── 6-digit invite code intercept (non-member) ──
+      // On channels with codeRedemptionEnabled, a bare 6-digit message may be
+      // an invite code. Attempt redemption; on failure (no matching code) fall
+      // through to normal processing — the number may be a regular message.
+      if (denyNonMember && /^\d{6}$/.test(trimmedContent)) {
+        const codeInterceptResult = await handleInviteCodeIntercept({
+          code: trimmedContent,
+          sourceChannel,
+          externalChatId: conversationExternalId,
+          externalMessageId,
+          senderExternalUserId: canonicalSenderId ?? rawSenderId,
+          senderName: actorDisplayName,
+          senderUsername: actorUsername,
+          replyCallbackUrl,
+          bearerToken: mintBearerToken(),
+          assistantId,
+          canonicalAssistantId,
+        });
+        if (codeInterceptResult)
+          return {
+            resolvedMember: null,
+            earlyResponse: codeInterceptResult,
+            guardianVerifyCode,
+          };
+      }
+
       if (denyNonMember) {
         log.info(
           { sourceChannel, externalUserId: canonicalSenderId },
@@ -455,6 +485,31 @@ export async function enforceIngressAcl(
             return {
               resolvedMember: null,
               earlyResponse: inviteResult,
+              guardianVerifyCode,
+            };
+        }
+
+        // ── 6-digit invite code intercept (inactive member) ──
+        // Same as the non-member branch: codes can reactivate revoked/pending
+        // members. Non-matching codes fall through to normal processing.
+        if (denyInactiveMember && /^\d{6}$/.test(trimmedContent)) {
+          const codeInterceptResult = await handleInviteCodeIntercept({
+            code: trimmedContent,
+            sourceChannel,
+            externalChatId: conversationExternalId,
+            externalMessageId,
+            senderExternalUserId: canonicalSenderId ?? rawSenderId,
+            senderName: actorDisplayName,
+            senderUsername: actorUsername,
+            replyCallbackUrl,
+            bearerToken: mintBearerToken(),
+            assistantId,
+            canonicalAssistantId,
+          });
+          if (codeInterceptResult)
+            return {
+              resolvedMember: null,
+              earlyResponse: codeInterceptResult,
               guardianVerifyCode,
             };
         }
@@ -793,6 +848,163 @@ async function handleInviteTokenIntercept(params: {
     eventId: dedupResult.eventId,
     denied: true,
     inviteRedemption: outcome.reason,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 6-digit invite code intercept
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle a bare 6-digit message as a potential invite code redemption.
+ *
+ * Checks channel policy (codeRedemptionEnabled), attempts redemption via
+ * `redeemInviteByCode`, and returns a Response to short-circuit the handler
+ * on success. Returns `null` when the code does not match any active invite,
+ * allowing the message to fall through to normal processing.
+ */
+async function handleInviteCodeIntercept(params: {
+  code: string;
+  sourceChannel: ChannelId;
+  externalChatId: string;
+  externalMessageId: string;
+  senderExternalUserId?: string;
+  senderName?: string;
+  senderUsername?: string;
+  replyCallbackUrl?: string;
+  bearerToken?: string;
+  assistantId?: string;
+  canonicalAssistantId: string;
+}): Promise<Response | null> {
+  const {
+    code,
+    sourceChannel,
+    externalChatId,
+    externalMessageId,
+    senderExternalUserId,
+    senderName,
+    senderUsername,
+    replyCallbackUrl,
+    bearerToken,
+    assistantId,
+    canonicalAssistantId,
+  } = params;
+
+  // Skip channels that don't support code redemption
+  if (!isInviteCodeRedemptionEnabled(sourceChannel)) {
+    return null;
+  }
+
+  const outcome = redeemInviteByCode({
+    code,
+    sourceChannel,
+    externalUserId: senderExternalUserId,
+    externalChatId,
+    displayName: senderName,
+    username: senderUsername,
+    assistantId: canonicalAssistantId,
+  });
+
+  // Non-matching codes fall through to normal message processing — a bare
+  // 6-digit number may be a regular message, not an invite code.
+  if (!outcome.ok && outcome.reason === "invalid_token") {
+    return null;
+  }
+
+  log.info(
+    {
+      sourceChannel,
+      externalChatId,
+      ok: outcome.ok,
+      type: outcome.ok ? outcome.type : undefined,
+      reason: !outcome.ok ? outcome.reason : undefined,
+    },
+    "Invite code intercept: redemption result",
+  );
+
+  // Record the inbound event for dedup tracking after a successful match.
+  const dedupResult = channelDeliveryStore.recordInbound(
+    sourceChannel,
+    externalChatId,
+    externalMessageId,
+    { assistantId: canonicalAssistantId },
+  );
+
+  if (dedupResult.duplicate) {
+    return Response.json({
+      accepted: true,
+      duplicate: true,
+      eventId: dedupResult.eventId,
+    });
+  }
+
+  // already_member: deliver acknowledgement and short-circuit
+  if (outcome.ok && outcome.type === "already_member") {
+    const replyText = getInviteRedemptionReply(outcome);
+    if (replyCallbackUrl) {
+      try {
+        await deliverChannelReply(
+          replyCallbackUrl,
+          {
+            chatId: externalChatId,
+            text: replyText,
+            assistantId,
+          },
+          bearerToken,
+        );
+      } catch (err) {
+        log.error(
+          { err, externalChatId },
+          "Failed to deliver invite code already-member reply",
+        );
+      }
+    }
+    channelDeliveryStore.markProcessed(dedupResult.eventId);
+    return Response.json({
+      accepted: true,
+      eventId: dedupResult.eventId,
+      inviteRedemption: "already_member",
+    });
+  }
+
+  const replyText = getInviteRedemptionReply(outcome);
+
+  if (replyCallbackUrl) {
+    try {
+      await deliverChannelReply(
+        replyCallbackUrl,
+        {
+          chatId: externalChatId,
+          text: replyText,
+          assistantId,
+        },
+        bearerToken,
+      );
+    } catch (err) {
+      log.error(
+        { err, externalChatId },
+        "Failed to deliver invite code redemption reply",
+      );
+    }
+  }
+
+  if (outcome.ok && outcome.type === "redeemed") {
+    channelDeliveryStore.markProcessed(dedupResult.eventId);
+    return Response.json({
+      accepted: true,
+      eventId: dedupResult.eventId,
+      inviteRedemption: "redeemed",
+      memberId: outcome.memberId,
+    });
+  }
+
+  // Failed redemption (expired, revoked, etc.) — inform and deny
+  channelDeliveryStore.markProcessed(dedupResult.eventId);
+  return Response.json({
+    accepted: true,
+    eventId: dedupResult.eventId,
+    denied: true,
+    inviteRedemption: !outcome.ok ? outcome.reason : undefined,
   });
 }
 


### PR DESCRIPTION
## Summary
- Add redeemInviteByCode function for 6-digit code redemption via invite code hash lookup
- Add channel-agnostic code interception in ACL enforcement layer (checks codeRedemptionEnabled policy)
- Update reply templates to be link/code-agnostic
- Non-matching codes fall through to normal message processing

Part of plan: invite-ui-instructions.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
