### PR TITLE
refactor: derive guardian displayName from USER.md at API read boundaries

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -1,6 +1,7 @@
 import * as net from "node:net";
 
 import type { ChannelId } from "../../channels/types.js";
+import { resolveGuardianName } from "../../config/user-reference.js";
 import { findContactChannel } from "../../contacts/contact-store.js";
 import { revokeMember } from "../../contacts/contacts-write.js";
 import type { ChannelStatus } from "../../contacts/types.js";
@@ -108,8 +109,11 @@ export function getGuardianStatus(
   const resolvedChannel = channel ?? "telegram";
 
   const binding = getGuardianBinding(resolvedAssistantId, resolvedChannel);
+  const guardianDisplayName = resolveGuardianName();
+
+  // Resolve guardianUsername from binding metadata or external conversation store.
+  // Usernames are a channel-specific concept and not part of the guardian name dedup.
   let guardianUsername: string | undefined;
-  let guardianDisplayName: string | undefined;
   if (binding?.metadataJson) {
     try {
       const parsed = JSON.parse(binding.metadataJson) as Record<
@@ -122,29 +126,17 @@ export function getGuardianStatus(
       ) {
         guardianUsername = parsed.username.trim();
       }
-      if (
-        typeof parsed.displayName === "string" &&
-        parsed.displayName.trim().length > 0
-      ) {
-        guardianDisplayName = parsed.displayName.trim();
-      }
     } catch {
       // ignore malformed metadata
     }
   }
-  if (
-    binding?.guardianDeliveryChatId &&
-    (!guardianUsername || !guardianDisplayName)
-  ) {
+  if (binding?.guardianDeliveryChatId && !guardianUsername) {
     const ext = externalConversationStore.getBindingByChannelChat(
       resolvedChannel,
       binding.guardianDeliveryChatId,
     );
-    if (!guardianUsername && ext?.username) {
+    if (ext?.username) {
       guardianUsername = ext.username;
-    }
-    if (!guardianDisplayName && ext?.displayName) {
-      guardianDisplayName = ext.displayName;
     }
   }
   const hasPendingChallenge =

--- a/assistant/src/daemon/handlers/contacts.ts
+++ b/assistant/src/daemon/handlers/contacts.ts
@@ -1,5 +1,6 @@
 import * as net from "node:net";
 
+import { resolveGuardianName } from "../../config/user-reference.js";
 import {
   getContact,
   listContacts,
@@ -36,7 +37,10 @@ function toChannelPayload(
 function toContactPayload(contact: ContactWithChannels): ContactPayload {
   return {
     id: contact.id,
-    displayName: contact.displayName,
+    displayName:
+      contact.role === "guardian"
+        ? resolveGuardianName(contact.displayName)
+        : contact.displayName,
     role: contact.role,
     notes: contact.notes ?? undefined,
     contactType: contact.contactType ?? undefined,

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -12,6 +12,7 @@
 import { createHash, randomBytes } from "node:crypto";
 
 import type { ChannelId } from "../../channels/types.js";
+import { resolveGuardianName } from "../../config/user-reference.js";
 import {
   getAssistantContactMetadata,
   getChannelById,
@@ -56,6 +57,18 @@ import {
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
+function withGuardianNameOverride<
+  T extends { role: string; displayName: string },
+>(contact: T): T {
+  if (contact.role === "guardian") {
+    return {
+      ...contact,
+      displayName: resolveGuardianName(contact.displayName),
+    };
+  }
+  return contact;
+}
+
 const VALID_CONTACT_TYPES: readonly ContactType[] = ["human", "assistant"];
 const VALID_ASSISTANT_SPECIES: readonly AssistantSpecies[] = [
   "vellum",
@@ -99,7 +112,10 @@ export function handleListContacts(url: URL, assistantId: string): Response {
       contactType,
       limit,
     });
-    return Response.json({ ok: true, contacts });
+    return Response.json({
+      ok: true,
+      contacts: contacts.map(withGuardianNameOverride),
+    });
   }
 
   const contacts = listContacts(
@@ -108,7 +124,10 @@ export function handleListContacts(url: URL, assistantId: string): Response {
     role ?? undefined,
     contactType,
   );
-  return Response.json({ ok: true, contacts });
+  return Response.json({
+    ok: true,
+    contacts: contacts.map(withGuardianNameOverride),
+  });
 }
 
 /**
@@ -128,7 +147,7 @@ export function handleGetContact(
       : undefined;
   return Response.json({
     ok: true,
-    contact,
+    contact: withGuardianNameOverride(contact),
     assistantMetadata: assistantMeta ?? undefined,
   });
 }
@@ -323,7 +342,7 @@ export async function handleUpsertContact(
     }
 
     return Response.json(
-      { ok: true, contact },
+      { ok: true, contact: withGuardianNameOverride(contact) },
       { status: contact.created ? 201 : 200 },
     );
   } catch (err) {
@@ -405,7 +424,12 @@ export async function handleUpdateContactChannel(
   }
 
   const parentContact = getContact(updated.contactId, assistantId);
-  return Response.json({ ok: true, contact: parentContact ?? undefined });
+  return Response.json({
+    ok: true,
+    contact: parentContact
+      ? withGuardianNameOverride(parentContact)
+      : undefined,
+  });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Override guardian `displayName` at IPC serialization boundary (`toContactPayload`) to derive from USER.md
- Simplify `getGuardianStatus()` to use `resolveGuardianName()` instead of parsing metadata JSON
- Add `withGuardianNameOverride` mapping at HTTP API boundary for all contact endpoints
- Non-guardian contacts are unaffected

Part of plan: guardian-name-dedup.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
