### PR TITLE
refactor: inline resolveGuardianDisplayName() at its single call-site

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -442,23 +442,6 @@ export function startPendingApprovalPromptWatcher(params: {
 }
 
 // ---------------------------------------------------------------------------
-// Guardian display name resolver
-// ---------------------------------------------------------------------------
-
-/**
- * Resolve a human-readable guardian name for trusted-contact notifications.
- * Delegates to {@link resolveGuardianName} which checks USER.md first, then
- * falls back to the contact's display name, then to DEFAULT_USER_REFERENCE.
- */
-export function resolveGuardianDisplayName(
-  assistantId: string,
-  sourceChannel: ChannelId,
-): string {
-  const guardian = findGuardianForChannel(sourceChannel, assistantId);
-  return resolveGuardianName(guardian?.contact.displayName);
-}
-
-// ---------------------------------------------------------------------------
 // Trusted contact approval notifier
 // ---------------------------------------------------------------------------
 
@@ -524,9 +507,12 @@ export function startTrustedContactApprovalNotifier(params: {
 
         if (info && !globalNotifiedApprovalRequestIds.has(info.requestId)) {
           globalNotifiedApprovalRequestIds.set(info.requestId, conversationId);
-          const guardianName = resolveGuardianDisplayName(
-            assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+          const guardian = findGuardianForChannel(
             sourceChannel,
+            assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
+          );
+          const guardianName = resolveGuardianName(
+            guardian?.contact.displayName,
           );
           const waitingText = `Waiting for ${guardianName}'s approval...`;
           try {


### PR DESCRIPTION
## Summary
- Inline the thin `resolveGuardianDisplayName()` wrapper directly at its single call-site in the trusted contact approval notifier
- The wrapper was a 2-line function that just called `findGuardianForChannel()` + `resolveGuardianName()` — no value in the indirection
- Follow-up cleanup from the guardian-name-dedup plan

## Original prompt
do the remaining cleanup that you identified, using your best judgement as to what is relevant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
