### PR TITLE
fix: skip no-op saves in response expectation editor

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -698,6 +698,12 @@ struct ContactDetailView: View {
         guard !trimmedName.isEmpty else { return }
         let trimmedNotes = editedNotes.trimmingCharacters(in: .whitespacesAndNewlines)
 
+        let originalNotes = displayContact.notes ?? ""
+        if trimmedName == displayContact.displayName && trimmedNotes == originalNotes {
+            isEditing = false
+            return
+        }
+
         isSaving = true
         errorMessage = nil
         do {


### PR DESCRIPTION
Address review feedback from PR #12721:
- Track original response expectation value when entering edit mode
- Compare before saving and skip if unchanged to avoid unnecessary writes and stale-name overwrites
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13024" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
