### PR TITLE
M4: Reduce vertical padding in RecordingSourcePickerView

### DIFF
--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -21,13 +21,13 @@ struct RecordingSourcePickerView: View {
             Text("Screen Recording")
                 .font(VFont.title)
                 .foregroundColor(VColor.textPrimary)
-                .padding(.top, VSpacing.md)
+                .padding(.top, VSpacing.sm)
                 .padding(.bottom, VSpacing.sm)
 
             Text("Choose what to record")
                 .font(VFont.body)
                 .foregroundColor(VColor.textSecondary)
-                .padding(.bottom, VSpacing.md)
+                .padding(.bottom, VSpacing.sm)
 
             // Scope picker (Display / Window)
             VSegmentedControl(
@@ -338,7 +338,7 @@ struct RecordingSourcePickerView: View {
                     .accessibilityHidden(true)
             }
         }
-        .padding(.vertical, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
     }
 }
 


### PR DESCRIPTION
Tightens header and bottom bar padding to reduce excessive white space in the recording picker modal. Closes #13036.

## Summary
- Reduced top padding of header title from `VSpacing.md` (12pt) to `VSpacing.sm` (8pt)
- Reduced bottom padding of subtitle from `VSpacing.md` (12pt) to `VSpacing.sm` (8pt)
- Reduced vertical padding of bottom bar from `VSpacing.lg` (16pt) to `VSpacing.md` (12pt)

## Test plan
- [ ] Open the recording source picker modal and verify the layout looks tighter with less vertical whitespace
- [ ] Confirm header, subtitle, and bottom bar spacing are visually balanced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
