### PR TITLE
fix(macos): remove SwiftUI zoom CommandGroup that shadows NSMenuItem shortcuts

### DIFF
--- a/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
+++ b/clients/macos/vellum-assistant-app/VellumAssistantApp.swift
@@ -27,45 +27,6 @@ struct VellumAssistantApp: App {
                 }
                 .keyboardShortcut(",", modifiers: .command)
             }
-
-            // Define zoom commands through SwiftUI's command system so they are
-            // consistently attached to the native View menu lifecycle.
-            CommandGroup(before: .windowSize) {
-                Button("Conversation Zoom In") {
-                    appDelegate.handleConversationZoomIn()
-                }
-                .keyboardShortcut("+", modifiers: .command)
-                .disabled(!appDelegate.isConversationZoomEnabled)
-
-                Button("Conversation Zoom Out") {
-                    appDelegate.handleConversationZoomOut()
-                }
-                .keyboardShortcut("-", modifiers: .command)
-                .disabled(!appDelegate.isConversationZoomEnabled)
-
-                Button("Conversation Actual Size") {
-                    appDelegate.handleConversationZoomReset()
-                }
-                .keyboardShortcut("0", modifiers: .command)
-                .disabled(!appDelegate.isConversationZoomEnabled)
-
-                Divider()
-
-                Button("Window Zoom In") {
-                    appDelegate.handleWindowZoomIn()
-                }
-                .keyboardShortcut("+", modifiers: [.command, .option])
-
-                Button("Window Zoom Out") {
-                    appDelegate.handleWindowZoomOut()
-                }
-                .keyboardShortcut("-", modifiers: [.command, .option])
-
-                Button("Window Actual Size") {
-                    appDelegate.handleWindowZoomReset()
-                }
-                .keyboardShortcut("0", modifiers: [.command, .option])
-            }
         }
     }
 }

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -97,11 +97,9 @@ extension AppDelegate {
 
             mainWindow?.close()
             mainWindow = nil
-            conversationZoomEnabledCancellable = nil
             conversationBadgeCancellable?.cancel()
             conversationBadgeCancellable = nil
             NSApp.dockTile.badgeLabel = nil
-            isConversationZoomEnabled = false
 
             if let hotKeyMonitor {
                 NSEvent.removeMonitor(hotKeyMonitor)
@@ -289,11 +287,9 @@ extension AppDelegate {
 
         mainWindow?.close()
         mainWindow = nil
-        conversationZoomEnabledCancellable = nil
         conversationBadgeCancellable?.cancel()
         conversationBadgeCancellable = nil
         NSApp.dockTile.badgeLabel = nil
-        isConversationZoomEnabled = false
 
         if let hotKeyMonitor {
             NSEvent.removeMonitor(hotKeyMonitor)

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -367,30 +367,9 @@ extension AppDelegate {
             )
         }
         mainWindow = main
-        observeConversationZoomEnabled(main.windowState)
         observeAssistantStatus()
         observeConversationBadge(main.threadManager)
         return main
-    }
-
-    /// Subscribe to `MainWindowState` changes and keep `isConversationZoomEnabled`
-    /// in sync so SwiftUI command groups can observe it via `@Published`.
-    func observeConversationZoomEnabled(_ windowState: MainWindowState) {
-        conversationZoomEnabledCancellable = windowState.objectWillChange
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self, weak windowState] _ in
-                guard let self, let windowState else { return }
-                // objectWillChange fires before the new value is set,
-                // so defer the read to the next run-loop tick.
-                DispatchQueue.main.async {
-                    let enabled = windowState.isConversationVisible
-                    if self.isConversationZoomEnabled != enabled {
-                        self.isConversationZoomEnabled = enabled
-                    }
-                }
-            }
-        // Set initial value.
-        isConversationZoomEnabled = windowState.isConversationVisible
     }
 
     func showMainWindow(initialMessage: String? = nil, isFirstLaunch: Bool = false) {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -94,11 +94,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var statusIconCancellable: AnyCancellable?
     var connectionStatusCancellable: AnyCancellable?
     var quickInputAttachmentCancellable: AnyCancellable?
-    var conversationZoomEnabledCancellable: AnyCancellable?
     var conversationBadgeCancellable: AnyCancellable?
-    /// Observable state for SwiftUI command group `.disabled()` modifiers.
-    /// Updated via Combine subscription to `MainWindowState.objectWillChange`.
-    @Published public var isConversationZoomEnabled: Bool = false
     var pulseTimer: Timer?
     var pulsePhase: CGFloat = 1.0
     var pulseDirection: CGFloat = -1.0


### PR DESCRIPTION
## Summary
- Zoom shortcuts (Cmd+/-, Cmd+0) were broken because SwiftUI CommandGroup registered the same shortcuts as NSMenuItems but with a .disabled() modifier that never updated (Scene body doesn't re-evaluate on @Published changes)
- Removed the SwiftUI zoom CommandGroup from VellumAssistantApp.swift and all related plumbing (isConversationZoomEnabled, observeConversationZoomEnabled)
- The existing NSMenuItem approach in setupViewMenu() handles everything correctly via validateMenuItem()

## Original prompt
Our keyboard shortcuts to zoom in/out on mac seem to have regressed and no longer work. Can you help me track down the root cause and fix?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
