### PR TITLE
chore: remove readHttpToken() definitions and bearer token management UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -11,12 +11,7 @@ struct SettingsChannelsTab: View {
     var daemonClient: DaemonClient?
     private static let smsFeatureFlagKey = "feature_flags.sms.enabled"
 
-    @State private var bearerToken: String = ""
-    @State private var tokenRevealed: Bool = false
-    @State private var tokenCopied: Bool = false
     @State private var showingPairingQR: Bool = false
-    @State private var showingRegenerateConfirmation: Bool = false
-    @State private var advancedExpanded: Bool = false
     @State private var isSmsFeatureEnabled: Bool = true
 
     // Telegram credential entry
@@ -67,7 +62,6 @@ struct SettingsChannelsTab: View {
         .onAppear {
             store.refreshAssistantEmail()
             store.refreshApprovedDevices()
-            refreshBearerToken()
             store.refreshChannelGuardianStatus(channel: "telegram")
             store.refreshChannelGuardianStatus(channel: "voice")
             store.refreshChannelGuardianStatus(channel: "slack")
@@ -92,97 +86,11 @@ struct SettingsChannelsTab: View {
                 store.refreshTwilioNumbers()
             }
         }
-        .alert("Regenerate Bearer Token", isPresented: $showingRegenerateConfirmation) {
-            Button("Cancel", role: .cancel) {}
-            Button("Regenerate", role: .destructive) {
-                regenerateHttpToken()
-            }
-        } message: {
-            Text("This will generate a new security token and restart your assistant. Any paired devices will need to reconnect.")
-        }
         .sheet(isPresented: $showingPairingQR) {
             PairingQRCodeSheet(
                 gatewayUrl: store.resolvedIosGatewayUrl,
                 daemonClient: daemonClient
             )
-        }
-    }
-
-    // MARK: - Bearer Token Content
-
-    private var bearerTokenContent: some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Text("Bearer Token")
-                .font(VFont.inputLabel)
-                .foregroundColor(VColor.textSecondary)
-
-            if bearerToken.isEmpty {
-                HStack(spacing: VSpacing.sm) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundColor(VColor.warning)
-                        .font(.system(size: 12))
-                    Text("Bearer token not found. Restart the daemon to generate it.")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                }
-            } else {
-                HStack(spacing: VSpacing.sm) {
-                    // Masked or revealed token
-                    if tokenRevealed {
-                        Text(bearerToken)
-                            .font(VFont.mono)
-                            .foregroundColor(VColor.textPrimary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                    } else {
-                        Text(String(repeating: "\u{2022}", count: min(bearerToken.count, 24)))
-                            .font(VFont.mono)
-                            .foregroundColor(VColor.textPrimary)
-                            .lineLimit(1)
-                    }
-
-                    Spacer()
-
-                    // Reveal/hide toggle
-                    Button {
-                        tokenRevealed.toggle()
-                    } label: {
-                        Image(systemName: tokenRevealed ? "eye.slash" : "eye")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundColor(VColor.textSecondary)
-                            .frame(width: 28, height: 28)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(tokenRevealed ? "Hide token" : "Reveal token")
-                    .help(tokenRevealed ? "Hide token" : "Reveal token")
-
-                    // Copy button
-                    Button {
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(bearerToken, forType: .string)
-                        tokenCopied = true
-                        Task {
-                            try? await Task.sleep(nanoseconds: 2_000_000_000)
-                            tokenCopied = false
-                        }
-                    } label: {
-                        Image(systemName: tokenCopied ? "checkmark" : "doc.on.doc")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundColor(tokenCopied ? VColor.success : VColor.textSecondary)
-                            .frame(width: 28, height: 28)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Copy bearer token")
-                    .help("Copy token")
-
-                }
-
-                VButton(label: "Regenerate", style: .tertiary) {
-                    showingRegenerateConfirmation = true
-                }
-            }
         }
     }
 
@@ -1548,37 +1456,6 @@ struct SettingsChannelsTab: View {
 
             // Device pairing row — mirrors Guardian Verification row layout
             mobilePairingRow
-
-            // Compact advanced disclosure for power users
-            Divider().background(VColor.surfaceBorder)
-
-            VStack(alignment: .leading, spacing: 0) {
-                Button {
-                    withAnimation(VAnimation.fast) {
-                        advancedExpanded.toggle()
-                    }
-                } label: {
-                    HStack(spacing: VSpacing.xs) {
-                        Text("Advanced")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 8, weight: .semibold))
-                            .foregroundColor(VColor.textMuted)
-                            .rotationEffect(.degrees(advancedExpanded ? 90 : 0))
-                            .animation(VAnimation.fast, value: advancedExpanded)
-                    }
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-
-                if advancedExpanded {
-                    VStack(alignment: .leading, spacing: VSpacing.sm) {
-                        bearerTokenContent
-                    }
-                    .padding(.top, VSpacing.sm)
-                }
-            }
         }
         .padding(VSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -1589,17 +1466,8 @@ struct SettingsChannelsTab: View {
     @ViewBuilder
     private var mobilePairingRow: some View {
         let hasGateway = !store.resolvedIosGatewayUrl.isEmpty || LANIPHelper.currentLANAddress() != nil
-        let hasToken = !bearerToken.isEmpty
 
-        if store.isRegeneratingToken {
-            HStack(spacing: VSpacing.sm) {
-                ProgressView()
-                    .controlSize(.small)
-                Text("Restarting daemon\u{2026}")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
-            }
-        } else if !hasGateway {
+        if !hasGateway {
             HStack(spacing: VSpacing.sm) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundColor(VColor.warning)
@@ -1607,20 +1475,6 @@ struct SettingsChannelsTab: View {
                 Text("Configure a gateway URL to enable pairing")
                     .font(VFont.body)
                     .foregroundColor(VColor.warning)
-            }
-        } else if !hasToken {
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
-                HStack(spacing: VSpacing.sm) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundColor(VColor.warning)
-                        .font(.system(size: 12))
-                    Text("Bearer token required")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.warning)
-                }
-                VButton(label: "Generate Token", style: .secondary) {
-                    regenerateHttpToken()
-                }
             }
         } else {
             VButton(label: "Pair Device", leftIcon: "qrcode", style: .primary) {
@@ -1630,7 +1484,7 @@ struct SettingsChannelsTab: View {
     }
 
 
-    // MARK: - Token Helpers
+    // MARK: - Feature Flags
 
     private func loadSmsFeatureFlag() async {
         // Primary source: gateway feature-flags API.
@@ -1658,51 +1512,4 @@ struct SettingsChannelsTab: View {
         // values are absent, keep the default enabled behavior.
     }
 
-    private func refreshBearerToken() {
-        bearerToken = readHttpToken() ?? ""
-    }
-
-    private func regenerateHttpToken() {
-        let tokenPath = resolveHttpTokenPath()
-        // Generate new random bytes before deleting the old file so a
-        // SecRandomCopyBytes failure doesn't leave us with no token at all.
-        var bytes = [UInt8](repeating: 0, count: 32)
-        guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else { return }
-        let newToken = bytes.map { String(format: "%02x", $0) }.joined()
-        try? FileManager.default.removeItem(atPath: tokenPath)
-        let dir = (tokenPath as NSString).deletingLastPathComponent
-        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        FileManager.default.createFile(atPath: tokenPath, contents: Data(newToken.utf8), attributes: [.posixPermissions: 0o600])
-        bearerToken = newToken
-        // Kill the daemon so the health monitor restarts it with the new token.
-        // The daemon only reads the token at startup, so a restart is required.
-        store.isRegeneratingToken = true
-        let pidPath = resolvePidPath()
-        if let pidStr = try? String(contentsOfFile: pidPath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines),
-           let pid = Int32(pidStr) {
-            kill(pid, SIGTERM)
-        }
-        // Wait for the daemon to restart and become reachable with the new token.
-        Task {
-            let base = store.localGatewayTarget.hasSuffix("/")
-                ? String(store.localGatewayTarget.dropLast())
-                : store.localGatewayTarget
-            guard let url = URL(string: "\(base)/v1/health") else {
-                store.isRegeneratingToken = false
-                return
-            }
-            var request = URLRequest(url: url)
-            request.setValue("Bearer \(newToken)", forHTTPHeaderField: "Authorization")
-            request.timeoutInterval = 2
-            for _ in 0..<30 { // up to ~30s
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
-                if let (_, response) = try? await URLSession.shared.data(for: request),
-                   let http = response as? HTTPURLResponse, http.statusCode == 200 {
-                    store.isRegeneratingToken = false
-                    return
-                }
-            }
-            store.isRegeneratingToken = false
-        }
-    }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -245,15 +245,6 @@ public final class SettingsStore: ObservableObject {
     @Published var isCheckingTunnel: Bool = false
     @Published var tunnelLastChecked: Date?
 
-    // MARK: - Token Regeneration State
-
-    /// Shared across Account and Channels tabs so both views know when the
-    /// daemon is restarting after a bearer token regeneration. Without this,
-    /// switching to Channels immediately after regenerating in Account could
-    /// cause PairingQRCodeSheet to read the new token while the daemon is
-    /// still running on the old one, leading to transient pairing failures.
-    @Published var isRegeneratingToken: Bool = false
-
     // MARK: - Dev Mode
 
     @Published var isDevMode: Bool
@@ -2249,11 +2240,6 @@ public final class SettingsStore: ObservableObject {
     /// Gateway URL for iOS pairing.
     var resolvedIosGatewayUrl: String {
         ingressPublicBaseUrl
-    }
-
-    /// Bearer token for iOS pairing.
-    var resolvedIosBearerToken: String {
-        readHttpToken() ?? ""
     }
 
     /// LAN pairing URL for the gateway (port 7830), or nil if no LAN IP available.

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -73,13 +73,6 @@ public func resolveVellumDir(environment: [String: String]? = nil) -> String {
     return NSHomeDirectory() + "/.vellum"
 }
 
-/// Resolve the runtime HTTP bearer token path.
-/// Uses BASE_DATA_DIR when set to match daemon root resolution.
-/// Available on all platforms since HTTP transport is used on both macOS and iOS.
-public func resolveHttpTokenPath(environment: [String: String]? = nil) -> String {
-    return resolveVellumDir(environment: environment) + "/http-token"
-}
-
 /// Resolve the feature-flag bearer token path.
 /// Uses BASE_DATA_DIR when set to match daemon root resolution.
 public func resolveFeatureFlagTokenPath(environment: [String: String]? = nil) -> String {
@@ -89,25 +82,6 @@ public func resolveFeatureFlagTokenPath(environment: [String: String]? = nil) ->
 /// Resolve the daemon PID file path, honoring `BASE_DATA_DIR`.
 public func resolvePidPath(environment: [String: String]? = nil) -> String {
     return resolveVellumDir(environment: environment) + "/vellum.pid"
-}
-
-/// Read the runtime HTTP bearer token from disk.
-/// Available on all platforms since HTTP transport is used on both macOS and iOS.
-public func readHttpToken(environment: [String: String]? = nil) -> String? {
-    let tokenPath = resolveHttpTokenPath(environment: environment)
-    let data: Data
-    do {
-        data = try Data(contentsOf: URL(fileURLWithPath: tokenPath))
-    } catch {
-        log.error("Failed to read HTTP token from \(tokenPath, privacy: .private): \(error)")
-        return nil
-    }
-    guard let token = String(data: data, encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-          !token.isEmpty else {
-        return nil
-    }
-    return token
 }
 
 /// Read the feature-flag bearer token from disk.


### PR DESCRIPTION
## Summary
- Remove `readHttpToken()` and `resolveHttpTokenPath()` function definitions from DaemonClient.swift
- Remove dead `resolvedIosBearerToken` property from SettingsStore.swift
- Remove all bearer token display/generate/regenerate UI from SettingsChannelsTab (bearerTokenContent, refreshBearerToken, regenerateHttpToken, token state variables, pairing gate)

Part of plan: remove-http-token.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
