### PR TITLE
refactor: remove assistantId from scoped approval grants store functions

### DIFF
--- a/assistant/src/__tests__/approval-primitive.test.ts
+++ b/assistant/src/__tests__/approval-primitive.test.ts
@@ -60,7 +60,6 @@ afterAll(() => {
 function mintParams(overrides: Partial<MintGrantParams> = {}): MintGrantParams {
   const futureExpiry = new Date(Date.now() + 60_000).toISOString();
   return {
-    assistantId: "self",
     scopeMode: "request_id",
     requestChannel: "telegram",
     decisionChannel: "telegram",
@@ -177,7 +176,6 @@ describe("approval-primitive / consumeGrantForInvocation", () => {
       toolName: "shell",
       inputDigest: computeToolApprovalDigest("shell", { command: "ls" }),
       consumingRequestId: "consumer-1",
-      assistantId: "self",
     });
 
     expect(result.ok).toBe(true);
@@ -200,7 +198,6 @@ describe("approval-primitive / consumeGrantForInvocation", () => {
       toolName: "shell",
       inputDigest: digest,
       consumingRequestId: "consumer-2",
-      assistantId: "self",
     });
 
     expect(result.ok).toBe(true);
@@ -224,7 +221,6 @@ describe("approval-primitive / consumeGrantForInvocation", () => {
       toolName: "shell",
       inputDigest: digest,
       consumingRequestId: "consumer-3",
-      assistantId: "self",
     });
 
     expect(result.ok).toBe(true);
@@ -242,7 +238,6 @@ describe("approval-primitive / consumeGrantForInvocation", () => {
         toolName: "shell",
         inputDigest: computeToolApprovalDigest("shell", { command: "ls" }),
         consumingRequestId: "consumer-miss",
-        assistantId: "self",
       },
       { maxWaitMs: 0 },
     );
@@ -267,7 +262,6 @@ describe("approval-primitive / consumeGrantForInvocation", () => {
         toolName: "file_write",
         inputDigest: digest,
         consumingRequestId: "consumer-mismatch-tool",
-        assistantId: "self",
       },
       { maxWaitMs: 0 },
     );
@@ -293,32 +287,6 @@ describe("approval-primitive / consumeGrantForInvocation", () => {
           command: "rm -rf /",
         }),
         consumingRequestId: "consumer-mismatch-input",
-        assistantId: "self",
-      },
-      { maxWaitMs: 0 },
-    );
-
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.reason).toBe("no_match");
-  });
-
-  test("miss: assistant ID mismatch", async () => {
-    mintGrantFromDecision(
-      mintParams({
-        scopeMode: "request_id",
-        requestId: "req-assist",
-        assistantId: "assistant-A",
-      }),
-    );
-
-    const result = await consumeGrantForInvocation(
-      {
-        requestId: "req-assist",
-        toolName: "shell",
-        inputDigest: computeToolApprovalDigest("shell", {}),
-        consumingRequestId: "consumer-assist-mismatch",
-        assistantId: "assistant-B",
       },
       { maxWaitMs: 0 },
     );
@@ -344,7 +312,6 @@ describe("approval-primitive / consumeGrantForInvocation", () => {
         toolName: "shell",
         inputDigest: computeToolApprovalDigest("shell", {}),
         consumingRequestId: "consumer-expired",
-        assistantId: "self",
       },
       { maxWaitMs: 0 },
     );
@@ -368,7 +335,6 @@ describe("approval-primitive / consumeGrantForInvocation", () => {
       toolName: "shell",
       inputDigest: computeToolApprovalDigest("shell", {}),
       consumingRequestId: "consumer-first",
-      assistantId: "self",
     });
     expect(first.ok).toBe(true);
 
@@ -378,7 +344,6 @@ describe("approval-primitive / consumeGrantForInvocation", () => {
         toolName: "shell",
         inputDigest: computeToolApprovalDigest("shell", {}),
         consumingRequestId: "consumer-second",
-        assistantId: "self",
       },
       { maxWaitMs: 0 },
     );
@@ -401,7 +366,6 @@ describe("approval-primitive / consumeGrantForInvocation", () => {
       toolName: "shell",
       inputDigest: digest,
       consumingRequestId: "consumer-sig-first",
-      assistantId: "self",
     });
     expect(first.ok).toBe(true);
 
@@ -410,7 +374,6 @@ describe("approval-primitive / consumeGrantForInvocation", () => {
         toolName: "shell",
         inputDigest: digest,
         consumingRequestId: "consumer-sig-second",
-        assistantId: "self",
       },
       { maxWaitMs: 0 },
     );
@@ -439,7 +402,6 @@ describe("approval-primitive / consumeGrantForInvocation", () => {
       toolName: "shell",
       inputDigest: digest,
       consumingRequestId: "consumer-ctx",
-      assistantId: "self",
       conversationId: "conv-ctx",
       callSessionId: "call-ctx",
     });
@@ -463,7 +425,6 @@ describe("approval-primitive / consumeGrantForInvocation", () => {
         toolName: "shell",
         inputDigest: digest,
         consumingRequestId: "consumer-ctx-mismatch",
-        assistantId: "self",
         conversationId: "conv-B",
       },
       { maxWaitMs: 0 },
@@ -497,7 +458,6 @@ describe("approval-primitive / consumeGrantForInvocation retry", () => {
       toolName: "shell",
       inputDigest: digest,
       consumingRequestId: "consumer-async-immediate",
-      assistantId: "self",
     });
     const elapsed = Date.now() - start;
 
@@ -528,7 +488,6 @@ describe("approval-primitive / consumeGrantForInvocation retry", () => {
         toolName: "shell",
         inputDigest: digest,
         consumingRequestId: "consumer-async-delayed",
-        assistantId: "self",
       },
       { maxWaitMs: 5_000, intervalMs: 100 },
     );
@@ -553,7 +512,6 @@ describe("approval-primitive / consumeGrantForInvocation retry", () => {
         toolName: "shell",
         inputDigest: digest,
         consumingRequestId: "consumer-async-timeout",
-        assistantId: "self",
       },
       { maxWaitMs: 500, intervalMs: 100 },
     );
@@ -580,7 +538,6 @@ describe("approval-primitive / consumeGrantForInvocation retry", () => {
         toolName: "shell",
         inputDigest: digest,
         consumingRequestId: "consumer-aborted",
-        assistantId: "self",
       },
       { maxWaitMs: 2_000, intervalMs: 50, signal: controller.signal },
     );
@@ -606,7 +563,6 @@ describe("approval-primitive / consumeGrantForInvocation retry", () => {
         toolName: "shell",
         inputDigest: digest,
         consumingRequestId: "consumer-pre-aborted",
-        assistantId: "self",
       },
       { maxWaitMs: 2_000, intervalMs: 50, signal: controller.signal },
     );
@@ -628,7 +584,6 @@ describe("approval-primitive / consumeGrantForInvocation retry", () => {
         toolName: "shell",
         inputDigest: digest,
         consumingRequestId: "consumer-no-retry",
-        assistantId: "self",
       },
       { maxWaitMs: 0 },
     );

--- a/assistant/src/__tests__/guardian-action-grant-mint-consume.test.ts
+++ b/assistant/src/__tests__/guardian-action-grant-mint-consume.test.ts
@@ -8,7 +8,6 @@
  *   3. tryMintGuardianActionGrant mints a tool_signature grant
  *   4. Voice consumer can consume the grant for the same tool+input
  *   5. Second consume attempt is denied (one-time use)
- *   6. Grant for a different assistantId is not consumable
  */
 
 import { mkdtempSync, rmSync } from "node:fs";
@@ -225,7 +224,6 @@ describe("guardian-action grant mint -> voice consume integration", () => {
       toolName: TOOL_NAME,
       inputDigest,
       consumingRequestId: "voice-req-1",
-      assistantId: ASSISTANT_ID,
       executionChannel: "voice",
       callSessionId: CALL_SESSION_ID,
       conversationId: CONVERSATION_ID,
@@ -240,67 +238,12 @@ describe("guardian-action grant mint -> voice consume integration", () => {
       toolName: TOOL_NAME,
       inputDigest,
       consumingRequestId: "voice-req-2",
-      assistantId: ASSISTANT_ID,
       executionChannel: "voice",
       callSessionId: CALL_SESSION_ID,
       conversationId: CONVERSATION_ID,
     });
     expect(secondConsume.ok).toBe(false);
     expect(secondConsume.grant).toBeNull();
-  });
-
-  test("grant minted for one assistantId cannot be consumed by another", async () => {
-    const inputDigest = computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT);
-
-    const request = createGuardianActionRequest({
-      assistantId: ASSISTANT_ID,
-      kind: "ask_guardian",
-      sourceChannel: "voice",
-      sourceConversationId: CONVERSATION_ID,
-      callSessionId: CALL_SESSION_ID,
-      pendingQuestionId: nextPendingQuestionId(),
-      questionText: "Can I run the command?",
-      expiresAt: Date.now() + 60_000,
-      toolName: TOOL_NAME,
-      inputDigest,
-    });
-
-    const resolved = resolveGuardianActionRequest(
-      request.id,
-      "Yes",
-      "telegram",
-    );
-    expect(resolved).not.toBeNull();
-
-    await tryMintGuardianActionGrant({
-      request: resolved!,
-      answerText: "Yes",
-      decisionChannel: "telegram",
-    });
-
-    // Attempt to consume with a different assistantId
-    const wrongAssistant = consumeScopedApprovalGrantByToolSignature({
-      toolName: TOOL_NAME,
-      inputDigest,
-      consumingRequestId: "voice-req-wrong",
-      assistantId: "other-assistant",
-      executionChannel: "voice",
-      callSessionId: CALL_SESSION_ID,
-      conversationId: CONVERSATION_ID,
-    });
-    expect(wrongAssistant.ok).toBe(false);
-
-    // Correct assistantId succeeds
-    const correctAssistant = consumeScopedApprovalGrantByToolSignature({
-      toolName: TOOL_NAME,
-      inputDigest,
-      consumingRequestId: "voice-req-correct",
-      assistantId: ASSISTANT_ID,
-      executionChannel: "voice",
-      callSessionId: CALL_SESSION_ID,
-      conversationId: CONVERSATION_ID,
-    });
-    expect(correctAssistant.ok).toBe(true);
   });
 
   test("no grant minted when guardian action request lacks tool metadata", async () => {
@@ -372,7 +315,6 @@ describe("guardian-action grant mint -> voice consume integration", () => {
       toolName: TOOL_NAME,
       inputDigest,
       consumingRequestId: "voice-req-desktop",
-      assistantId: ASSISTANT_ID,
       executionChannel: "voice",
       callSessionId: CALL_SESSION_ID,
       conversationId: CONVERSATION_ID,

--- a/assistant/src/__tests__/scoped-approval-grants.test.ts
+++ b/assistant/src/__tests__/scoped-approval-grants.test.ts
@@ -72,7 +72,6 @@ function grantParams(
 ): CreateScopedApprovalGrantParams {
   const futureExpiry = new Date(Date.now() + 60_000).toISOString();
   return {
-    assistantId: "self",
     scopeMode: "request_id",
     requestChannel: "telegram",
     decisionChannel: "telegram",
@@ -95,11 +94,7 @@ describe("scoped-approval-grants / request_id scope", () => {
     expect(grant.status).toBe("active");
     expect(grant.requestId).toBe("req-1");
 
-    const result = consumeScopedApprovalGrantByRequestId(
-      "req-1",
-      "consumer-1",
-      "self",
-    );
+    const result = consumeScopedApprovalGrantByRequestId("req-1", "consumer-1");
     expect(result.ok).toBe(true);
     expect(result.grant).not.toBeNull();
     expect(result.grant!.status).toBe("consumed");
@@ -111,18 +106,10 @@ describe("scoped-approval-grants / request_id scope", () => {
       grantParams({ scopeMode: "request_id", requestId: "req-2" }),
     );
 
-    const first = consumeScopedApprovalGrantByRequestId(
-      "req-2",
-      "consumer-a",
-      "self",
-    );
+    const first = consumeScopedApprovalGrantByRequestId("req-2", "consumer-a");
     expect(first.ok).toBe(true);
 
-    const second = consumeScopedApprovalGrantByRequestId(
-      "req-2",
-      "consumer-b",
-      "self",
-    );
+    const second = consumeScopedApprovalGrantByRequestId("req-2", "consumer-b");
     expect(second.ok).toBe(false);
     expect(second.grant).toBeNull();
   });
@@ -131,7 +118,6 @@ describe("scoped-approval-grants / request_id scope", () => {
     const result = consumeScopedApprovalGrantByRequestId(
       "nonexistent",
       "consumer-x",
-      "self",
     );
     expect(result.ok).toBe(false);
   });
@@ -149,7 +135,6 @@ describe("scoped-approval-grants / request_id scope", () => {
     const result = consumeScopedApprovalGrantByRequestId(
       "req-expired",
       "consumer-1",
-      "self",
     );
     expect(result.ok).toBe(false);
   });
@@ -421,11 +406,7 @@ describe("scoped-approval-grants / expiry", () => {
     expect(count).toBe(2);
 
     // Verify the alive grant is still active
-    const alive = consumeScopedApprovalGrantByRequestId(
-      "req-alive",
-      "c1",
-      "self",
-    );
+    const alive = consumeScopedApprovalGrantByRequestId("req-alive", "c1");
     expect(alive.ok).toBe(true);
   });
 
@@ -438,7 +419,7 @@ describe("scoped-approval-grants / expiry", () => {
         expiresAt: new Date(Date.now() + 60_000).toISOString(),
       }),
     );
-    consumeScopedApprovalGrantByRequestId("req-consumed", "c1", "self");
+    consumeScopedApprovalGrantByRequestId("req-consumed", "c1");
 
     // Force the expiry time to the past for the consumed grant (simulating time passing)
     // The sweep should not touch consumed grants
@@ -483,15 +464,11 @@ describe("scoped-approval-grants / revoke", () => {
     expect(count).toBe(2);
 
     // Revoked grant cannot be consumed
-    const revoked = consumeScopedApprovalGrantByRequestId(
-      "req-r1",
-      "c1",
-      "self",
-    );
+    const revoked = consumeScopedApprovalGrantByRequestId("req-r1", "c1");
     expect(revoked.ok).toBe(false);
 
     // Unaffected grant is still consumable
-    const alive = consumeScopedApprovalGrantByRequestId("req-r3", "c1", "self");
+    const alive = consumeScopedApprovalGrantByRequestId("req-r3", "c1");
     expect(alive.ok).toBe(true);
   });
 
@@ -506,11 +483,7 @@ describe("scoped-approval-grants / revoke", () => {
 
     revokeScopedApprovalGrantsForContext({ conversationId: "conv-1" });
 
-    const result = consumeScopedApprovalGrantByRequestId(
-      "req-revoke",
-      "c1",
-      "self",
-    );
+    const result = consumeScopedApprovalGrantByRequestId("req-revoke", "c1");
     expect(result.ok).toBe(false);
   });
 
@@ -530,11 +503,7 @@ describe("scoped-approval-grants / revoke", () => {
     );
 
     // The grant should still be active (not revoked)
-    const result = consumeScopedApprovalGrantByRequestId(
-      "req-guard",
-      "c1",
-      "self",
-    );
+    const result = consumeScopedApprovalGrantByRequestId("req-guard", "c1");
     expect(result.ok).toBe(true);
   });
 });

--- a/assistant/src/__tests__/scoped-grant-security-matrix.test.ts
+++ b/assistant/src/__tests__/scoped-grant-security-matrix.test.ts
@@ -89,7 +89,6 @@ function grantParams(
 ): CreateScopedApprovalGrantParams {
   const futureExpiry = new Date(Date.now() + 60_000).toISOString();
   return {
-    assistantId: "self",
     scopeMode: "tool_signature",
     toolName: "bash",
     inputDigest: computeToolApprovalDigest("bash", { cmd: "ls" }),
@@ -338,35 +337,6 @@ describe("security matrix: persistence and fail-closed behavior", () => {
 describe("security matrix: cross-scope invariants", () => {
   beforeEach(() => clearTables());
 
-  test("grant for one assistant cannot be consumed by another assistant", () => {
-    const digest = computeToolApprovalDigest("bash", { cmd: "ls" });
-    createScopedApprovalGrant(
-      grantParams({
-        toolName: "bash",
-        inputDigest: digest,
-        assistantId: "assistant-alpha",
-      }),
-    );
-
-    // Attempt consumption from a different assistant
-    const wrongAssistant = consumeScopedApprovalGrantByToolSignature({
-      toolName: "bash",
-      inputDigest: digest,
-      consumingRequestId: "c1",
-      assistantId: "assistant-beta",
-    });
-    expect(wrongAssistant.ok).toBe(false);
-
-    // Correct assistant succeeds
-    const correctAssistant = consumeScopedApprovalGrantByToolSignature({
-      toolName: "bash",
-      inputDigest: digest,
-      consumingRequestId: "c2",
-      assistantId: "assistant-alpha",
-    });
-    expect(correctAssistant.ok).toBe(true);
-  });
-
   test("all scope fields must match simultaneously for consumption", () => {
     const digest = computeToolApprovalDigest("bash", { cmd: "ls" });
 
@@ -375,7 +345,6 @@ describe("security matrix: cross-scope invariants", () => {
       grantParams({
         toolName: "bash",
         inputDigest: digest,
-        assistantId: "self",
         executionChannel: "voice",
         conversationId: "conv-123",
         callSessionId: "call-456",
@@ -391,7 +360,6 @@ describe("security matrix: cross-scope invariants", () => {
         toolName: "bash",
         inputDigest: digest,
         consumingRequestId: "c-chan",
-        assistantId: "self",
         executionChannel: "sms",
         conversationId: "conv-123",
         callSessionId: "call-456",
@@ -405,7 +373,6 @@ describe("security matrix: cross-scope invariants", () => {
         toolName: "bash",
         inputDigest: digest,
         consumingRequestId: "c-conv",
-        assistantId: "self",
         executionChannel: "voice",
         conversationId: "conv-999",
         callSessionId: "call-456",
@@ -419,7 +386,6 @@ describe("security matrix: cross-scope invariants", () => {
         toolName: "bash",
         inputDigest: digest,
         consumingRequestId: "c-call",
-        assistantId: "self",
         executionChannel: "voice",
         conversationId: "conv-123",
         callSessionId: "call-999",
@@ -433,7 +399,6 @@ describe("security matrix: cross-scope invariants", () => {
         toolName: "bash",
         inputDigest: digest,
         consumingRequestId: "c-user",
-        assistantId: "self",
         executionChannel: "voice",
         conversationId: "conv-123",
         callSessionId: "call-456",
@@ -447,7 +412,6 @@ describe("security matrix: cross-scope invariants", () => {
         toolName: "bash",
         inputDigest: digest,
         consumingRequestId: "c-all",
-        assistantId: "self",
         executionChannel: "voice",
         conversationId: "conv-123",
         callSessionId: "call-456",

--- a/assistant/src/__tests__/tool-approval-handler.test.ts
+++ b/assistant/src/__tests__/tool-approval-handler.test.ts
@@ -90,7 +90,6 @@ afterAll(() => {
 function mintParams(overrides: Partial<MintGrantParams> = {}): MintGrantParams {
   const futureExpiry = new Date(Date.now() + 60_000).toISOString();
   return {
-    assistantId: "self",
     scopeMode: "tool_signature",
     requestChannel: "telegram",
     decisionChannel: "telegram",

--- a/assistant/src/__tests__/tool-grant-request-escalation.test.ts
+++ b/assistant/src/__tests__/tool-grant-request-escalation.test.ts
@@ -684,7 +684,6 @@ describe("inline wait-and-resume", () => {
         toolName: "bash",
         inputDigest: "sha256:waitgrant",
         consumingRequestId: "consume-1",
-        assistantId: "self",
         conversationId: "conv-1",
         requesterExternalUserId: "requester-1",
         executionChannel: "telegram",
@@ -727,7 +726,6 @@ describe("inline wait-and-resume", () => {
         toolName: "bash",
         inputDigest: "sha256:denywait",
         consumingRequestId: "consume-1",
-        assistantId: "self",
       },
       { maxWaitMs: 2_000, intervalMs: 20 },
     );
@@ -759,7 +757,6 @@ describe("inline wait-and-resume", () => {
         toolName: "bash",
         inputDigest: "sha256:timeoutwait",
         consumingRequestId: "consume-1",
-        assistantId: "self",
       },
       { maxWaitMs: 100, intervalMs: 20 },
     );
@@ -797,7 +794,6 @@ describe("inline wait-and-resume", () => {
         toolName: "bash",
         inputDigest: "sha256:abortwait",
         consumingRequestId: "consume-1",
-        assistantId: "self",
       },
       { maxWaitMs: 5_000, intervalMs: 20, signal: controller.signal },
     );

--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -254,7 +254,6 @@ function grantParams(
 ): CreateScopedApprovalGrantParams {
   const futureExpiry = new Date(Date.now() + 60_000).toISOString();
   return {
-    assistantId: ASSISTANT_ID,
     scopeMode: "tool_signature",
     toolName: TOOL_NAME,
     inputDigest: computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT),
@@ -420,42 +419,6 @@ describe("voice bridge confirmation handling (grant consumption via primitive)",
     expect(decision).not.toBeNull();
     expect(decision!.decision).toBe("allow");
     expect(decision!.reason).toContain("guardian voice call");
-  });
-
-  test("non-guardian with grant for different assistantId: auto-denied", async () => {
-    // Create a grant scoped to a different assistant
-    createScopedApprovalGrant(
-      grantParams({
-        assistantId: "other-assistant",
-      }),
-    );
-
-    const mockData = createMockSession();
-    setupBridgeDeps(() => mockData.session);
-
-    const trustContext: TrustContext = {
-      sourceChannel: "voice",
-      trustClass: "trusted_contact",
-      requesterExternalUserId: "caller-123",
-    };
-
-    await startVoiceTurn({
-      conversationId: CONVERSATION_ID,
-      callSessionId: CALL_SESSION_ID,
-      content: "test utterance",
-      assistantId: ASSISTANT_ID,
-      trustContext,
-      isInbound: true,
-      onTextDelta: () => {},
-      onComplete: () => {},
-      onError: () => {},
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
-    const decision = mockData.getConfirmationDecision();
-    expect(decision).not.toBeNull();
-    expect(decision!.decision).toBe("deny");
   });
 
   test("grants revoked when revokeScopedApprovalGrantsForContext is called with callSessionId", () => {

--- a/assistant/src/approvals/approval-primitive.ts
+++ b/assistant/src/approvals/approval-primitive.ts
@@ -32,7 +32,6 @@ const log = getLogger("approval-primitive");
 // ---------------------------------------------------------------------------
 
 export interface MintGrantParams {
-  assistantId: string;
   scopeMode: "request_id" | "tool_signature";
   requestId?: string | null;
   toolName?: string | null;
@@ -76,7 +75,6 @@ export function mintGrantFromDecision(
         event: "approval_primitive_mint_rejected",
         reason: "missing_request_id",
         scopeMode: params.scopeMode,
-        assistantId: params.assistantId,
         requestChannel: params.requestChannel,
         decisionChannel: params.decisionChannel,
       },
@@ -96,7 +94,6 @@ export function mintGrantFromDecision(
         scopeMode: params.scopeMode,
         toolName: params.toolName ?? null,
         inputDigest: params.inputDigest ?? null,
-        assistantId: params.assistantId,
         requestChannel: params.requestChannel,
         decisionChannel: params.decisionChannel,
       },
@@ -107,7 +104,6 @@ export function mintGrantFromDecision(
 
   try {
     const grant = createScopedApprovalGrant({
-      assistantId: params.assistantId,
       scopeMode: params.scopeMode,
       requestId: params.requestId ?? null,
       toolName: params.toolName ?? null,
@@ -129,7 +125,6 @@ export function mintGrantFromDecision(
         scopeMode: params.scopeMode,
         toolName: params.toolName ?? null,
         requestId: params.requestId ?? null,
-        assistantId: params.assistantId,
         requestChannel: params.requestChannel,
         decisionChannel: params.decisionChannel,
         conversationId: params.conversationId ?? null,
@@ -146,7 +141,6 @@ export function mintGrantFromDecision(
         event: "approval_primitive_mint_error",
         scopeMode: params.scopeMode,
         toolName: params.toolName ?? null,
-        assistantId: params.assistantId,
         err: error,
       },
       "Failed to mint approval grant (storage error)",
@@ -162,7 +156,6 @@ export function mintGrantFromDecision(
 export interface ConsumeByRequestIdParams {
   requestId: string;
   consumingRequestId: string;
-  assistantId: string;
   now?: string;
 }
 
@@ -170,7 +163,6 @@ export interface ConsumeByToolSignatureParams {
   toolName: string;
   inputDigest: string;
   consumingRequestId: string;
-  assistantId?: string;
   executionChannel?: string;
   conversationId?: string;
   callSessionId?: string;
@@ -195,7 +187,6 @@ export interface ConsumeGrantParams {
   toolName: string;
   inputDigest: string;
   consumingRequestId: string;
-  assistantId: string;
   executionChannel?: string;
   conversationId?: string;
   callSessionId?: string;
@@ -221,7 +212,6 @@ function consumeGrantSync(params: ConsumeGrantParams): ConsumeGrantResult {
       consumeScopedApprovalGrantByRequestId(
         params.requestId,
         params.consumingRequestId,
-        params.assistantId,
         params.now,
       );
 
@@ -233,7 +223,6 @@ function consumeGrantSync(params: ConsumeGrantParams): ConsumeGrantResult {
           grantId: reqResult.grant.id,
           requestId: params.requestId,
           consumingRequestId: params.consumingRequestId,
-          assistantId: params.assistantId,
           toolName: params.toolName,
         },
         "Approval grant consumed via request_id",
@@ -248,7 +237,6 @@ function consumeGrantSync(params: ConsumeGrantParams): ConsumeGrantResult {
         reason: "no_match",
         requestId: params.requestId,
         consumingRequestId: params.consumingRequestId,
-        assistantId: params.assistantId,
         toolName: params.toolName,
       },
       "No request_id grant match, falling through to tool_signature",
@@ -261,7 +249,6 @@ function consumeGrantSync(params: ConsumeGrantParams): ConsumeGrantResult {
       toolName: params.toolName,
       inputDigest: params.inputDigest,
       consumingRequestId: params.consumingRequestId,
-      assistantId: params.assistantId,
       executionChannel: params.executionChannel,
       conversationId: params.conversationId,
       callSessionId: params.callSessionId,
@@ -277,7 +264,6 @@ function consumeGrantSync(params: ConsumeGrantParams): ConsumeGrantResult {
         grantId: sigResult.grant.id,
         toolName: params.toolName,
         consumingRequestId: params.consumingRequestId,
-        assistantId: params.assistantId,
         conversationId: params.conversationId ?? null,
         callSessionId: params.callSessionId ?? null,
       },
@@ -293,7 +279,6 @@ function consumeGrantSync(params: ConsumeGrantParams): ConsumeGrantResult {
       reason: "no_match",
       toolName: params.toolName,
       consumingRequestId: params.consumingRequestId,
-      assistantId: params.assistantId,
       conversationId: params.conversationId ?? null,
       callSessionId: params.callSessionId ?? null,
       executionChannel: params.executionChannel ?? null,

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -36,7 +36,6 @@ import {
   type GuardianApprovalRequest,
   updateApprovalDecision,
 } from "../memory/channel-guardian-store.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import type {
   ApprovalAction,
   ApprovalDecisionResult,
@@ -107,7 +106,6 @@ export function tryMintToolApprovalGrant(params: {
   }
 
   const result = mintGrantFromDecision({
-    assistantId: approval.assistantId,
     scopeMode: "tool_signature",
     toolName: approvalInfo.toolName,
     inputDigest,
@@ -277,7 +275,6 @@ export function mintCanonicalRequestGrant(params: {
   }
 
   const result = mintGrantFromDecision({
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     scopeMode: "tool_signature",
     toolName: request.toolName,
     inputDigest: request.inputDigest,

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -392,7 +392,6 @@ export async function startVoiceTurn(
               toolName: msg.toolName,
               inputDigest,
               consumingRequestId: msg.requestId,
-              assistantId: opts.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
               executionChannel: "voice",
               conversationId: opts.conversationId,
               callSessionId: opts.callSessionId,

--- a/assistant/src/memory/scoped-approval-grants.ts
+++ b/assistant/src/memory/scoped-approval-grants.ts
@@ -14,6 +14,7 @@
 import { and, eq, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import { getDb, rawChanges } from "./db.js";
 import { scopedApprovalGrants } from "./schema.js";
@@ -29,7 +30,6 @@ export type GrantStatus = "active" | "consumed" | "expired" | "revoked";
 
 export interface ScopedApprovalGrant {
   id: string;
-  assistantId: string;
   scopeMode: ScopeMode;
   requestId: string | null;
   toolName: string | null;
@@ -65,7 +65,6 @@ function rowToGrant(
 ): ScopedApprovalGrant {
   return {
     id: row.id,
-    assistantId: row.assistantId,
     scopeMode: row.scopeMode as ScopeMode,
     requestId: row.requestId,
     toolName: row.toolName,
@@ -91,7 +90,6 @@ function rowToGrant(
 // ---------------------------------------------------------------------------
 
 export interface CreateScopedApprovalGrantParams {
-  assistantId: string;
   scopeMode: ScopeMode;
   requestId?: string | null;
   toolName?: string | null;
@@ -115,7 +113,7 @@ function createScopedApprovalGrant(
 
   const row = {
     id,
-    assistantId: params.assistantId,
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     scopeMode: params.scopeMode,
     requestId: params.requestId ?? null,
     toolName: params.toolName ?? null,
@@ -143,7 +141,6 @@ function createScopedApprovalGrant(
       grantId: id,
       scopeMode: params.scopeMode,
       toolName: params.toolName ?? null,
-      assistantId: params.assistantId,
       requestChannel: params.requestChannel,
       decisionChannel: params.decisionChannel,
       executionChannel: params.executionChannel ?? null,
@@ -168,13 +165,12 @@ export interface ConsumeByRequestIdResult {
  * Atomically consume a grant by request ID.
  *
  * Only succeeds when exactly one active, non-expired grant matches the
- * given `requestId` and `assistantId`.  Uses compare-and-swap on the
- * `status` column so concurrent consumers race safely — at most one wins.
+ * given `requestId`.  Uses compare-and-swap on the `status` column so
+ * concurrent consumers race safely — at most one wins.
  */
 function consumeScopedApprovalGrantByRequestId(
   requestId: string,
   consumingRequestId: string,
-  assistantId: string,
   now?: string,
 ): ConsumeByRequestIdResult {
   const db = getDb();
@@ -189,7 +185,6 @@ function consumeScopedApprovalGrantByRequestId(
       .where(
         and(
           eq(scopedApprovalGrants.requestId, requestId),
-          eq(scopedApprovalGrants.assistantId, assistantId),
           eq(scopedApprovalGrants.scopeMode, "request_id"),
           eq(scopedApprovalGrants.status, "active"),
           sql`${scopedApprovalGrants.expiresAt} > ${currentTime}`,
@@ -204,7 +199,6 @@ function consumeScopedApprovalGrantByRequestId(
           event: "scoped_grant_consume_miss",
           requestId,
           consumingRequestId,
-          assistantId,
           scopeMode: "request_id",
           attempt,
         },
@@ -247,7 +241,6 @@ function consumeScopedApprovalGrantByRequestId(
         grantId: grant?.id,
         requestId,
         consumingRequestId,
-        assistantId,
         scopeMode: "request_id",
       },
       "Scoped approval grant consumed by request ID",
@@ -262,7 +255,6 @@ function consumeScopedApprovalGrantByRequestId(
       event: "scoped_grant_consume_miss",
       requestId,
       consumingRequestId,
-      assistantId,
       scopeMode: "request_id",
       reason: "cas_exhausted",
     },
@@ -280,7 +272,6 @@ export interface ConsumeByToolSignatureParams {
   inputDigest: string;
   consumingRequestId: string;
   /** Optional context constraints — only matched when the grant has a non-null value */
-  assistantId?: string;
   executionChannel?: string;
   conversationId?: string;
   callSessionId?: string;
@@ -318,12 +309,6 @@ function consumeScopedApprovalGrantByToolSignature(
     eq(scopedApprovalGrants.status, "active"),
     sql`${scopedApprovalGrants.expiresAt} > ${currentTime}`,
   ];
-
-  // assistantId is always set on grants — scope consumption to the current
-  // assistant so grants minted for one assistant cannot be consumed by another.
-  if (params.assistantId !== undefined) {
-    conditions.push(eq(scopedApprovalGrants.assistantId, params.assistantId));
-  }
 
   // Context constraints: grant field must be NULL (any) or match exactly
   if (params.executionChannel !== undefined) {
@@ -488,7 +473,6 @@ export function expireScopedApprovalGrants(now?: string): number {
 // ---------------------------------------------------------------------------
 
 export interface RevokeContextParams {
-  assistantId?: string;
   conversationId?: string;
   callSessionId?: string;
   requestChannel?: string;
@@ -510,9 +494,6 @@ export function revokeScopedApprovalGrantsForContext(
 
   const conditions = [eq(scopedApprovalGrants.status, "active")];
 
-  if (params.assistantId !== undefined) {
-    conditions.push(eq(scopedApprovalGrants.assistantId, params.assistantId));
-  }
   if (params.conversationId !== undefined) {
     conditions.push(
       eq(scopedApprovalGrants.conversationId, params.conversationId),
@@ -550,7 +531,6 @@ export function revokeScopedApprovalGrantsForContext(
       {
         event: "scoped_grant_revoked",
         count,
-        assistantId: params.assistantId,
         conversationId: params.conversationId,
         callSessionId: params.callSessionId,
         requestChannel: params.requestChannel,

--- a/assistant/src/runtime/guardian-action-grant-minter.ts
+++ b/assistant/src/runtime/guardian-action-grant-minter.ts
@@ -131,7 +131,6 @@ export async function tryMintGuardianActionGrant(params: {
   }
 
   const result = mintGrantFromDecision({
-    assistantId: request.assistantId,
     scopeMode: "tool_signature",
     toolName: request.toolName,
     inputDigest: request.inputDigest,

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -5,7 +5,6 @@ import {
   updateCanonicalGuardianRequest,
 } from "../memory/canonical-guardian-store.js";
 import { isUntrustedTrustClass } from "../runtime/actor-trust-resolver.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { createOrReuseToolGrantRequest } from "../runtime/tool-grant-request-helper.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
 import { getTaskRunRules } from "../tasks/ephemeral-permissions.js";
@@ -275,7 +274,6 @@ export class ToolApprovalHandler {
         inputDigest,
         consumingRequestId:
           context.requestId ?? `preexec-${context.sessionId}-${Date.now()}`,
-        assistantId: context.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID,
         executionChannel: context.executionChannel,
         conversationId: context.conversationId,
         callSessionId: context.callSessionId,


### PR DESCRIPTION
## Summary
- Remove assistantId from all scoped approval grant function signatures and callers
- Hardcode DAEMON_INTERNAL_ASSISTANT_ID internally for INSERT operations (column dropped in PR 7)
- Remove assistantId filter from WHERE clauses (redundant since all data is 'self')
- Remove 4 cross-assistant isolation tests that are no longer applicable

Part of plan: rm-assistant-id-from-daemon.md (PR 3 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
