### PR TITLE
feat(contacts): show contactType as read-only VBadge in header card

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -111,6 +111,7 @@ struct ContactDetailView: View {
 
             HStack(spacing: VSpacing.sm) {
                 roleBadge
+                contactTypeBadge
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -141,6 +142,15 @@ struct ContactDetailView: View {
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
             }
         }
+    }
+
+    private var contactTypeBadge: some View {
+        VBadge(
+            style: .label(formatContactType(displayContact.contactType)),
+            color: displayContact.contactType == "assistant"
+                ? VColor.accent
+                : VColor.textSecondary
+        )
     }
 
     // MARK: - Channels Section
@@ -583,11 +593,6 @@ struct ContactDetailView: View {
                 .foregroundColor(VColor.textPrimary)
 
             VStack(alignment: .leading, spacing: VSpacing.sm) {
-                metadataRow(
-                    label: "Contact type",
-                    value: formatContactType(displayContact.contactType)
-                )
-
                 editableNotesRow
 
                 metadataRow(


### PR DESCRIPTION
## Summary
- Add a VBadge showing 'Human' or 'Assistant' next to the role badge in the contact header card
- Remove the Contact type row from the Metadata section since it's now displayed in the header
- Badge uses accent color for assistants and muted color for humans

Part of plan: contacts-detail-card-merge.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
