### PR TITLE
fix: reject declined_by_user sentinel when auto-filling guardianName for voice invites

### DIFF
--- a/assistant/src/config/user-reference.ts
+++ b/assistant/src/config/user-reference.ts
@@ -2,6 +2,7 @@ import { readTextFileSync } from "../util/fs.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
 
 export const DEFAULT_USER_REFERENCE = "my human";
+export const DECLINED_BY_USER_SENTINEL = "declined_by_user";
 
 /**
  * Read the raw "Preferred name/reference:" value from USER.md.
@@ -70,7 +71,7 @@ export function resolveUserPronouns(): string | null {
 }
 
 function cleanPronounValue(raw: string): string | null {
-  if (raw === "declined_by_user") return null;
+  if (raw === DECLINED_BY_USER_SENTINEL) return null;
   // Strip "inferred: " prefix for clean output
   return raw.replace(/^inferred:\s*/i, "");
 }
@@ -89,7 +90,7 @@ export function resolveGuardianName(
   guardianDisplayName?: string | null,
 ): string {
   const preferredName = readPreferredNameFromUserMd();
-  if (preferredName != null) {
+  if (preferredName != null && preferredName !== DECLINED_BY_USER_SENTINEL) {
     return preferredName;
   }
 

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -10,6 +10,7 @@
 
 import { isChannelId } from "../channels/types.js";
 import {
+  DECLINED_BY_USER_SENTINEL,
   DEFAULT_USER_REFERENCE,
   resolveGuardianName,
 } from "../config/user-reference.js";
@@ -188,7 +189,8 @@ export function createIngressInvite(params: {
       params.guardianName?.trim() || resolveGuardianName();
     if (
       !effectiveGuardianName ||
-      effectiveGuardianName === DEFAULT_USER_REFERENCE
+      effectiveGuardianName === DEFAULT_USER_REFERENCE ||
+      effectiveGuardianName === DECLINED_BY_USER_SENTINEL
     ) {
       return { ok: false, error: "guardianName is required for voice invites" };
     }


### PR DESCRIPTION
Fixes feedback from PR #12941. Added check for the declined_by_user sentinel value so it is not used as a real guardian name in voice invite prompts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
