### PR TITLE
perf: pre-resolve subagentDetailStore data in parent, pass as let to MessageCellView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -376,7 +376,7 @@ struct MessageListView: View {
                             onAbortSubagent: onAbortSubagent,
                             onSubagentTap: onSubagentTap,
                             onModelPickerSelect: onModelPickerSelect,
-                            subagentDetailStore: subagentDetailStore,
+                            eventsBySubagent: subagentDetailStore.eventsBySubagent,
                             selectedModel: selectedModel,
                             configuredProviders: configuredProviders
                         )
@@ -825,7 +825,7 @@ private struct MessageCellView: View {
     var onAbortSubagent: ((String) -> Void)?
     var onSubagentTap: ((String) -> Void)?
     var onModelPickerSelect: ((UUID, String) -> Void)?
-    @ObservedObject var subagentDetailStore: SubagentDetailStore
+    let eventsBySubagent: [String: [SubagentEventItem]]
     let selectedModel: String
     let configuredProviders: Set<String>
 
@@ -958,7 +958,7 @@ private struct MessageCellView: View {
         ForEach(subagentsByParent[message.id] ?? []) { subagent in
             SubagentThreadView(
                 subagent: subagent,
-                events: subagentDetailStore.eventsBySubagent[subagent.id] ?? [],
+                events: eventsBySubagent[subagent.id] ?? [],
                 onAbort: { onAbortSubagent?(subagent.id) },
                 onTap: { onSubagentTap?(subagent.id) }
             )


### PR DESCRIPTION
## Summary
- Removes @ObservedObject var subagentDetailStore from MessageCellView
- Previously caused all N cells to re-render on every SubagentDetailStore publish
- Now parent pre-resolves needed data and passes as let constants
- MessageCellView is now a pure function of its let inputs, enabling struct diffing

Fixes review feedback on #12940

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12953" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
