### PR TITLE
fix: enable text selection during streaming

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -327,7 +327,6 @@ struct ChatBubble: View {
                     if hasRichContent {
                         MarkdownSegmentView(
                             segments: segments,
-                            isStreaming: message.isStreaming,
                             maxContentWidth: nil,
                             textColor: isUser ? VColor.userBubbleText : VColor.textPrimary,
                             secondaryTextColor: isUser ? VColor.userBubbleTextSecondary : VColor.textSecondary,
@@ -343,7 +342,7 @@ struct ChatBubble: View {
                             .lineSpacing(6)
                             .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
                             .tint(isUser ? VColor.userBubbleText : VColor.accent)
-                            .selectableText(true)
+                            .textSelection(.enabled)
                             // For assistant messages, fill available width for readability.
                             // For user messages, let the bubble shrink-wrap to text width.
                             .frame(maxWidth: isUser ? nil : .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -343,7 +343,7 @@ struct ChatBubble: View {
                             .lineSpacing(6)
                             .foregroundColor(isUser ? VColor.userBubbleText : VColor.textPrimary)
                             .tint(isUser ? VColor.userBubbleText : VColor.accent)
-                            .selectableText(!message.isStreaming)
+                            .selectableText(true)
                             // For assistant messages, fill available width for readability.
                             // For user messages, let the bubble shrink-wrap to text width.
                             .frame(maxWidth: isUser ? nil : .infinity, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -18,7 +18,7 @@ extension ChatBubble {
 
         bubbleChrome {
             if hasRichContent {
-                MarkdownSegmentView(segments: segments, isStreaming: streaming)
+                MarkdownSegmentView(segments: segments)
             } else {
                 let attributed = Self.cachedInlineMarkdown(for: segmentText, isStreaming: streaming)
                 Text(attributed)
@@ -26,7 +26,7 @@ extension ChatBubble {
                     .lineSpacing(6)
                     .foregroundColor(VColor.textPrimary)
                     .tint(VColor.accent)
-                    .selectableText(true)
+                    .textSelection(.enabled)
                     // Bound width before fixedSize so vertical measurement is
                     // computed within a finite horizontal space, preventing
                     // unbounded layout passes on long messages during scroll.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -26,7 +26,7 @@ extension ChatBubble {
                     .lineSpacing(6)
                     .foregroundColor(VColor.textPrimary)
                     .tint(VColor.accent)
-                    .selectableText(!streaming)
+                    .selectableText(true)
                     // Bound width before fixedSize so vertical measurement is
                     // computed within a finite horizontal space, preventing
                     // unbounded layout passes on long messages during scroll.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -260,7 +260,6 @@ struct MarkdownTableView: View {
     let headers: [String]
     let rows: [[String]]
     var maxWidth: CGFloat = 520
-    var isStreaming: Bool = false
 
     @Environment(\.conversationZoomScale) private var zoomScale
 
@@ -275,7 +274,7 @@ struct MarkdownTableView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.sm)
-                        .selectableText(true)
+                        .textSelection(.enabled)
                 }
             }
 
@@ -314,6 +313,6 @@ struct MarkdownTableView: View {
         return Text(attributed)
             .font(.custom("Inter", size: 13 * zoomScale))
             .foregroundColor(VColor.textPrimary)
-            .selectableText(true)
+            .textSelection(.enabled)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -275,7 +275,7 @@ struct MarkdownTableView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, VSpacing.sm)
                         .padding(.vertical, VSpacing.sm)
-                        .selectableText(!isStreaming)
+                        .selectableText(true)
                 }
             }
 
@@ -314,6 +314,6 @@ struct MarkdownTableView: View {
         return Text(attributed)
             .font(.custom("Inter", size: 13 * zoomScale))
             .foregroundColor(VColor.textPrimary)
-            .selectableText(!isStreaming)
+            .selectableText(true)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -7,7 +7,6 @@ import VellumAssistantShared
 /// unified Text views so that text selection can span across paragraphs.
 struct MarkdownSegmentView: View {
     let segments: [MarkdownSegment]
-    var isStreaming: Bool = false
     var maxContentWidth: CGFloat? = 520
     var textColor: Color = VColor.textPrimary
     var secondaryTextColor: Color = VColor.textSecondary
@@ -33,7 +32,7 @@ struct MarkdownSegmentView: View {
                         .lineSpacing(4)
                         .foregroundColor(textColor)
                         .tint(tintColor)
-                        .selectableText(true)
+                        .textSelection(.enabled)
                         // Bound horizontal space BEFORE fixedSize so SwiftUI can wrap text
                         // within a finite width rather than measuring against an unconstrained
                         // parent, which causes O(N²) layout passes and stack overflows on
@@ -51,7 +50,7 @@ struct MarkdownSegmentView: View {
                     Text(headingText)
                         .font(headingFont)
                         .foregroundColor(textColor)
-                        .selectableText(true)
+                        .textSelection(.enabled)
                         // Frame before fixedSize so the heading wraps within a known width.
                         .frame(maxWidth: maxContentWidth ?? .infinity, alignment: .leading)
                         .fixedSize(horizontal: false, vertical: true)
@@ -83,7 +82,7 @@ struct MarkdownSegmentView: View {
                                     .fixedSize(horizontal: false, vertical: true)
                             }
                             .padding(.leading, leftPad)
-                            .selectableText(true)
+                            .textSelection(.enabled)
                         }
                     }
                     .frame(maxWidth: maxContentWidth ?? .infinity, alignment: .leading)
@@ -101,7 +100,7 @@ struct MarkdownSegmentView: View {
                             Text(code)
                                 .font(.custom("DMMono-Regular", size: 13 * zoomScale))
                                 .foregroundColor(textColor)
-                                .selectableText(true)
+                                .textSelection(.enabled)
                                 .fixedSize(horizontal: true, vertical: true)
                                 .padding(VSpacing.sm)
                         }
@@ -111,7 +110,7 @@ struct MarkdownSegmentView: View {
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
 
                 case .table(let headers, let rows):
-                    MarkdownTableView(headers: headers, rows: rows, maxWidth: maxContentWidth ?? .infinity, isStreaming: isStreaming)
+                    MarkdownTableView(headers: headers, rows: rows, maxWidth: maxContentWidth ?? .infinity)
 
                 case .image(let alt, let url):
                     AnimatedImageView(urlString: url)
@@ -365,21 +364,6 @@ struct MarkdownSegmentView: View {
         }
 
         return result
-    }
-}
-
-// MARK: - Conditional text selection
-
-extension View {
-    /// Wraps `.textSelection(.enabled)` / `.textSelection(.disabled)` behind a
-    /// `@ViewBuilder` branch so the compiler doesn't try to unify the two
-    /// distinct `TextSelectability` conformances in a single ternary expression.
-    @ViewBuilder func selectableText(_ enabled: Bool) -> some View {
-        if enabled {
-            self.textSelection(.enabled)
-        } else {
-            self.textSelection(.disabled)
-        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -33,7 +33,7 @@ struct MarkdownSegmentView: View {
                         .lineSpacing(4)
                         .foregroundColor(textColor)
                         .tint(tintColor)
-                        .selectableText(!isStreaming)
+                        .selectableText(true)
                         // Bound horizontal space BEFORE fixedSize so SwiftUI can wrap text
                         // within a finite width rather than measuring against an unconstrained
                         // parent, which causes O(N²) layout passes and stack overflows on
@@ -51,7 +51,7 @@ struct MarkdownSegmentView: View {
                     Text(headingText)
                         .font(headingFont)
                         .foregroundColor(textColor)
-                        .selectableText(!isStreaming)
+                        .selectableText(true)
                         // Frame before fixedSize so the heading wraps within a known width.
                         .frame(maxWidth: maxContentWidth ?? .infinity, alignment: .leading)
                         .fixedSize(horizontal: false, vertical: true)
@@ -83,7 +83,7 @@ struct MarkdownSegmentView: View {
                                     .fixedSize(horizontal: false, vertical: true)
                             }
                             .padding(.leading, leftPad)
-                            .selectableText(!isStreaming)
+                            .selectableText(true)
                         }
                     }
                     .frame(maxWidth: maxContentWidth ?? .infinity, alignment: .leading)
@@ -101,7 +101,7 @@ struct MarkdownSegmentView: View {
                             Text(code)
                                 .font(.custom("DMMono-Regular", size: 13 * zoomScale))
                                 .foregroundColor(textColor)
-                                .selectableText(!isStreaming)
+                                .selectableText(true)
                                 .fixedSize(horizontal: true, vertical: true)
                                 .padding(VSpacing.sm)
                         }


### PR DESCRIPTION
## Summary
- Remove `!isStreaming` / `!streaming` guards from `selectableText()` calls in ChatBubble, ChatBubbleTextContent, and MarkdownSegmentView
- Text selection is now always enabled, allowing users to select text while the assistant is still streaming
- No visual changes (same layout, spacing, colors, typography)

## Files changed
- `clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift`
- `clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift`
- `clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift`

## Test plan
- [ ] Start a conversation and verify text can be selected while the assistant is streaming
- [ ] Verify text selection still works after streaming completes
- [ ] Verify no visual regressions (layout, spacing, colors, typography unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
