### PR TITLE
fix: use direct USER.md field check instead of sentinel comparison in resolveGuardianName

### DIFF
--- a/assistant/src/__tests__/user-reference.test.ts
+++ b/assistant/src/__tests__/user-reference.test.ts
@@ -87,6 +87,17 @@ describe("resolveGuardianName", () => {
     expect(resolveGuardianName("Jane")).toBe("John");
   });
 
+  test('returns "my human" when USER.md explicitly sets name to default value', () => {
+    mockFileExists = true;
+    mockFileContent = [
+      "## Onboarding Snapshot",
+      "",
+      "- Preferred name/reference: my human",
+    ].join("\n");
+    // The user's explicit choice must be respected even though it matches the default sentinel
+    expect(resolveGuardianName("Jane")).toBe("my human");
+  });
+
   test("falls back to guardianDisplayName when USER.md is empty", () => {
     mockFileExists = false;
     expect(resolveGuardianName("Jane")).toBe("Jane");

--- a/assistant/src/config/user-reference.ts
+++ b/assistant/src/config/user-reference.ts
@@ -4,6 +4,22 @@ import { getWorkspacePromptPath } from "../util/platform.js";
 export const DEFAULT_USER_REFERENCE = "my human";
 
 /**
+ * Read the raw "Preferred name/reference:" value from USER.md.
+ * Returns the trimmed value when present, or `null` when the file
+ * is missing, unreadable, or the field is empty.
+ */
+function readPreferredNameFromUserMd(): string | null {
+  const content = readTextFileSync(getWorkspacePromptPath("USER.md"));
+  if (content != null) {
+    const match = content.match(/Preferred name\/reference:[ \t]*(.*)/);
+    if (match && match[1].trim()) {
+      return match[1].trim();
+    }
+  }
+  return null;
+}
+
+/**
  * Resolve the name/reference the assistant uses when referring to
  * the human it represents in external communications.
  *
@@ -12,15 +28,7 @@ export const DEFAULT_USER_REFERENCE = "my human";
  * file is missing, unreadable, or the field is empty.
  */
 export function resolveUserReference(): string {
-  const content = readTextFileSync(getWorkspacePromptPath("USER.md"));
-  if (content != null) {
-    const match = content.match(/Preferred name\/reference:[ \t]*(.*)/);
-    if (match && match[1].trim()) {
-      return match[1].trim();
-    }
-  }
-
-  return DEFAULT_USER_REFERENCE;
+  return readPreferredNameFromUserMd() ?? DEFAULT_USER_REFERENCE;
 }
 
 /**
@@ -80,9 +88,9 @@ function cleanPronounValue(raw: string): string | null {
 export function resolveGuardianName(
   guardianDisplayName?: string | null,
 ): string {
-  const userRef = resolveUserReference();
-  if (userRef !== DEFAULT_USER_REFERENCE) {
-    return userRef;
+  const preferredName = readPreferredNameFromUserMd();
+  if (preferredName != null) {
+    return preferredName;
   }
 
   if (guardianDisplayName && guardianDisplayName.trim().length > 0) {


### PR DESCRIPTION
Fixes feedback from PR #12937. Extracted raw USER.md preferred-name lookup into a helper that returns string|null, so resolveGuardianName properly detects when the user has explicitly set their name (even to the default value) vs having no preference.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
