### PR TITLE
fix: improve playwright agent tool error handling and escaping

### DIFF
--- a/playwright/agent/tools/read-chat-messages.ts
+++ b/playwright/agent/tools/read-chat-messages.ts
@@ -90,6 +90,11 @@ end tell
       encoding: "utf-8",
       timeout: 30_000,
     }).trim();
+    if (output.startsWith("ERROR:")) {
+      return {
+        result: { success: false, data: output },
+      };
+    }
     return {
       result: { success: true, data: output || "(no text found)" },
     };

--- a/playwright/agent/tools/send-chat-message.ts
+++ b/playwright/agent/tools/send-chat-message.ts
@@ -50,7 +50,7 @@ export async function execute(
   const waitSeconds = (input.wait_seconds as number) ?? 10;
 
   // Escape the message for AppleScript string literal
-  const escaped = message.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  const escaped = message.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t");
 
   // Step 1: Focus the text field, clear it, type the message, and press Enter.
   // We find the text field via entire contents to handle any nesting.
@@ -194,11 +194,13 @@ end tell
     // Initial read to get baseline
     writeFileSync(readPath, readScript, "utf-8");
     let baseline = "";
+    let anyReadSucceeded = false;
     try {
       baseline = execSync(`osascript ${readPath}`, {
         encoding: "utf-8",
         timeout: 15_000,
       }).trim();
+      anyReadSucceeded = true;
     } catch {}
 
     // Poll for changes
@@ -210,6 +212,7 @@ end tell
           encoding: "utf-8",
           timeout: 15_000,
         }).trim();
+        anyReadSucceeded = true;
 
         // If a new window appeared (e.g., Secure Credential popup), return immediately
         if (lastOutput.startsWith("WINDOWS:") && !lastOutput.startsWith("WINDOWS:1\n")) {
@@ -231,6 +234,16 @@ end tell
           };
         }
       } catch {}
+    }
+
+    // If every read attempt failed, the app/window likely disappeared
+    if (!anyReadSucceeded) {
+      return {
+        result: {
+          success: false,
+          data: `Message was sent but all subsequent read attempts failed — the app window may have closed or crashed.`,
+        },
+      };
     }
 
     // Timeout — return whatever we have


### PR DESCRIPTION
Address review feedback from PR #12983:\n- Return failure from read_chat_messages when AppleScript returns ERROR prefix\n- Track read success in send_chat_message polling and fail when all reads fail\n- Add newline/carriage-return/tab escaping to AppleScript string escaping
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
