### PR TITLE
Hide channel rows when the assistant hasn't configured that channel

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -216,12 +216,16 @@ struct ContactDetailView: View {
                             Divider().background(VColor.divider)
                         }
                     }
-                } else {
-                    unconfiguredChannelRow(type: type)
-                }
 
-                if index < totalRows - 1 {
-                    Divider().background(VColor.divider)
+                    if index < totalRows - 1 {
+                        Divider().background(VColor.divider)
+                    }
+                } else if channelReadiness[type]?.ready == true {
+                    unconfiguredChannelRow(type: type)
+
+                    if index < totalRows - 1 {
+                        Divider().background(VColor.divider)
+                    }
                 }
             }
 
@@ -252,9 +256,8 @@ struct ContactDetailView: View {
             do {
                 channelReadiness = try await daemonClient?.fetchChannelReadiness() ?? [:]
             } catch {
-                // Silently fail — empty dict means probed channels (SMS, Telegram,
-                // Voice) hide their Invite buttons until a successful fetch, while
-                // non-probed channels (email, Slack) default to showing Invite.
+                // Silently fail — empty dict means unconfigured channel rows
+                // stay hidden until a successful readiness fetch.
             }
         }
     }
@@ -341,15 +344,7 @@ struct ContactDetailView: View {
 
                 // Voice invites require additional fields (phone number, friend/guardian
                 // names) that aren't available in this context, so hide the button.
-                // Channels that require infrastructure probing (SMS, Telegram) only
-                // show Invite when the server has explicitly confirmed readiness.
-                // Non-probed channels (email, Slack) default to ready unless
-                // explicitly marked false.
-                let probedChannels: Set<String> = ["sms", "telegram", "voice"]
-                let channelIsReady = probedChannels.contains(type)
-                    ? channelReadiness[type]?.ready == true
-                    : channelReadiness[type]?.ready != false
-                if displayContact.role != "guardian" && type != "voice" && channelIsReady {
+                if displayContact.role != "guardian" && type != "voice" {
                     if inviteInProgress == type {
                         ProgressView()
                             .controlSize(.small)

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -205,9 +205,15 @@ struct ContactDetailView: View {
                 by: { $0.type }
             )
             let extraChannels = displayContact.channels.filter { !Self.allChannelTypes.contains($0.type) }
-            let totalRows = Self.allChannelTypes.count + extraChannels.count
 
-            ForEach(Array(Self.allChannelTypes.enumerated()), id: \.element) { index, type in
+            // Compute which standard types are visible (have channels or readiness==true)
+            let visibleTypes = Self.allChannelTypes.filter { type in
+                channelsByType[type] != nil || channelReadiness[type]?.ready == true
+            }
+            let lastVisibleType = visibleTypes.last
+            let hasExtraChannels = !extraChannels.isEmpty
+
+            ForEach(Array(Self.allChannelTypes.enumerated()), id: \.element) { _, type in
                 if let channels = channelsByType[type] {
                     ForEach(Array(channels.enumerated()), id: \.element.id) { channelIndex, channel in
                         channelRow(channel)
@@ -217,13 +223,13 @@ struct ContactDetailView: View {
                         }
                     }
 
-                    if index < totalRows - 1 {
+                    if type != lastVisibleType || hasExtraChannels {
                         Divider().background(VColor.divider)
                     }
                 } else if channelReadiness[type]?.ready == true {
                     unconfiguredChannelRow(type: type)
 
-                    if index < totalRows - 1 {
+                    if type != lastVisibleType || hasExtraChannels {
                         Divider().background(VColor.divider)
                     }
                 }
@@ -232,7 +238,7 @@ struct ContactDetailView: View {
             ForEach(Array(extraChannels.enumerated()), id: \.element.id) { index, channel in
                 channelRow(channel)
 
-                if Self.allChannelTypes.count + index < totalRows - 1 {
+                if index < extraChannels.count - 1 {
                     Divider().background(VColor.divider)
                 }
             }


### PR DESCRIPTION
## Summary
- Only renders unconfigured channel rows when `channelReadiness[type]?.ready == true`
- Removes the `probedChannels` split-gating logic since all 5 channels now have readiness probes (from PR 1)
- Channels the assistant hasn't configured are completely hidden from the contact detail
- Existing configured channel rows are unaffected

## Depends on
- #13065 (Email/Slack probes)

## Test plan
- [ ] Verify unconfigured channel rows only appear when readiness reports `ready: true`
- [ ] Leave Email unconfigured (no AgentMail key) and verify the email row is hidden
- [ ] Configure Telegram and verify its unconfigured row appears with Invite button
- [ ] Verify voice row is still excluded from the Invite button (voice uses separate flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
