### PR TITLE
fix: treat missing channels as ready in invite gate to avoid blocking email/slack

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -256,8 +256,8 @@ struct ContactDetailView: View {
             do {
                 channelReadiness = try await daemonClient?.fetchChannelReadiness() ?? [:]
             } catch {
-                // Silently fail — default to empty dict means no Invite buttons shown
-                // until readiness is fetched, which is the safe default
+                // Silently fail — default to empty dict means all channels treated as
+                // ready (invite buttons shown), since we only hide on explicit false.
             }
         }
     }
@@ -337,9 +337,10 @@ struct ContactDetailView: View {
 
                 // Voice invites require additional fields (phone number, friend/guardian
                 // names) that aren't available in this context, so hide the button.
-                // channelReadiness gating: only show Invite when the assistant is
-                // configured for this channel (nil/false = not ready or not fetched yet).
-                if displayContact.role != "guardian" && type != "voice" && channelReadiness[type] == true {
+                // channelReadiness gating: only hide Invite when the channel is
+                // explicitly not ready (false). Channels without probes (e.g. email,
+                // slack) are treated as ready by default (nil = ready).
+                if displayContact.role != "guardian" && type != "voice" && channelReadiness[type] != false {
                     if inviteInProgress == type {
                         ProgressView()
                             .controlSize(.small)


### PR DESCRIPTION
## Summary
- Changed the invite button condition from `channelReadiness[type] == true` to `channelReadiness[type] != false`
- Channels without explicit readiness probes (e.g. email, slack) are now treated as ready by default
- Only channels explicitly marked as not ready (false) will have their invite button hidden

## Context
Fixes feedback from PR #12957. The `GET /v1/channels/readiness` endpoint only returns probes for `sms`, `voice`, and `telegram`. The previous `== true` condition meant `email` and `slack` rows never showed the Invite button, even though invite-code redemption is enabled for those channels.

## Test plan
- [ ] Verify email and slack channels now show Invite buttons in the contact detail view
- [ ] Verify channels with explicit `false` readiness (e.g. unconfigured SMS) still hide the Invite button
- [ ] Verify channels with explicit `true` readiness continue to show the Invite button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
