### PR TITLE
M3: Fix RecordingSourcePickerView background color

### DIFF
--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -62,7 +62,7 @@ struct RecordingSourcePickerView: View {
             bottomBar
         }
         .frame(width: 420)
-        .background(VColor.background)
+        .background(VColor.surface)
         .task {
             await viewModel.loadSources()
             await viewModel.loadPreviews()

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
@@ -63,7 +63,7 @@ final class RecordingSourcePickerWindow: NSObject, NSWindowDelegate {
         newWindow.titleVisibility = .hidden
         newWindow.titlebarAppearsTransparent = true
         newWindow.isMovableByWindowBackground = true
-        newWindow.backgroundColor = NSColor(VColor.background)
+        newWindow.backgroundColor = NSColor(VColor.surface)
         newWindow.isReleasedWhenClosed = false
         newWindow.level = .floating
         newWindow.center()


### PR DESCRIPTION
Changes picker modal background from VColor.background to VColor.surface for a cleaner white appearance in light mode. Closes #13035.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
