### PR TITLE
fix: restore Contacts tab CI build

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -59,7 +59,7 @@ struct ContactsContainerView: View {
                 .background(VColor.background)
             }
         }
-        .onChange(of: viewModel.contacts) { _ in
+        .onReceive(viewModel.$contacts) { _ in
             if selectedContactId == nil, let guardian = viewModel.guardianContact {
                 selectedContactId = guardian.id
             }


### PR DESCRIPTION
## Summary
- switch the Contacts tab auto-selection listener from `onChange` to `onReceive` for published contact updates
- keep guardian auto-selection behavior without requiring `IPCContactPayload` to conform to `Equatable`

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22733669058

🤖 Generated with Codex
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
