### PR TITLE
fix: restore channel_mismatch feedback for cross-channel invite codes

### DIFF
--- a/assistant/src/memory/invite-store.ts
+++ b/assistant/src/memory/invite-store.ts
@@ -384,3 +384,33 @@ export function findByInviteCodeHash(
 
   return row ? rowToInvite(row) : null;
 }
+
+// ---------------------------------------------------------------------------
+// findByInviteCodeHashAnyChannel
+// ---------------------------------------------------------------------------
+
+/**
+ * Find an active invite by its 6-digit invite code hash without channel
+ * scoping. Used as a fallback after a channel-scoped lookup fails, to
+ * distinguish "code doesn't exist" from "code exists but for a different
+ * channel" — the latter should produce a channel_mismatch response instead
+ * of silently falling through.
+ */
+export function findByInviteCodeHashAnyChannel(
+  hash: string,
+): IngressInvite | null {
+  const db = getDb();
+
+  const row = db
+    .select()
+    .from(assistantIngressInvites)
+    .where(
+      and(
+        eq(assistantIngressInvites.inviteCodeHash, hash),
+        eq(assistantIngressInvites.status, "active"),
+      ),
+    )
+    .get();
+
+  return row ? rowToInvite(row) : null;
+}

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -17,7 +17,10 @@ import type {
   MemberStatus,
 } from "../../../contacts/types.js";
 import * as channelDeliveryStore from "../../../memory/channel-delivery-store.js";
-import { findByInviteCodeHash } from "../../../memory/invite-store.js";
+import {
+  findByInviteCodeHash,
+  findByInviteCodeHashAnyChannel,
+} from "../../../memory/invite-store.js";
 import { getLogger } from "../../../util/logger.js";
 import { hashVoiceCode } from "../../../util/voice-code.js";
 import { notifyGuardianOfAccessRequest } from "../../access-request-helper.js";
@@ -903,6 +906,36 @@ async function handleInviteCodeIntercept(params: {
   const codeHash = hashVoiceCode(code);
   const candidateInvite = findByInviteCodeHash(codeHash, sourceChannel);
   if (!candidateInvite) {
+    // The code doesn't match any invite on this channel. Before falling
+    // through to normal processing, check if it matches on a different
+    // channel — if so, inform the user instead of silently ignoring it.
+    const crossChannelInvite = findByInviteCodeHashAnyChannel(codeHash);
+    if (crossChannelInvite) {
+      const mismatchReply = "This invite is not valid for this channel.";
+      if (replyCallbackUrl) {
+        try {
+          await deliverChannelReply(
+            replyCallbackUrl,
+            {
+              chatId: externalChatId,
+              text: mismatchReply,
+              assistantId,
+            },
+            bearerToken,
+          );
+        } catch (err) {
+          log.error(
+            { err, externalChatId },
+            "Failed to deliver invite code channel-mismatch reply",
+          );
+        }
+      }
+      return Response.json({
+        accepted: true,
+        denied: true,
+        inviteRedemption: "channel_mismatch",
+      });
+    }
     return null;
   }
 

--- a/playwright/agent/agent.ts
+++ b/playwright/agent/agent.ts
@@ -27,7 +27,8 @@ The test cases are written from the perspective of a non-technical end user. You
 
 Available tool categories:
 - App lifecycle: launch_app — launches the desktop application.
-- Desktop interaction: applescript, run_shell, wait — interact with the native macOS app via System Events (clicking buttons, typing text, reading accessibility trees, taking screenshots).
+- Chat interaction: send_chat_message, read_chat_messages — PREFERRED tools for chatting with the assistant. send_chat_message handles focusing the text field, typing, pressing Enter, and waiting for the response in one step. read_chat_messages reads all text from the main window using `entire contents` so it reliably finds all messages regardless of scroll position or nesting. ALWAYS use these instead of manually typing into the text field with applescript.
+- Desktop interaction: applescript, run_shell, wait — interact with the native macOS app via System Events (clicking buttons, typing text, reading accessibility trees, taking screenshots). Use applescript for UI interactions OTHER than sending/reading chat messages.
 - Secrets: type_env_var — type the value of an environment variable (e.g., ANTHROPIC_API_KEY) into the focused input field without exposing the secret in the conversation.
 - Secure Credentials: fill_secure_credential — fill a floating "Secure Credential" popup panel with an environment variable value and click Save. ALWAYS use this tool (not applescript or type_env_var) whenever you see a "Secure Credential" panel appear. The panel is a small floating window (~400x270px) separate from the main app window. The tool automatically finds the panel, locates the input field regardless of nesting depth, types the value, and clicks Save. If it fails on the first attempt, wait 1 second and try again — the panel may still be animating.
 - Browser tools: goto, click, fill, check, get_text, get_page_content, get_current_url, screenshot — for web-based UI testing.
@@ -52,6 +53,13 @@ Efficiency guidelines (CRITICAL — work as fast as possible):
 - Avoid redundant screenshots — only take a screenshot when you need visual confirmation that cannot be obtained from the accessibility tree.
 - If you are stuck on a step for more than 3-4 attempts, report the test as failed rather than continuing to retry.
 - Issue the report_result call AS SOON AS you have enough evidence to make a pass/fail determination. Do not perform extra verification beyond what the test requires.
+
+Chat interaction patterns (IMPORTANT):
+- ALWAYS use send_chat_message to send messages in the chat. Do NOT manually click the text field and type with applescript — the text field focus is unreliable and wastes iterations.
+- ALWAYS use read_chat_messages to read the conversation. Do NOT use narrow queries like "every static text of UI element 1 of scroll area 2" — these miss newly-added messages. The read_chat_messages tool uses "entire contents" which finds everything regardless of nesting.
+- After send_chat_message returns, check if WINDOWS count > 1 — this means a popup (like Secure Credential) appeared during the response.
+- If you need to check whether a popup appeared without sending a message, use read_chat_messages — it reports the window count.
+- The assistant may take 5-15 seconds to respond. send_chat_message waits automatically (default 10s). If you need to wait longer, call wait() then read_chat_messages.
 
 AppleScript tips (avoid common errors):
 - Dump the accessibility tree (entire contents of window 1) the FIRST TIME you see a new screen. Cache the structure mentally and reference elements directly after that.

--- a/playwright/agent/tools/index.ts
+++ b/playwright/agent/tools/index.ts
@@ -19,9 +19,11 @@ import * as getText from "./get-text";
 import * as goto from "./goto";
 import * as httpRequest from "./http-request";
 import * as launchApp from "./launch-app";
+import * as readChatMessages from "./read-chat-messages";
 import * as reportResult from "./report-result";
 import * as runShell from "./run-shell";
 import * as screenshot from "./screenshot";
+import * as sendChatMessage from "./send-chat-message";
 import * as typeEnvVar from "./type-env-var";
 import * as waitTool from "./wait";
 import type { ToolContext, ToolHandlerResult, ToolModule } from "./types";
@@ -42,9 +44,11 @@ const TOOLS: ToolModule[] = [
   goto,
   httpRequest,
   launchApp,
+  readChatMessages,
   reportResult,
   runShell,
   screenshot,
+  sendChatMessage,
   typeEnvVar,
   waitTool,
 ];

--- a/playwright/agent/tools/read-chat-messages.ts
+++ b/playwright/agent/tools/read-chat-messages.ts
@@ -1,0 +1,104 @@
+/**
+ * Read all chat messages from the Vellum desktop app.
+ *
+ * Uses `entire contents` to reliably read ALL static text in the main window,
+ * regardless of scroll position or nesting depth. This avoids the common pitfall
+ * of using narrowly-scoped queries like `every static text of UI element 1`
+ * that miss newly-added messages.
+ */
+
+import { execSync } from "child_process";
+import { unlinkSync, writeFileSync } from "fs";
+
+import type Anthropic from "@anthropic-ai/sdk";
+import type { Page } from "playwright";
+
+import type { ToolContext, ToolHandlerResult } from "./types";
+
+export const definition: Anthropic.Tool = {
+  name: "read_chat_messages",
+  description:
+    "Read all chat messages from the Vellum desktop app. Returns all visible text in the main window, plus the window count (to detect popups). Use this instead of manually querying static text elements via applescript — it handles scroll areas and nesting correctly.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      process_name: {
+        type: "string",
+        description:
+          "The name of the macOS process (default: Vellum)",
+      },
+    },
+    required: [],
+  },
+};
+
+export async function execute(
+  _page: Page,
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolHandlerResult> {
+  const processName = (input.process_name as string) ?? "Vellum";
+
+  const script = `
+tell application "System Events"
+  tell process "${processName}"
+    set windowCount to count of windows
+
+    -- Find the main app window (largest window)
+    set appWindow to missing value
+    set largestArea to 0
+    repeat with w in windows
+      try
+        set winSize to size of w
+        set winW to item 1 of winSize
+        set winH to item 2 of winSize
+        set winArea to winW * winH
+        if winArea > largestArea then
+          set largestArea to winArea
+          set appWindow to w
+        end if
+      end try
+    end repeat
+
+    if appWindow is missing value then
+      return "ERROR: no app window found"
+    end if
+
+    -- Collect all static text from the main window using entire contents
+    set allElems to entire contents of appWindow
+    set chatTexts to ""
+    repeat with elem in allElems
+      try
+        if class of elem is static text then
+          set textVal to value of elem
+          if textVal is not "" and textVal is not missing value then
+            set chatTexts to chatTexts & textVal & "\\n"
+          end if
+        end if
+      end try
+    end repeat
+
+    return "WINDOWS:" & windowCount & "\\n" & chatTexts
+  end tell
+end tell
+`;
+
+  const scriptPath = `/tmp/pw-agent-read-chat-w${context.workerIndex}.scpt`;
+  try {
+    writeFileSync(scriptPath, script, "utf-8");
+    const output = execSync(`osascript ${scriptPath}`, {
+      encoding: "utf-8",
+      timeout: 30_000,
+    }).trim();
+    return {
+      result: { success: true, data: output || "(no text found)" },
+    };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return {
+      result: { success: false, data: `Failed to read chat: ${msg}` },
+    };
+  } finally {
+    try { unlinkSync(scriptPath); } catch {}
+  }
+}

--- a/playwright/agent/tools/send-chat-message.ts
+++ b/playwright/agent/tools/send-chat-message.ts
@@ -1,0 +1,246 @@
+/**
+ * Send a message in the Vellum desktop app chat.
+ *
+ * Encapsulates the focus → clear → type → send → wait → verify flow
+ * so the agent doesn't waste iterations debugging text field interactions.
+ * Returns the updated chat content after the assistant responds.
+ */
+
+import { execSync } from "child_process";
+import { unlinkSync, writeFileSync } from "fs";
+
+import type Anthropic from "@anthropic-ai/sdk";
+import type { Page } from "playwright";
+
+import type { ToolContext, ToolHandlerResult } from "./types";
+
+export const definition: Anthropic.Tool = {
+  name: "send_chat_message",
+  description:
+    'Send a message in the Vellum desktop app chat and wait for the assistant to respond. Handles focusing the text field, typing, pressing Enter, and waiting for a response. Returns the full chat text after the response arrives. Use this instead of manually typing into the text field with applescript.',
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      message: {
+        type: "string",
+        description: "The message text to send",
+      },
+      process_name: {
+        type: "string",
+        description:
+          "The name of the macOS process (default: Vellum)",
+      },
+      wait_seconds: {
+        type: "number",
+        description:
+          "How many seconds to wait for the assistant to respond (default: 10)",
+      },
+    },
+    required: ["message"],
+  },
+};
+
+export async function execute(
+  _page: Page,
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolHandlerResult> {
+  const message = input.message as string;
+  const processName = (input.process_name as string) ?? "Vellum";
+  const waitSeconds = (input.wait_seconds as number) ?? 10;
+
+  // Escape the message for AppleScript string literal
+  const escaped = message.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+  // Step 1: Focus the text field, clear it, type the message, and press Enter.
+  // We find the text field via entire contents to handle any nesting.
+  const sendScript = `
+tell application "System Events"
+  tell process "${processName}"
+    set frontmost to true
+    delay 0.3
+
+    -- Find the main app window (largest window)
+    set appWindow to missing value
+    set largestArea to 0
+    repeat with w in windows
+      try
+        set winSize to size of w
+        set winW to item 1 of winSize
+        set winH to item 2 of winSize
+        set winArea to winW * winH
+        if winArea > largestArea then
+          set largestArea to winArea
+          set appWindow to w
+        end if
+      end try
+    end repeat
+
+    if appWindow is missing value then
+      error "Could not find the app window"
+    end if
+
+    -- Find the text field (chat input) in the main window.
+    -- Use entire contents to find it regardless of nesting.
+    set chatField to missing value
+    set allElems to entire contents of appWindow
+    repeat with elem in allElems
+      try
+        if class of elem is text field then
+          -- The chat input is in the main group, not in a scroll area popup
+          set chatField to elem
+        end if
+      end try
+    end repeat
+
+    if chatField is missing value then
+      error "Could not find the chat text field"
+    end if
+
+    -- Focus, clear, type, and send
+    set focused of chatField to true
+    delay 0.3
+    keystroke "a" using command down
+    delay 0.1
+    key code 51 -- delete
+    delay 0.1
+    keystroke "${escaped}"
+    delay 0.2
+
+    -- Verify the text was typed
+    set fieldValue to value of chatField
+    if fieldValue is "" then
+      error "Text field is empty after typing — keystroke did not register"
+    end if
+
+    -- Send with Enter
+    keystroke return
+    delay 0.5
+  end tell
+end tell
+`;
+
+  const sendPath = `/tmp/pw-agent-send-msg-w${context.workerIndex}.scpt`;
+  try {
+    writeFileSync(sendPath, sendScript, "utf-8");
+    execSync(`osascript ${sendPath}`, {
+      encoding: "utf-8",
+      timeout: 15_000,
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return {
+      result: { success: false, data: `Failed to send message: ${msg}` },
+    };
+  } finally {
+    try { unlinkSync(sendPath); } catch {}
+  }
+
+  // Step 2: Wait for the assistant to respond.
+  // We poll every 2 seconds, checking if new static text appears
+  // or if the window count increases (Secure Credential popup).
+  const pollInterval = 2000;
+  const maxPolls = Math.ceil((waitSeconds * 1000) / pollInterval);
+
+  const readScript = `
+tell application "System Events"
+  tell process "${processName}"
+    -- Count windows (>1 means a popup appeared)
+    set windowCount to count of windows
+
+    -- Find the main window (largest)
+    set appWindow to missing value
+    set largestArea to 0
+    repeat with w in windows
+      try
+        set winSize to size of w
+        set winW to item 1 of winSize
+        set winH to item 2 of winSize
+        set winArea to winW * winH
+        if winArea > largestArea then
+          set largestArea to winArea
+          set appWindow to w
+        end if
+      end try
+    end repeat
+
+    if appWindow is missing value then
+      return "ERROR: no app window"
+    end if
+
+    -- Collect all static text from the main window
+    set allElems to entire contents of appWindow
+    set chatTexts to ""
+    repeat with elem in allElems
+      try
+        if class of elem is static text then
+          set textVal to value of elem
+          if textVal is not "" and textVal is not missing value then
+            set chatTexts to chatTexts & textVal & "\\n"
+          end if
+        end if
+      end try
+    end repeat
+
+    return "WINDOWS:" & windowCount & "\\n" & chatTexts
+  end tell
+end tell
+`;
+
+  const readPath = `/tmp/pw-agent-read-chat-w${context.workerIndex}.scpt`;
+  let lastOutput = "";
+
+  try {
+    // Initial read to get baseline
+    writeFileSync(readPath, readScript, "utf-8");
+    let baseline = "";
+    try {
+      baseline = execSync(`osascript ${readPath}`, {
+        encoding: "utf-8",
+        timeout: 15_000,
+      }).trim();
+    } catch {}
+
+    // Poll for changes
+    for (let i = 0; i < maxPolls; i++) {
+      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+
+      try {
+        lastOutput = execSync(`osascript ${readPath}`, {
+          encoding: "utf-8",
+          timeout: 15_000,
+        }).trim();
+
+        // If a new window appeared (e.g., Secure Credential popup), return immediately
+        if (lastOutput.startsWith("WINDOWS:") && !lastOutput.startsWith("WINDOWS:1\n")) {
+          return {
+            result: {
+              success: true,
+              data: `Message sent. A new window appeared (likely a popup).\n\n${lastOutput}`,
+            },
+          };
+        }
+
+        // If the content has grown, the assistant responded
+        if (lastOutput.length > baseline.length + 20) {
+          return {
+            result: {
+              success: true,
+              data: `Message sent and response received.\n\n${lastOutput}`,
+            },
+          };
+        }
+      } catch {}
+    }
+
+    // Timeout — return whatever we have
+    return {
+      result: {
+        success: true,
+        data: `Message sent. Assistant may still be responding (waited ${waitSeconds}s).\n\n${lastOutput || baseline}`,
+      },
+    };
+  } finally {
+    try { unlinkSync(readPath); } catch {}
+  }
+}


### PR DESCRIPTION
After PR #12969 scoped invite-code lookup by channel, users entering a valid code on the wrong channel got no feedback (the code silently fell through to normal processing). Added a channel-agnostic fallback lookup so users are informed when they use the right code on the wrong channel.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
