### PR TITLE
Improve Screen Recording UI: Selection, Toggles, Padding

### DIFF
--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -21,13 +21,13 @@ struct RecordingSourcePickerView: View {
             Text("Screen Recording")
                 .font(VFont.title)
                 .foregroundColor(VColor.textPrimary)
-                .padding(.top, VSpacing.md)
+                .padding(.top, VSpacing.sm)
                 .padding(.bottom, VSpacing.sm)
 
             Text("Choose what to record")
                 .font(VFont.body)
                 .foregroundColor(VColor.textSecondary)
-                .padding(.bottom, VSpacing.md)
+                .padding(.bottom, VSpacing.sm)
 
             // Scope picker (Display / Window)
             VSegmentedControl(
@@ -338,7 +338,7 @@ struct RecordingSourcePickerView: View {
                     .accessibilityHidden(true)
             }
         }
-        .padding(.vertical, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
     }
 }
 

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -62,7 +62,7 @@ struct RecordingSourcePickerView: View {
             bottomBar
         }
         .frame(width: 420)
-        .background(VColor.background)
+        .background(VColor.surface)
         .task {
             await viewModel.loadSources()
             await viewModel.loadPreviews()

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerView.swift
@@ -10,6 +10,9 @@ struct RecordingSourcePickerView: View {
     var onStart: (IPCRecordingOptions) -> Void
     var onCancel: () -> Void
 
+    @State private var hoveredDisplayId: UInt32?
+    @State private var hoveredWindowId: Int?
+
     /// Row thumbnail size (80x50pt).
     private let rowThumbnailSize = CGSize(width: 80, height: 50)
     /// Preview pane height.
@@ -136,6 +139,8 @@ struct RecordingSourcePickerView: View {
         }
         .padding(.horizontal, VSpacing.lg)
         .padding(.vertical, VSpacing.xs)
+        .animation(VAnimation.fast, value: hoveredDisplayId)
+        .animation(VAnimation.fast, value: hoveredWindowId)
     }
 
     /// Source list that hugs content when items fit, scrolls when they overflow.
@@ -197,7 +202,7 @@ struct RecordingSourcePickerView: View {
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(isSelected ? VColor.accent.opacity(0.1) : Color.clear)
+                    .fill(isSelected ? VColor.accent.opacity(0.1) : (hoveredWindowId == window.id ? VColor.ghostHover : Color.clear))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.md)
@@ -205,6 +210,13 @@ struct RecordingSourcePickerView: View {
             )
         }
         .buttonStyle(.plain)
+        .onHover { hovering in
+            if hovering {
+                hoveredWindowId = window.id
+            } else if hoveredWindowId == window.id {
+                hoveredWindowId = nil
+            }
+        }
     }
 
     /// Row for a display source showing name, resolution + scale, and a badge
@@ -252,7 +264,7 @@ struct RecordingSourcePickerView: View {
             .contentShape(Rectangle())
             .background(
                 RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(isSelected ? VColor.accent.opacity(0.1) : Color.clear)
+                    .fill(isSelected ? VColor.accent.opacity(0.1) : (hoveredDisplayId == display.id ? VColor.ghostHover : Color.clear))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: VRadius.md)
@@ -260,6 +272,13 @@ struct RecordingSourcePickerView: View {
             )
         }
         .buttonStyle(.plain)
+        .onHover { hovering in
+            if hovering {
+                hoveredDisplayId = display.id
+            } else if hoveredDisplayId == display.id {
+                hoveredDisplayId = nil
+            }
+        }
     }
 
     private func emptyState(_ message: String) -> some View {

--- a/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
+++ b/clients/macos/vellum-assistant/Recording/RecordingSourcePickerWindow.swift
@@ -63,7 +63,7 @@ final class RecordingSourcePickerWindow: NSObject, NSWindowDelegate {
         newWindow.titleVisibility = .hidden
         newWindow.titlebarAppearsTransparent = true
         newWindow.isMovableByWindowBackground = true
-        newWindow.backgroundColor = NSColor(VColor.background)
+        newWindow.backgroundColor = NSColor(VColor.surface)
         newWindow.isReleasedWhenClosed = false
         newWindow.level = .floating
         newWindow.center()

--- a/clients/shared/DesignSystem/Components/Navigation/VSegmentedControl.swift
+++ b/clients/shared/DesignSystem/Components/Navigation/VSegmentedControl.swift
@@ -70,7 +70,7 @@ public struct VSegmentedControl<SelectionValue: Hashable>: View {
         .padding(2)
         .background(
             RoundedRectangle(cornerRadius: VRadius.md)
-                .fill(VColor.surfaceSubtle)
+                .fill(VColor.inputBackground)
         )
         .animation(VAnimation.fast, value: selection)
     }
@@ -97,8 +97,6 @@ private struct PillSegment: View {
 
     @State private var isHovered = false
 
-    @Environment(\.colorScheme) private var colorScheme
-
     var body: some View {
         Button(action: action) {
             Text(label)
@@ -111,6 +109,7 @@ private struct PillSegment: View {
                 .background(
                     RoundedRectangle(cornerRadius: VRadius.md - 1)
                         .fill(segmentBackground)
+                        .shadow(color: isSelected ? Color.black.opacity(0.08) : .clear, radius: 2, x: 0, y: 1)
                 )
                 .contentShape(Rectangle())
         }
@@ -126,9 +125,9 @@ private struct PillSegment: View {
 
     private var segmentBackground: Color {
         if isSelected {
-            return VColor.navActive
+            return VColor.segmentSelected
         } else if isHovered {
-            return VColor.navHover
+            return VColor.segmentHover
         } else {
             return .clear
         }

--- a/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
+++ b/clients/shared/DesignSystem/Core/Inputs/VToggle.swift
@@ -47,6 +47,11 @@ public struct VToggle: View {
             RoundedRectangle(cornerRadius: trackHeight / 2)
                 .fill(isOn ? Forest._600 : VColor.toggleOff)
                 .frame(width: trackWidth, height: trackHeight)
+                .overlay(
+                    RoundedRectangle(cornerRadius: trackHeight / 2)
+                        .stroke(VColor.toggleBorder, lineWidth: 1)
+                        .opacity(isOn ? 0 : 1)
+                )
 
             // Knob
             RoundedRectangle(cornerRadius: knobSize / 2)

--- a/clients/shared/DesignSystem/Tokens/ColorTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/ColorTokens.swift
@@ -207,6 +207,8 @@ public enum VColor {
     // Navigation
     public static let navHover = adaptiveColor(light: Color(hex: 0xE8E6DA), dark: Moss._700)
     public static let navActive = adaptiveColor(light: Color(hex: 0xD4DFD0), dark: Moss._600)
+    public static let segmentSelected = adaptiveColor(light: .white, dark: Moss._600)
+    public static let segmentHover = adaptiveColor(light: Stone._100, dark: Moss._600)
 
     // Interactive states
     public static let ghostHover = adaptiveColor(light: Stone._100, dark: Moss._700)


### PR DESCRIPTION
## Summary
Polishes the screen recording source picker UI based on feedback from Marina and Rok (LUM-12). Fixes toggle visibility, segmented control colors, modal background, padding, and adds hover interactivity to source rows.

## Changes
- **VToggle off-state border**: Added 1pt `VColor.toggleBorder` stroke so toggles read as controls when off
- **VSegmentedControl pill colors**: Updated pill container to `VColor.inputBackground`, selected segment to new `VColor.segmentSelected` token (white/Moss._600), added `VColor.segmentHover` token for dark mode hover contrast
- **Picker background**: Changed from `VColor.background` to `VColor.surface` (both SwiftUI view and NSWindow) for cleaner white appearance
- **Reduced padding**: Tightened header (12→8pt) and bottom bar (16→12pt) vertical padding
- **Row hover states**: Added `VColor.ghostHover` highlight on source rows with race-condition-safe hover tracking

## Milestone PRs (merged into feature branch)
- #13038: M1 — Add border to VToggle off-state for visibility
- #13039: M2 — Update VSegmentedControl pill-style colors to match DS
- #13044: M3 — Fix RecordingSourcePickerView background color
- #13047: M4 — Reduce vertical padding in RecordingSourcePickerView
- #13049: M5 — Add hover states to source picker rows

## Out of scope (follow-up tickets)
- Save screen recordings to disk (Marina's request)
- `asset_materialize` empty file bug + missing ffprobe/ffmpeg in sandbox

## Project issue
Closes #13032

## Test plan
- [ ] Build: `./build.sh`
- [ ] Open screen recording picker and verify toggle off-state has visible border
- [ ] Verify segmented control (Display/Window) matches DS colors in light and dark mode
- [ ] Verify modal background is white (light) / appropriate shade (dark)
- [ ] Verify reduced padding — modal should feel tighter
- [ ] Hover over source rows — should highlight with ghost hover color
- [ ] Test in both light and dark mode

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
