### PR TITLE
feat(contacts): display interaction count and last interaction in header card

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -112,6 +112,20 @@ struct ContactDetailView: View {
             HStack(spacing: VSpacing.sm) {
                 roleBadge
             }
+
+            HStack(spacing: VSpacing.sm) {
+                Text("\(displayContact.interactionCount) interaction\(displayContact.interactionCount == 1 ? "" : "s")")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                if let lastInteraction = displayContact.lastInteraction {
+                    Text("\u{00B7}")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                    Text("Last \(relativeTime(epochMs: Int(lastInteraction)))")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(VSpacing.lg)
@@ -589,18 +603,6 @@ struct ContactDetailView: View {
                 )
 
                 editableNotesRow
-
-                metadataRow(
-                    label: "Interactions",
-                    value: "\(displayContact.interactionCount)"
-                )
-
-                if let lastInteraction = displayContact.lastInteraction {
-                    metadataRow(
-                        label: "Last interaction",
-                        value: relativeTime(epochMs: Int(lastInteraction))
-                    )
-                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- Add interaction count and last interaction timestamp as small muted text below badges in header card
- Properly pluralize 'interaction/interactions' based on count
- Show relative time for last interaction with a dot separator
- Remove interaction rows from the Metadata section

Part of plan: contacts-detail-card-merge.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
