### PR TITLE
feat: add resolveGuardianName() helper that makes USER.md authoritative

### DIFF
--- a/assistant/src/__tests__/user-reference.test.ts
+++ b/assistant/src/__tests__/user-reference.test.ts
@@ -26,7 +26,8 @@ mock.module("node:fs", () => ({
 }));
 
 // Import after mocks are in place
-const { resolveUserReference } = await import("../config/user-reference.js");
+const { resolveUserReference, resolveGuardianName, DEFAULT_USER_REFERENCE } =
+  await import("../config/user-reference.js");
 
 describe("resolveUserReference", () => {
   beforeEach(() => {
@@ -67,5 +68,39 @@ describe("resolveUserReference", () => {
     mockFileExists = true;
     mockFileContent = "- Preferred name/reference:   Alice   \n";
     expect(resolveUserReference()).toBe("Alice");
+  });
+});
+
+describe("resolveGuardianName", () => {
+  beforeEach(() => {
+    mockFileExists = false;
+    mockFileContent = "";
+  });
+
+  test("returns USER.md name when present, ignoring guardianDisplayName", () => {
+    mockFileExists = true;
+    mockFileContent = [
+      "## Onboarding Snapshot",
+      "",
+      "- Preferred name/reference: John",
+    ].join("\n");
+    expect(resolveGuardianName("Jane")).toBe("John");
+  });
+
+  test("falls back to guardianDisplayName when USER.md is empty", () => {
+    mockFileExists = false;
+    expect(resolveGuardianName("Jane")).toBe("Jane");
+  });
+
+  test("falls back to DEFAULT_USER_REFERENCE when both are empty", () => {
+    mockFileExists = false;
+    expect(resolveGuardianName()).toBe(DEFAULT_USER_REFERENCE);
+    expect(resolveGuardianName(null)).toBe(DEFAULT_USER_REFERENCE);
+    expect(resolveGuardianName("")).toBe(DEFAULT_USER_REFERENCE);
+  });
+
+  test("trims whitespace on guardianDisplayName fallback", () => {
+    mockFileExists = false;
+    expect(resolveGuardianName("  Jane  ")).toBe("Jane");
   });
 });

--- a/assistant/src/config/user-reference.ts
+++ b/assistant/src/config/user-reference.ts
@@ -1,7 +1,7 @@
 import { readTextFileSync } from "../util/fs.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
 
-const DEFAULT_USER_REFERENCE = "my human";
+export const DEFAULT_USER_REFERENCE = "my human";
 
 /**
  * Resolve the name/reference the assistant uses when referring to
@@ -65,4 +65,29 @@ function cleanPronounValue(raw: string): string | null {
   if (raw === "declined_by_user") return null;
   // Strip "inferred: " prefix for clean output
   return raw.replace(/^inferred:\s*/i, "");
+}
+
+/**
+ * Resolve the guardian's display name.
+ *
+ * Priority:
+ *   1. USER.md "Preferred name/reference:" — the user-editable, actively
+ *      maintained source of truth.
+ *   2. guardianDisplayName (fallback for when USER.md is missing or empty,
+ *      e.g. pre-onboarding). Callers pass in Contact.displayName.
+ *   3. DEFAULT_USER_REFERENCE ("my human").
+ */
+export function resolveGuardianName(
+  guardianDisplayName?: string | null,
+): string {
+  const userRef = resolveUserReference();
+  if (userRef !== DEFAULT_USER_REFERENCE) {
+    return userRef;
+  }
+
+  if (guardianDisplayName && guardianDisplayName.trim().length > 0) {
+    return guardianDisplayName.trim();
+  }
+
+  return DEFAULT_USER_REFERENCE;
 }


### PR DESCRIPTION
## Summary
- Add `resolveGuardianName()` helper to `user-reference.ts` that reads USER.md first, falls back to an optional `guardianDisplayName` parameter, then to DEFAULT_USER_REFERENCE
- Export `DEFAULT_USER_REFERENCE` so callers can compare against the sentinel value
- Add comprehensive tests covering the priority ordering

Part of plan: guardian-name-dedup.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
