### PR TITLE
fix: make guardian display name read-only in Contacts edit mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -57,7 +57,7 @@ struct ContactDetailView: View {
     private var headerSection: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             HStack {
-                if isEditing {
+                if isEditing && displayContact.role != "guardian" {
                     TextField("Display name", text: $editedName)
                         .font(VFont.largeTitle)
                         .foregroundColor(VColor.textPrimary)
@@ -688,7 +688,8 @@ struct ContactDetailView: View {
     // MARK: - Actions
 
     private func saveCardEdits() async {
-        let trimmedName = editedName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let isGuardian = displayContact.role == "guardian"
+        let trimmedName = isGuardian ? displayContact.displayName : editedName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedName.isEmpty else { return }
         let trimmedNotes = editedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
 


### PR DESCRIPTION
## Summary
- Guardian's display name now renders as read-only `Text` instead of an editable `TextField` when in edit mode on the Contacts detail page
- The save function preserves the guardian's original display name to prevent accidental changes

## Original prompt
the guardian's display name should be read only on the Contacts page when in edit mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
