### PR TITLE
fix: remove leftover http-token references from gitignore migration and tests

### DIFF
--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -655,7 +655,7 @@ describe("WorkspaceGitService", () => {
         cwd: testDir,
       });
       const oldGitignore =
-        "# Runtime state - excluded from git tracking\ndata/\nlogs/\n*.log\n*.sock\n*.pid\n*.sqlite\n*.sqlite-journal\n*.sqlite-wal\n*.sqlite-shm\n*.db\n*.db-journal\n*.db-wal\n*.db-shm\nvellum.sock\nvellum.pid\nsession-token\nhttp-token\n";
+        "# Runtime state - excluded from git tracking\ndata/\nlogs/\n*.log\n*.sock\n*.pid\n*.sqlite\n*.sqlite-journal\n*.sqlite-wal\n*.sqlite-shm\n*.db\n*.db-journal\n*.db-wal\n*.db-shm\nvellum.sock\nvellum.pid\nsession-token\n";
       writeFileSync(join(testDir, ".gitignore"), oldGitignore);
       writeFileSync(join(testDir, "file.txt"), "content");
       execFileSync("git", ["add", "-A"], { cwd: testDir });

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -671,8 +671,15 @@ export class WorkspaceGitService {
       // This keeps user-tracked files under data/ visible to git.
       const lines = content.split("\n");
       const hadLegacyDataRule = lines.some((line) => line.trim() === "data/");
-      if (hadLegacyDataRule) {
-        content = lines.filter((line) => line.trim() !== "data/").join("\n");
+      const hadLegacyHttpToken = lines.some(
+        (line) => line.trim() === "http-token",
+      );
+      if (hadLegacyDataRule || hadLegacyHttpToken) {
+        content = lines
+          .filter(
+            (line) => line.trim() !== "data/" && line.trim() !== "http-token",
+          )
+          .join("\n");
         if (!content.endsWith("\n")) {
           content += "\n";
         }
@@ -681,7 +688,7 @@ export class WorkspaceGitService {
       const missingRules = WORKSPACE_GITIGNORE_RULES.filter(
         (rule) => !content.includes(rule),
       );
-      if (hadLegacyDataRule || missingRules.length > 0) {
+      if (hadLegacyDataRule || hadLegacyHttpToken || missingRules.length > 0) {
         let updated = content;
         if (missingRules.length > 0) {
           if (!updated.endsWith("\n")) {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for remove-http-token.md.

**Gap 1:** Test data in workspace-git-service.test.ts still included http-token in old gitignore simulation string
**Gap 2:** Gitignore migration in git-service.ts did not actively remove legacy http-token entries from existing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
