### PR TITLE
fix: add guardian preview and refresh status on appear in ContactDetailView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -62,6 +62,12 @@ struct ContactDetailView: View {
             currentContact = contact
             if contact.role == "guardian" {
                 startGuardianCountdownTimer()
+                // Refresh guardian verification state for all supported channels
+                // so the view shows current status even if the user hasn't visited
+                // the Channels settings tab yet.
+                for channel in Self.guardianSupportedChannels {
+                    store?.refreshChannelGuardianStatus(channel: channel)
+                }
             }
         }
         .onDisappear {
@@ -974,6 +980,61 @@ struct ContactDetailView: View {
                         status: "unverified",
                         policy: "allow"
                     )
+                ]
+            )
+        )
+        .frame(width: 500, height: 700)
+    }
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Guardian Contact") {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        ContactDetailView(
+            contact: ContactPayload(
+                id: "contact-guardian",
+                displayName: "Guardian",
+                role: "guardian",
+                notes: "Primary guardian contact for verification flows.",
+                contactType: "human",
+                lastInteraction: Date().timeIntervalSince1970 * 1000 - 1_800_000,
+                interactionCount: 8,
+                channels: [
+                    ContactChannelPayload(
+                        id: "ch-g1",
+                        type: "telegram",
+                        address: "@guardian_bot",
+                        isPrimary: true,
+                        status: "active",
+                        policy: "allow",
+                        verifiedAt: Int(Date().timeIntervalSince1970 * 1000) - 86_400_000,
+                        verifiedVia: "telegram"
+                    ),
+                    ContactChannelPayload(
+                        id: "ch-g2",
+                        type: "sms",
+                        address: "+15551234567",
+                        isPrimary: false,
+                        status: "active",
+                        policy: "allow"
+                    ),
+                    ContactChannelPayload(
+                        id: "ch-g3",
+                        type: "voice",
+                        address: "+15551234567",
+                        isPrimary: false,
+                        status: "pending",
+                        policy: "allow"
+                    ),
+                    ContactChannelPayload(
+                        id: "ch-g4",
+                        type: "slack",
+                        address: "#guardian-alerts",
+                        isPrimary: false,
+                        status: "unverified",
+                        policy: "restrict"
+                    ),
                 ]
             )
         )


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for guardian-verify-contacts.md:

1. **Missing guardian preview**: Added a guardian contact preview in ContactDetailView showing telegram/sms/voice/slack channels with role=guardian.
2. **Missing refresh on appear**: Added refreshChannelGuardianStatus calls for all four supported channels when a guardian contact is displayed, matching the pattern in SettingsChannelsTab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
