### PR TITLE
feat: add email channel invite adapter with stubbed address resolution

### DIFF
--- a/assistant/src/runtime/channel-invite-transport.ts
+++ b/assistant/src/runtime/channel-invite-transport.ts
@@ -119,6 +119,7 @@ export class InviteAdapterRegistry {
 // Singleton registry + backward-compatible free functions
 // ---------------------------------------------------------------------------
 
+import { emailInviteAdapter } from "./channel-invite-transports/email.js";
 import { smsInviteAdapter } from "./channel-invite-transports/sms.js";
 import { telegramInviteAdapter } from "./channel-invite-transports/telegram.js";
 import { voiceInviteAdapter } from "./channel-invite-transports/voice.js";
@@ -126,6 +127,7 @@ import { voiceInviteAdapter } from "./channel-invite-transports/voice.js";
 /** Create a registry instance with built-in adapters registered. */
 export function createInviteAdapterRegistry(): InviteAdapterRegistry {
   const registry = new InviteAdapterRegistry();
+  registry.register(emailInviteAdapter);
   registry.register(smsInviteAdapter);
   registry.register(telegramInviteAdapter);
   registry.register(voiceInviteAdapter);

--- a/assistant/src/runtime/channel-invite-transports/email.ts
+++ b/assistant/src/runtime/channel-invite-transports/email.ts
@@ -1,0 +1,50 @@
+/**
+ * Email channel invite adapter.
+ *
+ * Provides guardian instruction text for email-based invites. Email invites
+ * use the universal 6-digit code path for redemption, so this adapter only
+ * implements `buildGuardianInstruction` — no `buildShareLink` or
+ * `extractInboundToken` needed.
+ */
+
+import type {
+  ChannelInviteAdapter,
+  GuardianInstruction,
+} from "../channel-invite-transport.js";
+
+// ---------------------------------------------------------------------------
+// Email address resolution
+// ---------------------------------------------------------------------------
+
+// TODO: resolve from AgentMail provider (async — needs caching or pre-resolution)
+// The real implementation requires async inbox lookup via
+// `getActiveEmailProvider().health()` which doesn't fit the sync adapter
+// interface.
+function resolveAssistantEmailAddress(): string | undefined {
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter implementation
+// ---------------------------------------------------------------------------
+
+export const emailInviteAdapter: ChannelInviteAdapter = {
+  channel: "email",
+
+  buildGuardianInstruction(params: {
+    inviteCode: string;
+    contactName?: string;
+  }): GuardianInstruction {
+    const address = resolveAssistantEmailAddress();
+    const contactLabel = params.contactName || "the contact";
+    if (!address) {
+      return {
+        instruction: `Tell ${contactLabel} to email the assistant and include the code ${params.inviteCode} in the message.`,
+      };
+    }
+    return {
+      instruction: `Tell ${contactLabel} to email ${address} and include the code ${params.inviteCode} in the message.`,
+      channelHandle: address,
+    };
+  },
+};


### PR DESCRIPTION
## Summary
- Added email invite adapter at `assistant/src/runtime/channel-invite-transports/email.ts`
- Address resolution stubbed with TODO — real impl requires async AgentMail provider lookup
- Registered adapter in the default invite adapter registry

Part of plan: channel-contact-info-invite-links.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
