### PR TITLE
fix: migrate google-oauth-setup frontmatter to metadata.vellum

### DIFF
--- a/skills/google-oauth-setup/SKILL.md
+++ b/skills/google-oauth-setup/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: "google-oauth-setup"
 description: "Set up Google Cloud OAuth credentials for Gmail and Calendar using browser automation"
-user-invocable: true
-credential-setup-for: "gmail"
 compatibility: "Requires browser automation and public ingress for OAuth callback"
 metadata:
   emoji: "🔑"
+  vellum:
+    user-invocable: true
+    credential-setup-for: "gmail"
 ---
 
 You are helping your user set up Google Cloud OAuth credentials so Gmail and Google Calendar integrations can connect.


### PR DESCRIPTION
## Summary
- Moves `user-invocable` and `credential-setup-for` fields to `metadata.vellum` to conform to the Agent Skills spec

## Test plan
- [x] `node scripts/skills/lint-skill-spec.mjs google-oauth-setup` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
