### PR TITLE
fix: add lazy token resolution for HTTP transport connections during bootstrap

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1304,7 +1304,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     ///
     /// Token resolution order:
     /// 1. `tokenOverride` (for callers that need a specific token, e.g. feature-flag token)
-    /// 2. JWT from `ActorTokenManager.getToken()`
+    /// 2. JWT from `ActorTokenManager.getToken()` — persisted in Keychain, so available
+    ///    across app restarts once the initial bootstrap has completed. On first-ever
+    ///    launch the bootstrap endpoint is unprotected (pre-auth), so the lack of a
+    ///    token at that point is expected and harmless.
     ///
     /// Returns `nil` when the required port is unavailable.
     private func buildLocalRequest(

--- a/clients/shared/IPC/DaemonConnection.swift
+++ b/clients/shared/IPC/DaemonConnection.swift
@@ -27,8 +27,13 @@ extension DaemonClient {
         shouldReconnect = true
 
         // Check if we should use HTTP transport (both platforms).
+        // The bearer token may be nil at config time (e.g. managed mode or
+        // localHttpEnabled where the token isn't known until bootstrap).
+        // Resolve lazily from ActorTokenManager (Keychain) so connections
+        // started after a previous bootstrap carry the persisted JWT.
         if case .http(let baseURL, let bearerToken, let conversationKey) = config.transport {
             let resolvedToken = bearerToken
+                ?? ActorTokenManager.getToken().flatMap { $0.isEmpty ? nil : $0 }
             try await connectHTTP(baseURL: baseURL, bearerToken: resolvedToken, conversationKey: conversationKey)
             return
         }


### PR DESCRIPTION
Fixes feedback from PR #12924. Ensures HTTP transport connections have proper authentication even when ActorTokenManager hasn't been bootstrapped yet by adding lazy token resolution.

## Changes

**DaemonConnection.swift**: When connecting via HTTP transport with `bearerToken: nil` (managed mode, localHttpEnabled), the token is now resolved lazily from `ActorTokenManager` (Keychain) at connect time. This restores the fallback behavior that was lost when `readHttpToken()` was removed — connections started after a previous bootstrap session will carry the persisted JWT.

**DaemonClient.swift**: Updated `buildLocalRequest` documentation to clarify the token resolution chain and explain why the bootstrap timing gap is safe (the bootstrap endpoint is unprotected by design).

## Test plan
- [ ] Verify managed assistant connections authenticate correctly on app restart
- [ ] Verify localHttpEnabled connections authenticate after initial bootstrap
- [ ] Verify first-ever launch bootstrap still works (unprotected endpoint, no token needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
