### PR TITLE
perf(macos): remove LazyVStack item transitions to fix LazyTransition.updateValue hang (LUM-16)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -379,7 +379,6 @@ struct MessageListView: View {
                                     onTemporaryAllow: onTemporaryAllow
                                 )
                                 .id(message.id)
-                                .transition(.opacity)
                             } else {
                                 let hasPrecedingAssistant: Bool = {
                                     guard index > 0 else { return false }
@@ -395,21 +394,17 @@ struct MessageListView: View {
                                         onTemporaryAllow: onTemporaryAllow
                                     )
                                     .id(message.id)
-                                    .transition(.opacity)
                                 }
                             }
                         } else if message.modelPicker != nil {
                             modelPickerView(for: message)
                                 .id(message.id)
-                                .transition(.opacity)
                         } else if message.modelList != nil {
                             modelListView(for: message)
                                 .id(message.id)
-                                .transition(.opacity)
                         } else if message.commandList != nil {
                             CommandListBubble()
                                 .id(message.id)
-                                .transition(.opacity)
                         } else if let guardianDecision = message.guardianDecision {
                             GuardianDecisionBubble(
                                 decision: guardianDecision,
@@ -418,7 +413,6 @@ struct MessageListView: View {
                                 }
                             )
                             .id(message.id)
-                            .transition(.opacity)
                         } else {
                             let nextIsPendingConfirmation = index + 1 < displayMessages.count
                                 && displayMessages[index + 1].confirmation?.state == .pending
@@ -452,7 +446,6 @@ struct MessageListView: View {
                                 activeSurfaceId: activeSurfaceId
                             )
                                 .id(message.id)
-                                .transition(.opacity)
                         }
 
                         ForEach(subagentsByParent[message.id] ?? []) { subagent in
@@ -465,7 +458,6 @@ struct MessageListView: View {
                                 .frame(maxWidth: 520, alignment: .leading)
                                 .padding(.leading, 36)
                                 .id("subagent-\(subagent.id)")
-                                .transition(.opacity)
                         }
 
                         if shouldShowThinkingIndicator && anchoredThinkingIndex == index {


### PR DESCRIPTION
## Summary
- Remove .transition(.opacity) from all message cells inside the main LazyVStack ForEach
- LazyVStack items do not visually transition when loaded during scroll; these were pure overhead
- LazyTransition.updateValue was appearing in hang report stack traces for every visible cell
- Keep transitions on thinkingIndicatorRow and orphanSubagents (they animate while view is live)

Part of plan: scroll-hang-fix.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
