### PR TITLE
refactor: simplify resolveGuardianDisplayName() to use resolveGuardianName()

### DIFF
--- a/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
+++ b/assistant/src/__tests__/trusted-contact-approval-notifier.test.ts
@@ -79,10 +79,15 @@ mock.module("../runtime/gateway-client.js", () => ({
 }));
 
 // ── Guardian binding mock ──
-let mockGuardianBinding: Record<string, unknown> | null = null;
+// mockGuardianContact controls what findGuardianForChannel returns.
+// When non-null, it should look like { contact: { displayName: "..." }, channel: { ... } }.
+let mockGuardianContact: {
+  contact: { displayName: string };
+  channel: Record<string, unknown>;
+} | null = null;
 
 mock.module("../runtime/channel-guardian-service.js", () => ({
-  getGuardianBinding: () => mockGuardianBinding,
+  getGuardianBinding: () => null,
   // Re-export stubs for other functions to prevent import errors
   bindSessionIdentity: () => {},
   createOutboundSession: () => ({}),
@@ -97,6 +102,11 @@ mock.module("../runtime/channel-guardian-service.js", () => ({
     success: false,
     reason: "no_challenge",
   }),
+}));
+
+// ── Contact store mock ──
+mock.module("../contacts/contact-store.js", () => ({
+  findGuardianForChannel: () => mockGuardianContact,
 }));
 
 // ── Pending interactions mock ──
@@ -122,11 +132,22 @@ mock.module("../config/env.js", () => ({
 // ── User reference mock ──
 mock.module("../config/user-reference.js", () => ({
   resolveUserReference: () => "my human",
+  DEFAULT_USER_REFERENCE: "my human",
+  resolveGuardianName: (guardianDisplayName?: string | null): string => {
+    // Mirror the real implementation: USER.md name > guardianDisplayName > default
+    const userRef = "my human"; // In tests, resolveUserReference() returns this
+    if (userRef !== "my human") return userRef;
+    if (guardianDisplayName && guardianDisplayName.trim().length > 0) {
+      return guardianDisplayName.trim();
+    }
+    return "my human";
+  },
 }));
 
 // Import module under test AFTER mocks are set up
 import type { ChannelId } from "../channels/types.js";
-import { resolveUserReference } from "../config/user-reference.js";
+import { resolveGuardianName } from "../config/user-reference.js";
+import { findGuardianForChannel } from "../contacts/contact-store.js";
 import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 
 // We need to test the private functions by importing the module.
@@ -177,8 +198,6 @@ async function simulateNotifierPoll(params: {
   const { getApprovalInfoByConversation } =
     await import("../runtime/channel-approvals.js");
   const { deliverChannelReply } = await import("../runtime/gateway-client.js");
-  const { getGuardianBinding } =
-    await import("../runtime/channel-guardian-service.js");
 
   const pending = getApprovalInfoByConversation(params.conversationId);
   const info = pending[0];
@@ -197,37 +216,14 @@ async function simulateNotifierPoll(params: {
 
   notifiedRequestIds.set(info.requestId, conversationId);
 
-  // Resolve guardian name
-  let guardianName: string | undefined;
-  const binding = getGuardianBinding(
-    params.assistantId ?? "self",
+  // Resolve guardian name via the contacts-based approach
+  const guardian = findGuardianForChannel(
     params.sourceChannel,
+    params.assistantId ?? "self",
   );
-  if (binding?.metadataJson) {
-    try {
-      const parsed = JSON.parse(binding.metadataJson as string) as Record<
-        string,
-        unknown
-      >;
-      if (
-        typeof parsed.displayName === "string" &&
-        parsed.displayName.trim().length > 0
-      ) {
-        guardianName = parsed.displayName.trim();
-      } else if (
-        typeof parsed.username === "string" &&
-        parsed.username.trim().length > 0
-      ) {
-        guardianName = `@${parsed.username.trim()}`;
-      }
-    } catch {
-      // ignore
-    }
-  }
+  const guardianName = resolveGuardianName(guardian?.contact.displayName);
 
-  const waitingText = `Waiting for ${
-    guardianName ?? resolveUserReference()
-  }'s approval...`;
+  const waitingText = `Waiting for ${guardianName}'s approval...`;
 
   try {
     await deliverChannelReply(
@@ -255,7 +251,7 @@ describe("trusted-contact pending-approval notifier", () => {
     deliveredReplies.length = 0;
     deliverShouldFail = false;
     mockPendingApprovals = [];
-    mockGuardianBinding = null;
+    mockGuardianContact = null;
   });
 
   afterAll(() => {
@@ -276,9 +272,9 @@ describe("trusted-contact pending-approval notifier", () => {
       },
     ];
 
-    mockGuardianBinding = {
-      id: "binding-1",
-      metadataJson: JSON.stringify({ displayName: "Mom" }),
+    mockGuardianContact = {
+      contact: { displayName: "Mom" },
+      channel: {},
     };
 
     const notified = new Map<string, string>();
@@ -303,7 +299,7 @@ describe("trusted-contact pending-approval notifier", () => {
     expect(notified.has("req-1")).toBe(true);
   });
 
-  test("uses username with @ prefix when display name is not available", async () => {
+  test("uses contact displayName from contact store", async () => {
     mockPendingApprovals = [
       {
         requestId: "req-2",
@@ -313,9 +309,9 @@ describe("trusted-contact pending-approval notifier", () => {
       },
     ];
 
-    mockGuardianBinding = {
-      id: "binding-1",
-      metadataJson: JSON.stringify({ username: "guardian_user" }),
+    mockGuardianContact = {
+      contact: { displayName: "Guardian User" },
+      channel: {},
     };
 
     const notified = new Map<string, string>();
@@ -331,11 +327,11 @@ describe("trusted-contact pending-approval notifier", () => {
 
     expect(deliveredReplies).toHaveLength(1);
     expect(deliveredReplies[0].payload.text).toBe(
-      "Waiting for @guardian_user's approval...",
+      "Waiting for Guardian User's approval...",
     );
   });
 
-  test("falls back to user reference when no guardian name is available", async () => {
+  test("falls back to user reference when guardian has empty display name", async () => {
     mockPendingApprovals = [
       {
         requestId: "req-3",
@@ -345,10 +341,10 @@ describe("trusted-contact pending-approval notifier", () => {
       },
     ];
 
-    // No binding metadata
-    mockGuardianBinding = {
-      id: "binding-1",
-      metadataJson: null,
+    // Guardian contact exists but has an empty displayName
+    mockGuardianContact = {
+      contact: { displayName: "" },
+      channel: {},
     };
 
     const notified = new Map<string, string>();
@@ -368,7 +364,7 @@ describe("trusted-contact pending-approval notifier", () => {
     );
   });
 
-  test("falls back to user reference when no guardian binding exists", async () => {
+  test("falls back to user reference when no guardian contact exists", async () => {
     mockPendingApprovals = [
       {
         requestId: "req-4",
@@ -378,7 +374,7 @@ describe("trusted-contact pending-approval notifier", () => {
       },
     ];
 
-    mockGuardianBinding = null;
+    mockGuardianContact = null;
 
     const notified = new Map<string, string>();
     await simulateNotifierPoll({
@@ -407,9 +403,9 @@ describe("trusted-contact pending-approval notifier", () => {
       },
     ];
 
-    mockGuardianBinding = {
-      id: "binding-1",
-      metadataJson: JSON.stringify({ displayName: "Guardian" }),
+    mockGuardianContact = {
+      contact: { displayName: "Guardian" },
+      channel: {},
     };
 
     const notified = new Map<string, string>();
@@ -435,9 +431,9 @@ describe("trusted-contact pending-approval notifier", () => {
   });
 
   test("sends separate messages for different requestIds", async () => {
-    mockGuardianBinding = {
-      id: "binding-1",
-      metadataJson: JSON.stringify({ displayName: "Guardian" }),
+    mockGuardianContact = {
+      contact: { displayName: "Guardian" },
+      channel: {},
     };
 
     const notified = new Map<string, string>();
@@ -477,9 +473,9 @@ describe("trusted-contact pending-approval notifier", () => {
   });
 
   test("concurrent pollers for different conversations do not evict each other", async () => {
-    mockGuardianBinding = {
-      id: "binding-1",
-      metadataJson: JSON.stringify({ displayName: "Guardian" }),
+    mockGuardianContact = {
+      contact: { displayName: "Guardian" },
+      channel: {},
     };
 
     // Shared dedupe map simulating the module-level global
@@ -629,9 +625,9 @@ describe("trusted-contact pending-approval notifier", () => {
       },
     ];
 
-    mockGuardianBinding = {
-      id: "binding-1",
-      metadataJson: JSON.stringify({ displayName: "Guardian" }),
+    mockGuardianContact = {
+      contact: { displayName: "Guardian" },
+      channel: {},
     };
 
     const notified = new Map<string, string>();
@@ -677,7 +673,7 @@ describe("trusted-contact pending-approval notifier", () => {
     expect(deliveredReplies).toHaveLength(0);
   });
 
-  test("prefers displayName over username when both are present", async () => {
+  test("uses contact displayName from guardian contact record", async () => {
     mockPendingApprovals = [
       {
         requestId: "req-10",
@@ -687,12 +683,9 @@ describe("trusted-contact pending-approval notifier", () => {
       },
     ];
 
-    mockGuardianBinding = {
-      id: "binding-1",
-      metadataJson: JSON.stringify({
-        displayName: "Sarah",
-        username: "sarah_bot",
-      }),
+    mockGuardianContact = {
+      contact: { displayName: "Sarah" },
+      channel: {},
     };
 
     const notified = new Map<string, string>();
@@ -712,7 +705,7 @@ describe("trusted-contact pending-approval notifier", () => {
     );
   });
 
-  test("handles malformed metadataJson gracefully", async () => {
+  test("falls back to default when guardian contact has whitespace-only displayName", async () => {
     mockPendingApprovals = [
       {
         requestId: "req-11",
@@ -722,9 +715,9 @@ describe("trusted-contact pending-approval notifier", () => {
       },
     ];
 
-    mockGuardianBinding = {
-      id: "binding-1",
-      metadataJson: "not-valid-json{{{",
+    mockGuardianContact = {
+      contact: { displayName: "   " },
+      channel: {},
     };
 
     const notified = new Map<string, string>();
@@ -739,7 +732,7 @@ describe("trusted-contact pending-approval notifier", () => {
     });
 
     expect(deliveredReplies).toHaveLength(1);
-    // Falls back to generic phrasing
+    // Falls back to default user reference
     expect(deliveredReplies[0].payload.text).toBe(
       "Waiting for my human's approval...",
     );

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -8,7 +8,8 @@
  * focused on orchestration.
  */
 import type { ChannelId, InterfaceId } from "../../../channels/types.js";
-import { resolveUserReference } from "../../../config/user-reference.js";
+import { resolveGuardianName } from "../../../config/user-reference.js";
+import { findGuardianForChannel } from "../../../contacts/contact-store.js";
 import type { TrustContext } from "../../../daemon/session-runtime-assembly.js";
 import * as channelDeliveryStore from "../../../memory/channel-delivery-store.js";
 import {
@@ -23,7 +24,6 @@ import {
   getApprovalInfoByConversation,
   getChannelApprovalPrompt,
 } from "../../channel-approvals.js";
-import { getGuardianBinding } from "../../channel-guardian-service.js";
 import { deliverChannelReply } from "../../gateway-client.js";
 import type {
   ApprovalCopyGenerator,
@@ -446,34 +446,16 @@ export function startPendingApprovalPromptWatcher(params: {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve a human-readable guardian name from the guardian binding metadata.
- * Returns the display name, username (prefixed with @), or undefined if
- * no name is available.
+ * Resolve a human-readable guardian name for trusted-contact notifications.
+ * Delegates to {@link resolveGuardianName} which checks USER.md first, then
+ * falls back to the contact's display name, then to DEFAULT_USER_REFERENCE.
  */
 export function resolveGuardianDisplayName(
   assistantId: string,
   sourceChannel: ChannelId,
-): string | undefined {
-  const binding = getGuardianBinding(assistantId, sourceChannel);
-  if (!binding?.metadataJson) return undefined;
-  try {
-    const parsed = JSON.parse(binding.metadataJson) as Record<string, unknown>;
-    if (
-      typeof parsed.displayName === "string" &&
-      parsed.displayName.trim().length > 0
-    ) {
-      return parsed.displayName.trim();
-    }
-    if (
-      typeof parsed.username === "string" &&
-      parsed.username.trim().length > 0
-    ) {
-      return `@${parsed.username.trim()}`;
-    }
-  } catch {
-    // ignore malformed metadata
-  }
-  return undefined;
+): string {
+  const guardian = findGuardianForChannel(sourceChannel, assistantId);
+  return resolveGuardianName(guardian?.contact.displayName);
 }
 
 // ---------------------------------------------------------------------------
@@ -542,11 +524,10 @@ export function startTrustedContactApprovalNotifier(params: {
 
         if (info && !globalNotifiedApprovalRequestIds.has(info.requestId)) {
           globalNotifiedApprovalRequestIds.set(info.requestId, conversationId);
-          const guardianName =
-            resolveGuardianDisplayName(
-              assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
-              sourceChannel,
-            ) ?? resolveUserReference();
+          const guardianName = resolveGuardianDisplayName(
+            assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+            sourceChannel,
+          );
           const waitingText = `Waiting for ${guardianName}'s approval...`;
           try {
             await deliverChannelReply(


### PR DESCRIPTION
## Summary
- Simplify `resolveGuardianDisplayName()` to delegate to `resolveGuardianName()` instead of parsing metadata JSON
- Change return type from `string | undefined` to `string` (always returns a value)
- Remove `?? resolveUserReference()` fallback at call-site since the helper handles it internally
- Clean up dead imports

Part of plan: guardian-name-dedup.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
