### PR TITLE
feat: auto-select guardian contact on Contacts tab

### DIFF
--- a/.githooks/.githooks
+++ b/.githooks/.githooks
@@ -1,0 +1,1 @@
+/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.githooks

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -59,6 +59,11 @@ struct ContactsContainerView: View {
                 .background(VColor.background)
             }
         }
+        .onChange(of: viewModel.contacts) { _ in
+            if selectedContactId == nil, let guardian = viewModel.guardianContact {
+                selectedContactId = guardian.id
+            }
+        }
         .sheet(isPresented: $viewModel.isCreatingContact) {
             ContactCreateView(
                 daemonClient: daemonClient,


### PR DESCRIPTION
## Summary
- Auto-select the guardian ("Me") contact when the Contacts tab loads, instead of showing an empty placeholder
- Uses `.onChange(of: viewModel.contacts)` to select the guardian once contacts finish loading, only when no contact is already selected

## Original prompt
Lets update it such that when you click on the "Contacts" side nav item you by default have the guardian contact selected (maybe after a loading state if needed) rather than defaulting to an empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
