### PR TITLE
refactor: remove assistantId from notification and conversation attention store functions

### DIFF
--- a/assistant/src/__tests__/callback-handoff-copy.test.ts
+++ b/assistant/src/__tests__/callback-handoff-copy.test.ts
@@ -15,7 +15,6 @@ function buildSignal(
 ): NotificationSignal {
   return {
     signalId: "test-signal-1",
-    assistantId: "self",
     createdAt: Date.now(),
     sourceChannel: "voice",
     sourceSessionId: "test-session-1",

--- a/assistant/src/__tests__/conversation-attention-store.test.ts
+++ b/assistant/src/__tests__/conversation-attention-store.test.ts
@@ -86,7 +86,6 @@ describe("conversation-attention-store", () => {
       ensureConversation("conv-1");
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1",
         messageAt: 1000,
       });
@@ -104,13 +103,11 @@ describe("conversation-attention-store", () => {
       ensureConversation("conv-1");
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1",
         messageAt: 1000,
       });
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-2",
         messageAt: 2000,
       });
@@ -125,13 +122,11 @@ describe("conversation-attention-store", () => {
       ensureConversation("conv-1");
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-2",
         messageAt: 2000,
       });
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1",
         messageAt: 1000,
       });
@@ -146,13 +141,11 @@ describe("conversation-attention-store", () => {
       ensureConversation("conv-1");
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1",
         messageAt: 1000,
       });
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1-dup",
         messageAt: 1000,
       });
@@ -170,7 +163,6 @@ describe("conversation-attention-store", () => {
       ensureConversation("conv-1");
       const event = recordConversationSeenSignal({
         conversationId: "conv-1",
-        assistantId: "self",
         sourceChannel: "vellum",
         signalType: "macos_conversation_opened",
         confidence: "explicit",
@@ -189,7 +181,6 @@ describe("conversation-attention-store", () => {
       // Project an assistant message first
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1",
         messageAt: 1000,
       });
@@ -197,7 +188,6 @@ describe("conversation-attention-store", () => {
       // Now record a seen signal
       recordConversationSeenSignal({
         conversationId: "conv-1",
-        assistantId: "self",
         sourceChannel: "vellum",
         signalType: "macos_conversation_opened",
         confidence: "explicit",
@@ -215,7 +205,6 @@ describe("conversation-attention-store", () => {
 
       recordConversationSeenSignal({
         conversationId: "conv-1",
-        assistantId: "self",
         sourceChannel: "telegram",
         signalType: "telegram_inbound_message",
         confidence: "inferred",
@@ -236,7 +225,6 @@ describe("conversation-attention-store", () => {
       // Project two assistant messages
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1",
         messageAt: 1000,
       });
@@ -244,7 +232,6 @@ describe("conversation-attention-store", () => {
       // Mark as seen at msg-1
       recordConversationSeenSignal({
         conversationId: "conv-1",
-        assistantId: "self",
         sourceChannel: "vellum",
         signalType: "macos_conversation_opened",
         confidence: "explicit",
@@ -254,7 +241,6 @@ describe("conversation-attention-store", () => {
       // Project a second message
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-2",
         messageAt: 2000,
       });
@@ -262,7 +248,6 @@ describe("conversation-attention-store", () => {
       // Mark as seen at msg-2
       recordConversationSeenSignal({
         conversationId: "conv-1",
-        assistantId: "self",
         sourceChannel: "vellum",
         signalType: "macos_conversation_opened",
         confidence: "explicit",
@@ -280,7 +265,6 @@ describe("conversation-attention-store", () => {
 
       const event = recordConversationSeenSignal({
         conversationId: "conv-1",
-        assistantId: "self",
         sourceChannel: "telegram",
         signalType: "telegram_callback",
         confidence: "explicit",
@@ -301,7 +285,6 @@ describe("conversation-attention-store", () => {
       // Record seen signal without any assistant message
       recordConversationSeenSignal({
         conversationId: "conv-1",
-        assistantId: "self",
         sourceChannel: "vellum",
         signalType: "macos_notification_view",
         confidence: "inferred",
@@ -320,7 +303,6 @@ describe("conversation-attention-store", () => {
 
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1",
         messageAt: 1000,
       });
@@ -328,7 +310,6 @@ describe("conversation-attention-store", () => {
       // Mark as seen
       recordConversationSeenSignal({
         conversationId: "conv-1",
-        assistantId: "self",
         sourceChannel: "vellum",
         signalType: "macos_conversation_opened",
         confidence: "explicit",
@@ -338,7 +319,6 @@ describe("conversation-attention-store", () => {
       // Record another seen signal (should not regress)
       recordConversationSeenSignal({
         conversationId: "conv-1",
-        assistantId: "self",
         sourceChannel: "telegram",
         signalType: "telegram_inbound_message",
         confidence: "inferred",
@@ -369,13 +349,11 @@ describe("conversation-attention-store", () => {
 
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1",
         messageAt: 1000,
       });
       projectAssistantMessage({
         conversationId: "conv-2",
-        assistantId: "self",
         messageId: "msg-2",
         messageAt: 2000,
       });
@@ -392,7 +370,6 @@ describe("conversation-attention-store", () => {
 
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1",
         messageAt: 1000,
       });
@@ -413,18 +390,16 @@ describe("conversation-attention-store", () => {
 
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1",
         messageAt: 1000,
       });
       projectAssistantMessage({
         conversationId: "conv-2",
-        assistantId: "self",
         messageId: "msg-2",
         messageAt: 2000,
       });
 
-      const result = listConversationAttention({ assistantId: "self" });
+      const result = listConversationAttention({});
       expect(result).toHaveLength(2);
     });
 
@@ -435,7 +410,6 @@ describe("conversation-attention-store", () => {
       // conv-1: has assistant message, not seen
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1",
         messageAt: 1000,
       });
@@ -443,13 +417,11 @@ describe("conversation-attention-store", () => {
       // conv-2: has assistant message, seen
       projectAssistantMessage({
         conversationId: "conv-2",
-        assistantId: "self",
         messageId: "msg-2",
         messageAt: 2000,
       });
       recordConversationSeenSignal({
         conversationId: "conv-2",
-        assistantId: "self",
         sourceChannel: "vellum",
         signalType: "macos_conversation_opened",
         confidence: "explicit",
@@ -457,7 +429,6 @@ describe("conversation-attention-store", () => {
       });
 
       const unseen = listConversationAttention({
-        assistantId: "self",
         state: "unseen",
       });
       expect(unseen).toHaveLength(1);
@@ -470,20 +441,17 @@ describe("conversation-attention-store", () => {
 
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1",
         messageAt: 1000,
       });
 
       projectAssistantMessage({
         conversationId: "conv-2",
-        assistantId: "self",
         messageId: "msg-2",
         messageAt: 2000,
       });
       recordConversationSeenSignal({
         conversationId: "conv-2",
-        assistantId: "self",
         sourceChannel: "vellum",
         signalType: "macos_conversation_opened",
         confidence: "explicit",
@@ -491,7 +459,6 @@ describe("conversation-attention-store", () => {
       });
 
       const seen = listConversationAttention({
-        assistantId: "self",
         state: "seen",
       });
       expect(seen).toHaveLength(1);
@@ -505,25 +472,21 @@ describe("conversation-attention-store", () => {
 
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1",
         messageAt: 1000,
       });
       projectAssistantMessage({
         conversationId: "conv-2",
-        assistantId: "self",
         messageId: "msg-2",
         messageAt: 2000,
       });
       projectAssistantMessage({
         conversationId: "conv-3",
-        assistantId: "self",
         messageId: "msg-3",
         messageAt: 3000,
       });
 
       const result = listConversationAttention({
-        assistantId: "self",
         limit: 2,
       });
       expect(result).toHaveLength(2);
@@ -536,24 +499,21 @@ describe("conversation-attention-store", () => {
 
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1",
         messageAt: 1000,
       });
       projectAssistantMessage({
         conversationId: "conv-2",
-        assistantId: "self",
         messageId: "msg-2",
         messageAt: 3000,
       });
       projectAssistantMessage({
         conversationId: "conv-3",
-        assistantId: "self",
         messageId: "msg-3",
         messageAt: 2000,
       });
 
-      const result = listConversationAttention({ assistantId: "self" });
+      const result = listConversationAttention({});
       expect(result[0].conversationId).toBe("conv-2");
       expect(result[1].conversationId).toBe("conv-3");
       expect(result[2].conversationId).toBe("conv-1");
@@ -566,46 +526,26 @@ describe("conversation-attention-store", () => {
 
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1",
         messageAt: 1000,
       });
       projectAssistantMessage({
         conversationId: "conv-2",
-        assistantId: "self",
         messageId: "msg-2",
         messageAt: 2000,
       });
       projectAssistantMessage({
         conversationId: "conv-3",
-        assistantId: "self",
         messageId: "msg-3",
         messageAt: 3000,
       });
 
       const result = listConversationAttention({
-        assistantId: "self",
         before: 2500,
       });
       expect(result).toHaveLength(2);
       expect(result[0].conversationId).toBe("conv-2");
       expect(result[1].conversationId).toBe("conv-1");
-    });
-
-    test("filters by different assistant ID", () => {
-      ensureConversation("conv-1");
-
-      projectAssistantMessage({
-        conversationId: "conv-1",
-        assistantId: "self",
-        messageId: "msg-1",
-        messageAt: 1000,
-      });
-
-      const result = listConversationAttention({
-        assistantId: "other-assistant",
-      });
-      expect(result).toHaveLength(0);
     });
   });
 
@@ -617,14 +557,12 @@ describe("conversation-attention-store", () => {
 
       projectAssistantMessage({
         conversationId: "conv-1",
-        assistantId: "self",
         messageId: "msg-1",
         messageAt: 1000,
       });
 
       recordConversationSeenSignal({
         conversationId: "conv-1",
-        assistantId: "self",
         sourceChannel: "vellum",
         signalType: "macos_notification_view",
         confidence: "inferred",
@@ -633,7 +571,6 @@ describe("conversation-attention-store", () => {
 
       recordConversationSeenSignal({
         conversationId: "conv-1",
-        assistantId: "self",
         sourceChannel: "vellum",
         signalType: "macos_conversation_opened",
         confidence: "explicit",

--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -85,7 +85,6 @@ function makeSignal(
 ): NotificationSignal {
   return {
     signalId: "sig-test",
-    assistantId: "self",
     createdAt: Date.now(),
     sourceChannel: "scheduler",
     sourceSessionId: "sess-1",

--- a/assistant/src/__tests__/notification-broadcaster.test.ts
+++ b/assistant/src/__tests__/notification-broadcaster.test.ts
@@ -23,7 +23,7 @@ mock.module("../util/logger.js", () => ({
 
 // Mock destination-resolver to return a destination for every requested channel
 mock.module("../notifications/destination-resolver.js", () => ({
-  resolveDestinations: (_assistantId: string, channels: string[]) => {
+  resolveDestinations: (channels: string[]) => {
     const m = new Map();
     for (const ch of channels) {
       m.set(ch, { channel: ch, endpoint: `mock-${ch}` });
@@ -84,7 +84,6 @@ function makeSignal(
 ): NotificationSignal {
   return {
     signalId: "sig-broadcast-001",
-    assistantId: "self",
     createdAt: Date.now(),
     sourceChannel: "scheduler",
     sourceSessionId: "sess-001",

--- a/assistant/src/__tests__/notification-decision-fallback.test.ts
+++ b/assistant/src/__tests__/notification-decision-fallback.test.ts
@@ -63,7 +63,6 @@ function makeSignal(
 ): NotificationSignal {
   return {
     signalId: "sig-fallback-guardian-1",
-    assistantId: "self",
     createdAt: Date.now(),
     sourceChannel: "voice",
     sourceSessionId: "call-session-1",
@@ -307,7 +306,6 @@ describe("access-request instruction enforcement", () => {
   ): NotificationSignal {
     return {
       signalId: "sig-access-req-1",
-      assistantId: "self",
       createdAt: Date.now(),
       sourceChannel: "telegram",
       sourceSessionId: "tg-session-1",

--- a/assistant/src/__tests__/notification-decision-strategy.test.ts
+++ b/assistant/src/__tests__/notification-decision-strategy.test.ts
@@ -36,7 +36,6 @@ function makeSignal(
 ): NotificationSignal {
   return {
     signalId: "sig-test-001",
-    assistantId: "self",
     createdAt: Date.now(),
     sourceChannel: "scheduler",
     sourceSessionId: "sess-001",

--- a/assistant/src/__tests__/thread-seed-composer.test.ts
+++ b/assistant/src/__tests__/thread-seed-composer.test.ts
@@ -25,7 +25,6 @@ function makeSignal(
 ): NotificationSignal {
   return {
     signalId: "sig-seed-001",
-    assistantId: "self",
     createdAt: Date.now(),
     sourceChannel: "scheduler",
     sourceSessionId: "sess-1",

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -393,7 +393,6 @@ const accessRequestResolver: GuardianRequestResolver = {
           sourceEventName: "ingress.trusted_contact.guardian_decision",
           sourceChannel: channel,
           sourceSessionId: request.conversationId ?? "",
-          assistantId,
           attentionHints: {
             requiresAction: false,
             urgency: "medium",
@@ -408,7 +407,6 @@ const accessRequestResolver: GuardianRequestResolver = {
           sourceEventName: "ingress.trusted_contact.denied",
           sourceChannel: channel,
           sourceSessionId: request.conversationId ?? "",
-          assistantId,
           attentionHints: {
             requiresAction: false,
             urgency: "low",
@@ -582,7 +580,6 @@ const accessRequestResolver: GuardianRequestResolver = {
           sourceEventName: "ingress.trusted_contact.verification_sent",
           sourceChannel: channel,
           sourceSessionId: request.conversationId ?? "",
-          assistantId,
           attentionHints: {
             requiresAction: false,
             urgency: "low",

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -205,7 +205,6 @@ async function dispatchGuardianQuestionInner(
       sourceEventName: "guardian.question",
       sourceChannel: "voice",
       sourceSessionId: callSessionId,
-      assistantId,
       attentionHints: {
         requiresAction: true,
         urgency: "high",

--- a/assistant/src/calls/relay-access-wait.ts
+++ b/assistant/src/calls/relay-access-wait.ts
@@ -9,7 +9,6 @@
 import { findContactChannel } from "../contacts/contact-store.js";
 import { getCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import {
   getGuardianWaitUpdateInitialIntervalMs,
@@ -240,8 +239,6 @@ export function emitAccessRequestCallbackHandoff(
     return { emitted: false, callbackHandoffNotified: true };
   }
 
-  const assistantId =
-    params.accessRequestAssistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
   const fromNumber = params.accessRequestFromNumber ?? null;
 
   // Resolve canonical request for requestCode and conversationId
@@ -282,7 +279,6 @@ export function emitAccessRequestCallbackHandoff(
     sourceEventName: "ingress.access_request.callback_handoff",
     sourceChannel: "voice",
     sourceSessionId,
-    assistantId,
     attentionHints: {
       requiresAction: false,
       urgency: "medium",

--- a/assistant/src/config/bundled-skills/notifications/tools/send-notification.ts
+++ b/assistant/src/config/bundled-skills/notifications/tools/send-notification.ts
@@ -131,7 +131,6 @@ export async function run(
       sourceEventName,
       sourceChannel: "assistant_tool",
       sourceSessionId,
-      assistantId: context.assistantId,
       attentionHints: {
         requiresAction: parseBool(input.requires_action, true),
         urgency,

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -6,7 +6,6 @@ import {
   type SignalType,
 } from "../../memory/conversation-attention-store.js";
 import { updateDeliveryClientOutcome } from "../../notifications/deliveries-store.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
 import type { ClientMessage } from "../ipc-protocol.js";
 import {
   handleRideShotgunStart,
@@ -120,7 +119,6 @@ const inlineHandlers = defineHandlers({
     try {
       recordConversationSeenSignal({
         conversationId: msg.conversationId,
-        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
         sourceChannel: msg.sourceChannel,
         signalType: msg.signalType as SignalType,
         confidence: msg.confidence as Confidence,

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -434,13 +434,11 @@ export async function drainQueue(
   // Fire-and-forget: detect notification preferences in the queued message
   // and persist any that are found, mirroring the logic in processMessage.
   if (session.assistantId) {
-    const aid = session.assistantId;
     extractPreferences(resolvedContent)
       .then((result) => {
         if (!result.detected) return;
         for (const pref of result.preferences) {
           createPreference({
-            assistantId: aid,
             preferenceText: pref.preferenceText,
             appliesWhen: pref.appliesWhen,
             priority: pref.priority,
@@ -735,13 +733,11 @@ export async function processMessage(
   // and persist any that are found. Runs in the background so it doesn't
   // block the main conversation flow.
   if (session.assistantId) {
-    const aid = session.assistantId;
     extractPreferences(resolvedContent)
       .then((result) => {
         if (!result.detected) return;
         for (const pref of result.preferences) {
           createPreference({
-            assistantId: aid,
             preferenceText: pref.preferenceText,
             appliesWhen: pref.appliesWhen,
             priority: pref.priority,

--- a/assistant/src/memory/conversation-attention-store.ts
+++ b/assistant/src/memory/conversation-attention-store.ts
@@ -9,6 +9,7 @@
 import { and, desc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getDb } from "./db.js";
 import {
   conversationAssistantAttentionState,
@@ -32,7 +33,6 @@ export type Confidence = "explicit" | "inferred";
 export interface AttentionEvent {
   id: string;
   conversationId: string;
-  assistantId: string;
   sourceChannel: string;
   signalType: SignalType;
   confidence: Confidence;
@@ -45,7 +45,6 @@ export interface AttentionEvent {
 
 export interface AttentionState {
   conversationId: string;
-  assistantId: string;
   latestAssistantMessageId: string | null;
   latestAssistantMessageAt: number | null;
   lastSeenAssistantMessageId: string | null;
@@ -68,7 +67,6 @@ function rowToEvent(
   return {
     id: row.id,
     conversationId: row.conversationId,
-    assistantId: row.assistantId,
     sourceChannel: row.sourceChannel,
     signalType: row.signalType as SignalType,
     confidence: row.confidence as Confidence,
@@ -81,11 +79,13 @@ function rowToEvent(
 }
 
 function rowToState(
-  row: typeof conversationAssistantAttentionState.$inferSelect,
+  row: Omit<
+    typeof conversationAssistantAttentionState.$inferSelect,
+    "assistantId"
+  >,
 ): AttentionState {
   return {
     conversationId: row.conversationId,
-    assistantId: row.assistantId,
     latestAssistantMessageId: row.latestAssistantMessageId,
     latestAssistantMessageAt: row.latestAssistantMessageAt,
     lastSeenAssistantMessageId: row.lastSeenAssistantMessageId,
@@ -109,11 +109,10 @@ function rowToState(
  */
 export function projectAssistantMessage(params: {
   conversationId: string;
-  assistantId: string;
   messageId: string;
   messageAt: number;
 }): void {
-  const { conversationId, assistantId, messageId, messageAt } = params;
+  const { conversationId, messageId, messageAt } = params;
   const db = getDb();
   const now = Date.now();
 
@@ -129,7 +128,7 @@ export function projectAssistantMessage(params: {
     db.insert(conversationAssistantAttentionState)
       .values({
         conversationId,
-        assistantId,
+        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
         latestAssistantMessageId: messageId,
         latestAssistantMessageAt: messageAt,
         lastSeenAssistantMessageId: null,
@@ -175,7 +174,6 @@ export function projectAssistantMessage(params: {
  */
 export function recordConversationSeenSignal(params: {
   conversationId: string;
-  assistantId: string;
   sourceChannel: string;
   signalType: SignalType;
   confidence: Confidence;
@@ -186,7 +184,6 @@ export function recordConversationSeenSignal(params: {
 }): AttentionEvent {
   const {
     conversationId,
-    assistantId,
     sourceChannel,
     signalType,
     confidence,
@@ -205,7 +202,7 @@ export function recordConversationSeenSignal(params: {
   const event: typeof conversationAttentionEvents.$inferInsert = {
     id: eventId,
     conversationId,
-    assistantId,
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     sourceChannel,
     signalType,
     confidence,
@@ -252,7 +249,7 @@ export function recordConversationSeenSignal(params: {
       tx.insert(conversationAssistantAttentionState)
         .values({
           conversationId,
-          assistantId,
+          assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
           latestAssistantMessageId: latestMsgId,
           latestAssistantMessageAt: latestMsgAt,
           lastSeenAssistantMessageId: latestMsgId,
@@ -348,7 +345,6 @@ export function getAttentionStateByConversationIds(
 export type AttentionFilterState = "seen" | "unseen" | "all";
 
 export interface ListConversationAttentionParams {
-  assistantId: string;
   state?: AttentionFilterState;
   sourceChannel?: string;
   source?: string;
@@ -364,7 +360,6 @@ export function listConversationAttention(
   params: ListConversationAttentionParams,
 ): AttentionState[] {
   const {
-    assistantId,
     state: filterState = "all",
     sourceChannel,
     source,
@@ -373,9 +368,8 @@ export function listConversationAttention(
   } = params;
 
   const db = getDb();
-  const conditions = [
-    eq(conversationAssistantAttentionState.assistantId, assistantId),
-  ];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const conditions: any[] = [];
 
   if (sourceChannel) {
     conditions.push(eq(conversations.originChannel, sourceChannel));
@@ -415,7 +409,6 @@ export function listConversationAttention(
   let query = db
     .select({
       conversationId: conversationAssistantAttentionState.conversationId,
-      assistantId: conversationAssistantAttentionState.assistantId,
       latestAssistantMessageId:
         conversationAssistantAttentionState.latestAssistantMessageId,
       latestAssistantMessageAt:
@@ -448,8 +441,7 @@ export function listConversationAttention(
     );
   }
 
-  const rows = query
-    .where(and(...conditions))
+  const rows = (conditions.length > 0 ? query.where(and(...conditions)) : query)
     .orderBy(desc(conversationAssistantAttentionState.latestAssistantMessageAt))
     .limit(limit)
     .all();

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -7,7 +7,6 @@ import { parseChannelId, parseInterfaceId } from "../channels/types.js";
 import { CHANNEL_IDS, INTERFACE_IDS, isChannelId } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
 import type { TrustContext } from "../daemon/session-runtime-assembly.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import { createRowMapper } from "../util/row-mapper.js";
 import { deleteOrphanAttachments } from "./attachments-store.js";
@@ -394,7 +393,6 @@ export async function addMessage(
     try {
       projectAssistantMessage({
         conversationId,
-        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
         messageId: message.id,
         messageAt: message.createdAt,
       });

--- a/assistant/src/notifications/adapters/sms.ts
+++ b/assistant/src/notifications/adapters/sms.ts
@@ -13,6 +13,7 @@
  */
 
 import { getGatewayInternalBaseUrl } from "../../config/env.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
 import { mintDaemonDeliveryToken } from "../../runtime/auth/token-service.js";
 import { deliverChannelReply } from "../../runtime/gateway-client.js";
 import { getLogger } from "../../util/logger.js";
@@ -70,7 +71,7 @@ export class SmsAdapter implements ChannelAdapter {
         {
           chatId: phoneNumber,
           text: messageText,
-          assistantId: payload.assistantId,
+          assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
         },
         mintDaemonDeliveryToken(),
       );

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -77,10 +77,7 @@ export class NotificationBroadcaster {
     decision: NotificationDecision,
     options?: BroadcastDecisionOptions,
   ): Promise<NotificationDeliveryResult[]> {
-    const destinations = resolveDestinations(
-      signal.assistantId,
-      decision.selectedChannels,
-    );
+    const destinations = resolveDestinations(decision.selectedChannels);
 
     // Ensure vellum is processed first so the notification_thread_created IPC
     // push fires immediately, before slower channel sends (e.g. Telegram 30s
@@ -271,7 +268,6 @@ export class NotificationBroadcaster {
       const payload: ChannelDeliveryPayload = {
         deliveryId,
         sourceEventName: signal.sourceEventName,
-        assistantId: signal.assistantId,
         copy,
         deepLinkTarget,
       };
@@ -291,7 +287,6 @@ export class NotificationBroadcaster {
           createDelivery({
             id: deliveryId,
             notificationDecisionId: persistedDecisionId,
-            assistantId: signal.assistantId,
             channel,
             destination: destinationLabel,
             status: "pending",

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -696,12 +696,11 @@ export async function evaluateSignal(
   let resolvedPreferenceContext = preferenceContext;
   if (resolvedPreferenceContext === undefined) {
     try {
-      resolvedPreferenceContext =
-        getPreferenceSummary(signal.assistantId) ?? undefined;
+      resolvedPreferenceContext = getPreferenceSummary() ?? undefined;
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       log.warn(
-        { err: errMsg, assistantId: signal.assistantId },
+        { err: errMsg },
         "Failed to load preference summary, proceeding without preferences",
       );
       resolvedPreferenceContext = undefined;
@@ -712,7 +711,7 @@ export async function evaluateSignal(
   // so candidate lookup failures do not block the decision path.
   let candidateSet: ThreadCandidateSet | undefined;
   try {
-    candidateSet = buildThreadCandidates(availableChannels, signal.assistantId);
+    candidateSet = buildThreadCandidates(availableChannels);
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     log.warn(

--- a/assistant/src/notifications/deliveries-store.ts
+++ b/assistant/src/notifications/deliveries-store.ts
@@ -10,6 +10,7 @@ import { and, eq } from "drizzle-orm";
 
 import { getDb, rawChanges } from "../memory/db.js";
 import { notificationDeliveries } from "../memory/schema.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import type {
   NotificationChannel,
   NotificationDeliveryStatus,
@@ -18,7 +19,6 @@ import type {
 export interface NotificationDeliveryRow {
   id: string;
   notificationDecisionId: string;
-  assistantId: string;
   channel: string;
   destination: string;
   status: string;
@@ -47,7 +47,6 @@ function rowToDelivery(
   return {
     id: row.id,
     notificationDecisionId: row.notificationDecisionId,
-    assistantId: row.assistantId,
     channel: row.channel,
     destination: row.destination,
     status: row.status,
@@ -74,7 +73,6 @@ function rowToDelivery(
 export interface CreateDeliveryParams {
   id: string;
   notificationDecisionId: string;
-  assistantId: string;
   channel: NotificationChannel;
   destination: string;
   status: NotificationDeliveryStatus;
@@ -102,7 +100,7 @@ export function createDelivery(
   const row = {
     id: params.id,
     notificationDecisionId: params.notificationDecisionId,
-    assistantId: params.assistantId,
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     channel: params.channel,
     destination: params.destination,
     status: params.status,

--- a/assistant/src/notifications/destination-resolver.ts
+++ b/assistant/src/notifications/destination-resolver.ts
@@ -14,6 +14,7 @@
 import { isNotificationDeliverable } from "../channels/config.js";
 import type { ChannelId } from "../channels/types.js";
 import { findGuardianForChannel } from "../contacts/contact-store.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import type { ChannelDestination, NotificationChannel } from "./types.js";
 
@@ -28,7 +29,6 @@ const log = getLogger("destination-resolver");
  * resolved (e.g. no Telegram binding configured) are omitted from the result.
  */
 export function resolveDestinations(
-  assistantId: string,
   channels: readonly (ChannelId | NotificationChannel)[],
 ): Map<NotificationChannel, ChannelDestination> {
   const result = new Map<NotificationChannel, ChannelDestination>();
@@ -44,7 +44,10 @@ export function resolveDestinations(
         // Vellum delivery is local IPC — no external endpoint required.
         // Include the guardianPrincipalId so the adapter can annotate
         // guardian-sensitive notifications for scoped delivery.
-        const guardianResult = findGuardianForChannel("vellum", assistantId);
+        const guardianResult = findGuardianForChannel(
+          "vellum",
+          DAEMON_INTERNAL_ASSISTANT_ID,
+        );
         const metadata: Record<string, unknown> = {};
         if (guardianResult) {
           metadata.guardianPrincipalId = guardianResult.contact.principalId;
@@ -66,7 +69,10 @@ export function resolveDestinations(
       case "telegram":
       case "sms":
       case "slack": {
-        const guardianResult = findGuardianForChannel(channel, assistantId);
+        const guardianResult = findGuardianForChannel(
+          channel,
+          DAEMON_INTERNAL_ASSISTANT_ID,
+        );
         if (guardianResult && guardianResult.channel.externalChatId) {
           result.set(channel as NotificationChannel, {
             channel: channel as NotificationChannel,
@@ -87,7 +93,10 @@ export function resolveDestinations(
         break;
       }
       case "slack": {
-        const guardianResult = findGuardianForChannel("slack", assistantId);
+        const guardianResult = findGuardianForChannel(
+          "slack",
+          DAEMON_INTERNAL_ASSISTANT_ID,
+        );
         const chatId = guardianResult?.channel.externalChatId;
         // Slack bindings can originate from app_mention in shared channels.
         // Only route notifications to DM channels (IDs starting with "D")

--- a/assistant/src/notifications/deterministic-checks.ts
+++ b/assistant/src/notifications/deterministic-checks.ts
@@ -205,12 +205,7 @@ function checkDedupe(
         createdAt: notificationEvents.createdAt,
       })
       .from(notificationEvents)
-      .where(
-        and(
-          eq(notificationEvents.assistantId, signal.assistantId),
-          eq(notificationEvents.dedupeKey, decision.dedupeKey),
-        ),
-      )
+      .where(and(eq(notificationEvents.dedupeKey, decision.dedupeKey)))
       .all();
 
     // Filter by created_at > cutoff (the events store already checked

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -100,7 +100,7 @@ function getBroadcaster(): NotificationBroadcaster {
 
 // ── Connected channels resolution ──────────────────────────────────────
 
-function getConnectedChannels(assistantId: string): NotificationChannel[] {
+function getConnectedChannels(): NotificationChannel[] {
   const channels: NotificationChannel[] = [];
 
   // getDeliverableChannels() returns ChannelId[] but every returned channel
@@ -120,7 +120,10 @@ function getConnectedChannels(assistantId: string): NotificationChannel[] {
         // externalChatId check ensures we don't report a channel as
         // connected when the contacts record exists but lacks the
         // delivery address the destination-resolver needs.
-        const guardian = findGuardianForChannel(channel, assistantId);
+        const guardian = findGuardianForChannel(
+          channel,
+          DAEMON_INTERNAL_ASSISTANT_ID,
+        );
         if (guardian && guardian.channel.externalChatId) {
           channels.push(channel);
         }
@@ -130,7 +133,10 @@ function getConnectedChannels(assistantId: string): NotificationChannel[] {
         // Slack bindings can originate from shared channels (app_mention).
         // Only consider Slack connected when the stored chat ID is a DM
         // channel (D-prefixed) to prevent leaking notifications.
-        const slackGuardian = findGuardianForChannel("slack", assistantId);
+        const slackGuardian = findGuardianForChannel(
+          "slack",
+          DAEMON_INTERNAL_ASSISTANT_ID,
+        );
         const chatId = slackGuardian?.channel.externalChatId;
         if (slackGuardian && chatId && chatId.startsWith("D")) {
           channels.push(channel);
@@ -156,8 +162,6 @@ export interface EmitSignalParams<TEventName extends string = string> {
   sourceChannel: string;
   /** Session or conversation ID from the source context. */
   sourceSessionId: string;
-  /** Logical assistant ID (defaults to 'self'). */
-  assistantId?: string;
   /** Attention hints for the decision engine. */
   attentionHints: AttentionHints;
   /** Arbitrary context payload passed to the decision engine. */
@@ -205,11 +209,9 @@ export async function emitNotificationSignal<TEventName extends string>(
   params: EmitSignalParams<TEventName>,
 ): Promise<EmitSignalResult> {
   const signalId = uuid();
-  const assistantId = params.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
 
   const signal: NotificationSignal<TEventName> = {
     signalId,
-    assistantId,
     createdAt: Date.now(),
     sourceChannel: params.sourceChannel,
     sourceSessionId: params.sourceSessionId,
@@ -226,7 +228,6 @@ export async function emitNotificationSignal<TEventName extends string>(
     // Step 1: Persist the event
     const eventRow = createEvent({
       id: signalId,
-      assistantId,
       sourceEventName: params.sourceEventName,
       sourceChannel: params.sourceChannel,
       sourceSessionId: params.sourceSessionId,
@@ -250,12 +251,11 @@ export async function emitNotificationSignal<TEventName extends string>(
     }
 
     // Step 2: Evaluate the signal through the decision engine
-    const connectedChannels = getConnectedChannels(assistantId);
+    const connectedChannels = getConnectedChannels();
 
     log.debug(
       {
         channels: connectedChannels,
-        assistantId,
       },
       "connected channels resolved",
     );

--- a/assistant/src/notifications/events-store.ts
+++ b/assistant/src/notifications/events-store.ts
@@ -10,11 +10,11 @@ import { and, desc, eq } from "drizzle-orm";
 
 import { getDb } from "../memory/db.js";
 import { notificationEvents } from "../memory/schema.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import type { AttentionHints } from "./signal.js";
 
 export interface NotificationEventRow {
   id: string;
-  assistantId: string;
   sourceEventName: string;
   sourceChannel: string;
   sourceSessionId: string;
@@ -30,7 +30,6 @@ function rowToEvent(
 ): NotificationEventRow {
   return {
     id: row.id,
-    assistantId: row.assistantId,
     sourceEventName: row.sourceEventName,
     sourceChannel: row.sourceChannel,
     sourceSessionId: row.sourceSessionId,
@@ -44,7 +43,6 @@ function rowToEvent(
 
 export interface CreateEventParams {
   id: string;
-  assistantId: string;
   sourceEventName: string;
   sourceChannel: string;
   sourceSessionId: string;
@@ -70,19 +68,14 @@ export function createEvent(
     const existing = db
       .select()
       .from(notificationEvents)
-      .where(
-        and(
-          eq(notificationEvents.assistantId, params.assistantId),
-          eq(notificationEvents.dedupeKey, normalizedDedupeKey),
-        ),
-      )
+      .where(and(eq(notificationEvents.dedupeKey, normalizedDedupeKey)))
       .get();
     if (existing) return null;
   }
 
   const row = {
     id: params.id,
-    assistantId: params.assistantId,
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     sourceEventName: params.sourceEventName,
     sourceChannel: params.sourceChannel,
     sourceSessionId: params.sourceSessionId,
@@ -124,13 +117,13 @@ export interface ListEventsFilters {
   limit?: number;
 }
 
-/** List notification events for an assistant with optional filters. */
+/** List notification events with optional filters. */
 export function listEvents(
-  assistantId: string,
   filters?: ListEventsFilters,
 ): NotificationEventRow[] {
   const db = getDb();
-  const conditions = [eq(notificationEvents.assistantId, assistantId)];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const conditions: any[] = [];
 
   if (filters?.sourceEventName) {
     conditions.push(
@@ -140,10 +133,9 @@ export function listEvents(
 
   const limit = filters?.limit ?? 50;
 
-  const rows = db
-    .select()
-    .from(notificationEvents)
-    .where(and(...conditions))
+  const query = db.select().from(notificationEvents);
+
+  const rows = (conditions.length > 0 ? query.where(and(...conditions)) : query)
     .orderBy(desc(notificationEvents.createdAt))
     .limit(limit)
     .all();

--- a/assistant/src/notifications/preference-summary.ts
+++ b/assistant/src/notifications/preference-summary.ts
@@ -17,8 +17,8 @@ const log = getLogger("notification-preference-summary");
  * Build a compact preference summary for inclusion in the decision engine
  * system prompt. Returns null if no preferences are stored.
  */
-export function getPreferenceSummary(assistantId: string): string | null {
-  const preferences = listPreferences(assistantId);
+export function getPreferenceSummary(): string | null {
+  const preferences = listPreferences();
 
   if (preferences.length === 0) {
     return null;

--- a/assistant/src/notifications/preferences-store.ts
+++ b/assistant/src/notifications/preferences-store.ts
@@ -7,17 +7,17 @@
  * resolution.
  */
 
-import { desc, eq } from "drizzle-orm";
+import { desc } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../memory/db.js";
 import { notificationPreferences } from "../memory/schema.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 
 // ── Row type ────────────────────────────────────────────────────────────
 
 export interface NotificationPreferenceRow {
   id: string;
-  assistantId: string;
   preferenceText: string;
   appliesWhenJson: string; // serialised JSON
   priority: number;
@@ -30,7 +30,6 @@ function rowToPreference(
 ): NotificationPreferenceRow {
   return {
     id: row.id,
-    assistantId: row.assistantId,
     preferenceText: row.preferenceText,
     appliesWhenJson: row.appliesWhenJson,
     priority: row.priority,
@@ -52,7 +51,6 @@ export interface AppliesWhenConditions {
 // ── Create ──────────────────────────────────────────────────────────────
 
 export interface CreatePreferenceParams {
-  assistantId: string;
   preferenceText: string;
   appliesWhen?: AppliesWhenConditions;
   priority?: number;
@@ -66,7 +64,7 @@ export function createPreference(
 
   const row = {
     id: uuid(),
-    assistantId: params.assistantId,
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     preferenceText: params.preferenceText,
     appliesWhenJson: JSON.stringify(params.appliesWhen ?? {}),
     priority: params.priority ?? 0,
@@ -81,15 +79,12 @@ export function createPreference(
 
 // ── List ────────────────────────────────────────────────────────────────
 
-export function listPreferences(
-  assistantId: string,
-): NotificationPreferenceRow[] {
+export function listPreferences(): NotificationPreferenceRow[] {
   const db = getDb();
 
   const rows = db
     .select()
     .from(notificationPreferences)
-    .where(eq(notificationPreferences.assistantId, assistantId))
     .orderBy(desc(notificationPreferences.priority))
     .all();
 

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -27,7 +27,6 @@ export type NotificationContextPayload<TEventName extends string = string> =
 
 export interface NotificationSignal<TEventName extends string = string> {
   signalId: string;
-  assistantId: string;
   createdAt: number; // epoch ms
   sourceChannel: string; // free-form: 'vellum', 'telegram', 'voice', 'scheduler', etc.
   sourceSessionId: string;

--- a/assistant/src/notifications/thread-candidates.ts
+++ b/assistant/src/notifications/thread-candidates.ts
@@ -70,18 +70,13 @@ export type ThreadCandidateSet = Partial<
  */
 export function buildThreadCandidates(
   channels: NotificationChannel[],
-  assistantId: string,
 ): ThreadCandidateSet {
   const result: ThreadCandidateSet = {};
   const cutoff = Date.now() - CANDIDATE_RECENCY_WINDOW_MS;
 
   for (const channel of channels) {
     try {
-      const candidates = buildCandidatesForChannel(
-        channel,
-        assistantId,
-        cutoff,
-      );
+      const candidates = buildCandidatesForChannel(channel, cutoff);
       if (candidates.length > 0) {
         result[channel] = candidates;
       }
@@ -108,7 +103,6 @@ export function buildThreadCandidates(
  */
 function buildCandidatesForChannel(
   channel: NotificationChannel,
-  assistantId: string,
   cutoffMs: number,
 ): ThreadCandidate[] {
   const db = getDb();
@@ -143,7 +137,6 @@ function buildCandidatesForChannel(
     .where(
       and(
         eq(notificationDeliveries.channel, channel),
-        eq(notificationDeliveries.assistantId, assistantId),
         eq(notificationDeliveries.status, "sent"),
         isNotNull(notificationDeliveries.conversationId),
       ),
@@ -180,7 +173,6 @@ function buildCandidatesForChannel(
   if (candidates.length > 0) {
     const pendingCounts = batchCountPendingByConversation(
       candidates.map((c) => c.conversationId),
-      assistantId,
     );
     for (const candidate of candidates) {
       const pendingCount = pendingCounts.get(candidate.conversationId) ?? 0;
@@ -204,7 +196,6 @@ function buildCandidatesForChannel(
  */
 function batchCountPendingByConversation(
   conversationIds: string[],
-  assistantId: string,
 ): Map<string, number> {
   const result = new Map<string, number>();
   if (conversationIds.length === 0) return result;
@@ -225,7 +216,6 @@ function batchCountPendingByConversation(
             conversationIds,
           ),
           eq(channelGuardianApprovalRequests.status, "pending"),
-          eq(channelGuardianApprovalRequests.assistantId, assistantId),
         ),
       )
       .groupBy(channelGuardianApprovalRequests.conversationId)

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -61,9 +61,6 @@ export interface ChannelDeliveryPayload {
   /** Delivery audit record ID — passed through to the client for ack correlation. */
   deliveryId?: string;
   sourceEventName: string;
-  /** Originating assistant — used by channel adapters that need assistant-specific
-   *  routing (e.g. SMS outbound number selection via the gateway). */
-  assistantId?: string;
   copy: RenderedChannelCopy;
   deepLinkTarget?: Record<string, unknown>;
 }

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -224,7 +224,6 @@ export function notifyGuardianOfAccessRequest(
     sourceEventName: "ingress.access_request",
     sourceChannel,
     sourceSessionId: `access-req-${sourceChannel}-${actorExternalId}`,
-    assistantId: canonicalAssistantId,
     attentionHints: {
       requiresAction: true,
       urgency: "high",

--- a/assistant/src/runtime/channel-invite-transport.ts
+++ b/assistant/src/runtime/channel-invite-transport.ts
@@ -66,6 +66,14 @@ export interface ChannelInviteAdapter {
     inviteCode: string;
     contactName?: string;
   }): GuardianInstruction;
+
+  /**
+   * Resolve the channel-specific handle to reach the assistant (e.g.
+   * "@botName", "+15551234567", "hello@domain.agentmail.to").
+   * Returns `undefined` when the handle cannot be resolved (e.g.
+   * credentials not yet configured).
+   */
+  resolveChannelHandle?(): string | undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/channel-invite-transports/email.ts
+++ b/assistant/src/runtime/channel-invite-transports/email.ts
@@ -47,4 +47,8 @@ export const emailInviteAdapter: ChannelInviteAdapter = {
       channelHandle: address,
     };
   },
+
+  resolveChannelHandle(): string | undefined {
+    return resolveAssistantEmailAddress();
+  },
 };

--- a/assistant/src/runtime/channel-invite-transports/slack.ts
+++ b/assistant/src/runtime/channel-invite-transports/slack.ts
@@ -78,4 +78,10 @@ export const slackInviteAdapter: ChannelInviteAdapter = {
       channelHandle: `@${botInfo.botUsername}`,
     };
   },
+
+  resolveChannelHandle(): string | undefined {
+    const botInfo = resolveSlackBotInfo();
+    if (!botInfo) return undefined;
+    return `@${botInfo.botUsername}`;
+  },
 };

--- a/assistant/src/runtime/channel-invite-transports/sms.ts
+++ b/assistant/src/runtime/channel-invite-transports/sms.ts
@@ -67,4 +67,8 @@ export const smsInviteAdapter: ChannelInviteAdapter = {
       channelHandle: phoneNumber,
     };
   },
+
+  resolveChannelHandle(): string | undefined {
+    return resolveSmsPhoneNumber();
+  },
 };

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -85,6 +85,12 @@ export const telegramInviteAdapter: ChannelInviteAdapter = {
     };
   },
 
+  resolveChannelHandle(): string | undefined {
+    const botUsername = getTelegramBotUsername();
+    if (!botUsername) return undefined;
+    return `@${botUsername}`;
+  },
+
   extractInboundToken(params: {
     commandIntent?: Record<string, unknown>;
     content: string;

--- a/assistant/src/runtime/confirmation-request-guardian-bridge.ts
+++ b/assistant/src/runtime/confirmation-request-guardian-bridge.ts
@@ -146,7 +146,6 @@ export function bridgeConfirmationRequestToGuardian(
     sourceEventName: "guardian.question",
     sourceChannel,
     sourceSessionId: conversationId,
-    assistantId,
     attentionHints: {
       requiresAction: true,
       urgency: "high",

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -811,7 +811,6 @@ export class RuntimeHttpServer {
           try {
             recordConversationSeenSignal({
               conversationId,
-              assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
               sourceChannel: (body.sourceChannel as string) ?? "vellum",
               signalType: ((body.signalType as string) ??
                 "macos_conversation_opened") as SignalType,

--- a/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
@@ -807,7 +807,6 @@ async function handleAccessRequestApproval(
       sourceEventName: "ingress.trusted_contact.guardian_decision",
       sourceChannel: approval.channel,
       sourceSessionId: approval.conversationId,
-      assistantId,
       attentionHints: {
         requiresAction: false,
         urgency: "medium",
@@ -822,7 +821,6 @@ async function handleAccessRequestApproval(
       sourceEventName: "ingress.trusted_contact.denied",
       sourceChannel: approval.channel,
       sourceSessionId: approval.conversationId,
-      assistantId,
       attentionHints: {
         requiresAction: false,
         urgency: "low",
@@ -891,7 +889,6 @@ async function handleAccessRequestApproval(
       sourceEventName: "ingress.trusted_contact.guardian_decision",
       sourceChannel: approval.channel,
       sourceSessionId: approval.conversationId,
-      assistantId,
       attentionHints: {
         requiresAction: false,
         urgency: "medium",
@@ -918,7 +915,6 @@ async function handleAccessRequestApproval(
       sourceEventName: "ingress.trusted_contact.verification_sent",
       sourceChannel: approval.channel,
       sourceSessionId: approval.conversationId,
-      assistantId,
       attentionHints: {
         requiresAction: false,
         urgency: "low",

--- a/assistant/src/runtime/routes/conversation-attention-routes.ts
+++ b/assistant/src/runtime/routes/conversation-attention-routes.ts
@@ -10,7 +10,6 @@ import {
 } from "../../memory/conversation-attention-store.js";
 import * as conversationStore from "../../memory/conversation-store.js";
 import { truncate } from "../../util/truncate.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 
@@ -38,7 +37,6 @@ export function handleListConversationAttention(url: URL): Response {
   }
 
   const attentionStates = listConversationAttention({
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     state: stateParam as AttentionFilterState,
     sourceChannel: channel,
     source: sourceParam !== "all" ? sourceParam : undefined,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -501,7 +501,6 @@ export async function handleChannelInbound(
                 : body.callbackData!;
             recordConversationSeenSignal({
               conversationId: result.conversationId,
-              assistantId: canonicalAssistantId,
               signalType: `${sourceChannel}_callback` as SignalType,
               confidence: "inferred",
               sourceChannel,
@@ -515,7 +514,6 @@ export async function handleChannelInbound(
                 : trimmedContent;
             recordConversationSeenSignal({
               conversationId: result.conversationId,
-              assistantId: canonicalAssistantId,
               signalType: `${sourceChannel}_inbound_message` as SignalType,
               confidence: "inferred",
               sourceChannel,
@@ -554,7 +552,6 @@ export async function handleChannelInbound(
               : body.callbackData!;
           recordConversationSeenSignal({
             conversationId: result.conversationId,
-            assistantId: canonicalAssistantId,
             signalType: `${sourceChannel}_callback` as SignalType,
             confidence: "inferred",
             sourceChannel,

--- a/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
@@ -134,7 +134,6 @@ export function handleEscalationIntercept(
     sourceEventName: "ingress.escalation",
     sourceChannel,
     sourceSessionId: conversationId,
-    assistantId: canonicalAssistantId,
     attentionHints: {
       requiresAction: true,
       urgency: "high",

--- a/assistant/src/runtime/routes/inbound-stages/secret-ingress-check.ts
+++ b/assistant/src/runtime/routes/inbound-stages/secret-ingress-check.ts
@@ -115,7 +115,6 @@ export function runSecretIngressCheck(params: SecretIngressCheckParams): void {
           : "User sent media attachment";
       recordConversationSeenSignal({
         conversationId,
-        assistantId: canonicalAssistantId,
         signalType: "telegram_inbound_message",
         confidence: "inferred",
         sourceChannel: "telegram",

--- a/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
@@ -235,7 +235,6 @@ export async function handleVerificationIntercept(
         sourceEventName: "ingress.trusted_contact.activated",
         sourceChannel,
         sourceSessionId: conversationId,
-        assistantId: canonicalAssistantId,
         attentionHints: {
           requiresAction: false,
           urgency: "low",

--- a/assistant/src/runtime/tool-grant-request-helper.ts
+++ b/assistant/src/runtime/tool-grant-request-helper.ts
@@ -146,7 +146,6 @@ export function createOrReuseToolGrantRequest(
     sourceEventName: "guardian.question",
     sourceChannel,
     sourceSessionId: conversationId,
-    assistantId,
     attentionHints: {
       requiresAction: true,
       urgency: "high",


### PR DESCRIPTION
## Summary
- Remove assistantId from all notification store function signatures (emit-signal, events-store, preferences-store, deliveries-store, destination-resolver, thread-candidates, conversation-attention-store)
- Hardcode DAEMON_INTERNAL_ASSISTANT_ID internally for INSERT operations; remove assistantId WHERE clause filters (redundant since all data is 'self')
- Update ~30 callers across runtime routes, daemon handlers, approval flows, and call helpers

Part of plan: rm-assistant-id-from-daemon.md (PR 5 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
