### PR TITLE
fix: ensure reliable token availability for pairing and settings sync during bootstrap

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/PairingQRCodeSheet.swift
@@ -240,8 +240,10 @@ struct PairingQRCodeSheet: View {
     }
 
     /// Shared HTTP request logic for pairing registration.
+    /// Awaits token availability to handle the bootstrap window where the JWT
+    /// is being re-issued after a credential clear.
     private func performRegistrationRequest(gatewayBaseUrl: String, requestId: String, secret: String) async -> Result<Void, RegistrationRequestError> {
-        let bearerToken = ActorTokenManager.getToken()
+        let bearerToken = await ActorTokenManager.waitForToken(timeout: 10)
 
         let url = URL(string: "\(gatewayBaseUrl)/pairing/register")!
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1109,25 +1109,33 @@ public final class SettingsStore: ObservableObject {
     /// Re-sync locally-known keys to daemon on reconnect.
     /// Pushes keys present in the macOS keychain, and replays any pending
     /// deletion tombstones so user-initiated clears are eventually consistent.
+    /// Waits for the JWT to become available before syncing, because reconnect
+    /// can fire before async credential bootstrap completes.
     private func syncAllKeysToDaemon() {
-        let apiKeyProviders: [(String, String?)] = [
-            ("anthropic", APIKeyManager.getKey()),
-            ("brave", APIKeyManager.getKey(for: "brave")),
-            ("perplexity", APIKeyManager.getKey(for: "perplexity")),
-            ("gemini", APIKeyManager.getKey(for: "gemini")),
-        ]
-        for (provider, value) in apiKeyProviders {
-            if let key = value {
-                syncKeyToDaemon(provider: provider, value: key)
+        Task {
+            // Wait for the JWT to be populated; on reconnect the async
+            // credential bootstrap may still be in-flight.
+            guard let _ = await ActorTokenManager.waitForToken(timeout: 15) else { return }
+
+            let apiKeyProviders: [(String, String?)] = [
+                ("anthropic", APIKeyManager.getKey()),
+                ("brave", APIKeyManager.getKey(for: "brave")),
+                ("perplexity", APIKeyManager.getKey(for: "perplexity")),
+                ("gemini", APIKeyManager.getKey(for: "gemini")),
+            ]
+            for (provider, value) in apiKeyProviders {
+                if let key = value {
+                    syncKeyToDaemon(provider: provider, value: key)
+                }
             }
-        }
 
-        // ElevenLabs uses the credential type, not api_key
-        if let key = APIKeyManager.getKey(for: "elevenlabs") {
-            syncCredentialToDaemon(name: "elevenlabs:api_key", value: key)
-        }
+            // ElevenLabs uses the credential type, not api_key
+            if let key = APIKeyManager.getKey(for: "elevenlabs") {
+                syncCredentialToDaemon(name: "elevenlabs:api_key", value: key)
+            }
 
-        replayDeletionTombstones()
+            replayDeletionTombstones()
+        }
     }
 
     func fetchSlackChannelConfig() {

--- a/clients/shared/App/Auth/ActorTokenManager.swift
+++ b/clients/shared/App/Auth/ActorTokenManager.swift
@@ -116,6 +116,23 @@ public enum ActorTokenManager {
         _ = APIKeyManager.shared.deleteAPIKey(provider: refreshAfterProvider)
     }
 
+    // MARK: - Async Token Resolution
+
+    /// Waits for a non-empty token to become available, polling at 500ms intervals.
+    /// Returns the token once available, or `nil` if the timeout elapses.
+    /// Use this in callsites that fire during the bootstrap window (e.g. on
+    /// daemonDidReconnect) where the JWT may not yet be populated.
+    public static func waitForToken(timeout: TimeInterval = 10) async -> String? {
+        if let token = getToken(), !token.isEmpty { return token }
+
+        let deadline = CFAbsoluteTimeGetCurrent() + timeout
+        while CFAbsoluteTimeGetCurrent() < deadline {
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            if let token = getToken(), !token.isEmpty { return token }
+        }
+        return nil
+    }
+
     // MARK: - Proactive Refresh Checks
 
     /// Whether the access token needs proactive refresh.


### PR DESCRIPTION
## Summary

Fixes feedback from PR #12926. Ensures pairing registration and settings sync have proper token availability during the JWT bootstrap window.

## Problem

After removing `readHttpToken()` fallbacks (PR #12926), two callsites became vulnerable to the JWT bootstrap window:

1. **PairingQRCodeSheet** - `performRegistrationRequest` would send requests without Authorization when the JWT was being re-bootstrapped, causing 401 failures
2. **SettingsStore** - `syncAllKeysToDaemon()` fires on `daemonDidReconnect` which can happen before async credential bootstrap completes, silently dropping key/credential sync

## Solution

Added `ActorTokenManager.waitForToken(timeout:)` - an async polling method that waits for the JWT to become available (with configurable timeout), returning nil only if the timeout elapses.

- **PairingQRCodeSheet**: `performRegistrationRequest` now awaits token availability (10s timeout) instead of synchronously reading
- **SettingsStore**: `syncAllKeysToDaemon` now runs in a Task that awaits token availability (15s timeout) before proceeding with sync

## Test plan

- [ ] Verify pairing QR code registration works when JWT is briefly unavailable during bootstrap
- [ ] Verify key sync completes successfully on daemon reconnect during credential bootstrap
- [ ] Verify normal (non-bootstrap) flows remain unaffected — `waitForToken` returns immediately when token exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
