### PR TITLE
fix: wire migration 134 into db-init and drop dependent index before column

### DIFF
--- a/assistant/src/memory/migrations/134-contacts-notes-column.ts
+++ b/assistant/src/memory/migrations/134-contacts-notes-column.ts
@@ -1,68 +1,87 @@
 import { getLogger } from "../../util/logger.js";
 import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
 
 const log = getLogger("migration-134");
 
 export function migrateContactsNotesColumn(database: DrizzleDb): void {
-  const raw = getSqliteFrom(database);
+  withCrashRecovery(database, "migration_contacts_notes_column_v1", () => {
+    const raw = getSqliteFrom(database);
 
-  try {
-    raw.exec(/*sql*/ `ALTER TABLE contacts ADD COLUMN notes TEXT`);
-  } catch {
-    /* already exists */
-  }
+    try {
+      raw.exec(/*sql*/ `ALTER TABLE contacts ADD COLUMN notes TEXT`);
+    } catch {
+      /* already exists */
+    }
 
-  // Check if legacy columns still exist before attempting backfill + drop
-  const cols = new Set(
-    (
-      raw.query(`PRAGMA table_info(contacts)`).all() as Array<{ name: string }>
-    ).map((c) => c.name),
-  );
+    // Check which legacy columns still exist — handles partial completion
+    // if a previous run crashed after dropping some columns but not all.
+    const cols = new Set(
+      (
+        raw.query(`PRAGMA table_info(contacts)`).all() as Array<{
+          name: string;
+        }>
+      ).map((c) => c.name),
+    );
 
-  if (cols.has("relationship")) {
-    const rows = raw
-      .query(
-        `SELECT id, relationship, importance, response_expectation, preferred_tone
+    const legacyCols = [
+      "relationship",
+      "importance",
+      "response_expectation",
+      "preferred_tone",
+    ] as const;
+    const remaining = legacyCols.filter((c) => cols.has(c));
+
+    // Backfill notes from legacy columns if any are still present and notes
+    // haven't been populated yet (only run once, before any columns are dropped).
+    if (remaining.length === legacyCols.length) {
+      const rows = raw
+        .query(
+          `SELECT id, relationship, importance, response_expectation, preferred_tone
        FROM contacts
        WHERE relationship IS NOT NULL
           OR importance != 0.5
           OR response_expectation IS NOT NULL
           OR preferred_tone IS NOT NULL`,
-      )
-      .all() as Array<{
-      id: string;
-      relationship: string | null;
-      importance: number;
-      response_expectation: string | null;
-      preferred_tone: string | null;
-    }>;
+        )
+        .all() as Array<{
+        id: string;
+        relationship: string | null;
+        importance: number;
+        response_expectation: string | null;
+        preferred_tone: string | null;
+      }>;
 
-    const update = raw.prepare(`UPDATE contacts SET notes = ? WHERE id = ?`);
+      const update = raw.prepare(`UPDATE contacts SET notes = ? WHERE id = ?`);
 
-    for (const row of rows) {
-      const parts: string[] = [];
-      if (row.relationship) parts.push(`Relationship: ${row.relationship}`);
-      if (row.importance !== 0.5) parts.push(`Importance: ${row.importance}`);
-      if (row.response_expectation)
-        parts.push(`Response expectation: ${row.response_expectation}`);
-      if (row.preferred_tone)
-        parts.push(`Preferred tone: ${row.preferred_tone}`);
-      if (parts.length > 0) {
-        update.run(parts.join("\n"), row.id);
+      for (const row of rows) {
+        const parts: string[] = [];
+        if (row.relationship) parts.push(`Relationship: ${row.relationship}`);
+        if (row.importance !== 0.5) parts.push(`Importance: ${row.importance}`);
+        if (row.response_expectation)
+          parts.push(`Response expectation: ${row.response_expectation}`);
+        if (row.preferred_tone)
+          parts.push(`Preferred tone: ${row.preferred_tone}`);
+        if (parts.length > 0) {
+          update.run(parts.join("\n"), row.id);
+        }
+      }
+
+      const migrated = rows.length;
+      if (migrated > 0) {
+        log.info({ migrated }, "Migrated contact metadata to notes field");
       }
     }
 
-    const migrated = rows.length;
-    if (migrated > 0) {
-      log.info({ migrated }, "Migrated contact metadata to notes field");
-    }
-
-    // Drop indexes that reference columns we're about to remove
+    // Drop indexes that reference columns we're about to remove.
+    // Must happen before the column drops — SQLite rejects dropping a column
+    // that is still referenced by an index.
     raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_contacts_importance`);
 
-    raw.exec(/*sql*/ `ALTER TABLE contacts DROP COLUMN relationship`);
-    raw.exec(/*sql*/ `ALTER TABLE contacts DROP COLUMN importance`);
-    raw.exec(/*sql*/ `ALTER TABLE contacts DROP COLUMN response_expectation`);
-    raw.exec(/*sql*/ `ALTER TABLE contacts DROP COLUMN preferred_tone`);
-  }
+    // Drop each legacy column individually so partial completion is safe:
+    // on crash recovery the loop picks up only the columns that remain.
+    for (const col of remaining) {
+      raw.exec(/*sql*/ `ALTER TABLE contacts DROP COLUMN ${col}`);
+    }
+  });
 }

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -123,8 +123,14 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
       "Enforce NOT NULL on channel_guardian_bindings.guardian_principal_id after backfill",
   },
   {
-    key: "backfill_contact_interaction_stats",
+    key: "migration_contacts_notes_column_v1",
     version: 17,
+    description:
+      "Consolidate relationship/importance/response_expectation/preferred_tone into a single notes TEXT column, then drop the legacy columns",
+  },
+  {
+    key: "backfill_contact_interaction_stats",
+    version: 18,
     description:
       "Backfill contacts.last_interaction from the max lastSeenAt across each contact's channels",
   },


### PR DESCRIPTION
Address review feedback from PR #12771:\n- Import and call migrateContactsNotesColumn in initializeDb()\n- Drop idx_contacts_importance before dropping the importance column\n- Add MIGRATION_REGISTRY entry with crash-recovery guards for destructive migration
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13026" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
