### PR TITLE
Add readiness probes for Email and Slack channels

### DIFF
--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -275,6 +275,52 @@ const telegramProbe: ChannelProbe = {
   // Telegram has no remote checks currently
 };
 
+// ── Email Probe ────────────────────────────────────────────────────────────
+
+const emailProbe: ChannelProbe = {
+  channel: "email",
+  runLocalChecks(): ReadinessCheckResult[] {
+    const hasApiKey = !!(
+      getSecureKey("agentmail") || getSecureKey("credential:agentmail:api_key")
+    );
+    return [
+      {
+        name: "agentmail_api_key",
+        passed: hasApiKey,
+        message: hasApiKey
+          ? "AgentMail API key is configured"
+          : "AgentMail API key is not configured",
+      },
+    ];
+  },
+};
+
+// ── Slack Probe ────────────────────────────────────────────────────────────
+
+const slackProbe: ChannelProbe = {
+  channel: "slack",
+  runLocalChecks(): ReadinessCheckResult[] {
+    const hasBotToken = !!getSecureKey("credential:slack_channel:bot_token");
+    const hasAppToken = !!getSecureKey("credential:slack_channel:app_token");
+    return [
+      {
+        name: "bot_token",
+        passed: hasBotToken,
+        message: hasBotToken
+          ? "Slack bot token is configured"
+          : "Slack bot token is not configured",
+      },
+      {
+        name: "app_token",
+        passed: hasAppToken,
+        message: hasAppToken
+          ? "Slack app token is configured"
+          : "Slack app token is not configured",
+      },
+    ];
+  },
+};
+
 // ── Service ─────────────────────────────────────────────────────────────────
 
 export class ChannelReadinessService {
@@ -416,11 +462,13 @@ export class ChannelReadinessService {
 
 // ── Factory ─────────────────────────────────────────────────────────────────
 
-/** Create a service instance with built-in SMS, Voice, and Telegram probes registered. */
+/** Create a service instance with built-in SMS, Voice, Telegram, Email, and Slack probes registered. */
 export function createReadinessService(): ChannelReadinessService {
   const service = new ChannelReadinessService();
   service.registerProbe(smsProbe);
   service.registerProbe(voiceProbe);
   service.registerProbe(telegramProbe);
+  service.registerProbe(emailProbe);
+  service.registerProbe(slackProbe);
   return service;
 }


### PR DESCRIPTION
## Summary
- Adds `emailProbe` that checks for AgentMail API key via `getSecureKey("agentmail") || getSecureKey("credential:agentmail:api_key")`
- Adds `slackProbe` that checks for both `bot_token` and `app_token` via their `credential:slack_channel:*` secure keys
- Registers both in `createReadinessService()` so all 5 channel types (SMS, Voice, Telegram, Email, Slack) now have readiness probes

## Test plan
- [ ] Verify email probe reports ready when AgentMail API key is configured
- [ ] Verify slack probe reports ready when both bot_token and app_token are configured
- [ ] Verify `createReadinessService()` registers 5 probes
- [ ] Confirm no ingress check for email/slack (they use the 6-digit code flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
