### PR TITLE
perf(macos): cache groupedSegments in MarkdownSegmentView to avoid per-render recomputation (LUM-16)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -4,14 +4,14 @@ import VellumAssistantShared
 // MARK: - Markdown Table Support
 
 /// A segment of message content — either plain text or a parsed table.
-struct ListItem {
+struct ListItem: Hashable {
     let indent: Int
     let ordered: Bool
     let number: Int      // meaningful only when ordered == true
     let text: String
 }
 
-enum MarkdownSegment {
+enum MarkdownSegment: Hashable {
     case text(String)
     case table(headers: [String], rows: [[String]])
     case image(alt: String, url: String)

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -144,9 +144,39 @@ struct MarkdownSegmentView: View {
         case horizontalRule
     }
 
+    // Bounded LRU cache for groupedSegments results, keyed by a hash of
+    // the segment array. Avoids recomputing grouping on every body evaluation
+    // when the segment array hasn't changed (the common case during scrolling).
+    @MainActor private static var groupedSegmentsCache: [Int: (value: [SegmentGroup], accessTime: Int)] = [:]
+    @MainActor private static var groupedLRUCounter: Int = 0
+    private static let groupedCacheLimit = 200
+
     /// Groups consecutive text-selectable segments together so they render
     /// as a single Text view, enabling cross-paragraph text selection.
     private var groupedSegments: [SegmentGroup] {
+        var hasher = Hasher()
+        for segment in segments { hasher.combine(segment) }
+        let key = hasher.finalize()
+
+        if let cached = Self.groupedSegmentsCache[key] {
+            Self.groupedLRUCounter += 1
+            Self.groupedSegmentsCache[key] = (cached.value, Self.groupedLRUCounter)
+            return cached.value
+        }
+
+        let result = computeGroupedSegments()
+
+        if Self.groupedSegmentsCache.count >= Self.groupedCacheLimit {
+            if let lruKey = Self.groupedSegmentsCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
+                Self.groupedSegmentsCache.removeValue(forKey: lruKey)
+            }
+        }
+        Self.groupedLRUCounter += 1
+        Self.groupedSegmentsCache[key] = (result, Self.groupedLRUCounter)
+        return result
+    }
+
+    private func computeGroupedSegments() -> [SegmentGroup] {
         var groups: [SegmentGroup] = []
         var currentRun: [MarkdownSegment] = []
 
@@ -185,6 +215,12 @@ struct MarkdownSegmentView: View {
 
         flushRun()
         return groups
+    }
+
+    /// Clears the grouped segments cache. Called alongside `clearAttributedStringCache`
+    /// when switching threads or archiving a conversation to reclaim memory.
+    static func clearGroupedSegmentsCache() {
+        groupedSegmentsCache.removeAll()
     }
 
     // MARK: - Combined AttributedString

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -666,6 +666,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         ChatBubble.lastStreamingInlineMarkdown = nil
         ChatBubble.lastStreamingMarkdown = nil
         MarkdownSegmentView.clearAttributedStringCache()
+        MarkdownSegmentView.clearGroupedSegmentsCache()
     }
 
     /// Returns true if the thread has at least one user message.


### PR DESCRIPTION
## Summary
- Make MarkdownSegment and ListItem Hashable to enable hash-keyed caching
- Add static LRU cache (200 entries) for groupedSegments, keyed by segment array hash
- Avoid recomputing segment grouping on every MarkdownSegmentView body evaluation

Part of plan: scroll-hang-fix.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
