### PR TITLE
fix: pass contactName through HTTP route handler for personalized invite instructions

### DIFF
--- a/assistant/src/runtime/routes/invite-routes.ts
+++ b/assistant/src/runtime/routes/invite-routes.ts
@@ -52,6 +52,7 @@ export async function handleCreateInvite(req: Request): Promise<Response> {
     note: body.note as string | undefined,
     maxUses: body.maxUses as number | undefined,
     expiresInMs: body.expiresInMs as number | undefined,
+    contactName: body.contactName as string | undefined,
     expectedExternalUserId: body.expectedExternalUserId as string | undefined,
     voiceCodeDigits: body.voiceCodeDigits as number | undefined,
     friendName: body.friendName as string | undefined,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for invite-ui-instructions.md.

**Gap:** HTTP route handler missing contactName extraction
**What was expected:** The handleCreateInvite function should extract and pass contactName from the request body to createIngressInvite() to enable personalized guardian instructions
**What was found:** invite-routes.ts did not include contactName when calling createIngressInvite()

🤖 Generated with [Claude Code](https://claude.com/claude-code)