### PR TITLE
fix: pass binding displayName fallback to resolveGuardianName and apply override in merge handler

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -109,11 +109,13 @@ export function getGuardianStatus(
   const resolvedChannel = channel ?? "telegram";
 
   const binding = getGuardianBinding(resolvedAssistantId, resolvedChannel);
-  const guardianDisplayName = resolveGuardianName();
 
-  // Resolve guardianUsername from binding metadata or external conversation store.
-  // Usernames are a channel-specific concept and not part of the guardian name dedup.
+  // Resolve guardianUsername and displayName from binding metadata or
+  // external conversation store. The displayName is passed to
+  // resolveGuardianName() as a fallback for when USER.md is missing/empty
+  // (e.g. pre-onboarding).
   let guardianUsername: string | undefined;
+  let bindingDisplayName: string | undefined;
   if (binding?.metadataJson) {
     try {
       const parsed = JSON.parse(binding.metadataJson) as Record<
@@ -126,10 +128,17 @@ export function getGuardianStatus(
       ) {
         guardianUsername = parsed.username.trim();
       }
+      if (
+        typeof parsed.displayName === "string" &&
+        parsed.displayName.trim().length > 0
+      ) {
+        bindingDisplayName = parsed.displayName.trim();
+      }
     } catch {
       // ignore malformed metadata
     }
   }
+  const guardianDisplayName = resolveGuardianName(bindingDisplayName);
   if (binding?.guardianDeliveryChatId && !guardianUsername) {
     const ext = externalConversationStore.getBindingByChannelChat(
       resolvedChannel,

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -167,7 +167,10 @@ export async function handleMergeContacts(
 
   try {
     const contact = mergeContacts(body.keepId, body.mergeId, assistantId);
-    return Response.json({ ok: true, contact });
+    return Response.json({
+      ok: true,
+      contact: withGuardianNameOverride(contact),
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return httpError("BAD_REQUEST", message, 400);


### PR DESCRIPTION
Fixes feedback from PR #12942. Passes the binding's display name to resolveGuardianName() as fallback when USER.md has no preferred name, and applies withGuardianNameOverride to the contact returned by handleMergeContacts for consistency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
