### PR TITLE
Update invite result display to complement LLM-generated instructions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -378,6 +378,8 @@ struct ContactDetailView: View {
 
         if let inviteCode = result.inviteCode {
             VStack(alignment: .leading, spacing: VSpacing.sm) {
+                // Instruction text (LLM-generated or fallback) — already
+                // references the share URL and channel handle naturally.
                 if let instruction = result.guardianInstruction {
                     Text(instruction)
                         .font(VFont.body)
@@ -385,13 +387,7 @@ struct ContactDetailView: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
-                if let channelHandle = result.channelHandle {
-                    Text(channelHandle)
-                        .font(VFont.monoSmall)
-                        .foregroundColor(VColor.textMuted)
-                }
-
-                // When a share URL is available, show it prominently above the code
+                // Copyable share link when present
                 if let shareUrl = result.shareUrl {
                     HStack(spacing: VSpacing.sm) {
                         let truncated = shareUrl.count > 30
@@ -419,12 +415,6 @@ struct ContactDetailView: View {
                             }
                         }
                     }
-
-                    Divider().background(VColor.divider)
-
-                    Text("Or use this code:")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
                 }
 
                 // Large monospaced invite code for readability


### PR DESCRIPTION
## Summary
- Instruction text displays at the top of the invite result (it naturally references the share URL and channel handle)
- Removes separate `channelHandle` display line (embedded in the LLM instruction)
- Removes "Or use this code:" separator (the instruction already frames the code as primary or fallback)
- Share URL (when present) is shown as a copyable link below the instruction
- Invite code is always shown with large monospaced font and "Copy Code" button

## Depends on
- #13067 (LLM-generated instructions)

## Test plan
- [ ] Verify instruction text appears at the top of the invite result
- [ ] For Telegram (link-having channel), verify share URL is shown as copyable link below instruction
- [ ] For SMS/Email/Slack (code-only channels), verify layout works well without share URL
- [ ] Verify invite code is always shown prominently with "Copy Code" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
