### PR TITLE
fix: send Slack contact approval notifications as DMs

### DIFF
--- a/assistant/src/__tests__/access-request-decision.test.ts
+++ b/assistant/src/__tests__/access-request-decision.test.ts
@@ -331,4 +331,77 @@ describe("access request notification delivery", () => {
     expect(text).toContain("unable to deliver");
     expect(text).toContain("try again");
   });
+
+  test("slack approval notification is sent as DM using requesterExternalUserId", async () => {
+    await notifyRequesterOfApproval({
+      replyCallbackUrl: "http://localhost:7830/deliver/slack",
+      requesterChatId: "C12345-channel",
+      requesterExternalUserId: "U98765-user",
+      channel: "slack",
+      assistantId: "self",
+      bearerToken: "test-token",
+    });
+
+    expect(deliverReplyCalls.length).toBe(1);
+    const call = deliverReplyCalls[0];
+    // Should target the user ID (DM) not the channel
+    expect(call.payload.chatId).toBe("U98765-user");
+  });
+
+  test("slack denial notification is sent as DM using requesterExternalUserId", async () => {
+    await notifyRequesterOfDenial({
+      replyCallbackUrl: "http://localhost:7830/deliver/slack",
+      requesterChatId: "C12345-channel",
+      requesterExternalUserId: "U98765-user",
+      channel: "slack",
+      assistantId: "self",
+      bearerToken: "test-token",
+    });
+
+    expect(deliverReplyCalls.length).toBe(1);
+    const call = deliverReplyCalls[0];
+    expect(call.payload.chatId).toBe("U98765-user");
+  });
+
+  test("slack delivery failure notification is sent as DM using requesterExternalUserId", async () => {
+    await notifyRequesterOfDeliveryFailure({
+      replyCallbackUrl: "http://localhost:7830/deliver/slack",
+      requesterChatId: "C12345-channel",
+      requesterExternalUserId: "U98765-user",
+      channel: "slack",
+      assistantId: "self",
+      bearerToken: "test-token",
+    });
+
+    expect(deliverReplyCalls.length).toBe(1);
+    const call = deliverReplyCalls[0];
+    expect(call.payload.chatId).toBe("U98765-user");
+  });
+
+  test("non-slack channels still use requesterChatId", async () => {
+    await notifyRequesterOfApproval({
+      replyCallbackUrl: "http://localhost:7830/deliver/telegram",
+      requesterChatId: "chat-123",
+      requesterExternalUserId: "user-456",
+      channel: "telegram",
+      assistantId: "self",
+      bearerToken: "test-token",
+    });
+
+    expect(deliverReplyCalls.length).toBe(1);
+    expect(deliverReplyCalls[0].payload.chatId).toBe("chat-123");
+  });
+
+  test("slack without requesterExternalUserId falls back to requesterChatId", async () => {
+    await notifyRequesterOfApproval({
+      replyCallbackUrl: "http://localhost:7830/deliver/slack",
+      requesterChatId: "C12345-channel",
+      channel: "slack",
+      assistantId: "self",
+      bearerToken: "test-token",
+    });
+
+    expect(deliverReplyCalls.length).toBe(1);
+    expect(deliverReplyCalls[0].payload.chatId).toBe("C12345-channel");
+  });
 });

--- a/assistant/src/runtime/routes/access-request-decision.ts
+++ b/assistant/src/runtime/routes/access-request-decision.ts
@@ -142,6 +142,23 @@ export async function deliverVerificationCodeToGuardian(params: {
 }
 
 /**
+ * Resolve the delivery target for requester notifications. On Slack,
+ * posting to a user ID (rather than the originating channel) delivers
+ * the message as a DM, which is less disruptive than replying in a
+ * shared channel.
+ */
+function resolveRequesterTarget(params: {
+  channel?: string;
+  requesterChatId: string;
+  requesterExternalUserId?: string;
+}): string {
+  if (params.channel === "slack" && params.requesterExternalUserId) {
+    return params.requesterExternalUserId;
+  }
+  return params.requesterChatId;
+}
+
+/**
  * Notify the requester that the guardian has approved their access request
  * and they should enter the verification code they receive from the guardian.
  */
@@ -150,16 +167,20 @@ export async function notifyRequesterOfApproval(params: {
   requesterChatId: string;
   assistantId: string;
   bearerToken?: string;
+  channel?: string;
+  requesterExternalUserId?: string;
 }): Promise<void> {
   const text =
     "Your access request has been approved! " +
     "Please enter the 6-digit verification code you receive from the guardian.";
 
+  const targetChatId = resolveRequesterTarget(params);
+
   try {
     await deliverChannelReply(
       params.replyCallbackUrl,
       {
-        chatId: params.requesterChatId,
+        chatId: targetChatId,
         text,
         assistantId: params.assistantId,
       },
@@ -183,16 +204,20 @@ export async function notifyRequesterOfDeliveryFailure(params: {
   requesterChatId: string;
   assistantId: string;
   bearerToken?: string;
+  channel?: string;
+  requesterExternalUserId?: string;
 }): Promise<void> {
   const text =
     "Your access request was approved, but we were unable to " +
     "deliver the verification code. Please try again later.";
 
+  const targetChatId = resolveRequesterTarget(params);
+
   try {
     await deliverChannelReply(
       params.replyCallbackUrl,
       {
-        chatId: params.requesterChatId,
+        chatId: targetChatId,
         text,
         assistantId: params.assistantId,
       },
@@ -214,14 +239,18 @@ export async function notifyRequesterOfDenial(params: {
   requesterChatId: string;
   assistantId: string;
   bearerToken?: string;
+  channel?: string;
+  requesterExternalUserId?: string;
 }): Promise<void> {
   const text = "Your access request has been denied by the guardian.";
+
+  const targetChatId = resolveRequesterTarget(params);
 
   try {
     await deliverChannelReply(
       params.replyCallbackUrl,
       {
-        chatId: params.requesterChatId,
+        chatId: targetChatId,
         text,
         assistantId: params.assistantId,
       },

--- a/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
@@ -789,6 +789,8 @@ async function handleAccessRequestApproval(
       requesterChatId: approval.requesterChatId,
       assistantId,
       bearerToken,
+      channel: approval.channel,
+      requesterExternalUserId: approval.requesterExternalUserId,
     });
 
     // Emit both guardian_decision and denied signals so all lifecycle
@@ -863,6 +865,8 @@ async function handleAccessRequestApproval(
       requesterChatId: approval.requesterChatId,
       assistantId,
       bearerToken,
+      channel: approval.channel,
+      requesterExternalUserId: approval.requesterExternalUserId,
     });
   } else {
     // Let the requester know something went wrong without revealing details
@@ -871,6 +875,8 @@ async function handleAccessRequestApproval(
       requesterChatId: approval.requesterChatId,
       assistantId,
       bearerToken,
+      channel: approval.channel,
+      requesterExternalUserId: approval.requesterExternalUserId,
     });
   }
 


### PR DESCRIPTION
## Summary
- Trusted contact approval/denial/failure notifications on Slack are now delivered as DMs to the requester instead of being posted in the shared channel
- Uses the requester's Slack user ID as the `chatId` (Slack's `chat.postMessage` auto-opens a DM when given a user ID)
- Non-Slack channels are unaffected — they continue using the original `requesterChatId`

## Test plan
- [x] Added 5 new tests covering Slack DM routing, non-Slack fallback, and missing user ID fallback
- [x] All 15 tests pass
- [ ] Manual QA: approve a contact request on Slack, verify notification arrives as DM

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
