### PR TITLE
feat: drop assistant_id columns from all daemon SQLite tables

### DIFF
--- a/.githooks/.githooks
+++ b/.githooks/.githooks
@@ -1,0 +1,1 @@
+/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.githooks

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -886,7 +886,7 @@ describe("verification rate limiting store", () => {
     );
     expect(rl.invalidAttempts).toBe(1);
     expect(rl.lockedUntil).toBeNull();
-    expect(rl.assistantId).toBe("self");
+    // assistantId column has been removed; no longer asserted
     expect(rl.channel).toBe("telegram");
     expect(rl.actorExternalUserId).toBe("user-42");
   });
@@ -3742,7 +3742,6 @@ describe("outbound voice verification", () => {
       db.insert(channelGuardianVerificationChallenges)
         .values({
           id: `rate-limit-voice-${i}`,
-          assistantId: "self",
           channel: "voice",
           challengeHash: `hash-${i}`,
           expiresAt: now + 600_000,

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -817,8 +817,8 @@ describe("twilio webhook routes", () => {
       expect(res.status).toBe(200);
       const session = getCallSessionByCallSid("CA_inbound_assist_1");
       expect(session).not.toBeNull();
-      // Daemon always uses internal scope — external assistant IDs are not leaked into session state.
-      expect(session!.assistantId).toBe("self");
+      // Session was created for the inbound call.
+      expect(session!.status).toBe("initiated");
     });
 
     test("outbound call flow remains non-regressed with callSessionId present", async () => {

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -7,7 +7,6 @@ import {
   callPendingQuestions,
   callSessions,
 } from "../memory/schema.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import { cast, createRowMapper } from "../util/row-mapper.js";
 import { validateTransition } from "./call-state-machine.js";
@@ -39,7 +38,6 @@ const parseCallSession = createRowMapper<
   guardianVerificationSessionId: "guardianVerificationSessionId",
   callerIdentityMode: "callerIdentityMode",
   callerIdentitySource: "callerIdentitySource",
-  assistantId: "assistantId",
   initiatedFromConversationId: "initiatedFromConversationId",
   startedAt: "startedAt",
   endedAt: "endedAt",
@@ -101,7 +99,6 @@ export function createCallSession(opts: {
     guardianVerificationSessionId: opts.guardianVerificationSessionId ?? null,
     callerIdentityMode: opts.callerIdentityMode ?? null,
     callerIdentitySource: opts.callerIdentitySource ?? null,
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     initiatedFromConversationId: opts.initiatedFromConversationId ?? null,
     startedAt: null,
     endedAt: null,

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -197,7 +197,6 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
 
     return buildVoiceWebhookTwiml(
       session.id,
-      session.assistantId ?? undefined,
       session.task,
       session.guardianVerificationSessionId,
     );
@@ -226,7 +225,6 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
 
   return buildVoiceWebhookTwiml(
     callSessionId,
-    session.assistantId ?? undefined,
     session.task,
     session.guardianVerificationSessionId,
   );
@@ -244,7 +242,6 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
  */
 function buildVoiceWebhookTwiml(
   callSessionId: string,
-  assistantId: string | undefined,
   task: string | null,
   guardianVerificationSessionId?: string | null,
 ): Response {

--- a/assistant/src/calls/types.ts
+++ b/assistant/src/calls/types.ts
@@ -73,7 +73,6 @@ export interface CallSession {
   guardianVerificationSessionId: string | null;
   callerIdentityMode: string | null;
   callerIdentitySource: string | null;
-  assistantId: string | null;
   initiatedFromConversationId?: string | null;
   startedAt: number | null;
   endedAt: number | null;

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, isNull, like, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, like, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../memory/db.js";
@@ -8,7 +8,6 @@ import {
   contactChannels,
   contacts,
 } from "../memory/schema.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { emitContactChange } from "./contact-events.js";
 import type {
   AssistantContactMetadata,
@@ -105,7 +104,7 @@ interface SyncChannelData {
 
 // ── CRUD ─────────────────────────────────────────────────────────────
 
-/** Retrieve a contact by ID without assistantId scoping.
+/** Retrieve a contact by ID.
  * Used by functions that have already resolved identity through channel lookups. */
 export function getContactInternal(id: string): ContactWithChannels | null {
   const db = getDb();
@@ -116,19 +115,7 @@ export function getContactInternal(id: string): ContactWithChannels | null {
 
 export function getContact(id: string): ContactWithChannels | null {
   const db = getDb();
-  const row = db
-    .select()
-    .from(contacts)
-    .where(
-      and(
-        eq(contacts.id, id),
-        or(
-          eq(contacts.assistantId, DAEMON_INTERNAL_ASSISTANT_ID),
-          isNull(contacts.assistantId),
-        ),
-      ),
-    )
-    .get();
+  const row = db.select().from(contacts).where(eq(contacts.id, id)).get();
   if (!row) return null;
   return withChannels(parseContact(row));
 }
@@ -267,7 +254,6 @@ export function upsertContact(params: {
       role: params.role ?? "contact",
       contactType: params.contactType ?? "human",
       principalId: params.principalId ?? null,
-      assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
       createdAt: now,
       updatedAt: now,
     })
@@ -420,20 +406,10 @@ export function searchContacts(params: {
       .where(
         params.channelType
           ? and(
-              or(
-                eq(contacts.assistantId, DAEMON_INTERNAL_ASSISTANT_ID),
-                isNull(contacts.assistantId),
-              ),
               eq(contactChannels.type, params.channelType),
               like(contactChannels.address, `%${normalizedAddress}%`),
             )
-          : and(
-              or(
-                eq(contacts.assistantId, DAEMON_INTERNAL_ASSISTANT_ID),
-                isNull(contacts.assistantId),
-              ),
-              like(contactChannels.address, `%${normalizedAddress}%`),
-            ),
+          : and(like(contactChannels.address, `%${normalizedAddress}%`)),
       )
       .all();
 
@@ -461,15 +437,7 @@ export function searchContacts(params: {
       .select({ contactId: contactChannels.contactId })
       .from(contactChannels)
       .innerJoin(contacts, eq(contactChannels.contactId, contacts.id))
-      .where(
-        and(
-          or(
-            eq(contacts.assistantId, DAEMON_INTERNAL_ASSISTANT_ID),
-            isNull(contacts.assistantId),
-          ),
-          eq(contactChannels.type, params.channelType),
-        ),
-      )
+      .where(eq(contactChannels.type, params.channelType))
       .all();
 
     const contactIds = [...new Set(channelRows.map((r) => r.contactId))];
@@ -491,12 +459,7 @@ export function searchContacts(params: {
   }
 
   // Search by display name, optionally filtered by channelType
-  const conditions = [
-    or(
-      eq(contacts.assistantId, DAEMON_INTERNAL_ASSISTANT_ID),
-      isNull(contacts.assistantId),
-    )!,
-  ];
+  const conditions = [];
   if (params.query) {
     const sanitized = escapeLike(params.query);
     if (!sanitized && !params.role && !params.contactType) return [];
@@ -561,12 +524,7 @@ export function listContacts(
 ): ContactWithChannels[] {
   const db = getDb();
   const effectiveLimit = opts?.uncapped ? limit : Math.min(limit, 200);
-  const conditions = [
-    or(
-      eq(contacts.assistantId, DAEMON_INTERNAL_ASSISTANT_ID),
-      isNull(contacts.assistantId),
-    )!,
-  ];
+  const conditions = [];
   if (role) conditions.push(eq(contacts.role, role));
   if (contactType) conditions.push(eq(contacts.contactType, contactType));
   const rows = db
@@ -602,30 +560,14 @@ export function mergeContacts(
     const keep = tx
       .select()
       .from(contacts)
-      .where(
-        and(
-          eq(contacts.id, keepId),
-          or(
-            eq(contacts.assistantId, DAEMON_INTERNAL_ASSISTANT_ID),
-            isNull(contacts.assistantId),
-          ),
-        ),
-      )
+      .where(eq(contacts.id, keepId))
       .get();
     if (!keep) throw new Error(`Contact "${keepId}" not found`);
 
     const merge = tx
       .select()
       .from(contacts)
-      .where(
-        and(
-          eq(contacts.id, mergeId),
-          or(
-            eq(contacts.assistantId, DAEMON_INTERNAL_ASSISTANT_ID),
-            isNull(contacts.assistantId),
-          ),
-        ),
-      )
+      .where(eq(contacts.id, mergeId))
       .get();
     if (!merge) throw new Error(`Contact "${mergeId}" not found`);
 
@@ -641,10 +583,6 @@ export function mergeContacts(
         lastInteraction: mergedLastInteraction,
         notes: [keep.notes, merge.notes].filter(Boolean).join("\n") || null,
         updatedAt: now,
-        // Rebind legacy null-scoped contacts to DAEMON_INTERNAL_ASSISTANT_ID
-        ...(keep.assistantId == null
-          ? { assistantId: DAEMON_INTERNAL_ASSISTANT_ID }
-          : {}),
       })
       .where(eq(contacts.id, keepId))
       .run();
@@ -808,7 +746,6 @@ export function findGuardianForChannel(
     eq(contacts.role, "guardian"),
     eq(contactChannels.type, channelType),
     eq(contactChannels.status, "active"),
-    eq(contacts.assistantId, DAEMON_INTERNAL_ASSISTANT_ID),
   ];
   const rows = db
     .select({
@@ -843,7 +780,6 @@ export function revokeGuardianChannel(channelType: string): boolean {
     eq(contacts.role, "guardian"),
     eq(contactChannels.type, channelType),
     eq(contactChannels.status, "active"),
-    eq(contacts.assistantId, DAEMON_INTERNAL_ASSISTANT_ID),
   ];
   const rows = db
     .select({
@@ -891,11 +827,7 @@ export function listGuardianChannels(): {
     .from(contacts)
     .innerJoin(contactChannels, eq(contacts.id, contactChannels.contactId))
     .where(
-      and(
-        eq(contacts.role, "guardian"),
-        eq(contactChannels.status, "active"),
-        eq(contacts.assistantId, DAEMON_INTERNAL_ASSISTANT_ID),
-      ),
+      and(eq(contacts.role, "guardian"), eq(contactChannels.status, "active")),
     )
     .orderBy(desc(contactChannels.verifiedAt))
     .all();

--- a/assistant/src/memory/conversation-attention-store.ts
+++ b/assistant/src/memory/conversation-attention-store.ts
@@ -9,7 +9,6 @@
 import { and, desc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getDb } from "./db.js";
 import {
   conversationAssistantAttentionState,
@@ -79,10 +78,7 @@ function rowToEvent(
 }
 
 function rowToState(
-  row: Omit<
-    typeof conversationAssistantAttentionState.$inferSelect,
-    "assistantId"
-  >,
+  row: typeof conversationAssistantAttentionState.$inferSelect,
 ): AttentionState {
   return {
     conversationId: row.conversationId,
@@ -128,7 +124,6 @@ export function projectAssistantMessage(params: {
     db.insert(conversationAssistantAttentionState)
       .values({
         conversationId,
-        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
         latestAssistantMessageId: messageId,
         latestAssistantMessageAt: messageAt,
         lastSeenAssistantMessageId: null,
@@ -202,7 +197,6 @@ export function recordConversationSeenSignal(params: {
   const event: typeof conversationAttentionEvents.$inferInsert = {
     id: eventId,
     conversationId,
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     sourceChannel,
     signalType,
     confidence,
@@ -249,7 +243,6 @@ export function recordConversationSeenSignal(params: {
       tx.insert(conversationAssistantAttentionState)
         .values({
           conversationId,
-          assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
           latestAssistantMessageId: latestMsgId,
           latestAssistantMessageAt: latestMsgAt,
           lastSeenAssistantMessageId: latestMsgId,

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -36,6 +36,7 @@ import {
   migrateBackfillContactInteractionStats,
   migrateBackfillGuardianPrincipalId,
   migrateCallSessionMode,
+  migrateDropAssistantIdColumns,
   migrateCanonicalGuardianDeliveriesDestinationIndex,
   migrateCanonicalGuardianRequesterChatId,
   migrateChannelInboundDeliveredSegments,
@@ -288,6 +289,9 @@ export function initializeDb(): void {
 
   // 39. Backfill contact interaction stats from channel lastSeenAt
   migrateBackfillContactInteractionStats(database);
+
+  // 40. Drop assistant_id columns from all 16 daemon tables
+  migrateDropAssistantIdColumns(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -10,7 +10,6 @@
 import { and, desc, eq, inArray, lt } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import { getDb, rawChanges } from "./db.js";
 import { guardianActionDeliveries, guardianActionRequests } from "./schema.js";
@@ -179,7 +178,6 @@ export function createGuardianActionRequest(params: {
 
   const row = {
     id,
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     kind: params.kind,
     sourceChannel: params.sourceChannel,
     sourceConversationId: params.sourceConversationId,

--- a/assistant/src/memory/guardian-approvals.ts
+++ b/assistant/src/memory/guardian-approvals.ts
@@ -9,7 +9,6 @@
 import { and, count, desc, eq, gt, lte } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getDb } from "./db.js";
 import { channelGuardianApprovalRequests } from "./schema.js";
 
@@ -105,7 +104,6 @@ export function createApprovalRequest(params: {
     runId: params.runId,
     requestId: params.requestId ?? null,
     conversationId: params.conversationId,
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     channel: params.channel,
     requesterExternalUserId: params.requesterExternalUserId,
     requesterChatId: params.requesterChatId,

--- a/assistant/src/memory/guardian-rate-limits.ts
+++ b/assistant/src/memory/guardian-rate-limits.ts
@@ -8,7 +8,6 @@
 import { and, eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getDb } from "./db.js";
 import { channelGuardianRateLimits } from "./schema.js";
 
@@ -18,7 +17,6 @@ import { channelGuardianRateLimits } from "./schema.js";
 
 export interface VerificationRateLimit {
   id: string;
-  assistantId: string;
   channel: string;
   actorExternalUserId: string;
   actorChatId: string;
@@ -50,7 +48,6 @@ function rowToRateLimit(
   const timestamps = parseTimestamps(row.attemptTimestampsJson);
   return {
     id: row.id,
-    assistantId: row.assistantId,
     channel: row.channel,
     actorExternalUserId: row.actorExternalUserId,
     actorChatId: row.actorChatId,
@@ -151,7 +148,6 @@ export function recordInvalidAttempt(
   const lockedUntil = 1 >= maxAttempts ? now + lockoutMs : null;
   const row = {
     id,
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     channel,
     actorExternalUserId,
     actorChatId,

--- a/assistant/src/memory/guardian-verification.ts
+++ b/assistant/src/memory/guardian-verification.ts
@@ -8,7 +8,6 @@
 
 import { and, count, desc, eq, gt, gte, inArray, or } from "drizzle-orm";
 
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getDb } from "./db.js";
 import { channelGuardianVerificationChallenges } from "./schema.js";
 
@@ -31,7 +30,6 @@ export type VerificationPurpose = "guardian" | "trusted_contact";
 
 export interface VerificationChallenge {
   id: string;
-  assistantId: string;
   channel: string;
   challengeHash: string;
   expiresAt: number;
@@ -69,7 +67,6 @@ function rowToChallenge(
 ): VerificationChallenge {
   return {
     id: row.id,
-    assistantId: row.assistantId,
     channel: row.channel,
     challengeHash: row.challengeHash,
     expiresAt: row.expiresAt,
@@ -124,7 +121,6 @@ export function createChallenge(params: {
 
   const row = {
     id: params.id,
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     channel: params.channel,
     challengeHash: params.challengeHash,
     expiresAt: params.expiresAt,
@@ -288,7 +284,6 @@ export function createVerificationSession(params: {
 
   const row = {
     id: params.id,
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     channel: params.channel,
     challengeHash: params.challengeHash,
     expiresAt: params.expiresAt,

--- a/assistant/src/memory/invite-store.ts
+++ b/assistant/src/memory/invite-store.ts
@@ -10,7 +10,6 @@ import { createHash, randomBytes, randomUUID } from "node:crypto";
 
 import { and, desc, eq, gt } from "drizzle-orm";
 
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getDb } from "./db.js";
 import { assistantIngressInvites } from "./schema.js";
 
@@ -119,7 +118,6 @@ export function createInvite(params: {
 
   const row = {
     id,
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     sourceChannel: params.sourceChannel,
     tokenHash: tokenH,
     createdBySessionId: params.createdBySessionId ?? null,
@@ -158,9 +156,8 @@ export function listInvites(params: {
 }): IngressInvite[] {
   const db = getDb();
 
-  const conditions = [
-    eq(assistantIngressInvites.assistantId, DAEMON_INTERNAL_ASSISTANT_ID),
-  ];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const conditions: any[] = [];
 
   if (params.sourceChannel) {
     conditions.push(
@@ -171,10 +168,9 @@ export function listInvites(params: {
     conditions.push(eq(assistantIngressInvites.status, params.status));
   }
 
-  const rows = db
-    .select()
-    .from(assistantIngressInvites)
-    .where(and(...conditions))
+  const query = db.select().from(assistantIngressInvites);
+
+  const rows = (conditions.length > 0 ? query.where(and(...conditions)) : query)
     .orderBy(desc(assistantIngressInvites.createdAt))
     .limit(params.limit ?? 100)
     .offset(params.offset ?? 0)
@@ -335,7 +331,6 @@ export function findActiveVoiceInvites(params: {
     .from(assistantIngressInvites)
     .where(
       and(
-        eq(assistantIngressInvites.assistantId, DAEMON_INTERNAL_ASSISTANT_ID),
         eq(assistantIngressInvites.sourceChannel, "voice"),
         eq(assistantIngressInvites.status, "active"),
         eq(

--- a/assistant/src/memory/migrations/136-drop-assistant-id-columns.ts
+++ b/assistant/src/memory/migrations/136-drop-assistant-id-columns.ts
@@ -1,0 +1,135 @@
+import { getLogger } from "../../util/logger.js";
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const log = getLogger("migration-136");
+
+/**
+ * Drop `assistant_id` columns from all 16 daemon tables that carried the
+ * per-assistant scoping column. After wave-1 PRs normalised every value to
+ * 'self' (the implicit single-tenant identity), the column is dead weight.
+ *
+ * Steps:
+ *  1. Safety assertion: verify all rows are 'self' or NULL.
+ *  2. Drop composite indexes that include `assistant_id`.
+ *  3. `ALTER TABLE ... DROP COLUMN assistant_id` for each table.
+ *  4. Recreate indexes without the `assistant_id` column.
+ */
+export function migrateDropAssistantIdColumns(database: DrizzleDb): void {
+  withCrashRecovery(database, "migration_drop_assistant_id_columns_v1", () => {
+    const raw = getSqliteFrom(database);
+
+    // The 16 tables that carry assistant_id.
+    const tables = [
+      "contacts",
+      "assistant_ingress_invites",
+      "assistant_inbox_thread_state",
+      "call_sessions",
+      "channel_guardian_verification_challenges",
+      "channel_guardian_approval_requests",
+      "channel_guardian_rate_limits",
+      "guardian_action_requests",
+      "scoped_approval_grants",
+      "notification_events",
+      "notification_preferences",
+      "notification_deliveries",
+      "conversation_attention_events",
+      "conversation_assistant_attention_state",
+      "actor_token_records",
+      "actor_refresh_token_records",
+    ];
+
+    // --- Safety assertion ---
+    // Verify all existing assistant_id values are 'self' or NULL before dropping.
+    for (const table of tables) {
+      const cols = new Set(
+        (
+          raw.query(`PRAGMA table_info(${table})`).all() as Array<{
+            name: string;
+          }>
+        ).map((c) => c.name),
+      );
+
+      if (!cols.has("assistant_id")) {
+        log.info(
+          { table },
+          "Table does not have assistant_id column — skipping",
+        );
+        continue;
+      }
+
+      const unexpected = raw
+        .query(
+          `SELECT DISTINCT assistant_id FROM ${table} WHERE assistant_id IS NOT NULL AND assistant_id != 'self'`,
+        )
+        .all() as Array<{ assistant_id: string }>;
+
+      if (unexpected.length > 0) {
+        log.warn(
+          { table, values: unexpected.map((r) => r.assistant_id) },
+          "Unexpected assistant_id values found — skipping table",
+        );
+        continue;
+      }
+    }
+
+    // --- Drop indexes that include assistant_id ---
+    // conversation_attention_events indexes
+    raw.exec(
+      /*sql*/ `DROP INDEX IF EXISTS idx_conv_attn_events_assistant_observed`,
+    );
+    // conversation_assistant_attention_state indexes
+    raw.exec(
+      /*sql*/ `DROP INDEX IF EXISTS idx_conv_attn_state_assistant_latest_msg`,
+    );
+    raw.exec(
+      /*sql*/ `DROP INDEX IF EXISTS idx_conv_attn_state_assistant_last_seen`,
+    );
+
+    // --- Drop assistant_id column from each table ---
+    for (const table of tables) {
+      const cols = new Set(
+        (
+          raw.query(`PRAGMA table_info(${table})`).all() as Array<{
+            name: string;
+          }>
+        ).map((c) => c.name),
+      );
+
+      if (!cols.has("assistant_id")) continue;
+
+      // Re-verify safety before each drop
+      const unexpected = raw
+        .query(
+          `SELECT DISTINCT assistant_id FROM ${table} WHERE assistant_id IS NOT NULL AND assistant_id != 'self'`,
+        )
+        .all() as Array<{ assistant_id: string }>;
+
+      if (unexpected.length > 0) {
+        log.warn(
+          { table, values: unexpected.map((r) => r.assistant_id) },
+          "Unexpected assistant_id values — skipping column drop",
+        );
+        continue;
+      }
+
+      raw.exec(/*sql*/ `ALTER TABLE ${table} DROP COLUMN assistant_id`);
+      log.info({ table }, "Dropped assistant_id column");
+    }
+
+    // --- Recreate indexes without assistant_id ---
+    // conversation_attention_events: preserve (observedAt) only
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_events_observed ON conversation_attention_events (observed_at)`,
+    );
+    // conversation_assistant_attention_state: preserve (latestAssistantMessageAt) and (lastSeenAssistantMessageAt)
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_state_latest_msg ON conversation_assistant_attention_state (latest_assistant_message_at)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_state_last_seen ON conversation_assistant_attention_state (last_seen_assistant_message_at)`,
+    );
+
+    log.info("Completed dropping assistant_id columns from all tables");
+  });
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -78,6 +78,7 @@ export { migrateContactsAssistantId } from "./132-contacts-assistant-id.js";
 export { migrateAssistantContactMetadata } from "./133-assistant-contact-metadata.js";
 export { migrateContactsNotesColumn } from "./134-contacts-notes-column.js";
 export { migrateBackfillContactInteractionStats } from "./135-backfill-contact-interaction-stats.js";
+export { migrateDropAssistantIdColumns } from "./136-drop-assistant-id-columns.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -134,6 +134,13 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Backfill contacts.last_interaction from the max lastSeenAt across each contact's channels",
   },
+  {
+    key: "migration_drop_assistant_id_columns_v1",
+    version: 19,
+    dependsOn: ["migration_normalize_assistant_id_to_self_v1"],
+    description:
+      "Drop assistant_id columns from all 16 daemon tables after normalization to single-tenant identity",
+  },
 ];
 
 export interface MigrationValidationResult {

--- a/assistant/src/memory/schema/calls.ts
+++ b/assistant/src/memory/schema/calls.ts
@@ -6,7 +6,6 @@ import {
   text,
 } from "drizzle-orm/sqlite-core";
 
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
 import { conversations } from "./conversations.js";
 
 export const callSessions = sqliteTable(
@@ -26,7 +25,6 @@ export const callSessions = sqliteTable(
     guardianVerificationSessionId: text("guardian_verification_session_id"),
     callerIdentityMode: text("caller_identity_mode"),
     callerIdentitySource: text("caller_identity_source"),
-    assistantId: text("assistant_id"),
     initiatedFromConversationId: text("initiated_from_conversation_id"),
     startedAt: integer("started_at"),
     endedAt: integer("ended_at"),
@@ -91,7 +89,6 @@ export const channelGuardianVerificationChallenges = sqliteTable(
   "channel_guardian_verification_challenges",
   {
     id: text("id").primaryKey(),
-    assistantId: text("assistant_id").notNull(),
     channel: text("channel").notNull(),
     challengeHash: text("challenge_hash").notNull(),
     expiresAt: integer("expires_at").notNull(),
@@ -128,9 +125,6 @@ export const channelGuardianApprovalRequests = sqliteTable(
     runId: text("run_id").notNull(),
     requestId: text("request_id"),
     conversationId: text("conversation_id").notNull(),
-    assistantId: text("assistant_id")
-      .notNull()
-      .default(DAEMON_INTERNAL_ASSISTANT_ID),
     channel: text("channel").notNull(),
     requesterExternalUserId: text("requester_external_user_id").notNull(),
     requesterChatId: text("requester_chat_id").notNull(),
@@ -151,7 +145,6 @@ export const channelGuardianRateLimits = sqliteTable(
   "channel_guardian_rate_limits",
   {
     id: text("id").primaryKey(),
-    assistantId: text("assistant_id").notNull(),
     channel: text("channel").notNull(),
     actorExternalUserId: text("actor_external_user_id").notNull(),
     actorChatId: text("actor_chat_id").notNull(),

--- a/assistant/src/memory/schema/contacts.ts
+++ b/assistant/src/memory/schema/contacts.ts
@@ -1,6 +1,5 @@
 import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
 import { conversations } from "./conversations.js";
 
 export const contacts = sqliteTable("contacts", {
@@ -13,7 +12,6 @@ export const contacts = sqliteTable("contacts", {
   updatedAt: integer("updated_at").notNull(),
   role: text("role").notNull().default("contact"), // 'guardian' | 'contact'
   principalId: text("principal_id"), // internal auth principal (nullable)
-  assistantId: text("assistant_id"), // which assistant this guardian is for (nullable, daemon default is DAEMON_INTERNAL_ASSISTANT_ID)
   contactType: text("contact_type").notNull().default("human"), // 'human' | 'assistant'
 });
 
@@ -69,9 +67,6 @@ export const assistantIngressInvites = sqliteTable(
   "assistant_ingress_invites",
   {
     id: text("id").primaryKey(),
-    assistantId: text("assistant_id")
-      .notNull()
-      .default(DAEMON_INTERNAL_ASSISTANT_ID),
     sourceChannel: text("source_channel").notNull(),
     tokenHash: text("token_hash").notNull(),
     createdBySessionId: text("created_by_session_id"),
@@ -103,9 +98,6 @@ export const assistantInboxThreadState = sqliteTable(
     conversationId: text("conversation_id")
       .primaryKey()
       .references(() => conversations.id, { onDelete: "cascade" }),
-    assistantId: text("assistant_id")
-      .notNull()
-      .default(DAEMON_INTERNAL_ASSISTANT_ID),
     sourceChannel: text("source_channel").notNull(),
     externalChatId: text("external_chat_id").notNull(),
     externalUserId: text("external_user_id"),

--- a/assistant/src/memory/schema/guardian.ts
+++ b/assistant/src/memory/schema/guardian.ts
@@ -1,15 +1,11 @@
 import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
 import { callPendingQuestions, callSessions } from "./calls.js";
 
 export const guardianActionRequests = sqliteTable(
   "guardian_action_requests",
   {
     id: text("id").primaryKey(),
-    assistantId: text("assistant_id")
-      .notNull()
-      .default(DAEMON_INTERNAL_ASSISTANT_ID),
     kind: text("kind").notNull(), // 'ask_guardian'
     sourceChannel: text("source_channel").notNull(), // 'voice'
     sourceConversationId: text("source_conversation_id").notNull(),
@@ -145,7 +141,6 @@ export const scopedApprovalGrants = sqliteTable(
   "scoped_approval_grants",
   {
     id: text("id").primaryKey(),
-    assistantId: text("assistant_id").notNull(),
     scopeMode: text("scope_mode").notNull(), // 'request_id' | 'tool_signature'
     requestId: text("request_id"),
     toolName: text("tool_name"),

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -173,7 +173,6 @@ export const llmUsageEvents = sqliteTable(
 export const actorTokenRecords = sqliteTable("actor_token_records", {
   id: text("id").primaryKey(),
   tokenHash: text("token_hash").notNull(),
-  assistantId: text("assistant_id").notNull(),
   guardianPrincipalId: text("guardian_principal_id").notNull(),
   hashedDeviceId: text("hashed_device_id").notNull(),
   platform: text("platform").notNull(),
@@ -190,7 +189,6 @@ export const actorRefreshTokenRecords = sqliteTable(
     id: text("id").primaryKey(),
     tokenHash: text("token_hash").notNull(),
     familyId: text("family_id").notNull(),
-    assistantId: text("assistant_id").notNull(),
     guardianPrincipalId: text("guardian_principal_id").notNull(),
     hashedDeviceId: text("hashed_device_id").notNull(),
     platform: text("platform").notNull(),

--- a/assistant/src/memory/schema/notifications.ts
+++ b/assistant/src/memory/schema/notifications.ts
@@ -11,7 +11,6 @@ import { conversations } from "./conversations.js";
 
 export const notificationEvents = sqliteTable("notification_events", {
   id: text("id").primaryKey(),
-  assistantId: text("assistant_id").notNull(),
   sourceEventName: text("source_event_name").notNull(),
   sourceChannel: text("source_channel").notNull(),
   sourceSessionId: text("source_session_id").notNull(),
@@ -39,7 +38,6 @@ export const notificationDecisions = sqliteTable("notification_decisions", {
 
 export const notificationPreferences = sqliteTable("notification_preferences", {
   id: text("id").primaryKey(),
-  assistantId: text("assistant_id").notNull(),
   preferenceText: text("preference_text").notNull(),
   appliesWhenJson: text("applies_when_json").notNull().default("{}"),
   priority: integer("priority").notNull().default(0),
@@ -95,7 +93,6 @@ export const notificationDeliveries = sqliteTable(
     notificationDecisionId: text("notification_decision_id")
       .notNull()
       .references(() => notificationDecisions.id, { onDelete: "cascade" }),
-    assistantId: text("assistant_id").notNull(),
     channel: text("channel").notNull(),
     destination: text("destination").notNull(),
     status: text("status").notNull().default("pending"),
@@ -132,7 +129,6 @@ export const conversationAttentionEvents = sqliteTable(
     conversationId: text("conversation_id")
       .notNull()
       .references(() => conversations.id, { onDelete: "cascade" }),
-    assistantId: text("assistant_id").notNull(),
     sourceChannel: text("source_channel").notNull(),
     signalType: text("signal_type").notNull(),
     confidence: text("confidence").notNull(),
@@ -147,10 +143,7 @@ export const conversationAttentionEvents = sqliteTable(
       table.conversationId,
       table.observedAt,
     ),
-    index("idx_conv_attn_events_assistant_observed").on(
-      table.assistantId,
-      table.observedAt,
-    ),
+    index("idx_conv_attn_events_observed").on(table.observedAt),
     index("idx_conv_attn_events_channel_observed").on(
       table.sourceChannel,
       table.observedAt,
@@ -164,7 +157,6 @@ export const conversationAssistantAttentionState = sqliteTable(
     conversationId: text("conversation_id")
       .primaryKey()
       .references(() => conversations.id, { onDelete: "cascade" }),
-    assistantId: text("assistant_id").notNull(),
     latestAssistantMessageId: text("latest_assistant_message_id"),
     latestAssistantMessageAt: integer("latest_assistant_message_at"),
     lastSeenAssistantMessageId: text("last_seen_assistant_message_id"),
@@ -179,13 +171,7 @@ export const conversationAssistantAttentionState = sqliteTable(
     updatedAt: integer("updated_at").notNull(),
   },
   (table) => [
-    index("idx_conv_attn_state_assistant_latest_msg").on(
-      table.assistantId,
-      table.latestAssistantMessageAt,
-    ),
-    index("idx_conv_attn_state_assistant_last_seen").on(
-      table.assistantId,
-      table.lastSeenAssistantMessageAt,
-    ),
+    index("idx_conv_attn_state_latest_msg").on(table.latestAssistantMessageAt),
+    index("idx_conv_attn_state_last_seen").on(table.lastSeenAssistantMessageAt),
   ],
 );

--- a/assistant/src/memory/scoped-approval-grants.ts
+++ b/assistant/src/memory/scoped-approval-grants.ts
@@ -14,7 +14,6 @@
 import { and, eq, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getLogger } from "../util/logger.js";
 import { getDb, rawChanges } from "./db.js";
 import { scopedApprovalGrants } from "./schema.js";
@@ -113,7 +112,6 @@ function createScopedApprovalGrant(
 
   const row = {
     id,
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     scopeMode: params.scopeMode,
     requestId: params.requestId ?? null,
     toolName: params.toolName ?? null,

--- a/assistant/src/notifications/deliveries-store.ts
+++ b/assistant/src/notifications/deliveries-store.ts
@@ -10,7 +10,6 @@ import { and, eq } from "drizzle-orm";
 
 import { getDb, rawChanges } from "../memory/db.js";
 import { notificationDeliveries } from "../memory/schema.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import type {
   NotificationChannel,
   NotificationDeliveryStatus,
@@ -100,7 +99,6 @@ export function createDelivery(
   const row = {
     id: params.id,
     notificationDecisionId: params.notificationDecisionId,
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     channel: params.channel,
     destination: params.destination,
     status: params.status,

--- a/assistant/src/notifications/events-store.ts
+++ b/assistant/src/notifications/events-store.ts
@@ -10,7 +10,6 @@ import { and, desc, eq } from "drizzle-orm";
 
 import { getDb } from "../memory/db.js";
 import { notificationEvents } from "../memory/schema.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import type { AttentionHints } from "./signal.js";
 
 export interface NotificationEventRow {
@@ -75,7 +74,6 @@ export function createEvent(
 
   const row = {
     id: params.id,
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     sourceEventName: params.sourceEventName,
     sourceChannel: params.sourceChannel,
     sourceSessionId: params.sourceSessionId,

--- a/assistant/src/notifications/preferences-store.ts
+++ b/assistant/src/notifications/preferences-store.ts
@@ -12,7 +12,6 @@ import { v4 as uuid } from "uuid";
 
 import { getDb } from "../memory/db.js";
 import { notificationPreferences } from "../memory/schema.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 
 // ── Row type ────────────────────────────────────────────────────────────
 
@@ -64,7 +63,6 @@ export function createPreference(
 
   const row = {
     id: uuid(),
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     preferenceText: params.preferenceText,
     appliesWhenJson: JSON.stringify(params.appliesWhen ?? {}),
     priority: params.priority ?? 0,

--- a/assistant/src/runtime/actor-refresh-token-store.ts
+++ b/assistant/src/runtime/actor-refresh-token-store.ts
@@ -12,7 +12,6 @@ import { getDb } from "../memory/db.js";
 import { rawChanges } from "../memory/raw-query.js";
 import { actorRefreshTokenRecords } from "../memory/schema.js";
 import { getLogger } from "../util/logger.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 
 const log = getLogger("actor-refresh-token-store");
 
@@ -22,7 +21,6 @@ export interface RefreshTokenRecord {
   id: string;
   tokenHash: string;
   familyId: string;
-  assistantId: string;
   guardianPrincipalId: string;
   hashedDeviceId: string;
   platform: string;
@@ -54,7 +52,6 @@ export function createRefreshTokenRecord(params: {
     id,
     tokenHash: params.tokenHash,
     familyId: params.familyId,
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     guardianPrincipalId: params.guardianPrincipalId,
     hashedDeviceId: params.hashedDeviceId,
     platform: params.platform,
@@ -145,7 +142,6 @@ function rowToRecord(
     id: row.id,
     tokenHash: row.tokenHash,
     familyId: row.familyId,
-    assistantId: row.assistantId,
     guardianPrincipalId: row.guardianPrincipalId,
     hashedDeviceId: row.hashedDeviceId,
     platform: row.platform,

--- a/assistant/src/runtime/actor-token-store.ts
+++ b/assistant/src/runtime/actor-token-store.ts
@@ -14,7 +14,6 @@ import { v4 as uuid } from "uuid";
 import { getDb } from "../memory/db.js";
 import { actorTokenRecords } from "../memory/schema.js";
 import { getLogger } from "../util/logger.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 
 const log = getLogger("actor-token-store");
 
@@ -27,7 +26,6 @@ export type ActorTokenStatus = "active" | "revoked";
 export interface ActorTokenRecord {
   id: string;
   tokenHash: string;
-  assistantId: string;
   guardianPrincipalId: string;
   hashedDeviceId: string;
   platform: string;
@@ -60,7 +58,6 @@ export function createActorTokenRecord(params: {
   const row = {
     id,
     tokenHash: params.tokenHash,
-    assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
     guardianPrincipalId: params.guardianPrincipalId,
     hashedDeviceId: params.hashedDeviceId,
     platform: params.platform,
@@ -221,7 +218,6 @@ function rowToRecord(
   return {
     id: row.id,
     tokenHash: row.tokenHash,
-    assistantId: row.assistantId,
     guardianPrincipalId: row.guardianPrincipalId,
     hashedDeviceId: row.hashedDeviceId,
     platform: row.platform,


### PR DESCRIPTION
## Summary
- Add migration 136 to drop assistant_id from all 16 daemon tables (safety assertion, index management, column drops)
- Update all 5 Drizzle schema files to remove assistantId columns and indexes
- Remove assistantId from all store INSERT operations, interfaces (CallSession, ActorTokenRecord, RefreshTokenRecord, VerificationRateLimit, VerificationChallenge), and query filters
- Clean up unused assistantId parameter from buildVoiceWebhookTwiml and fix related tests

Part of plan: rm-assistant-id-from-daemon.md (PR 7 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
