### PR TITLE
fix: recover dedup record on invite-code redemption failure for retryability

### DIFF
--- a/assistant/src/memory/channel-delivery-store.ts
+++ b/assistant/src/memory/channel-delivery-store.ts
@@ -22,6 +22,7 @@ export {
 export type { InboundResult, RecordInboundOptions } from "./delivery-crud.js";
 export {
   clearPayload,
+  deleteInbound,
   findMessageBySourceId,
   getLatestStoredPayload,
   linkMessage,

--- a/assistant/src/memory/delivery-crud.ts
+++ b/assistant/src/memory/delivery-crud.ts
@@ -126,6 +126,19 @@ export function recordInbound(
 }
 
 /**
+ * Delete an inbound event record by its event ID. Used to roll back a
+ * dedup record when downstream processing (e.g. invite redemption) fails,
+ * so that webhook retries can re-attempt instead of short-circuiting as
+ * duplicates.
+ */
+export function deleteInbound(eventId: string): void {
+  const db = getDb();
+  db.delete(channelInboundEvents)
+    .where(eq(channelInboundEvents.id, eventId))
+    .run();
+}
+
+/**
  * Link an inbound event to the user message it created, so edits can
  * later find the correct message by source_message_id -> message_id.
  */

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -959,15 +959,27 @@ async function handleInviteCodeIntercept(params: {
     });
   }
 
-  const outcome = redeemInviteByCode({
-    code,
-    sourceChannel,
-    externalUserId: senderExternalUserId,
-    externalChatId,
-    displayName: senderName,
-    username: senderUsername,
-    assistantId: canonicalAssistantId,
-  });
+  let outcome: ReturnType<typeof redeemInviteByCode>;
+  try {
+    outcome = redeemInviteByCode({
+      code,
+      sourceChannel,
+      externalUserId: senderExternalUserId,
+      externalChatId,
+      displayName: senderName,
+      username: senderUsername,
+      assistantId: canonicalAssistantId,
+    });
+  } catch (err) {
+    // Redemption threw — roll back the dedup record so webhook retries
+    // can re-attempt instead of short-circuiting as duplicates.
+    log.error(
+      { err, sourceChannel, externalChatId },
+      "Invite code intercept: redemption threw, rolling back dedup record",
+    );
+    channelDeliveryStore.deleteInbound(dedupResult.eventId);
+    throw err;
+  }
 
   log.info(
     {


### PR DESCRIPTION
Wraps redeemInviteByCode in try/catch to delete the dedup record on failure, preserving webhook retry capability while keeping the dedup-before-redemption ordering that prevents race conditions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
