### PR TITLE
fix: filter declined_by_user sentinel in resolveUserReference()

### DIFF
--- a/assistant/src/config/user-reference.ts
+++ b/assistant/src/config/user-reference.ts
@@ -29,7 +29,11 @@ function readPreferredNameFromUserMd(): string | null {
  * file is missing, unreadable, or the field is empty.
  */
 export function resolveUserReference(): string {
-  return readPreferredNameFromUserMd() ?? DEFAULT_USER_REFERENCE;
+  const preferredName = readPreferredNameFromUserMd();
+  if (preferredName != null && preferredName !== DECLINED_BY_USER_SENTINEL) {
+    return preferredName;
+  }
+  return DEFAULT_USER_REFERENCE;
 }
 
 /**


### PR DESCRIPTION
PR #12971 added sentinel filtering to resolveGuardianName() and cleanPronounValue() but missed resolveUserReference(). This caused the literal string 'declined_by_user' to leak into the system prompt when users decline providing their name. Added the same DECLINED_BY_USER_SENTINEL check.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
