### PR TITLE
fix: fallback to post-send read for baseline window count when pre-send probe fails

### DIFF
--- a/playwright/agent/tools/send-chat-message.ts
+++ b/playwright/agent/tools/send-chat-message.ts
@@ -132,6 +132,7 @@ end tell
 `;
   const countPath = `/tmp/pw-agent-count-win-w${context.workerIndex}.scpt`;
   let baselineWindowCount = 1;
+  let preSendProbeSucceeded = false;
   try {
     writeFileSync(countPath, countScript, "utf-8");
     const raw = execSync(`osascript ${countPath}`, {
@@ -141,6 +142,7 @@ end tell
     const parsed = parseInt(raw, 10);
     if (!Number.isNaN(parsed)) {
       baselineWindowCount = parsed;
+      preSendProbeSucceeded = true;
     }
   } catch {} finally {
     try { unlinkSync(countPath); } catch {}
@@ -217,7 +219,9 @@ end tell
   let lastOutput = "";
 
   try {
-    // Initial read to get baseline content (window count baseline already captured pre-send)
+    // Initial read to get baseline content. If the pre-send window count
+    // probe failed, fall back to parsing WINDOWS:<n> from this first read
+    // so we don't default to 1 and falsely detect popups in multi-window apps.
     writeFileSync(readPath, readScript, "utf-8");
     let baseline = "";
     let anyReadSucceeded = false;
@@ -227,6 +231,16 @@ end tell
         timeout: 15_000,
       }).trim();
       anyReadSucceeded = true;
+
+      if (!preSendProbeSucceeded) {
+        const baselineWindowMatch = baseline.match(/^WINDOWS:(\d+)/);
+        if (baselineWindowMatch) {
+          const parsed = parseInt(baselineWindowMatch[1], 10);
+          if (!Number.isNaN(parsed)) {
+            baselineWindowCount = parsed;
+          }
+        }
+      }
     } catch {}
 
     // Poll for changes


### PR DESCRIPTION
Address review feedback from PR #12999:\n- Restore WINDOWS:<n> parsing from the first post-send read as a fallback when the pre-send probe fails\n- Prevents false popup detection in multi-window states caused by transient osascript failures
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
