### PR TITLE
fix: resolve playwright from runtime-installed copy in compiled binaries

### DIFF
--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -5,7 +5,7 @@ import { getLogger } from "../../util/logger.js";
 import { getDataDir } from "../../util/platform.js";
 import { authSessionCache } from "./auth-cache.js";
 import type { ExtractedCredential } from "./network-recording-types.js";
-import { checkBrowserRuntime } from "./runtime-check.js";
+import { checkBrowserRuntime, importPlaywright } from "./runtime-check.js";
 
 const log = getLogger("browser-manager");
 
@@ -130,17 +130,8 @@ export function setLaunchFn(fn: LaunchFn | null): void {
 }
 
 async function getDefaultLaunchFn(): Promise<LaunchFn> {
-  const pw = await import("playwright");
-  // In compiled Bun binaries, CJS→ESM interop may place named exports
-  // under .default instead of at the top level of the module namespace.
-  const chromium =
-    pw.chromium ?? (pw.default as typeof pw | undefined)?.chromium;
-  if (!chromium) {
-    throw new Error(
-      "Failed to resolve Playwright chromium — the module loaded but 'chromium' is missing",
-    );
-  }
-  return chromium.launchPersistentContext.bind(chromium);
+  const pw = await importPlaywright();
+  return pw.chromium.launchPersistentContext.bind(pw.chromium);
 }
 
 function getProfileDir(): string {

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -1,11 +1,11 @@
-import { mkdirSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { getLogger } from "../../util/logger.js";
 import { getDataDir } from "../../util/platform.js";
 import { authSessionCache } from "./auth-cache.js";
 import type { ExtractedCredential } from "./network-recording-types.js";
-import { checkBrowserRuntime, importPlaywright } from "./runtime-check.js";
+import { importPlaywright } from "./runtime-check.js";
 
 const log = getLogger("browser-manager");
 
@@ -129,11 +129,6 @@ export function setLaunchFn(fn: LaunchFn | null): void {
   launchPersistentContext = fn;
 }
 
-async function getDefaultLaunchFn(): Promise<LaunchFn> {
-  const pw = await importPlaywright();
-  return pw.chromium.launchPersistentContext.bind(pw.chromium);
-}
-
 function getProfileDir(): string {
   return join(getDataDir(), "browser-profile");
 }
@@ -168,10 +163,24 @@ class BrowserManager {
     this.contextCreating = (async () => {
       await authSessionCache.load();
 
-      // Auto-install Chromium if needed (skip when test launcher is injected)
-      if (!launchPersistentContext) {
-        const status = await checkBrowserRuntime();
-        if (status.playwrightAvailable && !status.chromiumInstalled) {
+      // Resolve launch function: use injected test launcher or resolve
+      // playwright (may install at runtime in compiled binaries).
+      let launch: LaunchFn;
+      if (launchPersistentContext) {
+        launch = launchPersistentContext;
+      } else {
+        const pw = await importPlaywright();
+
+        // Auto-install Chromium if the browser binary is missing
+        let chromiumInstalled = false;
+        try {
+          const execPath = pw.chromium.executablePath();
+          chromiumInstalled = existsSync(execPath);
+        } catch {
+          // executablePath() may throw if registry is missing
+        }
+
+        if (!chromiumInstalled) {
           log.info("Chromium not installed, installing via playwright...");
           const proc = Bun.spawn(
             ["bunx", "playwright", "install", "chromium"],
@@ -204,11 +213,12 @@ class BrowserManager {
             throw new Error(`Failed to install Chromium: ${msg}`);
           }
         }
+
+        launch = pw.chromium.launchPersistentContext.bind(pw.chromium);
       }
 
       const profileDir = getProfileDir();
       mkdirSync(profileDir, { recursive: true });
-      const launch = launchPersistentContext ?? (await getDefaultLaunchFn());
       const headless = !canDisplayGui();
       const ctx = await launch(profileDir, { headless });
       log.info(

--- a/assistant/src/tools/browser/runtime-check.ts
+++ b/assistant/src/tools/browser/runtime-check.ts
@@ -1,6 +1,7 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+
+import { getWorkspaceDir } from "../../util/platform.js";
 
 export interface BrowserRuntimeStatus {
   playwrightAvailable: boolean;
@@ -10,28 +11,69 @@ export interface BrowserRuntimeStatus {
 }
 
 /**
+ * Resolve playwright's chromium export from a module namespace object,
+ * handling CJS→ESM interop where named exports may land under .default.
+ */
+function resolveChromium(
+  pw: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (pw.chromium) return pw;
+  const def = pw.default as Record<string, unknown> | undefined;
+  if (def?.chromium) return def;
+  return undefined;
+}
+
+/**
+ * Try importing playwright from the bundled binary. Returns the module
+ * if chromium is resolvable, otherwise undefined. This never installs
+ * anything — safe for diagnostic/read-only use.
+ */
+async function tryBundledPlaywright(): Promise<
+  typeof import("playwright") | undefined
+> {
+  try {
+    const pw = await import("playwright");
+    const mod = resolveChromium(pw as unknown as Record<string, unknown>);
+    if (mod?.chromium) return mod as unknown as typeof import("playwright");
+  } catch {
+    // Bundled import failed entirely
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the package entry point from its package.json exports/main fields.
+ */
+function resolvePackageEntry(pkgDir: string): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf-8"));
+    // Prefer ESM entry from exports map
+    const exportsRoot = pkg.exports?.["."];
+    if (typeof exportsRoot === "object" && exportsRoot?.import) {
+      return join(pkgDir, exportsRoot.import);
+    }
+    if (pkg.module) return join(pkgDir, pkg.module);
+    if (pkg.main) return join(pkgDir, pkg.main);
+  } catch {
+    // Fall through to default
+  }
+  return join(pkgDir, "index.mjs");
+}
+
+/**
  * Import playwright, falling back to a runtime-installed copy if the
  * bundled import fails (compiled Bun binaries can't initialize
  * playwright's in-process client/server bridge correctly).
  */
 export async function importPlaywright(): Promise<typeof import("playwright")> {
   // Try bundled import (works in dev/source mode)
-  try {
-    const pw = await import("playwright");
-    const mod = pw.chromium
-      ? pw
-      : (pw.default as typeof pw | undefined)?.chromium
-        ? (pw.default as typeof pw)
-        : undefined;
-    if (mod?.chromium) return mod;
-  } catch {
-    // Bundled import failed entirely — fall through to runtime install
-  }
+  const bundled = await tryBundledPlaywright();
+  if (bundled) return bundled;
 
   // Compiled binary fallback: install playwright to disk and import
   // from an absolute path so the JS runtime resolves it from the
   // filesystem instead of the compiled module cache.
-  const externalDir = join(homedir(), ".vellum", "workspace", "external");
+  const externalDir = join(getWorkspaceDir(), "external");
   const pwPkg = join(externalDir, "node_modules", "playwright");
 
   if (!existsSync(join(pwPkg, "package.json"))) {
@@ -39,26 +81,23 @@ export async function importPlaywright(): Promise<typeof import("playwright")> {
     if (!existsSync(join(externalDir, "package.json"))) {
       writeFileSync(join(externalDir, "package.json"), '{"private":true}\n');
     }
-    const proc = Bun.spawnSync(["bun", "add", "playwright"], {
+    const proc = Bun.spawn(["bun", "add", "playwright"], {
       cwd: externalDir,
       stdout: "pipe",
       stderr: "pipe",
     });
-    if (proc.exitCode !== 0) {
-      const stderr = new TextDecoder().decode(proc.stderr);
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
       throw new Error(`Failed to install playwright: ${stderr}`);
     }
   }
 
   // Dynamic import with a runtime-computed path — bun can't statically
   // analyze this, so it resolves from the filesystem at runtime.
-  const entryPath = join(pwPkg, "index.mjs");
+  const entryPath = resolvePackageEntry(pwPkg);
   const pw: Record<string, unknown> = await import(entryPath);
-  const mod = pw.chromium
-    ? pw
-    : (pw.default as Record<string, unknown> | undefined)?.chromium
-      ? (pw.default as Record<string, unknown>)
-      : undefined;
+  const mod = resolveChromium(pw);
   if (!mod?.chromium) {
     throw new Error(
       "Failed to resolve Playwright chromium from runtime-installed copy",
@@ -68,10 +107,18 @@ export async function importPlaywright(): Promise<typeof import("playwright")> {
 }
 
 export async function checkBrowserRuntime(): Promise<BrowserRuntimeStatus> {
-  // Check if playwright can be imported
+  // Diagnostic only — no side effects (no playwright installation)
   let chromium: { executablePath: () => string };
   try {
-    const pw = await importPlaywright();
+    const pw = await tryBundledPlaywright();
+    if (!pw) {
+      return {
+        playwrightAvailable: false,
+        chromiumInstalled: false,
+        chromiumPath: null,
+        error: "playwright package not available",
+      };
+    }
     chromium = pw.chromium;
   } catch {
     return {

--- a/assistant/src/tools/browser/runtime-check.ts
+++ b/assistant/src/tools/browser/runtime-check.ts
@@ -1,4 +1,6 @@
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 export interface BrowserRuntimeStatus {
   playwrightAvailable: boolean;
@@ -7,14 +9,70 @@ export interface BrowserRuntimeStatus {
   error: string | null;
 }
 
+/**
+ * Import playwright, falling back to a runtime-installed copy if the
+ * bundled import fails (compiled Bun binaries can't initialize
+ * playwright's in-process client/server bridge correctly).
+ */
+export async function importPlaywright(): Promise<typeof import("playwright")> {
+  // Try bundled import (works in dev/source mode)
+  try {
+    const pw = await import("playwright");
+    const mod = pw.chromium
+      ? pw
+      : (pw.default as typeof pw | undefined)?.chromium
+        ? (pw.default as typeof pw)
+        : undefined;
+    if (mod?.chromium) return mod;
+  } catch {
+    // Bundled import failed entirely — fall through to runtime install
+  }
+
+  // Compiled binary fallback: install playwright to disk and import
+  // from an absolute path so the JS runtime resolves it from the
+  // filesystem instead of the compiled module cache.
+  const externalDir = join(homedir(), ".vellum", "workspace", "external");
+  const pwPkg = join(externalDir, "node_modules", "playwright");
+
+  if (!existsSync(join(pwPkg, "package.json"))) {
+    mkdirSync(externalDir, { recursive: true });
+    if (!existsSync(join(externalDir, "package.json"))) {
+      writeFileSync(join(externalDir, "package.json"), '{"private":true}\n');
+    }
+    const proc = Bun.spawnSync(["bun", "add", "playwright"], {
+      cwd: externalDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (proc.exitCode !== 0) {
+      const stderr = new TextDecoder().decode(proc.stderr);
+      throw new Error(`Failed to install playwright: ${stderr}`);
+    }
+  }
+
+  // Dynamic import with a runtime-computed path — bun can't statically
+  // analyze this, so it resolves from the filesystem at runtime.
+  const entryPath = join(pwPkg, "index.mjs");
+  const pw: Record<string, unknown> = await import(entryPath);
+  const mod = pw.chromium
+    ? pw
+    : (pw.default as Record<string, unknown> | undefined)?.chromium
+      ? (pw.default as Record<string, unknown>)
+      : undefined;
+  if (!mod?.chromium) {
+    throw new Error(
+      "Failed to resolve Playwright chromium from runtime-installed copy",
+    );
+  }
+  return mod as unknown as typeof import("playwright");
+}
+
 export async function checkBrowserRuntime(): Promise<BrowserRuntimeStatus> {
   // Check if playwright can be imported
   let chromium: { executablePath: () => string };
   try {
-    const pw = await import("playwright");
-    // In compiled Bun binaries, CJS→ESM interop may place named exports
-    // under .default instead of at the top level of the module namespace.
-    chromium = pw.chromium ?? (pw.default as typeof pw | undefined)?.chromium;
+    const pw = await importPlaywright();
+    chromium = pw.chromium;
   } catch {
     return {
       playwrightAvailable: false,


### PR DESCRIPTION
## Summary
- In compiled Bun binaries, `import("playwright")` bundles a broken copy where `chromium` is `undefined` — the in-process client/server bridge fails to initialize
- Add `importPlaywright()` that tries the bundled import first (works in dev), then falls back to installing playwright to `~/.vellum/workspace/external/` and importing from the absolute filesystem path
- The dynamic import with a runtime-computed path bypasses the compiled module cache and loads a working copy from disk

## Test plan
- [ ] Build release binary (`build.sh release`)
- [ ] Test on clean machine (no pre-existing `node_modules/playwright` or `~/Library/Caches/ms-playwright/`)
- [ ] Verify browser skill loads and can navigate/screenshot a page
- [ ] Verify dev mode (`bun run`) still works (bundled import path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
