### PR TITLE
fix: stabilize app edit mode without WKWebView reloads

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -14,7 +14,6 @@ enum ViewSelection: Equatable {
 @MainActor
 public final class MainWindowState: ObservableObject {
     @AppStorage("lastActivePanel") private var lastActivePanelString: String?
-    @AppStorage("chatDockOpen") private var chatDockOpen = false
     @AppStorage("isAppChatOpen") private var isAppChatOpen = false
 
     /// The single source of truth for what the main content area displays.
@@ -134,16 +133,9 @@ public final class MainWindowState: ObservableObject {
             return false
         }
         set {
-            if newValue {
-                // No-op: callers should use setAppEditing(appId:threadId:) directly
-                // since transitioning to .appEditing requires a thread ID.
-            } else {
-                // Closing chat dock: transition from .appEditing to .app
-                if case .appEditing(let appId, _) = selection {
-                    selection = .app(appId)
-                }
+            if !newValue, case .appEditing(let appId, _) = selection {
+                selection = .app(appId)
             }
-            chatDockOpen = newValue
         }
     }
 
@@ -223,24 +215,9 @@ public final class MainWindowState: ObservableObject {
         activeDynamicParsedSurface = nil
     }
 
-    func toggleChatDock() {
-        if case .appEditing(let appId, _) = selection {
-            // Currently editing -> close chat dock
-            selection = .app(appId)
-            chatDockOpen = false
-        } else if case .app(let appId) = selection {
-            // Currently app only -> open chat dock (needs thread)
-            // The view layer will wire the thread ID via setAppEditing
-            // For now, mark intent by keeping .app and letting the view handle transition
-            _ = appId
-            chatDockOpen = true
-        }
-    }
-
     /// Transition to appEditing with a specific thread
     func setAppEditing(appId: String, threadId: UUID) {
         selection = .appEditing(appId: appId, threadId: threadId)
-        chatDockOpen = true
     }
 
     func resetLayout() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
@@ -29,29 +29,9 @@ extension MainWindowView {
                     // Use the publish target's appId (not windowState.selection) to avoid
                     // a race where the user navigates away before this async callback fires.
                     if let targetAppId = appId {
-                        isAppChatOpen = true
-                        let threadId = threadManager.activeThreadId ?? threadManager.visibleThreads.first?.id
-                        if let threadId {
-                            threadManager.selectThread(id: threadId)
-                            windowState.setAppEditing(appId: targetAppId, threadId: threadId)
-                        } else {
-                            threadManager.createThread()
-                            if let newThreadId = threadManager.activeThreadId {
-                                windowState.setAppEditing(appId: targetAppId, threadId: newThreadId)
-                            }
-                        }
+                        enterAppEditing(appId: targetAppId)
                     } else if case .app(let currentAppId) = windowState.selection {
-                        isAppChatOpen = true
-                        let threadId = threadManager.activeThreadId ?? threadManager.visibleThreads.first?.id
-                        if let threadId {
-                            threadManager.selectThread(id: threadId)
-                            windowState.setAppEditing(appId: currentAppId, threadId: threadId)
-                        } else {
-                            threadManager.createThread()
-                            if let newThreadId = threadManager.activeThreadId {
-                                windowState.setAppEditing(appId: currentAppId, threadId: newThreadId)
-                            }
-                        }
+                        enterAppEditing(appId: currentAppId)
                     }
                     // Inject message into active session to trigger assistant-driven setup
                     if let viewModel = threadManager.activeViewModel {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -31,6 +31,7 @@ struct MainWindowView: View {
     let sidebarCollapsedWidth: CGFloat = 52
     @AppStorage("sidePanelWidth") var sidePanelWidth: Double = 400
     @AppStorage("appPanelWidth") var appPanelWidth: Double = -1
+    @AppStorage("appChatDockWidth") var appChatDockWidth: Double = -1
     let daemonClient: DaemonClient
     let surfaceManager: SurfaceManager
     let ambientAgent: AmbientAgent
@@ -144,6 +145,16 @@ struct MainWindowView: View {
         if let id = threadManager.visibleThreads.first?.id { return id }
         threadManager.createThread()
         return threadManager.activeThreadId!
+    }
+
+    func enterAppEditing(appId: String) {
+        let threadId = resolveThreadId()
+        threadManager.selectThread(id: threadId)
+        windowState.setAppEditing(appId: appId, threadId: threadId)
+    }
+
+    func exitAppEditing(appId: String) {
+        windowState.selection = .app(appId)
     }
 
     /// Whether the chat bubble toggle is active (chat is open).

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -125,9 +125,7 @@ extension MainWindowView {
                 onAction: { actionId, actionData in
                     if !windowState.isChatDockOpen {
                         let appId = dpData.appId ?? surfaceId
-                        if let threadId = threadManager.activeThreadId {
-                            windowState.setAppEditing(appId: appId, threadId: threadId)
-                        }
+                        enterAppEditing(appId: appId)
                     }
                     // Route relay_prompt actions directly as chat messages so they
                     // reach the active session instead of being lost when the surface
@@ -207,27 +205,56 @@ extension MainWindowView {
         )
     }
 
+    func clampedChatDockWidth(geometry: GeometryProxy) -> Binding<Double> {
+        let settingsOpen: Bool = {
+            if case .panel(.settings) = windowState.selection { return true }
+            return false
+        }()
+        let sidebarWidth: CGFloat = settingsOpen ? 0 : (sidebarExpanded ? sidebarExpandedWidth : sidebarCollapsedWidth)
+        let hstackSpacing: CGFloat = 16
+        let outerPadding: CGFloat = 32
+        let windowWidth: Double = Double(geometry.size.width) / zoomManager.zoomLevel
+        let availableWidth: Double = windowWidth - Double(sidebarWidth) - Double(hstackSpacing) - Double(outerPadding)
+
+        let preferredMin: Double = 300
+        let dividerBudget: Double = Double(VSpacing.xs) + 12
+        let maxDock: Double = availableWidth - 300 - dividerBudget
+        let effectiveMin: Double = min(preferredMin, max(maxDock, 100))
+
+        return Binding<Double>(
+            get: {
+                let raw = appChatDockWidth > 0 ? appChatDockWidth : availableWidth * 0.4
+                return min(max(raw, effectiveMin), max(maxDock, effectiveMin))
+            },
+            set: {
+                appChatDockWidth = min(max($0, effectiveMin), max(maxDock, effectiveMin))
+            }
+        )
+    }
+
     @ViewBuilder
     func chatContentView(geometry: GeometryProxy) -> some View {
         switch windowState.selection {
         case .thread:
             // Show chat for this thread (threadManager.activeViewModel is synced)
             defaultChatLayout
-        case .app:
-            // App workspace: full width (no chat dock), wrapped in rounded container
+        case .app(let appId), .appEditing(let appId, _):
             if let surface = windowState.activeDynamicParsedSurface,
                case .dynamicPage(let dpData) = surface.data {
-                dynamicWorkspaceView(surface: surface, data: dpData)
-                    .background(VColor.background)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                AppWorkspaceDockLayout(
+                    dockWidth: clampedChatDockWidth(geometry: geometry),
+                    showDock: windowState.isChatDockOpen,
+                    dock: {
+                        chatView
+                    },
+                    workspace: {
+                        dynamicWorkspaceView(surface: surface, data: dpData)
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                    }
+                )
             } else {
-                // Loading state while waiting for daemon to send surface data
-                // via ui_surface_show in response to app_open_request.
                 AppLoadingView(
-                    appId: {
-                        if case .app(let id) = windowState.selection { return id }
-                        return nil
-                    }(),
+                    appId: appId,
                     onRetry: { appId in
                         try? daemonClient.sendAppOpen(appId: appId)
                     },
@@ -235,28 +262,7 @@ extension MainWindowView {
                         windowState.closeDynamicPanel()
                     }
                 )
-                .id({
-                    if case .app(let id) = windowState.selection { return id }
-                    return nil
-                }() as String?)
-            }
-        case .appEditing:
-            // VSplitView: ChatView (left) + workspace (right)
-            if let surface = windowState.activeDynamicParsedSurface,
-               case .dynamicPage(let dpData) = surface.data {
-                VSplitView(
-                    panelWidth: clampedPanelWidth(geometry: geometry),
-                    showPanel: true,
-                    main: {
-                        chatView
-                    },
-                    panel: {
-                        dynamicWorkspaceView(surface: surface, data: dpData)
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-                    }
-                )
-            } else {
-                defaultChatLayout
+                .id(appId)
             }
         case .panel(let panelType):
             if panelType == .directory {
@@ -564,23 +570,11 @@ extension MainWindowView {
                 onBundleAndShare: bundleAndShare,
                 isChatDockOpen: windowState.isChatDockOpen,
                 onToggleChatDock: {
-                    if case .appEditing(let appId, _) = windowState.selection {
-                        // Toggle off: go back to full-screen app view
-                        isAppChatOpen = false
-                        windowState.selection = .app(appId)
-                    } else if case .app(let appId) = windowState.selection {
-                        // Toggle on: find most recent thread and enter editing mode
-                        isAppChatOpen = true
-                        let threadId = threadManager.activeThreadId ?? threadManager.visibleThreads.first?.id
-                        if let threadId {
-                            threadManager.selectThread(id: threadId)
-                            windowState.setAppEditing(appId: appId, threadId: threadId)
-                        } else {
-                            // No threads exist — create one, then transition
-                            threadManager.createThread()
-                            if let newThreadId = threadManager.activeThreadId {
-                                windowState.setAppEditing(appId: appId, threadId: newThreadId)
-                            }
+                    withAnimation(VAnimation.panel) {
+                        if case .appEditing(let appId, _) = windowState.selection {
+                            exitAppEditing(appId: appId)
+                        } else if case .app(let appId) = windowState.selection {
+                            enterAppEditing(appId: appId)
                         }
                     }
                 },

--- a/clients/shared/DesignSystem/Components/Layout/AppWorkspaceDockLayout.swift
+++ b/clients/shared/DesignSystem/Components/Layout/AppWorkspaceDockLayout.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
+
+public struct AppWorkspaceDockLayout<Dock: View, Workspace: View>: View {
+    // MARK: - Properties
+
+    public let dock: Dock
+    public let workspace: Workspace
+    @Binding public var dockWidth: Double
+    public var showDock: Bool = false
+    @State private var dragStartWidth: Double?
+    @State private var dragStartAvailableWidth: CGFloat?
+    @State private var isDragging: Bool = false
+    @State private var isDividerHovered: Bool = false
+    private let dragCoordinateSpaceName = "AppWorkspaceDockDragCoordinateSpace"
+
+    // MARK: - Body
+
+    public var body: some View {
+        GeometryReader { geometry in
+            HStack(spacing: 0) {
+                if showDock {
+                    dock
+                        .frame(width: dockWidth)
+                        .animation(nil, value: dockWidth)
+                        .background(VColor.backgroundSubtle)
+                        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                        .padding([.bottom, .leading], VSpacing.xs)
+                        .transition(.move(edge: .leading))
+
+                    dragDivider(availableWidth: geometry.size.width)
+                }
+
+                workspace
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(VColor.backgroundSubtle)
+                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                    .padding(.leading, showDock ? 0 : VSpacing.xs)
+                    .padding([.bottom, .trailing], VSpacing.xs)
+            }
+            .coordinateSpace(name: dragCoordinateSpaceName)
+            .animation(isDragging ? nil : VAnimation.standard, value: showDock)
+        }
+    }
+
+    private func dragDivider(availableWidth: CGFloat) -> some View {
+        ZStack {
+            // Thin vertical line
+            Rectangle()
+                .fill(isDividerHovered || isDragging ? VColor.accent : VColor.surfaceBorder)
+                .frame(width: 1)
+
+            // Small pill — only visible on hover/drag
+            if isDividerHovered || isDragging {
+                Capsule()
+                    .fill(VColor.accent)
+                    .frame(width: 4, height: 32)
+                    .transition(.opacity)
+            }
+        }
+        .frame(width: 8)
+        .contentShape(Rectangle())
+        .animation(VAnimation.fast, value: isDividerHovered)
+        .animation(VAnimation.fast, value: isDragging)
+        #if os(macOS)
+        .onHover { hovering in
+            isDividerHovered = hovering
+            if hovering {
+                NSCursor.pointingHand.push()
+            } else {
+                NSCursor.pop()
+            }
+        }
+        #endif
+        .gesture(
+            DragGesture(minimumDistance: 0, coordinateSpace: .named(dragCoordinateSpaceName))
+                .onChanged { value in
+                    self.handleDragChanged(value, availableWidth: availableWidth)
+                }
+                .onEnded { _ in
+                    self.resetDragState()
+                }
+        )
+        .onDisappear {
+            self.resetDragState()
+        }
+    }
+
+    // MARK: - Drag Helpers
+
+    private func handleDragChanged(_ value: DragGesture.Value, availableWidth: CGFloat) {
+        if dragStartWidth == nil || !isDragging {
+            dragStartWidth = dockWidth
+            dragStartAvailableWidth = availableWidth
+            isDragging = true
+        }
+
+        guard let initialWidth = dragStartWidth,
+              let initialAvailableWidth = dragStartAvailableWidth else {
+            return
+        }
+
+        let deltaX = value.location.x - value.startLocation.x
+        // Dragging right grows the dock (opposite of VSplitView's panel)
+        let newWidth = initialWidth + Double(deltaX)
+
+        let minDockWidth: CGFloat = 300
+        let minWorkspaceWidth: CGFloat = 300
+        let dividerAndPadding = VSpacing.xs + 12
+        let maxAllowed = initialAvailableWidth - minWorkspaceWidth - dividerAndPadding
+
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            dockWidth = min(max(newWidth, minDockWidth), maxAllowed)
+        }
+    }
+
+    private func resetDragState() {
+        isDragging = false
+        dragStartWidth = nil
+        dragStartAvailableWidth = nil
+    }
+
+    // MARK: - Initialization
+
+    public init(
+        dockWidth: Binding<Double>,
+        showDock: Bool = false,
+        @ViewBuilder dock: () -> Dock,
+        @ViewBuilder workspace: () -> Workspace
+    ) {
+        self.dock = dock()
+        self.workspace = workspace()
+        self._dockWidth = dockWidth
+        self.showDock = showDock
+    }
+}


### PR DESCRIPTION
## Summary
- Merge `.app` and `.appEditing` switch arms in `PanelCoordinator` so the workspace view stays in the same SwiftUI tree position regardless of edit mode, preventing WKWebView destruction/recreation (visible full-page reload) when toggling the chat dock
- Add `AppWorkspaceDockLayout`: a left-docking split layout where the workspace is always rendered and the chat dock slides in from the left
- Centralize thread resolution into `enterAppEditing`/`exitAppEditing` helpers, simplifying `onToggleChatDock`, `surfaceSlotView` action handler, and credential setup flow
- Remove unused `toggleChatDock()` and write-only `chatDockOpen` AppStorage from `MainWindowState`

## Test plan
- [ ] Open an app → click "Edit app" → no reload/flicker, chat slides in from left
- [ ] Click "Close chat" → chat slides out, workspace stays (no reload)
- [ ] Repeat toggle multiple times → workspace content persists each time
- [ ] First-time edit mode opens ~40/60 split (chat/app)
- [ ] Drag divider to resize → width persists across toggles
- [ ] relay_prompt from app → chat opens with message, no reload
- [ ] Publish with missing credentials → chat opens for credential setup, no reload
- [ ] Close workspace (xmark) → returns to thread view correctly
- [ ] Non-app panels (directory, settings) still work with existing VSplitView

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
