### PR TITLE
feat(contacts): move notes into header card as always-visible field

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView+EditableMetadata.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView+EditableMetadata.swift
@@ -1,75 +1,9 @@
 import SwiftUI
 import VellumAssistantShared
 
-// MARK: - Editable Metadata Rows
+// MARK: - Metadata Save Functions
 
 extension ContactDetailView {
-
-    var editableNotesRow: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xs) {
-            HStack {
-                Text("Notes")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
-                Spacer()
-                if isEditingNotes {
-                    HStack(spacing: VSpacing.sm) {
-                        Button {
-                            Task { await saveNotes() }
-                        } label: {
-                            Image(systemName: "checkmark")
-                                .foregroundColor(VColor.success)
-                                .font(.system(size: 12, weight: .semibold))
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("Save notes")
-
-                        Button {
-                            isEditingNotes = false
-                        } label: {
-                            Image(systemName: "xmark")
-                                .foregroundColor(VColor.textMuted)
-                                .font(.system(size: 12, weight: .semibold))
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("Cancel editing")
-                    }
-                }
-            }
-
-            if isEditingNotes {
-                TextEditor(text: $editedNotes)
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-                    .scrollContentBackground(.hidden)
-                    .frame(minHeight: 80, maxHeight: 200)
-                    .padding(VSpacing.xs)
-                    .background(VColor.inputBackground)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-            } else if let notes = displayContact.notes, !notes.isEmpty {
-                Text(notes)
-                    .font(VFont.body)
-                    .foregroundColor(VColor.textPrimary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .onTapGesture {
-                        editedNotes = notes
-                        isEditingNotes = true
-                    }
-            } else {
-                Button {
-                    editedNotes = ""
-                    isEditingNotes = true
-                } label: {
-                    Text("+ Add notes")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.accent)
-                }
-                .buttonStyle(.plain)
-            }
-        }
-    }
-
-    // MARK: - Metadata Save Functions
 
     /// Returns true on success so callers can conditionally dismiss their editor.
     func saveMetadataField(

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Detail view for a single contact, showing header info, channels with
-/// verification status, action buttons, and metadata.
+/// Detail view for a single contact, showing header info (including notes),
+/// channels with verification status, and action buttons.
 @MainActor
 struct ContactDetailView: View {
     private static let allChannelTypes = ["telegram", "sms", "email", "voice", "slack"]
@@ -45,7 +45,6 @@ struct ContactDetailView: View {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
                 headerSection
                 channelsSection
-                metadataSection
             }
             .padding(VSpacing.xl)
         }
@@ -127,6 +126,36 @@ struct ContactDetailView: View {
                         .foregroundColor(VColor.textMuted)
                 }
             }
+
+            Divider().background(VColor.divider)
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text("Notes")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+
+                if isEditingNotes {
+                    TextEditor(text: $editedNotes)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                        .scrollContentBackground(.hidden)
+                        .frame(minHeight: 60, maxHeight: 160)
+                        .padding(VSpacing.xs)
+                        .background(VColor.inputBackground)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                } else if let notes = displayContact.notes, !notes.isEmpty {
+                    Text(notes)
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textPrimary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    Text("No notes")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textMuted)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(VSpacing.lg)
@@ -595,36 +624,6 @@ struct ContactDetailView: View {
             return ("Blocked", Color.red.opacity(0.15), VColor.error)
         default:
             return ("Unverified", VColor.surfaceSubtle, VColor.textMuted)
-        }
-    }
-
-    // MARK: - Metadata Section
-
-    private var metadataSection: some View {
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            Text("Metadata")
-                .font(VFont.sectionTitle)
-                .foregroundColor(VColor.textPrimary)
-
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
-                editableNotesRow
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(VSpacing.lg)
-        .vCard(background: VColor.surfaceSubtle)
-    }
-
-    func metadataRow(label: String, value: String) -> some View {
-        HStack(spacing: VSpacing.sm) {
-            Text(label)
-                .font(VFont.caption)
-                .foregroundColor(VColor.textSecondary)
-                .frame(width: 140, alignment: .leading)
-            Text(value)
-                .font(VFont.body)
-                .foregroundColor(VColor.textPrimary)
-            Spacer()
         }
     }
 


### PR DESCRIPTION
## Summary
- Move notes display from the separate Metadata section into the header card, below a divider
- Replace the '+ Add notes' button with a 'No notes' muted placeholder when empty
- Remove the Metadata section entirely (all its content is now in the header card)
- Clean up editableNotesRow from the extension file (inline the notes UI in header)

Part of plan: contacts-detail-card-merge.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
