### PR TITLE
fix: restore bearer token for pairing flow after http-token removal

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -42,6 +42,7 @@ import {
   initAuthSigningKey,
   loadOrCreateSigningKey,
   mintCliEdgeToken,
+  mintPairingBearerToken,
 } from "../runtime/auth/token-service.js";
 import { ensureVellumGuardianBinding } from "../runtime/guardian-vellum-migration.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
@@ -390,9 +391,15 @@ export async function runDaemon(): Promise<void> {
 
     const hostname = getRuntimeHttpHost();
 
+    // Mint a JWT bearer token for the pairing flow. This replaces the
+    // old static http-token that was removed — the pairing IPC handler
+    // and HTTP auto-approve logic both guard on a non-empty bearer token.
+    const pairingBearerToken = mintPairingBearerToken();
+
     runtimeHttp = new RuntimeHttpServer({
       port: httpPort,
       hostname,
+      bearerToken: pairingBearerToken,
       processMessage: (
         conversationId,
         content,
@@ -589,7 +596,7 @@ export async function runDaemon(): Promise<void> {
       runtimeHttp.setPairingBroadcast((msg) =>
         server.broadcast(msg as ServerMessage),
       );
-      initPairingHandlers(runtimeHttp.getPairingStore(), undefined);
+      initPairingHandlers(runtimeHttp.getPairingStore(), pairingBearerToken);
       initSlashPairingContext(runtimeHttp.getPairingStore());
       server.setHttpPort(httpPort);
       log.info(

--- a/assistant/src/runtime/auth/token-service.ts
+++ b/assistant/src/runtime/auth/token-service.ts
@@ -342,6 +342,33 @@ export function mintCliEdgeToken(): string {
 }
 
 // ---------------------------------------------------------------------------
+// Pairing bearer token
+// ---------------------------------------------------------------------------
+
+/**
+ * Mint a JWT bearer token for the iOS pairing flow.
+ *
+ * Minted once at daemon startup and reused for all pairing approvals
+ * during this daemon's lifetime. The token is stored on approved pairing
+ * entries and returned in HTTP responses as a legacy compatibility field.
+ * (iOS clients also receive proper JWT credentials via mintCredentialPair.)
+ *
+ * The 24-hour TTL covers a typical daemon lifecycle. The daemon re-mints
+ * on each restart since the signing key is stable across restarts.
+ *
+ * aud=vellum-daemon, sub=svc:daemon:pairing, scope_profile=gateway_service_v1
+ */
+export function mintPairingBearerToken(): string {
+  return mintToken({
+    aud: "vellum-daemon",
+    sub: "svc:daemon:pairing",
+    scope_profile: "gateway_service_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 86400, // 24 hours — covers a typical daemon lifecycle
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Hash
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes feedback from PR #12930. Ensures pairing flow has a proper bearer token for IPC approval and HTTP auto-approve after the http-token file was removed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
