### PR TITLE
perf: hash only segment type sequence in groupedSegments cache key

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -151,11 +151,29 @@ struct MarkdownSegmentView: View {
     @MainActor private static var groupedLRUCounter: Int = 0
     private static let groupedCacheLimit = 200
 
+    /// Returns a small integer discriminant for each `MarkdownSegment` case,
+    /// used to build a structural cache key without touching string content.
+    private static func segmentTypeDiscriminant(_ segment: MarkdownSegment) -> Int {
+        switch segment {
+        case .text:           return 0
+        case .table:          return 1
+        case .image:          return 2
+        case .heading:        return 3
+        case .codeBlock:      return 4
+        case .horizontalRule: return 5
+        case .list:           return 6
+        }
+    }
+
     /// Groups consecutive text-selectable segments together so they render
     /// as a single Text view, enabling cross-paragraph text selection.
     private var groupedSegments: [SegmentGroup] {
+        // Hash only the structural identity (count + type sequence), NOT string
+        // content. Hashing full payloads is O(total text length) on every body
+        // evaluation and reintroduces the scroll jank the cache was meant to fix.
         var hasher = Hasher()
-        for segment in segments { hasher.combine(segment) }
+        hasher.combine(segments.count)
+        for segment in segments { hasher.combine(Self.segmentTypeDiscriminant(segment)) }
         let key = hasher.finalize()
 
         if let cached = Self.groupedSegmentsCache[key] {


### PR DESCRIPTION
## Summary
- Changes groupedSegments LRU cache key to hash segment count + type sequence only
- Previously hashed full string payloads (O(total text length)) on every body evaluation
- Now O(segment count) — avoids reintroducing scroll jank

Fixes review feedback on #12933

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
