### PR TITLE
Display channel handles in unconfigured channel rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -326,6 +326,13 @@ struct ContactDetailView: View {
                     .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
 
+                if let handle = channelReadiness[type]?.channelHandle {
+                    Text(handle)
+                        .font(VFont.monoSmall)
+                        .foregroundColor(VColor.textMuted)
+                        .lineLimit(1)
+                }
+
                 Spacer()
 
                 Text("Not set up")


### PR DESCRIPTION
## Summary
- Shows the channel handle (e.g. `@TelegramBot`, `+15551234567`, `@SlackBot`) in unconfigured channel rows
- Handle appears between the channel name and "Not set up" status text
- Uses `VFont.monoSmall` and `VColor.textMuted` design tokens for visual differentiation
- Gracefully hidden when `channelHandle` is nil (credentials not configured)

Part of plan: channel-invite-ui-info.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
