### PR TITLE
perf: remove groupedSegments LRU cache

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -144,37 +144,12 @@ struct MarkdownSegmentView: View {
         case horizontalRule
     }
 
-    // Bounded LRU cache for groupedSegments results. Keyed by a full content
-    // hash of the segment array; the entry also stores the original segments for
-    // an equality check on hit, guarding against hash collisions.
-    @MainActor private static var groupedSegmentsCache: [Int: (segments: [MarkdownSegment], value: [SegmentGroup], accessTime: Int)] = [:]
-    @MainActor private static var groupedLRUCounter: Int = 0
-    private static let groupedCacheLimit = 200
-
     /// Groups consecutive text-selectable segments together so they render
     /// as a single Text view, enabling cross-paragraph text selection.
-    private var groupedSegments: [SegmentGroup] {
-        var hasher = Hasher()
-        for segment in segments { hasher.combine(segment) }
-        let key = hasher.finalize()
-
-        if let cached = Self.groupedSegmentsCache[key], cached.segments == segments {
-            Self.groupedLRUCounter += 1
-            Self.groupedSegmentsCache[key] = (cached.segments, cached.value, Self.groupedLRUCounter)
-            return cached.value
-        }
-
-        let result = computeGroupedSegments()
-
-        if Self.groupedSegmentsCache.count >= Self.groupedCacheLimit {
-            if let lruKey = Self.groupedSegmentsCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
-                Self.groupedSegmentsCache.removeValue(forKey: lruKey)
-            }
-        }
-        Self.groupedLRUCounter += 1
-        Self.groupedSegmentsCache[key] = (segments, result, Self.groupedLRUCounter)
-        return result
-    }
+    /// `computeGroupedSegments` is a pure O(segment-count) switch/append walk
+    /// with no string operations, so it is cheap enough to call on every body
+    /// evaluation without a separate cache.
+    private var groupedSegments: [SegmentGroup] { computeGroupedSegments() }
 
     private func computeGroupedSegments() -> [SegmentGroup] {
         var groups: [SegmentGroup] = []
@@ -215,12 +190,6 @@ struct MarkdownSegmentView: View {
 
         flushRun()
         return groups
-    }
-
-    /// Clears the grouped segments cache. Called alongside `clearAttributedStringCache`
-    /// when switching threads or archiving a conversation to reclaim memory.
-    static func clearGroupedSegmentsCache() {
-        groupedSegmentsCache.removeAll()
     }
 
     // MARK: - Combined AttributedString

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -666,7 +666,6 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         ChatBubble.lastStreamingInlineMarkdown = nil
         ChatBubble.lastStreamingMarkdown = nil
         MarkdownSegmentView.clearAttributedStringCache()
-        MarkdownSegmentView.clearGroupedSegmentsCache()
     }
 
     /// Returns true if the thread has at least one user message.


### PR DESCRIPTION
## Summary
- Removes the static LRU cache from `groupedSegments` in `MarkdownSegmentView`
- `computeGroupedSegments()` is a pure O(segment-count) switch/append walk with no string operations — fast enough to call on every body evaluation without caching
- Every cache strategy tried introduced either correctness bugs (structural-only hash caused cross-message collisions) or O(text-length) overhead per render (full content hash + equality check) — worse than the uncached baseline
- The expensive operation (`buildCombinedAttributedString`) already has its own cache; `groupedSegments` was solving a non-problem
- Also removes the now-dead `clearGroupedSegmentsCache()` call from `ThreadManager`

Addresses review feedback on #12958

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
