### PR TITLE
Remove assistantId from guardian-verification and guardian-rate-limits

### DIFF
--- a/assistant/src/__tests__/access-request-decision.test.ts
+++ b/assistant/src/__tests__/access-request-decision.test.ts
@@ -156,7 +156,7 @@ describe("access request decision handler", () => {
     expect(result.type).toBe("approved");
 
     // There should be an active session for this channel
-    const session = findActiveSession("self", "telegram");
+    const session = findActiveSession("telegram");
     expect(session).not.toBeNull();
     expect(session!.expectedExternalUserId).toBe("user-unknown-456");
     expect(session!.expectedChatId).toBe("chat-123");
@@ -185,7 +185,7 @@ describe("access request decision handler", () => {
     expect(updated!.decidedByExternalUserId).toBe("guardian-user-789");
 
     // No verification session should be created
-    const session = findActiveSession("self", "telegram");
+    const session = findActiveSession("telegram");
     expect(session).toBeNull();
   });
 

--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -1056,7 +1056,7 @@ describe("SMS guardian verify intercept", () => {
   test("verification code reply works with sourceChannel sms", async () => {
     const { createVerificationChallenge } =
       await import("../runtime/channel-guardian-service.js");
-    const { secret } = createVerificationChallenge("self", "sms");
+    const { secret } = createVerificationChallenge("sms");
 
     const deliverSpy = spyOn(
       gatewayClient,
@@ -1100,7 +1100,7 @@ describe("SMS guardian verify intercept", () => {
     const { createVerificationChallenge } =
       await import("../runtime/channel-guardian-service.js");
     // Ensure there is a pending challenge so bare-code verification is intercepted.
-    createVerificationChallenge("self", "sms");
+    createVerificationChallenge("sms");
 
     const deliverSpy = spyOn(
       gatewayClient,
@@ -1148,7 +1148,6 @@ describe("SMS guardian verify intercept", () => {
     const challengeHash = createHash("sha256").update(secret).digest("hex");
     createChallenge({
       id: `challenge-hex-${Date.now()}`,
-      assistantId: "self",
       channel: "sms",
       challengeHash,
       expiresAt: Date.now() + 600_000,
@@ -1510,7 +1509,7 @@ describe("assistant-scoped guardian verification via handleChannelInbound", () =
   test("verification code uses the threaded assistantId (default: self)", async () => {
     const { createVerificationChallenge } =
       await import("../runtime/channel-guardian-service.js");
-    const { secret } = createVerificationChallenge("self", "telegram");
+    const { secret } = createVerificationChallenge("telegram");
 
     const deliverSpy = spyOn(
       gatewayClient,
@@ -1538,7 +1537,7 @@ describe("assistant-scoped guardian verification via handleChannelInbound", () =
       await import("../runtime/channel-guardian-service.js");
 
     // All assistant IDs canonicalize to 'self' in the single-tenant daemon
-    const { secret } = createVerificationChallenge("self", "telegram");
+    const { secret } = createVerificationChallenge("telegram");
 
     const deliverSpy = spyOn(
       gatewayClient,
@@ -1572,7 +1571,7 @@ describe("assistant-scoped guardian verification via handleChannelInbound", () =
       await import("../runtime/channel-guardian-service.js");
 
     // Both IDs canonicalize to 'self', so the challenge is found
-    const { secret } = createVerificationChallenge("self", "telegram");
+    const { secret } = createVerificationChallenge("telegram");
 
     const deliverSpy = spyOn(
       gatewayClient,

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -207,7 +207,6 @@ describe("verification challenge lifecycle", () => {
   test("createChallenge creates a pending challenge", () => {
     const challenge = createChallenge({
       id: "chal-1",
-      assistantId: "asst-1",
       channel: "telegram",
       challengeHash: "abc123hash",
       expiresAt: Date.now() + 600_000,
@@ -223,17 +222,12 @@ describe("verification challenge lifecycle", () => {
   test("findPendingChallengeByHash finds a matching pending challenge", () => {
     createChallenge({
       id: "chal-1",
-      assistantId: "asst-1",
       channel: "telegram",
       challengeHash: "abc123hash",
       expiresAt: Date.now() + 600_000,
     });
 
-    const found = findPendingChallengeByHash(
-      "asst-1",
-      "telegram",
-      "abc123hash",
-    );
+    const found = findPendingChallengeByHash("telegram", "abc123hash");
     expect(found).not.toBeNull();
     expect(found!.id).toBe("chal-1");
   });
@@ -241,41 +235,30 @@ describe("verification challenge lifecycle", () => {
   test("findPendingChallengeByHash returns null for wrong hash", () => {
     createChallenge({
       id: "chal-1",
-      assistantId: "asst-1",
       channel: "telegram",
       challengeHash: "abc123hash",
       expiresAt: Date.now() + 600_000,
     });
 
-    const found = findPendingChallengeByHash(
-      "asst-1",
-      "telegram",
-      "wrong-hash",
-    );
+    const found = findPendingChallengeByHash("telegram", "wrong-hash");
     expect(found).toBeNull();
   });
 
   test("findPendingChallengeByHash returns null for expired challenge", () => {
     createChallenge({
       id: "chal-1",
-      assistantId: "asst-1",
       channel: "telegram",
       challengeHash: "abc123hash",
       expiresAt: Date.now() - 1000, // already expired
     });
 
-    const found = findPendingChallengeByHash(
-      "asst-1",
-      "telegram",
-      "abc123hash",
-    );
+    const found = findPendingChallengeByHash("telegram", "abc123hash");
     expect(found).toBeNull();
   });
 
   test("consumeChallenge marks challenge as consumed", () => {
     createChallenge({
       id: "chal-1",
-      assistantId: "asst-1",
       channel: "telegram",
       challengeHash: "abc123hash",
       expiresAt: Date.now() + 600_000,
@@ -284,62 +267,40 @@ describe("verification challenge lifecycle", () => {
     consumeChallenge("chal-1", "user-42", "chat-42");
 
     // After consumption, findPendingChallengeByHash should return null
-    const found = findPendingChallengeByHash(
-      "asst-1",
-      "telegram",
-      "abc123hash",
-    );
+    const found = findPendingChallengeByHash("telegram", "abc123hash");
     expect(found).toBeNull();
   });
 
   test("consumed challenge cannot be found again (replay prevention)", () => {
     createChallenge({
       id: "chal-1",
-      assistantId: "asst-1",
       channel: "telegram",
       challengeHash: "abc123hash",
       expiresAt: Date.now() + 600_000,
     });
 
     // First consumption succeeds
-    const found1 = findPendingChallengeByHash(
-      "asst-1",
-      "telegram",
-      "abc123hash",
-    );
+    const found1 = findPendingChallengeByHash("telegram", "abc123hash");
     expect(found1).not.toBeNull();
     consumeChallenge("chal-1", "user-42", "chat-42");
 
     // Second lookup returns null because challenge is consumed
-    const found2 = findPendingChallengeByHash(
-      "asst-1",
-      "telegram",
-      "abc123hash",
-    );
+    const found2 = findPendingChallengeByHash("telegram", "abc123hash");
     expect(found2).toBeNull();
   });
 
-  test("findPendingChallengeByHash scoped to assistant and channel", () => {
+  test("findPendingChallengeByHash scoped to channel", () => {
     createChallenge({
       id: "chal-1",
-      assistantId: "asst-1",
       channel: "telegram",
       challengeHash: "abc123hash",
       expiresAt: Date.now() + 600_000,
     });
 
-    // Different assistant
-    expect(
-      findPendingChallengeByHash("asst-2", "telegram", "abc123hash"),
-    ).toBeNull();
-    // Different channel
-    expect(
-      findPendingChallengeByHash("asst-1", "slack", "abc123hash"),
-    ).toBeNull();
-    // Correct match
-    expect(
-      findPendingChallengeByHash("asst-1", "telegram", "abc123hash"),
-    ).not.toBeNull();
+    // Different channel — should not find
+    expect(findPendingChallengeByHash("slack", "abc123hash")).toBeNull();
+    // Correct channel — should find
+    expect(findPendingChallengeByHash("telegram", "abc123hash")).not.toBeNull();
   });
 });
 
@@ -353,7 +314,7 @@ describe("guardian service challenge validation", () => {
   });
 
   test("createVerificationChallenge returns a secret, verifyCommand, ttlSeconds, and instruction", () => {
-    const result = createVerificationChallenge("asst-1", "telegram");
+    const result = createVerificationChallenge("telegram");
 
     expect(result.challengeId).toBeDefined();
     expect(result.secret).toBeDefined();
@@ -368,24 +329,23 @@ describe("guardian service challenge validation", () => {
   });
 
   test("createVerificationChallenge produces a non-empty instruction for telegram channel", () => {
-    const result = createVerificationChallenge("asst-1", "telegram");
+    const result = createVerificationChallenge("telegram");
     expect(result.instruction).toBeDefined();
     expect(result.instruction.length).toBeGreaterThan(0);
     expect(result.instruction).toContain(`the code: ${result.secret}`);
   });
 
   test("createVerificationChallenge produces a non-empty instruction for sms channel", () => {
-    const result = createVerificationChallenge("asst-1", "sms");
+    const result = createVerificationChallenge("sms");
     expect(result.instruction).toBeDefined();
     expect(result.instruction.length).toBeGreaterThan(0);
     expect(result.instruction).toContain(`the code: ${result.secret}`);
   });
 
   test("validateAndConsumeChallenge succeeds with correct secret", () => {
-    const { secret } = createVerificationChallenge("asst-1", "telegram");
+    const { secret } = createVerificationChallenge("telegram");
 
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       secret,
       "user-42",
@@ -399,25 +359,18 @@ describe("guardian service challenge validation", () => {
   });
 
   test("validateAndConsumeChallenge does not create a guardian binding (caller responsibility)", () => {
-    const { secret } = createVerificationChallenge("asst-1", "telegram");
+    const { secret } = createVerificationChallenge("telegram");
 
-    validateAndConsumeChallenge(
-      "asst-1",
-      "telegram",
-      secret,
-      "user-42",
-      "chat-42",
-    );
+    validateAndConsumeChallenge("telegram", secret, "user-42", "chat-42");
 
     const binding = getGuardianBinding("asst-1", "telegram");
     expect(binding).toBeNull();
   });
 
   test("validateAndConsumeChallenge fails with wrong secret", () => {
-    createVerificationChallenge("asst-1", "telegram");
+    createVerificationChallenge("telegram");
 
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       "wrong-secret",
       "user-42",
@@ -439,14 +392,12 @@ describe("guardian service challenge validation", () => {
     const challengeHash = createHash("sha256").update(secret).digest("hex");
     createChallenge({
       id: "chal-expired",
-      assistantId: "asst-1",
       channel: "telegram",
       challengeHash,
       expiresAt: Date.now() - 1000, // already expired
     });
 
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       secret,
       "user-42",
@@ -463,11 +414,10 @@ describe("guardian service challenge validation", () => {
   });
 
   test("consumed challenge cannot be reused", () => {
-    const { secret } = createVerificationChallenge("asst-1", "telegram");
+    const { secret } = createVerificationChallenge("telegram");
 
     // First use succeeds
     const result1 = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       secret,
       "user-42",
@@ -477,7 +427,6 @@ describe("guardian service challenge validation", () => {
 
     // Second use with same secret fails (replay prevention)
     const result2 = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       secret,
       "user-99",
@@ -487,10 +436,9 @@ describe("guardian service challenge validation", () => {
   });
 
   test("validateAndConsumeChallenge succeeds with sms channel", () => {
-    const { secret } = createVerificationChallenge("asst-1", "sms");
+    const { secret } = createVerificationChallenge("sms");
 
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "sms",
       secret,
       "phone-user-1",
@@ -509,12 +457,11 @@ describe("guardian service challenge validation", () => {
   });
 
   test("sms and telegram guardian challenges are independent", () => {
-    const telegramChallenge = createVerificationChallenge("asst-1", "telegram");
-    const smsChallenge = createVerificationChallenge("asst-1", "sms");
+    const telegramChallenge = createVerificationChallenge("telegram");
+    const smsChallenge = createVerificationChallenge("sms");
 
     // Validate SMS challenge against telegram channel should fail
     const crossResult = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       smsChallenge.secret,
       "user-1",
@@ -524,7 +471,6 @@ describe("guardian service challenge validation", () => {
 
     // Validate SMS challenge against correct channel should succeed
     const smsResult = validateAndConsumeChallenge(
-      "asst-1",
       "sms",
       smsChallenge.secret,
       "user-1",
@@ -534,7 +480,6 @@ describe("guardian service challenge validation", () => {
 
     // Telegram challenge should still be valid
     const telegramResult = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       telegramChallenge.secret,
       "user-2",
@@ -557,9 +502,8 @@ describe("guardian service challenge validation", () => {
     expect(oldBinding).not.toBeNull();
     expect(oldBinding!.guardianExternalUserId).toBe("old-user");
 
-    const { secret } = createVerificationChallenge("asst-1", "telegram");
+    const { secret } = createVerificationChallenge("telegram");
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       secret,
       "new-user",
@@ -934,13 +878,12 @@ describe("verification rate limiting store", () => {
   });
 
   test("getRateLimit returns null when no record exists", () => {
-    const rl = getRateLimit("asst-1", "telegram", "user-42", "chat-42");
+    const rl = getRateLimit("telegram", "user-42", "chat-42");
     expect(rl).toBeNull();
   });
 
   test("recordInvalidAttempt creates a new record on first failure", () => {
     const rl = recordInvalidAttempt(
-      "asst-1",
       "telegram",
       "user-42",
       "chat-42",
@@ -950,14 +893,13 @@ describe("verification rate limiting store", () => {
     );
     expect(rl.invalidAttempts).toBe(1);
     expect(rl.lockedUntil).toBeNull();
-    expect(rl.assistantId).toBe("asst-1");
+    expect(rl.assistantId).toBe("self");
     expect(rl.channel).toBe("telegram");
     expect(rl.actorExternalUserId).toBe("user-42");
   });
 
   test("recordInvalidAttempt increments counter on subsequent failures", () => {
     recordInvalidAttempt(
-      "asst-1",
       "telegram",
       "user-42",
       "chat-42",
@@ -966,7 +908,6 @@ describe("verification rate limiting store", () => {
       1_800_000,
     );
     recordInvalidAttempt(
-      "asst-1",
       "telegram",
       "user-42",
       "chat-42",
@@ -975,7 +916,6 @@ describe("verification rate limiting store", () => {
       1_800_000,
     );
     const rl = recordInvalidAttempt(
-      "asst-1",
       "telegram",
       "user-42",
       "chat-42",
@@ -990,7 +930,6 @@ describe("verification rate limiting store", () => {
   test("recordInvalidAttempt sets lockedUntil when max attempts reached", () => {
     for (let i = 0; i < 4; i++) {
       recordInvalidAttempt(
-        "asst-1",
         "telegram",
         "user-42",
         "chat-42",
@@ -1000,7 +939,6 @@ describe("verification rate limiting store", () => {
       );
     }
     const rl = recordInvalidAttempt(
-      "asst-1",
       "telegram",
       "user-42",
       "chat-42",
@@ -1016,7 +954,6 @@ describe("verification rate limiting store", () => {
   test("resetRateLimit clears the counter and lockout", () => {
     for (let i = 0; i < 5; i++) {
       recordInvalidAttempt(
-        "asst-1",
         "telegram",
         "user-42",
         "chat-42",
@@ -1025,13 +962,13 @@ describe("verification rate limiting store", () => {
         1_800_000,
       );
     }
-    const locked = getRateLimit("asst-1", "telegram", "user-42", "chat-42");
+    const locked = getRateLimit("telegram", "user-42", "chat-42");
     expect(locked).not.toBeNull();
     expect(locked!.lockedUntil).not.toBeNull();
 
-    resetRateLimit("asst-1", "telegram", "user-42", "chat-42");
+    resetRateLimit("telegram", "user-42", "chat-42");
 
-    const after = getRateLimit("asst-1", "telegram", "user-42", "chat-42");
+    const after = getRateLimit("telegram", "user-42", "chat-42");
     expect(after).not.toBeNull();
     expect(after!.invalidAttempts).toBe(0);
     expect(after!.lockedUntil).toBeNull();
@@ -1039,7 +976,6 @@ describe("verification rate limiting store", () => {
 
   test("rate limits are scoped per actor and channel", () => {
     recordInvalidAttempt(
-      "asst-1",
       "telegram",
       "user-42",
       "chat-42",
@@ -1048,7 +984,6 @@ describe("verification rate limiting store", () => {
       1_800_000,
     );
     recordInvalidAttempt(
-      "asst-1",
       "telegram",
       "user-99",
       "chat-99",
@@ -1057,9 +992,9 @@ describe("verification rate limiting store", () => {
       1_800_000,
     );
 
-    const rl42 = getRateLimit("asst-1", "telegram", "user-42", "chat-42");
-    const rl99 = getRateLimit("asst-1", "telegram", "user-99", "chat-99");
-    const rlSms = getRateLimit("asst-1", "sms", "user-42", "chat-42");
+    const rl42 = getRateLimit("telegram", "user-42", "chat-42");
+    const rl99 = getRateLimit("telegram", "user-99", "chat-99");
+    const rlSms = getRateLimit("sms", "user-42", "chat-42");
 
     expect(rl42).not.toBeNull();
     expect(rl42!.invalidAttempts).toBe(1);
@@ -1080,12 +1015,11 @@ describe("guardian service rate limiting", () => {
 
   test("repeated invalid submissions hit rate limit", () => {
     // Create a valid challenge so there is a pending challenge
-    createVerificationChallenge("asst-1", "telegram");
+    createVerificationChallenge("telegram");
 
     // Submit wrong codes repeatedly
     for (let i = 0; i < 5; i++) {
       const result = validateAndConsumeChallenge(
-        "asst-1",
         "telegram",
         `wrong-secret-${i}`,
         "user-42",
@@ -1096,7 +1030,6 @@ describe("guardian service rate limiting", () => {
 
     // The 6th attempt should be rate-limited even without a new challenge
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       "another-wrong",
       "user-42",
@@ -1110,40 +1043,21 @@ describe("guardian service rate limiting", () => {
     );
 
     // Verify the rate limit record
-    const rl = getRateLimit("asst-1", "telegram", "user-42", "chat-42");
+    const rl = getRateLimit("telegram", "user-42", "chat-42");
     expect(rl).not.toBeNull();
     expect(rl!.lockedUntil).not.toBeNull();
   });
 
   test("valid challenge still succeeds when under threshold", () => {
     // Record a couple invalid attempts
-    const { secret: _secret } = createVerificationChallenge(
-      "asst-1",
-      "telegram",
-    );
-    validateAndConsumeChallenge(
-      "asst-1",
-      "telegram",
-      "wrong-1",
-      "user-42",
-      "chat-42",
-    );
-    validateAndConsumeChallenge(
-      "asst-1",
-      "telegram",
-      "wrong-2",
-      "user-42",
-      "chat-42",
-    );
+    const { secret: _secret } = createVerificationChallenge("telegram");
+    validateAndConsumeChallenge("telegram", "wrong-1", "user-42", "chat-42");
+    validateAndConsumeChallenge("telegram", "wrong-2", "user-42", "chat-42");
 
     // Valid attempt should still succeed (under the 5-attempt threshold)
     // Need a new challenge since the old one is still pending but the secret was never consumed
-    const { secret: secret2 } = createVerificationChallenge(
-      "asst-1",
-      "telegram",
-    );
+    const { secret: secret2 } = createVerificationChallenge("telegram");
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       secret2,
       "user-42",
@@ -1152,18 +1066,17 @@ describe("guardian service rate limiting", () => {
     expect(result.success).toBe(true);
 
     // Rate limit should be reset after success
-    const rl = getRateLimit("asst-1", "telegram", "user-42", "chat-42");
+    const rl = getRateLimit("telegram", "user-42", "chat-42");
     expect(rl).not.toBeNull();
     expect(rl!.invalidAttempts).toBe(0);
     expect(rl!.lockedUntil).toBeNull();
   });
 
   test("rate-limit uses generic failure message (no oracle leakage)", () => {
-    createVerificationChallenge("asst-1", "telegram");
+    createVerificationChallenge("telegram");
 
     // Capture a normal invalid-code failure response
     const normalFailure = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       "wrong-first",
       "user-42",
@@ -1175,7 +1088,6 @@ describe("guardian service rate limiting", () => {
     // Trigger rate limit (4 more attempts to reach 5 total)
     for (let i = 0; i < 4; i++) {
       validateAndConsumeChallenge(
-        "asst-1",
         "telegram",
         `wrong-${i}`,
         "user-42",
@@ -1184,13 +1096,12 @@ describe("guardian service rate limiting", () => {
     }
 
     // Verify lockout is actually active before testing the rate-limited response
-    const rl = getRateLimit("asst-1", "telegram", "user-42", "chat-42");
+    const rl = getRateLimit("telegram", "user-42", "chat-42");
     expect(rl).not.toBeNull();
     expect(rl!.lockedUntil).toBeGreaterThan(Date.now());
 
     // The rate-limited response should be indistinguishable from normal failure
     const rateLimitedResult = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       "anything",
       "user-42",
@@ -1209,10 +1120,9 @@ describe("guardian service rate limiting", () => {
 
   test("rate limit does not affect different actors", () => {
     // Rate-limit user-42
-    createVerificationChallenge("asst-1", "telegram");
+    createVerificationChallenge("telegram");
     for (let i = 0; i < 5; i++) {
       validateAndConsumeChallenge(
-        "asst-1",
         "telegram",
         `wrong-${i}`,
         "user-42",
@@ -1221,9 +1131,8 @@ describe("guardian service rate limiting", () => {
     }
 
     // user-99 should still be able to verify
-    const { secret } = createVerificationChallenge("asst-1", "telegram");
+    const { secret } = createVerificationChallenge("telegram");
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       secret,
       "user-99",
@@ -1318,16 +1227,12 @@ describe("channel-scoped guardian resolution", () => {
 
   test("validateAndConsumeChallenge scoped to channel", () => {
     // Create challenge on telegram
-    const { secret: secretTelegram } = createVerificationChallenge(
-      "self",
-      "telegram",
-    );
+    const { secret: secretTelegram } = createVerificationChallenge("telegram");
     // Create challenge on sms
-    const { secret: secretSms } = createVerificationChallenge("self", "sms");
+    const { secret: secretSms } = createVerificationChallenge("sms");
 
     // Attempting to consume telegram challenge on sms should fail
     const crossResult = validateAndConsumeChallenge(
-      "self",
       "sms",
       secretTelegram,
       "user-1",
@@ -1337,7 +1242,6 @@ describe("channel-scoped guardian resolution", () => {
 
     // Consuming with correct channel should succeed
     const resultTelegram = validateAndConsumeChallenge(
-      "self",
       "telegram",
       secretTelegram,
       "user-1",
@@ -1346,7 +1250,6 @@ describe("channel-scoped guardian resolution", () => {
     expect(resultTelegram.success).toBe(true);
 
     const resultSms = validateAndConsumeChallenge(
-      "self",
       "sms",
       secretSms,
       "user-2",
@@ -1633,7 +1536,7 @@ describe("IPC handler channel-aware guardian status", () => {
   });
 
   test("status action includes hasPendingChallenge when challenge exists", () => {
-    createVerificationChallenge("self", "voice");
+    createVerificationChallenge("voice");
 
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
@@ -1677,7 +1580,7 @@ describe("voice guardian challenge generation", () => {
   });
 
   test("createVerificationChallenge for voice returns a high-entropy hex secret", () => {
-    const result = createVerificationChallenge("asst-1", "voice");
+    const result = createVerificationChallenge("voice");
 
     expect(result.challengeId).toBeDefined();
     expect(result.secret).toBeDefined();
@@ -1686,20 +1589,20 @@ describe("voice guardian challenge generation", () => {
   });
 
   test("createVerificationChallenge for non-voice returns high-entropy hex secret", () => {
-    const result = createVerificationChallenge("asst-1", "telegram");
+    const result = createVerificationChallenge("telegram");
 
     expect(result.secret.length).toBe(64);
     expect(result.secret).toMatch(/^[0-9a-f]{64}$/);
   });
 
   test("voice challenge verifyCommand contains the hex secret", () => {
-    const result = createVerificationChallenge("asst-1", "voice");
+    const result = createVerificationChallenge("voice");
 
     expect(result.verifyCommand).toBe(result.secret);
   });
 
   test("voice challenge instruction contains voice-specific copy", () => {
-    const result = createVerificationChallenge("asst-1", "voice");
+    const result = createVerificationChallenge("voice");
 
     // Inbound challenges use high-entropy hex, so the voice template says
     // "enter the code" rather than "six-digit code".
@@ -1708,8 +1611,8 @@ describe("voice guardian challenge generation", () => {
   });
 
   test("voice challenge secrets are different across calls", () => {
-    const result1 = createVerificationChallenge("asst-1", "voice");
-    const result2 = createVerificationChallenge("asst-2", "voice");
+    const result1 = createVerificationChallenge("voice");
+    const result2 = createVerificationChallenge("voice");
 
     // High-entropy hex secrets: collision probability is negligible
     expect(result1.secret).toMatch(/^[0-9a-f]{64}$/);
@@ -1717,7 +1620,7 @@ describe("voice guardian challenge generation", () => {
   });
 
   test("voice ttlSeconds is 600 (10 minutes)", () => {
-    const result = createVerificationChallenge("asst-1", "voice");
+    const result = createVerificationChallenge("voice");
     expect(result.ttlSeconds).toBe(600);
   });
 });
@@ -1732,10 +1635,9 @@ describe("voice guardian challenge validation", () => {
   });
 
   test("validateAndConsumeChallenge succeeds with correct voice secret", () => {
-    const { secret } = createVerificationChallenge("asst-1", "voice");
+    const { secret } = createVerificationChallenge("voice");
 
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "voice",
       secret,
       "voice-user-1",
@@ -1749,10 +1651,9 @@ describe("voice guardian challenge validation", () => {
   });
 
   test("validateAndConsumeChallenge does not create a guardian binding for voice (caller responsibility)", () => {
-    const { secret } = createVerificationChallenge("asst-1", "voice");
+    const { secret } = createVerificationChallenge("voice");
 
     validateAndConsumeChallenge(
-      "asst-1",
       "voice",
       secret,
       "voice-user-1",
@@ -1764,10 +1665,9 @@ describe("voice guardian challenge validation", () => {
   });
 
   test("validateAndConsumeChallenge fails with wrong voice secret", () => {
-    createVerificationChallenge("asst-1", "voice");
+    createVerificationChallenge("voice");
 
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "voice",
       "000000",
       "voice-user-1",
@@ -1783,12 +1683,11 @@ describe("voice guardian challenge validation", () => {
   });
 
   test("voice and telegram guardian challenges are independent", () => {
-    const voiceChallenge = createVerificationChallenge("asst-1", "voice");
-    const telegramChallenge = createVerificationChallenge("asst-1", "telegram");
+    const voiceChallenge = createVerificationChallenge("voice");
+    const telegramChallenge = createVerificationChallenge("telegram");
 
     // Voice secret against telegram channel should fail
     const crossResult = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       voiceChallenge.secret,
       "user-1",
@@ -1798,7 +1697,6 @@ describe("voice guardian challenge validation", () => {
 
     // Voice secret against correct channel should succeed
     const voiceResult = validateAndConsumeChallenge(
-      "asst-1",
       "voice",
       voiceChallenge.secret,
       "voice-user-1",
@@ -1808,7 +1706,6 @@ describe("voice guardian challenge validation", () => {
 
     // Telegram challenge should still be valid
     const telegramResult = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       telegramChallenge.secret,
       "user-2",
@@ -1818,10 +1715,9 @@ describe("voice guardian challenge validation", () => {
   });
 
   test("consumed voice challenge cannot be reused", () => {
-    const { secret } = createVerificationChallenge("asst-1", "voice");
+    const { secret } = createVerificationChallenge("voice");
 
     const result1 = validateAndConsumeChallenge(
-      "asst-1",
       "voice",
       secret,
       "voice-user-1",
@@ -1830,7 +1726,6 @@ describe("voice guardian challenge validation", () => {
     expect(result1.success).toBe(true);
 
     const result2 = validateAndConsumeChallenge(
-      "asst-1",
       "voice",
       secret,
       "voice-user-2",
@@ -1852,9 +1747,8 @@ describe("voice guardian challenge validation", () => {
     expect(oldBinding).not.toBeNull();
     expect(oldBinding!.guardianExternalUserId).toBe("old-voice-user");
 
-    const { secret } = createVerificationChallenge("asst-1", "voice");
+    const { secret } = createVerificationChallenge("voice");
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "voice",
       secret,
       "new-voice-user",
@@ -1957,11 +1851,10 @@ describe("voice guardian rate limiting", () => {
   });
 
   test("repeated invalid voice submissions hit rate limit", () => {
-    createVerificationChallenge("asst-1", "voice");
+    createVerificationChallenge("voice");
 
     for (let i = 0; i < 5; i++) {
       const result = validateAndConsumeChallenge(
-        "asst-1",
         "voice",
         `${100000 + i}`,
         "voice-user-1",
@@ -1972,7 +1865,6 @@ describe("voice guardian rate limiting", () => {
 
     // The 6th attempt should be rate-limited
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "voice",
       "999999",
       "voice-user-1",
@@ -1980,43 +1872,35 @@ describe("voice guardian rate limiting", () => {
     );
     expect(result.success).toBe(false);
 
-    const rl = getRateLimit("asst-1", "voice", "voice-user-1", "voice-chat-1");
+    const rl = getRateLimit("voice", "voice-user-1", "voice-chat-1");
     expect(rl).not.toBeNull();
     expect(rl!.lockedUntil).not.toBeNull();
   });
 
   test("voice rate limit does not affect telegram rate limit", () => {
-    createVerificationChallenge("asst-1", "voice");
+    createVerificationChallenge("voice");
     for (let i = 0; i < 5; i++) {
-      validateAndConsumeChallenge(
-        "asst-1",
-        "voice",
-        `${100000 + i}`,
-        "user-1",
-        "chat-1",
-      );
+      validateAndConsumeChallenge("voice", `${100000 + i}`, "user-1", "chat-1");
     }
 
-    const voiceRl = getRateLimit("asst-1", "voice", "user-1", "chat-1");
+    const voiceRl = getRateLimit("voice", "user-1", "chat-1");
     expect(voiceRl).not.toBeNull();
     expect(voiceRl!.lockedUntil).not.toBeNull();
 
     // Telegram should be unaffected
-    const telegramRl = getRateLimit("asst-1", "telegram", "user-1", "chat-1");
+    const telegramRl = getRateLimit("telegram", "user-1", "chat-1");
     expect(telegramRl).toBeNull();
   });
 
   test("successful voice verification resets rate limit", () => {
-    const { secret: _s } = createVerificationChallenge("asst-1", "voice");
+    const { secret: _s } = createVerificationChallenge("voice");
     validateAndConsumeChallenge(
-      "asst-1",
       "voice",
       "000000",
       "voice-user-1",
       "voice-chat-1",
     );
     validateAndConsumeChallenge(
-      "asst-1",
       "voice",
       "111111",
       "voice-user-1",
@@ -2024,9 +1908,8 @@ describe("voice guardian rate limiting", () => {
     );
 
     // Valid attempt should succeed (under the 5-attempt threshold)
-    const { secret } = createVerificationChallenge("asst-1", "voice");
+    const { secret } = createVerificationChallenge("voice");
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "voice",
       secret,
       "voice-user-1",
@@ -2034,7 +1917,7 @@ describe("voice guardian rate limiting", () => {
     );
     expect(result.success).toBe(true);
 
-    const rl = getRateLimit("asst-1", "voice", "voice-user-1", "voice-chat-1");
+    const rl = getRateLimit("voice", "voice-user-1", "voice-chat-1");
     expect(rl).not.toBeNull();
     expect(rl!.invalidAttempts).toBe(0);
     expect(rl!.lockedUntil).toBeNull();
@@ -2051,62 +1934,61 @@ describe("pending challenge lookup", () => {
   });
 
   test("findPendingChallengeForChannel returns pending challenge", () => {
-    createVerificationChallenge("asst-1", "voice");
+    createVerificationChallenge("voice");
 
-    const pending = findPendingChallengeForChannel("asst-1", "voice");
+    const pending = findPendingChallengeForChannel("voice");
     expect(pending).not.toBeNull();
     expect(pending!.channel).toBe("voice");
     expect(pending!.status).toBe("pending");
   });
 
   test("findPendingChallengeForChannel returns null when no challenge exists", () => {
-    const pending = findPendingChallengeForChannel("asst-1", "voice");
+    const pending = findPendingChallengeForChannel("voice");
     expect(pending).toBeNull();
   });
 
   test("findPendingChallengeForChannel returns null for different channel", () => {
-    createVerificationChallenge("asst-1", "telegram");
+    createVerificationChallenge("telegram");
 
-    const pending = findPendingChallengeForChannel("asst-1", "voice");
+    const pending = findPendingChallengeForChannel("voice");
     expect(pending).toBeNull();
   });
 
   test("findPendingChallengeForChannel returns null after challenge is consumed", () => {
-    const { secret } = createVerificationChallenge("asst-1", "voice");
+    const { secret } = createVerificationChallenge("voice");
     validateAndConsumeChallenge(
-      "asst-1",
       "voice",
       secret,
       "voice-user-1",
       "voice-chat-1",
     );
 
-    const pending = findPendingChallengeForChannel("asst-1", "voice");
+    const pending = findPendingChallengeForChannel("voice");
     expect(pending).toBeNull();
   });
 
   test("getPendingChallenge service helper returns pending voice challenge", () => {
-    createVerificationChallenge("asst-1", "voice");
+    createVerificationChallenge("voice");
 
-    const pending = getPendingChallenge("asst-1", "voice");
+    const pending = getPendingChallenge("voice");
     expect(pending).not.toBeNull();
     expect(pending!.channel).toBe("voice");
   });
 
   test("getPendingChallenge returns null when no challenge exists", () => {
-    const pending = getPendingChallenge("asst-1", "voice");
+    const pending = getPendingChallenge("voice");
     expect(pending).toBeNull();
   });
 
   test("creating a new challenge revokes prior pending challenges", () => {
-    createVerificationChallenge("asst-1", "voice");
-    const pending1 = findPendingChallengeForChannel("asst-1", "voice");
+    createVerificationChallenge("voice");
+    const pending1 = findPendingChallengeForChannel("voice");
     expect(pending1).not.toBeNull();
     const firstId = pending1!.id;
 
     // Creating a second challenge should revoke the first
-    createVerificationChallenge("asst-1", "voice");
-    const pending2 = findPendingChallengeForChannel("asst-1", "voice");
+    createVerificationChallenge("voice");
+    const pending2 = findPendingChallengeForChannel("voice");
     expect(pending2).not.toBeNull();
     expect(pending2!.id).not.toBe(firstId);
   });
@@ -2256,7 +2138,6 @@ describe("outbound verification sessions", () => {
 
   test("createOutboundSession creates a session with expected identity fields", () => {
     const result = createOutboundSession({
-      assistantId: "asst-1",
       channel: "sms",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
@@ -2268,7 +2149,7 @@ describe("outbound verification sessions", () => {
     expect(result.expiresAt).toBeGreaterThan(Date.now());
     expect(result.ttlSeconds).toBe(600);
 
-    const session = serviceFindActiveSession("asst-1", "sms");
+    const session = serviceFindActiveSession("sms");
     expect(session).not.toBeNull();
     expect(session!.expectedPhoneE164).toBe("+15551234567");
     expect(session!.destinationAddress).toBe("+15551234567");
@@ -2278,7 +2159,6 @@ describe("outbound verification sessions", () => {
 
   test("createOutboundSession for telegram with pending_bootstrap status", () => {
     const result = createOutboundSession({
-      assistantId: "asst-1",
       channel: "telegram",
       identityBindingStatus: "pending_bootstrap",
       destinationAddress: "@some_handle",
@@ -2286,7 +2166,7 @@ describe("outbound verification sessions", () => {
 
     expect(result.sessionId).toBeDefined();
 
-    const session = serviceFindActiveSession("asst-1", "telegram");
+    const session = serviceFindActiveSession("telegram");
     expect(session).not.toBeNull();
     expect(session!.identityBindingStatus).toBe("pending_bootstrap");
     expect(session!.status).toBe("pending_bootstrap");
@@ -2298,7 +2178,6 @@ describe("outbound verification sessions", () => {
 
   test("validateAndConsumeChallenge succeeds with correct secret and matching identity (SMS)", () => {
     const { secret } = createOutboundSession({
-      assistantId: "asst-1",
       channel: "sms",
       expectedPhoneE164: "+15551234567",
       expectedExternalUserId: "+15551234567",
@@ -2306,7 +2185,6 @@ describe("outbound verification sessions", () => {
     });
 
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "sms",
       secret,
       "+15551234567",
@@ -2318,7 +2196,6 @@ describe("outbound verification sessions", () => {
 
   test("validateAndConsumeChallenge succeeds with correct secret and matching identity (Telegram)", () => {
     const { secret } = createOutboundSession({
-      assistantId: "asst-1",
       channel: "telegram",
       expectedExternalUserId: "tg-user-42",
       expectedChatId: "tg-chat-42",
@@ -2326,7 +2203,6 @@ describe("outbound verification sessions", () => {
     });
 
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       secret,
       "tg-user-42",
@@ -2340,7 +2216,6 @@ describe("outbound verification sessions", () => {
 
   test("validateAndConsumeChallenge rejects correct secret with wrong identity (anti-oracle)", () => {
     const { secret } = createOutboundSession({
-      assistantId: "asst-1",
       channel: "sms",
       expectedPhoneE164: "+15551234567",
       expectedExternalUserId: "+15551234567",
@@ -2348,7 +2223,6 @@ describe("outbound verification sessions", () => {
     });
 
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "sms",
       secret,
       "+15559999999",
@@ -2366,7 +2240,6 @@ describe("outbound verification sessions", () => {
 
   test("validateAndConsumeChallenge rejects correct secret with wrong Telegram identity", () => {
     const { secret } = createOutboundSession({
-      assistantId: "asst-1",
       channel: "telegram",
       expectedExternalUserId: "tg-user-42",
       expectedChatId: "tg-chat-42",
@@ -2374,7 +2247,6 @@ describe("outbound verification sessions", () => {
     });
 
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       secret,
       "tg-user-WRONG",
@@ -2392,7 +2264,6 @@ describe("outbound verification sessions", () => {
     const challengeHash = createHash("sha256").update(secret).digest("hex");
     createVerificationSession({
       id: "session-expired",
-      assistantId: "asst-1",
       channel: "sms",
       challengeHash,
       expiresAt: Date.now() - 1000,
@@ -2402,7 +2273,6 @@ describe("outbound verification sessions", () => {
     });
 
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "sms",
       secret,
       "+15551234567",
@@ -2416,7 +2286,6 @@ describe("outbound verification sessions", () => {
 
   test("revoked outbound session is rejected", () => {
     const { secret, sessionId } = createOutboundSession({
-      assistantId: "asst-1",
       channel: "sms",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
@@ -2426,7 +2295,6 @@ describe("outbound verification sessions", () => {
     serviceUpdateSessionStatus(sessionId, "revoked");
 
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "sms",
       secret,
       "+15551234567",
@@ -2440,7 +2308,6 @@ describe("outbound verification sessions", () => {
 
   test("outbound session cannot be consumed twice (replay prevention)", () => {
     const { secret } = createOutboundSession({
-      assistantId: "asst-1",
       channel: "sms",
       expectedPhoneE164: "+15551234567",
       expectedExternalUserId: "+15551234567",
@@ -2448,7 +2315,6 @@ describe("outbound verification sessions", () => {
     });
 
     const result1 = validateAndConsumeChallenge(
-      "asst-1",
       "sms",
       secret,
       "+15551234567",
@@ -2457,7 +2323,6 @@ describe("outbound verification sessions", () => {
     expect(result1.success).toBe(true);
 
     const result2 = validateAndConsumeChallenge(
-      "asst-1",
       "sms",
       secret,
       "+15551234567",
@@ -2469,10 +2334,9 @@ describe("outbound verification sessions", () => {
   // ── Backward compat: existing inbound-only flow still works ──
 
   test("backward compat: inbound-only challenge without expected identity still works", () => {
-    const { secret } = createVerificationChallenge("asst-1", "telegram");
+    const { secret } = createVerificationChallenge("telegram");
 
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       secret,
       "user-42",
@@ -2489,26 +2353,25 @@ describe("outbound verification sessions", () => {
 
   test("session state transitions (pending_bootstrap → awaiting_response → verified)", () => {
     const { sessionId } = createOutboundSession({
-      assistantId: "asst-1",
       channel: "telegram",
       identityBindingStatus: "pending_bootstrap",
       destinationAddress: "@some_handle",
     });
 
-    const initial = serviceFindActiveSession("asst-1", "telegram");
+    const initial = serviceFindActiveSession("telegram");
     expect(initial).not.toBeNull();
     expect(initial!.status).toBe("pending_bootstrap");
 
     // Transition to awaiting_response
     serviceUpdateSessionStatus(sessionId, "awaiting_response");
-    const awaiting = storeFindActiveSession("asst-1", "telegram");
+    const awaiting = storeFindActiveSession("telegram");
     expect(awaiting).not.toBeNull();
     expect(awaiting!.status).toBe("awaiting_response");
 
     // Transition to verified
     serviceUpdateSessionStatus(sessionId, "verified");
     // verified is not an "active" status, so findActiveSession returns null
-    const active = storeFindActiveSession("asst-1", "telegram");
+    const active = storeFindActiveSession("telegram");
     expect(active).toBeNull();
   });
 
@@ -2516,25 +2379,23 @@ describe("outbound verification sessions", () => {
 
   test("creating a new outbound session auto-revokes prior pending/awaiting sessions", () => {
     const { sessionId: firstId } = createOutboundSession({
-      assistantId: "asst-1",
       channel: "sms",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
     });
 
-    const first = serviceFindActiveSession("asst-1", "sms");
+    const first = serviceFindActiveSession("sms");
     expect(first).not.toBeNull();
     expect(first!.id).toBe(firstId);
 
     // Create a second session — first should be revoked
     const { sessionId: secondId } = createOutboundSession({
-      assistantId: "asst-1",
       channel: "sms",
       expectedPhoneE164: "+15559876543",
       destinationAddress: "+15559876543",
     });
 
-    const second = serviceFindActiveSession("asst-1", "sms");
+    const second = serviceFindActiveSession("sms");
     expect(second).not.toBeNull();
     expect(second!.id).toBe(secondId);
 
@@ -2553,20 +2414,19 @@ describe("outbound verification sessions", () => {
 
   test("findActiveSession returns the most recent active session", () => {
     createOutboundSession({
-      assistantId: "asst-1",
       channel: "sms",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
     });
 
-    const session = serviceFindActiveSession("asst-1", "sms");
+    const session = serviceFindActiveSession("sms");
     expect(session).not.toBeNull();
     expect(session!.status).toBe("awaiting_response");
     expect(session!.expectedPhoneE164).toBe("+15551234567");
   });
 
   test("findActiveSession returns null when no active session exists", () => {
-    const session = serviceFindActiveSession("asst-1", "sms");
+    const session = serviceFindActiveSession("sms");
     expect(session).toBeNull();
   });
 
@@ -2574,14 +2434,12 @@ describe("outbound verification sessions", () => {
 
   test("findSessionByIdentity returns session matching phone E164", () => {
     createOutboundSession({
-      assistantId: "asst-1",
       channel: "sms",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
     });
 
     const session = serviceFindSessionByIdentity(
-      "asst-1",
       "sms",
       undefined,
       undefined,
@@ -2593,32 +2451,25 @@ describe("outbound verification sessions", () => {
 
   test("findSessionByIdentity returns session matching external user ID", () => {
     createOutboundSession({
-      assistantId: "asst-1",
       channel: "telegram",
       expectedExternalUserId: "tg-user-42",
       expectedChatId: "tg-chat-42",
       destinationAddress: "tg-chat-42",
     });
 
-    const session = serviceFindSessionByIdentity(
-      "asst-1",
-      "telegram",
-      "tg-user-42",
-    );
+    const session = serviceFindSessionByIdentity("telegram", "tg-user-42");
     expect(session).not.toBeNull();
     expect(session!.expectedExternalUserId).toBe("tg-user-42");
   });
 
   test("findSessionByIdentity returns null for non-matching identity", () => {
     createOutboundSession({
-      assistantId: "asst-1",
       channel: "sms",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
     });
 
     const session = serviceFindSessionByIdentity(
-      "asst-1",
       "sms",
       undefined,
       undefined,
@@ -2631,13 +2482,12 @@ describe("outbound verification sessions", () => {
 
   test("bindSessionIdentity transitions from pending_bootstrap to bound", () => {
     const { sessionId } = createOutboundSession({
-      assistantId: "asst-1",
       channel: "telegram",
       identityBindingStatus: "pending_bootstrap",
       destinationAddress: "@some_handle",
     });
 
-    const before = serviceFindActiveSession("asst-1", "telegram");
+    const before = serviceFindActiveSession("telegram");
     expect(before).not.toBeNull();
     expect(before!.identityBindingStatus).toBe("pending_bootstrap");
     expect(before!.expectedExternalUserId).toBeNull();
@@ -2646,7 +2496,7 @@ describe("outbound verification sessions", () => {
     // Bind the identity
     serviceBindSessionIdentity(sessionId, "tg-user-42", "tg-chat-42");
 
-    const after = storeFindActiveSession("asst-1", "telegram");
+    const after = storeFindActiveSession("telegram");
     expect(after).not.toBeNull();
     expect(after!.identityBindingStatus).toBe("bound");
     expect(after!.expectedExternalUserId).toBe("tg-user-42");
@@ -2657,7 +2507,6 @@ describe("outbound verification sessions", () => {
 
   test("pending_bootstrap session allows consumption without identity check", () => {
     const { secret } = createOutboundSession({
-      assistantId: "asst-1",
       channel: "telegram",
       identityBindingStatus: "pending_bootstrap",
       destinationAddress: "@some_handle",
@@ -2665,7 +2514,6 @@ describe("outbound verification sessions", () => {
 
     // Any actor can consume during pending_bootstrap
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       secret,
       "any-user",
@@ -2679,7 +2527,6 @@ describe("outbound verification sessions", () => {
 
   test("updateSessionDelivery updates delivery tracking fields", () => {
     const { sessionId } = createOutboundSession({
-      assistantId: "asst-1",
       channel: "sms",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
@@ -2688,7 +2535,7 @@ describe("outbound verification sessions", () => {
     const now = Date.now();
     storeUpdateSessionDelivery(sessionId, now, 1, now + 30_000);
 
-    const session = serviceFindActiveSession("asst-1", "sms");
+    const session = serviceFindActiveSession("sms");
     expect(session).not.toBeNull();
     expect(session!.lastSentAt).toBe(now);
     expect(session!.sendCount).toBe(1);
@@ -2699,7 +2546,6 @@ describe("outbound verification sessions", () => {
 
   test("Telegram identity match succeeds via chatId alone", () => {
     const { secret } = createOutboundSession({
-      assistantId: "asst-1",
       channel: "telegram",
       expectedChatId: "tg-chat-42",
       destinationAddress: "tg-chat-42",
@@ -2707,7 +2553,6 @@ describe("outbound verification sessions", () => {
 
     // Actor has a different external user ID but matching chat ID
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "telegram",
       secret,
       "tg-user-DIFFERENT",
@@ -2721,7 +2566,6 @@ describe("outbound verification sessions", () => {
 
   test("SMS identity match succeeds via expectedExternalUserId", () => {
     const { secret } = createOutboundSession({
-      assistantId: "asst-1",
       channel: "sms",
       expectedExternalUserId: "sms-user-42",
       expectedPhoneE164: "+15551234567",
@@ -2730,7 +2574,6 @@ describe("outbound verification sessions", () => {
 
     // Actor matches expectedExternalUserId
     const result = validateAndConsumeChallenge(
-      "asst-1",
       "sms",
       secret,
       "sms-user-42",
@@ -2772,7 +2615,7 @@ describe("outbound SMS verification", () => {
     expect(resp!.channel).toBe("sms");
 
     // Verify the session was created with expected identity
-    const session = serviceFindActiveSession("self", "sms");
+    const session = serviceFindActiveSession("sms");
     expect(session).not.toBeNull();
     expect(session!.expectedPhoneE164).toBe("+15551234567");
     expect(session!.destinationAddress).toBe("+15551234567");
@@ -2882,7 +2725,7 @@ describe("outbound SMS verification", () => {
     expect(startResponse!.success).toBe(true);
 
     // Manually update the session's nextResendAt to the past to simulate cooldown elapsed
-    const session = serviceFindActiveSession("self", "sms");
+    const session = serviceFindActiveSession("sms");
     expect(session).not.toBeNull();
     storeUpdateSessionDelivery(
       session!.id,
@@ -2925,7 +2768,7 @@ describe("outbound SMS verification", () => {
     );
 
     // Set the send count to MAX_SENDS_PER_SESSION and nextResendAt to the past
-    const session = serviceFindActiveSession("self", "sms");
+    const session = serviceFindActiveSession("sms");
     expect(session).not.toBeNull();
     storeUpdateSessionDelivery(
       session!.id,
@@ -2967,7 +2810,7 @@ describe("outbound SMS verification", () => {
     );
 
     // Verify session exists
-    const sessionBefore = serviceFindActiveSession("self", "sms");
+    const sessionBefore = serviceFindActiveSession("sms");
     expect(sessionBefore).not.toBeNull();
 
     // Cancel it
@@ -2988,14 +2831,13 @@ describe("outbound SMS verification", () => {
     expect(resp!.channel).toBe("sms");
 
     // Verify session is no longer active
-    const sessionAfter = serviceFindActiveSession("self", "sms");
+    const sessionAfter = serviceFindActiveSession("sms");
     expect(sessionAfter).toBeNull();
   });
 
   test("inbound SMS from expected identity + correct code succeeds", () => {
     // Create an outbound session
     const { secret } = createOutboundSession({
-      assistantId: "self",
       channel: "sms",
       expectedPhoneE164: "+15551234567",
       expectedExternalUserId: "+15551234567",
@@ -3004,7 +2846,6 @@ describe("outbound SMS verification", () => {
 
     // Validate with matching identity
     const result = validateAndConsumeChallenge(
-      "self",
       "sms",
       secret,
       "+15551234567",
@@ -3020,7 +2861,6 @@ describe("outbound SMS verification", () => {
   test("inbound SMS from wrong identity + correct code is rejected", () => {
     // Create an outbound session with expected identity +15551234567
     const { secret } = createOutboundSession({
-      assistantId: "self",
       channel: "sms",
       expectedPhoneE164: "+15551234567",
       expectedExternalUserId: "+15551234567",
@@ -3029,7 +2869,6 @@ describe("outbound SMS verification", () => {
 
     // Try to validate with a different phone number (anti-oracle: same generic error)
     const result = validateAndConsumeChallenge(
-      "self",
       "sms",
       secret,
       "+15559999999",
@@ -3145,7 +2984,7 @@ describe("outbound SMS verification", () => {
     expect(resp!.secret).toBeDefined();
 
     // Verify the session was created with the normalized E.164 number
-    const session = serviceFindActiveSession("self", "sms");
+    const session = serviceFindActiveSession("sms");
     expect(session).not.toBeNull();
     expect(session!.expectedPhoneE164).toBe("+15551234567");
     expect(session!.destinationAddress).toBe("+15551234567");
@@ -3223,7 +3062,7 @@ describe("outbound Telegram verification", () => {
     expect(telegramDeliverCalls.length).toBe(0);
 
     // Verify the session is in pending_bootstrap state
-    const session = serviceFindActiveSession("self", "telegram");
+    const session = serviceFindActiveSession("telegram");
     expect(session).not.toBeNull();
     expect(session!.identityBindingStatus).toBe("pending_bootstrap");
     // destinationAddress is normalized: '@' stripped and lowercased
@@ -3280,7 +3119,7 @@ describe("outbound Telegram verification", () => {
     expect(resp!.telegramBootstrapUrl).toBeUndefined();
 
     // Verify the session was created with expected identity
-    const session = serviceFindActiveSession("self", "telegram");
+    const session = serviceFindActiveSession("telegram");
     expect(session).not.toBeNull();
     expect(session!.expectedChatId).toBe("123456789");
     expect(session!.identityBindingStatus).toBe("bound");
@@ -3349,7 +3188,6 @@ describe("outbound Telegram verification", () => {
 
     createVerificationSession({
       id: "session-bootstrap-1",
-      assistantId: "self",
       channel: "telegram",
       challengeHash: "some-challenge-hash",
       expiresAt: Date.now() + 600_000,
@@ -3359,7 +3197,7 @@ describe("outbound Telegram verification", () => {
       bootstrapTokenHash: tokenHash,
     });
 
-    const found = resolveBootstrapToken("self", "telegram", token);
+    const found = resolveBootstrapToken("telegram", token);
     expect(found).not.toBeNull();
     expect(found!.id).toBe("session-bootstrap-1");
     expect(found!.status).toBe("pending_bootstrap");
@@ -3372,7 +3210,6 @@ describe("outbound Telegram verification", () => {
 
     createVerificationSession({
       id: "session-bootstrap-2",
-      assistantId: "self",
       channel: "telegram",
       challengeHash: "some-challenge-hash",
       expiresAt: Date.now() + 600_000,
@@ -3382,7 +3219,7 @@ describe("outbound Telegram verification", () => {
       bootstrapTokenHash: tokenHash,
     });
 
-    const found = resolveBootstrapToken("self", "telegram", "wrong_token");
+    const found = resolveBootstrapToken("telegram", "wrong_token");
     expect(found).toBeNull();
   });
 
@@ -3393,7 +3230,6 @@ describe("outbound Telegram verification", () => {
 
     createVerificationSession({
       id: "session-bootstrap-3",
-      assistantId: "self",
       channel: "telegram",
       challengeHash: "some-challenge-hash",
       expiresAt: Date.now() - 1000, // already expired
@@ -3403,14 +3239,13 @@ describe("outbound Telegram verification", () => {
       bootstrapTokenHash: tokenHash,
     });
 
-    const found = resolveBootstrapToken("self", "telegram", token);
+    const found = resolveBootstrapToken("telegram", token);
     expect(found).toBeNull();
   });
 
   test("identity-bound consume: right chat_id + right code succeeds", () => {
     // Create an awaiting_response session with expected identity
     const sessionResult = createOutboundSession({
-      assistantId: "self",
       channel: "telegram",
       expectedExternalUserId: "user-42",
       expectedChatId: "chat-42",
@@ -3419,7 +3254,6 @@ describe("outbound Telegram verification", () => {
     });
 
     const result = validateAndConsumeChallenge(
-      "self",
       "telegram",
       sessionResult.secret,
       "user-42",
@@ -3433,7 +3267,6 @@ describe("outbound Telegram verification", () => {
 
   test("identity mismatch: wrong chat_id + right code rejects", () => {
     const sessionResult = createOutboundSession({
-      assistantId: "self",
       channel: "telegram",
       expectedExternalUserId: "user-42",
       expectedChatId: "chat-42",
@@ -3442,7 +3275,6 @@ describe("outbound Telegram verification", () => {
     });
 
     const result = validateAndConsumeChallenge(
-      "self",
       "telegram",
       sessionResult.secret,
       "attacker-99",
@@ -3456,7 +3288,6 @@ describe("outbound Telegram verification", () => {
 
   test("revoked session rejects verification", () => {
     const sessionResult = createOutboundSession({
-      assistantId: "self",
       channel: "telegram",
       expectedExternalUserId: "user-42",
       expectedChatId: "chat-42",
@@ -3468,7 +3299,6 @@ describe("outbound Telegram verification", () => {
     serviceUpdateSessionStatus(sessionResult.sessionId, "revoked");
 
     const result = validateAndConsumeChallenge(
-      "self",
       "telegram",
       sessionResult.secret,
       "user-42",
@@ -3480,10 +3310,9 @@ describe("outbound Telegram verification", () => {
 
   test("inbound-only Telegram verification flow still works with bare code", () => {
     // Create an inbound-only challenge (no outbound session, no expected identity)
-    const challengeResult = createVerificationChallenge("self", "telegram");
+    const challengeResult = createVerificationChallenge("telegram");
 
     const result = validateAndConsumeChallenge(
-      "self",
       "telegram",
       challengeResult.secret,
       "user-42",
@@ -3510,7 +3339,7 @@ describe("outbound Telegram verification", () => {
     );
 
     // Fast-forward the cooldown
-    const session = serviceFindActiveSession("self", "telegram");
+    const session = serviceFindActiveSession("telegram");
     expect(session).not.toBeNull();
     storeUpdateSessionDelivery(
       session!.id,
@@ -3586,7 +3415,7 @@ describe("outbound Telegram verification", () => {
       startCtx,
     );
 
-    const session = serviceFindActiveSession("self", "telegram");
+    const session = serviceFindActiveSession("telegram");
     expect(session).not.toBeNull();
 
     const { ctx, lastResponse } = createMockCtx();
@@ -3605,7 +3434,7 @@ describe("outbound Telegram verification", () => {
     expect(resp!.success).toBe(true);
 
     // Session should be revoked
-    const revoked = serviceFindActiveSession("self", "telegram");
+    const revoked = serviceFindActiveSession("telegram");
     expect(revoked).toBeNull();
   });
 
@@ -3670,7 +3499,7 @@ describe("outbound Telegram verification", () => {
     );
 
     // Set the send count to MAX_SENDS_PER_SESSION and nextResendAt to the past
-    const session = serviceFindActiveSession("self", "telegram");
+    const session = serviceFindActiveSession("telegram");
     expect(session).not.toBeNull();
     storeUpdateSessionDelivery(
       session!.id,
@@ -3766,7 +3595,7 @@ describe("outbound voice verification", () => {
     expect(resp!.channel).toBe("voice");
 
     // Verify the session was created with expected identity
-    const session = serviceFindActiveSession("self", "voice");
+    const session = serviceFindActiveSession("voice");
     expect(session).not.toBeNull();
     expect(session!.expectedPhoneE164).toBe("+15551234567");
     expect(session!.destinationAddress).toBe("+15551234567");
@@ -3824,7 +3653,7 @@ describe("outbound voice verification", () => {
     expect(resp!.secret!.length).toBe(6);
 
     // Verify the session was created with the normalized E.164 number
-    const session = serviceFindActiveSession("self", "voice");
+    const session = serviceFindActiveSession("voice");
     expect(session).not.toBeNull();
     expect(session!.expectedPhoneE164).toBe("+15551234567");
     expect(session!.destinationAddress).toBe("+15551234567");
@@ -3929,7 +3758,7 @@ describe("outbound voice verification", () => {
     expect(resp!.success).toBe(true);
 
     // Session should no longer be active
-    const session = serviceFindActiveSession("self", "voice");
+    const session = serviceFindActiveSession("voice");
     expect(session).toBeNull();
   });
 
@@ -4048,7 +3877,7 @@ describe("M1–M4 hardening coverage", () => {
     );
 
     // Move past cooldown
-    const session = serviceFindActiveSession("self", "sms");
+    const session = serviceFindActiveSession("sms");
     expect(session).not.toBeNull();
     storeUpdateSessionDelivery(
       session!.id,
@@ -4105,7 +3934,6 @@ describe("M1–M4 hardening coverage", () => {
 
   test("bootstrap (pending_bootstrap) sessions use high-entropy hex secrets, identity-bound use 6-digit numeric", () => {
     const bootstrapResult = createOutboundSession({
-      assistantId: "asst-entropy",
       channel: "telegram",
       identityBindingStatus: "pending_bootstrap",
       destinationAddress: "@testuser",
@@ -4118,7 +3946,6 @@ describe("M1–M4 hardening coverage", () => {
 
     // Identity-bound: 6-digit numeric code
     const boundResult = createOutboundSession({
-      assistantId: "asst-entropy",
       channel: "sms",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
@@ -4133,7 +3960,6 @@ describe("M1–M4 hardening coverage", () => {
   test("all identity-bound channels (SMS, Telegram chat ID, voice) use 6-digit numeric codes", () => {
     // SMS
     const smsResult = createOutboundSession({
-      assistantId: "asst-codes",
       channel: "sms",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
@@ -4144,7 +3970,6 @@ describe("M1–M4 hardening coverage", () => {
 
     // Telegram (bound via chat ID)
     const tgResult = createOutboundSession({
-      assistantId: "asst-codes",
       channel: "telegram",
       expectedChatId: "123456789",
       identityBindingStatus: "bound",
@@ -4156,7 +3981,6 @@ describe("M1–M4 hardening coverage", () => {
 
     // Voice
     const voiceResult = createOutboundSession({
-      assistantId: "asst-codes",
       channel: "voice",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",

--- a/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
+++ b/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
@@ -243,7 +243,6 @@ describe("Verification control messages are deterministic (guard)", () => {
     const challengeHash = createHash("sha256").update(secret).digest("hex");
     createChallenge({
       id: "challenge-guard-test",
-      assistantId: "self",
       channel: "telegram",
       challengeHash,
       expiresAt: Date.now() + 600_000,
@@ -329,7 +328,6 @@ describe("Verification control messages are deterministic (guard)", () => {
       .digest("hex");
 
     createOutboundSession({
-      assistantId: "self",
       channel: "telegram",
       identityBindingStatus: "pending_bootstrap",
       destinationAddress: "test_user",

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -297,12 +297,10 @@ function addTrustedVoiceContact(
 }
 
 function createVoiceVerificationSession(
-  assistantId: string,
   expectedPhoneE164: string,
   sessionId?: string,
 ): string {
   const { secret } = createOutboundSession({
-    assistantId,
     channel: "voice",
     expectedExternalUserId: expectedPhoneE164,
     expectedChatId: expectedPhoneE164,
@@ -313,12 +311,10 @@ function createVoiceVerificationSession(
 }
 
 function createPendingVoiceGuardianChallenge(
-  assistantId: string,
   secret: string = "123456",
 ): string {
   createChallenge({
     id: randomUUID(),
-    assistantId,
     channel: "voice",
     challengeHash: createHash("sha256").update(secret).digest("hex"),
     expiresAt: Date.now() + 10 * 60 * 1000,
@@ -1337,7 +1333,7 @@ describe("relay-server", () => {
     });
 
     // Create a pending voice guardian challenge
-    const secret = createPendingVoiceGuardianChallenge("self");
+    const secret = createPendingVoiceGuardianChallenge();
 
     mockSendMessage.mockImplementation(
       createMockProviderResponse(["Hello, how can I help you?"]),
@@ -1414,7 +1410,7 @@ describe("relay-server", () => {
       toNumber: "+15551111111",
     });
 
-    const secret = createPendingVoiceGuardianChallenge("self");
+    const secret = createPendingVoiceGuardianChallenge();
 
     mockSendMessage.mockImplementation(
       createMockProviderResponse(["Hello, verified caller!"]),
@@ -1678,7 +1674,7 @@ describe("relay-server", () => {
       toNumber: "+15551111111",
     });
 
-    const secret = createPendingVoiceGuardianChallenge("self");
+    const secret = createPendingVoiceGuardianChallenge();
     const spokenCode = secret.split("").join(" ");
 
     const { relay } = createMockWs(session.id);
@@ -1735,7 +1731,7 @@ describe("relay-server", () => {
       toNumber: "+15551111111",
     });
 
-    createPendingVoiceGuardianChallenge("self");
+    createPendingVoiceGuardianChallenge();
 
     const { ws, relay } = createMockWs(session.id);
 
@@ -1779,7 +1775,7 @@ describe("relay-server", () => {
       toNumber: "+15551111111",
     });
 
-    createPendingVoiceGuardianChallenge("self");
+    createPendingVoiceGuardianChallenge();
 
     const { ws, relay } = createMockWs(session.id);
 
@@ -1889,7 +1885,7 @@ describe("relay-server", () => {
       toNumber: "+15551111111",
     });
 
-    createPendingVoiceGuardianChallenge("self");
+    createPendingVoiceGuardianChallenge();
 
     const { ws, relay } = createMockWs(session.id);
 
@@ -1947,7 +1943,6 @@ describe("relay-server", () => {
     });
 
     const secret = createVoiceVerificationSession(
-      "self",
       "+15559999999",
       "gv-session-ptr-success",
     );
@@ -2002,11 +1997,7 @@ describe("relay-server", () => {
       initiatedFromConversationId: "conv-gv-pointer-fail-origin",
     });
 
-    createVoiceVerificationSession(
-      "self",
-      "+15559999999",
-      "gv-session-ptr-fail",
-    );
+    createVoiceVerificationSession("+15559999999", "gv-session-ptr-fail");
 
     const { relay } = createMockWs(session.id);
 
@@ -3894,7 +3885,6 @@ describe("relay-server", () => {
     const tcSecret = "654321";
     createVerificationSession({
       id: randomUUID(),
-      assistantId: "self",
       channel: "voice",
       challengeHash: createHash("sha256").update(tcSecret).digest("hex"),
       expiresAt: Date.now() + 10 * 60 * 1000,
@@ -3971,7 +3961,7 @@ describe("relay-server", () => {
     });
 
     // Create a guardian challenge (default verificationPurpose = 'guardian')
-    const secret = createPendingVoiceGuardianChallenge("self");
+    const secret = createPendingVoiceGuardianChallenge();
 
     mockSendMessage.mockImplementation(
       createMockProviderResponse(["Hello, how can I help you?"]),

--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -176,7 +176,7 @@ describe("Slack inbound trusted contact verification", () => {
     await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
 
     // An active outbound session should exist for the slack channel
-    const session = findActiveSession("self", "slack");
+    const session = findActiveSession("slack");
     expect(session).not.toBeNull();
     expect(session!.expectedExternalUserId).toBe("U0123UNKNOWN");
     expect(session!.expectedChatId).toBe("U0123UNKNOWN");
@@ -285,7 +285,7 @@ describe("Slack inbound trusted contact verification", () => {
     const req = buildSlackInboundRequest();
     await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
 
-    const session = findActiveSession("self", "slack");
+    const session = findActiveSession("slack");
     expect(session).not.toBeNull();
 
     // The challenge hash is stored in the session — extract the secret
@@ -317,7 +317,6 @@ describe("Slack inbound trusted contact verification", () => {
       await import("../runtime/channel-guardian-service.js");
 
     const outboundSession = createOutboundSession({
-      assistantId: "self",
       channel: "slack",
       expectedExternalUserId: "U0123UNKNOWN",
       expectedChatId: "U0123UNKNOWN",

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -402,7 +402,6 @@ describe("trusted contact activated notification signal", () => {
 
     // Create an identity-bound outbound session (simulates M3 approval flow)
     const session = createOutboundSession({
-      assistantId: "self",
       channel: "telegram",
       expectedExternalUserId: "requester-user-456",
       expectedChatId: "chat-123",
@@ -468,7 +467,6 @@ describe("trusted contact activated notification signal", () => {
     });
 
     const session = createOutboundSession({
-      assistantId: "self",
       channel: "telegram",
       expectedExternalUserId: "requester-user-456",
       expectedChatId: "chat-123",
@@ -499,7 +497,7 @@ describe("trusted contact activated notification signal", () => {
     // Create an inbound challenge (guardian flow, not trusted contact)
     const { createVerificationChallenge } =
       await import("../runtime/channel-guardian-service.js");
-    const { secret } = createVerificationChallenge("self", "telegram");
+    const { secret } = createVerificationChallenge("telegram");
 
     // "Guardian" enters the verification code
     const verifyReq = buildInboundRequest({
@@ -539,7 +537,6 @@ describe("trusted contact activated notification signal", () => {
     });
 
     const session = createOutboundSession({
-      assistantId: "self",
       channel: "telegram",
       expectedExternalUserId: "requester-user-456",
       expectedChatId: "chat-123",

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -258,7 +258,6 @@ for (const config of CHANNEL_CONFIGS) {
 
     test("verification creates active member for channel", () => {
       const session = createOutboundSession({
-        assistantId: "self",
         channel: config.channel,
         expectedExternalUserId: config.senderExternalUserId,
         expectedChatId: config.externalChatId,
@@ -268,7 +267,6 @@ for (const config of CHANNEL_CONFIGS) {
       });
 
       const challengeResult = validateAndConsumeChallenge(
-        "self",
         config.channel,
         session.secret,
         config.senderExternalUserId,
@@ -345,7 +343,6 @@ describe("SMS identity binding with E.164 phone numbers", () => {
   test("SMS verification session binds to phone E.164", () => {
     const phone = "+15551234567";
     const session = createOutboundSession({
-      assistantId: "self",
       channel: "sms",
       expectedExternalUserId: phone,
       expectedPhoneE164: phone,
@@ -357,7 +354,6 @@ describe("SMS identity binding with E.164 phone numbers", () => {
 
     // Verify with matching phone identity
     const result = validateAndConsumeChallenge(
-      "self",
       "sms",
       session.secret,
       phone,
@@ -374,7 +370,6 @@ describe("SMS identity binding with E.164 phone numbers", () => {
     const wrongPhone = "+15559999999";
 
     const session = createOutboundSession({
-      assistantId: "self",
       channel: "sms",
       expectedExternalUserId: expectedPhone,
       expectedPhoneE164: expectedPhone,
@@ -385,7 +380,6 @@ describe("SMS identity binding with E.164 phone numbers", () => {
 
     // Try to verify with a different phone (anti-oracle: same error message)
     const result = validateAndConsumeChallenge(
-      "self",
       "sms",
       session.secret,
       wrongPhone,
@@ -407,7 +401,6 @@ describe("cross-channel isolation", () => {
   test("verification sessions are scoped per channel", () => {
     // Create sessions on both channels
     const telegramSession = createOutboundSession({
-      assistantId: "self",
       channel: "telegram",
       expectedExternalUserId: "user-123",
       expectedChatId: "chat-123",
@@ -416,7 +409,6 @@ describe("cross-channel isolation", () => {
     });
 
     const smsSession = createOutboundSession({
-      assistantId: "self",
       channel: "sms",
       expectedExternalUserId: "+15551234567",
       expectedPhoneE164: "+15551234567",
@@ -427,7 +419,6 @@ describe("cross-channel isolation", () => {
 
     // Telegram code should not work on SMS channel
     const wrongChannelResult = validateAndConsumeChallenge(
-      "self",
       "sms",
       telegramSession.secret,
       "+15551234567",
@@ -437,7 +428,6 @@ describe("cross-channel isolation", () => {
 
     // SMS code should work on SMS channel
     const correctChannelResult = validateAndConsumeChallenge(
-      "self",
       "sms",
       smsSession.secret,
       "+15551234567",

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -91,7 +91,6 @@ describe("trusted contact verification → member activation", () => {
   test("successful verification creates active member with allow policy", () => {
     // Simulate M3: guardian approves, outbound session created for the requester
     const session = createOutboundSession({
-      assistantId: "self",
       channel: "telegram",
       expectedExternalUserId: "requester-user-123",
       expectedChatId: "requester-chat-123",
@@ -102,7 +101,6 @@ describe("trusted contact verification → member activation", () => {
 
     // Requester enters the 6-digit code
     const result = validateAndConsumeChallenge(
-      "self",
       "telegram",
       session.secret,
       "requester-user-123",
@@ -237,7 +235,6 @@ describe("trusted contact verification → member activation", () => {
   test("post-verify message is accepted (ACL check passes)", () => {
     // Create and verify a trusted contact
     const session = createOutboundSession({
-      assistantId: "self",
       channel: "telegram",
       expectedExternalUserId: "requester-user-456",
       expectedChatId: "requester-chat-456",
@@ -247,7 +244,6 @@ describe("trusted contact verification → member activation", () => {
     });
 
     validateAndConsumeChallenge(
-      "self",
       "telegram",
       session.secret,
       "requester-user-456",
@@ -278,7 +274,6 @@ describe("trusted contact verification → member activation", () => {
   test("member lookup is scoped by channel type", () => {
     // Create member on the telegram channel
     const session = createOutboundSession({
-      assistantId: "self",
       channel: "telegram",
       expectedExternalUserId: "user-cross-test",
       expectedChatId: "chat-cross-test",
@@ -288,7 +283,6 @@ describe("trusted contact verification → member activation", () => {
     });
 
     validateAndConsumeChallenge(
-      "self",
       "telegram",
       session.secret,
       "user-cross-test",
@@ -345,7 +339,6 @@ describe("trusted contact verification → member activation", () => {
 
     // Guardian re-approves, new outbound session created
     const session = createOutboundSession({
-      assistantId: "self",
       channel: "telegram",
       expectedExternalUserId: "user-revoked",
       expectedChatId: "chat-revoked",
@@ -356,7 +349,6 @@ describe("trusted contact verification → member activation", () => {
 
     // Requester enters the new code
     const result = validateAndConsumeChallenge(
-      "self",
       "telegram",
       session.secret,
       "user-revoked",
@@ -400,7 +392,6 @@ describe("trusted contact verification → member activation", () => {
 
     // Create an outbound session for a requester (different user than guardian)
     const session = createOutboundSession({
-      assistantId: "self",
       channel: "telegram",
       expectedExternalUserId: "requester-user-789",
       expectedChatId: "requester-chat-789",
@@ -410,7 +401,6 @@ describe("trusted contact verification → member activation", () => {
     });
 
     const result = validateAndConsumeChallenge(
-      "self",
       "telegram",
       session.secret,
       "requester-user-789",
@@ -437,10 +427,9 @@ describe("trusted contact verification → member activation", () => {
 
     const { createVerificationChallenge } =
       await import("../runtime/channel-guardian-service.js");
-    const { secret } = createVerificationChallenge("self", "telegram");
+    const { secret } = createVerificationChallenge("telegram");
 
     const result = validateAndConsumeChallenge(
-      "self",
       "telegram",
       secret,
       "guardian-user",

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -482,7 +482,6 @@ const accessRequestResolver: GuardianRequestResolver = {
     // Non-voice approvals: mint an identity-bound verification session so the
     // requester can verify their identity.
     const session = createOutboundSession({
-      assistantId,
       channel,
       expectedExternalUserId: requesterExternalUserId,
       expectedChatId: requesterChatId,

--- a/assistant/src/calls/relay-setup-router.ts
+++ b/assistant/src/calls/relay-setup-router.ts
@@ -164,7 +164,7 @@ export function routeSetup(ctx: SetupContext): {
   }
 
   // ── Inbound call ACL evaluation ─────────────────────────────────
-  const pendingChallenge = getPendingChallenge(assistantId, "voice");
+  const pendingChallenge = getPendingChallenge("voice");
 
   if (actorTrust.trustClass === "unknown" && !pendingChallenge) {
     // Check for blocked caller

--- a/assistant/src/calls/relay-verification.ts
+++ b/assistant/src/calls/relay-verification.ts
@@ -126,7 +126,6 @@ export function attemptGuardianCodeVerification(
   } = params;
 
   const result = validateAndConsumeChallenge(
-    guardianChallengeAssistantId,
     "voice",
     enteredCode,
     guardianVerificationFromNumber,

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -91,11 +91,7 @@ export function createGuardianChallenge(
     };
   }
 
-  const result = createVerificationChallenge(
-    resolvedAssistantId,
-    resolvedChannel,
-    sessionId,
-  );
+  const result = createVerificationChallenge(resolvedChannel, sessionId);
 
   return {
     success: true,
@@ -133,15 +129,11 @@ export function getGuardianStatus(
       guardianUsername = ext.username;
     }
   }
-  const hasPendingChallenge =
-    getPendingChallenge(resolvedAssistantId, resolvedChannel) != null;
+  const hasPendingChallenge = getPendingChallenge(resolvedChannel) != null;
 
   // Include active outbound session state so the UI can resume
   // after app restart and detect bootstrap completion.
-  const activeOutboundSession = findActiveSession(
-    resolvedAssistantId,
-    resolvedChannel,
-  );
+  const activeOutboundSession = findActiveSession(resolvedChannel);
   const outboundFields: Record<string, unknown> = {};
   if (activeOutboundSession) {
     outboundFields.verificationSessionId = activeOutboundSession.id;
@@ -180,7 +172,7 @@ export function revokeGuardianForChannel(
   // Always revoke pending challenges first — the macOS app uses
   // action: "revoke" to cancel an in-flight challenge even before
   // a binding exists (e.g. during verification setup).
-  revokePendingChallenges(assistantId, resolvedChannel);
+  revokePendingChallenges(resolvedChannel);
 
   // Capture binding before revoking so we can revoke the guardian's
   // contact record — without this, the guardian would still pass

--- a/assistant/src/memory/guardian-rate-limits.ts
+++ b/assistant/src/memory/guardian-rate-limits.ts
@@ -8,6 +8,7 @@
 import { and, eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getDb } from "./db.js";
 import { channelGuardianRateLimits } from "./schema.js";
 
@@ -69,7 +70,6 @@ function rowToRateLimit(
  * Get the rate-limit record for a given actor on a specific channel.
  */
 export function getRateLimit(
-  assistantId: string,
   channel: string,
   actorExternalUserId: string,
   actorChatId: string,
@@ -80,7 +80,6 @@ export function getRateLimit(
     .from(channelGuardianRateLimits)
     .where(
       and(
-        eq(channelGuardianRateLimits.assistantId, assistantId),
         eq(channelGuardianRateLimits.channel, channel),
         eq(channelGuardianRateLimits.actorExternalUserId, actorExternalUserId),
         eq(channelGuardianRateLimits.actorChatId, actorChatId),
@@ -101,7 +100,6 @@ export function getRateLimit(
  * accumulate indefinitely.
  */
 export function recordInvalidAttempt(
-  assistantId: string,
   channel: string,
   actorExternalUserId: string,
   actorChatId: string,
@@ -113,12 +111,7 @@ export function recordInvalidAttempt(
   const now = Date.now();
   const cutoff = now - windowMs;
 
-  const existing = getRateLimit(
-    assistantId,
-    channel,
-    actorExternalUserId,
-    actorChatId,
-  );
+  const existing = getRateLimit(channel, actorExternalUserId, actorChatId);
 
   if (existing) {
     // Keep only timestamps within the sliding window, then add the new one
@@ -158,7 +151,7 @@ export function recordInvalidAttempt(
   const lockedUntil = 1 >= maxAttempts ? now + lockoutMs : null;
   const row = {
     id,
-    assistantId,
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     channel,
     actorExternalUserId,
     actorChatId,
@@ -181,7 +174,6 @@ export function recordInvalidAttempt(
  * successful verification).
  */
 export function resetRateLimit(
-  assistantId: string,
   channel: string,
   actorExternalUserId: string,
   actorChatId: string,
@@ -197,7 +189,6 @@ export function resetRateLimit(
     })
     .where(
       and(
-        eq(channelGuardianRateLimits.assistantId, assistantId),
         eq(channelGuardianRateLimits.channel, channel),
         eq(channelGuardianRateLimits.actorExternalUserId, actorExternalUserId),
         eq(channelGuardianRateLimits.actorChatId, actorChatId),

--- a/assistant/src/memory/guardian-verification.ts
+++ b/assistant/src/memory/guardian-verification.ts
@@ -8,6 +8,7 @@
 
 import { and, count, desc, eq, gt, gte, inArray, or } from "drizzle-orm";
 
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getDb } from "./db.js";
 import { channelGuardianVerificationChallenges } from "./schema.js";
 
@@ -101,7 +102,6 @@ function rowToChallenge(
 
 export function createChallenge(params: {
   id: string;
-  assistantId: string;
   channel: string;
   challengeHash: string;
   expiresAt: number;
@@ -110,16 +110,12 @@ export function createChallenge(params: {
   const db = getDb();
   const now = Date.now();
 
-  // Revoke any prior pending challenges for the same (assistantId, channel)
+  // Revoke any prior pending challenges for the same channel
   // to close the replay window — only the latest challenge should be valid.
   db.update(channelGuardianVerificationChallenges)
     .set({ status: "revoked", updatedAt: now })
     .where(
       and(
-        eq(
-          channelGuardianVerificationChallenges.assistantId,
-          params.assistantId,
-        ),
         eq(channelGuardianVerificationChallenges.channel, params.channel),
         eq(channelGuardianVerificationChallenges.status, "pending"),
       ),
@@ -128,7 +124,7 @@ export function createChallenge(params: {
 
   const row = {
     id: params.id,
-    assistantId: params.assistantId,
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     channel: params.channel,
     challengeHash: params.challengeHash,
     expiresAt: params.expiresAt,
@@ -157,16 +153,12 @@ export function createChallenge(params: {
   return rowToChallenge(row);
 }
 
-export function revokePendingChallenges(
-  assistantId: string,
-  channel: string,
-): void {
+export function revokePendingChallenges(channel: string): void {
   const db = getDb();
   db.update(channelGuardianVerificationChallenges)
     .set({ status: "revoked", updatedAt: Date.now() })
     .where(
       and(
-        eq(channelGuardianVerificationChallenges.assistantId, assistantId),
         eq(channelGuardianVerificationChallenges.channel, channel),
         eq(channelGuardianVerificationChallenges.status, "pending"),
       ),
@@ -175,7 +167,6 @@ export function revokePendingChallenges(
 }
 
 export function findPendingChallengeByHash(
-  assistantId: string,
   channel: string,
   challengeHash: string,
 ): VerificationChallenge | null {
@@ -188,7 +179,6 @@ export function findPendingChallengeByHash(
     .from(channelGuardianVerificationChallenges)
     .where(
       and(
-        eq(channelGuardianVerificationChallenges.assistantId, assistantId),
         eq(channelGuardianVerificationChallenges.channel, channel),
         eq(channelGuardianVerificationChallenges.challengeHash, challengeHash),
         inArray(channelGuardianVerificationChallenges.status, [
@@ -205,7 +195,7 @@ export function findPendingChallengeByHash(
 }
 
 /**
- * Find any pending inbound (non-expired) challenge for a given (assistantId, channel).
+ * Find any pending inbound (non-expired) challenge for a given channel.
  * Scoped to 'pending' status only — this is the inbound verification path used by
  * the relay-server to gate incoming voice calls. Outbound session states
  * (pending_bootstrap, awaiting_response) are excluded so that an active outbound
@@ -213,7 +203,6 @@ export function findPendingChallengeByHash(
  * guardian verification flow.
  */
 export function findPendingChallengeForChannel(
-  assistantId: string,
   channel: string,
 ): VerificationChallenge | null {
   const db = getDb();
@@ -224,7 +213,6 @@ export function findPendingChallengeForChannel(
     .from(channelGuardianVerificationChallenges)
     .where(
       and(
-        eq(channelGuardianVerificationChallenges.assistantId, assistantId),
         eq(channelGuardianVerificationChallenges.channel, channel),
         eq(channelGuardianVerificationChallenges.status, "pending"),
         gt(channelGuardianVerificationChallenges.expiresAt, now),
@@ -261,11 +249,10 @@ export function consumeChallenge(
 /**
  * Create an outbound verification session with expected-identity binding.
  * Auto-revokes prior pending/awaiting_response sessions for the same
- * (assistantId, channel) to close the replay window.
+ * channel to close the replay window.
  */
 export function createVerificationSession(params: {
   id: string;
-  assistantId: string;
   channel: string;
   challengeHash: string;
   expiresAt: number;
@@ -284,15 +271,11 @@ export function createVerificationSession(params: {
   const db = getDb();
   const now = Date.now();
 
-  // Revoke any prior pending/awaiting_response sessions for the same (assistantId, channel)
+  // Revoke any prior pending/awaiting_response sessions for the same channel
   db.update(channelGuardianVerificationChallenges)
     .set({ status: "revoked", updatedAt: now })
     .where(
       and(
-        eq(
-          channelGuardianVerificationChallenges.assistantId,
-          params.assistantId,
-        ),
         eq(channelGuardianVerificationChallenges.channel, params.channel),
         inArray(channelGuardianVerificationChallenges.status, [
           "pending",
@@ -305,7 +288,7 @@ export function createVerificationSession(params: {
 
   const row = {
     id: params.id,
-    assistantId: params.assistantId,
+    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     channel: params.channel,
     challengeHash: params.challengeHash,
     expiresAt: params.expiresAt,
@@ -336,10 +319,9 @@ export function createVerificationSession(params: {
 
 /**
  * Find the most recent pending_bootstrap or awaiting_response session
- * for a given (assistantId, channel).
+ * for a given channel.
  */
 export function findActiveSession(
-  assistantId: string,
   channel: string,
 ): VerificationChallenge | null {
   const db = getDb();
@@ -350,7 +332,6 @@ export function findActiveSession(
     .from(channelGuardianVerificationChallenges)
     .where(
       and(
-        eq(channelGuardianVerificationChallenges.assistantId, assistantId),
         eq(channelGuardianVerificationChallenges.channel, channel),
         inArray(channelGuardianVerificationChallenges.status, [
           "pending_bootstrap",
@@ -370,7 +351,6 @@ export function findActiveSession(
  * Used by the Telegram /start gv_<token> bootstrap flow.
  */
 export function findSessionByBootstrapTokenHash(
-  assistantId: string,
   channel: string,
   tokenHash: string,
 ): VerificationChallenge | null {
@@ -382,7 +362,6 @@ export function findSessionByBootstrapTokenHash(
     .from(channelGuardianVerificationChallenges)
     .where(
       and(
-        eq(channelGuardianVerificationChallenges.assistantId, assistantId),
         eq(channelGuardianVerificationChallenges.channel, channel),
         eq(channelGuardianVerificationChallenges.bootstrapTokenHash, tokenHash),
         eq(channelGuardianVerificationChallenges.status, "pending_bootstrap"),
@@ -399,7 +378,6 @@ export function findSessionByBootstrapTokenHash(
  * given identity fields with an active status.
  */
 export function findSessionByIdentity(
-  assistantId: string,
   channel: string,
   externalUserId?: string,
   chatId?: string,
@@ -415,7 +393,6 @@ export function findSessionByIdentity(
   const now = Date.now();
 
   const conditions = [
-    eq(channelGuardianVerificationChallenges.assistantId, assistantId),
     eq(channelGuardianVerificationChallenges.channel, channel),
     inArray(channelGuardianVerificationChallenges.status, [
       "pending_bootstrap",

--- a/assistant/src/runtime/channel-guardian-service.ts
+++ b/assistant/src/runtime/channel-guardian-service.ts
@@ -111,7 +111,6 @@ function generateNumericSecret(digits: number = 6): string {
  * the user; only the hash is persisted.
  */
 export function createVerificationChallenge(
-  assistantId: string,
   channel: string,
   sessionId?: string,
 ): CreateChallengeResult {
@@ -124,7 +123,6 @@ export function createVerificationChallenge(
 
   createChallenge({
     id: challengeId,
-    assistantId,
     channel,
     challengeHash,
     expiresAt,
@@ -162,7 +160,6 @@ export function createVerificationChallenge(
  * period. On success the counter resets.
  */
 export function validateAndConsumeChallenge(
-  assistantId: string,
   channel: string,
   secret: string,
   actorExternalUserId: string,
@@ -171,12 +168,7 @@ export function validateAndConsumeChallenge(
   _actorDisplayName?: string,
 ): ValidateChallengeResult {
   // ── Rate-limit check ──
-  const existing = getRateLimit(
-    assistantId,
-    channel,
-    actorExternalUserId,
-    actorChatId,
-  );
+  const existing = getRateLimit(channel, actorExternalUserId, actorChatId);
   if (
     existing &&
     existing.lockedUntil != null &&
@@ -195,14 +187,9 @@ export function validateAndConsumeChallenge(
 
   const challengeHash = hashSecret(secret);
 
-  const challenge = findPendingChallengeByHash(
-    assistantId,
-    channel,
-    challengeHash,
-  );
+  const challenge = findPendingChallengeByHash(channel, challengeHash);
   if (!challenge) {
     recordInvalidAttempt(
-      assistantId,
       channel,
       actorExternalUserId,
       actorChatId,
@@ -221,7 +208,6 @@ export function validateAndConsumeChallenge(
 
   if (Date.now() > challenge.expiresAt) {
     recordInvalidAttempt(
-      assistantId,
       channel,
       actorExternalUserId,
       actorChatId,
@@ -295,7 +281,6 @@ export function validateAndConsumeChallenge(
       // Anti-oracle: use the same generic error message to avoid leaking
       // whether the identity is wrong vs. the code is wrong.
       recordInvalidAttempt(
-        assistantId,
         channel,
         actorExternalUserId,
         actorChatId,
@@ -319,7 +304,7 @@ export function validateAndConsumeChallenge(
   consumeChallenge(challenge.id, actorExternalUserId, actorChatId);
 
   // Reset the rate-limit counter on success
-  resetRateLimit(assistantId, channel, actorExternalUserId, actorChatId);
+  resetRateLimit(channel, actorExternalUserId, actorChatId);
 
   // Return the verification type — role-specific side effects are
   // handled by callers: verification-intercept (channel) and
@@ -389,27 +374,23 @@ export function revokeBinding(assistantId: string, channel: string): boolean {
 }
 
 /**
- * Revoke all pending challenges for a given assistant and channel.
+ * Revoke all pending challenges for a given channel.
  * Called when the user cancels verification so that stale challenges
  * don't gate inbound calls.
  */
-export function revokePendingChallenges(
-  assistantId: string,
-  channel: string,
-): void {
-  storeRevokePendingChallenges(assistantId, channel);
+export function revokePendingChallenges(channel: string): void {
+  storeRevokePendingChallenges(channel);
 }
 
 /**
  * Look up a pending (non-expired) verification challenge for a given
- * assistant and channel. Used by relay setup to detect whether an active
+ * channel. Used by relay setup to detect whether an active
  * voice verification session exists.
  */
 export function getPendingChallenge(
-  assistantId: string,
   channel: string,
 ): VerificationChallenge | null {
-  return findPendingChallengeForChannel(assistantId, channel);
+  return findPendingChallengeForChannel(channel);
 }
 
 // ---------------------------------------------------------------------------
@@ -435,7 +416,6 @@ export interface CreateOutboundSessionResult {
  * the TTL window.
  */
 export function createOutboundSession(params: {
-  assistantId: string;
   channel: string;
   expectedExternalUserId?: string;
   expectedChatId?: string;
@@ -460,7 +440,6 @@ export function createOutboundSession(params: {
 
   createVerificationSession({
     id: sessionId,
-    assistantId: params.assistantId,
     channel: params.channel,
     challengeHash,
     expiresAt,
@@ -489,33 +468,24 @@ export function createOutboundSession(params: {
 }
 
 /**
- * Find the most recent active outbound session for a given
- * (assistantId, channel).
+ * Find the most recent active outbound session for a given channel.
  */
 export function findActiveSession(
-  assistantId: string,
   channel: string,
 ): VerificationChallenge | null {
-  return storeFindActiveSession(assistantId, channel);
+  return storeFindActiveSession(channel);
 }
 
 /**
  * Identity-bound session lookup for the consume path.
  */
 export function findSessionByIdentity(
-  assistantId: string,
   channel: string,
   externalUserId?: string,
   chatId?: string,
   phoneE164?: string,
 ): VerificationChallenge | null {
-  return storeFindSessionByIdentity(
-    assistantId,
-    channel,
-    externalUserId,
-    chatId,
-    phoneE164,
-  );
+  return storeFindSessionByIdentity(channel, externalUserId, chatId, phoneE164);
 }
 
 /**
@@ -578,10 +548,9 @@ export function bindSessionIdentity(
  * Hashes the raw token with SHA-256 and looks up the session.
  */
 export function resolveBootstrapToken(
-  assistantId: string,
   channel: string,
   token: string,
 ): VerificationChallenge | null {
   const tokenHash = hashSecret(token);
-  return storeFindSessionByBootstrapTokenHash(assistantId, channel, tokenHash);
+  return storeFindSessionByBootstrapTokenHash(channel, tokenHash);
 }

--- a/assistant/src/runtime/guardian-outbound-actions.ts
+++ b/assistant/src/runtime/guardian-outbound-actions.ts
@@ -363,7 +363,6 @@ function startOutboundSms(
   }
 
   const sessionResult = createOutboundSession({
-    assistantId,
     channel,
     expectedPhoneE164: destination,
     expectedExternalUserId: destination,
@@ -456,7 +455,6 @@ function startOutboundTelegram(
     }
 
     const sessionResult = createOutboundSession({
-      assistantId,
       channel,
       expectedChatId: destination,
       identityBindingStatus: "bound",
@@ -514,7 +512,6 @@ function startOutboundTelegram(
     .digest("hex");
 
   const sessionResult = createOutboundSession({
-    assistantId,
     channel,
     identityBindingStatus: "pending_bootstrap",
     destinationAddress: normalizedDestination,
@@ -589,7 +586,6 @@ function startOutboundVoice(
   }
 
   const sessionResult = createOutboundSession({
-    assistantId,
     channel,
     expectedPhoneE164: destination,
     expectedExternalUserId: destination,
@@ -709,7 +705,6 @@ function startOutboundSlack(
   }
 
   const sessionResult = createOutboundSession({
-    assistantId,
     channel,
     expectedExternalUserId: destination,
     expectedChatId: destination,
@@ -756,7 +751,7 @@ export function resendOutbound(
   const channel = params.channel;
   const originConversationId = params.originConversationId;
 
-  const session = findActiveSession(assistantId, channel);
+  const session = findActiveSession(channel);
   if (!session) {
     return {
       success: false,
@@ -831,7 +826,6 @@ export function resendOutbound(
 
   if (channel === "telegram") {
     const newSession = createOutboundSession({
-      assistantId,
       channel,
       expectedChatId: destination,
       identityBindingStatus: "bound",
@@ -870,7 +864,6 @@ export function resendOutbound(
     };
   } else if (channel === "voice") {
     const newSession = createOutboundSession({
-      assistantId,
       channel,
       expectedPhoneE164: destination,
       expectedExternalUserId: destination,
@@ -907,7 +900,6 @@ export function resendOutbound(
     };
   } else if (channel === "slack") {
     const newSession = createOutboundSession({
-      assistantId,
       channel,
       expectedExternalUserId: destination,
       expectedChatId: destination,
@@ -949,7 +941,6 @@ export function resendOutbound(
 
   // SMS resend
   const newSession = createOutboundSession({
-    assistantId,
     channel,
     expectedPhoneE164: destination,
     expectedExternalUserId: destination,
@@ -990,7 +981,7 @@ export function cancelOutbound(
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const channel = params.channel;
 
-  const session = findActiveSession(assistantId, channel);
+  const session = findActiveSession(channel);
   if (!session) {
     return {
       success: false,

--- a/assistant/src/runtime/routes/access-request-decision.ts
+++ b/assistant/src/runtime/routes/access-request-decision.ts
@@ -10,7 +10,6 @@ import {
   resolveApprovalRequest,
 } from "../../memory/channel-guardian-store.js";
 import { getLogger } from "../../util/logger.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { createOutboundSession } from "../channel-guardian-service.js";
 import { deliverChannelReply } from "../gateway-client.js";
 
@@ -87,7 +86,6 @@ export function handleAccessRequestDecision(
   // so only the original requester can consume the code. Mark as
   // trusted_contact so the consume path skips guardian binding creation.
   const session = createOutboundSession({
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     channel: approval.channel,
     expectedExternalUserId: approval.requesterExternalUserId,
     expectedChatId: approval.requesterChatId,

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -555,7 +555,6 @@ export async function handleVerifyContactChannel(
     }
 
     const sessionResult = createOutboundSession({
-      assistantId,
       channel: verificationChannel,
       expectedPhoneE164: phoneE164,
       expectedExternalUserId: channel.externalUserId ?? undefined,
@@ -589,7 +588,6 @@ export async function handleVerifyContactChannel(
     // Telegram with known chat ID: identity is already bound
     if (channel.externalChatId) {
       const sessionResult = createOutboundSession({
-        assistantId,
         channel: verificationChannel,
         expectedChatId: channel.externalChatId,
         expectedExternalUserId: channel.externalUserId ?? undefined,
@@ -639,7 +637,6 @@ export async function handleVerifyContactChannel(
       .digest("hex");
 
     const sessionResult = createOutboundSession({
-      assistantId,
       channel: verificationChannel,
       identityBindingStatus: "pending_bootstrap",
       destinationAddress: effectiveDestination,
@@ -675,7 +672,6 @@ export async function handleVerifyContactChannel(
     }
 
     const sessionResult = createOutboundSession({
-      assistantId,
       channel: verificationChannel,
       expectedExternalUserId: channel.externalUserId ?? undefined,
       expectedChatId: channel.externalChatId ?? undefined,

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -191,14 +191,8 @@ export async function enforceIngressAcl(
         // omitted: rebind sessions create a consumable challenge while a
         // binding already exists, and the identity check inside
         // validateAndConsumeChallenge prevents unauthorized takeovers.
-        const hasPendingChallenge = !!getPendingChallenge(
-          canonicalAssistantId,
-          sourceChannel,
-        );
-        const hasActiveOutboundSession = !!findActiveSession(
-          canonicalAssistantId,
-          sourceChannel,
-        );
+        const hasPendingChallenge = !!getPendingChallenge(sourceChannel);
+        const hasActiveOutboundSession = !!findActiveSession(sourceChannel);
         if (hasPendingChallenge || hasActiveOutboundSession) {
           denyNonMember = false;
         } else {
@@ -219,7 +213,6 @@ export async function enforceIngressAcl(
         ).payload as string;
         const bootstrapTokenForAcl = bootstrapPayload.slice(3); // strip 'gv_' prefix
         const bootstrapSessionForAcl = resolveBootstrapToken(
-          canonicalAssistantId,
           sourceChannel,
           bootstrapTokenForAcl,
         );
@@ -420,14 +413,8 @@ export async function enforceIngressAcl(
         // revoked/blocked — otherwise the user can never re-verify.
         let denyInactiveMember = true;
         if (isGuardianVerifyCode) {
-          const hasPendingChallenge = !!getPendingChallenge(
-            canonicalAssistantId,
-            sourceChannel,
-          );
-          const hasActiveOutboundSession = !!findActiveSession(
-            canonicalAssistantId,
-            sourceChannel,
-          );
+          const hasPendingChallenge = !!getPendingChallenge(sourceChannel);
+          const hasActiveOutboundSession = !!findActiveSession(sourceChannel);
           if (hasPendingChallenge || hasActiveOutboundSession) {
             denyInactiveMember = false;
           } else {
@@ -448,7 +435,6 @@ export async function enforceIngressAcl(
           ).payload as string;
           const bootstrapTokenForAcl = bootstrapPayload.slice(3);
           const bootstrapSessionForAcl = resolveBootstrapToken(
-            canonicalAssistantId,
             sourceChannel,
             bootstrapTokenForAcl,
           );
@@ -1112,14 +1098,8 @@ function initiateSlackVerificationChallenge(params: {
   // this sender to avoid flooding them with duplicate codes. We scope by
   // sender identity (expectedExternalUserId) so that a pending session for
   // user A does not suppress challenges for user B.
-  const existingChallenge = getPendingChallenge(
-    canonicalAssistantId,
-    sourceChannel,
-  );
-  const existingSession = findActiveSession(
-    canonicalAssistantId,
-    sourceChannel,
-  );
+  const existingChallenge = getPendingChallenge(sourceChannel);
+  const existingSession = findActiveSession(sourceChannel);
   const senderHasPending =
     (existingChallenge &&
       existingChallenge.expectedExternalUserId === senderUserId) ||
@@ -1140,7 +1120,6 @@ function initiateSlackVerificationChallenge(params: {
 
   try {
     const session = createOutboundSession({
-      assistantId: canonicalAssistantId,
       channel: sourceChannel,
       expectedExternalUserId: senderUserId,
       expectedChatId: senderUserId,

--- a/assistant/src/runtime/routes/inbound-stages/bootstrap-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/bootstrap-intercept.ts
@@ -74,11 +74,7 @@ export async function handleBootstrapIntercept(
   }
 
   const bootstrapToken = (commandIntent.payload as string).slice(3);
-  const bootstrapSession = resolveBootstrapToken(
-    canonicalAssistantId,
-    sourceChannel,
-    bootstrapToken,
-  );
+  const bootstrapSession = resolveBootstrapToken(sourceChannel, bootstrapToken);
 
   if (!bootstrapSession || bootstrapSession.status !== "pending_bootstrap") {
     // Not found or expired — fall through to normal /start handling
@@ -94,7 +90,6 @@ export async function handleBootstrapIntercept(
   // Create a new identity-bound outbound session with a fresh secret.
   // The old bootstrap session is auto-revoked by createOutboundSession.
   const newSession = createOutboundSession({
-    assistantId: canonicalAssistantId,
     channel: sourceChannel,
     expectedExternalUserId: rawSenderId,
     expectedChatId: conversationExternalId,

--- a/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
@@ -95,8 +95,8 @@ export async function handleVerificationIntercept(
   // Only intercept when there is a pending challenge or active outbound session
   const shouldIntercept =
     guardianVerifyCode !== undefined &&
-    (!!getPendingChallenge(canonicalAssistantId, sourceChannel) ||
-      !!findActiveSession(canonicalAssistantId, sourceChannel));
+    (!!getPendingChallenge(sourceChannel) ||
+      !!findActiveSession(sourceChannel));
 
   if (
     isDuplicate ||
@@ -108,7 +108,6 @@ export async function handleVerificationIntercept(
   }
 
   const verifyResult = validateAndConsumeChallenge(
-    canonicalAssistantId,
     sourceChannel,
     guardianVerifyCode,
     canonicalSenderId ?? rawSenderId,

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -1,6 +1,5 @@
 import { startCall } from "../../calls/call-domain.js";
 import { getConfig } from "../../config/loader.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
 import { findActiveSession } from "../../runtime/channel-guardian-service.js";
 import { normalizePhoneNumber } from "../../util/phone.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
@@ -22,8 +21,7 @@ export async function executeCallStart(
       ? normalizePhoneNumber(input.phone_number)
       : null;
   if (requestedPhone) {
-    const assistantId = context.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
-    const activeVoiceVerification = findActiveSession(assistantId, "voice");
+    const activeVoiceVerification = findActiveSession("voice");
     const verificationDestination =
       activeVoiceVerification?.destinationAddress ??
       activeVoiceVerification?.expectedPhoneE164;


### PR DESCRIPTION
## Summary
- Remove assistantId parameter from all function signatures in guardian-verification.ts and guardian-rate-limits.ts store files, hardcoding DAEMON_INTERNAL_ASSISTANT_ID for INSERT operations and removing it from WHERE clause filters
- Update the service layer (channel-guardian-service.ts) to remove assistantId from all wrapper functions that forward to the stores
- Update all production callers and test files across 23 files total

Part of plan: rm-assistant-id-from-daemon.md (PR 1 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
