### PR TITLE
Refactor `fetchChannelReadiness` to return rich channel info

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -33,7 +33,7 @@ struct ContactDetailView: View {
     )?
     @State private var inviteError: String?
     @State private var inviteCopiedType: String?
-    @State private var channelReadiness: [String: Bool] = [:]
+    @State private var channelReadiness: [String: DaemonClient.ChannelReadinessInfo] = [:]
 
     var displayContact: ContactPayload {
         currentContact ?? contact
@@ -340,8 +340,8 @@ struct ContactDetailView: View {
                 // explicitly marked false.
                 let probedChannels: Set<String> = ["sms", "telegram", "voice"]
                 let channelIsReady = probedChannels.contains(type)
-                    ? channelReadiness[type] == true
-                    : channelReadiness[type] != false
+                    ? channelReadiness[type]?.ready == true
+                    : channelReadiness[type]?.ready != false
                 if displayContact.role != "guardian" && type != "voice" && channelIsReady {
                     if inviteInProgress == type {
                         ProgressView()

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1697,10 +1697,16 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         #endif
     }
 
+    /// Rich channel readiness information returned by `fetchChannelReadiness()`.
+    public struct ChannelReadinessInfo {
+        public let ready: Bool
+        public let channelHandle: String?
+    }
+
     /// Fetch per-channel readiness state from the gateway.
     /// Routes through `HTTPTransport` when available. Falls back to the
     /// local gateway for socket-based connections.
-    public func fetchChannelReadiness() async throws -> [String: Bool] {
+    public func fetchChannelReadiness() async throws -> [String: ChannelReadinessInfo] {
         if let httpTransport {
             return try await httpTransport.fetchChannelReadiness()
         }
@@ -1718,12 +1724,16 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             struct Snapshot: Decodable {
                 let channel: String
                 let ready: Bool
+                let channelHandle: String?
             }
         }
         let decoded = try JSONDecoder().decode(ReadinessResponse.self, from: data)
-        var result: [String: Bool] = [:]
+        var result: [String: ChannelReadinessInfo] = [:]
         for snapshot in decoded.snapshots {
-            result[snapshot.channel] = snapshot.ready
+            result[snapshot.channel] = ChannelReadinessInfo(
+                ready: snapshot.ready,
+                channelHandle: snapshot.channelHandle
+            )
         }
         return result
         #else

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1142,6 +1142,7 @@ public final class HTTPTransport {
         struct ChannelReadinessSnapshot: Decodable {
             let channel: String
             let ready: Bool
+            let channelHandle: String?
         }
     }
 
@@ -1272,7 +1273,7 @@ public final class HTTPTransport {
 
     /// Fetch per-channel readiness from `GET /v1/channels/readiness`.
     /// Returns a dictionary mapping channel type strings to their readiness state.
-    func fetchChannelReadiness(isRetry: Bool = false) async throws -> [String: Bool] {
+    func fetchChannelReadiness(isRetry: Bool = false) async throws -> [String: DaemonClient.ChannelReadinessInfo] {
         guard let url = buildURL(for: .channelsReadiness) else { return [:] }
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
@@ -1291,9 +1292,12 @@ public final class HTTPTransport {
         }
 
         let decoded = try decoder.decode(HTTPChannelReadinessResponse.self, from: data)
-        var result: [String: Bool] = [:]
+        var result: [String: DaemonClient.ChannelReadinessInfo] = [:]
         for snapshot in decoded.snapshots {
-            result[snapshot.channel] = snapshot.ready
+            result[snapshot.channel] = DaemonClient.ChannelReadinessInfo(
+                ready: snapshot.ready,
+                channelHandle: snapshot.channelHandle
+            )
         }
         return result
     }


### PR DESCRIPTION
## Summary
- Adds `ChannelReadinessInfo` struct with `ready: Bool` and `channelHandle: String?`
- Updates `fetchChannelReadiness()` in both `DaemonClient` and `HTTPDaemonClient` to return `[String: ChannelReadinessInfo]`
- Updates `ContactDetailView` to use the new type with backward-compatible readiness checks

Part of plan: channel-invite-ui-info.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
