### PR TITLE
M5: Add hover states to source picker rows

### DIFF
--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -10,6 +10,9 @@ struct RecordingSourcePickerView: View {
     var onStart: (IPCRecordingOptions) -> Void
     var onCancel: () -> Void
 
+    @State private var hoveredDisplayId: UInt32?
+    @State private var hoveredWindowId: Int?
+
     /// Row thumbnail size (80x50pt).
     private let rowThumbnailSize = CGSize(width: 80, height: 50)
     /// Preview pane height.
@@ -136,6 +139,8 @@ struct RecordingSourcePickerView: View {
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.xs)
+        .animation(VAnimation.fast, value: hoveredDisplayId)
+        .animation(VAnimation.fast, value: hoveredWindowId)
     }
 
     /// Source list that hugs content when items fit, scrolls when they overflow.
@@ -197,7 +202,7 @@ struct RecordingSourcePickerView: View {
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(isSelected ? VColor.accent.opacity(0.1) : Color.clear)
+                    .fill(isSelected ? VColor.accent.opacity(0.1) : (hoveredWindowId == window.id ? VColor.ghostHover : Color.clear))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.md)
@@ -205,6 +210,7 @@ struct RecordingSourcePickerView: View {
             )
         }
         .buttonStyle(.plain)
+        .onHover { hovering in hoveredWindowId = hovering ? window.id : nil }
     }
 
     /// Row for a display source showing name, resolution + scale, and a badge
@@ -252,7 +258,7 @@ struct RecordingSourcePickerView: View {
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(isSelected ? VColor.accent.opacity(0.1) : Color.clear)
+                    .fill(isSelected ? VColor.accent.opacity(0.1) : (hoveredDisplayId == display.id ? VColor.ghostHover : Color.clear))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.md)
@@ -260,6 +266,7 @@ struct RecordingSourcePickerView: View {
             )
         }
         .buttonStyle(.plain)
+        .onHover { hovering in hoveredDisplayId = hovering ? display.id : nil }
     }
 
     private func emptyState(_ message: String) -> some View {

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -210,7 +210,13 @@ struct RecordingSourcePickerView: View {
             )
         }
         .buttonStyle(.plain)
-        .onHover { hovering in hoveredWindowId = hovering ? window.id : nil }
+        .onHover { hovering in
+            if hovering {
+                hoveredWindowId = window.id
+            } else if hoveredWindowId == window.id {
+                hoveredWindowId = nil
+            }
+        }
     }
 
     /// Row for a display source showing name, resolution + scale, and a badge
@@ -266,7 +272,13 @@ struct RecordingSourcePickerView: View {
             )
         }
         .buttonStyle(.plain)
-        .onHover { hovering in hoveredDisplayId = hovering ? display.id : nil }
+        .onHover { hovering in
+            if hovering {
+                hoveredDisplayId = display.id
+            } else if hoveredDisplayId == display.id {
+                hoveredDisplayId = nil
+            }
+        }
     }
 
     private func emptyState(_ message: String) -> some View {


### PR DESCRIPTION
Adds hover highlight (VColor.ghostHover) to display and window source rows for clearer interactivity. Closes #13037.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
