### PR TITLE
fix: remove residual transition from thinkingIndicatorRow inside MessageCellView (LUM-16)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -868,7 +868,6 @@ private struct MessageCellView: View {
         }
         .frame(maxWidth: 520, alignment: .leading)
         .id("thinking-indicator")
-        .transition(.opacity.combined(with: .move(edge: .bottom)))
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for scroll-hang-fix.md.

**Gap:** Thinking indicator inside MessageCellView retains transition
**What was expected:** No .transition() on views inside the main ForEach items (MessageCellView is a ForEach item), per the LazyTransition.updateValue hang fix
**What was found:** thinkingIndicatorRow inside MessageCellView had .transition(.opacity.combined(with: .move(edge: .bottom)))

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
