### PR TITLE
fix: address review nits on LocalInstanceResources type

### DIFF
--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -16,19 +16,13 @@ import { probePort } from "./port-probe.js";
  */
 export interface LocalInstanceResources {
   /**
-   * Instance-specific data root. For named instances this is
-   * `~/.vellum/instances/<name>/`; the daemon's working directory
-   * (`.vellum/`) lives inside it (e.g. `~/.vellum/instances/<name>/.vellum/`).
-   * Distinct from `AssistantEntry.baseDataDir`, which is a legacy field from
-   * the pre-multi-instance layout kept for backward compatibility.
+   * Instance-specific data root (e.g. `~/.vellum/instances/<name>/`).
+   * The daemon's `.vellum/` directory lives inside it. Equivalent to
+   * `AssistantEntry.baseDataDir` minus the trailing `/.vellum` suffix —
+   * `baseDataDir` is kept on the flat entry for legacy lockfile compat.
    */
   instanceDir: string;
-  /**
-   * Allocated port for process management — detecting conflicts, displaying
-   * status, and waking/sleeping. Overlaps with `AssistantEntry.runtimeUrl`
-   * (which is the full URL clients connect to) but kept separately so
-   * lifecycle commands can reason about port numbers directly.
-   */
+  /** HTTP port for the daemon runtime server */
   daemonPort: number;
   /** HTTP port for the gateway */
   gatewayPort: number;
@@ -36,7 +30,7 @@ export interface LocalInstanceResources {
   qdrantPort: number;
   /** Absolute path to the Unix domain socket for IPC */
   socketPath: string;
-  /** Absolute path to the daemon PID file used for process lifecycle */
+  /** Absolute path to the daemon PID file */
   pidFile: string;
 }
 
@@ -46,6 +40,7 @@ export interface AssistantEntry {
   /** Loopback URL for same-machine health checks (e.g. `http://127.0.0.1:7831`).
    *  Avoids mDNS resolution issues when the machine checks its own gateway. */
   localUrl?: string;
+  /** @deprecated Use `resources.instanceDir` for multi-instance entries. Legacy equivalent of `join(instanceDir, ".vellum")`. */
   baseDataDir?: string;
   bearerToken?: string;
   cloud: string;


### PR DESCRIPTION
## Summary
Addresses dvargas92495's review nits from #12615 that #12698 only rewrote comments for without addressing the substance:

- **Nit 1** (`instanceDir` redundant with `baseDataDir`): Clarified the relationship — `instanceDir` is canonical, `baseDataDir` is `join(instanceDir, ".vellum")` kept for legacy lockfile compat. Marked `baseDataDir` as `@deprecated`.
- **Nit 3** (inconsistent comment style): Made all port field comments consistent short one-liners instead of having `daemonPort` be verbose while others are terse.

Nit 2 (daemonPort vs runtimeUrl) was acknowledged as "harmless to keep" by the reviewer. Nit 4 (instance nesting) is by design — `~/.vellum/` is the platform root with shared resources (`bin/`, `protected/`, `workspace/`), and `instances/` is a subdirectory for per-instance data.

## Test plan
- [ ] `bunx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
