### PR TITLE
feat: auto-populate voice invite guardianName from USER.md when not provided

### DIFF
--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -10,6 +10,10 @@
 
 import { isChannelId } from "../channels/types.js";
 import {
+  DEFAULT_USER_REFERENCE,
+  resolveGuardianName,
+} from "../config/user-reference.js";
+import {
   createInvite,
   findByTokenHash,
   hashToken,
@@ -179,9 +183,11 @@ export function createIngressInvite(params: {
     if (typeof params.friendName !== "string" || !params.friendName.trim()) {
       return { ok: false, error: "friendName is required for voice invites" };
     }
+    const effectiveGuardianName =
+      params.guardianName?.trim() || resolveGuardianName();
     if (
-      typeof params.guardianName !== "string" ||
-      !params.guardianName.trim()
+      !effectiveGuardianName ||
+      effectiveGuardianName === DEFAULT_USER_REFERENCE
     ) {
       return { ok: false, error: "guardianName is required for voice invites" };
     }
@@ -203,7 +209,7 @@ export function createIngressInvite(params: {
           voiceCodeHash,
           voiceCodeDigits: 6,
           friendName: params.friendName,
-          guardianName: params.guardianName,
+          guardianName: effectiveGuardianName,
         }
       : { inviteCodeHash }),
   });

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -158,6 +158,7 @@ export function createIngressInvite(params: {
   // exactly once and never stored.
   let voiceCode: string | undefined;
   let voiceCodeHash: string | undefined;
+  let effectiveGuardianName: string | undefined;
   const isVoice = params.sourceChannel === "voice";
 
   // For non-voice invites: generate a 6-digit invite code for guardian-mediated
@@ -183,7 +184,7 @@ export function createIngressInvite(params: {
     if (typeof params.friendName !== "string" || !params.friendName.trim()) {
       return { ok: false, error: "friendName is required for voice invites" };
     }
-    const effectiveGuardianName =
+    effectiveGuardianName =
       params.guardianName?.trim() || resolveGuardianName();
     if (
       !effectiveGuardianName ||


### PR DESCRIPTION
## Summary
- Auto-populate voice invite `guardianName` from USER.md via `resolveGuardianName()` when the caller doesn't provide one
- Explicit `guardianName` values from the caller still take precedence
- Validation error still fires if neither source provides a usable name

Part of plan: guardian-name-dedup.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
