### PR TITLE
feat: lint unknown frontmatter fields in SKILL.md

### DIFF
--- a/scripts/skills/lint-skill-spec.mjs
+++ b/scripts/skills/lint-skill-spec.mjs
@@ -12,6 +12,7 @@
  *   6. `description` constraints: 1-1024 chars, non-empty.
  *   7. Optional `compatibility`: 1-500 chars if present.
  *   8. Frontmatter is followed by Markdown body content.
+ *   9. No unknown frontmatter fields (only spec + Vellum extensions allowed).
  *
  * Usage:
  *   node scripts/skills/lint-skill-spec.mjs [skill-name ...]
@@ -228,6 +229,27 @@ function validateSkill(skillName) {
       (e) => `skills/${skillName}/SKILL.md: ${e}`,
     ),
   );
+
+  // 5. Check for unknown fields
+  const knownFields = new Set([
+    "name",
+    "description",
+    "license",
+    "compatibility",
+    "metadata",
+    "allowed-tools",
+    // Vellum extensions
+    "user-invocable",
+    "credential-setup-for",
+  ]);
+  for (const key of Object.keys(frontmatter)) {
+    if (!knownFields.has(key)) {
+      errors.push(
+        `skills/${skillName}/SKILL.md: Unknown frontmatter field "${key}". ` +
+          `Allowed fields: ${[...knownFields].join(", ")}.`,
+      );
+    }
+  }
 
   return errors;
 }


### PR DESCRIPTION
## Summary
- Add validation to reject unknown frontmatter fields in SKILL.md files
- Only allows fields from the Agent Skills spec plus Vellum extensions

**Allowed fields:**
- Spec: `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`
- Vellum: `user-invocable`, `credential-setup-for`

This prevents using non-standard fields like `includes` which was incorrectly used in #12690.

## Test plan
- [x] Run `node scripts/skills/lint-skill-spec.mjs` - passes with current skills
- [ ] Verify a skill with an unknown field like `includes` fails the linter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
