### PR TITLE
Fix restart-safe assistant_id migration bootstrap

### DIFF
--- a/assistant/src/memory/migrations/026-guardian-verification-sessions.ts
+++ b/assistant/src/memory/migrations/026-guardian-verification-sessions.ts
@@ -1,4 +1,5 @@
 import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
 
 /**
  * Extend channel_guardian_verification_challenges with outbound verification
@@ -83,13 +84,31 @@ export function migrateGuardianVerificationSessions(database: DrizzleDb): void {
   }
 
   // -- Indexes for session lookups --
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_sessions_active ON channel_guardian_verification_challenges(assistant_id, channel, status)`,
-  );
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_sessions_identity ON channel_guardian_verification_challenges(assistant_id, channel, expected_external_user_id, expected_chat_id, status)`,
-  );
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_sessions_destination ON channel_guardian_verification_challenges(assistant_id, channel, destination_address)`,
-  );
+  if (
+    tableHasColumn(
+      database,
+      "channel_guardian_verification_challenges",
+      "assistant_id",
+    )
+  ) {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_sessions_active ON channel_guardian_verification_challenges(assistant_id, channel, status)`,
+    );
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_sessions_identity ON channel_guardian_verification_challenges(assistant_id, channel, expected_external_user_id, expected_chat_id, status)`,
+    );
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_sessions_destination ON channel_guardian_verification_challenges(assistant_id, channel, destination_address)`,
+    );
+  } else {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_sessions_active ON channel_guardian_verification_challenges(channel, status)`,
+    );
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_sessions_identity ON channel_guardian_verification_challenges(channel, expected_external_user_id, expected_chat_id, status)`,
+    );
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_sessions_destination ON channel_guardian_verification_challenges(channel, destination_address)`,
+    );
+  }
 }

--- a/assistant/src/memory/migrations/027a-guardian-bootstrap-token.ts
+++ b/assistant/src/memory/migrations/027a-guardian-bootstrap-token.ts
@@ -1,4 +1,5 @@
 import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
 
 /**
  * Add bootstrap_token_hash column to channel_guardian_verification_challenges.
@@ -16,7 +17,19 @@ export function migrateGuardianBootstrapToken(database: DrizzleDb): void {
   }
 
   // Index for looking up pending_bootstrap sessions by bootstrap token hash
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_sessions_bootstrap ON channel_guardian_verification_challenges(assistant_id, channel, bootstrap_token_hash, status)`,
-  );
+  if (
+    tableHasColumn(
+      database,
+      "channel_guardian_verification_challenges",
+      "assistant_id",
+    )
+  ) {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_sessions_bootstrap ON channel_guardian_verification_challenges(assistant_id, channel, bootstrap_token_hash, status)`,
+    );
+  } else {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_guardian_sessions_bootstrap ON channel_guardian_verification_challenges(channel, bootstrap_token_hash, status)`,
+    );
+  }
 }

--- a/assistant/src/memory/migrations/038-actor-token-records.ts
+++ b/assistant/src/memory/migrations/038-actor-token-records.ts
@@ -1,4 +1,5 @@
 import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
 
 /**
  * Create the actor_token_records table for hash-only actor token persistence.
@@ -24,9 +25,15 @@ export function createActorTokenRecordsTable(database: DrizzleDb): void {
   `);
 
   // Unique active token per device binding
-  database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_actor_tokens_active_device
+  if (tableHasColumn(database, "actor_token_records", "assistant_id")) {
+    database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_actor_tokens_active_device
       ON actor_token_records(assistant_id, guardian_principal_id, hashed_device_id)
       WHERE status = 'active'`);
+  } else {
+    database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_actor_tokens_active_device
+      ON actor_token_records(guardian_principal_id, hashed_device_id)
+      WHERE status = 'active'`);
+  }
 
   // Token hash lookup for verification
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_actor_tokens_hash

--- a/assistant/src/memory/migrations/039-actor-refresh-token-records.ts
+++ b/assistant/src/memory/migrations/039-actor-refresh-token-records.ts
@@ -1,4 +1,5 @@
 import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
 
 /**
  * Create the actor_refresh_token_records table for hash-only refresh token persistence.
@@ -34,10 +35,18 @@ export function createActorRefreshTokenRecordsTable(database: DrizzleDb): void {
   // Unique active refresh token per device binding.
   // DROP first so that databases that already created the older non-unique
   // index with the same name get upgraded to UNIQUE.
-  database.run(/*sql*/ `DROP INDEX IF EXISTS idx_refresh_tokens_active_device`);
-  database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_refresh_tokens_active_device
+  if (tableHasColumn(database, "actor_refresh_token_records", "assistant_id")) {
+    database.run(
+      /*sql*/ `DROP INDEX IF EXISTS idx_refresh_tokens_active_device`,
+    );
+    database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_refresh_tokens_active_device
       ON actor_refresh_token_records(assistant_id, guardian_principal_id, hashed_device_id)
       WHERE status = 'active'`);
+  } else {
+    database.run(/*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_refresh_tokens_active_device
+      ON actor_refresh_token_records(guardian_principal_id, hashed_device_id)
+      WHERE status = 'active'`);
+  }
 
   // Family lookup for replay detection (revoke entire family)
   database.run(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_refresh_tokens_family

--- a/assistant/src/memory/migrations/110-channel-guardian.ts
+++ b/assistant/src/memory/migrations/110-channel-guardian.ts
@@ -1,4 +1,5 @@
 import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
 
 /**
  * Channel guardian tables: bindings, verification challenges, approval requests,
@@ -43,9 +44,21 @@ export function createChannelGuardianTables(database: DrizzleDb): void {
     )
   `);
 
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_guardian_challenges_lookup ON channel_guardian_verification_challenges(assistant_id, channel, challenge_hash, status)`,
-  );
+  if (
+    tableHasColumn(
+      database,
+      "channel_guardian_verification_challenges",
+      "assistant_id",
+    )
+  ) {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_guardian_challenges_lookup ON channel_guardian_verification_challenges(assistant_id, channel, challenge_hash, status)`,
+    );
+  } else {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_channel_guardian_challenges_lookup ON channel_guardian_verification_challenges(channel, challenge_hash, status)`,
+    );
+  }
 
   database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS channel_guardian_approval_requests (
@@ -139,7 +152,15 @@ export function createChannelGuardianTables(database: DrizzleDb): void {
     /* already exists */
   }
 
-  database.run(
-    /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_guardian_rate_limits_actor ON channel_guardian_rate_limits(assistant_id, channel, actor_external_user_id, actor_chat_id)`,
-  );
+  if (
+    tableHasColumn(database, "channel_guardian_rate_limits", "assistant_id")
+  ) {
+    database.run(
+      /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_guardian_rate_limits_actor ON channel_guardian_rate_limits(assistant_id, channel, actor_external_user_id, actor_chat_id)`,
+    );
+  } else {
+    database.run(
+      /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_guardian_rate_limits_actor ON channel_guardian_rate_limits(channel, actor_external_user_id, actor_chat_id)`,
+    );
+  }
 }

--- a/assistant/src/memory/migrations/112-assistant-inbox.ts
+++ b/assistant/src/memory/migrations/112-assistant-inbox.ts
@@ -1,5 +1,6 @@
 import type { DrizzleDb } from "../db-connection.js";
 import { migrateBackfillInboxThreadStateFromBindings } from "./014-backfill-inbox-thread-state.js";
+import { tableHasColumn } from "./schema-introspection.js";
 
 /**
  * Assistant inbox tables: ingress invites, ingress members, inbox thread state.
@@ -28,12 +29,21 @@ export function createAssistantInboxTables(database: DrizzleDb): void {
   database.run(
     /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_ingress_invites_token_hash ON assistant_ingress_invites(token_hash)`,
   );
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_ingress_invites_channel_status ON assistant_ingress_invites(assistant_id, source_channel, status, expires_at)`,
-  );
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_ingress_invites_channel_created ON assistant_ingress_invites(assistant_id, source_channel, created_at)`,
-  );
+  if (tableHasColumn(database, "assistant_ingress_invites", "assistant_id")) {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_ingress_invites_channel_status ON assistant_ingress_invites(assistant_id, source_channel, status, expires_at)`,
+    );
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_ingress_invites_channel_created ON assistant_ingress_invites(assistant_id, source_channel, created_at)`,
+    );
+  } else {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_ingress_invites_channel_status ON assistant_ingress_invites(source_channel, status, expires_at)`,
+    );
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_ingress_invites_channel_created ON assistant_ingress_invites(source_channel, created_at)`,
+    );
+  }
 
   database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS assistant_ingress_members (
@@ -90,15 +100,29 @@ export function createAssistantInboxTables(database: DrizzleDb): void {
     )
   `);
 
-  database.run(
-    /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_inbox_thread_state_channel ON assistant_inbox_thread_state(assistant_id, source_channel, external_chat_id)`,
-  );
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_inbox_thread_state_last_msg ON assistant_inbox_thread_state(assistant_id, last_message_at)`,
-  );
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_inbox_thread_state_escalation ON assistant_inbox_thread_state(assistant_id, has_pending_escalation, last_message_at)`,
-  );
+  if (
+    tableHasColumn(database, "assistant_inbox_thread_state", "assistant_id")
+  ) {
+    database.run(
+      /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_inbox_thread_state_channel ON assistant_inbox_thread_state(assistant_id, source_channel, external_chat_id)`,
+    );
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_inbox_thread_state_last_msg ON assistant_inbox_thread_state(assistant_id, last_message_at)`,
+    );
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_inbox_thread_state_escalation ON assistant_inbox_thread_state(assistant_id, has_pending_escalation, last_message_at)`,
+    );
+  } else {
+    database.run(
+      /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_inbox_thread_state_channel ON assistant_inbox_thread_state(source_channel, external_chat_id)`,
+    );
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_inbox_thread_state_last_msg ON assistant_inbox_thread_state(last_message_at)`,
+    );
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_inbox_thread_state_escalation ON assistant_inbox_thread_state(has_pending_escalation, last_message_at)`,
+    );
+  }
 
   migrateBackfillInboxThreadStateFromBindings(database);
 }

--- a/assistant/src/memory/migrations/114-notifications.ts
+++ b/assistant/src/memory/migrations/114-notifications.ts
@@ -2,6 +2,7 @@ import type { DrizzleDb } from "../db-connection.js";
 import { migrateNotificationTablesSchema } from "./019-notification-tables-schema-migration.js";
 import { migrateNotificationDeliveryPairingColumns } from "./027-notification-delivery-pairing-columns.js";
 import { migrateNotificationDeliveryClientAck } from "./028-notification-delivery-client-ack.js";
+import { tableHasColumn } from "./schema-introspection.js";
 
 /**
  * Notification system tables: preferences, events, decisions, and deliveries.
@@ -24,12 +25,18 @@ export function createNotificationTables(database: DrizzleDb): void {
     )
   `);
 
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_notification_preferences_assistant_id ON notification_preferences(assistant_id)`,
-  );
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_notification_preferences_assistant_priority ON notification_preferences(assistant_id, priority DESC)`,
-  );
+  if (tableHasColumn(database, "notification_preferences", "assistant_id")) {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_notification_preferences_assistant_id ON notification_preferences(assistant_id)`,
+    );
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_notification_preferences_assistant_priority ON notification_preferences(assistant_id, priority DESC)`,
+    );
+  } else {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_notification_preferences_priority ON notification_preferences(priority DESC)`,
+    );
+  }
 
   database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS notification_events (
@@ -46,12 +53,21 @@ export function createNotificationTables(database: DrizzleDb): void {
     )
   `);
 
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_notification_events_assistant_event_created ON notification_events(assistant_id, source_event_name, created_at)`,
-  );
-  database.run(
-    /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_events_dedupe ON notification_events(assistant_id, dedupe_key) WHERE dedupe_key IS NOT NULL`,
-  );
+  if (tableHasColumn(database, "notification_events", "assistant_id")) {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_notification_events_assistant_event_created ON notification_events(assistant_id, source_event_name, created_at)`,
+    );
+    database.run(
+      /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_events_dedupe ON notification_events(assistant_id, dedupe_key) WHERE dedupe_key IS NOT NULL`,
+    );
+  } else {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_notification_events_event_created ON notification_events(source_event_name, created_at)`,
+    );
+    database.run(
+      /*sql*/ `CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_events_dedupe ON notification_events(dedupe_key) WHERE dedupe_key IS NOT NULL`,
+    );
+  }
 
   database.run(/*sql*/ `
     CREATE TABLE IF NOT EXISTS notification_decisions (
@@ -97,9 +113,15 @@ export function createNotificationTables(database: DrizzleDb): void {
   database.run(
     /*sql*/ `CREATE INDEX IF NOT EXISTS idx_notification_deliveries_decision_id ON notification_deliveries(notification_decision_id)`,
   );
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_notification_deliveries_assistant_status ON notification_deliveries(assistant_id, status)`,
-  );
+  if (tableHasColumn(database, "notification_deliveries", "assistant_id")) {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_notification_deliveries_assistant_status ON notification_deliveries(assistant_id, status)`,
+    );
+  } else {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_notification_deliveries_status ON notification_deliveries(status)`,
+    );
+  }
 
   // Add conversation pairing audit columns (idempotent ALTER TABLE)
   migrateNotificationDeliveryPairingColumns(database);

--- a/assistant/src/memory/migrations/117-conversation-attention.ts
+++ b/assistant/src/memory/migrations/117-conversation-attention.ts
@@ -1,4 +1,5 @@
 import type { DrizzleDb } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
 
 /**
  * Conversation attention tables: append-only evidence log and single-row
@@ -24,9 +25,17 @@ export function createConversationAttentionTables(database: DrizzleDb): void {
   database.run(
     /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_events_conv_observed ON conversation_attention_events(conversation_id, observed_at DESC)`,
   );
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_events_assistant_observed ON conversation_attention_events(assistant_id, observed_at DESC)`,
-  );
+  if (
+    tableHasColumn(database, "conversation_attention_events", "assistant_id")
+  ) {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_events_assistant_observed ON conversation_attention_events(assistant_id, observed_at DESC)`,
+    );
+  } else {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_events_observed ON conversation_attention_events(observed_at)`,
+    );
+  }
   database.run(
     /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_events_channel_observed ON conversation_attention_events(source_channel, observed_at DESC)`,
   );
@@ -50,10 +59,25 @@ export function createConversationAttentionTables(database: DrizzleDb): void {
     )
   `);
 
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_state_assistant_latest_msg ON conversation_assistant_attention_state(assistant_id, latest_assistant_message_at DESC)`,
-  );
-  database.run(
-    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_state_assistant_last_seen ON conversation_assistant_attention_state(assistant_id, last_seen_assistant_message_at DESC)`,
-  );
+  if (
+    tableHasColumn(
+      database,
+      "conversation_assistant_attention_state",
+      "assistant_id",
+    )
+  ) {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_state_assistant_latest_msg ON conversation_assistant_attention_state(assistant_id, latest_assistant_message_at DESC)`,
+    );
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_state_assistant_last_seen ON conversation_assistant_attention_state(assistant_id, last_seen_assistant_message_at DESC)`,
+    );
+  } else {
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_state_latest_msg ON conversation_assistant_attention_state(latest_assistant_message_at)`,
+    );
+    database.run(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conv_attn_state_last_seen ON conversation_assistant_attention_state(last_seen_assistant_message_at)`,
+    );
+  }
 }

--- a/assistant/src/memory/migrations/schema-introspection.ts
+++ b/assistant/src/memory/migrations/schema-introspection.ts
@@ -1,0 +1,18 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Startup still replays the historical table/index bootstrap helpers on every
+ * process launch, so migrations need a cheap way to branch on the live schema.
+ */
+export function tableHasColumn(
+  database: DrizzleDb,
+  tableName: string,
+  columnName: string,
+): boolean {
+  const raw = getSqliteFrom(database);
+  const columns = raw.query(`PRAGMA table_info(${tableName})`).all() as Array<{
+    name: string;
+  }>;
+
+  return columns.some((column) => column.name === columnName);
+}


### PR DESCRIPTION
## Summary
- make migration bootstrap helpers probe the live schema before recreating assistant_id indexes
- keep startup idempotent after migration 136 drops assistant_id columns and indexes
- verify the three failing CI test files now pass when run individually

## Original prompt
Fix these tests: https://github.com/vellum-ai/vellum-assistant/actions/runs/22734254441/job/65931262282

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
