### PR TITLE
M1: Add border to VToggle off-state for visibility

### DIFF
--- a/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
@@ -47,6 +47,11 @@ public struct VToggle: View {
             RoundedRectangle(cornerRadius: trackHeight / 2)
                 .fill(isOn ? Forest._600 : VColor.toggleOff)
                 .frame(width: trackWidth, height: trackHeight)
+                .overlay(
+                    RoundedRectangle(cornerRadius: trackHeight / 2)
+                        .stroke(VColor.toggleBorder, lineWidth: 1)
+                        .opacity(isOn ? 0 : 1)
+                )
 
             // Knob
             RoundedRectangle(cornerRadius: knobSize / 2)


### PR DESCRIPTION
Adds a 1pt stroke using VColor.toggleBorder on the toggle track when off, so it reads as an interactive control. Closes #13033.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13038" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
