### PR TITLE
fix: require session token for managed SettingsStore requests

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -970,22 +970,14 @@ public final class SettingsStore: ObservableObject {
         let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
         let assistant = connectedId.flatMap { LockfileAssistant.loadByName($0) }
         if let assistant, assistant.isManaged {
-            let baseURL = assistant.runtimeUrl ?? AuthService.shared.baseURL
-            // Strip "v1/" prefix — the platform proxy already namespaces under /v1/assistants/{id}/
-            let proxyPath = path.hasPrefix("v1/") ? String(path.dropFirst(3)) : path
-            // Django URL convention: trailing slash
-            let trailingSlash = proxyPath.hasSuffix("/") ? "" : "/"
-            guard let url = URL(string: "\(baseURL)/v1/assistants/\(assistant.assistantId)/\(proxyPath)\(trailingSlash)") else { return nil }
-            var request = URLRequest(url: url)
-            request.httpMethod = method
-            request.timeoutInterval = 5
-            if let token = SessionTokenManager.getToken() {
-                request.setValue(token, forHTTPHeaderField: "X-Session-Token")
-            }
-            if let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
-                request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
-            }
-            return request
+            return Self.buildManagedAssistantProxyRequest(
+                baseURL: assistant.runtimeUrl ?? AuthService.shared.baseURL,
+                assistantId: assistant.assistantId,
+                path: path,
+                method: method,
+                sessionToken: SessionTokenManager.getToken(),
+                organizationId: UserDefaults.standard.string(forKey: "connectedOrganizationId")
+            )
         }
 
         // Local mode: direct to daemon runtime HTTP server
@@ -997,6 +989,32 @@ public final class SettingsStore: ObservableObject {
         request.httpMethod = method
         request.timeoutInterval = 5
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        return request
+    }
+
+    /// Managed requests must fail closed without a session token so callers
+    /// preserve work for later retry instead of sending unauthenticated writes.
+    nonisolated static func buildManagedAssistantProxyRequest(
+        baseURL: String,
+        assistantId: String,
+        path: String,
+        method: String,
+        sessionToken: String?,
+        organizationId: String?
+    ) -> URLRequest? {
+        guard let token = sessionToken, !token.isEmpty else { return nil }
+        // Strip "v1/" prefix — the platform proxy already namespaces under /v1/assistants/{id}/
+        let proxyPath = path.hasPrefix("v1/") ? String(path.dropFirst(3)) : path
+        // Django URL convention: trailing slash
+        let trailingSlash = proxyPath.hasSuffix("/") ? "" : "/"
+        guard let url = URL(string: "\(baseURL)/v1/assistants/\(assistantId)/\(proxyPath)\(trailingSlash)") else { return nil }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.timeoutInterval = 5
+        request.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        if let orgId = organizationId, !orgId.isEmpty {
+            request.setValue(orgId, forHTTPHeaderField: "Vellum-Organization-Id")
+        }
         return request
     }
 

--- a/clients/macos/vellum-assistantTests/SettingsStoreManagedRequestTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreManagedRequestTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+final class SettingsStoreManagedRequestTests: XCTestCase {
+    func testBuildManagedAssistantProxyRequestReturnsNilWithoutSessionToken() {
+        let request = SettingsStore.buildManagedAssistantProxyRequest(
+            baseURL: "https://platform.vellum.ai",
+            assistantId: "ast_123",
+            path: "v1/secrets",
+            method: "DELETE",
+            sessionToken: nil,
+            organizationId: "org_456"
+        )
+
+        XCTAssertNil(request)
+    }
+
+    func testBuildManagedAssistantProxyRequestStripsV1PrefixAndSetsHeaders() {
+        let request = SettingsStore.buildManagedAssistantProxyRequest(
+            baseURL: "https://platform.vellum.ai",
+            assistantId: "ast_123",
+            path: "v1/secrets",
+            method: "POST",
+            sessionToken: "session-token",
+            organizationId: "org_456"
+        )
+
+        XCTAssertEqual(
+            request?.url?.absoluteString,
+            "https://platform.vellum.ai/v1/assistants/ast_123/secrets/"
+        )
+        XCTAssertEqual(request?.httpMethod, "POST")
+        XCTAssertEqual(request?.value(forHTTPHeaderField: "X-Session-Token"), "session-token")
+        XCTAssertEqual(request?.value(forHTTPHeaderField: "Vellum-Organization-Id"), "org_456")
+    }
+}


### PR DESCRIPTION
## Summary
- require a session token before building managed SettingsStore proxy requests
- keep tombstone replay and other managed writes deferred until auth is ready instead of dispatching unauthenticated requests
- add focused managed request construction tests for the missing-token and v1-stripping paths

Apple refs checked (2026-03-05): [setValue(_:forHTTPHeaderField:)](https://developer.apple.com/documentation/foundation/nsmutableurlrequest/setvalue%28_%3Aforhttpheaderfield%3A%29), [Meet async/await in Swift](https://developer.apple.com/kr/videos/play/wwdc2021/10132/)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
