### PR TITLE
feat: show invite links prominently and display channel handle in Contacts UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -28,7 +28,8 @@ struct ContactDetailView: View {
         token: String,
         shareUrl: String?,
         inviteCode: String?,
-        guardianInstruction: String?
+        guardianInstruction: String?,
+        channelHandle: String?
     )?
     @State private var inviteError: String?
     @State private var inviteCopiedType: String?
@@ -377,6 +378,48 @@ struct ContactDetailView: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
+                if let channelHandle = result.channelHandle {
+                    Text(channelHandle)
+                        .font(VFont.monoSmall)
+                        .foregroundColor(VColor.textMuted)
+                }
+
+                // When a share URL is available, show it prominently above the code
+                if let shareUrl = result.shareUrl {
+                    HStack(spacing: VSpacing.sm) {
+                        let truncated = shareUrl.count > 30
+                            ? String(shareUrl.prefix(30)) + "..."
+                            : shareUrl
+                        Text(truncated)
+                            .font(VFont.monoSmall)
+                            .foregroundColor(VColor.textSecondary)
+
+                        VButton(
+                            label: inviteCopiedType == "\(type)-link" ? "Copied!" : "Copy Link",
+                            icon: "doc.on.doc",
+                            style: .secondary,
+                            size: .medium
+                        ) {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(shareUrl, forType: .string)
+                            inviteCopiedType = "\(type)-link"
+                            Task {
+                                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                                guard !Task.isCancelled else { return }
+                                if inviteCopiedType == "\(type)-link" {
+                                    inviteCopiedType = nil
+                                }
+                            }
+                        }
+                    }
+
+                    Divider().background(VColor.divider)
+
+                    Text("Or use this code:")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+
                 // Large monospaced invite code for readability
                 Text(inviteCode)
                     .font(VFont.inviteCode)
@@ -387,7 +430,7 @@ struct ContactDetailView: View {
                 VButton(
                     label: inviteCopiedType == type ? "Copied!" : "Copy Code",
                     icon: "doc.on.doc",
-                    style: .secondary,
+                    style: result.shareUrl != nil ? .tertiary : .secondary,
                     size: .medium
                 ) {
                     NSPasteboard.general.clearContents()
@@ -398,44 +441,6 @@ struct ContactDetailView: View {
                         guard !Task.isCancelled else { return }
                         if inviteCopiedType == type {
                             inviteCopiedType = nil
-                        }
-                    }
-                }
-
-                // Show share URL as secondary option when available (e.g. Telegram deep link)
-                if let shareUrl = result.shareUrl {
-                    Divider().background(VColor.divider)
-
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        Text("Or share this link:")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-
-                        HStack(spacing: VSpacing.sm) {
-                            let truncated = shareUrl.count > 30
-                                ? String(shareUrl.prefix(30)) + "..."
-                                : shareUrl
-                            Text(truncated)
-                                .font(VFont.monoSmall)
-                                .foregroundColor(VColor.textSecondary)
-
-                            VButton(
-                                label: inviteCopiedType == "\(type)-link" ? "Copied!" : "Copy Link",
-                                icon: "doc.on.doc",
-                                style: .tertiary,
-                                size: .medium
-                            ) {
-                                NSPasteboard.general.clearContents()
-                                NSPasteboard.general.setString(shareUrl, forType: .string)
-                                inviteCopiedType = "\(type)-link"
-                                Task {
-                                    try? await Task.sleep(nanoseconds: 2_000_000_000)
-                                    guard !Task.isCancelled else { return }
-                                    if inviteCopiedType == "\(type)-link" {
-                                        inviteCopiedType = nil
-                                    }
-                                }
-                            }
                         }
                     }
                 }
@@ -769,7 +774,8 @@ struct ContactDetailView: View {
                         token: result.token,
                         shareUrl: result.shareUrl,
                         inviteCode: result.inviteCode,
-                        guardianInstruction: result.guardianInstruction
+                        guardianInstruction: result.guardianInstruction,
+                        channelHandle: result.channelHandle
                     )
                 } else {
                     inviteError = "Failed to create invite"

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1653,7 +1653,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         note: String? = nil,
         maxUses: Int? = nil,
         contactName: String? = nil
-    ) async throws -> (inviteId: String, token: String, shareUrl: String?, inviteCode: String?, guardianInstruction: String?)? {
+    ) async throws -> (inviteId: String, token: String, shareUrl: String?, inviteCode: String?, guardianInstruction: String?, channelHandle: String?)? {
         if let httpTransport {
             return try await httpTransport.createInvite(sourceChannel: sourceChannel, note: note, maxUses: maxUses, contactName: contactName)
         }
@@ -1682,6 +1682,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                 let share: ShareData?
                 let inviteCode: String?
                 let guardianInstruction: String?
+                let channelHandle: String?
             }
             struct ShareData: Decodable {
                 let url: String
@@ -1690,7 +1691,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
         let decoded = try JSONDecoder().decode(CreateInviteResponse.self, from: data)
         guard let invite = decoded.invite, let token = invite.token else { return nil }
-        return (inviteId: invite.id, token: token, shareUrl: invite.share?.url, inviteCode: invite.inviteCode, guardianInstruction: invite.guardianInstruction)
+        return (inviteId: invite.id, token: token, shareUrl: invite.share?.url, inviteCode: invite.inviteCode, guardianInstruction: invite.guardianInstruction, channelHandle: invite.channelHandle)
         #else
         return nil
         #endif

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1126,6 +1126,7 @@ public final class HTTPTransport {
             let status: String
             let inviteCode: String?
             let guardianInstruction: String?
+            let channelHandle: String?
         }
         struct SharePayload: Decodable {
             let url: String
@@ -1235,7 +1236,7 @@ public final class HTTPTransport {
         maxUses: Int? = nil,
         contactName: String? = nil,
         isRetry: Bool = false
-    ) async throws -> (inviteId: String, token: String, shareUrl: String?, inviteCode: String?, guardianInstruction: String?)? {
+    ) async throws -> (inviteId: String, token: String, shareUrl: String?, inviteCode: String?, guardianInstruction: String?, channelHandle: String?)? {
         guard let url = buildURL(for: .contactsInvitesCreate) else { return nil }
 
         var request = URLRequest(url: url)
@@ -1264,7 +1265,7 @@ public final class HTTPTransport {
 
         let decoded = try decoder.decode(HTTPCreateInviteResponse.self, from: data)
         guard let invite = decoded.invite, let token = invite.token else { return nil }
-        return (inviteId: invite.id, token: token, shareUrl: invite.share?.url, inviteCode: invite.inviteCode, guardianInstruction: invite.guardianInstruction)
+        return (inviteId: invite.id, token: token, shareUrl: invite.share?.url, inviteCode: invite.inviteCode, guardianInstruction: invite.guardianInstruction, channelHandle: invite.channelHandle)
     }
 
     // MARK: - Channel Readiness


### PR DESCRIPTION
## Summary
- Updated DaemonClient and HTTPDaemonClient to pass `channelHandle` from invite responses
- Restructured invite display in ContactDetailView to show invite links above codes when available
- Added channel handle display (phone number, bot username, email) below instruction text

Part of plan: channel-contact-info-invite-links.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
