### PR TITLE
fix: strip threadTs from Slack callback URL when DMing requester

### DIFF
--- a/assistant/src/__tests__/access-request-decision.test.ts
+++ b/assistant/src/__tests__/access-request-decision.test.ts
@@ -333,7 +333,8 @@ describe("access request notification delivery", () => {
 
   test("slack approval notification is sent as DM using requesterExternalUserId", async () => {
     await notifyRequesterOfApproval({
-      replyCallbackUrl: "http://localhost:7830/deliver/slack",
+      replyCallbackUrl:
+        "http://localhost:7830/deliver/slack?threadTs=1234.5678",
       requesterChatId: "C12345-channel",
       requesterExternalUserId: "U98765-user",
       channel: "slack",
@@ -345,11 +346,14 @@ describe("access request notification delivery", () => {
     const call = deliverReplyCalls[0];
     // Should target the user ID (DM) not the channel
     expect(call.payload.chatId).toBe("U98765-user");
+    // threadTs should be stripped — it belongs to the guardian's channel thread
+    expect(call.url).not.toContain("threadTs");
   });
 
   test("slack denial notification is sent as DM using requesterExternalUserId", async () => {
     await notifyRequesterOfDenial({
-      replyCallbackUrl: "http://localhost:7830/deliver/slack",
+      replyCallbackUrl:
+        "http://localhost:7830/deliver/slack?threadTs=1234.5678",
       requesterChatId: "C12345-channel",
       requesterExternalUserId: "U98765-user",
       channel: "slack",
@@ -360,11 +364,13 @@ describe("access request notification delivery", () => {
     expect(deliverReplyCalls.length).toBe(1);
     const call = deliverReplyCalls[0];
     expect(call.payload.chatId).toBe("U98765-user");
+    expect(call.url).not.toContain("threadTs");
   });
 
   test("slack delivery failure notification is sent as DM using requesterExternalUserId", async () => {
     await notifyRequesterOfDeliveryFailure({
-      replyCallbackUrl: "http://localhost:7830/deliver/slack",
+      replyCallbackUrl:
+        "http://localhost:7830/deliver/slack?threadTs=1234.5678",
       requesterChatId: "C12345-channel",
       requesterExternalUserId: "U98765-user",
       channel: "slack",
@@ -375,11 +381,13 @@ describe("access request notification delivery", () => {
     expect(deliverReplyCalls.length).toBe(1);
     const call = deliverReplyCalls[0];
     expect(call.payload.chatId).toBe("U98765-user");
+    expect(call.url).not.toContain("threadTs");
   });
 
-  test("non-slack channels still use requesterChatId", async () => {
+  test("non-slack channels still use requesterChatId and preserve threadTs", async () => {
     await notifyRequesterOfApproval({
-      replyCallbackUrl: "http://localhost:7830/deliver/telegram",
+      replyCallbackUrl:
+        "http://localhost:7830/deliver/telegram?threadTs=1234.5678",
       requesterChatId: "chat-123",
       requesterExternalUserId: "user-456",
       channel: "telegram",
@@ -389,6 +397,8 @@ describe("access request notification delivery", () => {
 
     expect(deliverReplyCalls.length).toBe(1);
     expect(deliverReplyCalls[0].payload.chatId).toBe("chat-123");
+    // threadTs should be preserved for non-slack channels
+    expect(deliverReplyCalls[0].url).toContain("threadTs=1234.5678");
   });
 
   test("slack without requesterExternalUserId falls back to requesterChatId", async () => {

--- a/assistant/src/runtime/routes/access-request-decision.ts
+++ b/assistant/src/runtime/routes/access-request-decision.ts
@@ -145,17 +145,28 @@ export async function deliverVerificationCodeToGuardian(params: {
  * Resolve the delivery target for requester notifications. On Slack,
  * posting to a user ID (rather than the originating channel) delivers
  * the message as a DM, which is less disruptive than replying in a
- * shared channel.
+ * shared channel. When routing to a DM, the `threadTs` query param is
+ * stripped from the callback URL because it belongs to the guardian's
+ * channel thread and would cause `thread_not_found` errors in the DM.
  */
 function resolveRequesterTarget(params: {
   channel?: string;
+  replyCallbackUrl: string;
   requesterChatId: string;
   requesterExternalUserId?: string;
-}): string {
+}): { chatId: string; callbackUrl: string } {
   if (params.channel === "slack" && params.requesterExternalUserId) {
-    return params.requesterExternalUserId;
+    const url = new URL(params.replyCallbackUrl);
+    url.searchParams.delete("threadTs");
+    return {
+      chatId: params.requesterExternalUserId,
+      callbackUrl: url.toString(),
+    };
   }
-  return params.requesterChatId;
+  return {
+    chatId: params.requesterChatId,
+    callbackUrl: params.replyCallbackUrl,
+  };
 }
 
 /**
@@ -174,13 +185,13 @@ export async function notifyRequesterOfApproval(params: {
     "Your access request has been approved! " +
     "Please enter the 6-digit verification code you receive from the guardian.";
 
-  const targetChatId = resolveRequesterTarget(params);
+  const target = resolveRequesterTarget(params);
 
   try {
     await deliverChannelReply(
-      params.replyCallbackUrl,
+      target.callbackUrl,
       {
-        chatId: targetChatId,
+        chatId: target.chatId,
         text,
         assistantId: params.assistantId,
       },
@@ -211,13 +222,13 @@ export async function notifyRequesterOfDeliveryFailure(params: {
     "Your access request was approved, but we were unable to " +
     "deliver the verification code. Please try again later.";
 
-  const targetChatId = resolveRequesterTarget(params);
+  const target = resolveRequesterTarget(params);
 
   try {
     await deliverChannelReply(
-      params.replyCallbackUrl,
+      target.callbackUrl,
       {
-        chatId: targetChatId,
+        chatId: target.chatId,
         text,
         assistantId: params.assistantId,
       },
@@ -244,13 +255,13 @@ export async function notifyRequesterOfDenial(params: {
 }): Promise<void> {
   const text = "Your access request has been denied by the guardian.";
 
-  const targetChatId = resolveRequesterTarget(params);
+  const target = resolveRequesterTarget(params);
 
   try {
     await deliverChannelReply(
-      params.replyCallbackUrl,
+      target.callbackUrl,
       {
-        chatId: targetChatId,
+        chatId: target.chatId,
         text,
         assistantId: params.assistantId,
       },

--- a/assistant/src/runtime/routes/access-request-decision.ts
+++ b/assistant/src/runtime/routes/access-request-decision.ts
@@ -156,11 +156,17 @@ function resolveRequesterTarget(params: {
   requesterExternalUserId?: string;
 }): { chatId: string; callbackUrl: string } {
   if (params.channel === "slack" && params.requesterExternalUserId) {
-    const url = new URL(params.replyCallbackUrl);
-    url.searchParams.delete("threadTs");
+    let callbackUrl = params.replyCallbackUrl;
+    try {
+      const url = new URL(params.replyCallbackUrl);
+      url.searchParams.delete("threadTs");
+      callbackUrl = url.toString();
+    } catch {
+      // Malformed URL — use as-is; the downstream fetch will handle the error.
+    }
     return {
       chatId: params.requesterExternalUserId,
-      callbackUrl: url.toString(),
+      callbackUrl,
     };
   }
   return {


### PR DESCRIPTION
## Summary
- Follow-up to #12949 — addresses review feedback about stale `threadTs` causing `thread_not_found` errors
- When routing Slack notifications to a DM, the `threadTs` query param (which belongs to the guardian's channel thread) is now stripped from the callback URL
- Non-Slack channels are unaffected — `threadTs` is preserved

## Test plan
- [x] Updated existing Slack DM tests to include `threadTs` in callback URLs and verify it's stripped
- [x] Added assertion that non-Slack channels preserve `threadTs`
- [x] All 15 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
