### PR TITLE
chore: remove http-token file writing from daemon and CLI reading

### DIFF
--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -94,10 +94,6 @@ export function getRuntimeHttpHost(): string {
   return str("RUNTIME_HTTP_HOST") || "127.0.0.1";
 }
 
-export function getRuntimeProxyBearerToken(): string | undefined {
-  return str("RUNTIME_PROXY_BEARER_TOKEN");
-}
-
 export function getRuntimeGatewayOriginSecret(): string | undefined {
   return str("RUNTIME_GATEWAY_ORIGIN_SECRET");
 }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1,5 +1,3 @@
-import { randomBytes } from "node:crypto";
-import { chmodSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { config as dotenvConfig } from "dotenv";
@@ -14,7 +12,6 @@ import {
   getQdrantUrlEnv,
   getRuntimeHttpHost,
   getRuntimeHttpPort,
-  getRuntimeProxyBearerToken,
   validateEnv,
 } from "../config/env.js";
 import { loadConfig } from "../config/loader.js";
@@ -51,7 +48,6 @@ import { migrateKeychainToEncrypted } from "../security/keychain-to-encrypted-mi
 import { getLogger, initLogger } from "../util/logger.js";
 import {
   ensureDataDir,
-  getHttpTokenPath,
   getInterfacesDir,
   getRootDir,
   getSocketPath,
@@ -147,26 +143,6 @@ export async function runDaemon(): Promise<void> {
     // Copy any existing macOS keychain secrets into the encrypted file store
     // before config loads, so the new encrypted-store-first read path sees them.
     migrateKeychainToEncrypted();
-
-    // Resolve and write the bearer token as early as possible so the CLI
-    // (which polls for this file during gateway startup) doesn't time out
-    // waiting for Qdrant or other slow init steps to finish.
-    const httpTokenPath = getHttpTokenPath();
-    let bearerToken = getRuntimeProxyBearerToken();
-    if (!bearerToken) {
-      try {
-        const existing = readFileSync(httpTokenPath, "utf-8").trim();
-        if (existing) bearerToken = existing;
-      } catch {
-        // File doesn't exist or can't be read — will generate below
-      }
-    }
-    if (!bearerToken) {
-      bearerToken = randomBytes(32).toString("hex");
-    }
-    writeFileSync(httpTokenPath, bearerToken, { mode: 0o600 });
-    chmodSync(httpTokenPath, 0o600);
-    log.info("Daemon startup: bearer token written");
 
     // Load (or generate + persist) the auth signing key so tokens survive
     // daemon restarts. Must happen after ensureDataDir() creates the
@@ -407,7 +383,6 @@ export async function runDaemon(): Promise<void> {
     runtimeHttp = new RuntimeHttpServer({
       port: httpPort,
       hostname,
-      bearerToken,
       processMessage: (
         conversationId,
         content,
@@ -604,7 +579,7 @@ export async function runDaemon(): Promise<void> {
       runtimeHttp.setPairingBroadcast((msg) =>
         server.broadcast(msg as ServerMessage),
       );
-      initPairingHandlers(runtimeHttp.getPairingStore(), bearerToken);
+      initPairingHandlers(runtimeHttp.getPairingStore(), undefined);
       initSlashPairingContext(runtimeHttp.getPairingStore());
       server.setHttpPort(httpPort);
       log.info(

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -243,10 +243,6 @@ export function isIOSPairingEnabled(): boolean {
   return existsSync(join(getRootDir(), "ios-pairing-enabled"));
 }
 
-export function getHttpTokenPath(): string {
-  return join(getRootDir(), "http-token");
-}
-
 /**
  * Returns the path to the platform API token file (~/.vellum/platform-token).
  * This token is the X-Session-Token used to authenticate with the Vellum

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -1,6 +1,3 @@
-import { readFileSync } from "fs";
-import { join } from "path";
-
 import {
   findAssistantByName,
   loadLatestAssistant,
@@ -60,21 +57,8 @@ function parseArgs(): ParsedArgs {
     process.env.RUNTIME_URL || entry?.runtimeUrl || FALLBACK_RUNTIME_URL;
   let assistantId =
     process.env.ASSISTANT_ID || entry?.assistantId || FALLBACK_ASSISTANT_ID;
-  let bearerToken =
+  const bearerToken =
     process.env.RUNTIME_PROXY_BEARER_TOKEN || entry?.bearerToken || undefined;
-
-  // For local assistants, read the daemon's http-token file as a fallback
-  // when the lockfile doesn't include a bearer token.
-  if (!bearerToken && entry?.cloud === "local") {
-    const tokenDir =
-      entry.baseDataDir ?? join(process.env.HOME ?? "", ".vellum");
-    try {
-      const token = readFileSync(join(tokenDir, "http-token"), "utf-8").trim();
-      if (token) bearerToken = token;
-    } catch {
-      // Token file may not exist
-    }
-  }
   const species: Species = (entry?.species as Species) ?? "vellum";
 
   for (let i = 0; i < flagArgs.length; i++) {

--- a/cli/src/commands/contacts.ts
+++ b/cli/src/commands/contacts.ts
@@ -1,7 +1,3 @@
-import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
-
 import { loadLatestAssistant } from "../lib/assistant-config";
 import { GATEWAY_PORT } from "../lib/constants.js";
 
@@ -17,21 +13,7 @@ function getGatewayUrl(): string {
 
 function getBearerToken(): string | undefined {
   const entry = loadLatestAssistant();
-  if (entry?.bearerToken) return entry.bearerToken;
-  try {
-    const tokenPath = join(
-      process.env.BASE_DATA_DIR?.trim() || homedir(),
-      ".vellum",
-      "http-token",
-    );
-    if (existsSync(tokenPath)) {
-      const token = readFileSync(tokenPath, "utf-8").trim();
-      if (token) return token;
-    }
-  } catch {
-    // ignore
-  }
-  return undefined;
+  return entry?.bearerToken;
 }
 
 function buildHeaders(): Record<string, string> {

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -756,21 +756,10 @@ async function hatchLocal(
     throw error;
   }
 
-  // Read the bearer token written by the daemon so the client can authenticate
-  // with the gateway (which requires auth by default).
-  let bearerToken: string | undefined;
-  try {
-    const token = readFileSync(join(baseDataDir, "http-token"), "utf-8").trim();
-    if (token) bearerToken = token;
-  } catch {
-    // Token file may not exist if daemon started without HTTP server
-  }
-
   const localEntry: AssistantEntry = {
     assistantId: instanceName,
     runtimeUrl,
     baseDataDir,
-    bearerToken,
     cloud: "local",
     species,
     hatchedAt: new Date().toISOString(),
@@ -792,7 +781,7 @@ async function hatchLocal(
     console.log("");
 
     // Generate and display pairing QR code
-    await displayPairingQRCode(runtimeUrl, bearerToken);
+    await displayPairingQRCode(runtimeUrl, undefined);
   }
 }
 

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -829,73 +829,10 @@ export async function startGateway(
     process.env.GATEWAY_DEFAULT_ASSISTANT_ID ||
     loadLatestAssistant()?.assistantId;
 
-  // Read the bearer token so the gateway can authenticate proxied requests
-  // (e.g. from paired iOS devices). Respect VELLUM_HTTP_TOKEN_PATH and
-  // BASE_DATA_DIR for consistency with gateway/config.ts and the daemon.
-  const httpTokenPath =
-    process.env.VELLUM_HTTP_TOKEN_PATH ??
-    join(
-      process.env.BASE_DATA_DIR?.trim() || homedir(),
-      ".vellum",
-      "http-token",
-    );
-  let runtimeProxyBearerToken: string | undefined;
-  try {
-    const tok = readFileSync(httpTokenPath, "utf-8").trim();
-    if (tok) runtimeProxyBearerToken = tok;
-  } catch {
-    // Token file doesn't exist yet — daemon hasn't written it.
-  }
-
-  // If no token is available (first startup — daemon hasn't written it yet),
-  // poll for the file to appear. On fresh installs the daemon may take 60s+
-  // for Qdrant download, migrations, and first-time init. Starting the
-  // gateway without auth is a security risk since the config is loaded once
-  // at startup and never reloads, so we fail rather than silently disabling auth.
-  if (!runtimeProxyBearerToken) {
-    console.log("   Waiting for bearer token file...");
-    const maxWait = 60000;
-    const pollInterval = 500;
-    const start = Date.now();
-    const pidFile = join(
-      process.env.BASE_DATA_DIR?.trim() || homedir(),
-      ".vellum",
-      "vellum.pid",
-    );
-    while (Date.now() - start < maxWait) {
-      await new Promise((r) => setTimeout(r, pollInterval));
-      try {
-        const tok = readFileSync(httpTokenPath, "utf-8").trim();
-        if (tok) {
-          runtimeProxyBearerToken = tok;
-          break;
-        }
-      } catch {
-        // File still doesn't exist, keep polling.
-      }
-      // Check if the daemon process is still alive — no point waiting if it crashed
-      try {
-        const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
-        if (pid) process.kill(pid, 0); // throws if process doesn't exist
-      } catch {
-        break; // daemon process is gone
-      }
-    }
-  }
-
-  if (!runtimeProxyBearerToken) {
-    throw new Error(
-      `Bearer token file not found at ${httpTokenPath} after 60s.\n` +
-        "  The gateway cannot start without authentication — this would leave the proxy permanently unauthenticated.\n" +
-        "  Ensure the daemon is running and has written the token file, or set VELLUM_HTTP_TOKEN_PATH to the correct path.",
-    );
-  }
-
   const gatewayEnv: Record<string, string> = {
     ...(process.env as Record<string, string>),
     GATEWAY_RUNTIME_PROXY_ENABLED: "true",
     GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "true",
-    RUNTIME_PROXY_BEARER_TOKEN: runtimeProxyBearerToken,
     RUNTIME_HTTP_PORT: process.env.RUNTIME_HTTP_PORT || "7821",
     // Skip the drain window for locally-launched gateways — there is no load
     // balancer draining connections, so waiting serves no purpose and causes


### PR DESCRIPTION
## Summary
- Remove http-token file generation and writing from daemon startup (`lifecycle.ts`)
- Remove `getHttpTokenPath()` from platform.ts and `getRuntimeProxyBearerToken()` from env.ts
- Remove http-token file reading from CLI commands (hatch, contacts, client)
- Remove http-token polling and `RUNTIME_PROXY_BEARER_TOKEN` env var from gateway startup (`local.ts`)

Part of plan: remove-http-token.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
