### PR TITLE
refactor: simplify resolveGuardianLabel() to use resolveGuardianName()

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -60,9 +60,20 @@ mock.module("../daemon/identity-helpers.js", () => ({
 
 // ── User-reference mock (isolate from real USER.md) ──────────────────
 
+let mockUserReference = "my human";
 mock.module("../config/user-reference.js", () => ({
-  resolveUserReference: () => "my human",
+  resolveUserReference: () => mockUserReference,
   resolveUserPronouns: () => null,
+  DEFAULT_USER_REFERENCE: "my human",
+  resolveGuardianName: (guardianDisplayName?: string | null) => {
+    if (mockUserReference !== "my human") {
+      return mockUserReference;
+    }
+    if (guardianDisplayName && guardianDisplayName.trim().length > 0) {
+      return guardianDisplayName.trim();
+    }
+    return "my human";
+  },
 }));
 
 // ── Config mock ─────────────────────────────────────────────────────
@@ -344,6 +355,7 @@ describe("relay-server", () => {
   beforeEach(() => {
     resetTables();
     activeRelayConnections.clear();
+    mockUserReference = "my human";
     mockSendMessage.mockImplementation(createMockProviderResponse(["Hello"]));
     mockConfig.calls.verification.enabled = false;
     mockConfig.calls.verification.maxAttempts = 3;
@@ -4125,6 +4137,138 @@ describe("relay-server", () => {
     expect(
       events.some((e) => e.eventType === "invite_redemption_succeeded"),
     ).toBe(true);
+
+    relay.destroy();
+  });
+
+  // ── resolveGuardianLabel resolution priority ─────────────────────────
+
+  test("guardian label: USER.md name takes precedence over Contact.displayName", async () => {
+    mockUserReference = "Alice";
+
+    // Create a guardian binding with a different displayName
+    createGuardianBinding({
+      assistantId: "self",
+      channel: "voice",
+      guardianExternalUserId: "+15559990001",
+      guardianDeliveryChatId: "+15559990001",
+      guardianPrincipalId: "+15559990001",
+      verifiedVia: "test",
+      metadataJson: JSON.stringify({ displayName: "Bob" }),
+    });
+
+    ensureConversation("conv-label-user-md");
+    const session = createCallSession({
+      conversationId: "conv-label-user-md",
+      provider: "twilio",
+      fromNumber: "+15559990099",
+      toNumber: "+15551111111",
+      assistantId: "self",
+    });
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_label_user_md",
+        from: "+15559990099",
+        to: "+15551111111",
+      }),
+    );
+
+    expect(relay.getConnectionState()).toBe("awaiting_name");
+
+    // The greeting should use the USER.md name ("Alice"), not Contact.displayName ("Bob")
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === "text");
+    const promptText = textMessages.map((m) => m.token ?? "").join("");
+    expect(promptText).toContain("Alice");
+    expect(promptText).not.toContain("Bob");
+
+    relay.destroy();
+  });
+
+  test("guardian label: Contact.displayName used when USER.md is empty", async () => {
+    mockUserReference = "my human";
+
+    // Create a guardian binding with a displayName
+    createGuardianBinding({
+      assistantId: "self",
+      channel: "voice",
+      guardianExternalUserId: "+15559990002",
+      guardianDeliveryChatId: "+15559990002",
+      guardianPrincipalId: "+15559990002",
+      verifiedVia: "test",
+      metadataJson: JSON.stringify({ displayName: "Charlie" }),
+    });
+
+    ensureConversation("conv-label-contact");
+    const session = createCallSession({
+      conversationId: "conv-label-contact",
+      provider: "twilio",
+      fromNumber: "+15559990098",
+      toNumber: "+15551111111",
+      assistantId: "self",
+    });
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_label_contact",
+        from: "+15559990098",
+        to: "+15551111111",
+      }),
+    );
+
+    expect(relay.getConnectionState()).toBe("awaiting_name");
+
+    // The greeting should use Contact.displayName ("Charlie")
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === "text");
+    const promptText = textMessages.map((m) => m.token ?? "").join("");
+    expect(promptText).toContain("Charlie");
+
+    relay.destroy();
+  });
+
+  test("guardian label: DEFAULT_USER_REFERENCE used when both USER.md and Contact.displayName are empty", async () => {
+    mockUserReference = "my human";
+
+    // No guardian binding — no Contact.displayName available
+
+    ensureConversation("conv-label-default");
+    const session = createCallSession({
+      conversationId: "conv-label-default",
+      provider: "twilio",
+      fromNumber: "+15559990097",
+      toNumber: "+15551111111",
+      assistantId: "self",
+    });
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_label_default",
+        from: "+15559990097",
+        to: "+15551111111",
+      }),
+    );
+
+    expect(relay.getConnectionState()).toBe("awaiting_name");
+
+    // The greeting should use the default "my human"
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === "text");
+    const promptText = textMessages.map((m) => m.token ?? "").join("");
+    expect(promptText).toContain("my human");
 
     relay.destroy();
   });

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -10,7 +10,7 @@ import { randomInt } from "node:crypto";
 
 import type { ServerWebSocket } from "bun";
 
-import { resolveUserReference } from "../config/user-reference.js";
+import { resolveGuardianName } from "../config/user-reference.js";
 import {
   findGuardianForChannel,
   listGuardianChannels,
@@ -31,7 +31,6 @@ import {
   toTrustContext,
 } from "../runtime/actor-trust-resolver.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
-import { getGuardianBinding } from "../runtime/channel-guardian-service.js";
 import {
   composeVerificationVoice,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,
@@ -1597,70 +1596,21 @@ export class RelayConnection {
 
   /**
    * Resolve a human-readable guardian label for voice wait copy.
-   * Prefers displayName from the guardian binding metadata, falls back
-   * to @username, then the user's preferred name from USER.md.
+   * Delegates to the shared resolveGuardianName() which checks USER.md
+   * first, then falls back to Contact.displayName, then DEFAULT_USER_REFERENCE.
    */
   private resolveGuardianLabel(): string {
     const assistantId =
       this.accessRequestAssistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
 
-    // Try the voice-channel binding first, then fall back to any active
-    // binding for the assistant (mirrors the cross-channel fallback pattern
-    // in access-request-helper.ts).
-    let metadataJson: string | null = null;
-    // Contacts-first: prefer the voice-bound guardian, then fall back to
-    // any guardian channel (mirrors the voice-first pattern in the legacy path).
+    // Look up the guardian contact for a displayName fallback
     const voiceGuardian = findGuardianForChannel("voice", assistantId);
     const guardianChannels = voiceGuardian
       ? null
       : listGuardianChannels(assistantId);
     const guardianContact = voiceGuardian?.contact ?? guardianChannels?.contact;
-    if (guardianContact) {
-      const meta: Record<string, string> = {};
-      if (guardianContact.displayName) {
-        meta.displayName = guardianContact.displayName;
-      }
-      // Preserve the username fallback: use the voice channel's externalUserId
-      // so downstream parsing can fall back to @username when displayName is a
-      // raw external ID (e.g., phone number from contact-sync).
-      const voiceChannel =
-        voiceGuardian?.channel ??
-        guardianChannels?.channels.find((ch) => ch.type === "voice");
-      if (voiceChannel?.externalUserId) {
-        meta.username = voiceChannel.externalUserId;
-      }
-      if (Object.keys(meta).length > 0) {
-        metadataJson = JSON.stringify(meta);
-      }
-    }
-    if (!metadataJson) {
-      const voiceBinding = getGuardianBinding(assistantId, "voice");
-      if (voiceBinding?.metadataJson) {
-        metadataJson = voiceBinding.metadataJson;
-      }
-    }
 
-    if (metadataJson) {
-      try {
-        const parsed = JSON.parse(metadataJson) as Record<string, unknown>;
-        if (
-          typeof parsed.displayName === "string" &&
-          parsed.displayName.trim().length > 0
-        ) {
-          return parsed.displayName.trim();
-        }
-        if (
-          typeof parsed.username === "string" &&
-          parsed.username.trim().length > 0
-        ) {
-          return `@${parsed.username.trim()}`;
-        }
-      } catch {
-        // ignore malformed metadata
-      }
-    }
-
-    return resolveUserReference();
+    return resolveGuardianName(guardianContact?.displayName);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Simplify `resolveGuardianLabel()` in relay-server.ts from ~60 lines of multi-tier resolution to a single `resolveGuardianName()` call
- Remove vestigial `@username` fallback path and metadata JSON parsing
- Clean up dead imports (`getGuardianBinding`, `resolveUserReference`)

Part of plan: guardian-name-dedup.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
