### PR TITLE
perf(instruments): add os_signpost markers for Instruments profiling

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -1,3 +1,4 @@
+import os
 import SwiftUI
 import VellumAssistantShared
 
@@ -70,6 +71,8 @@ func parseListLine(_ line: String) -> ListItem? {
 
 /// Parses message text into segments, extracting markdown tables, code blocks, headings, lists, and rules.
 func parseMarkdownSegments(_ text: String) -> [MarkdownSegment] {
+    os_signpost(.begin, log: PerfSignposts.log, name: "markdownParse")
+    defer { os_signpost(.end, log: PerfSignposts.log, name: "markdownParse") }
     let lines = text.components(separatedBy: .newlines)
     var segments: [MarkdownSegment] = []
     var currentText: [String] = []

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -1,4 +1,5 @@
 @preconcurrency import AppKit
+import os
 import SwiftUI
 import VellumAssistantShared
 
@@ -152,6 +153,8 @@ struct MarkdownSegmentView: View {
     private var groupedSegments: [SegmentGroup] { computeGroupedSegments() }
 
     private func computeGroupedSegments() -> [SegmentGroup] {
+        os_signpost(.begin, log: PerfSignposts.log, name: "markdownGroupSegments")
+        defer { os_signpost(.end, log: PerfSignposts.log, name: "markdownGroupSegments") }
         var groups: [SegmentGroup] = []
         var currentRun: [MarkdownSegment] = []
 
@@ -244,6 +247,8 @@ struct MarkdownSegmentView: View {
     /// Builds (or retrieves from cache) a single AttributedString from
     /// consecutive text-selectable segments.
     private func buildCombinedAttributedString(from segments: [MarkdownSegment]) -> AttributedString {
+        os_signpost(.begin, log: PerfSignposts.log, name: "attributedStringBuild")
+        defer { os_signpost(.end, log: PerfSignposts.log, name: "attributedStringBuild") }
         // Build a stable cache key from the segment contents and style
         // inputs that affect the output (e.g. secondaryTextColor for list
         // prefix coloring, zoomScale for font sizing) so different visual

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -451,10 +451,14 @@ struct MessageListView: View {
                 ThreadScrollbarVisibilityController(shouldShow: shouldShowThreadScrollbar)
             }
             .onPreferenceChange(ScrollViewportHeightKey.self) { height in
+                os_signpost(.begin, log: PerfSignposts.log, name: "anchorPreferenceChange")
                 anchorTracker.updateViewport(height: height, storedViewportHeight: &scrollViewportHeight)
+                os_signpost(.end, log: PerfSignposts.log, name: "anchorPreferenceChange")
             }
             .onPreferenceChange(AnchorMinYKey.self) { minY in
+                os_signpost(.begin, log: PerfSignposts.log, name: "anchorPreferenceChange")
                 anchorTracker.update(minY: minY, viewportHeight: scrollViewportHeight)
+                os_signpost(.end, log: PerfSignposts.log, name: "anchorPreferenceChange")
             }
             .overlay(alignment: .bottom) {
                 if (!isNearBottom || !hasReceivedScrollEvent) && !anchorTracker.isVisible {

--- a/clients/macos/vellum-assistant/Telemetry/PerfSignposts.swift
+++ b/clients/macos/vellum-assistant/Telemetry/PerfSignposts.swift
@@ -13,41 +13,4 @@ enum PerfSignposts {
         category: .pointsOfInterest
     )
 
-    // MARK: - Helpers
-
-    /// Wraps `ChatMarkdownParser.parseMarkdownSegments()`.
-    @inlinable static func beginMarkdownParse() {
-        os_signpost(.begin, log: log, name: "markdownParse")
-    }
-
-    @inlinable static func endMarkdownParse() {
-        os_signpost(.end, log: log, name: "markdownParse")
-    }
-
-    /// Wraps `MarkdownSegmentView.computeGroupedSegments()`.
-    @inlinable static func beginMarkdownGroupSegments() {
-        os_signpost(.begin, log: log, name: "markdownGroupSegments")
-    }
-
-    @inlinable static func endMarkdownGroupSegments() {
-        os_signpost(.end, log: log, name: "markdownGroupSegments")
-    }
-
-    /// Wraps `MarkdownSegmentView.buildCombinedAttributedString(from:)`.
-    @inlinable static func beginAttributedStringBuild() {
-        os_signpost(.begin, log: log, name: "attributedStringBuild")
-    }
-
-    @inlinable static func endAttributedStringBuild() {
-        os_signpost(.end, log: log, name: "attributedStringBuild")
-    }
-
-    /// Wraps the `onPreferenceChange` handlers in `MessageListView`.
-    @inlinable static func beginAnchorPreferenceChange() {
-        os_signpost(.begin, log: log, name: "anchorPreferenceChange")
-    }
-
-    @inlinable static func endAnchorPreferenceChange() {
-        os_signpost(.end, log: log, name: "anchorPreferenceChange")
-    }
 }

--- a/clients/macos/vellum-assistant/Telemetry/PerfSignposts.swift
+++ b/clients/macos/vellum-assistant/Telemetry/PerfSignposts.swift
@@ -1,3 +1,4 @@
+import Foundation
 import os
 
 // MARK: - Performance Signposts

--- a/clients/macos/vellum-assistant/Telemetry/PerfSignposts.swift
+++ b/clients/macos/vellum-assistant/Telemetry/PerfSignposts.swift
@@ -1,0 +1,52 @@
+import os
+
+// MARK: - Performance Signposts
+
+/// Namespace for os_signpost markers used during Instruments profiling sessions.
+/// Use the Points of Interest or Time Profiler template in Instruments to see
+/// named coloured intervals for the hot paths identified in the scroll hang investigation.
+enum PerfSignposts {
+    /// Shared log handle targeting the Points of Interest instrument lane.
+    static let log = OSLog(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
+        category: .pointsOfInterest
+    )
+
+    // MARK: - Helpers
+
+    /// Wraps `ChatMarkdownParser.parseMarkdownSegments()`.
+    @inlinable static func beginMarkdownParse() {
+        os_signpost(.begin, log: log, name: "markdownParse")
+    }
+
+    @inlinable static func endMarkdownParse() {
+        os_signpost(.end, log: log, name: "markdownParse")
+    }
+
+    /// Wraps `MarkdownSegmentView.computeGroupedSegments()`.
+    @inlinable static func beginMarkdownGroupSegments() {
+        os_signpost(.begin, log: log, name: "markdownGroupSegments")
+    }
+
+    @inlinable static func endMarkdownGroupSegments() {
+        os_signpost(.end, log: log, name: "markdownGroupSegments")
+    }
+
+    /// Wraps `MarkdownSegmentView.buildCombinedAttributedString(from:)`.
+    @inlinable static func beginAttributedStringBuild() {
+        os_signpost(.begin, log: log, name: "attributedStringBuild")
+    }
+
+    @inlinable static func endAttributedStringBuild() {
+        os_signpost(.end, log: log, name: "attributedStringBuild")
+    }
+
+    /// Wraps the `onPreferenceChange` handlers in `MessageListView`.
+    @inlinable static func beginAnchorPreferenceChange() {
+        os_signpost(.begin, log: log, name: "anchorPreferenceChange")
+    }
+
+    @inlinable static func endAnchorPreferenceChange() {
+        os_signpost(.end, log: log, name: "anchorPreferenceChange")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds PerfSignposts.swift with a shared .pointsOfInterest OSLog handle
- Wraps markdown parse, groupedSegments, attributedString build, and anchor preference change handlers with os_signpost begin/end intervals
- Makes Instruments Time Profiler and Points of Interest template show named coloured regions for the hot paths identified in the scroll hang investigation

Part of #12978 (M1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
