### PR TITLE
refactor: remove assistantId from token record and call session store functions

### DIFF
--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -129,7 +129,6 @@ describe("actor-token store (hash-only)", () => {
 
     const record = createActorTokenRecord({
       tokenHash,
-      assistantId: "self",
       guardianPrincipalId: "principal-store",
       hashedDeviceId: "hashed-dev-store",
       platform: "macos",
@@ -148,7 +147,6 @@ describe("actor-token store (hash-only)", () => {
 
     createActorTokenRecord({
       tokenHash,
-      assistantId: "self",
       guardianPrincipalId: "principal-bind",
       hashedDeviceId: "hashed-dev-bind",
       platform: "ios",
@@ -156,7 +154,6 @@ describe("actor-token store (hash-only)", () => {
     });
 
     const found = findActiveByDeviceBinding(
-      "self",
       "principal-bind",
       "hashed-dev-bind",
     );
@@ -169,7 +166,6 @@ describe("actor-token store (hash-only)", () => {
 
     createActorTokenRecord({
       tokenHash,
-      assistantId: "self",
       guardianPrincipalId: "principal-revoke",
       hashedDeviceId: "hashed-dev-revoke",
       platform: "macos",
@@ -177,7 +173,6 @@ describe("actor-token store (hash-only)", () => {
     });
 
     const count = revokeByDeviceBinding(
-      "self",
       "principal-revoke",
       "hashed-dev-revoke",
     );
@@ -192,7 +187,6 @@ describe("actor-token store (hash-only)", () => {
 
     createActorTokenRecord({
       tokenHash,
-      assistantId: "self",
       guardianPrincipalId: "principal-single",
       hashedDeviceId: "hashed-dev-single",
       platform: "macos",

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -1333,7 +1333,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15559999999",
       toNumber: "+15551111111",
-      assistantId: "self",
       // no task — inbound call
     });
 
@@ -1413,7 +1412,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15559999999",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const secret = createPendingVoiceGuardianChallenge("self");
@@ -1474,7 +1472,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15550001111",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     createGuardianBinding({
@@ -1524,7 +1521,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15550002222",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     createGuardianBinding({
@@ -1578,7 +1574,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15551111111",
       toNumber: "+15550001111",
-      assistantId: "self",
       initiatedFromConversationId: "conv-guardian-outbound-voice-origin",
     });
 
@@ -1630,7 +1625,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15551111111",
       toNumber: "+15550001111",
-      assistantId: "self",
       initiatedFromConversationId: "conv-guardian-outbound-strict-origin",
     });
 
@@ -1682,7 +1676,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15550003333",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const secret = createPendingVoiceGuardianChallenge("self");
@@ -1740,7 +1733,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15559999999",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     createPendingVoiceGuardianChallenge("self");
@@ -1785,7 +1777,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15559999999",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     createPendingVoiceGuardianChallenge("self");
@@ -1851,7 +1842,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15559999999",
       toNumber: "+15551111111",
-      assistantId: "self",
       // no task — inbound call
     });
 
@@ -1897,7 +1887,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15559999999",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     createPendingVoiceGuardianChallenge("self");
@@ -1952,7 +1941,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15551111111",
       toNumber: "+15559999999",
-      assistantId: "self",
       callMode: "guardian_verification",
       guardianVerificationSessionId: "gv-session-ptr-success",
       initiatedFromConversationId: "conv-gv-pointer-success-origin",
@@ -2009,7 +1997,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15551111111",
       toNumber: "+15559999999",
-      assistantId: "self",
       callMode: "guardian_verification",
       guardianVerificationSessionId: "gv-session-ptr-fail",
       initiatedFromConversationId: "conv-gv-pointer-fail-origin",
@@ -2071,7 +2058,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15558887777",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     // Create a voice invite with friend/guardian names
@@ -2146,7 +2132,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15558886666",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     // Create a voice invite with friend/guardian names
@@ -2228,7 +2213,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15558885555",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     // No voice invite created for this caller
@@ -2282,7 +2266,6 @@ describe("relay-server", () => {
         provider: "twilio",
         fromNumber: "+15558885556",
         toNumber: "+15551111111",
-        assistantId: "self",
       });
 
       const { ws, relay } = createMockWs(session.id);
@@ -2323,7 +2306,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15558884444",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { ws, relay } = createMockWs(session.id);
@@ -2388,7 +2370,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15558883333",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { ws, relay } = createMockWs(session.id);
@@ -2422,7 +2403,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15558882222",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { ws, relay } = createMockWs(session.id);
@@ -2480,7 +2460,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15558881111",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     // Create a blocked member
@@ -2531,7 +2510,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770001",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { relay } = createMockWs(session.id);
@@ -2579,7 +2557,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770002",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     // Track provider calls to verify no LLM turn is triggered on approval
@@ -2670,7 +2647,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770003",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { ws, relay } = createMockWs(session.id);
@@ -2754,7 +2730,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770004",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { ws, relay } = createMockWs(session.id);
@@ -2831,7 +2806,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770005",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { relay } = createMockWs(session.id);
@@ -2877,7 +2851,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770010",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { ws, relay } = createMockWs(session.id);
@@ -2935,7 +2908,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770011",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     mockSendMessage.mockImplementation(
@@ -3001,7 +2973,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770012",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { relay } = createMockWs(session.id);
@@ -3037,7 +3008,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770013",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { ws, relay } = createMockWs(session.id);
@@ -3108,7 +3078,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770014",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { ws, relay } = createMockWs(session.id);
@@ -3194,7 +3163,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770015",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { ws, relay } = createMockWs(session.id);
@@ -3252,7 +3220,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770016",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { ws, relay } = createMockWs(session.id);
@@ -3301,7 +3268,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770017",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { ws, relay } = createMockWs(session.id);
@@ -3365,7 +3331,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770020",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { ws, relay } = createMockWs(session.id);
@@ -3468,7 +3433,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770021",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { relay } = createMockWs(session.id);
@@ -3526,7 +3490,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770022",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { relay } = createMockWs(session.id);
@@ -3595,7 +3558,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770023",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { relay } = createMockWs(session.id);
@@ -3673,7 +3635,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770024",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { relay } = createMockWs(session.id);
@@ -3764,7 +3725,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557770025",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     // Do NOT add caller as trusted contact
@@ -3851,7 +3811,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15551111111",
       toNumber: "+15559876543",
-      assistantId: "self",
       initiatedFromConversationId: "conv-relay-ptr-complete-origin",
     });
     updateCallSession(session.id, {
@@ -3890,7 +3849,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15551111111",
       toNumber: "+15559876543",
-      assistantId: "self",
       initiatedFromConversationId: "conv-relay-ptr-fail-origin",
     });
     updateCallSession(session.id, { status: "in_progress" });
@@ -3927,7 +3885,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15553334444",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     // Create a trusted-contact verification challenge with status 'pending'
@@ -4011,7 +3968,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15552223333",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     // Create a guardian challenge (default verificationPurpose = 'guardian')
@@ -4067,7 +4023,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15557776666",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const code = generateVoiceCode(6);
@@ -4163,7 +4118,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15559990099",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { ws, relay } = createMockWs(session.id);
@@ -4210,7 +4164,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15559990098",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { ws, relay } = createMockWs(session.id);
@@ -4247,7 +4200,6 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15559990097",
       toNumber: "+15551111111",
-      assistantId: "self",
     });
 
     const { ws, relay } = createMockWs(session.id);

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -290,7 +290,6 @@ export function createInboundVoiceSession(
     provider: "twilio",
     fromNumber,
     toNumber,
-    assistantId,
   });
 
   updateCallSession(session.id, { providerCallSid: callSid });
@@ -411,7 +410,6 @@ export async function startCall(
       task: callContext ? `${task}\n\nContext: ${callContext}` : task,
       callerIdentityMode: identityResult.mode,
       callerIdentitySource: identityResult.source,
-      assistantId,
       initiatedFromConversationId: conversationId,
     });
     sessionId = session.id;
@@ -935,7 +933,6 @@ export async function startGuardianVerificationCall(
       toNumber: phoneNumber,
       callMode: "guardian_verification",
       guardianVerificationSessionId,
-      assistantId,
       initiatedFromConversationId: originConversationId,
     });
     sessionId = session.id;

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -7,6 +7,7 @@ import {
   callPendingQuestions,
   callSessions,
 } from "../memory/schema.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import { cast, createRowMapper } from "../util/row-mapper.js";
 import { validateTransition } from "./call-state-machine.js";
@@ -83,7 +84,6 @@ export function createCallSession(opts: {
   guardianVerificationSessionId?: string;
   callerIdentityMode?: string;
   callerIdentitySource?: string;
-  assistantId?: string;
   initiatedFromConversationId?: string;
 }): CallSession {
   const db = getDb();
@@ -101,7 +101,7 @@ export function createCallSession(opts: {
     guardianVerificationSessionId: opts.guardianVerificationSessionId ?? null,
     callerIdentityMode: opts.callerIdentityMode ?? null,
     callerIdentitySource: opts.callerIdentitySource ?? null,
-    assistantId: opts.assistantId ?? null,
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     initiatedFromConversationId: opts.initiatedFromConversationId ?? null,
     startedAt: null,
     endedAt: null,

--- a/assistant/src/runtime/actor-refresh-token-store.ts
+++ b/assistant/src/runtime/actor-refresh-token-store.ts
@@ -12,6 +12,7 @@ import { getDb } from "../memory/db.js";
 import { rawChanges } from "../memory/raw-query.js";
 import { actorRefreshTokenRecords } from "../memory/schema.js";
 import { getLogger } from "../util/logger.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 
 const log = getLogger("actor-refresh-token-store");
 
@@ -38,7 +39,6 @@ export interface RefreshTokenRecord {
 export function createRefreshTokenRecord(params: {
   tokenHash: string;
   familyId: string;
-  assistantId: string;
   guardianPrincipalId: string;
   hashedDeviceId: string;
   platform: string;
@@ -54,7 +54,7 @@ export function createRefreshTokenRecord(params: {
     id,
     tokenHash: params.tokenHash,
     familyId: params.familyId,
-    assistantId: params.assistantId,
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     guardianPrincipalId: params.guardianPrincipalId,
     hashedDeviceId: params.hashedDeviceId,
     platform: params.platform,
@@ -120,7 +120,6 @@ export function revokeFamily(familyId: string): number {
 
 /** Revoke all active refresh tokens for a device binding. */
 export function revokeByDeviceBinding(
-  assistantId: string,
   guardianPrincipalId: string,
   hashedDeviceId: string,
 ): number {
@@ -130,7 +129,6 @@ export function revokeByDeviceBinding(
     .set({ status: "revoked", updatedAt: now })
     .where(
       and(
-        eq(actorRefreshTokenRecords.assistantId, assistantId),
         eq(actorRefreshTokenRecords.guardianPrincipalId, guardianPrincipalId),
         eq(actorRefreshTokenRecords.hashedDeviceId, hashedDeviceId),
         eq(actorRefreshTokenRecords.status, "active"),

--- a/assistant/src/runtime/actor-token-store.ts
+++ b/assistant/src/runtime/actor-token-store.ts
@@ -14,6 +14,7 @@ import { v4 as uuid } from "uuid";
 import { getDb } from "../memory/db.js";
 import { actorTokenRecords } from "../memory/schema.js";
 import { getLogger } from "../util/logger.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 
 const log = getLogger("actor-token-store");
 
@@ -46,7 +47,6 @@ export interface ActorTokenRecord {
  */
 export function createActorTokenRecord(params: {
   tokenHash: string;
-  assistantId: string;
   guardianPrincipalId: string;
   hashedDeviceId: string;
   platform: string;
@@ -60,7 +60,7 @@ export function createActorTokenRecord(params: {
   const row = {
     id,
     tokenHash: params.tokenHash,
-    assistantId: params.assistantId,
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     guardianPrincipalId: params.guardianPrincipalId,
     hashedDeviceId: params.hashedDeviceId,
     platform: params.platform,
@@ -72,10 +72,7 @@ export function createActorTokenRecord(params: {
   };
 
   db.insert(actorTokenRecords).values(row).run();
-  log.info(
-    { id, assistantId: params.assistantId, platform: params.platform },
-    "Actor token record created",
-  );
+  log.info({ id, platform: params.platform }, "Actor token record created");
 
   return row;
 }
@@ -102,12 +99,11 @@ export function findActiveByTokenHash(
 }
 
 /**
- * Find an active token for a specific (assistantId, guardianPrincipalId, deviceId).
+ * Find an active token for a specific (guardianPrincipalId, deviceId).
  * Used for idempotent bootstrap — if an active token already exists for this
  * device binding, we can revoke-and-remint or return the existing record.
  */
 export function findActiveByDeviceBinding(
-  assistantId: string,
   guardianPrincipalId: string,
   hashedDeviceId: string,
 ): ActorTokenRecord | null {
@@ -117,7 +113,6 @@ export function findActiveByDeviceBinding(
     .from(actorTokenRecords)
     .where(
       and(
-        eq(actorTokenRecords.assistantId, assistantId),
         eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
         eq(actorTokenRecords.hashedDeviceId, hashedDeviceId),
         eq(actorTokenRecords.status, "active"),
@@ -133,7 +128,6 @@ export function findActiveByDeviceBinding(
  * Called before minting a new token to ensure one-active-per-device.
  */
 export function revokeByDeviceBinding(
-  assistantId: string,
   guardianPrincipalId: string,
   hashedDeviceId: string,
 ): number {
@@ -141,7 +135,6 @@ export function revokeByDeviceBinding(
   const now = Date.now();
 
   const condition = and(
-    eq(actorTokenRecords.assistantId, assistantId),
     eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
     eq(actorTokenRecords.hashedDeviceId, hashedDeviceId),
     eq(actorTokenRecords.status, "active"),
@@ -166,12 +159,11 @@ export function revokeByDeviceBinding(
 }
 
 /**
- * Find all active actor token records for a given (assistantId, guardianPrincipalId).
+ * Find all active actor token records for a given guardianPrincipalId.
  * Used for multi-device guardian fanout — returns all bound devices (macOS, iOS, etc.)
  * so notification targeting can reach every device for the same guardian identity.
  */
 export function findActiveByGuardianPrincipalId(
-  assistantId: string,
   guardianPrincipalId: string,
 ): ActorTokenRecord[] {
   const db = getDb();
@@ -180,7 +172,6 @@ export function findActiveByGuardianPrincipalId(
     .from(actorTokenRecords)
     .where(
       and(
-        eq(actorTokenRecords.assistantId, assistantId),
         eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
         eq(actorTokenRecords.status, "active"),
       ),

--- a/assistant/src/runtime/auth/__tests__/credential-service.test.ts
+++ b/assistant/src/runtime/auth/__tests__/credential-service.test.ts
@@ -74,7 +74,6 @@ afterAll(() => {
 describe("mintCredentialPair", () => {
   test("returns JWT access token and opaque refresh token", () => {
     const result = mintCredentialPair({
-      assistantId: "self",
       platform: "macos",
       deviceId: "device-123",
       guardianPrincipalId: "principal-abc",
@@ -91,7 +90,6 @@ describe("mintCredentialPair", () => {
 
   test("access token is a valid 3-part JWT", () => {
     const result = mintCredentialPair({
-      assistantId: "self",
       platform: "macos",
       deviceId: "device-jwt",
       guardianPrincipalId: "principal-jwt",
@@ -104,7 +102,6 @@ describe("mintCredentialPair", () => {
 
   test("access token verifies against vellum-gateway audience", () => {
     const result = mintCredentialPair({
-      assistantId: "self",
       platform: "macos",
       deviceId: "device-verify",
       guardianPrincipalId: "principal-verify",
@@ -125,7 +122,6 @@ describe("mintCredentialPair", () => {
 
   test("access token hash is stored in actor-token store", () => {
     const result = mintCredentialPair({
-      assistantId: "self",
       platform: "macos",
       deviceId: "device-store",
       guardianPrincipalId: "principal-store",
@@ -144,7 +140,6 @@ describe("mintCredentialPair", () => {
       .update("device-dup")
       .digest("hex");
     const params = {
-      assistantId: "self",
       platform: "macos" as const,
       deviceId: "device-dup",
       guardianPrincipalId: "principal-dup",
@@ -179,7 +174,6 @@ describe("rotateCredentials", () => {
       .update("device-rot")
       .digest("hex");
     const initial = mintCredentialPair({
-      assistantId: "self",
       platform: "ios",
       deviceId: "device-rot",
       guardianPrincipalId: "principal-rot",
@@ -209,7 +203,6 @@ describe("rotateCredentials", () => {
       .update("device-replay")
       .digest("hex");
     const initial = mintCredentialPair({
-      assistantId: "self",
       platform: "ios",
       deviceId: "device-replay",
       guardianPrincipalId: "principal-replay",
@@ -254,7 +247,6 @@ describe("rotateCredentials", () => {
       .update("device-bind")
       .digest("hex");
     const initial = mintCredentialPair({
-      assistantId: "self",
       platform: "ios",
       deviceId: "device-bind",
       guardianPrincipalId: "principal-bind",
@@ -279,7 +271,6 @@ describe("rotateCredentials", () => {
       .update("device-plat")
       .digest("hex");
     const initial = mintCredentialPair({
-      assistantId: "self",
       platform: "ios",
       deviceId: "device-plat",
       guardianPrincipalId: "principal-plat",

--- a/assistant/src/runtime/auth/credential-service.ts
+++ b/assistant/src/runtime/auth/credential-service.ts
@@ -132,7 +132,6 @@ function mintAccessToken(guardianPrincipalId: string): {
 // ---------------------------------------------------------------------------
 
 function mintRefreshTokenInternal(params: {
-  assistantId: string;
   guardianPrincipalId: string;
   hashedDeviceId: string;
   platform: string;
@@ -155,7 +154,6 @@ function mintRefreshTokenInternal(params: {
   createRefreshTokenRecord({
     tokenHash: refreshTokenHash,
     familyId,
-    assistantId: params.assistantId,
     guardianPrincipalId: params.guardianPrincipalId,
     hashedDeviceId: params.hashedDeviceId,
     platform: params.platform,
@@ -184,20 +182,14 @@ function mintRefreshTokenInternal(params: {
  * Revokes any existing credentials for the device before minting.
  */
 export function mintCredentialPair(params: {
-  assistantId: string;
   platform: string;
   deviceId: string;
   guardianPrincipalId: string;
   hashedDeviceId: string;
 }): CredentialPairResult {
   // Revoke any existing credentials for this device
-  revokeActorTokensByDevice(
-    params.assistantId,
-    params.guardianPrincipalId,
-    params.hashedDeviceId,
-  );
+  revokeActorTokensByDevice(params.guardianPrincipalId, params.hashedDeviceId);
   revokeRefreshTokensByDevice(
-    params.assistantId,
     params.guardianPrincipalId,
     params.hashedDeviceId,
   );
@@ -207,7 +199,6 @@ export function mintCredentialPair(params: {
 
   createActorTokenRecord({
     tokenHash: access.tokenHash,
-    assistantId: params.assistantId,
     guardianPrincipalId: params.guardianPrincipalId,
     hashedDeviceId: params.hashedDeviceId,
     platform: params.platform,
@@ -217,7 +208,6 @@ export function mintCredentialPair(params: {
 
   // Mint new refresh token
   const refresh = mintRefreshTokenInternal({
-    assistantId: params.assistantId,
     guardianPrincipalId: params.guardianPrincipalId,
     hashedDeviceId: params.hashedDeviceId,
     platform: params.platform,
@@ -270,7 +260,6 @@ export function rotateCredentials(params: {
     );
     revokeFamily(record.familyId);
     revokeActorTokensByDevice(
-      record.assistantId,
       record.guardianPrincipalId,
       record.hashedDeviceId,
     );
@@ -314,7 +303,6 @@ export function rotateCredentials(params: {
 
     // Revoke old access tokens for this device
     revokeActorTokensByDevice(
-      record.assistantId,
       record.guardianPrincipalId,
       record.hashedDeviceId,
     );
@@ -324,7 +312,6 @@ export function rotateCredentials(params: {
 
     createActorTokenRecord({
       tokenHash: access.tokenHash,
-      assistantId: record.assistantId,
       guardianPrincipalId: record.guardianPrincipalId,
       hashedDeviceId: record.hashedDeviceId,
       platform: params.platform,
@@ -336,7 +323,6 @@ export function rotateCredentials(params: {
     // absolute expiry so rotation resets inactivity but never extends
     // the session lifetime.
     const refresh = mintRefreshTokenInternal({
-      assistantId: record.assistantId,
       guardianPrincipalId: record.guardianPrincipalId,
       hashedDeviceId: record.hashedDeviceId,
       platform: params.platform,

--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -123,13 +123,13 @@ export async function handleGuardianBootstrap(
       );
     }
 
-    const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
-    const { guardianPrincipalId, isNew } = ensureGuardianPrincipal(assistantId);
+    const { guardianPrincipalId, isNew } = ensureGuardianPrincipal(
+      DAEMON_INTERNAL_ASSISTANT_ID,
+    );
     const hashedDeviceId = hashDeviceId(deviceId);
 
     // Mint credential pair (access token + refresh token)
     const credentials = mintCredentialPair({
-      assistantId,
       platform,
       deviceId,
       guardianPrincipalId,
@@ -137,7 +137,7 @@ export async function handleGuardianBootstrap(
     });
 
     log.info(
-      { assistantId, platform, guardianPrincipalId, isNew },
+      { platform, guardianPrincipalId, isNew },
       "Guardian bootstrap completed",
     );
 

--- a/assistant/src/runtime/routes/pairing-routes.ts
+++ b/assistant/src/runtime/routes/pairing-routes.ts
@@ -37,22 +37,22 @@ function mintPairingCredentials(
   platform: string,
 ): PairingCredentials | null {
   try {
-    const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
     // Pairing can run before a local client has touched the actor-token
     // bootstrap path. Ensure the vellum guardian principal exists so iOS
     // pairings always have a mint target.
-    const guardianPrincipalId = ensureVellumGuardianBinding(assistantId);
+    const guardianPrincipalId = ensureVellumGuardianBinding(
+      DAEMON_INTERNAL_ASSISTANT_ID,
+    );
     const hashedDeviceId = hashDeviceId(deviceId);
 
     const credentials = mintCredentialPair({
-      assistantId,
       platform,
       deviceId,
       guardianPrincipalId,
       hashedDeviceId,
     });
 
-    log.info({ assistantId, platform }, "Minted credentials during pairing");
+    log.info({ platform }, "Minted credentials during pairing");
     return {
       accessToken: credentials.accessToken,
       accessTokenExpiresAt: credentials.accessTokenExpiresAt,


### PR DESCRIPTION
## Summary
- Remove `assistantId` parameter from `mintCredentialPair`, `createActorTokenRecord`, `createRefreshTokenRecord`, and call session store functions
- Hardcode `DAEMON_INTERNAL_ASSISTANT_ID` internally for INSERT operations (column still exists, will be dropped in follow-up PR)
- Update all callers (`guardian-bootstrap-routes.ts`, `pairing-routes.ts`, etc.) to stop passing `assistantId`

Part of plan: rm-assistant-id-from-daemon.md (PR 6 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
