### PR TITLE
Include `channelHandle` in channel readiness API response

### DIFF
--- a/assistant/src/runtime/routes/channel-readiness-routes.ts
+++ b/assistant/src/runtime/routes/channel-readiness-routes.ts
@@ -7,6 +7,7 @@
 
 import type { ChannelId } from "../../channels/types.js";
 import { getReadinessService } from "../../daemon/handlers/config-channels.js";
+import { getInviteAdapterRegistry } from "../channel-invite-transport.js";
 import type { RouteDefinition } from "../http-router.js";
 
 /**
@@ -21,18 +22,23 @@ export async function handleGetChannelReadiness(url: URL): Promise<Response> {
 
   const service = getReadinessService();
   const snapshots = await service.getReadiness(channel, includeRemote);
+  const adapterRegistry = getInviteAdapterRegistry();
 
   return Response.json({
     success: true,
-    snapshots: snapshots.map((s) => ({
-      channel: s.channel,
-      ready: s.ready,
-      checkedAt: s.checkedAt,
-      stale: s.stale,
-      reasons: s.reasons,
-      localChecks: s.localChecks,
-      remoteChecks: s.remoteChecks,
-    })),
+    snapshots: snapshots.map((s) => {
+      const adapter = adapterRegistry.get(s.channel);
+      return {
+        channel: s.channel,
+        ready: s.ready,
+        checkedAt: s.checkedAt,
+        stale: s.stale,
+        reasons: s.reasons,
+        localChecks: s.localChecks,
+        remoteChecks: s.remoteChecks,
+        channelHandle: adapter?.resolveChannelHandle?.() ?? undefined,
+      };
+    }),
   });
 }
 
@@ -62,18 +68,23 @@ export async function handleRefreshChannelReadiness(
     body.channel,
     body.includeRemote,
   );
+  const adapterRegistry = getInviteAdapterRegistry();
 
   return Response.json({
     success: true,
-    snapshots: snapshots.map((s) => ({
-      channel: s.channel,
-      ready: s.ready,
-      checkedAt: s.checkedAt,
-      stale: s.stale,
-      reasons: s.reasons,
-      localChecks: s.localChecks,
-      remoteChecks: s.remoteChecks,
-    })),
+    snapshots: snapshots.map((s) => {
+      const adapter = adapterRegistry.get(s.channel);
+      return {
+        channel: s.channel,
+        ready: s.ready,
+        checkedAt: s.checkedAt,
+        stale: s.stale,
+        reasons: s.reasons,
+        localChecks: s.localChecks,
+        remoteChecks: s.remoteChecks,
+        channelHandle: adapter?.resolveChannelHandle?.() ?? undefined,
+      };
+    }),
   });
 }
 


### PR DESCRIPTION
## Summary
- Enriches `GET /v1/channels/readiness` and `POST /v1/channels/readiness/refresh` responses with `channelHandle` per channel
- Calls `resolveChannelHandle()` on the invite adapter registry for each channel in the readiness snapshot
- Gateway proxy passes through raw JSON, so no gateway changes needed

Part of plan: channel-invite-ui-info.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
