### PR TITLE
fix: scope invite-code lookup by channel and fix null return type consistency

### DIFF
--- a/assistant/src/memory/invite-store.ts
+++ b/assistant/src/memory/invite-store.ts
@@ -358,10 +358,16 @@ export function findActiveVoiceInvites(params: {
 // ---------------------------------------------------------------------------
 
 /**
- * Find an active invite by its 6-digit invite code hash.
- * Used by the channel-agnostic code redemption flow.
+ * Find an active invite by its 6-digit invite code hash, scoped to a specific
+ * source channel. Channel scoping is required because 6-digit codes are drawn
+ * from a small keyspace and can collide across channels — without it, `.get()`
+ * could return an arbitrary match, leading to nondeterministic redemption or
+ * false channel-mismatch failures downstream.
  */
-export function findByInviteCodeHash(hash: string): IngressInvite | undefined {
+export function findByInviteCodeHash(
+  hash: string,
+  sourceChannel: string,
+): IngressInvite | null {
   const db = getDb();
 
   const row = db
@@ -370,10 +376,11 @@ export function findByInviteCodeHash(hash: string): IngressInvite | undefined {
     .where(
       and(
         eq(assistantIngressInvites.inviteCodeHash, hash),
+        eq(assistantIngressInvites.sourceChannel, sourceChannel),
         eq(assistantIngressInvites.status, "active"),
       ),
     )
     .get();
 
-  return row ? rowToInvite(row) : undefined;
+  return row ? rowToInvite(row) : null;
 }

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -444,7 +444,7 @@ export function redeemInviteByCode(params: {
   }
 
   const codeHash = hashVoiceCode(code);
-  const invite = findByInviteCodeHash(codeHash);
+  const invite = findByInviteCodeHash(codeHash, sourceChannel);
 
   if (!invite) {
     return { ok: false, reason: "invalid_token" };
@@ -463,12 +463,6 @@ export function redeemInviteByCode(params: {
 
   if (invite.useCount >= invite.maxUses) {
     return { ok: false, reason: "max_uses_reached" };
-  }
-
-  // Enforce channel match: the invite must belong to the channel the caller
-  // is redeeming from.
-  if (sourceChannel !== invite.sourceChannel) {
-    return { ok: false, reason: "channel_mismatch" };
   }
 
   // Code is valid — now safe to check existing membership without leaking


### PR DESCRIPTION
Fixes feedback from PR #12923. Scoped findByInviteCodeHash to filter by source channel to prevent 6-digit code collisions across channels, and changed return type from undefined to null for consistency with sibling lookups.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
