### PR TITLE
feat: add thread title actions drawer with pin/rename/copy/archive

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
@@ -71,17 +71,3 @@ final class SidebarInteractionState {
     /// or the top (false). Set based on drag direction.
     var dropIndicatorAtBottom: Bool = false
 }
-
-/// Copy-thread confirmation state.
-@Observable
-@MainActor
-final class CopyThreadState {
-    var showConfirmation = false
-    var confirmationTimer: DispatchWorkItem?
-
-    func cancel() {
-        confirmationTimer?.cancel()
-        confirmationTimer = nil
-        showConfirmation = false
-    }
-}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -120,15 +120,8 @@ extension MainWindowView {
             ))
             Button("Cancel", role: .cancel) { sidebar.renamingThreadId = nil }
             Button("Save") {
-                if let id = sidebar.renamingThreadId, !sidebar.renameText.isEmpty {
-                    threadManager.updateThreadTitle(id: id, title: sidebar.renameText)
-                    if let sessionId = threadManager.threads.first(where: { $0.id == id })?.sessionId {
-                        try? daemonClient.send(IPCSessionRenameRequest(
-                            type: "session_rename",
-                            sessionId: sessionId,
-                            title: sidebar.renameText
-                        ))
-                    }
+                if let id = sidebar.renamingThreadId {
+                    threadManager.renameThread(id: id, title: sidebar.renameText)
                 }
                 sidebar.renamingThreadId = nil
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -16,9 +16,9 @@ struct MainWindowView: View {
     @State private var selectedThreadId: UUID?
     @State var sharing = SharingState()
     @State var sidebar = SidebarInteractionState()
-    @State private var copyThread = CopyThreadState()
     @AppStorage("isAppChatOpen") var isAppChatOpen: Bool = false
     @State private var jitPermissionManager = JITPermissionManager()
+    @State var showThreadActionsDrawer = false
     /// Stores the thread ID the user was on before entering temporary chat,
     /// so we can restore it when they exit instead of jumping to visibleThreads.first
     /// (which may be a pinned thread unrelated to what they were doing).
@@ -158,7 +158,7 @@ struct MainWindowView: View {
     }
 
     /// Whether the chat bubble toggle is active (chat is open).
-    private var isChatBubbleActive: Bool {
+    var isChatBubbleActive: Bool {
         switch windowState.selection {
         case .appEditing:
             return true
@@ -193,6 +193,28 @@ struct MainWindowView: View {
         )
     }
 
+    func copyActiveThreadToClipboard() {
+        let messages = threadManager.activeViewModel?.messages ?? []
+        let title = threadManager.activeThread?.title
+        let names = resolveParticipantNames()
+        let markdown = ChatTranscriptFormatter.threadMarkdown(
+            messages: messages,
+            threadTitle: title,
+            participantNames: names
+        )
+        guard !markdown.isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(markdown, forType: .string)
+        windowState.showToast(message: "Thread copied to clipboard", style: .success)
+    }
+
+    func startRenameActiveThread() {
+        guard let id = threadManager.activeThreadId,
+              let thread = threadManager.activeThread else { return }
+        sidebar.renamingThreadId = id
+        sidebar.renameText = thread.title
+    }
+
     var body: some View {
         coreLayoutView
             .opacity(showComingAlive ? 0 : 1)
@@ -215,6 +237,10 @@ struct MainWindowView: View {
                 // but not on draft promotion (nil → UUID) which happens on first send.
                 if let oldId, oldId != newId, voiceModeManager.state != .off {
                     voiceModeManager.deactivate()
+                }
+                // Dismiss thread actions drawer on thread switch
+                if showThreadActionsDrawer {
+                    showThreadActionsDrawer = false
                 }
             }
             .onChange(of: windowState.selection) { oldSelection, newSelection in
@@ -344,36 +370,6 @@ struct MainWindowView: View {
                 windowState.selection = .panel(.settings)
             }
             if windowState.isShowingChat || isChatBubbleActive {
-                // Copy Thread button — only visible when there's content to copy
-                if threadManager.activeViewModel?.messages.contains(where: {
-                    !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                }) == true {
-                    VIconButton(
-                        label: "Copy thread",
-                        icon: copyThread.showConfirmation ? "checkmark" : "list.clipboard",
-                        isActive: copyThread.showConfirmation,
-                        iconOnly: true,
-                        tooltip: copyThread.showConfirmation ? "Copied!" : "Copy thread"
-                    ) {
-                        let messages = threadManager.activeViewModel?.messages ?? []
-                        let title = threadManager.activeThread?.title
-                        let names = resolveParticipantNames()
-                        let markdown = ChatTranscriptFormatter.threadMarkdown(
-                            messages: messages,
-                            threadTitle: title,
-                            participantNames: names
-                        )
-                        guard !markdown.isEmpty else { return }
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(markdown, forType: .string)
-                        copyThread.cancel()
-                        copyThread.showConfirmation = true
-                        let timer = DispatchWorkItem { [copyThread] in copyThread.showConfirmation = false }
-                        copyThread.confirmationTimer = timer
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: timer)
-                    }
-                }
-
                 // Voice mode toggle
                 VIconButton(
                     label: "Voice Mode",
@@ -519,7 +515,6 @@ struct MainWindowView: View {
             daemonClient.startSSE()
         }
         .onDisappear {
-            copyThread.cancel()
             sharing.errorDismissTask?.cancel()
             sharing.errorDismissTask = nil
             sharing.credentialPollTimer?.invalidate()

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -244,6 +244,8 @@ extension MainWindowView {
                 AppWorkspaceDockLayout(
                     dockWidth: clampedChatDockWidth(geometry: geometry),
                     showDock: windowState.isChatDockOpen,
+                    dockBackground: VColor.chatBackground,
+                    dockCornerRadius: 0,
                     dock: {
                         chatView
                     },
@@ -271,6 +273,8 @@ extension MainWindowView {
                     VSplitView(
                         panelWidth: clampedPanelWidth(geometry: geometry),
                         showPanel: true,
+                        mainBackground: VColor.chatBackground,
+                        mainCornerRadius: 0,
                         main: {
                             chatView
                         },
@@ -367,6 +371,8 @@ extension MainWindowView {
                 VSplitView(
                     panelWidth: clampedPanelWidth(geometry: geometry),
                     showPanel: true,
+                    mainBackground: VColor.chatBackground,
+                    mainCornerRadius: 0,
                     main: {
                         chatView
                     },
@@ -404,6 +410,8 @@ extension MainWindowView {
         VSplitView(
             panelWidth: $sidePanelWidth,
             showPanel: showConfigPanel || showSubagentPanel,
+            mainBackground: VColor.chatBackground,
+            mainCornerRadius: 0,
             main: { slotView(for: config.center.content) },
             panel: {
                 if let subagentId = windowState.selectedSubagentId,
@@ -428,11 +436,52 @@ extension MainWindowView {
         )
     }
 
+    private var threadHeaderPresentation: ThreadHeaderPresentation {
+        ThreadHeaderPresentation(
+            activeThread: threadManager.activeThread,
+            activeViewModel: threadManager.activeViewModel,
+            isConversationVisible: windowState.isShowingChat || isChatBubbleActive
+        )
+    }
+
+    private func dismissThreadDrawer() {
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+            showThreadActionsDrawer = false
+        }
+    }
+
     @ViewBuilder
     var chatView: some View {
         if let viewModel = threadManager.activeViewModel {
             let activeThread = threadManager.activeThread
+            let presentation = threadHeaderPresentation
             VStack(spacing: 0) {
+                // Thread title header
+                HStack {
+                    ThreadTitleActionsControl(
+                        presentation: presentation,
+                        onCopy: { copyActiveThreadToClipboard(); dismissThreadDrawer() },
+                        onPin: {
+                            guard let id = threadManager.activeThreadId else { return }
+                            threadManager.pinThread(id: id)
+                            dismissThreadDrawer()
+                        },
+                        onUnpin: {
+                            guard let id = threadManager.activeThreadId else { return }
+                            threadManager.unpinThread(id: id)
+                            dismissThreadDrawer()
+                        },
+                        onArchive: {
+                            guard let id = threadManager.activeThreadId else { return }
+                            threadManager.archiveThread(id: id)
+                            dismissThreadDrawer()
+                        },
+                        onRename: { startRenameActiveThread(); dismissThreadDrawer() },
+                        showDrawer: $showThreadActionsDrawer
+                    )
+                    Spacer()
+                }
+
                 ActiveChatViewWrapper(
                     viewModel: viewModel,
                     windowState: windowState,
@@ -458,6 +507,38 @@ extension MainWindowView {
                     }
                 }
                 .animation(VAnimation.fast, value: conversationZoomManager.showZoomIndicator)
+            }
+            .overlay {
+                if showThreadActionsDrawer {
+                    Color.clear
+                        .contentShape(Rectangle())
+                        .onTapGesture { dismissThreadDrawer() }
+                }
+            }
+            .overlay(alignment: .topLeading) {
+                if showThreadActionsDrawer {
+                    ThreadActionsDrawer(
+                        presentation: presentation,
+                        onCopy: { copyActiveThreadToClipboard(); dismissThreadDrawer() },
+                        onPin: {
+                            guard let id = threadManager.activeThreadId else { return }
+                            threadManager.pinThread(id: id)
+                            dismissThreadDrawer()
+                        },
+                        onUnpin: {
+                            guard let id = threadManager.activeThreadId else { return }
+                            threadManager.unpinThread(id: id)
+                            dismissThreadDrawer()
+                        },
+                        onArchive: {
+                            guard let id = threadManager.activeThreadId else { return }
+                            threadManager.archiveThread(id: id)
+                            dismissThreadDrawer()
+                        },
+                        onRename: { startRenameActiveThread(); dismissThreadDrawer() }
+                    )
+                    .offset(x: VSpacing.lg, y: 32)
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadHeaderPresentation.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadHeaderPresentation.swift
@@ -1,0 +1,42 @@
+import Foundation
+import VellumAssistantShared
+
+/// Presentation model for the thread title + actions control in the top bar.
+/// Keeps UI logic deterministic and testable.
+@MainActor
+struct ThreadHeaderPresentation {
+    let displayTitle: String
+    let isStarted: Bool
+    let showsActionsMenu: Bool
+    let isPrivateThread: Bool
+    let canCopy: Bool
+    let isPinned: Bool
+
+    init(activeThread: ThreadModel?, activeViewModel: ChatViewModel?, isConversationVisible: Bool) {
+        guard isConversationVisible, let thread = activeThread else {
+            self.displayTitle = "New thread"
+            self.isStarted = false
+            self.showsActionsMenu = false
+            self.isPrivateThread = false
+            self.canCopy = false
+            self.isPinned = false
+            return
+        }
+
+        self.displayTitle = thread.title
+        self.isPinned = thread.isPinned
+        self.isPrivateThread = thread.kind == .private
+
+        // "Started" = has a sessionId OR has at least one non-empty user message
+        let hasUserMessage = activeViewModel?.messages.contains(where: {
+            !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }) ?? false
+        self.isStarted = thread.sessionId != nil || hasUserMessage
+
+        // Private threads don't show the full actions menu
+        self.showsActionsMenu = isStarted && !isPrivateThread
+
+        // Can copy when there's non-empty content
+        self.canCopy = hasUserMessage
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -83,6 +83,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     private let daemonClient: DaemonClient
     private let sessionRestorer: ThreadSessionRestorer
     private let activityNotificationService: ActivityNotificationService?
+    /// Queued renames for threads that don't yet have a sessionId.
+    /// Flushed in backfillSessionId when the daemon assigns a session.
+    private var pendingRenames: [UUID: String] = [:]
     /// Flag to suppress lastActiveThreadIdString writes during initialization and session restoration.
     private var isRestoringThreads = false
     /// Subscription to activeViewModel's messages count changes.
@@ -943,6 +946,25 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         threads[index].title = title
     }
 
+    /// Rename a thread and send the rename to the daemon.
+    /// If the thread doesn't have a sessionId yet, the rename is queued
+    /// and flushed when backfillSessionId is called.
+    func renameThread(id: UUID, title: String) {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        guard let index = threads.firstIndex(where: { $0.id == id }) else { return }
+        threads[index].title = trimmed
+        if let sessionId = threads[index].sessionId {
+            try? daemonClient.send(IPCSessionRenameRequest(
+                type: "session_rename",
+                sessionId: sessionId,
+                title: trimmed
+            ))
+        } else {
+            pendingRenames[id] = trimmed
+        }
+    }
+
     func makeViewModel() -> ChatViewModel {
         let viewModel = ChatViewModel(daemonClient: daemonClient)
         viewModel.onToolCallsComplete = { [weak self, weak viewModel] toolCalls in
@@ -1198,6 +1220,14 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         // a session would have been skipped by sendReorderThreads()
         // because it filters out threads without a sessionId.
         sendReorderThreads()
+        // Flush any rename that was queued before the session ID was assigned.
+        if let pendingTitle = pendingRenames.removeValue(forKey: threadId) {
+            try? daemonClient.send(IPCSessionRenameRequest(
+                type: "session_rename",
+                sessionId: sessionId,
+                title: pendingTitle
+            ))
+        }
     }
 
     // MARK: - Lazy VM Creation

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTitleActionsControl.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+import VellumAssistantShared
+
+/// Top-left thread header above the chat: shows thread title + chevron.
+/// Tapping opens a drawer-style popover with thread actions.
+struct ThreadTitleActionsControl: View {
+    let presentation: ThreadHeaderPresentation
+    let onCopy: () -> Void
+    let onPin: () -> Void
+    let onUnpin: () -> Void
+    let onArchive: () -> Void
+    let onRename: () -> Void
+    @Binding var showDrawer: Bool
+
+    var body: some View {
+        Button {
+            if presentation.showsActionsMenu {
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                    showDrawer.toggle()
+                }
+            }
+        } label: {
+            HStack(spacing: VSpacing.xs) {
+                Text(presentation.displayTitle)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(1)
+                if presentation.showsActionsMenu {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(VColor.textMuted)
+                        .rotationEffect(.degrees(showDrawer ? -180 : 0))
+                        .animation(VAnimation.fast, value: showDrawer)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.leading, VSpacing.lg)
+        .padding(.vertical, VSpacing.sm)
+    }
+}
+
+/// Drawer-style popover for thread actions, matching the preferences drawer pattern.
+struct ThreadActionsDrawer: View {
+    let presentation: ThreadHeaderPresentation
+    let onCopy: () -> Void
+    let onPin: () -> Void
+    let onUnpin: () -> Void
+    let onArchive: () -> Void
+    let onRename: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if presentation.canCopy {
+                DrawerMenuItem(icon: "doc.on.doc", label: "Copy full thread", action: onCopy)
+
+                VColor.surfaceBorder.frame(height: 1)
+                    .padding(.vertical, VSpacing.xs)
+            }
+
+            DrawerMenuItem(
+                icon: presentation.isPinned ? "pin.slash" : "pin",
+                label: presentation.isPinned ? "Unpin" : "Pin",
+                action: presentation.isPinned ? onUnpin : onPin
+            )
+
+            DrawerMenuItem(icon: "pencil", label: "Rename thread", action: onRename)
+
+            VColor.surfaceBorder.frame(height: 1)
+                .padding(.vertical, VSpacing.xs)
+
+            DrawerMenuItem(icon: "archivebox", label: "Archive thread", action: onArchive)
+        }
+        .padding(.vertical, VSpacing.sm)
+        .background(VColor.surfaceSubtle)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.15), radius: 6, y: 2)
+        .frame(width: 200)
+        .transition(.opacity.combined(with: .scale(scale: 0.95, anchor: .topLeading)))
+    }
+}

--- a/clients/macos/vellum-assistantTests/ThreadHeaderPresentationTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadHeaderPresentationTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ThreadHeaderPresentationTests: XCTestCase {
+
+    // MARK: - No active thread / draft
+
+    func testDraftShowsNewThreadTitle() {
+        let p = ThreadHeaderPresentation(
+            activeThread: nil,
+            activeViewModel: nil,
+            isConversationVisible: true
+        )
+        XCTAssertEqual(p.displayTitle, "New thread")
+        XCTAssertFalse(p.isStarted)
+        XCTAssertFalse(p.showsActionsMenu)
+        XCTAssertFalse(p.canCopy)
+    }
+
+    func testConversationNotVisibleShowsNewThread() {
+        let thread = ThreadModel(title: "My Thread", sessionId: "session-1")
+        let p = ThreadHeaderPresentation(
+            activeThread: thread,
+            activeViewModel: nil,
+            isConversationVisible: false
+        )
+        XCTAssertEqual(p.displayTitle, "New thread")
+        XCTAssertFalse(p.showsActionsMenu)
+    }
+
+    // MARK: - Started standard thread
+
+    func testStartedStandardThreadShowsActionsMenu() {
+        let thread = ThreadModel(title: "Test Thread", sessionId: "session-1")
+        let vm = ChatViewModel(daemonClient: DaemonClient())
+        let p = ThreadHeaderPresentation(
+            activeThread: thread,
+            activeViewModel: vm,
+            isConversationVisible: true
+        )
+        XCTAssertEqual(p.displayTitle, "Test Thread")
+        XCTAssertTrue(p.isStarted)
+        XCTAssertTrue(p.showsActionsMenu)
+    }
+
+    // MARK: - Private thread
+
+    func testPrivateThreadHidesActionsMenu() {
+        let thread = ThreadModel(title: "Private Chat", sessionId: "session-2", kind: .private)
+        let p = ThreadHeaderPresentation(
+            activeThread: thread,
+            activeViewModel: nil,
+            isConversationVisible: true
+        )
+        XCTAssertTrue(p.isStarted)
+        XCTAssertTrue(p.isPrivateThread)
+        XCTAssertFalse(p.showsActionsMenu)
+    }
+
+    // MARK: - Not started (no sessionId, no messages)
+
+    func testUnstartedThreadDoesNotShowActions() {
+        let thread = ThreadModel(title: "New Conversation")
+        let vm = ChatViewModel(daemonClient: DaemonClient())
+        let p = ThreadHeaderPresentation(
+            activeThread: thread,
+            activeViewModel: vm,
+            isConversationVisible: true
+        )
+        XCTAssertFalse(p.isStarted)
+        XCTAssertFalse(p.showsActionsMenu)
+        XCTAssertFalse(p.canCopy)
+    }
+
+    // MARK: - Pin state
+
+    func testPinnedThreadShowsPinnedState() {
+        let thread = ThreadModel(title: "Pinned", sessionId: "s", isPinned: true)
+        let p = ThreadHeaderPresentation(
+            activeThread: thread,
+            activeViewModel: nil,
+            isConversationVisible: true
+        )
+        XCTAssertTrue(p.isPinned)
+    }
+}

--- a/clients/macos/vellum-assistantTests/ThreadManagerRenameTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerRenameTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+@MainActor
+final class ThreadManagerRenameTests: XCTestCase {
+
+    private var daemonClient: DaemonClient!
+    private var threadManager: ThreadManager!
+    private var capturedMessages: [Any] = []
+
+    override func setUp() {
+        super.setUp()
+        daemonClient = DaemonClient()
+        daemonClient.isConnected = true
+        capturedMessages = []
+        daemonClient.sendOverride = { [weak self] msg in
+            guard let self else { return }
+            capturedMessages.append(msg)
+        }
+        threadManager = ThreadManager(daemonClient: daemonClient)
+        threadManager.createThread()
+    }
+
+    override func tearDown() {
+        daemonClient?.sendOverride = nil
+        threadManager = nil
+        capturedMessages = []
+        daemonClient = nil
+        super.tearDown()
+    }
+
+    // MARK: - Rename with sessionId
+
+    func testRenameWithSessionIdSendsIPC() {
+        guard let thread = threadManager.threads.first else {
+            XCTFail("Expected at least one thread")
+            return
+        }
+
+        threadManager.threads[0].sessionId = "session-abc"
+        capturedMessages = [] // clear setup noise
+
+        threadManager.renameThread(id: thread.id, title: "Renamed Thread")
+
+        XCTAssertEqual(threadManager.threads[0].title, "Renamed Thread")
+
+        let renameMessages = capturedMessages.compactMap { $0 as? IPCSessionRenameRequest }
+        XCTAssertEqual(renameMessages.count, 1)
+        XCTAssertEqual(renameMessages.first?.sessionId, "session-abc")
+        XCTAssertEqual(renameMessages.first?.title, "Renamed Thread")
+    }
+
+    // MARK: - Empty/whitespace rename rejected
+
+    func testEmptyRenameIsRejected() {
+        guard let thread = threadManager.threads.first else {
+            XCTFail("Expected at least one thread")
+            return
+        }
+        let originalTitle = thread.title
+        threadManager.threads[0].sessionId = "session-abc"
+
+        threadManager.renameThread(id: thread.id, title: "")
+
+        XCTAssertEqual(threadManager.threads[0].title, originalTitle)
+        let renameMessages = capturedMessages.compactMap { $0 as? IPCSessionRenameRequest }
+        XCTAssertTrue(renameMessages.isEmpty)
+    }
+
+    func testWhitespaceOnlyRenameIsRejected() {
+        guard let thread = threadManager.threads.first else {
+            XCTFail("Expected at least one thread")
+            return
+        }
+        let originalTitle = thread.title
+        threadManager.threads[0].sessionId = "session-abc"
+
+        threadManager.renameThread(id: thread.id, title: "   \n  ")
+
+        XCTAssertEqual(threadManager.threads[0].title, originalTitle)
+        let renameMessages = capturedMessages.compactMap { $0 as? IPCSessionRenameRequest }
+        XCTAssertTrue(renameMessages.isEmpty)
+    }
+
+    // MARK: - Rename trims whitespace
+
+    func testRenameTrimsWhitespace() {
+        guard let thread = threadManager.threads.first else {
+            XCTFail("Expected at least one thread")
+            return
+        }
+        threadManager.threads[0].sessionId = "session-abc"
+        capturedMessages = []
+
+        threadManager.renameThread(id: thread.id, title: "  Trimmed Title  ")
+
+        XCTAssertEqual(threadManager.threads[0].title, "Trimmed Title")
+    }
+}

--- a/clients/shared/DesignSystem/Components/Layout/AppWorkspaceDockLayout.swift
+++ b/clients/shared/DesignSystem/Components/Layout/AppWorkspaceDockLayout.swift
@@ -10,6 +10,8 @@ public struct AppWorkspaceDockLayout<Dock: View, Workspace: View>: View {
     public let workspace: Workspace
     @Binding public var dockWidth: Double
     public var showDock: Bool = false
+    public var dockBackground: Color?
+    public var dockCornerRadius: CGFloat?
     @State private var dragStartWidth: Double?
     @State private var dragStartAvailableWidth: CGFloat?
     @State private var isDragging: Bool = false
@@ -25,8 +27,8 @@ public struct AppWorkspaceDockLayout<Dock: View, Workspace: View>: View {
                     dock
                         .frame(width: dockWidth)
                         .animation(nil, value: dockWidth)
-                        .background(VColor.backgroundSubtle)
-                        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                        .background(dockBackground ?? VColor.backgroundSubtle)
+                        .clipShape(RoundedRectangle(cornerRadius: dockCornerRadius ?? VRadius.lg))
                         .padding([.bottom, .leading], VSpacing.xs)
                         .transition(.move(edge: .leading))
 
@@ -129,6 +131,8 @@ public struct AppWorkspaceDockLayout<Dock: View, Workspace: View>: View {
     public init(
         dockWidth: Binding<Double>,
         showDock: Bool = false,
+        dockBackground: Color? = nil,
+        dockCornerRadius: CGFloat? = nil,
         @ViewBuilder dock: () -> Dock,
         @ViewBuilder workspace: () -> Workspace
     ) {
@@ -136,5 +140,7 @@ public struct AppWorkspaceDockLayout<Dock: View, Workspace: View>: View {
         self.workspace = workspace()
         self._dockWidth = dockWidth
         self.showDock = showDock
+        self.dockBackground = dockBackground
+        self.dockCornerRadius = dockCornerRadius
     }
 }

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -10,6 +10,8 @@ public struct VSplitView<Main: View, Panel: View>: View {
     public let panel: Panel?
     @Binding public var panelWidth: Double
     public var showPanel: Bool = false
+    public var mainBackground: Color?
+    public var mainCornerRadius: CGFloat?
     @State private var dragStartWidth: Double?
     @State private var dragStartAvailableWidth: CGFloat?
     @State private var isDragging: Bool = false
@@ -24,8 +26,8 @@ public struct VSplitView<Main: View, Panel: View>: View {
                 // Main content - styled as panel
                 main
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(VColor.backgroundSubtle)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+                    .background(mainBackground ?? VColor.backgroundSubtle)
+                    .clipShape(RoundedRectangle(cornerRadius: mainCornerRadius ?? VRadius.lg))
                     .padding([.bottom, .leading], VSpacing.xs)
                     .padding(.trailing, showPanel ? 0 : VSpacing.xs)
 
@@ -138,6 +140,8 @@ public struct VSplitView<Main: View, Panel: View>: View {
     public init(
         panelWidth: Binding<Double>,
         showPanel: Bool = false,
+        mainBackground: Color? = nil,
+        mainCornerRadius: CGFloat? = nil,
         @ViewBuilder main: () -> Main,
         @ViewBuilder panel: () -> Panel
     ) {
@@ -145,6 +149,8 @@ public struct VSplitView<Main: View, Panel: View>: View {
         self.panel = panel()
         self._panelWidth = panelWidth
         self.showPanel = showPanel
+        self.mainBackground = mainBackground
+        self.mainCornerRadius = mainCornerRadius
     }
 }
 


### PR DESCRIPTION
## Summary
- Add inline thread title header at top of chat content area with chevron that opens a drawer-style popover for thread actions (copy, pin/unpin, rename, archive)
- Centralize rename logic in `ThreadManager.renameThread()` with pending queue for pre-sessionId threads
- Use `VColor.chatBackground` with no rounded corners on the chat container; remove top-bar copy button (now in drawer)

## Test plan
- [ ] Click thread title chevron — drawer opens with spring animation
- [ ] Click outside drawer — dismisses
- [ ] Pin/Unpin, Rename, Copy, Archive actions work from drawer
- [ ] Switch threads — drawer auto-dismisses
- [ ] Chat container has flat edges and #E8E6DA background
- [ ] ThreadHeaderPresentationTests pass (6 tests)
- [ ] ThreadManagerRenameTests pass (4 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
