### PR TITLE
Add `resolveChannelHandle()` to ChannelInviteAdapter interface

### DIFF
--- a/assistant/src/runtime/channel-invite-transport.ts
+++ b/assistant/src/runtime/channel-invite-transport.ts
@@ -66,6 +66,14 @@ export interface ChannelInviteAdapter {
     inviteCode: string;
     contactName?: string;
   }): GuardianInstruction;
+
+  /**
+   * Resolve the channel-specific handle to reach the assistant (e.g.
+   * "@botName", "+15551234567", "hello@domain.agentmail.to").
+   * Returns `undefined` when the handle cannot be resolved (e.g.
+   * credentials not yet configured).
+   */
+  resolveChannelHandle?(): string | undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/channel-invite-transports/email.ts
+++ b/assistant/src/runtime/channel-invite-transports/email.ts
@@ -47,4 +47,8 @@ export const emailInviteAdapter: ChannelInviteAdapter = {
       channelHandle: address,
     };
   },
+
+  resolveChannelHandle(): string | undefined {
+    return resolveAssistantEmailAddress();
+  },
 };

--- a/assistant/src/runtime/channel-invite-transports/slack.ts
+++ b/assistant/src/runtime/channel-invite-transports/slack.ts
@@ -78,4 +78,10 @@ export const slackInviteAdapter: ChannelInviteAdapter = {
       channelHandle: `@${botInfo.botUsername}`,
     };
   },
+
+  resolveChannelHandle(): string | undefined {
+    const botInfo = resolveSlackBotInfo();
+    if (!botInfo) return undefined;
+    return `@${botInfo.botUsername}`;
+  },
 };

--- a/assistant/src/runtime/channel-invite-transports/sms.ts
+++ b/assistant/src/runtime/channel-invite-transports/sms.ts
@@ -67,4 +67,8 @@ export const smsInviteAdapter: ChannelInviteAdapter = {
       channelHandle: phoneNumber,
     };
   },
+
+  resolveChannelHandle(): string | undefined {
+    return resolveSmsPhoneNumber();
+  },
 };

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -85,6 +85,12 @@ export const telegramInviteAdapter: ChannelInviteAdapter = {
     };
   },
 
+  resolveChannelHandle(): string | undefined {
+    const botUsername = getTelegramBotUsername();
+    if (!botUsername) return undefined;
+    return `@${botUsername}`;
+  },
+
   extractInboundToken(params: {
     commandIntent?: Record<string, unknown>;
     content: string;


### PR DESCRIPTION
## Summary
- Adds optional `resolveChannelHandle()` method to the `ChannelInviteAdapter` interface
- Implements it in all four channel adapters (email, slack, telegram, sms)
- Each adapter returns the same handle value that `buildGuardianInstruction` sets as `channelHandle`

Part of plan: channel-invite-ui-info.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
