### PR TITLE
fix: use VFont design token for invite code display

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -377,7 +377,7 @@ struct ContactDetailView: View {
 
                 // Large monospaced invite code for readability
                 Text(inviteCode)
-                    .font(.system(size: 28, weight: .medium, design: .monospaced))
+                    .font(VFont.inviteCode)
                     .foregroundColor(VColor.textPrimary)
                     .tracking(4)
                     .padding(.vertical, VSpacing.xs)

--- a/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/TypographyTokens.swift
@@ -89,6 +89,9 @@ public enum VFont {
     public static let monoBodyMedium = dmMono("DMMono-Medium", size: 13)
     public static let monoMedium = dmMono("DMMono-Medium", size: 16)
 
+    /// Large monospaced font for displaying invite codes
+    public static let inviteCode = Font.system(size: 28, weight: .medium, design: .monospaced)
+
     /// Display font (used for panel headers like "AGENT", "GENERATED CONTENT")
     public static let display    = Font.custom("Inter-SemiBold", size: adaptiveSize(18))
     public static let panelTitle   = Font.custom("Inter-Medium", size: adaptiveSize(24))


### PR DESCRIPTION
Fixes feedback from PR #12929. Added VFont.inviteCode design token and replaced raw .font(.system(...)) with the token in ContactDetailView.

## Summary
- Added `VFont.inviteCode` token to `TypographyTokens.swift` (28pt medium monospaced system font)
- Replaced raw `.font(.system(size: 28, weight: .medium, design: .monospaced))` with `.font(VFont.inviteCode)` in `ContactDetailView.swift`

## Test plan
- [ ] Verify invite code display still renders correctly with the same visual appearance
- [ ] Confirm no other raw font usages were introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
