### PR TITLE
fix: remove stale guardian verification locals

### DIFF
--- a/assistant/src/runtime/guardian-outbound-actions.ts
+++ b/assistant/src/runtime/guardian-outbound-actions.ts
@@ -978,7 +978,6 @@ export function resendOutbound(
 export function cancelOutbound(
   params: CancelOutboundParams,
 ): OutboundActionResult {
-  const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const channel = params.channel;
 
   const session = findActiveSession(channel);

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -292,13 +292,8 @@ export async function enforceIngressAcl(
         // user can reply with the code in the DM to self-verify.
         if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
           const slackVerifyResult = initiateSlackVerificationChallenge({
-            canonicalAssistantId,
             sourceChannel,
-            conversationExternalId,
             senderUserId: (canonicalSenderId ?? rawSenderId)!,
-            replyCallbackUrl,
-            mintBearerToken,
-            assistantId,
           });
 
           if (slackVerifyResult.initiated) {
@@ -524,13 +519,8 @@ export async function enforceIngressAcl(
             (canonicalSenderId ?? rawSenderId)
           ) {
             const slackVerifyResult = initiateSlackVerificationChallenge({
-              canonicalAssistantId,
               sourceChannel,
-              conversationExternalId,
               senderUserId: (canonicalSenderId ?? rawSenderId)!,
-              replyCallbackUrl,
-              mintBearerToken,
-              assistantId,
             });
 
             if (slackVerifyResult.initiated) {
@@ -1084,15 +1074,10 @@ interface SlackVerificationResult {
  * creates a trusted contact record (not a guardian binding).
  */
 function initiateSlackVerificationChallenge(params: {
-  canonicalAssistantId: string;
   sourceChannel: ChannelId;
-  conversationExternalId: string;
   senderUserId: string;
-  replyCallbackUrl: string | undefined;
-  mintBearerToken: () => string;
-  assistantId: string;
 }): SlackVerificationResult {
-  const { canonicalAssistantId, sourceChannel, senderUserId } = params;
+  const { sourceChannel, senderUserId } = params;
 
   // Skip if there is already a pending challenge or active session for
   // this sender to avoid flooding them with duplicate codes. We scope by


### PR DESCRIPTION
## Summary
- remove a leftover unused local from outbound cancellation after the assistant-scope refactor
- trim the Slack verification helper and its call sites down to the only arguments it still consumes
- restore a clean assistant lint pass for the failing CI job

## Original prompt
[](/Users/sidd/vocify/claude-skills/skills/do/SKILL.md) Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22733241671/job/65927680091

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13073" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
