### PR TITLE
fix: reset selectedTab when Contacts feature flag is disabled

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -168,6 +168,9 @@ struct SettingsPanel: View {
                let enabled = notification.userInfo?["enabled"] as? Bool,
                key == Self.contactsFeatureFlagKey {
                 isContactsEnabled = enabled
+                if !enabled && selectedTab == .contacts {
+                    selectedTab = .account
+                }
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in


### PR DESCRIPTION
Address review feedback from PR #13016:
- When the Contacts feature flag notification fires with enabled=false and the user is currently viewing the Contacts tab, reset selectedTab to the account tab so the disabled feature isn't left reachable
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
