### PR TITLE
Generate invite instructions via LLM instead of static templates

### DIFF
--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -32,15 +32,15 @@ import {
   renderHistoryContent,
 } from "./shared.js";
 
-export function handleContactsInvite(
+export async function handleContactsInvite(
   msg: ContactsInviteRequest,
   socket: net.Socket,
   ctx: HandlerContext,
-): void {
+): Promise<void> {
   try {
     switch (msg.action) {
       case "create": {
-        const result = createIngressInvite({
+        const result = await createIngressInvite({
           sourceChannel: msg.sourceChannel,
           note: msg.note,
           maxUses: msg.maxUses,

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -45,6 +45,7 @@ export async function handleContactsInvite(
           note: msg.note,
           maxUses: msg.maxUses,
           expiresInMs: msg.expiresInMs,
+          contactName: msg.contactName,
           friendName: msg.friendName,
           guardianName: msg.guardianName,
         });

--- a/assistant/src/daemon/ipc-contract/inbox.ts
+++ b/assistant/src/daemon/ipc-contract/inbox.ts
@@ -23,6 +23,8 @@ export interface ContactsInviteRequest {
   externalChatId?: string;
   /** Filter by status (list only). */
   status?: string;
+  /** Contact display name for personalizing invite instructions (create only). */
+  contactName?: string;
   /** Invitee's first name (voice invite create only). */
   friendName?: string;
   /** Guardian's first name (voice invite create only). */

--- a/assistant/src/runtime/channel-invite-transport.ts
+++ b/assistant/src/runtime/channel-invite-transport.ts
@@ -2,13 +2,13 @@
  * Channel invite adapter abstraction.
  *
  * Defines an adapter interface for building shareable invite links,
- * extracting inbound invite tokens, and generating guardian instructions
- * from channel-specific payloads. Each channel (Telegram, voice, etc.)
+ * extracting inbound invite tokens, and resolving channel handles from
+ * channel-specific payloads. Each channel (Telegram, voice, etc.)
  * registers an adapter that knows how to handle invite flows for that
  * channel.
  *
  * All methods are optional: a channel that only provides
- * `buildGuardianInstruction` (e.g. SMS) is a valid adapter. The adapter
+ * `resolveChannelHandle` (e.g. SMS) is a valid adapter. The adapter
  * layer is intentionally thin — redemption logic lives in
  * `invite-redemption-service.ts`.
  */
@@ -24,13 +24,6 @@ export interface InviteShareLink {
   url: string;
   /** Human-readable text suitable for display alongside the link. */
   displayText: string;
-}
-
-export interface GuardianInstruction {
-  /** Human-readable instruction text for the guardian. */
-  instruction: string;
-  /** Channel-specific handle to reach the assistant (e.g. "@botName", "+15551234567", "hello@domain.agentmail.to"). */
-  channelHandle?: string;
 }
 
 export interface ChannelInviteAdapter {
@@ -56,16 +49,6 @@ export interface ChannelInviteAdapter {
     content: string;
     sourceMetadata?: Record<string, unknown>;
   }): string | undefined;
-
-  /**
-   * Build guardian instruction for this channel. Returns structured data
-   * with the instruction text and an optional channel-specific handle.
-   * Optional — falls back to generic instruction if not implemented.
-   */
-  buildGuardianInstruction?(params: {
-    inviteCode: string;
-    contactName?: string;
-  }): GuardianInstruction;
 
   /**
    * Resolve the channel-specific handle to reach the assistant (e.g.

--- a/assistant/src/runtime/channel-invite-transports/email.ts
+++ b/assistant/src/runtime/channel-invite-transports/email.ts
@@ -1,16 +1,13 @@
 /**
  * Email channel invite adapter.
  *
- * Provides guardian instruction text for email-based invites. Email invites
- * use the universal 6-digit code path for redemption, so this adapter only
- * implements `buildGuardianInstruction` — no `buildShareLink` or
- * `extractInboundToken` needed.
+ * Resolves the assistant's email address for invite instructions. Email
+ * invites use the universal 6-digit code path for redemption, so this
+ * adapter only implements `resolveChannelHandle` — no `buildShareLink`
+ * or `extractInboundToken` needed.
  */
 
-import type {
-  ChannelInviteAdapter,
-  GuardianInstruction,
-} from "../channel-invite-transport.js";
+import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
 
 // ---------------------------------------------------------------------------
 // Email address resolution
@@ -30,23 +27,6 @@ function resolveAssistantEmailAddress(): string | undefined {
 
 export const emailInviteAdapter: ChannelInviteAdapter = {
   channel: "email",
-
-  buildGuardianInstruction(params: {
-    inviteCode: string;
-    contactName?: string;
-  }): GuardianInstruction {
-    const address = resolveAssistantEmailAddress();
-    const contactLabel = params.contactName || "the contact";
-    if (!address) {
-      return {
-        instruction: `Tell ${contactLabel} to email the assistant and include the code ${params.inviteCode} in the message.`,
-      };
-    }
-    return {
-      instruction: `Tell ${contactLabel} to email ${address} and include the code ${params.inviteCode} in the message.`,
-      channelHandle: address,
-    };
-  },
 
   resolveChannelHandle(): string | undefined {
     return resolveAssistantEmailAddress();

--- a/assistant/src/runtime/channel-invite-transports/slack.ts
+++ b/assistant/src/runtime/channel-invite-transports/slack.ts
@@ -1,19 +1,15 @@
 /**
  * Slack channel invite adapter.
  *
- * Provides guardian instruction text that includes the assistant's Slack
- * bot @username and workspace name when available. Slack invites use the
- * universal 6-digit code path for redemption, so this adapter only
- * implements `buildGuardianInstruction` — no `buildShareLink` or
- * `extractInboundToken` needed.
+ * Resolves the assistant's Slack bot @username for invite instructions.
+ * Slack invites use the universal 6-digit code path for redemption, so
+ * this adapter only implements `resolveChannelHandle` — no
+ * `buildShareLink` or `extractInboundToken` needed.
  */
 
 import type { ChannelId } from "../../channels/types.js";
 import { getCredentialMetadata } from "../../tools/credentials/metadata-store.js";
-import type {
-  ChannelInviteAdapter,
-  GuardianInstruction,
-} from "../channel-invite-transport.js";
+import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
 
 // ---------------------------------------------------------------------------
 // Slack bot info resolution
@@ -53,31 +49,6 @@ function resolveSlackBotInfo(): SlackBotInfo | undefined {
 
 export const slackInviteAdapter: ChannelInviteAdapter = {
   channel: "slack" as ChannelId,
-
-  buildGuardianInstruction(params: {
-    inviteCode: string;
-    contactName?: string;
-  }): GuardianInstruction {
-    const botInfo = resolveSlackBotInfo();
-    const contactLabel = params.contactName || "the contact";
-
-    if (!botInfo) {
-      return {
-        instruction: `Tell ${contactLabel} to message the assistant on Slack and provide the code ${params.inviteCode}.`,
-      };
-    }
-
-    let instruction = `Tell ${contactLabel} to message @${botInfo.botUsername} on Slack and provide the code ${params.inviteCode}`;
-    if (botInfo.teamName) {
-      instruction += ` (workspace: ${botInfo.teamName})`;
-    }
-    instruction += ".";
-
-    return {
-      instruction,
-      channelHandle: `@${botInfo.botUsername}`,
-    };
-  },
 
   resolveChannelHandle(): string | undefined {
     const botInfo = resolveSlackBotInfo();

--- a/assistant/src/runtime/channel-invite-transports/sms.ts
+++ b/assistant/src/runtime/channel-invite-transports/sms.ts
@@ -1,20 +1,17 @@
 /**
  * SMS channel invite adapter.
  *
- * Provides guardian instruction text that includes the assistant's Twilio
- * phone number. SMS invites use the universal 6-digit code path for
- * redemption, so this adapter only implements `buildGuardianInstruction` —
- * no `buildShareLink` or `extractInboundToken` needed.
+ * Resolves the assistant's Twilio phone number for invite instructions.
+ * SMS invites use the universal 6-digit code path for redemption, so
+ * this adapter only implements `resolveChannelHandle` — no
+ * `buildShareLink` or `extractInboundToken` needed.
  */
 
 import type { ChannelId } from "../../channels/types.js";
 import { getTwilioPhoneNumberEnv } from "../../config/env.js";
 import { loadRawConfig } from "../../config/loader.js";
 import { getSecureKey } from "../../security/secure-keys.js";
-import type {
-  ChannelInviteAdapter,
-  GuardianInstruction,
-} from "../channel-invite-transport.js";
+import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
 
 // ---------------------------------------------------------------------------
 // Phone number resolution
@@ -50,23 +47,6 @@ function resolveSmsPhoneNumber(): string | undefined {
 
 export const smsInviteAdapter: ChannelInviteAdapter = {
   channel: "sms" as ChannelId,
-
-  buildGuardianInstruction(params: {
-    inviteCode: string;
-    contactName?: string;
-  }): GuardianInstruction {
-    const phoneNumber = resolveSmsPhoneNumber();
-    const contactLabel = params.contactName || "the contact";
-    if (!phoneNumber) {
-      return {
-        instruction: `Tell ${contactLabel} to text the assistant and provide the code ${params.inviteCode}.`,
-      };
-    }
-    return {
-      instruction: `Tell ${contactLabel} to text ${phoneNumber} and provide the code ${params.inviteCode}.`,
-      channelHandle: phoneNumber,
-    };
-  },
 
   resolveChannelHandle(): string | undefined {
     return resolveSmsPhoneNumber();

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -12,7 +12,6 @@ import type { ChannelId } from "../../channels/types.js";
 import { getCredentialMetadata } from "../../tools/credentials/metadata-store.js";
 import type {
   ChannelInviteAdapter,
-  GuardianInstruction,
   InviteShareLink,
 } from "../channel-invite-transport.js";
 
@@ -65,23 +64,6 @@ export const telegramInviteAdapter: ChannelInviteAdapter = {
     return {
       url,
       displayText: `Open in Telegram: ${url}`,
-    };
-  },
-
-  buildGuardianInstruction(params: {
-    inviteCode: string;
-    contactName?: string;
-  }): GuardianInstruction {
-    const botUsername = getTelegramBotUsername();
-    const contactLabel = params.contactName || "the contact";
-    if (!botUsername) {
-      return {
-        instruction: `Tell ${contactLabel} to message the assistant on Telegram and provide the code ${params.inviteCode}.`,
-      };
-    }
-    return {
-      instruction: `Tell ${contactLabel} to message @${botUsername} on Telegram and provide the code ${params.inviteCode}.`,
-      channelHandle: `@${botUsername}`,
     };
   },
 

--- a/assistant/src/runtime/invite-instruction-generator.ts
+++ b/assistant/src/runtime/invite-instruction-generator.ts
@@ -1,0 +1,147 @@
+/**
+ * Generative invite instructions for guardian-mediated channel invites.
+ *
+ * Uses the configured provider to generate natural, varied instructions
+ * for guardians who need to help a contact message the assistant.
+ * Falls back to a deterministic template when the provider is unavailable
+ * or generation fails/times out.
+ */
+
+import {
+  createTimeout,
+  extractText,
+  resolveConfiguredProvider,
+  userMessage,
+} from "../providers/provider-send-message.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("invite-instruction-generator");
+const GENERATION_TIMEOUT_MS = 5_000;
+
+export interface GeneratedInviteInstruction {
+  instruction: string;
+}
+
+/**
+ * Build a deterministic fallback instruction when LLM generation
+ * is unavailable or fails.
+ */
+export function buildFallbackInstruction(params: {
+  contactName?: string;
+  channelLabel: string;
+  channelHandle?: string;
+  inviteCode: string;
+  shareUrl?: string;
+}): string {
+  const contact = params.contactName || "the contact";
+  const handle = params.channelHandle
+    ? ` at ${params.channelHandle}`
+    : ` on ${params.channelLabel}`;
+
+  if (params.shareUrl) {
+    return `Send ${contact} this link: ${params.shareUrl} — or tell them to message me${handle} with the code below.`;
+  }
+  return `Tell ${contact} to message me${handle} with the code below.`;
+}
+
+/**
+ * Generate a natural-language invite instruction via the configured LLM.
+ * Falls back to a static template on failure/timeout.
+ */
+export async function generateInviteInstruction(params: {
+  contactName?: string;
+  channelType: string;
+  channelHandle?: string;
+  inviteCode: string;
+  shareUrl?: string;
+}): Promise<string> {
+  const channelLabel = channelDisplayLabel(params.channelType);
+  const fallback = buildFallbackInstruction({
+    ...params,
+    channelLabel,
+  });
+
+  const resolved = resolveConfiguredProvider();
+  if (!resolved) {
+    return fallback;
+  }
+
+  const { signal, cleanup } = createTimeout(GENERATION_TIMEOUT_MS);
+
+  try {
+    const contactName = params.contactName || "the contact";
+    const promptParts = [
+      "Generate a short, natural instruction for a guardian who needs to invite someone to message an AI assistant.",
+      "",
+      `Contact name: ${contactName}`,
+      `Channel: ${channelLabel}`,
+    ];
+
+    if (params.channelHandle) {
+      promptParts.push(
+        `Assistant's handle on this channel: ${params.channelHandle}`,
+      );
+    }
+
+    if (params.shareUrl) {
+      promptParts.push(`Invite link: ${params.shareUrl}`);
+    }
+
+    promptParts.push(
+      "",
+      "Requirements:",
+      "- Speak from the assistant's perspective — use 'me' and 'I' (e.g., 'tell them to message me').",
+      "- Do NOT include the invite code in the instruction — the code is displayed separately below.",
+      "- Instead, reference 'the code below' or 'the code shown below'.",
+      params.shareUrl
+        ? "- Lead with the invite link as the primary action. Mention the code as a fallback/alternative."
+        : "- Tell the guardian to instruct the contact to message the assistant on this channel with the code.",
+      "- Keep it to 1-2 sentences, conversational and clear.",
+      "- Do NOT use quotes or markdown formatting.",
+      "",
+      "Respond with ONLY the instruction text, nothing else.",
+    );
+
+    const response = await resolved.provider.sendMessage(
+      [userMessage(promptParts.join("\n"))],
+      undefined,
+      undefined,
+      { signal, config: { modelIntent: "latency-optimized" } },
+    );
+
+    const text = extractText(response)?.trim();
+    if (text && text.length > 0 && text.length < 500) {
+      return text;
+    }
+
+    log.warn(
+      { raw: text },
+      "Generated instruction failed validation, using fallback",
+    );
+    return fallback;
+  } catch (err) {
+    if (signal.aborted) {
+      log.warn("Invite instruction generation timed out, using fallback");
+    } else {
+      log.warn({ err }, "Invite instruction generation failed, using fallback");
+    }
+    return fallback;
+  } finally {
+    cleanup();
+  }
+}
+
+function channelDisplayLabel(type: string): string {
+  switch (type) {
+    case "telegram":
+      return "Telegram";
+    case "sms":
+      return "SMS";
+    case "email":
+      return "Email";
+    case "slack":
+      return "Slack";
+    default:
+      return type;
+  }
+}

--- a/assistant/src/runtime/invite-instruction-generator.ts
+++ b/assistant/src/runtime/invite-instruction-generator.ts
@@ -30,7 +30,6 @@ export function buildFallbackInstruction(params: {
   contactName?: string;
   channelLabel: string;
   channelHandle?: string;
-  inviteCode: string;
   shareUrl?: string;
 }): string {
   const contact = params.contactName || "the contact";
@@ -52,7 +51,6 @@ export async function generateInviteInstruction(params: {
   contactName?: string;
   channelType: string;
   channelHandle?: string;
-  inviteCode: string;
   shareUrl?: string;
 }): Promise<string> {
   const channelLabel = channelDisplayLabel(params.channelType);
@@ -141,7 +139,9 @@ function channelDisplayLabel(type: string): string {
       return "Email";
     case "slack":
       return "Slack";
+    case "voice":
+      return "Voice";
     default:
-      return type;
+      return type.charAt(0).toUpperCase() + type.slice(1);
   }
 }

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -240,7 +240,6 @@ export async function createIngressInvite(params: {
       contactName: params.contactName,
       channelType: params.sourceChannel,
       channelHandle,
-      inviteCode,
       shareUrl: share?.url,
     });
   }

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -26,6 +26,7 @@ import {
 import { isValidE164 } from "../util/phone.js";
 import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
 import { getInviteAdapterRegistry } from "./channel-invite-transport.js";
+import { generateInviteInstruction } from "./invite-instruction-generator.js";
 import {
   type InviteRedemptionOutcome,
   redeemInvite as redeemInviteTyped,
@@ -140,7 +141,7 @@ export type IngressResult<T> =
 // Invite operations
 // ---------------------------------------------------------------------------
 
-export function createIngressInvite(params: {
+export async function createIngressInvite(params: {
   sourceChannel?: string;
   note?: string;
   maxUses?: number;
@@ -152,7 +153,7 @@ export function createIngressInvite(params: {
   voiceCodeDigits?: number;
   friendName?: string;
   guardianName?: string;
-}): IngressResult<InviteResponseData> {
+}): Promise<IngressResult<InviteResponseData>> {
   if (!params.sourceChannel) {
     return { ok: false, error: "sourceChannel is required for create" };
   }
@@ -230,27 +231,18 @@ export function createIngressInvite(params: {
     const adapter = channelId
       ? getInviteAdapterRegistry().get(channelId)
       : undefined;
+    channelHandle = adapter?.resolveChannelHandle?.();
 
-    if (adapter?.buildGuardianInstruction) {
-      try {
-        const adapterResult = adapter.buildGuardianInstruction({
-          inviteCode,
-          contactName: params.contactName,
-        });
-        if (adapterResult) {
-          guardianInstruction = adapterResult.instruction;
-          channelHandle = adapterResult.channelHandle;
-        }
-      } catch {
-        // Fall through to generic instruction if adapter fails
-      }
-    }
+    // Build share URL if adapter supports it
+    const share = buildSharePayload(params.sourceChannel, rawToken);
 
-    if (!guardianInstruction) {
-      const contactLabel = params.contactName || "the contact";
-      const channelLabel = params.sourceChannel;
-      guardianInstruction = `Tell ${contactLabel} to contact the assistant on ${channelLabel} and provide the code ${inviteCode}.`;
-    }
+    guardianInstruction = await generateInviteInstruction({
+      contactName: params.contactName,
+      channelType: params.sourceChannel,
+      channelHandle,
+      inviteCode,
+      shareUrl: share?.url,
+    });
   }
 
   // Voice invites must not expose the token — callers must redeem via the

--- a/assistant/src/runtime/routes/invite-routes.ts
+++ b/assistant/src/runtime/routes/invite-routes.ts
@@ -47,7 +47,7 @@ export function handleListInvites(url: URL): Response {
 export async function handleCreateInvite(req: Request): Promise<Response> {
   const body = (await req.json()) as Record<string, unknown>;
 
-  const result = createIngressInvite({
+  const result = await createIngressInvite({
     sourceChannel: body.sourceChannel as string | undefined,
     note: body.note as string | undefined,
     maxUses: body.maxUses as number | undefined,

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -914,12 +914,14 @@ public struct IPCContactsInviteRequest: Codable, Sendable {
     public let externalChatId: String?
     /// Filter by status (list only).
     public let status: String?
+    /// Contact display name for personalizing invite instructions (create only).
+    public let contactName: String?
     /// Invitee's first name (voice invite create only).
     public let friendName: String?
     /// Guardian's first name (voice invite create only).
     public let guardianName: String?
 
-    public init(type: String, action: String, sourceChannel: String? = nil, note: String? = nil, maxUses: Double? = nil, expiresInMs: Double? = nil, inviteId: String? = nil, token: String? = nil, externalUserId: String? = nil, externalChatId: String? = nil, status: String? = nil, friendName: String? = nil, guardianName: String? = nil) {
+    public init(type: String, action: String, sourceChannel: String? = nil, note: String? = nil, maxUses: Double? = nil, expiresInMs: Double? = nil, inviteId: String? = nil, token: String? = nil, externalUserId: String? = nil, externalChatId: String? = nil, status: String? = nil, contactName: String? = nil, friendName: String? = nil, guardianName: String? = nil) {
         self.type = type
         self.action = action
         self.sourceChannel = sourceChannel
@@ -931,6 +933,7 @@ public struct IPCContactsInviteRequest: Codable, Sendable {
         self.externalUserId = externalUserId
         self.externalChatId = externalChatId
         self.status = status
+        self.contactName = contactName
         self.friendName = friendName
         self.guardianName = guardianName
     }


### PR DESCRIPTION
## Summary
- Creates `invite-instruction-generator.ts` following the `guardian-question-copy.ts` pattern: 5s timeout, latency-optimized model, deterministic fallback
- Instructions use first-person ("message me") instead of third-person ("message the assistant")
- Invite code is NOT embedded in the instruction text (displayed separately in UI)
- When a share URL exists, the instruction leads with the link
- `createIngressInvite` is now async; both the HTTP route and IPC handler callers await it

## Test plan
- [ ] Click "Invite" on a configured channel and verify instruction text is natural/varied and uses first-person
- [ ] For Telegram, verify the instruction mentions the invite link prominently
- [ ] Check that the invite code is NOT embedded in the instruction text
- [ ] Kill the LLM provider and verify fallback instructions still work
- [ ] Verify 5-second timeout works (instruction falls back gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
