### PR TITLE
fix: respect task cancellation in waitForToken and skip actor gate in managed mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1113,9 +1113,15 @@ public final class SettingsStore: ObservableObject {
     /// can fire before async credential bootstrap completes.
     private func syncAllKeysToDaemon() {
         Task {
-            // Wait for the JWT to be populated; on reconnect the async
+            // In managed mode, auth is handled by SessionTokenManager — no actor token needed.
+            // In local mode, wait for the JWT to be populated; on reconnect the async
             // credential bootstrap may still be in-flight.
-            guard let _ = await ActorTokenManager.waitForToken(timeout: 15) else { return }
+            let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+            let isManagedMode = connectedId
+                .flatMap { LockfileAssistant.loadByName($0) }?.isManaged ?? false
+            if !isManagedMode {
+                guard let _ = await ActorTokenManager.waitForToken(timeout: 15) else { return }
+            }
 
             let apiKeyProviders: [(String, String?)] = [
                 ("anthropic", APIKeyManager.getKey()),

--- a/clients/shared/App/Auth/ActorTokenManager.swift
+++ b/clients/shared/App/Auth/ActorTokenManager.swift
@@ -128,6 +128,7 @@ public enum ActorTokenManager {
         let deadline = CFAbsoluteTimeGetCurrent() + timeout
         while CFAbsoluteTimeGetCurrent() < deadline {
             try? await Task.sleep(nanoseconds: 500_000_000)
+            guard !Task.isCancelled else { return nil }
             if let token = getToken(), !token.isEmpty { return token }
         }
         return nil


### PR DESCRIPTION
Two fixes from PR #12973 review feedback:

1. **Added `Task.isCancelled` guard after sleep in `waitForToken`** — Previously, `try? await Task.sleep(...)` swallowed `CancellationError` without checking `Task.isCancelled`, causing cancelled tasks to continue polling until timeout. Now returns `nil` immediately when the task is cancelled.

2. **Skip actor token wait in `syncAllKeysToDaemon` when in managed mode** — In managed mode, auth is handled by `SessionTokenManager`, not actor JWT. If the actor token never arrives (managed mode), the entire key sync was silently skipped. Now checks `LockfileAssistant.isManaged` (same pattern used by `buildDaemonRequest`) and skips the actor token wait in managed mode.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
