### PR TITLE
feat: add Slack channel invite adapter with bot username resolution

### DIFF
--- a/assistant/src/runtime/channel-invite-transport.ts
+++ b/assistant/src/runtime/channel-invite-transport.ts
@@ -120,6 +120,7 @@ export class InviteAdapterRegistry {
 // ---------------------------------------------------------------------------
 
 import { emailInviteAdapter } from "./channel-invite-transports/email.js";
+import { slackInviteAdapter } from "./channel-invite-transports/slack.js";
 import { smsInviteAdapter } from "./channel-invite-transports/sms.js";
 import { telegramInviteAdapter } from "./channel-invite-transports/telegram.js";
 import { voiceInviteAdapter } from "./channel-invite-transports/voice.js";
@@ -128,6 +129,7 @@ import { voiceInviteAdapter } from "./channel-invite-transports/voice.js";
 export function createInviteAdapterRegistry(): InviteAdapterRegistry {
   const registry = new InviteAdapterRegistry();
   registry.register(emailInviteAdapter);
+  registry.register(slackInviteAdapter);
   registry.register(smsInviteAdapter);
   registry.register(telegramInviteAdapter);
   registry.register(voiceInviteAdapter);

--- a/assistant/src/runtime/channel-invite-transports/slack.ts
+++ b/assistant/src/runtime/channel-invite-transports/slack.ts
@@ -1,0 +1,81 @@
+/**
+ * Slack channel invite adapter.
+ *
+ * Provides guardian instruction text that includes the assistant's Slack
+ * bot @username and workspace name when available. Slack invites use the
+ * universal 6-digit code path for redemption, so this adapter only
+ * implements `buildGuardianInstruction` — no `buildShareLink` or
+ * `extractInboundToken` needed.
+ */
+
+import type { ChannelId } from "../../channels/types.js";
+import { getCredentialMetadata } from "../../tools/credentials/metadata-store.js";
+import type {
+  ChannelInviteAdapter,
+  GuardianInstruction,
+} from "../channel-invite-transport.js";
+
+// ---------------------------------------------------------------------------
+// Slack bot info resolution
+// ---------------------------------------------------------------------------
+
+interface SlackBotInfo {
+  botUsername: string;
+  teamName?: string;
+}
+
+/**
+ * Resolve the Slack bot username and team name from credential metadata.
+ * Mirrors the metadata parsing pattern in `config-slack-channel.ts`.
+ */
+function resolveSlackBotInfo(): SlackBotInfo | undefined {
+  const meta = getCredentialMetadata("slack_channel", "bot_token");
+  if (!meta?.accountInfo) return undefined;
+
+  try {
+    const parsed = JSON.parse(meta.accountInfo) as {
+      botUsername?: string;
+      teamName?: string;
+    };
+    if (!parsed.botUsername) return undefined;
+    return {
+      botUsername: parsed.botUsername,
+      teamName: parsed.teamName,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Adapter implementation
+// ---------------------------------------------------------------------------
+
+export const slackInviteAdapter: ChannelInviteAdapter = {
+  channel: "slack" as ChannelId,
+
+  buildGuardianInstruction(params: {
+    inviteCode: string;
+    contactName?: string;
+  }): GuardianInstruction {
+    const botInfo = resolveSlackBotInfo();
+    const contactLabel = params.contactName || "the contact";
+
+    if (!botInfo) {
+      return {
+        instruction: `Tell ${contactLabel} to message the assistant on Slack and provide the code ${params.inviteCode}.`,
+      };
+    }
+
+    let instruction = `Tell ${contactLabel} to message @${botInfo.botUsername} on Slack and provide the code ${params.inviteCode}`;
+    if (botInfo.teamName) {
+      instruction += ` (workspace: ${botInfo.teamName})`;
+    }
+    instruction += ".";
+
+    return {
+      instruction,
+      channelHandle: `@${botInfo.botUsername}`,
+    };
+  },
+};


### PR DESCRIPTION
## Summary
- Added Slack invite adapter at `assistant/src/runtime/channel-invite-transports/slack.ts`
- Resolves bot username and team name from credential metadata (same pattern as config-slack-channel.ts)
- Returns `channelHandle: "@botUsername"` when Slack is configured
- Registered adapter in the default invite adapter registry

Part of plan: channel-contact-info-invite-links.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
