### PR TITLE
refactor: buildGuardianInstruction returns structured data with channelHandle

### DIFF
--- a/assistant/src/runtime/channel-invite-transport.ts
+++ b/assistant/src/runtime/channel-invite-transport.ts
@@ -26,6 +26,13 @@ export interface InviteShareLink {
   displayText: string;
 }
 
+export interface GuardianInstruction {
+  /** Human-readable instruction text for the guardian. */
+  instruction: string;
+  /** Channel-specific handle to reach the assistant (e.g. "@botName", "+15551234567", "hello@domain.agentmail.to"). */
+  channelHandle?: string;
+}
+
 export interface ChannelInviteAdapter {
   /** The channel this adapter handles. */
   channel: ChannelId;
@@ -51,13 +58,14 @@ export interface ChannelInviteAdapter {
   }): string | undefined;
 
   /**
-   * Build guardian instruction text for this channel. Optional — falls
-   * back to generic instruction if not implemented.
+   * Build guardian instruction for this channel. Returns structured data
+   * with the instruction text and an optional channel-specific handle.
+   * Optional — falls back to generic instruction if not implemented.
    */
   buildGuardianInstruction?(params: {
     inviteCode: string;
     contactName?: string;
-  }): string;
+  }): GuardianInstruction;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/channel-invite-transports/sms.ts
+++ b/assistant/src/runtime/channel-invite-transports/sms.ts
@@ -11,7 +11,10 @@ import type { ChannelId } from "../../channels/types.js";
 import { getTwilioPhoneNumberEnv } from "../../config/env.js";
 import { loadRawConfig } from "../../config/loader.js";
 import { getSecureKey } from "../../security/secure-keys.js";
-import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
+import type {
+  ChannelInviteAdapter,
+  GuardianInstruction,
+} from "../channel-invite-transport.js";
 
 // ---------------------------------------------------------------------------
 // Phone number resolution
@@ -51,12 +54,17 @@ export const smsInviteAdapter: ChannelInviteAdapter = {
   buildGuardianInstruction(params: {
     inviteCode: string;
     contactName?: string;
-  }): string {
+  }): GuardianInstruction {
     const phoneNumber = resolveSmsPhoneNumber();
     const contactLabel = params.contactName || "the contact";
     if (!phoneNumber) {
-      return `Tell ${contactLabel} to text the assistant and provide the code ${params.inviteCode}.`;
+      return {
+        instruction: `Tell ${contactLabel} to text the assistant and provide the code ${params.inviteCode}.`,
+      };
     }
-    return `Tell ${contactLabel} to text ${phoneNumber} and provide the code ${params.inviteCode}.`;
+    return {
+      instruction: `Tell ${contactLabel} to text ${phoneNumber} and provide the code ${params.inviteCode}.`,
+      channelHandle: phoneNumber,
+    };
   },
 };

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -12,6 +12,7 @@ import type { ChannelId } from "../../channels/types.js";
 import { getCredentialMetadata } from "../../tools/credentials/metadata-store.js";
 import type {
   ChannelInviteAdapter,
+  GuardianInstruction,
   InviteShareLink,
 } from "../channel-invite-transport.js";
 
@@ -70,13 +71,18 @@ export const telegramInviteAdapter: ChannelInviteAdapter = {
   buildGuardianInstruction(params: {
     inviteCode: string;
     contactName?: string;
-  }): string {
+  }): GuardianInstruction {
     const botUsername = getTelegramBotUsername();
     const contactLabel = params.contactName || "the contact";
     if (!botUsername) {
-      return `Tell ${contactLabel} to message the assistant on Telegram and provide the code ${params.inviteCode}.`;
+      return {
+        instruction: `Tell ${contactLabel} to message the assistant on Telegram and provide the code ${params.inviteCode}.`,
+      };
     }
-    return `Tell ${contactLabel} to message @${botUsername} on Telegram and provide the code ${params.inviteCode}.`;
+    return {
+      instruction: `Tell ${contactLabel} to message @${botUsername} on Telegram and provide the code ${params.inviteCode}.`,
+      channelHandle: `@${botUsername}`,
+    };
   },
 
   extractInboundToken(params: {

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -60,6 +60,7 @@ export interface InviteResponseData {
   // Non-voice invite fields (present only for non-voice invites)
   inviteCode?: string;
   guardianInstruction?: string;
+  channelHandle?: string;
   createdAt: number;
 }
 
@@ -94,6 +95,7 @@ function inviteToResponse(
     voiceCode?: string;
     inviteCode?: string;
     guardianInstruction?: string;
+    channelHandle?: string;
   },
 ): InviteResponseData {
   const share = buildSharePayload(inv.sourceChannel, opts?.rawToken);
@@ -121,6 +123,7 @@ function inviteToResponse(
     ...(opts?.guardianInstruction
       ? { guardianInstruction: opts.guardianInstruction }
       : {}),
+    ...(opts?.channelHandle ? { channelHandle: opts.channelHandle } : {}),
     createdAt: inv.createdAt,
   };
 }
@@ -219,6 +222,7 @@ export function createIngressInvite(params: {
 
   // Build guardian instruction for non-voice invites
   let guardianInstruction: string | undefined;
+  let channelHandle: string | undefined;
   if (!isVoice && inviteCode) {
     const channelId = isChannelId(params.sourceChannel)
       ? params.sourceChannel
@@ -229,10 +233,14 @@ export function createIngressInvite(params: {
 
     if (adapter?.buildGuardianInstruction) {
       try {
-        guardianInstruction = adapter.buildGuardianInstruction({
+        const adapterResult = adapter.buildGuardianInstruction({
           inviteCode,
           contactName: params.contactName,
         });
+        if (adapterResult) {
+          guardianInstruction = adapterResult.instruction;
+          channelHandle = adapterResult.channelHandle;
+        }
       } catch {
         // Fall through to generic instruction if adapter fails
       }
@@ -254,6 +262,7 @@ export function createIngressInvite(params: {
       voiceCode,
       inviteCode,
       guardianInstruction,
+      channelHandle,
     }),
   };
 }


### PR DESCRIPTION
## Summary
- Changed `buildGuardianInstruction` return type from `string` to `GuardianInstruction` (`{ instruction, channelHandle? }`)
- Updated Telegram adapter to return `channelHandle: "@botUsername"` and SMS adapter to return `channelHandle: phoneNumber`
- Added `channelHandle` field to `InviteResponseData` so it flows through the API response

Part of plan: channel-contact-info-invite-links.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
