### PR TITLE
Support macOS platform URL env override

### DIFF
--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -120,6 +120,12 @@ The fastest way to build and launch the app locally:
 ./build.sh run
 ```
 
+To point managed sign-in at a specific platform host for a local run:
+
+```bash
+VELLUM_ASSISTANT_PLATFORM_URL=https://platform.vellum.ai ./build.sh run
+```
+
 This builds a debug `.app` bundle, codesigns it, and launches it immediately.
 
 ## Build

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 #   DISPLAY_VERSION   Override CFBundleShortVersionString (default: 0.1.0)
 #   BUILD_VERSION     Override CFBundleVersion (default: 1)
 #   SIGN_IDENTITY     Override code signing identity
+#   VELLUM_ASSISTANT_PLATFORM_URL  Override managed sign-in platform URL for app launches
 
 # ---------------------------------------------------------------------------
 # swift_with_retry — run a swift command with retries for transient SPM
@@ -534,6 +535,20 @@ for SPM_BUNDLE in "$BIN_PATH"/*.bundle; do
 done
 
 # Always regenerate Info.plist (fast, depends on env vars like DISPLAY_VERSION)
+LSE_ENVIRONMENT_PLIST=""
+if [ -n "${VELLUM_ASSISTANT_PLATFORM_URL:-}" ]; then
+    PLATFORM_URL_OVERRIDE="${VELLUM_ASSISTANT_PLATFORM_URL%/}"
+    echo "Embedding app platform URL override: $PLATFORM_URL_OVERRIDE"
+    LSE_ENVIRONMENT_PLIST=$(cat <<EOF
+    <key>LSEnvironment</key>
+    <dict>
+        <key>VELLUM_ASSISTANT_PLATFORM_URL</key>
+        <string>$PLATFORM_URL_OVERRIDE</string>
+    </dict>
+EOF
+)
+fi
+
 cat > "$CONTENTS/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -559,6 +574,7 @@ cat > "$CONTENTS/Info.plist" <<PLIST
     <string>en</string>
     <key>LSUIElement</key>
     <true/>
+    $LSE_ENVIRONMENT_PLIST
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>LSApplicationCategoryType</key>

--- a/clients/macos/vellum-assistantTests/AuthServiceBaseURLTests.swift
+++ b/clients/macos/vellum-assistantTests/AuthServiceBaseURLTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import VellumAssistantShared
+
+@MainActor
+final class AuthServiceBaseURLTests: XCTestCase {
+    func testResolveBaseURLPrefersEnvironmentOverride() {
+        withUserDefaultsSuite { defaults in
+            defaults.set("https://defaults.example.com/", forKey: "authServiceBaseURL")
+
+            let resolved = AuthService.resolveBaseURL(
+                configuredBaseURL: "https://configured.example.com/",
+                environment: ["VELLUM_ASSISTANT_PLATFORM_URL": "https://env.example.com/"],
+                userDefaults: defaults
+            )
+
+            XCTAssertEqual(resolved, "https://env.example.com")
+        }
+    }
+
+    func testResolveBaseURLFallsBackToConfiguredValue() {
+        withUserDefaultsSuite { defaults in
+            let resolved = AuthService.resolveBaseURL(
+                configuredBaseURL: "https://configured.example.com/",
+                environment: [:],
+                userDefaults: defaults
+            )
+
+            XCTAssertEqual(resolved, "https://configured.example.com")
+        }
+    }
+
+    private func withUserDefaultsSuite(_ body: (UserDefaults) -> Void) {
+        let suiteName = "AuthServiceBaseURLTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(defaults)
+    }
+}

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -6,6 +6,8 @@ private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.
 @MainActor
 public final class AuthService {
     public static let shared = AuthService()
+    private static let platformURLOverrideEnvironmentKey = "VELLUM_ASSISTANT_PLATFORM_URL"
+    private static let authServiceBaseURLDefaultsName = "authServiceBaseURL"
 
     private static let defaultBaseURL: String = {
         #if DEBUG && os(macOS)
@@ -17,23 +19,44 @@ public final class AuthService {
 
     /// Platform base URL from daemon config. Set by SettingsStore when the
     /// `platform_config_response` arrives. When non-empty, takes precedence
-    /// over the hardcoded default and DEBUG UserDefaults override.
+    /// over persisted defaults, but an explicit per-launch env override still wins.
     public var configuredBaseURL: String = ""
 
     public var baseURL: String {
-        if !configuredBaseURL.isEmpty {
-            return configuredBaseURL
-        }
-        #if DEBUG
-        // Allow overriding the auth service URL via UserDefaults for development/testing.
-        if let override = UserDefaults.standard.string(forKey: "authServiceBaseURL"), !override.isEmpty {
-            return override
-        }
-        #endif
-        return Self.defaultBaseURL
+        Self.resolveBaseURL(
+            configuredBaseURL: configuredBaseURL,
+            environment: ProcessInfo.processInfo.environment,
+            userDefaults: .standard
+        )
     }
 
     private init() {}
+
+    static func resolveBaseURL(
+        configuredBaseURL: String,
+        environment: [String: String],
+        userDefaults: UserDefaults
+    ) -> String {
+        if let override = normalizedBaseURL(environment[platformURLOverrideEnvironmentKey]) {
+            return override
+        }
+        if let configured = normalizedBaseURL(configuredBaseURL) {
+            return configured
+        }
+        #if DEBUG
+        // Keep the UserDefaults override as a fallback for direct debug sessions.
+        if let override = normalizedBaseURL(userDefaults.string(forKey: authServiceBaseURLDefaultsName)) {
+            return override
+        }
+        #endif
+        return defaultBaseURL
+    }
+
+    private static func normalizedBaseURL(_ raw: String?) -> String? {
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let normalized = trimmed.replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
+        return normalized.isEmpty ? nil : normalized
+    }
 
     public func getConfig() async throws -> AllauthResponse<ConfigData> {
         try await request(path: "config")


### PR DESCRIPTION
## Summary
- let the macOS auth flow prefer VELLUM_ASSISTANT_PLATFORM_URL for managed sign-in
- inject the platform URL override into app launches from build.sh run
- document the override and add coverage for auth base URL precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
