### PR TITLE
fix: remove stale assistantId expectations from notification tests

### DIFF
--- a/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
+++ b/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
@@ -351,11 +351,12 @@ describe("bridgeConfirmationRequestToGuardian", () => {
     expect(emittedSignals).toHaveLength(0);
   });
 
-  test("passes assistantId to notification signal", () => {
+  test("does not pass assistantId to notification signal", () => {
     const canonicalRequest = makeCanonicalRequest();
     const trustContext = makeTrustedContactContext();
 
-    // Use default assistantId 'self' which has a binding
+    // assistantId is used internally for guardian binding lookup but is no
+    // longer forwarded to the notification signal after the assistantId removal refactor.
     bridgeConfirmationRequestToGuardian({
       canonicalRequest,
       trustContext,
@@ -363,7 +364,7 @@ describe("bridgeConfirmationRequestToGuardian", () => {
       toolName: "bash",
     });
 
-    expect(emittedSignals[0].assistantId).toBe("self");
+    expect(emittedSignals[0].assistantId).toBeUndefined();
   });
 
   test("includes requesterChatId as null when not provided", () => {

--- a/assistant/src/__tests__/send-notification-tool.test.ts
+++ b/assistant/src/__tests__/send-notification-tool.test.ts
@@ -44,7 +44,6 @@ describe("send-notification tool", () => {
       sourceEventName: "user.send_notification",
       sourceChannel: "assistant_tool",
       sourceSessionId: "conv-override",
-      assistantId: "ast-alpha",
       attentionHints: {
         requiresAction: true,
         urgency: "high",


### PR DESCRIPTION
## Summary
- Remove `assistantId` from `send-notification-tool.test.ts` expected signal payload (no longer passed after assistantId removal refactor)
- Update `confirmation-request-guardian-bridge.test.ts` to assert `assistantId` is `undefined` in emitted signals (was `"self"`)

## Original prompt
fix this CI failure https://github.com/vellum-ai/vellum-assistant/actions/runs/22732778986

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
