### PR TITLE
feat: inline tool progress for interleaved assistant content [LUM-17]

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -115,6 +115,7 @@ export class AgentLoop {
         name: string,
         input: Record<string, unknown>,
         onOutput?: (chunk: string) => void,
+        toolUseId?: string,
       ) => Promise<{
         content: string;
         isError: boolean;
@@ -140,6 +141,7 @@ export class AgentLoop {
       name: string,
       input: Record<string, unknown>,
       onOutput?: (chunk: string) => void,
+      toolUseId?: string,
     ) => Promise<{
       content: string;
       isError: boolean;
@@ -507,6 +509,7 @@ export class AgentLoop {
                   chunk,
                 });
               },
+              toolUse.id,
             );
 
             const toolDurationMs = Date.now() - toolStart;

--- a/assistant/src/daemon/handlers/session-user-message.ts
+++ b/assistant/src/daemon/handlers/session-user-message.ts
@@ -539,6 +539,11 @@ async function handlePendingConfirmationReply(
           causedByRequestId: requestId,
           decisionText: messageText.trim(),
         });
+        // Notify agent loop so the outcome is persisted on the tool_use block
+        session.onConfirmationOutcome?.(
+          routerResult.requestId,
+          "resolved_stale",
+        );
       }
 
       const consumedChannelMeta = {
@@ -646,6 +651,8 @@ function autoDenyPendingConfirmations(
         source: "auto_deny",
         causedByRequestId: requestId,
       });
+      // Notify agent loop so the outcome is persisted on the tool_use block
+      session.onConfirmationOutcome?.(interaction.requestId, "denied");
     }
   }
   session.denyAllPendingConfirmations();

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -70,6 +70,14 @@ export interface HistoryToolCall {
   isError?: boolean;
   /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot). */
   imageData?: string;
+  /** Unix ms when the tool started executing. */
+  startedAt?: number;
+  /** Unix ms when the tool completed. */
+  completedAt?: number;
+  /** Confirmation decision for this tool call: "approved" | "denied" | "timed_out". */
+  confirmationDecision?: string;
+  /** Friendly label for the confirmation (e.g. "Edit File", "Run Command"). */
+  confirmationLabel?: string;
 }
 
 export interface HistorySurface {
@@ -468,6 +476,15 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
         : {};
       const id = typeof block.id === "string" ? block.id : "";
       const entry: HistoryToolCall = { name, input };
+      // Extract persisted timing/confirmation metadata
+      if (typeof block._startedAt === "number")
+        entry.startedAt = block._startedAt;
+      if (typeof block._completedAt === "number")
+        entry.completedAt = block._completedAt;
+      if (typeof block._confirmationDecision === "string")
+        entry.confirmationDecision = block._confirmationDecision;
+      if (typeof block._confirmationLabel === "string")
+        entry.confirmationLabel = block._confirmationLabel;
       toolCalls.push(entry);
       if (id) pendingToolUses.set(id, entry);
       contentOrder.push(`tool:${toolCalls.length - 1}`);

--- a/assistant/src/daemon/ipc-contract/messages.ts
+++ b/assistant/src/daemon/ipc-contract/messages.ts
@@ -80,6 +80,8 @@ export interface ToolUseStart {
   toolName: string;
   input: Record<string, unknown>;
   sessionId?: string;
+  /** The tool_use block ID for client-side correlation. */
+  toolUseId?: string;
 }
 
 export interface ToolOutputChunk {

--- a/assistant/src/daemon/ipc-contract/messages.ts
+++ b/assistant/src/daemon/ipc-contract/messages.ts
@@ -242,6 +242,8 @@ export interface ConfirmationStateChanged {
   causedByRequestId?: string;
   /** Normalized user text for analytics/debug (e.g. "approve", "deny"). */
   decisionText?: string;
+  /** The tool_use block ID this confirmation applies to, for disambiguating parallel tool calls. */
+  toolUseId?: string;
 }
 
 /**

--- a/assistant/src/daemon/ipc-contract/sessions.ts
+++ b/assistant/src/daemon/ipc-contract/sessions.ts
@@ -288,6 +288,14 @@ export interface HistoryResponseToolCall {
   isError?: boolean;
   /** Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot). */
   imageData?: string;
+  /** Unix ms when the tool started executing. */
+  startedAt?: number;
+  /** Unix ms when the tool completed. */
+  completedAt?: number;
+  /** Confirmation decision for this tool call: "approved" | "denied" | "timed_out". */
+  confirmationDecision?: string;
+  /** Friendly label for the confirmation (e.g. "Edit File", "Run Command"). */
+  confirmationLabel?: string;
 }
 
 export interface HistoryResponseSurface {

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -67,6 +67,20 @@ export interface EventHandlerState {
   firstThinkingDeltaEmitted: boolean;
   /** Name of the last completed tool, used to generate contextual statusText. */
   lastCompletedToolName: string | undefined;
+  /** Tracks tool_use_id → timing data for persisting on content blocks. */
+  readonly toolCallTimestamps: Map<
+    string,
+    { startedAt: number; completedAt?: number }
+  >;
+  /** The tool_use_id of the currently executing tool (set in handleToolUse, cleared in handleToolResult). */
+  currentToolUseId: string | undefined;
+  /** Maps confirmation requestId → tool_use_id for linking decisions to tools. */
+  readonly requestIdToToolUseId: Map<string, string>;
+  /** Stores confirmation outcomes keyed by tool_use_id. */
+  readonly toolConfirmationOutcomes: Map<
+    string,
+    { decision: string; label: string }
+  >;
 }
 
 /** Immutable context shared across event handlers within a single agent loop run. */
@@ -108,6 +122,10 @@ export function createEventHandlerState(): EventHandlerState {
     firstTextDeltaEmitted: false,
     firstThinkingDeltaEmitted: false,
     lastCompletedToolName: undefined,
+    toolCallTimestamps: new Map(),
+    currentToolUseId: undefined,
+    requestIdToToolUseId: new Map(),
+    toolConfirmationOutcomes: new Map(),
   };
 }
 
@@ -253,6 +271,8 @@ export function handleToolUse(
 ): void {
   state.toolUseIdToName.set(event.id, event.name);
   state.currentTurnToolNames.push(event.name);
+  state.toolCallTimestamps.set(event.id, { startedAt: Date.now() });
+  state.currentToolUseId = event.id;
   const statusText = `Running ${friendlyToolName(event.name)}`;
   deps.ctx.emitActivityState(
     "tool_running",
@@ -266,6 +286,7 @@ export function handleToolUse(
     toolName: event.name,
     input: event.input,
     sessionId: deps.ctx.conversationId,
+    toolUseId: event.id,
   });
 }
 
@@ -391,6 +412,11 @@ export function handleToolResult(
     isError: event.isError,
     contentBlocks: event.contentBlocks,
   });
+
+  // Record tool completion timestamp
+  const ts = state.toolCallTimestamps.get(event.toolUseId);
+  if (ts) ts.completedAt = Date.now();
+  state.currentToolUseId = undefined;
 
   const toolName = state.toolUseIdToName.get(event.toolUseId);
   if (toolName === "file_write" || toolName === "bash") {
@@ -531,6 +557,30 @@ export async function handleMessageComplete(
       },
       "Parsed attachment directives from assistant message",
     );
+  }
+
+  // Annotate tool_use blocks with timing and confirmation metadata.
+  // The blocks are JSON-serialized for persistence, so adding underscore-prefixed
+  // fields is safe and requires no DB migration.
+  for (const block of cleanedBlocks) {
+    if (block.type === "tool_use") {
+      const rec = block as unknown as Record<string, unknown>;
+      const id = rec.id as string | undefined;
+      if (id) {
+        const ts = state.toolCallTimestamps.get(id);
+        if (ts) {
+          rec._startedAt = ts.startedAt;
+          if (ts.completedAt != null) {
+            rec._completedAt = ts.completedAt;
+          }
+        }
+        const confirmation = state.toolConfirmationOutcomes.get(id);
+        if (confirmation) {
+          rec._confirmationDecision = confirmation.decision;
+          rec._confirmationLabel = confirmation.label;
+        }
+      }
+    }
   }
 
   // Build content with UI surfaces

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -81,6 +81,8 @@ export interface EventHandlerState {
     string,
     { decision: string; label: string }
   >;
+  /** tool_use_ids emitted in the current turn (populated in handleToolUse, cleared after annotation). */
+  currentTurnToolUseIds: string[];
 }
 
 /** Immutable context shared across event handlers within a single agent loop run. */
@@ -126,6 +128,7 @@ export function createEventHandlerState(): EventHandlerState {
     currentToolUseId: undefined,
     requestIdToToolUseId: new Map(),
     toolConfirmationOutcomes: new Map(),
+    currentTurnToolUseIds: [],
   };
 }
 
@@ -273,6 +276,7 @@ export function handleToolUse(
   state.currentTurnToolNames.push(event.name);
   state.toolCallTimestamps.set(event.id, { startedAt: Date.now() });
   state.currentToolUseId = event.id;
+  state.currentTurnToolUseIds.push(event.id);
   const statusText = `Running ${friendlyToolName(event.name)}`;
   deps.ctx.emitActivityState(
     "tool_running",
@@ -459,6 +463,68 @@ export function handleToolResult(
     deps.reqId,
     statusText,
   );
+
+  // Once all tools for this turn have completed, annotate the persisted
+  // assistant message with timing and confirmation metadata.
+  const allToolsDone = state.currentTurnToolUseIds.every((id) => {
+    const ts = state.toolCallTimestamps.get(id);
+    return ts && ts.completedAt != null;
+  });
+  if (allToolsDone && state.currentTurnToolUseIds.length > 0) {
+    annotatePersistedAssistantMessage(state);
+  }
+}
+
+/**
+ * After all tools for the current turn complete, fetch the persisted assistant
+ * message, annotate its tool_use blocks with timing and confirmation metadata,
+ * and update the DB. This runs post-tool-execution so the metadata maps are
+ * fully populated (unlike message_complete which fires before tools run).
+ */
+function annotatePersistedAssistantMessage(state: EventHandlerState): void {
+  const messageId = state.lastAssistantMessageId;
+  if (!messageId) return;
+
+  const row = conversationStore.getMessageById(messageId);
+  if (!row) return;
+
+  let content: ContentBlock[];
+  try {
+    content = JSON.parse(row.content) as ContentBlock[];
+  } catch {
+    return;
+  }
+
+  let modified = false;
+  for (const block of content) {
+    if (block.type === "tool_use") {
+      const rec = block as unknown as Record<string, unknown>;
+      const id = rec.id as string | undefined;
+      if (!id) continue;
+
+      const ts = state.toolCallTimestamps.get(id);
+      if (ts) {
+        rec._startedAt = ts.startedAt;
+        if (ts.completedAt != null) {
+          rec._completedAt = ts.completedAt;
+        }
+        modified = true;
+      }
+      const confirmation = state.toolConfirmationOutcomes.get(id);
+      if (confirmation) {
+        rec._confirmationDecision = confirmation.decision;
+        rec._confirmationLabel = confirmation.label;
+        modified = true;
+      }
+    }
+  }
+
+  if (modified) {
+    conversationStore.updateMessageContent(messageId, JSON.stringify(content));
+  }
+
+  // Clear for the next turn
+  state.currentTurnToolUseIds = [];
 }
 
 export function handleError(
@@ -491,6 +557,9 @@ export async function handleMessageComplete(
   deps: EventHandlerDeps,
   event: Extract<AgentEvent, { type: "message_complete" }>,
 ): Promise<void> {
+  // Reset per-turn tool tracking for the new turn.
+  state.currentTurnToolUseIds = [];
+
   // Flush any remaining directive display buffer
   if (state.pendingDirectiveDisplayBuffer.length > 0) {
     deps.onEvent({
@@ -559,29 +628,10 @@ export async function handleMessageComplete(
     );
   }
 
-  // Annotate tool_use blocks with timing and confirmation metadata.
-  // The blocks are JSON-serialized for persistence, so adding underscore-prefixed
-  // fields is safe and requires no DB migration.
-  for (const block of cleanedBlocks) {
-    if (block.type === "tool_use") {
-      const rec = block as unknown as Record<string, unknown>;
-      const id = rec.id as string | undefined;
-      if (id) {
-        const ts = state.toolCallTimestamps.get(id);
-        if (ts) {
-          rec._startedAt = ts.startedAt;
-          if (ts.completedAt != null) {
-            rec._completedAt = ts.completedAt;
-          }
-        }
-        const confirmation = state.toolConfirmationOutcomes.get(id);
-        if (confirmation) {
-          rec._confirmationDecision = confirmation.decision;
-          rec._confirmationLabel = confirmation.label;
-        }
-      }
-    }
-  }
+  // NOTE: Tool timing/confirmation annotations are NOT applied here because
+  // message_complete fires BEFORE tool_use/tool_result events. The annotations
+  // are applied in handleToolResult after all tools for the turn complete,
+  // then the persisted message is updated via updateMessageContent.
 
   // Build content with UI surfaces
   const contentWithSurfaces: ContentBlock[] = [...cleanedBlocks];

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -487,14 +487,15 @@ export async function runAgentLoopImpl(
         confirmationState === "denied" ||
         confirmationState === "timed_out"
       ) {
-        const toolUseId = state.requestIdToToolUseId.get(requestId);
-        if (toolUseId) {
-          const name = state.toolUseIdToName.get(toolUseId) ?? toolName ?? "";
+        const resolvedId =
+          state.requestIdToToolUseId.get(requestId) ?? toolUseId;
+        if (resolvedId) {
+          const name = state.toolUseIdToName.get(resolvedId) ?? toolName ?? "";
           // Build a friendly label from the tool name
           const label =
             TOOL_FRIENDLY_LABEL[name] ??
             name.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-          state.toolConfirmationOutcomes.set(toolUseId, {
+          state.toolConfirmationOutcomes.set(resolvedId, {
             decision: confirmationState,
             label,
           });

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -118,6 +118,27 @@ import type { TraceEmitter } from "./trace-emitter.js";
 
 const log = getLogger("session-agent-loop");
 
+/** Title-cased friendly labels for tool names, used in confirmation chips. */
+const TOOL_FRIENDLY_LABEL: Record<string, string> = {
+  bash: "Run Command",
+  web_search: "Web Search",
+  web_fetch: "Web Fetch",
+  file_read: "Read File",
+  file_write: "Write File",
+  file_edit: "Edit File",
+  browser_navigate: "Browser",
+  browser_click: "Browser",
+  browser_type: "Browser",
+  browser_screenshot: "Browser",
+  browser_scroll: "Browser",
+  browser_wait: "Browser",
+  app_create: "Create App",
+  app_update: "Update App",
+  skill_load: "Load Skill",
+  app_file_edit: "Edit App File",
+  app_file_write: "Write App File",
+};
+
 type GitServiceInitializer = {
   ensureInitialized(): Promise<void>;
 };
@@ -221,6 +242,17 @@ export interface AgentLoopSessionContext {
         >
       : never,
   ): void;
+
+  /**
+   * Optional callback invoked by the Session when a confirmation state changes.
+   * The agent loop registers this to track requestId → toolUseId mappings
+   * and record confirmation outcomes for persistence.
+   */
+  onConfirmationOutcome?: (
+    requestId: string,
+    state: string,
+    toolName?: string,
+  ) => void;
 
   getWorkspaceGitService?: (workspaceDir: string) => GitServiceInitializer;
   commitTurnChanges?: typeof commitTurnChanges;
@@ -432,6 +464,35 @@ export async function runAgentLoopImpl(
     }
 
     const state = createEventHandlerState();
+
+    // Register confirmation outcome tracker so the agent loop can link
+    // confirmation decisions to tool_use_ids for persistence.
+    ctx.onConfirmationOutcome = (requestId, confirmationState, toolName) => {
+      if (confirmationState === "pending") {
+        // At "pending" time, currentToolUseId is the tool awaiting confirmation
+        if (state.currentToolUseId) {
+          state.requestIdToToolUseId.set(requestId, state.currentToolUseId);
+        }
+      } else if (
+        confirmationState === "approved" ||
+        confirmationState === "denied" ||
+        confirmationState === "timed_out"
+      ) {
+        const toolUseId = state.requestIdToToolUseId.get(requestId);
+        if (toolUseId) {
+          const name = state.toolUseIdToName.get(toolUseId) ?? toolName ?? "";
+          // Build a friendly label from the tool name
+          const label =
+            TOOL_FRIENDLY_LABEL[name] ??
+            name.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+          state.toolConfirmationOutcomes.set(toolUseId, {
+            decision: confirmationState,
+            label,
+          });
+        }
+      }
+    };
+
     let runMessages = ctx.messages;
 
     const memoryResult = await prepareMemoryContext(
@@ -1347,6 +1408,7 @@ export async function runAgentLoopImpl(
 
     ctx.abortController = null;
     ctx.processing = false;
+    ctx.onConfirmationOutcome = undefined;
     ctx.surfaceActionRequestIds.delete(ctx.currentRequestId ?? "");
     ctx.currentRequestId = undefined;
     ctx.currentActiveSurfaceId = undefined;

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -252,6 +252,7 @@ export interface AgentLoopSessionContext {
     requestId: string,
     state: string,
     toolName?: string,
+    toolUseId?: string,
   ) => void;
 
   getWorkspaceGitService?: (workspaceDir: string) => GitServiceInitializer;
@@ -467,11 +468,19 @@ export async function runAgentLoopImpl(
 
     // Register confirmation outcome tracker so the agent loop can link
     // confirmation decisions to tool_use_ids for persistence.
-    ctx.onConfirmationOutcome = (requestId, confirmationState, toolName) => {
+    ctx.onConfirmationOutcome = (
+      requestId,
+      confirmationState,
+      toolName,
+      toolUseId,
+    ) => {
       if (confirmationState === "pending") {
-        // At "pending" time, currentToolUseId is the tool awaiting confirmation
-        if (state.currentToolUseId) {
-          state.requestIdToToolUseId.set(requestId, state.currentToolUseId);
+        // Use the toolUseId passed from the prompter (which knows which tool
+        // requested confirmation) instead of the ambient state.currentToolUseId,
+        // which is unreliable when multiple tools execute in parallel.
+        const resolvedToolUseId = toolUseId ?? state.currentToolUseId;
+        if (resolvedToolUseId) {
+          state.requestIdToToolUseId.set(requestId, resolvedToolUseId);
         }
       } else if (
         confirmationState === "approved" ||

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -135,6 +135,7 @@ export function createToolExecutor(
   name: string,
   input: Record<string, unknown>,
   onOutput?: (chunk: string) => void,
+  toolUseId?: string,
 ) => Promise<ToolExecutionResult> {
   // Register the session's sendToClient for browser screencast surface messages
   registerSessionSender(ctx.conversationId, (msg) => ctx.sendToClient(msg));
@@ -143,6 +144,7 @@ export function createToolExecutor(
     name: string,
     input: Record<string, unknown>,
     onOutput?: (chunk: string) => void,
+    toolUseId?: string,
   ) => {
     if (isDoordashCommand(name, input)) {
       markDoordashStepInProgress(ctx, input);
@@ -172,6 +174,7 @@ export function createToolExecutor(
       allowedToolNames: ctx.allowedToolNames,
       memoryScopeId: ctx.memoryPolicy.scopeId,
       forcePromptSideEffects: ctx.memoryPolicy.strictSideEffects,
+      toolUseId,
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => {
         // Tool context's sendToClient uses a loose { type: string; [key: string]: unknown }

--- a/assistant/src/daemon/session-tool-setup.ts
+++ b/assistant/src/daemon/session-tool-setup.ts
@@ -258,6 +258,10 @@ export function createToolExecutor(
           undefined,
           ctx.conversationId,
           req.executionTarget,
+          undefined,
+          undefined,
+          undefined,
+          toolUseId,
         );
         if (
           (response.decision === "always_allow" ||

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -222,6 +222,12 @@ export class Session {
    * no-op for socketless sessions.
    */
   private onStateSignal?: (msg: ServerMessage) => void;
+  /** Set by the agent loop to track confirmation outcomes for persistence. */
+  onConfirmationOutcome?: (
+    requestId: string,
+    state: string,
+    toolName?: string,
+  ) => void;
 
   constructor(
     conversationId: string,
@@ -252,6 +258,9 @@ export class Session {
         state,
         source,
       });
+      // Notify the agent loop so it can track requestId → toolUseId mappings
+      // and record confirmation outcomes for persistence.
+      this.onConfirmationOutcome?.(requestId, state);
       // Emit activity state transitions for confirmation lifecycle
       if (state === "pending") {
         this.emitActivityState(
@@ -554,6 +563,8 @@ export class Session {
         ? { decisionText: emissionContext.decisionText }
         : {}),
     });
+    // Notify the agent loop of the confirmation outcome for persistence
+    this.onConfirmationOutcome?.(requestId, resolvedState);
     this.emitActivityState(
       "thinking",
       "confirmation_resolved",

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -227,6 +227,7 @@ export class Session {
     requestId: string,
     state: string,
     toolName?: string,
+    toolUseId?: string,
   ) => void;
 
   constructor(
@@ -249,7 +250,7 @@ export class Session {
       : { ...DEFAULT_MEMORY_POLICY };
     this.traceEmitter = new TraceEmitter(conversationId, sendToClient);
     this.prompter = new PermissionPrompter(sendToClient);
-    this.prompter.setOnStateChanged((requestId, state, source) => {
+    this.prompter.setOnStateChanged((requestId, state, source, toolUseId) => {
       // Route through emitConfirmationStateChanged so the onStateSignal
       // listener publishes to the SSE hub for HTTP/SSE consumers.
       this.emitConfirmationStateChanged({
@@ -257,10 +258,11 @@ export class Session {
         requestId,
         state,
         source,
+        toolUseId,
       });
       // Notify the agent loop so it can track requestId → toolUseId mappings
       // and record confirmation outcomes for persistence.
-      this.onConfirmationOutcome?.(requestId, state);
+      this.onConfirmationOutcome?.(requestId, state, undefined, toolUseId);
       // Emit activity state transitions for confirmation lifecycle
       if (state === "pending") {
         this.emitActivityState(
@@ -532,6 +534,9 @@ export class Session {
       return;
     }
 
+    // Capture toolUseId before resolving (resolution deletes the pending entry)
+    const toolUseId = this.prompter.getToolUseId(requestId);
+
     this.prompter.resolveConfirmation(
       requestId,
       decision,
@@ -556,6 +561,7 @@ export class Session {
       requestId,
       state: resolvedState,
       source: emissionContext?.source ?? "button",
+      toolUseId,
       ...(emissionContext?.causedByRequestId
         ? { causedByRequestId: emissionContext.causedByRequestId }
         : {}),
@@ -564,7 +570,12 @@ export class Session {
         : {}),
     });
     // Notify the agent loop of the confirmation outcome for persistence
-    this.onConfirmationOutcome?.(requestId, resolvedState);
+    this.onConfirmationOutcome?.(
+      requestId,
+      resolvedState,
+      undefined,
+      toolUseId,
+    );
     this.emitActivityState(
       "thinking",
       "confirmation_resolved",

--- a/assistant/src/permissions/prompter.ts
+++ b/assistant/src/permissions/prompter.ts
@@ -19,12 +19,14 @@ interface PendingPrompt {
   }) => void;
   reject: (reason: Error) => void;
   timer: ReturnType<typeof setTimeout>;
+  toolUseId?: string;
 }
 
 export type ConfirmationStateCallback = (
   requestId: string,
   state: "pending" | "approved" | "denied" | "timed_out" | "resolved_stale",
   source: "button" | "inline_nl" | "auto_deny" | "timeout" | "system",
+  toolUseId?: string,
 ) => void;
 
 export class PermissionPrompter {
@@ -62,6 +64,7 @@ export class PermissionPrompter {
     persistentDecisionsAllowed?: boolean,
     signal?: AbortSignal,
     temporaryOptionsAvailable?: Array<"allow_10m" | "allow_thread">,
+    toolUseId?: string,
   ): Promise<{
     decision: UserDecision;
     selectedPattern?: string;
@@ -80,11 +83,11 @@ export class PermissionPrompter {
           { requestId, toolName },
           "Permission prompt timed out, defaulting to deny",
         );
-        this.onStateChanged?.(requestId, "timed_out", "timeout");
+        this.onStateChanged?.(requestId, "timed_out", "timeout", toolUseId);
         resolve({ decision: "deny" });
       }, timeoutMs);
 
-      this.pending.set(requestId, { resolve, reject, timer });
+      this.pending.set(requestId, { resolve, reject, timer, toolUseId });
 
       if (signal) {
         const onAbort = () => {
@@ -120,12 +123,17 @@ export class PermissionPrompter {
         temporaryOptionsAvailable,
       });
 
-      this.onStateChanged?.(requestId, "pending", "system");
+      this.onStateChanged?.(requestId, "pending", "system", toolUseId);
     });
   }
 
   hasPendingRequest(requestId: string): boolean {
     return this.pending.has(requestId);
+  }
+
+  /** Returns the toolUseId associated with a pending request, if any. */
+  getToolUseId(requestId: string): string | undefined {
+    return this.pending.get(requestId)?.toolUseId;
   }
 
   resolveConfirmation(

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -266,6 +266,7 @@ export class PermissionChecker {
           persistentDecisionsAllowed,
           context.signal,
           temporaryOptionsAvailable,
+          context.toolUseId,
         );
 
         const decision = response.decision;

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -167,6 +167,8 @@ export interface ToolContext {
   requesterChatId?: string;
   /** Slack channel ID for channel-scoped permission enforcement. When set, tools are checked against the channel's permission profile. */
   channelPermissionChannelId?: string;
+  /** The tool_use block ID from the LLM response, used to correlate confirmation prompts with specific tool invocations. */
+  toolUseId?: string;
 }
 
 export interface DiffInfo {

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -195,6 +195,7 @@ struct AssistantProgressView: View {
                 if let confirmation = decidedConfirmation, confirmation.state != .pending {
                     compactPermissionChip(confirmation)
                         .padding(.horizontal, VSpacing.sm)
+                        .padding(.top, VSpacing.sm)
                         .padding(.bottom, VSpacing.sm)
                 }
             }
@@ -240,9 +241,11 @@ struct AssistantProgressView: View {
 
                 Spacer()
 
-                // Elapsed time (after 5 seconds, only when active)
+                // Elapsed time: live counter when active, final duration when complete
                 if isActive {
                     elapsedTimeLabel
+                } else if !toolCalls.isEmpty {
+                    completedDurationLabel
                 }
 
                 // Chevron (only if tools exist)
@@ -370,6 +373,22 @@ struct AssistantProgressView: View {
         }
     }
 
+    // MARK: - Completed Duration
+
+    @ViewBuilder
+    private var completedDurationLabel: some View {
+        let earliest = toolCalls.compactMap(\.startedAt).min()
+        let latest = toolCalls.compactMap(\.completedAt).max()
+        if let start = earliest, let end = latest {
+            let seconds = end.timeIntervalSince(start)
+            Text(seconds < 60
+                ? String(format: "%.1fs", seconds)
+                : "\(Int(seconds) / 60)m \(Int(seconds) % 60)s")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+        }
+    }
+
     // MARK: - Expanded Content
 
     @ViewBuilder
@@ -417,13 +436,13 @@ struct AssistantProgressView: View {
                 .font(VFont.captionMedium)
                 .foregroundColor(chipColor)
         }
-        .padding(.horizontal, VSpacing.md)
+        .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
         .background(
-            Capsule().fill(chipColor.opacity(0.1))
+            Capsule().fill(Color.clear)
         )
         .overlay(
-            Capsule().stroke(chipColor.opacity(0.3), lineWidth: 0.5)
+            Capsule().stroke(chipColor.opacity(0.3), lineWidth: 1)
         )
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -206,6 +206,7 @@ struct AssistantProgressView: View {
                     .padding(.bottom, VSpacing.md)
             }
         }
+        .padding(.bottom, isExpanded ? VSpacing.sm : 0)
         .background(VColor.surface.opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .onChange(of: phase) { _, newPhase in
@@ -254,8 +255,8 @@ struct AssistantProgressView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, VSpacing.lg)
-        .padding(.vertical, VSpacing.md)
+        .padding(.horizontal, VSpacing.sm)
+        .padding(.vertical, VSpacing.sm)
     }
 
     // MARK: - Status Icon
@@ -264,22 +265,30 @@ struct AssistantProgressView: View {
     private var statusIcon: some View {
         switch phase {
         case .complete:
-            Image(systemName: hasAnyErrors ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
-                .font(.system(size: 16))
-                .foregroundColor(hasAnyErrors ? VColor.warning : VColor.success)
+            statusIconTile(
+                systemName: hasAnyErrors ? "exclamationmark.triangle.fill" : "checkmark.circle.fill",
+                iconColor: hasAnyErrors ? VColor.warning : VColor.success,
+                tileColor: hasAnyErrors ? Amber._200 : Forest._200
+            )
         case .error:
-            Image(systemName: "exclamationmark.circle.fill")
-                .font(.system(size: 16))
-                .foregroundColor(VColor.error)
+            statusIconTile(
+                systemName: "exclamationmark.circle.fill",
+                iconColor: VColor.error,
+                tileColor: Danger._200
+            )
         case .denied:
             if decidedConfirmation?.state == .timedOut {
-                Image(systemName: "clock.fill")
-                    .font(.system(size: 16))
-                    .foregroundColor(VColor.textMuted)
+                statusIconTile(
+                    systemName: "clock.fill",
+                    iconColor: VColor.textMuted,
+                    tileColor: Moss._200
+                )
             } else {
-                Image(systemName: "exclamationmark.circle.fill")
-                    .font(.system(size: 16))
-                    .foregroundColor(VColor.error)
+                statusIconTile(
+                    systemName: "exclamationmark.circle.fill",
+                    iconColor: VColor.error,
+                    tileColor: Danger._200
+                )
             }
         default:
             Circle()
@@ -287,6 +296,17 @@ struct AssistantProgressView: View {
                 .frame(width: 8, height: 8)
                 .modifier(AssistantProgressPulsingModifier())
         }
+    }
+
+    private func statusIconTile(systemName: String, iconColor: Color, tileColor: Color) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: 14))
+            .foregroundColor(iconColor)
+            .padding(VSpacing.sm)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(tileColor)
+            )
     }
 
     // MARK: - Headline Label
@@ -297,7 +317,7 @@ struct AssistantProgressView: View {
                 processingLabel
             } else {
                 Text(headlineText)
-                    .font(VFont.captionMedium)
+                    .font(VFont.bodyMedium)
                     .foregroundColor(VColor.textPrimary)
                     .animation(.easeInOut(duration: 0.3), value: headlineText)
             }
@@ -323,7 +343,7 @@ struct AssistantProgressView: View {
 
             HStack(spacing: VSpacing.xs) {
                 Text(labels[labelIndex])
-                    .font(VFont.captionMedium)
+                    .font(VFont.bodyMedium)
                     .foregroundColor(VColor.textPrimary)
                     .animation(.easeInOut(duration: 0.3), value: labelIndex)
 
@@ -477,7 +497,7 @@ private struct StepDetailRow: View {
                     VStack(alignment: .leading, spacing: VSpacing.xxs) {
                         if toolCall.isComplete {
                             Text(toolCall.actionDescription)
-                                .font(VFont.captionMedium)
+                                .font(VFont.bodyMedium)
                                 .foregroundColor(toolCall.isError ? VColor.error : VColor.textPrimary)
                                 .lineLimit(1)
                                 .truncationMode(.tail)
@@ -487,7 +507,7 @@ private struct StepDetailRow: View {
                                 inputSummary: toolCall.inputSummary,
                                 buildingStatus: toolCall.buildingStatus
                             ))
-                            .font(VFont.captionMedium)
+                            .font(VFont.bodyMedium)
                             .foregroundColor(VColor.textMuted)
                             .lineLimit(1)
                             .truncationMode(.tail)
@@ -497,7 +517,7 @@ private struct StepDetailRow: View {
                                 inputSummary: toolCall.inputSummary,
                                 buildingStatus: toolCall.buildingStatus
                             ))
-                            .font(VFont.captionMedium)
+                            .font(VFont.bodyMedium)
                             .foregroundColor(VColor.textPrimary)
                             .lineLimit(1)
                             .truncationMode(.tail)
@@ -506,7 +526,7 @@ private struct StepDetailRow: View {
                         // Reason subtitle — only for completed tools
                         if let reason = toolCall.reasonDescription, !reason.isEmpty, toolCall.isComplete {
                             Text(reason)
-                                .font(VFont.small)
+                                .font(VFont.caption)
                                 .foregroundColor(VColor.textMuted)
                                 .lineLimit(1)
                                 .truncationMode(.tail)
@@ -534,9 +554,13 @@ private struct StepDetailRow: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .padding(.horizontal, VSpacing.lg)
+            .padding(.horizontal, VSpacing.sm)
             .padding(.vertical, VSpacing.sm)
-            .background(isHovered && hasDetails ? VColor.surfaceBorder.opacity(0.3) : .clear)
+            .background(
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .fill(isHovered && hasDetails ? Moss._100 : .clear)
+            )
+            .padding(.horizontal, VSpacing.sm)
             .onHover { isHovered = $0 }
 
             // Expanded detail section (completed only)

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -183,8 +183,8 @@ struct AssistantProgressView: View {
             // Permission chip below header (when not expanded)
             if !isExpanded, let confirmation = decidedConfirmation, confirmation.state != .pending {
                 compactPermissionChip(confirmation)
-                    .padding(.horizontal, VSpacing.lg)
-                    .padding(.bottom, VSpacing.md)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.bottom, VSpacing.sm)
             }
 
             // Expanded content
@@ -194,16 +194,16 @@ struct AssistantProgressView: View {
                 // Permission chip at bottom of expanded list
                 if let confirmation = decidedConfirmation, confirmation.state != .pending {
                     compactPermissionChip(confirmation)
-                        .padding(.horizontal, VSpacing.lg)
-                        .padding(.bottom, VSpacing.md)
+                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.bottom, VSpacing.sm)
                 }
             }
 
             // Code preview (streaming code phase)
             if phase == .streamingCode, let code = streamingCodePreview {
                 CodePreviewView(code: code)
-                    .padding(.horizontal, VSpacing.lg)
-                    .padding(.bottom, VSpacing.md)
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.bottom, VSpacing.sm)
             }
         }
         .padding(.bottom, isExpanded ? VSpacing.sm : 0)

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -270,7 +270,7 @@ struct AssistantProgressView: View {
         case .complete:
             statusIconTile(
                 systemName: hasAnyErrors ? "exclamationmark.triangle.fill" : "checkmark.circle.fill",
-                iconColor: hasAnyErrors ? VColor.warning : VColor.success,
+                iconColor: hasAnyErrors ? VColor.warning : VColor.iconAccent,
                 tileColor: hasAnyErrors ? Amber._200 : Forest._200
             )
         case .error:
@@ -411,7 +411,7 @@ struct AssistantProgressView: View {
     private func compactPermissionChip(_ confirmation: ToolConfirmationData) -> some View {
         let isApproved = confirmation.state == .approved
         let isDenied = confirmation.state == .denied
-        let chipColor: Color = isApproved ? VColor.success : isDenied ? VColor.error : VColor.textMuted
+        let chipColor: Color = isApproved ? VColor.iconAccent : isDenied ? VColor.error : VColor.textMuted
 
         return HStack(spacing: VSpacing.xs) {
             Group {
@@ -497,7 +497,7 @@ private struct StepDetailRow: View {
                     if toolCall.isComplete {
                         Image(systemName: toolCall.isError ? "exclamationmark.circle.fill" : "checkmark.circle.fill")
                             .font(.system(size: 14))
-                            .foregroundColor(toolCall.isError ? VColor.error : VColor.success)
+                            .foregroundColor(toolCall.isError ? VColor.error : VColor.iconAccent)
                             .frame(width: 16)
                     } else if phase == .denied {
                         Image(systemName: "exclamationmark.circle.fill")

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -180,21 +180,34 @@ struct AssistantProgressView: View {
             // Header row (always visible)
             headerRow
 
+            // Permission chip below header (when not expanded)
+            if !isExpanded, let confirmation = decidedConfirmation, confirmation.state != .pending {
+                compactPermissionChip(confirmation)
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.bottom, VSpacing.md)
+            }
+
             // Expanded content
             if isExpanded {
                 expandedContent
+
+                // Permission chip at bottom of expanded list
+                if let confirmation = decidedConfirmation, confirmation.state != .pending {
+                    compactPermissionChip(confirmation)
+                        .padding(.horizontal, VSpacing.lg)
+                        .padding(.bottom, VSpacing.md)
+                }
             }
 
             // Code preview (streaming code phase)
             if phase == .streamingCode, let code = streamingCodePreview {
                 CodePreviewView(code: code)
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.bottom, VSpacing.xs)
+                    .padding(.horizontal, VSpacing.lg)
+                    .padding(.bottom, VSpacing.md)
             }
         }
-        .padding(VSpacing.md)
         .background(VColor.surface.opacity(0.5))
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .onChange(of: phase) { _, newPhase in
             if newPhase == .processing {
                 processingStartDate = Date()
@@ -231,24 +244,18 @@ struct AssistantProgressView: View {
                     elapsedTimeLabel
                 }
 
-                // Permission chip (trailing, when decided)
-                if let confirmation = decidedConfirmation, confirmation.state != .pending {
-                    compactPermissionChip(confirmation)
-                }
-
                 // Chevron (only if tools exist)
                 if hasChevron {
-                    Image(systemName: "chevron.right")
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                         .font(.system(size: 9, weight: .semibold))
                         .foregroundColor(VColor.textMuted)
-                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
                 }
             }
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
     }
 
     // MARK: - Status Icon
@@ -258,20 +265,20 @@ struct AssistantProgressView: View {
         switch phase {
         case .complete:
             Image(systemName: hasAnyErrors ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
-                .font(.system(size: 12))
+                .font(.system(size: 16))
                 .foregroundColor(hasAnyErrors ? VColor.warning : VColor.success)
         case .error:
-            Image(systemName: "xmark.circle.fill")
-                .font(.system(size: 12))
+            Image(systemName: "exclamationmark.circle.fill")
+                .font(.system(size: 16))
                 .foregroundColor(VColor.error)
         case .denied:
             if decidedConfirmation?.state == .timedOut {
                 Image(systemName: "clock.fill")
-                    .font(.system(size: 12))
+                    .font(.system(size: 16))
                     .foregroundColor(VColor.textMuted)
             } else {
-                Image(systemName: "xmark.circle.fill")
-                    .font(.system(size: 12))
+                Image(systemName: "exclamationmark.circle.fill")
+                    .font(.system(size: 16))
                     .foregroundColor(VColor.error)
             }
         default:
@@ -290,8 +297,8 @@ struct AssistantProgressView: View {
                 processingLabel
             } else {
                 Text(headlineText)
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.textPrimary)
                     .animation(.easeInOut(duration: 0.3), value: headlineText)
             }
         }
@@ -316,8 +323,8 @@ struct AssistantProgressView: View {
 
             HStack(spacing: VSpacing.xs) {
                 Text(labels[labelIndex])
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.textPrimary)
                     .animation(.easeInOut(duration: 0.3), value: labelIndex)
 
                 ForEach(0..<3, id: \.self) { index in
@@ -347,54 +354,56 @@ struct AssistantProgressView: View {
 
     @ViewBuilder
     private var expandedContent: some View {
-        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+        VStack(alignment: .leading, spacing: 0) {
             ForEach(toolCalls) { toolCall in
                 if !toolCall.isComplete && toolCall.toolName == "claude_code"
                     && !toolCall.claudeCodeSteps.isEmpty {
                     ClaudeCodeProgressView(steps: toolCall.claudeCodeSteps, isRunning: true)
-                        .padding(.horizontal, VSpacing.sm)
+                        .padding(.horizontal, VSpacing.lg)
                 } else {
                     StepDetailRow(toolCall: toolCall, phase: phase, onRehydrate: onRehydrate)
                 }
             }
         }
-        .padding(.bottom, VSpacing.xs)
     }
 
     // MARK: - Permission Chip
 
     private func compactPermissionChip(_ confirmation: ToolConfirmationData) -> some View {
         let isApproved = confirmation.state == .approved
+        let isDenied = confirmation.state == .denied
+        let chipColor: Color = isApproved ? VColor.success : isDenied ? VColor.error : VColor.textMuted
+
         return HStack(spacing: VSpacing.xs) {
             Group {
                 switch confirmation.state {
                 case .approved:
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(VColor.success)
+                        .foregroundColor(chipColor)
                 case .denied:
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundColor(VColor.error)
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .foregroundColor(chipColor)
                 case .timedOut:
                     Image(systemName: "clock.fill")
-                        .foregroundColor(VColor.textMuted)
+                        .foregroundColor(chipColor)
                 default:
                     EmptyView()
                 }
             }
             .font(.system(size: 12))
 
-            Text(isApproved ? "\(confirmation.toolCategory) allowed" :
-                 confirmation.state == .denied ? "\(confirmation.toolCategory) denied" : "Timed out")
-                .font(VFont.caption)
-                .foregroundColor(isApproved ? VColor.success : VColor.textSecondary)
+            Text(isApproved ? "\(confirmation.toolCategory) Allowed" :
+                 isDenied ? "\(confirmation.toolCategory) Denied" : "Timed Out")
+                .font(VFont.captionMedium)
+                .foregroundColor(chipColor)
         }
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.xs)
         .background(
-            Capsule().fill(isApproved ? VColor.success.opacity(0.1) : VColor.surface)
+            Capsule().fill(chipColor.opacity(0.1))
         )
         .overlay(
-            Capsule().stroke(isApproved ? VColor.success.opacity(0.3) : VColor.surfaceBorder, lineWidth: 0.5)
+            Capsule().stroke(chipColor.opacity(0.3), lineWidth: 0.5)
         )
     }
 }
@@ -447,21 +456,21 @@ private struct StepDetailRow: View {
                 HStack(spacing: VSpacing.sm) {
                     // Status icon
                     if toolCall.isComplete {
-                        Image(systemName: toolCall.isError ? "xmark.circle.fill" : "checkmark.circle.fill")
-                            .font(.system(size: 10))
+                        Image(systemName: toolCall.isError ? "exclamationmark.circle.fill" : "checkmark.circle.fill")
+                            .font(.system(size: 14))
                             .foregroundColor(toolCall.isError ? VColor.error : VColor.success)
-                            .frame(width: 14)
+                            .frame(width: 16)
                     } else if phase == .denied {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: 10))
+                        Image(systemName: "exclamationmark.circle.fill")
+                            .font(.system(size: 14))
                             .foregroundColor(VColor.textMuted)
-                            .frame(width: 14)
+                            .frame(width: 16)
                     } else {
                         Circle()
                             .fill(VColor.accent)
                             .frame(width: 6, height: 6)
                             .modifier(AssistantProgressPulsingModifier())
-                            .frame(width: 14)
+                            .frame(width: 16)
                     }
 
                     // Title + reason
@@ -469,7 +478,7 @@ private struct StepDetailRow: View {
                         if toolCall.isComplete {
                             Text(toolCall.actionDescription)
                                 .font(VFont.captionMedium)
-                                .foregroundColor(toolCall.isError ? VColor.error : VColor.textSecondary)
+                                .foregroundColor(toolCall.isError ? VColor.error : VColor.textPrimary)
                                 .lineLimit(1)
                                 .truncationMode(.tail)
                         } else if phase == .denied {
@@ -489,7 +498,7 @@ private struct StepDetailRow: View {
                                 buildingStatus: toolCall.buildingStatus
                             ))
                             .font(VFont.captionMedium)
-                            .foregroundColor(VColor.textSecondary)
+                            .foregroundColor(VColor.textPrimary)
                             .lineLimit(1)
                             .truncationMode(.tail)
                         }
@@ -525,10 +534,9 @@ private struct StepDetailRow: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .padding(.horizontal, VSpacing.sm)
-            .padding(.vertical, VSpacing.xxs)
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
             .background(isHovered && hasDetails ? VColor.surfaceBorder.opacity(0.3) : .clear)
-            .background(VColor.surface.opacity(0.5))
             .onHover { isHovered = $0 }
 
             // Expanded detail section (completed only)
@@ -569,7 +577,7 @@ private struct StepDetailRow: View {
     @ViewBuilder
     private var stepDetailContent: some View {
         VStack(alignment: .leading, spacing: VSpacing.sm) {
-            Divider().padding(.horizontal, VSpacing.sm)
+            Divider().padding(.horizontal, VSpacing.lg)
 
             // Technical details
             VStack(alignment: .leading, spacing: VSpacing.xs) {
@@ -602,7 +610,7 @@ private struct StepDetailRow: View {
                     }
                 }
             }
-            .padding(.horizontal, VSpacing.md)
+            .padding(.horizontal, VSpacing.lg)
 
             // Claude Code sub-steps
             if !toolCall.claudeCodeSteps.isEmpty {
@@ -617,7 +625,7 @@ private struct StepDetailRow: View {
                         isRunning: false
                     )
                 }
-                .padding(.horizontal, VSpacing.md)
+                .padding(.horizontal, VSpacing.lg)
             }
 
             // Screenshot — Retina rendering + double-click → Preview.app
@@ -629,7 +637,7 @@ private struct StepDetailRow: View {
                     .aspectRatio(contentMode: .fit)
                     .frame(maxWidth: .infinity)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                    .padding(.horizontal, VSpacing.md)
+                    .padding(.horizontal, VSpacing.lg)
                     .onTapGesture(count: 2) { openImageInPreview(img) }
                     .onHover { hovering in
                         if hovering { NSCursor.pointingHand.push() }
@@ -643,7 +651,7 @@ private struct StepDetailRow: View {
                     .aspectRatio(contentMode: .fit)
                     .frame(maxWidth: .infinity)
                     .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
-                    .padding(.horizontal, VSpacing.md)
+                    .padding(.horizontal, VSpacing.lg)
                     .onTapGesture(count: 2) { openImageInPreview(img) }
                     .onHover { hovering in
                         if hovering { NSCursor.pointingHand.push() }
@@ -698,7 +706,7 @@ private struct StepDetailRow: View {
                         .accessibilityLabel("Copy output")
                     }
                 }
-                .padding(.horizontal, VSpacing.md)
+                .padding(.horizontal, VSpacing.lg)
             }
         }
         .padding(.bottom, VSpacing.sm)

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -28,7 +28,7 @@ struct AssistantProgressView: View {
     let processingStatusText: String?
     let streamingCodePreview: String?
     let streamingCodeToolName: String?
-    let decidedConfirmation: ToolConfirmationData?
+    let decidedConfirmations: [ToolConfirmationData]
     var onRehydrate: (() -> Void)?
 
     @State private var isExpanded: Bool = false
@@ -38,9 +38,11 @@ struct AssistantProgressView: View {
     // MARK: - Derived State
 
     /// Whether the permission was denied or timed out, meaning incomplete tools were blocked.
-    /// Mirrors `ChatBubbleToolStatusView.permissionWasDenied`.
+    /// Checks both live confirmation (during streaming) and persisted per-tool-call data
+    /// (after history restore).
     private var permissionWasDenied: Bool {
-        decidedConfirmation?.state == .denied || decidedConfirmation?.state == .timedOut
+        decidedConfirmations.contains { $0.state == .denied || $0.state == .timedOut }
+            || toolCalls.contains { $0.confirmationDecision == .denied || $0.confirmationDecision == .timedOut }
     }
 
     private var phase: ProgressPhase {
@@ -180,9 +182,9 @@ struct AssistantProgressView: View {
             // Header row (always visible)
             headerRow
 
-            // Permission chip below header (when not expanded)
-            if !isExpanded, let confirmation = decidedConfirmation, confirmation.state != .pending {
-                compactPermissionChip(confirmation)
+            // Permission chips below header (when not expanded)
+            if !isExpanded {
+                permissionChips
                     .padding(.horizontal, VSpacing.sm)
                     .padding(.bottom, VSpacing.sm)
             }
@@ -191,13 +193,11 @@ struct AssistantProgressView: View {
             if isExpanded {
                 expandedContent
 
-                // Permission chip at bottom of expanded list
-                if let confirmation = decidedConfirmation, confirmation.state != .pending {
-                    compactPermissionChip(confirmation)
-                        .padding(.horizontal, VSpacing.sm)
-                        .padding(.top, VSpacing.sm)
-                        .padding(.bottom, VSpacing.sm)
-                }
+                // Permission chips at bottom of expanded list
+                permissionChips
+                    .padding(.horizontal, VSpacing.sm)
+                    .padding(.top, VSpacing.sm)
+                    .padding(.bottom, VSpacing.sm)
             }
 
             // Code preview (streaming code phase)
@@ -219,6 +219,11 @@ struct AssistantProgressView: View {
         .onAppear {
             if phase == .processing && processingStartDate == nil {
                 processingStartDate = Date()
+            }
+            // Seed startDate from persisted timestamps so the header timer
+            // shows correct elapsed time after history restore.
+            if let earliest = toolCalls.compactMap(\.startedAt).min() {
+                startDate = earliest
             }
         }
     }
@@ -280,7 +285,7 @@ struct AssistantProgressView: View {
                 tileColor: Danger._200
             )
         case .denied:
-            if decidedConfirmation?.state == .timedOut {
+            if decidedConfirmations.contains(where: { $0.state == .timedOut }) {
                 statusIconTile(
                     systemName: "clock.fill",
                     iconColor: VColor.textMuted,
@@ -406,7 +411,19 @@ struct AssistantProgressView: View {
         }
     }
 
-    // MARK: - Permission Chip
+    // MARK: - Permission Chips
+
+    @ViewBuilder
+    private var permissionChips: some View {
+        let resolved = decidedConfirmations.filter { $0.state != .pending }
+        if !resolved.isEmpty {
+            HStack(spacing: VSpacing.xs) {
+                ForEach(Array(resolved.enumerated()), id: \.offset) { _, confirmation in
+                    compactPermissionChip(confirmation)
+                }
+            }
+        }
+    }
 
     private func compactPermissionChip(_ confirmation: ToolConfirmationData) -> some View {
         let isApproved = confirmation.state == .approved
@@ -831,7 +848,7 @@ private struct AssistantProgressPulsingModifier: ViewModifier {
             processingStatusText: nil,
             streamingCodePreview: nil,
             streamingCodeToolName: nil,
-            decidedConfirmation: nil
+            decidedConfirmations: []
         )
         .frame(width: 520)
         .padding()
@@ -853,7 +870,7 @@ private struct AssistantProgressPulsingModifier: ViewModifier {
             processingStatusText: nil,
             streamingCodePreview: nil,
             streamingCodeToolName: nil,
-            decidedConfirmation: nil
+            decidedConfirmations: []
         )
         .frame(width: 520)
         .padding()
@@ -874,7 +891,7 @@ private struct AssistantProgressPulsingModifier: ViewModifier {
             processingStatusText: nil,
             streamingCodePreview: nil,
             streamingCodeToolName: nil,
-            decidedConfirmation: nil
+            decidedConfirmations: []
         )
         .frame(width: 520)
         .padding()
@@ -895,7 +912,7 @@ private struct AssistantProgressPulsingModifier: ViewModifier {
             processingStatusText: "Processing results",
             streamingCodePreview: nil,
             streamingCodeToolName: nil,
-            decidedConfirmation: nil
+            decidedConfirmations: []
         )
         .frame(width: 520)
         .padding()
@@ -917,7 +934,7 @@ private struct AssistantProgressPulsingModifier: ViewModifier {
             processingStatusText: nil,
             streamingCodePreview: nil,
             streamingCodeToolName: nil,
-            decidedConfirmation: nil
+            decidedConfirmations: []
         )
         .frame(width: 520)
         .padding()
@@ -938,7 +955,7 @@ private struct AssistantProgressPulsingModifier: ViewModifier {
             processingStatusText: nil,
             streamingCodePreview: nil,
             streamingCodeToolName: nil,
-            decidedConfirmation: nil
+            decidedConfirmations: []
         )
         .frame(width: 520)
         .padding()
@@ -971,7 +988,7 @@ private struct AssistantProgressPulsingModifier: ViewModifier {
             export default App;
             """,
             streamingCodeToolName: "app_create",
-            decidedConfirmation: nil
+            decidedConfirmations: []
         )
         .frame(width: 520)
         .padding()

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -62,6 +62,10 @@ extension ChatBubble {
             }
         }
 
+        // When tool calls render inline (visible progress views), they must
+        // break text runs just like surfaces do — skip coalescing entirely.
+        guard !shouldRenderToolProgressInline else { return groups }
+
         // Post-process: coalesce text groups that are only separated by tool call
         // groups so that the user can drag-select across text that spans a tool
         // invocation (tool calls render as EmptyView and produce no visual gap).

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -4,6 +4,17 @@ import VellumAssistantShared
 // MARK: - Interleaved Content
 
 extension ChatBubble {
+    /// Whether tool progress should be rendered inline at tool-call block positions
+    /// instead of in the trailing status area.
+    var shouldRenderToolProgressInline: Bool {
+        guard !hideToolCalls else { return false }
+        guard hasInterleavedContent else { return false }
+        return message.contentOrder.contains(where: {
+            if case .toolCall = $0 { return true }
+            return false
+        })
+    }
+
     /// Whether this message has meaningful interleaved content (multiple block types).
     var hasInterleavedContent: Bool {
         // Use interleaved path when contentOrder has more than one distinct block type
@@ -96,9 +107,59 @@ extension ChatBubble {
         return coalesced
     }
 
+    /// Returns true when there is non-empty text content after a tool-call group.
+    /// Used to decide whether the inline progress block should remain in
+    /// an active "thinking/processing" phase while the model continues.
+    private func hasTextAfterToolGroup(_ toolIndices: [Int]) -> Bool {
+        let indexSet = Set(toolIndices)
+        guard let lastToolRefIndex = message.contentOrder.lastIndex(where: {
+            if case .toolCall(let i) = $0 { return indexSet.contains(i) }
+            return false
+        }) else {
+            return hasText
+        }
+        let start = message.contentOrder.index(after: lastToolRefIndex)
+        guard start < message.contentOrder.endIndex else { return false }
+        for ref in message.contentOrder[start...] {
+            guard case .text(let textIndex) = ref,
+                  textIndex >= 0,
+                  textIndex < message.textSegments.count else { continue }
+            if !message.textSegments[textIndex].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return true
+            }
+        }
+        return false
+    }
+
+    @ViewBuilder
+    private func inlineToolProgress(toolIndices: [Int], isLatestGroup: Bool) -> some View {
+        let groupedToolCalls: [ToolCallData] = toolIndices.compactMap { idx -> ToolCallData? in
+            guard idx < message.toolCalls.count else { return nil }
+            return message.toolCalls[idx]
+        }
+        if !groupedToolCalls.isEmpty {
+            AssistantProgressView(
+                toolCalls: groupedToolCalls,
+                isStreaming: isLatestGroup ? message.isStreaming : false,
+                hasText: hasTextAfterToolGroup(toolIndices),
+                isProcessing: isLatestGroup && isProcessingAfterTools,
+                processingStatusText: isLatestGroup && isProcessingAfterTools ? processingStatusText : nil,
+                streamingCodePreview: isLatestGroup ? message.streamingCodePreview : nil,
+                streamingCodeToolName: isLatestGroup ? message.streamingCodeToolName : nil,
+                decidedConfirmation: isLatestGroup ? decidedConfirmation : nil,
+                onRehydrate: onRehydrate
+            )
+            .frame(maxWidth: 520, alignment: .leading)
+        }
+    }
+
     @ViewBuilder
     var interleavedContent: some View {
         let groups = groupContentBlocks()
+        let latestToolGroup: [Int]? = groups.reversed().compactMap { group in
+            guard case .toolCalls(let indices) = group else { return nil }
+            return indices
+        }.first
 
         // Render all content groups in order: text, tool calls, and surfaces.
         // Uses \.self identity (backed by Hashable conformance) instead of
@@ -119,9 +180,13 @@ extension ChatBubble {
                 if !joined.isEmpty {
                     textBubble(for: joined)
                 }
-            case .toolCalls:
-                // Tool calls are rendered by trailingStatus below the message
-                EmptyView()
+            case .toolCalls(let indices):
+                if shouldRenderToolProgressInline {
+                    inlineToolProgress(toolIndices: indices, isLatestGroup: indices == latestToolGroup)
+                } else {
+                    // Tool calls are rendered by trailingStatus below the message
+                    EmptyView()
+                }
             case .surface(let i):
                 if i < message.inlineSurfaces.count,
                    message.inlineSurfaces[i].id != activeSurfaceId {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -142,6 +142,10 @@ extension ChatBubble {
             return message.toolCalls[idx]
         }
         if !groupedToolCalls.isEmpty {
+            // The single decidedConfirmation always corresponds to the most recent
+            // permission prompt, which belongs to the latest tool group. Earlier
+            // groups' confirmations are consumed and no longer available in the
+            // message list, so we only show the chip on the latest group.
             AssistantProgressView(
                 toolCalls: groupedToolCalls,
                 isStreaming: isLatestGroup ? message.isStreaming : false,

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -142,10 +142,34 @@ extension ChatBubble {
             return message.toolCalls[idx]
         }
         if !groupedToolCalls.isEmpty {
-            // The single decidedConfirmation always corresponds to the most recent
-            // permission prompt, which belongs to the latest tool group. Earlier
-            // groups' confirmations are consumed and no longer available in the
-            // message list, so we only show the chip on the latest group.
+            // Derive confirmations from this group's own tool call stamps.
+            // We intentionally do NOT use the message-level decidedConfirmation
+            // here because it comes from the confirmation message at index+1,
+            // which can be stale — after the confirmation is resolved and new
+            // tool groups are added, the old confirmation message stays at
+            // index+1 and would leak to unrelated groups.
+            // Deduplicate by (toolCategory, state) so repeated identical permissions
+            // collapse into one chip.
+            let groupConfirmations: [ToolConfirmationData] = {
+                var seen = Set<String>()
+                var result: [ToolConfirmationData] = []
+                for tc in groupedToolCalls {
+                    guard let decision = tc.confirmationDecision else { continue }
+                    let label = tc.confirmationLabel ?? tc.toolName
+                    let key = "\(label)|\(decision)"
+                    guard seen.insert(key).inserted else { continue }
+                    var data = ToolConfirmationData(
+                        requestId: "",
+                        toolName: tc.toolName,
+                        riskLevel: "medium",
+                        state: decision
+                    )
+                    data._overrideToolCategory = tc.confirmationLabel
+                    result.append(data)
+                }
+                return result
+            }()
+
             AssistantProgressView(
                 toolCalls: groupedToolCalls,
                 isStreaming: isLatestGroup ? message.isStreaming : false,
@@ -154,7 +178,7 @@ extension ChatBubble {
                 processingStatusText: isLatestGroup && isProcessingAfterTools ? processingStatusText : nil,
                 streamingCodePreview: isLatestGroup ? message.streamingCodePreview : nil,
                 streamingCodeToolName: isLatestGroup ? message.streamingCodeToolName : nil,
-                decidedConfirmation: isLatestGroup ? decidedConfirmation : nil,
+                decidedConfirmations: groupConfirmations,
                 onRehydrate: onRehydrate
             )
             .frame(maxWidth: 520, alignment: .leading)

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -23,6 +23,7 @@ extension ChatBubble {
             && !inlineToolProgressRenderedInContent
         let hasStreamingCode = message.isStreaming && message.streamingCodePreview != nil
             && !(message.streamingCodePreview?.isEmpty ?? true)
+            && !inlineToolProgressRenderedInContent
         let shouldShowProcessing = isProcessingAfterTools && !inlineToolProgressRenderedInContent
 
         // Use live confirmations if available, otherwise derive from persisted tool call data

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -16,25 +16,29 @@ extension ChatBubble {
 
     @ViewBuilder
     var trailingStatus: some View {
-        let hasToolCalls = !message.toolCalls.isEmpty && !hideToolCalls
+        let inlineToolProgressRenderedInContent = shouldRenderToolProgressInline
+        let hasToolCalls = !message.toolCalls.isEmpty
+            && !hideToolCalls
+            && !inlineToolProgressRenderedInContent
         let hasStreamingCode = message.isStreaming && message.streamingCodePreview != nil
             && !(message.streamingCodePreview?.isEmpty ?? true)
+        let shouldShowProcessing = isProcessingAfterTools && !inlineToolProgressRenderedInContent
 
-        if hasToolCalls || hasStreamingCode || isProcessingAfterTools {
+        if hasToolCalls || hasStreamingCode || shouldShowProcessing {
             // Unified progress view handles all tool/streaming/processing states
             AssistantProgressView(
                 toolCalls: hideToolCalls ? [] : message.toolCalls,
                 isStreaming: message.isStreaming,
                 hasText: hasText,
-                isProcessing: isProcessingAfterTools,
-                processingStatusText: isProcessingAfterTools ? processingStatusText : nil,
+                isProcessing: shouldShowProcessing,
+                processingStatusText: shouldShowProcessing ? processingStatusText : nil,
                 streamingCodePreview: message.streamingCodePreview,
                 streamingCodeToolName: message.streamingCodeToolName,
                 decidedConfirmation: decidedConfirmation,
                 onRehydrate: onRehydrate
             )
             .frame(maxWidth: 520, alignment: .leading)
-        } else if let confirmation = decidedConfirmation {
+        } else if let confirmation = decidedConfirmation, !inlineToolProgressRenderedInContent {
             // No tool display needed — only show permission chip.
             VStack(alignment: .leading, spacing: 0) {
                 HStack(alignment: .center, spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -12,6 +12,7 @@ extension ChatBubble {
     /// Whether the permission was denied, meaning incomplete tools were blocked (not running).
     var permissionWasDenied: Bool {
         decidedConfirmation?.state == .denied || decidedConfirmation?.state == .timedOut
+            || message.toolCalls.contains { $0.confirmationDecision == .denied || $0.confirmationDecision == .timedOut }
     }
 
     @ViewBuilder
@@ -24,6 +25,14 @@ extension ChatBubble {
             && !(message.streamingCodePreview?.isEmpty ?? true)
         let shouldShowProcessing = isProcessingAfterTools && !inlineToolProgressRenderedInContent
 
+        // Use live confirmations if available, otherwise derive from persisted tool call data
+        let effectiveConfirmations: [ToolConfirmationData] = {
+            if let live = decidedConfirmation {
+                return [live]
+            }
+            return message.derivedConfirmationsFromToolCalls()
+        }()
+
         if hasToolCalls || hasStreamingCode || shouldShowProcessing {
             // Unified progress view handles all tool/streaming/processing states
             AssistantProgressView(
@@ -34,15 +43,17 @@ extension ChatBubble {
                 processingStatusText: shouldShowProcessing ? processingStatusText : nil,
                 streamingCodePreview: message.streamingCodePreview,
                 streamingCodeToolName: message.streamingCodeToolName,
-                decidedConfirmation: decidedConfirmation,
+                decidedConfirmations: effectiveConfirmations,
                 onRehydrate: onRehydrate
             )
             .frame(maxWidth: 520, alignment: .leading)
-        } else if let confirmation = decidedConfirmation, !inlineToolProgressRenderedInContent {
-            // No tool display needed — only show permission chip.
+        } else if !effectiveConfirmations.isEmpty, !inlineToolProgressRenderedInContent {
+            // No tool display needed — only show permission chips.
             VStack(alignment: .leading, spacing: 0) {
                 HStack(alignment: .center, spacing: VSpacing.sm) {
-                    compactPermissionChip(confirmation)
+                    ForEach(Array(effectiveConfirmations.enumerated()), id: \.offset) { _, confirmation in
+                        compactPermissionChip(confirmation)
+                    }
                     Spacer()
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -62,7 +62,7 @@ extension ChatBubble {
     func compactPermissionChip(_ confirmation: ToolConfirmationData) -> some View {
         let isApproved = confirmation.state == .approved
         let isDenied = confirmation.state == .denied
-        let chipColor: Color = isApproved ? VColor.success : isDenied ? VColor.error : VColor.textMuted
+        let chipColor: Color = isApproved ? VColor.iconAccent : isDenied ? VColor.error : VColor.textMuted
 
         return HStack(spacing: VSpacing.xs) {
             Group {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -61,36 +61,39 @@ extension ChatBubble {
 
     func compactPermissionChip(_ confirmation: ToolConfirmationData) -> some View {
         let isApproved = confirmation.state == .approved
+        let isDenied = confirmation.state == .denied
+        let chipColor: Color = isApproved ? VColor.success : isDenied ? VColor.error : VColor.textMuted
+
         return HStack(spacing: VSpacing.xs) {
             Group {
                 switch confirmation.state {
                 case .approved:
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(VColor.success)
+                        .foregroundColor(chipColor)
                 case .denied:
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundColor(VColor.error)
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .foregroundColor(chipColor)
                 case .timedOut:
                     Image(systemName: "clock.fill")
-                        .foregroundColor(VColor.textMuted)
+                        .foregroundColor(chipColor)
                 default:
                     EmptyView()
                 }
             }
             .font(.system(size: 12))
 
-            Text(isApproved ? "\(confirmation.toolCategory) allowed" :
-                 confirmation.state == .denied ? "\(confirmation.toolCategory) denied" : "Timed out")
-                .font(VFont.caption)
-                .foregroundColor(isApproved ? VColor.success : VColor.textSecondary)
+            Text(isApproved ? "\(confirmation.toolCategory) Allowed" :
+                 isDenied ? "\(confirmation.toolCategory) Denied" : "Timed Out")
+                .font(VFont.captionMedium)
+                .foregroundColor(chipColor)
         }
         .padding(.horizontal, VSpacing.md)
         .padding(.vertical, VSpacing.xs)
         .background(
-            Capsule().fill(isApproved ? VColor.success.opacity(0.1) : VColor.surface)
+            Capsule().fill(chipColor.opacity(0.1))
         )
         .overlay(
-            Capsule().stroke(isApproved ? VColor.success.opacity(0.3) : VColor.surfaceBorder, lineWidth: 0.5)
+            Capsule().stroke(chipColor.opacity(0.3), lineWidth: 0.5)
         )
     }
 }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -87,13 +87,13 @@ extension ChatBubble {
                 .font(VFont.captionMedium)
                 .foregroundColor(chipColor)
         }
-        .padding(.horizontal, VSpacing.md)
+        .padding(.horizontal, VSpacing.sm)
         .padding(.vertical, VSpacing.xs)
         .background(
-            Capsule().fill(chipColor.opacity(0.1))
+            Capsule().fill(Color.clear)
         )
         .overlay(
-            Capsule().stroke(chipColor.opacity(0.3), lineWidth: 0.5)
+            Capsule().stroke(chipColor.opacity(0.3), lineWidth: 1)
         )
     }
 }

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -46,6 +46,9 @@ public struct ToolConfirmationData: Equatable {
     /// The decision string that was used to approve (e.g. "allow", "allow_10m", "allow_thread", "always_allow").
     /// Set when the state transitions to `.approved`.
     public var approvedDecision: String?
+    /// When set, `toolCategory` returns this instead of deriving from `toolName`.
+    /// Used for confirmation data synthesized from persisted per-tool-call labels.
+    public var _overrideToolCategory: String?
 
     /// Normalized target label shown in confirmation UIs.
     public var normalizedExecutionTarget: String? {
@@ -439,6 +442,7 @@ public struct ToolConfirmationData: Equatable {
 
     /// User-facing tool category label (e.g. "Run Command", "Write File").
     public var toolCategory: String {
+        if let override = _overrideToolCategory { return override }
         switch toolName {
         case "bash", "host_bash":                    return "Run Command"
         case "file_write", "host_file_write":        return "Write File"
@@ -779,6 +783,12 @@ public struct ToolCallData: Identifiable, Equatable {
     public var arrivedBeforeText: Bool
     public var startedAt: Date?
     public var completedAt: Date?
+    /// The tool_use block ID from the daemon, for correlating confirmations to tool calls.
+    public var toolUseId: String?
+    /// Persisted confirmation decision for this tool call (survives app restart / thread switch).
+    public var confirmationDecision: ToolConfirmationState?
+    /// Friendly label for the confirmation (e.g. "Edit File", "Run Command").
+    public var confirmationLabel: String?
     /// Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot).
     public var imageData: String?
     /// Human-readable building status from app tool input (e.g. "Adding dark mode styles").
@@ -813,6 +823,10 @@ public struct ToolCallData: Identifiable, Equatable {
             && lhs.buildingStatus == rhs.buildingStatus
             && lhs.reasonDescription == rhs.reasonDescription
             && lhs.claudeCodeSteps == rhs.claudeCodeSteps
+            && lhs.startedAt == rhs.startedAt
+            && lhs.completedAt == rhs.completedAt
+            && lhs.confirmationDecision == rhs.confirmationDecision
+            && lhs.confirmationLabel == rhs.confirmationLabel
     }
 
     public init(id: UUID = UUID(), toolName: String, inputSummary: String, inputFull: String? = nil, inputRawValue: String? = nil, result: String? = nil, isError: Bool = false, isComplete: Bool = false, arrivedBeforeText: Bool = true, imageData: String? = nil, startedAt: Date? = nil, completedAt: Date? = nil) {
@@ -1634,6 +1648,29 @@ public struct ChatMessage: Identifiable, Equatable {
         self.toolCalls = toolCalls
         self.inlineSurfaces = inlineSurfaces
         self.isError = isError
+    }
+
+    /// Synthesize `ToolConfirmationData` entries from persisted per-tool-call confirmation data.
+    /// Returns one entry per unique (toolCategory, state) pair, deduplicated.
+    /// Used as a fallback when live `decidedConfirmation` is nil (e.g. after history restore).
+    public func derivedConfirmationsFromToolCalls() -> [ToolConfirmationData] {
+        var seen = Set<String>()
+        var result: [ToolConfirmationData] = []
+        for tc in toolCalls {
+            guard let decision = tc.confirmationDecision else { continue }
+            let label = tc.confirmationLabel ?? tc.toolName
+            let key = "\(label)|\(decision)"
+            guard seen.insert(key).inserted else { continue }
+            var data = ToolConfirmationData(
+                requestId: "",
+                toolName: tc.toolName,
+                riskLevel: "medium",
+                state: decision
+            )
+            data._overrideToolCategory = tc.confirmationLabel
+            result.append(data)
+        }
+        return result
     }
 
     /// Release heavyweight data (images, attachment binary data, completed surface

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1612,12 +1612,21 @@ extension ChatViewModel {
             for i in messages.indices {
                 guard messages[i].confirmation?.requestId == msg.requestId else { continue }
                 confirmationToolName = messages[i].confirmation?.toolName
-                // The assistant message owning the tool calls is the one before the confirmation message.
-                if i > messages.startIndex {
-                    let before = messages.index(before: i)
-                    if messages[before].role == .assistant {
-                        precedingAssistantId = messages[before].id
+                // Walk backwards past other confirmation messages to find the
+                // tool-bearing assistant message. With parallel confirmations the
+                // order is [assistant(A), confirm2, confirm1], so looking only one
+                // message back would hit confirm2 instead of assistant(A).
+                var searchIdx = i
+                while searchIdx > messages.startIndex {
+                    searchIdx = messages.index(before: searchIdx)
+                    let candidate = messages[searchIdx]
+                    if candidate.role == .assistant && !candidate.toolCalls.isEmpty {
+                        precedingAssistantId = candidate.id
+                        break
                     }
+                    // Skip past confirmation messages (assistant messages with .confirmation set)
+                    if candidate.role == .assistant && candidate.confirmation != nil { continue }
+                    break
                 }
                 switch msg.state {
                 case "approved":

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -27,6 +27,31 @@ extension ChatViewModel {
         return messageSessionId == sessionId
     }
 
+    /// Map daemon confirmation state string to ToolConfirmationState.
+    private func mapConfirmationState(_ state: String) -> ToolConfirmationState? {
+        switch state {
+        case "approved": return .approved
+        case "denied": return .denied
+        case "timed_out": return .timedOut
+        default: return nil
+        }
+    }
+
+    /// Stamp confirmation decision on the most recent incomplete tool call matching the tool name.
+    private func stampConfirmationOnToolCall(toolName: String, decision: ToolConfirmationState) {
+        guard let assistantId = currentAssistantMessageId,
+              let msgIdx = messages.firstIndex(where: { $0.id == assistantId }) else { return }
+        // Find the last tool call that matches the tool name and lacks a confirmation decision
+        if let tcIdx = messages[msgIdx].toolCalls.lastIndex(where: {
+            $0.toolName == toolName && $0.confirmationDecision == nil
+        }) {
+            messages[msgIdx].toolCalls[tcIdx].confirmationDecision = decision
+            // Use the tool category from the confirmation data as the label
+            let label = ToolConfirmationData(requestId: "", toolName: toolName, riskLevel: "").toolCategory
+            messages[msgIdx].toolCalls[tcIdx].confirmationLabel = label
+        }
+    }
+
     /// Priority list of input keys whose values are most useful as a tool call summary.
     static let toolInputPriorityKeys = [
         "command", "file_path", "path", "query", "url", "pattern", "glob"
@@ -1135,6 +1160,7 @@ extension ChatViewModel {
                 startedAt: Date()
             )
             toolCall.buildingStatus = buildingStatus
+            toolCall.toolUseId = msg.toolUseId
             toolCall.reasonDescription = (msg.input["reason"]?.value as? String)
                 ?? (msg.input["reasoning"]?.value as? String)
             // Add to existing assistant message or create one.
@@ -1571,8 +1597,10 @@ extension ChatViewModel {
         case .confirmationStateChanged(let msg):
             guard belongsToSession(msg.sessionId) else { return }
             // Find the confirmation with this requestId and update its state.
+            var confirmationToolName: String?
             for i in messages.indices {
                 guard messages[i].confirmation?.requestId == msg.requestId else { continue }
+                confirmationToolName = messages[i].confirmation?.toolName
                 switch msg.state {
                 case "approved":
                     messages[i].confirmation?.state = .approved
@@ -1588,6 +1616,12 @@ extension ChatViewModel {
                     break
                 }
                 break
+            }
+            // Stamp confirmation data on the corresponding ToolCallData in the
+            // preceding assistant message so it survives thread switches.
+            if let toolName = confirmationToolName,
+               let state = mapConfirmationState(msg.state) {
+                stampConfirmationOnToolCall(toolName: toolName, decision: state)
             }
 
         case .assistantActivityState(let msg):

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -38,9 +38,10 @@ extension ChatViewModel {
     }
 
     /// Stamp confirmation decision on the tool call matching the toolUseId (preferred) or tool name (fallback).
-    private func stampConfirmationOnToolCall(toolName: String, decision: ToolConfirmationState, toolUseId: String? = nil) {
-        guard let assistantId = currentAssistantMessageId,
-              let msgIdx = messages.firstIndex(where: { $0.id == assistantId }) else { return }
+    /// When `targetMessageId` is provided, stamps on that specific message instead of `currentAssistantMessageId`.
+    private func stampConfirmationOnToolCall(toolName: String, decision: ToolConfirmationState, toolUseId: String? = nil, targetMessageId: UUID? = nil) {
+        let assistantId = targetMessageId ?? currentAssistantMessageId
+        guard let assistantId, let msgIdx = messages.firstIndex(where: { $0.id == assistantId }) else { return }
         // Prefer matching by toolUseId for correctness when multiple calls share the same name
         let tcIdx: Int?
         if let toolUseId = toolUseId {
@@ -1607,9 +1608,17 @@ extension ChatViewModel {
             guard belongsToSession(msg.sessionId) else { return }
             // Find the confirmation with this requestId and update its state.
             var confirmationToolName: String?
+            var precedingAssistantId: UUID?
             for i in messages.indices {
                 guard messages[i].confirmation?.requestId == msg.requestId else { continue }
                 confirmationToolName = messages[i].confirmation?.toolName
+                // The assistant message owning the tool calls is the one before the confirmation message.
+                if i > messages.startIndex {
+                    let before = messages.index(before: i)
+                    if messages[before].role == .assistant {
+                        precedingAssistantId = messages[before].id
+                    }
+                }
                 switch msg.state {
                 case "approved":
                     messages[i].confirmation?.state = .approved
@@ -1630,7 +1639,7 @@ extension ChatViewModel {
             // preceding assistant message so it survives thread switches.
             if let toolName = confirmationToolName,
                let state = mapConfirmationState(msg.state) {
-                stampConfirmationOnToolCall(toolName: toolName, decision: state, toolUseId: msg.toolUseId)
+                stampConfirmationOnToolCall(toolName: toolName, decision: state, toolUseId: msg.toolUseId, targetMessageId: precedingAssistantId)
             }
 
         case .assistantActivityState(let msg):

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -37,14 +37,23 @@ extension ChatViewModel {
         }
     }
 
-    /// Stamp confirmation decision on the most recent incomplete tool call matching the tool name.
-    private func stampConfirmationOnToolCall(toolName: String, decision: ToolConfirmationState) {
+    /// Stamp confirmation decision on the tool call matching the toolUseId (preferred) or tool name (fallback).
+    private func stampConfirmationOnToolCall(toolName: String, decision: ToolConfirmationState, toolUseId: String? = nil) {
         guard let assistantId = currentAssistantMessageId,
               let msgIdx = messages.firstIndex(where: { $0.id == assistantId }) else { return }
-        // Find the last tool call that matches the tool name and lacks a confirmation decision
-        if let tcIdx = messages[msgIdx].toolCalls.lastIndex(where: {
-            $0.toolName == toolName && $0.confirmationDecision == nil
-        }) {
+        // Prefer matching by toolUseId for correctness when multiple calls share the same name
+        let tcIdx: Int?
+        if let toolUseId = toolUseId {
+            tcIdx = messages[msgIdx].toolCalls.firstIndex(where: {
+                $0.toolUseId == toolUseId
+            })
+        } else {
+            // Fallback: match by tool name (ambiguous when duplicates exist)
+            tcIdx = messages[msgIdx].toolCalls.lastIndex(where: {
+                $0.toolName == toolName && $0.confirmationDecision == nil
+            })
+        }
+        if let tcIdx = tcIdx {
             messages[msgIdx].toolCalls[tcIdx].confirmationDecision = decision
             // Use the tool category from the confirmation data as the label
             let label = ToolConfirmationData(requestId: "", toolName: toolName, riskLevel: "").toolCategory
@@ -1621,7 +1630,7 @@ extension ChatViewModel {
             // preceding assistant message so it survives thread switches.
             if let toolName = confirmationToolName,
                let state = mapConfirmationState(msg.state) {
-                stampConfirmationOnToolCall(toolName: toolName, decision: state)
+                stampConfirmationOnToolCall(toolName: toolName, decision: state, toolUseId: msg.toolUseId)
             }
 
         case .assistantActivityState(let msg):

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -42,14 +42,16 @@ extension ChatViewModel {
     private func stampConfirmationOnToolCall(toolName: String, decision: ToolConfirmationState, toolUseId: String? = nil, targetMessageId: UUID? = nil) {
         let assistantId = targetMessageId ?? currentAssistantMessageId
         guard let assistantId, let msgIdx = messages.firstIndex(where: { $0.id == assistantId }) else { return }
-        // Prefer matching by toolUseId for correctness when multiple calls share the same name
-        let tcIdx: Int?
+        // Prefer matching by toolUseId for correctness when multiple calls share the same name.
+        // Fall back to tool name if ID match fails (e.g. after history restore where
+        // ToolCallData entries may not carry toolUseId yet).
+        var tcIdx: Int?
         if let toolUseId = toolUseId {
             tcIdx = messages[msgIdx].toolCalls.firstIndex(where: {
                 $0.toolUseId == toolUseId
             })
-        } else {
-            // Fallback: match by tool name (ambiguous when duplicates exist)
+        }
+        if tcIdx == nil {
             tcIdx = messages[msgIdx].toolCalls.lastIndex(where: {
                 $0.toolName == toolName && $0.confirmationDecision == nil
             })

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2142,6 +2142,22 @@ public final class ChatViewModel: ObservableObject {
                     toolCall.cachedImage = decodedImage
                     toolCall.reasonDescription = (tc.input["reason"]?.value as? String)
                         ?? (tc.input["reasoning"]?.value as? String)
+                    // Restore persisted timing and confirmation data
+                    if let startMs = tc.startedAt {
+                        toolCall.startedAt = Date(timeIntervalSince1970: Double(startMs) / 1000.0)
+                    }
+                    if let endMs = tc.completedAt {
+                        toolCall.completedAt = Date(timeIntervalSince1970: Double(endMs) / 1000.0)
+                    }
+                    if let decision = tc.confirmationDecision {
+                        switch decision {
+                        case "approved": toolCall.confirmationDecision = .approved
+                        case "denied": toolCall.confirmationDecision = .denied
+                        case "timed_out": toolCall.confirmationDecision = .timedOut
+                        default: break
+                        }
+                    }
+                    toolCall.confirmationLabel = tc.confirmationLabel
                     // Cap tool input size to prevent unbounded memory from large history
                     // restores. Check size synchronously to avoid a race where a deferred
                     // Task might run before self.messages is populated with these new items.

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2348,13 +2348,25 @@ public struct IPCHistoryResponseToolCall: Codable, Sendable {
     public let isError: Bool?
     /// Base64-encoded image data from tool contentBlocks (e.g. browser_screenshot).
     public let imageData: String?
+    /// Unix ms when the tool started executing.
+    public let startedAt: Int?
+    /// Unix ms when the tool completed.
+    public let completedAt: Int?
+    /// Confirmation decision for this tool call: "approved" | "denied" | "timed_out".
+    public let confirmationDecision: String?
+    /// Friendly label for the confirmation (e.g. "Edit File", "Run Command").
+    public let confirmationLabel: String?
 
-    public init(name: String, input: [String: AnyCodable], result: String? = nil, isError: Bool? = nil, imageData: String? = nil) {
+    public init(name: String, input: [String: AnyCodable], result: String? = nil, isError: Bool? = nil, imageData: String? = nil, startedAt: Int? = nil, completedAt: Int? = nil, confirmationDecision: String? = nil, confirmationLabel: String? = nil) {
         self.name = name
         self.input = input
         self.result = result
         self.isError = isError
         self.imageData = imageData
+        self.startedAt = startedAt
+        self.completedAt = completedAt
+        self.confirmationDecision = confirmationDecision
+        self.confirmationLabel = confirmationLabel
     }
 }
 
@@ -4893,12 +4905,15 @@ public struct IPCToolUseStart: Codable, Sendable {
     public let toolName: String
     public let input: [String: AnyCodable]
     public let sessionId: String?
+    /// The tool_use block ID for client-side correlation.
+    public let toolUseId: String?
 
-    public init(type: String, toolName: String, input: [String: AnyCodable], sessionId: String? = nil) {
+    public init(type: String, toolName: String, input: [String: AnyCodable], sessionId: String? = nil, toolUseId: String? = nil) {
         self.type = type
         self.toolName = toolName
         self.input = input
         self.sessionId = sessionId
+        self.toolUseId = toolUseId
     }
 }
 

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -802,8 +802,10 @@ public struct IPCConfirmationStateChanged: Codable, Sendable {
     public let causedByRequestId: String?
     /// Normalized user text for analytics/debug (e.g. "approve", "deny").
     public let decisionText: String?
+    /// The tool_use block ID this confirmation applies to, for disambiguating parallel tool calls.
+    public let toolUseId: String?
 
-    public init(type: String, sessionId: String, requestId: String, state: String, source: String, causedByRequestId: String? = nil, decisionText: String? = nil) {
+    public init(type: String, sessionId: String, requestId: String, state: String, source: String, causedByRequestId: String? = nil, decisionText: String? = nil, toolUseId: String? = nil) {
         self.type = type
         self.sessionId = sessionId
         self.requestId = requestId
@@ -811,6 +813,7 @@ public struct IPCConfirmationStateChanged: Codable, Sendable {
         self.source = source
         self.causedByRequestId = causedByRequestId
         self.decisionText = decisionText
+        self.toolUseId = toolUseId
     }
 }
 


### PR DESCRIPTION
[LUM-17](https://linear.app/vellum/issue/LUM-17/refine-tool-calls-should-in-chat)

## Summary
- Render `AssistantProgressView` inline at each tool-call group position in interleaved messages, preserving reading order and context for multi-step tool use
- Anchor decided confirmation chips to specific assistant messages and tool-call indices so they render on the correct progress block rather than always attaching to the latest group
- Skip trailing status rendering when inline tool progress is active to avoid duplicate UI

## Test plan
- [ ] Verify interleaved messages (text → tool calls → text → tool calls) render progress blocks inline at each tool-call position
- [ ] Verify decided confirmation chips appear on the correct tool-call group, not just the latest
- [ ] Verify non-interleaved messages still render tool progress in the trailing status area
- [ ] Verify streaming code preview and processing states render correctly on the latest tool group only

🤖 Generated with [Claude Code](https://claude.com/claude-code)