### PR TITLE
feat(google-oauth-setup): add CLI-based setup path using gws

### DIFF
--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: "Google OAuth Setup"
-description: "Set up Google Cloud OAuth credentials for Gmail and Calendar using browser automation"
+description: "Set up Google Cloud OAuth credentials for Gmail and Calendar"
 user-invocable: true
 credential-setup-for: "gmail"
 includes: ["browser", "public-ingress"]
-metadata: {"vellum": {"emoji": "\ud83d\udd11"}}
+metadata: { "vellum": { "emoji": "\ud83d\udd11" } }
 ---
 
 You are helping your user set up Google Cloud OAuth credentials so Gmail and Google Calendar integrations can connect.
 
 ## Client Check
 
-Determine whether the user has browser automation available (macOS desktop app) or is on a non-interactive channel (Telegram, SMS, etc.).
+Determine which setup path to use based on the user's client:
 
-- **macOS desktop app**: Follow the **Automated Setup** path below.
-- **Telegram or other channel** (no browser automation): Follow the **Manual Setup for Channels** path below.
+- **macOS desktop app**: Follow **Path C: CLI Setup** below (preferred). If `gcloud` or `gws` cannot be installed (e.g., corporate restrictions, Homebrew unavailable), fall back to **Path B: Browser Automation**.
+- **Telegram or other channel** (no browser automation): Follow **Path A: Manual Setup for Channels** below.
 
 ---
 
@@ -29,6 +29,7 @@ Tell the user:
 > **Setting up Gmail & Calendar from Telegram**
 >
 > Since I can't automate the browser from here, I'll walk you through each step with direct links. You'll need:
+>
 > 1. A Google account with access to Google Cloud Console
 > 2. About 5 minutes
 >
@@ -96,6 +97,7 @@ Tell the user:
 ### Channel Step 5: Create OAuth Credentials (Web Application)
 
 Before sending Step 4 to the user, resolve the concrete callback URL:
+
 - Read the configured public gateway URL (`ingress.publicBaseUrl`). If it is missing, run the `public-ingress` skill first.
 - Build `oauthCallbackUrl` as `<public gateway URL>/webhooks/oauth/callback`.
 - When you send the instructions below, replace `OAUTH_CALLBACK_URL` with that concrete value. Never send placeholders literally.
@@ -140,7 +142,7 @@ credential_store store:
 
 **Step 6b: Client Secret (requires split entry to avoid security filters)**
 
-The Client Secret starts with `GOCSPX-` which triggers the ingress secret scanner on channel messages. To work around this, ask the user to send only the portion *after* the prefix.
+The Client Secret starts with `GOCSPX-` which triggers the ingress secret scanner on channel messages. To work around this, ask the user to send only the portion _after_ the prefix.
 
 Tell the user:
 
@@ -232,6 +234,7 @@ Use `ui_show` with `surface_type: "confirmation"`. Set `message` to just the tit
 - **message:** `Set up Google Cloud for Gmail & Calendar`
 - **detail:**
   > Here's what will happen:
+  >
   > 1. **A browser opens on the side** so you can watch everything I do
   > 2. **You sign in** to your Google account in the browser
   > 3. **I automate everything** including project creation, APIs, OAuth config, and credentials
@@ -267,6 +270,7 @@ Navigate to `https://console.cloud.google.com/projectcreate`.
 Take a `browser_snapshot`. Find the project name input field (look for an element with label containing "Project name" or a text input near the top of the form). Type "Vellum Assistant" into it.
 
 Look for a "Create" button in the snapshot and click it. Wait 10-15 seconds for project creation, then take a screenshot to check for:
+
 - **Success message** or redirect to the new project dashboard. Note the project ID from the URL or page content.
 - **"Project name already in use" error**: that's fine. Navigate to `https://console.cloud.google.com/cloud-resource-manager` to find and select the existing "Vellum Assistant" project. Use `browser_extract` to read the project ID from the page.
 - **Organization restriction or quota error**: tell the user what happened and ask them to resolve it.
@@ -282,10 +286,12 @@ Tell the user: "Project created!"
 Tell the user: "Enabling Gmail and Calendar APIs..."
 
 Navigate to each API's library page and enable it if not already enabled:
+
 1. `https://console.cloud.google.com/apis/library/gmail.googleapis.com?project=PROJECT_ID`
 2. `https://console.cloud.google.com/apis/library/calendar-json.googleapis.com?project=PROJECT_ID`
 
 For each page: take a `browser_snapshot`. Look for:
+
 - **"Enable" button**: click it, wait a few seconds, take another snapshot to confirm.
 - **"Manage" button or "API enabled" text**: the API is already enabled. Skip it.
 
@@ -316,12 +322,14 @@ Select **"External"** and click **Create** or **Get Started**.
 Google Cloud uses either a multi-page wizard or a single-page form. Adapt to what you see:
 
 **App information section:**
+
 - **App name**: Type "Vellum Assistant" in the app name field.
 - **User support email**: This is typically a dropdown showing the signed-in user's email. Use `browser_snapshot` to find a `<select>` or clickable dropdown element near "User support email". Select the user's email.
 - **Developer contact email**: Type the user's email into this field. (Use the same email visible in the support email dropdown if you can read it, or use `browser_extract` to find the email shown on the page.)
 - Click **Save and Continue** if on a multi-page wizard.
 
 **Scopes section:**
+
 - Click **"Add or Remove Scopes"** (or similar button).
 - In the scope picker dialog, look for a text input labeled **"Manually add scopes"** or **"Filter"** at the bottom or top of the dialog.
 - Paste all 6 scopes at once as a comma-separated string into that input:
@@ -333,11 +341,13 @@ Google Cloud uses either a multi-page wizard or a single-page form. Adapt to wha
 - Click **Save and Continue** (or **Update** then **Save and Continue**).
 
 **Test users section:**
+
 - Click **"Add Users"** or similar.
 - Enter the user's email address.
 - Click **Add** then **Save and Continue**.
 
 **Summary section:**
+
 - Click **"Back to Dashboard"** or **"Submit"**.
 
 **What you should see when done:** A consent screen dashboard showing "Vellum Assistant" as the app name.
@@ -357,6 +367,7 @@ Navigate to `https://console.cloud.google.com/apis/credentials?project=PROJECT_I
 Take a `browser_snapshot`. Find and click a button labeled **"Create Credentials"** or **"+ Create Credentials"**. A dropdown menu should appear. Take another snapshot and click **"OAuth client ID"**.
 
 On the creation form (take a snapshot to see the fields):
+
 - **Application type**: Find the dropdown and select **"Desktop app"**. This may be a `<select>` element or a custom dropdown. Use the snapshot to identify it. You might need to click the dropdown first, then take another snapshot to see the options, then click "Desktop app".
 - **Name**: Type "Vellum Assistant" in the name field.
 - Do NOT add any redirect URIs. The desktop app flow doesn't need them.
@@ -441,3 +452,157 @@ Tell the user: "**Gmail and Calendar are connected!** You can now read, search, 
 - **Element not found:** Take a fresh `browser_snapshot` to re-assess. The GCP UI may have changed. Describe what you see and try alternative approaches. If stuck after 2 attempts, ask the user for guidance. They can see the Chrome window too.
 - **OAuth flow timeout or failure:** Offer to retry. The credentials are already stored, so reconnecting only requires re-running the authorization flow.
 - **Any unexpected state:** Take a `browser_screenshot`, describe what you see, and ask the user for guidance.
+
+---
+
+# Path C: CLI Setup (macOS Desktop App)
+
+You will set up Google Cloud OAuth credentials using the `gcloud` and `gws` command-line tools. This avoids browser automation entirely — the user only needs to sign in once via the browser and copy-paste credentials from terminal output into secure prompts.
+
+## CLI Step 1: Confirm
+
+Use `ui_show` with `surface_type: "confirmation"`:
+
+- **message:** `Set up Google Cloud for Gmail & Calendar`
+- **detail:**
+  > Here's what will happen:
+  >
+  > 1. **Install CLI tools** (`gcloud` and `gws`) if not already installed
+  > 2. **You sign in** to your Google account once via the browser
+  > 3. **CLI automates everything** — project creation, APIs, consent screen, and credentials
+  > 4. **You copy-paste credentials** from the terminal output into secure prompts
+  > 5. **You authorize Vellum** with one click
+  >
+  > Takes about a minute after first-time setup. Ready?
+
+If the user declines, acknowledge and stop.
+
+## CLI Step 2: Install Prerequisites
+
+Check for and install each prerequisite. If any installation fails (e.g., Homebrew not available, corporate restrictions), tell the user what went wrong and **fall back to Path B (Browser Automation)**.
+
+### gcloud
+
+```bash
+which gcloud
+```
+
+If missing:
+
+```bash
+brew install google-cloud-sdk
+```
+
+After installation, verify it works:
+
+```bash
+gcloud --version
+```
+
+### gws
+
+```bash
+which gws
+```
+
+If missing:
+
+```bash
+npm install -g @googleworkspace/cli
+```
+
+After installation, verify it works:
+
+```bash
+gws --version
+```
+
+## CLI Step 3: Sign In to Google
+
+Tell the user: "Opening your browser so you can sign in to Google..."
+
+```bash
+gcloud auth login
+```
+
+This opens the browser for Google sign-in. Wait for the command to complete — it prints the authenticated account email on success.
+
+If the user is already authenticated (`gcloud auth list` shows an active account), skip this step and tell the user: "Already signed in, continuing setup..."
+
+## CLI Step 4: GCP Project Setup
+
+Tell the user: "Setting up your Google Cloud project, APIs, and credentials..."
+
+```bash
+gws auth setup
+```
+
+This command automates:
+
+- GCP project creation (or selection of an existing one)
+- OAuth consent screen configuration
+- OAuth credential creation
+
+Wait for the command to complete. It may have interactive prompts — let them run in the terminal and the user can respond if needed.
+
+Note the **project ID** from the output — you'll need it for the next step.
+
+## CLI Step 5: Enable Additional APIs
+
+`gws auth setup` enables the APIs it needs, but Vellum also requires the Calendar and People APIs. Enable them explicitly using the project ID from step 4:
+
+```bash
+gcloud services enable calendar-json.googleapis.com --project=PROJECT_ID
+gcloud services enable people.googleapis.com --project=PROJECT_ID
+```
+
+If either command reports the API is already enabled, that's fine — continue.
+
+## CLI Step 6: Collect Credentials
+
+The `gws auth setup` output or the GCP Console shows the Client ID and Client Secret. Ask the user to copy-paste them into secure prompts.
+
+**Client ID:**
+
+```
+credential_store prompt:
+  service: "integration:gmail"
+  field: "client_id"
+  label: "Google OAuth Client ID"
+  description: "Copy the Client ID from the setup output or GCP Console. It looks like 123456789-xxxxx.apps.googleusercontent.com"
+  placeholder: "xxxxx.apps.googleusercontent.com"
+```
+
+**Client Secret:**
+
+```
+credential_store prompt:
+  service: "integration:gmail"
+  field: "client_secret"
+  label: "Google OAuth Client Secret"
+  description: "Copy the Client Secret from the setup output or GCP Console. It starts with GOCSPX-"
+  placeholder: "GOCSPX-..."
+```
+
+Wait for both prompts to be completed before continuing.
+
+## CLI Step 7: Authorize
+
+Tell the user: "Starting the authorization flow — a Google sign-in page will open. Just click 'Allow' when it appears."
+
+Use `credential_store` with:
+
+```
+action: "oauth2_connect"
+service: "integration:gmail"
+```
+
+This auto-reads client_id and client_secret from the secure store and auto-fills auth_url, token_url, scopes, and extra_params from well-known config.
+
+**If the user sees a "This app isn't verified" warning:** Tell them: "You'll see an 'app isn't verified' warning. This is normal for personal apps in testing mode. Click **Advanced**, then **Go to Vellum Assistant (unsafe)** to proceed."
+
+**Verify:** The `oauth2_connect` call returns a success message with the connected account email.
+
+## CLI Step 8: Done!
+
+Tell the user: "**Gmail and Calendar are connected!** You can now read, search, and send emails, plus view and manage your calendar. Try asking me to check your inbox or show your upcoming events!"


### PR DESCRIPTION
## Summary

- Adds **Path C: CLI Setup** to the `google-oauth-setup` skill for macOS desktop users, using `gcloud` + `gws` CLI tools instead of browser automation
- Updates Client Check to prefer CLI path on macOS desktop, with browser automation as fallback when CLI tools can't be installed
- Channel path (Path A) and browser automation path (Path B) remain unchanged

The CLI path replaces 250+ lines of fragile DOM scraping with a simple `gws auth setup` command that automates GCP project creation, API enablement, consent screen configuration, and credential generation.

## Test plan

- [ ] Run skill on a fresh macOS machine (no existing GCP project) — verify `gcloud`/`gws` install + setup works end-to-end
- [ ] Verify `gws auth setup` creates project + credentials and displays Client ID/Secret in terminal output
- [ ] Verify user can copy-paste credentials into secure prompts and `oauth2_connect` succeeds
- [ ] Test on machine with existing `gcloud`/`gws` (install steps skipped)
- [ ] Test fallback: when `gws` unavailable, verify assistant falls back to Path B (browser automation)
- [ ] Verify channel path (Path A) still works unchanged
- [ ] Existing skills tests pass (44/44 ✅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
