### PR TITLE
feat: coalesce adjacent text segments in interleaved rendering

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -25,7 +25,7 @@ extension ChatBubble {
     /// array offset, which avoids spurious view invalidation when the array is
     /// recreated with identical values on each render pass.
     enum ContentGroup: Hashable {
-        case text(Int)
+        case texts([Int])
         case toolCalls([Int])
         case surface(Int)
     }
@@ -35,7 +35,11 @@ extension ChatBubble {
         for ref in message.contentOrder {
             switch ref {
             case .text(let i):
-                groups.append(.text(i))
+                if case .texts(let indices) = groups.last {
+                    groups[groups.count - 1] = .texts(indices + [i])
+                } else {
+                    groups.append(.texts([i]))
+                }
             case .toolCall(let i):
                 if case .toolCalls(let indices) = groups.last {
                     groups[groups.count - 1] = .toolCalls(indices + [i])
@@ -60,12 +64,17 @@ extension ChatBubble {
         // conversations with many interleaved blocks.
         ForEach(groups, id: \.self) { group in
             switch group {
-            case .text(let i):
-                if i < message.textSegments.count {
-                    let segmentText = message.textSegments[i].trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !segmentText.isEmpty {
-                        textBubble(for: segmentText)
+            case .texts(let indices):
+                let joined = indices
+                    .compactMap { i in
+                        i < message.textSegments.count
+                            ? message.textSegments[i].trimmingCharacters(in: .whitespacesAndNewlines)
+                            : nil
                     }
+                    .filter { !$0.isEmpty }
+                    .joined(separator: "\n")
+                if !joined.isEmpty {
+                    textBubble(for: joined)
                 }
             case .toolCalls:
                 // Tool calls are rendered by trailingStatus below the message

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1914,6 +1914,55 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertEqual(msg.contentOrder, [.toolCall(0), .text(0)])
     }
 
+    // MARK: - Adjacent Text Segment Coalescing
+
+    func testMultipleAssistantDeltasWithNoToolBoundariesRemainOneTextSegment() {
+        // Multiple assistant text deltas without any tool calls between them
+        // should all accumulate into a single text segment.
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Hello ")))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "from ")))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "the assistant.")))
+        // Flush buffered streaming text so assertions can inspect messages.
+        viewModel.flushStreamingBuffer()
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.textSegments, ["Hello from the assistant."])
+        XCTAssertEqual(msg.contentOrder, [.text(0)])
+    }
+
+    func testTextToolTextCreatesSeparateTextSegments() {
+        // Text delta → tool call start (flushes automatically) + result → more text delta
+        // should produce separate text segments with interleaved content order.
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Let me check.")))
+        viewModel.handleServerMessage(.toolUseStart(ToolUseStartMessage(type: "tool_use_start", toolName: "bash", input: ["command": AnyCodable("ls")], sessionId: nil)))
+        viewModel.handleServerMessage(.toolResult(ToolResultMessage(type: "tool_result", toolName: "bash", result: "file.txt", isError: nil, diff: nil, status: nil, sessionId: nil, imageData: nil)))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Here are the files.")))
+        // Flush the second text delta so it lands in messages.
+        viewModel.flushStreamingBuffer()
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.textSegments.count, 2)
+        XCTAssertEqual(msg.textSegments[0], "Let me check.")
+        XCTAssertEqual(msg.textSegments[1], "Here are the files.")
+        XCTAssertEqual(msg.contentOrder, [.text(0), .toolCall(0), .text(1)])
+    }
+
+    func testStreamingCompletionPreservesFinalJoinedText() {
+        // Streaming deltas followed by message_complete should preserve the
+        // full joined text in the message's .text property.
+        // message_complete calls flushStreamingBuffer() internally.
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Part one. ")))
+        viewModel.handleServerMessage(.assistantTextDelta(AssistantTextDeltaMessage(text: "Part two.")))
+        viewModel.handleServerMessage(.messageComplete(MessageCompleteMessage()))
+
+        XCTAssertEqual(viewModel.messages.count, 1)
+        let msg = viewModel.messages[0]
+        XCTAssertEqual(msg.text, "Part one. Part two.")
+        XCTAssertEqual(msg.textSegments, ["Part one. Part two."])
+    }
+
     // MARK: - Retry Button Visibility (Send-Only Errors)
 
     func testIsRetryableErrorRequiresSendFailure() {


### PR DESCRIPTION
## Summary

- Replace `ContentGroup.text(Int)` with `ContentGroup.texts([Int])` in `ChatBubbleInterleavedContent.swift` to merge consecutive text segments into a single text bubble
- Update `groupContentBlocks()` to coalesce adjacent `.text(Int)` content order entries into `.texts([Int])` groups
- Join coalesced text segments with newlines when rendering, producing one `textBubble(for:)` call per contiguous text run
- Add 3 tests: multiple deltas without tool boundaries stay in one segment, text-tool-text creates separate segments, streaming completion preserves joined text

## Test plan

- [x] `swift build` passes
- [x] New tests pass: `testMultipleAssistantDeltasWithNoToolBoundariesRemainOneTextSegment`, `testTextToolTextCreatesSeparateTextSegments`, `testStreamingCompletionPreservesFinalJoinedText`
- [ ] Manual: verify interleaved messages render text as contiguous selectable blocks between tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
