### PR TITLE
refactor: stop seeding guardian displayName at bootstrap since it's now derived at read time

### DIFF
--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -355,9 +355,7 @@ export function getGuardianBinding(
       status: "active" as const,
       verifiedAt: result.channel.verifiedAt ?? 0,
       verifiedVia: result.channel.verifiedVia ?? "",
-      metadataJson: result.contact.displayName
-        ? JSON.stringify({ displayName: result.contact.displayName })
-        : null,
+      metadataJson: null,
       createdAt: result.channel.createdAt,
       updatedAt: result.channel.updatedAt ?? result.channel.createdAt,
     };

--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -13,7 +13,6 @@ import { createHash } from "node:crypto";
 
 import { v4 as uuid } from "uuid";
 
-import { resolveUserReference } from "../../config/user-reference.js";
 import { findGuardianForChannel } from "../../contacts/contact-store.js";
 import { createGuardianBinding } from "../../contacts/contacts-write.js";
 import { getLogger } from "../../util/logger.js";
@@ -56,7 +55,6 @@ function ensureGuardianPrincipal(assistantId: string): {
 
   // Mint a new principal ID for the vellum channel
   const guardianPrincipalId = `vellum-principal-${uuid()}`;
-  const guardianDisplayName = resolveUserReference();
 
   createGuardianBinding({
     assistantId,
@@ -65,10 +63,7 @@ function ensureGuardianPrincipal(assistantId: string): {
     guardianDeliveryChatId: "local",
     guardianPrincipalId,
     verifiedVia: "bootstrap",
-    metadataJson: JSON.stringify({
-      bootstrappedAt: Date.now(),
-      displayName: guardianDisplayName,
-    }),
+    metadataJson: JSON.stringify({ bootstrappedAt: Date.now() }),
   });
 
   log.info(


### PR DESCRIPTION
## Summary
- Remove USER.md read at guardian bootstrap — no longer seeds `displayName` into metadata JSON
- Simplify `getGuardianBinding()` to stop synthesizing `displayName` into `metadataJson` (all consumers now use `resolveGuardianName()`)
- Guardian contacts now get `displayName = guardianExternalUserId` (the principalId), making stale-name bugs immediately obvious

Part of plan: guardian-name-dedup.md (PR 6 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
