### PR TITLE
feat(privacy): add performance reports toggle and Report a Problem flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -249,7 +249,7 @@ struct SettingsPanel: View {
         case .appearance:
             SettingsAppearanceTab(store: store)
         case .privacy:
-            SettingsPrivacyTab(daemonClient: daemonClient)
+            SettingsPrivacyTab(daemonClient: daemonClient, store: store)
         case .contacts:
             ContactsContainerView(daemonClient: daemonClient)
         case .advanced:

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -1,3 +1,4 @@
+import Sentry
 import SwiftUI
 import VellumAssistantShared
 
@@ -14,12 +15,20 @@ struct SettingsPrivacyTab: View {
     @State private var isUpdating: Bool = false
     @State private var loadError: String?
 
+    @AppStorage("sendPerformanceReports") private var sendPerformanceReports: Bool = false
+
+    @State private var isReportSheetPresented: Bool = false
+
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
             diagnosticsSection
+            reportProblemSection
         }
         .onAppear {
             Task { await loadPrivacyFlags() }
+        }
+        .sheet(isPresented: $isReportSheetPresented) {
+            ReportProblemSheet(isPresented: $isReportSheetPresented)
         }
     }
 
@@ -69,6 +78,52 @@ struct SettingsPrivacyTab: View {
                 ))
                 .disabled(isLoading || isUpdating || daemonClient == nil)
             }
+
+            Divider()
+                .foregroundColor(VColor.divider)
+
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Share performance metrics")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Text("Send anonymised performance metrics (hang rate, scroll speed) to help us improve responsiveness. No personal data or message content is included.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                Spacer()
+                VToggle(isOn: $sendPerformanceReports)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(VSpacing.lg)
+        .vCard(background: VColor.surfaceSubtle)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Report a Problem Section
+
+    private var reportProblemSection: some View {
+        VStack(alignment: .leading, spacing: VSpacing.md) {
+            Text("Feedback")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            HStack {
+                VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text("Report a Problem")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                    Text("Send a manual report to the development team. Always available, even when automatic reporting is off.")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                Spacer()
+                Button("Report a Problem") {
+                    isReportSheetPresented = true
+                }
+                .buttonStyle(.bordered)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(VSpacing.lg)
@@ -111,6 +166,83 @@ struct SettingsPrivacyTab: View {
     }
 }
 
+// MARK: - Report a Problem Sheet
+
+/// Sheet that lets the user write a description and send a manual Sentry report.
+/// The report is always sent regardless of the auto-reporting opt-out setting.
+@MainActor
+private struct ReportProblemSheet: View {
+    @Binding var isPresented: Bool
+    @State private var userDescription: String = ""
+    @State private var isSending: Bool = false
+    @State private var didSend: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: VSpacing.lg) {
+            Text("Report a Problem")
+                .font(VFont.sectionTitle)
+                .foregroundColor(VColor.textPrimary)
+
+            Text("Describe what happened (optional)")
+                .font(VFont.body)
+                .foregroundColor(VColor.textSecondary)
+
+            TextEditor(text: $userDescription)
+                .font(VFont.body)
+                .frame(minHeight: 120)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(VColor.divider, lineWidth: 1)
+                )
+
+            if didSend {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(VColor.success)
+                    Text("Report sent. Thank you!")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    isPresented = false
+                }
+                .buttonStyle(.bordered)
+                .disabled(isSending)
+
+                Button("Send Report") {
+                    sendReport()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isSending || didSend)
+            }
+        }
+        .padding(VSpacing.lg)
+        .frame(width: 440)
+    }
+
+    private func sendReport() {
+        isSending = true
+        let event = Event(level: .info)
+        event.message = SentryMessage(
+            formatted: userDescription.isEmpty ? "Manual problem report" : userDescription
+        )
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        event.tags = ["source": "manual_report", "app_version": appVersion]
+        SentrySDK.capture(event: event)
+        isSending = false
+        didSend = true
+        // Dismiss automatically after a short delay so the user can see the confirmation.
+        Task {
+            try? await Task.sleep(nanoseconds: 1_200_000_000)
+            isPresented = false
+        }
+    }
+}
+
 #Preview("SettingsPrivacyTab") {
     ZStack {
         VColor.background.ignoresSafeArea()
@@ -118,4 +250,9 @@ struct SettingsPrivacyTab: View {
             .frame(width: 480)
             .padding()
     }
+}
+
+#Preview("ReportProblemSheet") {
+    ReportProblemSheet(isPresented: .constant(true))
+        .padding()
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -7,6 +7,7 @@ import VellumAssistantShared
 @MainActor
 struct SettingsPrivacyTab: View {
     var daemonClient: DaemonClient?
+    @ObservedObject var store: SettingsStore
 
     private static let collectUsageDataKey = "feature_flags.collect-usage-data.enabled"
 
@@ -14,8 +15,6 @@ struct SettingsPrivacyTab: View {
     @State private var isLoading: Bool = false
     @State private var isUpdating: Bool = false
     @State private var loadError: String?
-
-    @AppStorage("sendPerformanceReports") private var sendPerformanceReports: Bool = false
 
     @State private var isReportSheetPresented: Bool = false
 
@@ -92,7 +91,10 @@ struct SettingsPrivacyTab: View {
                         .foregroundColor(VColor.textMuted)
                 }
                 Spacer()
-                VToggle(isOn: $sendPerformanceReports)
+                VToggle(isOn: Binding(
+                    get: { store.sendPerformanceReports },
+                    set: { store.sendPerformanceReports = $0 }
+                ))
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -176,6 +178,7 @@ private struct ReportProblemSheet: View {
     @State private var userDescription: String = ""
     @State private var isSending: Bool = false
     @State private var didSend: Bool = false
+    @State private var dismissTask: Task<Void, Never>?
 
     var body: some View {
         VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -232,12 +235,22 @@ private struct ReportProblemSheet: View {
         )
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
         event.tags = ["source": "manual_report", "app_version": appVersion]
+        // Ensure Sentry is running for this manual report — it may have been
+        // shut down via the opt-out path. Manual reports always go through.
+        if !SentrySDK.isEnabled {
+            SentrySDK.start { options in
+                options.dsn = "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992"
+                options.sendDefaultPii = false
+            }
+        }
         SentrySDK.capture(event: event)
         isSending = false
         didSend = true
         // Dismiss automatically after a short delay so the user can see the confirmation.
-        Task {
+        dismissTask?.cancel()
+        dismissTask = Task {
             try? await Task.sleep(nanoseconds: 1_200_000_000)
+            guard !Task.isCancelled else { return }
             isPresented = false
         }
     }
@@ -246,7 +259,7 @@ private struct ReportProblemSheet: View {
 #Preview("SettingsPrivacyTab") {
     ZStack {
         VColor.background.ignoresSafeArea()
-        SettingsPrivacyTab(daemonClient: nil)
+        SettingsPrivacyTab(daemonClient: nil, store: SettingsStore())
             .frame(width: 480)
             .padding()
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -235,15 +235,21 @@ private struct ReportProblemSheet: View {
         )
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
         event.tags = ["source": "manual_report", "app_version": appVersion]
-        // Ensure Sentry is running for this manual report — it may have been
-        // shut down via the opt-out path. Manual reports always go through.
-        if !SentrySDK.isEnabled {
+        // If the user opted out, Sentry is closed by checkAndApplyPrivacyFlag().
+        // Start it temporarily for this manual report only, then flush and close
+        // to fully restore the opted-out state so no automatic events slip through.
+        let wasDisabled = !SentrySDK.isEnabled
+        if wasDisabled {
             SentrySDK.start { options in
                 options.dsn = "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992"
                 options.sendDefaultPii = false
             }
         }
         SentrySDK.capture(event: event)
+        if wasDisabled {
+            SentrySDK.flush(timeout: 5)
+            SentrySDK.close()
+        }
         isSending = false
         didSend = true
         // Dismiss automatically after a short delay so the user can see the confirmation.

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsPrivacyTab.swift
@@ -211,6 +211,7 @@ private struct ReportProblemSheet: View {
             HStack {
                 Spacer()
                 Button("Cancel") {
+                    dismissTask?.cancel()
                     isPresented = false
                 }
                 .buttonStyle(.bordered)
@@ -229,35 +230,41 @@ private struct ReportProblemSheet: View {
 
     private func sendReport() {
         isSending = true
-        let event = Event(level: .info)
-        event.message = SentryMessage(
-            formatted: userDescription.isEmpty ? "Manual problem report" : userDescription
-        )
+        // Capture Sendable (value type) copies before hopping off the main actor.
+        let message = userDescription.isEmpty ? "Manual problem report" : userDescription
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
-        event.tags = ["source": "manual_report", "app_version": appVersion]
-        // If the user opted out, Sentry is closed by checkAndApplyPrivacyFlag().
-        // Start it temporarily for this manual report only, then flush and close
-        // to fully restore the opted-out state so no automatic events slip through.
-        let wasDisabled = !SentrySDK.isEnabled
-        if wasDisabled {
-            SentrySDK.start { options in
-                options.dsn = "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992"
-                options.sendDefaultPii = false
+        // Run Sentry operations on a background thread so SentrySDK.flush(timeout:)
+        // — which can block for up to 5 seconds — never freezes the main thread.
+        // If the user opted out, Sentry is closed by checkAndApplyPrivacyFlag();
+        // start it temporarily, flush to ensure delivery, then close to restore
+        // the opted-out state so no automatic events slip through afterward.
+        Task.detached {
+            let event = Event(level: .info)
+            event.message = SentryMessage(formatted: message)
+            event.tags = ["source": "manual_report", "app_version": appVersion]
+            let wasDisabled = !SentrySDK.isEnabled
+            if wasDisabled {
+                SentrySDK.start { options in
+                    options.dsn = "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992"
+                    options.sendDefaultPii = false
+                }
             }
-        }
-        SentrySDK.capture(event: event)
-        if wasDisabled {
-            SentrySDK.flush(timeout: 5)
-            SentrySDK.close()
-        }
-        isSending = false
-        didSend = true
-        // Dismiss automatically after a short delay so the user can see the confirmation.
-        dismissTask?.cancel()
-        dismissTask = Task {
-            try? await Task.sleep(nanoseconds: 1_200_000_000)
-            guard !Task.isCancelled else { return }
-            isPresented = false
+            SentrySDK.capture(event: event)
+            if wasDisabled {
+                SentrySDK.flush(timeout: 5)
+                SentrySDK.close()
+            }
+            await MainActor.run {
+                isSending = false
+                didSend = true
+                // Dismiss automatically after a short delay so the user can see the confirmation.
+                dismissTask?.cancel()
+                dismissTask = Task {
+                    try? await Task.sleep(nanoseconds: 1_200_000_000)
+                    guard !Task.isCancelled else { return }
+                    isPresented = false
+                }
+            }
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2,6 +2,7 @@ import Carbon.HIToolbox
 import Combine
 import Foundation
 import os
+import SwiftUI
 import VellumAssistantShared
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "SettingsStore")
@@ -255,6 +256,13 @@ public final class SettingsStore: ObservableObject {
     /// Sourced from `DaemonClient.isTrustRulesSheetOpen` so each view can
     /// disable its button when the other surface is showing trust rules.
     @Published var isAnyTrustRulesSheetOpen = false
+
+    // MARK: - Privacy
+
+    /// Whether the user has opted in to sharing anonymised performance metrics (e.g. hang rate,
+    /// scroll speed). Defaults to `false`. Read by the MetricKit integration (M4) to decide
+    /// whether to forward payloads.
+    @AppStorage("sendPerformanceReports") var sendPerformanceReports: Bool = false
 
     // MARK: - Private
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -2,7 +2,6 @@ import Carbon.HIToolbox
 import Combine
 import Foundation
 import os
-import SwiftUI
 import VellumAssistantShared
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "SettingsStore")
@@ -262,7 +261,7 @@ public final class SettingsStore: ObservableObject {
     /// Whether the user has opted in to sharing anonymised performance metrics (e.g. hang rate,
     /// scroll speed). Defaults to `false`. Read by the MetricKit integration (M4) to decide
     /// whether to forward payloads.
-    @AppStorage("sendPerformanceReports") var sendPerformanceReports: Bool = false
+    @Published var sendPerformanceReports: Bool = UserDefaults.standard.object(forKey: "sendPerformanceReports") as? Bool ?? false
 
     // MARK: - Private
 
@@ -411,6 +410,12 @@ public final class SettingsStore: ObservableObject {
             .dropFirst()
             .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
             .sink { value in UserDefaults.standard.set(value, forKey: "cmdEnterToSend") }
+            .store(in: &cancellables)
+
+        $sendPerformanceReports
+            .dropFirst()
+            .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
+            .sink { UserDefaults.standard.set($0, forKey: "sendPerformanceReports") }
             .store(in: &cancellables)
 
         // Persist shortcut changes immediately so the hotkey re-registers without delay


### PR DESCRIPTION
## Summary
- Adds 'Share performance metrics' opt-in toggle (default off) to SettingsPrivacyTab
- Adds 'Report a Problem' button that opens a sheet to send a manual Sentry report at any time, even when auto-reporting is off
- Adds sendPerformanceReports AppStorage key for MetricKit integration (M4) to read

Part of #12978 (M3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
