### PR TITLE
Migrate SettingsChannelsTab to use shared GuardianVerificationFlowView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -37,14 +37,8 @@ struct SettingsChannelsTab: View {
     // Email copy state
     @State private var emailCopied: Bool = false
 
-    // Guardian copy state (tracks which channel's command was just copied)
-    @State private var guardianCommandCopiedChannel: String?
-
     // Outbound guardian verification destination input (keyed by channel)
     @State private var guardianDestinationText: [String: String] = [:]
-
-    // Outbound verification code copy state (tracks which channel's code was just copied)
-    @State private var outboundCodeCopiedChannel: String?
 
     // Countdown timer for outbound verification expiry (ref-counted so
     // closing one channel row doesn't stop the timer for remaining rows)
@@ -52,7 +46,7 @@ struct SettingsChannelsTab: View {
     @State private var countdownTimer: Timer?
     @State private var countdownTimerRefCount: Int = 0
 
-    // Shared label column width for channelStatusRow and guardianLabel alignment
+    // Shared label column width for channelStatusRow and guardian verification alignment
     private let labelColumnWidth: CGFloat = 140
 
     var body: some View {
@@ -208,7 +202,7 @@ struct SettingsChannelsTab: View {
             // Guardian row (only when credentials exist)
             if store.telegramHasBotToken {
                 Divider().background(VColor.surfaceBorder)
-                guardianStatusRow(channel: "telegram")
+                guardianVerificationView(channel: "telegram")
             }
 
             // Approved users (only when bot token exists and guardian is verified)
@@ -360,7 +354,7 @@ struct SettingsChannelsTab: View {
             // Guardian row (only when bot token and app token are configured)
             if store.slackChannelHasBotToken && store.slackChannelHasAppToken {
                 Divider().background(VColor.surfaceBorder)
-                guardianStatusRow(channel: "slack")
+                guardianVerificationView(channel: "slack")
 
                 Divider().background(VColor.surfaceBorder)
                 slackApprovedUsersSection
@@ -548,7 +542,7 @@ struct SettingsChannelsTab: View {
             // Guardian row (only when credentials exist)
             if store.twilioHasCredentials {
                 Divider().background(VColor.surfaceBorder)
-                guardianStatusRow(channel: "sms")
+                guardianVerificationView(channel: "sms")
             }
         }
         .padding(VSpacing.lg)
@@ -624,7 +618,7 @@ struct SettingsChannelsTab: View {
             // voice verification initiates an outbound call which requires a valid caller number)
             if store.twilioHasCredentials && store.twilioPhoneNumber != nil {
                 Divider().background(VColor.surfaceBorder)
-                guardianStatusRow(channel: "voice")
+                guardianVerificationView(channel: "voice")
             }
         }
         .padding(VSpacing.lg)
@@ -792,463 +786,26 @@ struct SettingsChannelsTab: View {
 
     // MARK: - Guardian Verification Row
 
-    private var guardianLabel: some View {
-        HStack(spacing: VSpacing.xs) {
-            Text("Guardian Verification")
-            VInfoTooltip("Guardian verification links your account identity for this channel.")
-        }
-        .font(VFont.caption)
-        .foregroundColor(VColor.textSecondary)
-        .frame(width: labelColumnWidth, alignment: .leading)
-    }
-
-    private func guardianPrimaryIdentity(channel: String, identity: String?) -> String? {
-        if channel == "telegram" {
-            if let username = store.telegramGuardianUsername?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !username.isEmpty {
-                return username.hasPrefix("@") ? username : "@\(username)"
-            }
-            if let displayName = store.telegramGuardianDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !displayName.isEmpty {
-                return displayName
-            }
-        } else if channel == "sms" {
-            if let displayName = store.smsGuardianDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !displayName.isEmpty {
-                return displayName
-            }
-        } else if channel == "voice" {
-            if let displayName = store.voiceGuardianDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !displayName.isEmpty {
-                return displayName
-            }
-        } else if channel == "slack" {
-            if let username = store.slackGuardianUsername?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !username.isEmpty {
-                return username.hasPrefix("@") ? username : "@\(username)"
-            }
-            if let displayName = store.slackGuardianDisplayName?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !displayName.isEmpty {
-                return displayName
-            }
-        }
-        return identity
-    }
-
-    private func guardianSecondaryIdentity(primary: String?, identity: String?) -> String? {
-        guard let identity = identity?.trimmingCharacters(in: .whitespacesAndNewlines), !identity.isEmpty else {
-            return nil
-        }
-        if let primary {
-            let normalizedPrimary = primary.trimmingCharacters(in: .whitespacesAndNewlines)
-            if normalizedPrimary.caseInsensitiveCompare(identity) == .orderedSame {
-                return nil
-            }
-        }
-        return "ID: \(identity)"
-    }
-
     @ViewBuilder
-    private func guardianStatusRow(channel: String) -> some View {
-        let identity: String? = {
-            switch channel {
-            case "telegram": return store.telegramGuardianIdentity
-            case "sms": return store.smsGuardianIdentity
-            case "voice": return store.voiceGuardianIdentity
-            case "slack": return store.slackGuardianIdentity
-            default: return nil
-            }
-        }()
-        let verified: Bool = {
-            switch channel {
-            case "telegram": return store.telegramGuardianVerified
-            case "sms": return store.smsGuardianVerified
-            case "voice": return store.voiceGuardianVerified
-            case "slack": return store.slackGuardianVerified
-            default: return false
-            }
-        }()
-        let inProgress: Bool = {
-            switch channel {
-            case "telegram": return store.telegramGuardianVerificationInProgress
-            case "sms": return store.smsGuardianVerificationInProgress
-            case "voice": return store.voiceGuardianVerificationInProgress
-            case "slack": return store.slackGuardianVerificationInProgress
-            default: return false
-            }
-        }()
-        let instruction: String? = {
-            switch channel {
-            case "telegram": return store.telegramGuardianInstruction
-            case "sms": return store.smsGuardianInstruction
-            case "voice": return store.voiceGuardianInstruction
-            case "slack": return store.slackGuardianInstruction
-            default: return nil
-            }
-        }()
-        let error: String? = {
-            switch channel {
-            case "telegram": return store.telegramGuardianError
-            case "sms": return store.smsGuardianError
-            case "voice": return store.voiceGuardianError
-            case "slack": return store.slackGuardianError
-            default: return nil
-            }
-        }()
-        let alreadyBound: Bool = {
-            switch channel {
-            case "telegram": return store.telegramGuardianAlreadyBound
-            case "sms": return store.smsGuardianAlreadyBound
-            case "voice": return store.voiceGuardianAlreadyBound
-            case "slack": return store.slackGuardianAlreadyBound
-            default: return false
-            }
-        }()
-        let outboundSessionId: String? = {
-            switch channel {
-            case "telegram": return store.telegramOutboundSessionId
-            case "sms": return store.smsOutboundSessionId
-            case "voice": return store.voiceOutboundSessionId
-            case "slack": return store.slackOutboundSessionId
-            default: return nil
-            }
-        }()
-        let outboundExpiresAt: Date? = {
-            switch channel {
-            case "telegram": return store.telegramOutboundExpiresAt
-            case "sms": return store.smsOutboundExpiresAt
-            case "voice": return store.voiceOutboundExpiresAt
-            case "slack": return store.slackOutboundExpiresAt
-            default: return nil
-            }
-        }()
-        let outboundNextResendAt: Date? = {
-            switch channel {
-            case "telegram": return store.telegramOutboundNextResendAt
-            case "sms": return store.smsOutboundNextResendAt
-            case "voice": return store.voiceOutboundNextResendAt
-            case "slack": return store.slackOutboundNextResendAt
-            default: return nil
-            }
-        }()
-        let outboundSendCount: Int = {
-            switch channel {
-            case "telegram": return store.telegramOutboundSendCount
-            case "sms": return store.smsOutboundSendCount
-            case "voice": return store.voiceOutboundSendCount
-            case "slack": return store.slackOutboundSendCount
-            default: return 0
-            }
-        }()
-        let bootstrapUrl: String? = channel == "telegram" ? store.telegramBootstrapUrl : nil
-        let outboundCode: String? = {
-            switch channel {
-            case "telegram": return store.telegramOutboundCode
-            case "sms": return store.smsOutboundCode
-            case "voice": return store.voiceOutboundCode
-            case "slack": return store.slackOutboundCode
-            default: return nil
-            }
-        }()
-        let primaryIdentity = guardianPrimaryIdentity(channel: channel, identity: identity)
-        let secondaryIdentity = guardianSecondaryIdentity(primary: primaryIdentity, identity: identity)
-        let telegramProfileURL: URL? = channel == "telegram"
-            ? identity.flatMap { URL(string: "https://web.telegram.org/a/#\($0)") }
-            : nil
-
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            if verified {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    HStack(spacing: VSpacing.sm) {
-                        guardianLabel
-                        VStack(alignment: .leading, spacing: 2) {
-                            if let telegramProfileURL {
-                                Link(primaryIdentity ?? "Verified", destination: telegramProfileURL)
-                                    .font(VFont.body)
-                                    .lineLimit(1)
-                                    .onHover { hovering in
-                                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                                    }
-                            } else {
-                                Text(primaryIdentity ?? "Verified")
-                                    .font(VFont.body)
-                                    .foregroundColor(VColor.textSecondary)
-                                    .lineLimit(1)
-                            }
-                            if let secondaryIdentity {
-                                if let telegramProfileURL {
-                                    Link(secondaryIdentity, destination: telegramProfileURL)
-                                        .font(VFont.caption)
-                                        .lineLimit(1)
-                                        .onHover { hovering in
-                                            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                                        }
-                                } else {
-                                    Text(secondaryIdentity)
-                                        .font(VFont.caption)
-                                        .foregroundColor(VColor.textMuted)
-                                        .lineLimit(1)
-                                }
-                            }
-                        }
-                        Spacer()
-                    }
-                    VButton(label: "Revoke", style: .secondary) {
-                        store.revokeChannelGuardian(channel: channel)
-                    }
-                }
-            } else if inProgress && outboundSessionId == nil {
-                HStack(spacing: VSpacing.sm) {
-                    guardianLabel
-                    ProgressView()
-                        .controlSize(.small)
-                    Text("Sending verification...")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                }
-            } else if outboundSessionId != nil {
-                guardianOutboundPendingView(
-                    channel: channel,
-                    expiresAt: outboundExpiresAt,
-                    nextResendAt: outboundNextResendAt,
-                    sendCount: outboundSendCount,
-                    bootstrapUrl: bootstrapUrl,
-                    outboundCode: outboundCode
-                )
-            } else if let instruction {
-                guardianInstructionView(channel: channel, instruction: instruction)
-            } else {
-                guardianDestinationInputView(channel: channel)
-            }
-
-            if let error {
-                VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text(error)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.error)
-                    if alreadyBound {
-                        VButton(label: "Replace", style: .secondary) {
-                            store.startChannelGuardianVerification(channel: channel, rebind: true)
-                        }
-                    }
-                }
-                .padding(.leading, labelColumnWidth + VSpacing.sm)
-            }
-        }
-    }
-
-    // MARK: - Outbound Guardian Destination Input
-
-    @ViewBuilder
-    private func guardianDestinationInputView(channel: String) -> some View {
-        let destinationBinding = Binding<String>(
-            get: { guardianDestinationText[channel] ?? "" },
-            set: { guardianDestinationText[channel] = $0 }
+    private func guardianVerificationView(channel: String) -> some View {
+        GuardianVerificationFlowView(
+            state: store.guardianChannelState(for: channel),
+            countdownNow: $countdownNow,
+            destinationText: Binding<String>(
+                get: { guardianDestinationText[channel] ?? "" },
+                set: { guardianDestinationText[channel] = $0 }
+            ),
+            onStartOutbound: { dest in store.startOutboundGuardianVerification(channel: channel, destination: dest) },
+            onResend: { store.resendOutboundGuardian(channel: channel) },
+            onCancelOutbound: { store.cancelOutboundGuardian(channel: channel) },
+            onRevoke: { store.revokeChannelGuardian(channel: channel) },
+            onStartChallenge: { rebind in store.startChannelGuardianVerification(channel: channel, rebind: rebind) },
+            onCancelChallenge: { store.cancelGuardianChallenge(channel: channel) },
+            botUsername: store.telegramBotUsername,
+            phoneNumber: store.twilioPhoneNumber,
+            showLabel: true,
+            labelColumnWidth: labelColumnWidth
         )
-        let destination = destinationBinding.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        let placeholder: String = {
-            switch channel {
-            case "telegram": return "@username or chat ID"
-            case "sms", "voice": return "+1234567890"
-            case "slack": return "Slack user ID"
-            default: return "Destination"
-            }
-        }()
-
-        VStack(alignment: .leading, spacing: VSpacing.md) {
-            guardianLabel
-
-            TextField(placeholder, text: destinationBinding)
-                .vInputStyle()
-                .font(VFont.body)
-                .foregroundColor(VColor.textPrimary)
-                .frame(maxWidth: 360)
-
-            if channel == "telegram" {
-                HStack(spacing: 0) {
-                    Text("Enter a @username or chat ID. ")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
-
-                    Button {
-                        if let url = URL(string: "https://web.telegram.org/k/#@userinfobot") {
-                            NSWorkspace.shared.open(url)
-                        }
-                    } label: {
-                        Text("Find yours →")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.accent)
-                    }
-                    .buttonStyle(.plain)
-                    .onHover { hovering in
-                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                    }
-                }
-            } else if channel == "voice" || channel == "sms" {
-                Text("This is your personal phone number")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-            }
-
-            VButton(label: "Send", style: .secondary) {
-                store.startOutboundGuardianVerification(channel: channel, destination: destination)
-            }
-            .disabled(destination.isEmpty)
-        }
-    }
-
-    // MARK: - Outbound Guardian Pending View
-
-    @ViewBuilder
-    private func guardianOutboundPendingView(
-        channel: String,
-        expiresAt: Date?,
-        nextResendAt: Date?,
-        sendCount: Int,
-        bootstrapUrl: String?,
-        outboundCode: String?
-    ) -> some View {
-        let isCodeCopied = outboundCodeCopiedChannel == channel
-        let canResend: Bool = {
-            // Bootstrap sessions (Telegram handle-based) don't support resend
-            if bootstrapUrl != nil { return false }
-            guard let nextResendAt else { return true }
-            return countdownNow >= nextResendAt
-        }()
-        let resendCooldownText: String? = {
-            guard let nextResendAt, countdownNow < nextResendAt else { return nil }
-            let remaining = Int(nextResendAt.timeIntervalSince(countdownNow))
-            return "Resend in \(remaining)s"
-        }()
-
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            HStack(spacing: VSpacing.sm) {
-                guardianLabel
-                Spacer()
-            }
-
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
-                // Verification Code label + code box
-                if let outboundCode {
-                    HStack(spacing: VSpacing.xs) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(VColor.success)
-                            .font(.system(size: 12))
-                        Text("Verification Code Sent")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.success)
-                    }
-
-                    HStack(spacing: VSpacing.sm) {
-                        Text(outboundCode)
-                            .font(VFont.mono)
-                            .foregroundColor(VColor.textPrimary)
-                            .textSelection(.enabled)
-                            .lineLimit(1)
-
-                        Spacer()
-
-                        Button {
-                            NSPasteboard.general.clearContents()
-                            NSPasteboard.general.setString(outboundCode, forType: .string)
-                            outboundCodeCopiedChannel = channel
-                            // Use GCD instead of Task to avoid Swift concurrency executor
-                            // tracking issues when the countdown timer rebuilds this view.
-                            let copiedChannel = channel
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                                if outboundCodeCopiedChannel == copiedChannel {
-                                    outboundCodeCopiedChannel = nil
-                                }
-                            }
-                        } label: {
-                            HStack(spacing: VSpacing.xs) {
-                                Image(systemName: isCodeCopied ? "checkmark" : "doc.on.doc")
-                                    .font(.system(size: 12, weight: .medium))
-                                Text(isCodeCopied ? "Copied" : "Copy")
-                                    .font(VFont.caption)
-                            }
-                            .foregroundColor(isCodeCopied ? VColor.success : VColor.textSecondary)
-                            .frame(height: 28)
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("Copy verification code")
-                        .help("Copy code")
-                    }
-                    .padding(VSpacing.md)
-                    .frame(width: 360)
-                    .background(VColor.surface)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                    )
-                }
-
-                // Send count + countdown in one line
-                HStack(spacing: VSpacing.md) {
-                    if sendCount > 0 {
-                        Text("Sent \(sendCount) time\(sendCount == 1 ? "" : "s")")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                    }
-                    if let expiresAt {
-                        let remaining = expiresAt.timeIntervalSince(countdownNow)
-                        if remaining > 0 {
-                            let minutes = Int(remaining) / 60
-                            let seconds = Int(remaining) % 60
-                            Text("Expires in \(minutes):\(String(format: "%02d", seconds))")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                        } else {
-                            Text("Verification expired")
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.error)
-                        }
-                    }
-                }
-
-                // Resend + Cancel in one line
-                // Disable resend during bootstrap: when bootstrapUrl is set the session is
-                // in pending_bootstrap state and the daemon rejects resend attempts.
-                HStack(spacing: VSpacing.sm) {
-                    VButton(label: resendCooldownText ?? "Resend", style: .secondary, isFullWidth: true) {
-                        store.resendOutboundGuardian(channel: channel)
-                    }
-                    .disabled(!canResend)
-                    .frame(width: 160)
-
-                    VButton(label: "Cancel", style: .tertiary) {
-                        store.cancelOutboundGuardian(channel: channel)
-                    }
-                }
-
-                // Telegram bootstrap URL deep link
-                if let bootstrapUrl, let url = URL(string: bootstrapUrl) {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        Text("Ask your guardian to open this link:")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-
-                        Button {
-                            NSWorkspace.shared.open(url)
-                        } label: {
-                            HStack(spacing: VSpacing.xs) {
-                                Image(systemName: "arrow.up.right.square")
-                                    .font(.system(size: 12))
-                                Text("Open in Telegram")
-                                    .font(VFont.caption)
-                            }
-                            .foregroundColor(VColor.accent)
-                        }
-                        .buttonStyle(.plain)
-                        .onHover { hovering in
-                            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                        }
-                    }
-                }
-            }
-        }
         .onAppear { startCountdownTimer() }
         .onDisappear { stopCountdownTimer() }
     }
@@ -1271,140 +828,6 @@ struct SettingsChannelsTab: View {
         guard countdownTimerRefCount == 0 else { return }
         countdownTimer?.invalidate()
         countdownTimer = nil
-    }
-
-    private func guardianInstructionSubtext(channel: String) -> String {
-        if channel == "telegram" {
-            let handle = store.telegramBotUsername.map { "@\($0)" } ?? "your bot"
-            return "Message \(handle) with the below code within the next 10 minutes"
-        } else if channel == "voice" {
-            let number = store.twilioPhoneNumber ?? "your assistant"
-            return "Call \(number) and say the six-digit code below within the next 10 minutes"
-        } else {
-            let number = store.twilioPhoneNumber ?? "your assistant"
-            return "Text \(number) with the below code within the next 10 minutes"
-        }
-    }
-
-    /// Extracts a guardian verification code from a raw instruction string.
-    /// Supports two formats:
-    ///   1. "N-digit code: <digits>" (numeric codes, e.g. "6-digit code: 123456")
-    ///   2. "the code: <hex>" (high-entropy hex codes for inbound challenges)
-    private func extractGuardianCommand(from instruction: String) -> String? {
-        // Try N-digit code format (e.g., "6-digit code: 123456")
-        if let code = extractNumericCode(from: instruction) {
-            return code
-        }
-        // Try generic "the code: <hex>" format for high-entropy codes
-        if let range = instruction.range(of: #"the code:\s*([0-9a-fA-F]+)"#, options: .regularExpression) {
-            let match = String(instruction[range])
-            if let hexRange = match.range(of: #"[0-9a-fA-F]{6,}"#, options: .regularExpression) {
-                return String(match[hexRange])
-            }
-        }
-        return nil
-    }
-
-    /// Extracts a numeric verification code from instruction text.
-    /// Matches the format "N-digit code: <digits>" used for identity-bound codes.
-    private func extractNumericCode(from instruction: String) -> String? {
-        guard let range = instruction.range(of: #"\d+-digit code:\s*(\d+)"#, options: .regularExpression) else {
-            return nil
-        }
-        let match = String(instruction[range])
-        // Extract just the digits after "N-digit code: "
-        guard let colonRange = match.range(of: #":\s*"#, options: .regularExpression) else {
-            return nil
-        }
-        return String(match[colonRange.upperBound...])
-    }
-
-    @ViewBuilder
-    private func guardianInstructionView(channel: String, instruction: String) -> some View {
-        // All channels now use code-only verification. extractGuardianCommand
-        // handles both "six-digit code: 123456" and "the code: <hex>" formats.
-        let command: String? = extractGuardianCommand(from: instruction)
-        let isCopied = guardianCommandCopiedChannel == channel
-
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            HStack(spacing: VSpacing.sm) {
-                guardianLabel
-                Text("Verification pending")
-                    .font(VFont.body)
-                    .foregroundColor(VColor.warning)
-                Spacer()
-            }
-
-            if let command {
-                Text(guardianInstructionSubtext(channel: channel))
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textMuted)
-                    .padding(.leading, labelColumnWidth + VSpacing.sm)
-
-                HStack(spacing: VSpacing.sm) {
-                    Text(command)
-                        .font(VFont.mono)
-                        .foregroundColor(VColor.textPrimary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .textSelection(.enabled)
-
-                    Spacer()
-
-                    Button {
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(command, forType: .string)
-                        guardianCommandCopiedChannel = channel
-                        Task {
-                            try? await Task.sleep(nanoseconds: 2_000_000_000)
-                            if guardianCommandCopiedChannel == channel {
-                                guardianCommandCopiedChannel = nil
-                            }
-                        }
-                    } label: {
-                        HStack(spacing: VSpacing.xs) {
-                            Image(systemName: isCopied ? "checkmark" : "doc.on.doc")
-                                .font(.system(size: 12, weight: .medium))
-                            Text(isCopied ? "Copied" : "Copy")
-                                .font(VFont.caption)
-                        }
-                        .foregroundColor(isCopied ? VColor.success : VColor.textSecondary)
-                        .frame(height: 28)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Copy verification command")
-                    .help("Copy command")
-                }
-                .padding(VSpacing.md)
-                .background(VColor.surface)
-                .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: VRadius.md)
-                        .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                )
-                .padding(.leading, labelColumnWidth + VSpacing.sm)
-            } else {
-                // Fallback: show raw instruction if command can't be parsed
-                Text(instruction)
-                    .font(VFont.mono)
-                    .foregroundColor(VColor.textPrimary)
-                    .padding(VSpacing.md)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(VColor.surface)
-                    .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: VRadius.md)
-                            .stroke(VColor.surfaceBorder.opacity(0.5), lineWidth: 1)
-                    )
-                    .textSelection(.enabled)
-                    .padding(.leading, labelColumnWidth + VSpacing.sm)
-            }
-
-            VButton(label: "Cancel", style: .tertiary) {
-                store.cancelGuardianChallenge(channel: channel)
-            }
-        }
     }
 
     // MARK: - Mobile Card (Pairing + Approved Devices)


### PR DESCRIPTION
## Summary
- Replace private guardian verification views in SettingsChannelsTab with shared GuardianVerificationFlowView
- Remove ~600 lines of now-redundant private methods (guardianStatusRow, guardianOutboundPendingView, guardianInstructionView, guardianDestinationInputView, etc.)
- Remove orphaned state variables (guardianCommandCopiedChannel, outboundCodeCopiedChannel) whose copy feedback is now managed internally by the shared view
- Both Channels tab and Contacts page now use the same shared verification UI components

Part of plan: guardian-verify-contacts.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
