### PR TITLE
fix: add dedup tracking and expiry filtering to channel_mismatch path

### DIFF
--- a/assistant/src/memory/invite-store.ts
+++ b/assistant/src/memory/invite-store.ts
@@ -8,7 +8,7 @@
 
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, gt } from "drizzle-orm";
 
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getDb } from "./db.js";
@@ -400,6 +400,7 @@ export function findByInviteCodeHashAnyChannel(
   hash: string,
 ): IngressInvite | null {
   const db = getDb();
+  const now = Date.now();
 
   const row = db
     .select()
@@ -408,6 +409,7 @@ export function findByInviteCodeHashAnyChannel(
       and(
         eq(assistantIngressInvites.inviteCodeHash, hash),
         eq(assistantIngressInvites.status, "active"),
+        gt(assistantIngressInvites.expiresAt, now),
       ),
     )
     .get();

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -911,6 +911,23 @@ async function handleInviteCodeIntercept(params: {
     // channel — if so, inform the user instead of silently ignoring it.
     const crossChannelInvite = findByInviteCodeHashAnyChannel(codeHash);
     if (crossChannelInvite) {
+      // Record inbound for dedup tracking — without this, duplicate webhook
+      // deliveries would re-enter ACL and send the mismatch reply again.
+      const dedupResult = channelDeliveryStore.recordInbound(
+        sourceChannel,
+        externalChatId,
+        externalMessageId,
+        { assistantId: canonicalAssistantId },
+      );
+
+      if (dedupResult.duplicate) {
+        return Response.json({
+          accepted: true,
+          duplicate: true,
+          eventId: dedupResult.eventId,
+        });
+      }
+
       const mismatchReply = "This invite is not valid for this channel.";
       if (replyCallbackUrl) {
         try {
@@ -930,8 +947,10 @@ async function handleInviteCodeIntercept(params: {
           );
         }
       }
+      channelDeliveryStore.markProcessed(dedupResult.eventId);
       return Response.json({
         accepted: true,
+        eventId: dedupResult.eventId,
         denied: true,
         inviteRedemption: "channel_mismatch",
       });


### PR DESCRIPTION
Address review feedback from PR #12985:\n- Add channelDeliveryStore.recordInbound() and markProcessed() to channel_mismatch early-return path for dedup consistency\n- Add expiresAt check to findByInviteCodeHashAnyChannel to prevent expired invites from triggering false channel_mismatch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/12996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
