### PR TITLE
fix: gitignore .githooks/.githooks circular symlink

### DIFF
--- a/.githooks/.githooks
+++ b/.githooks/.githooks
@@ -1,1 +1,1 @@
-/Users/ashleeradka/Development/vellum-assistant/.githooks
+/Users/noaflaherty/Repos/vellum-ai/vellum-assistant/.githooks

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist
 
 # misc
 .DS_Store
+.githooks/.githooks
 *.pem
 .qdrant-initialized
 .claude/*


### PR DESCRIPTION
## Summary
- Reverts the `.githooks/.githooks` symlink that keeps flipping between developers' absolute paths
- Adds `.githooks/.githooks` to `.gitignore` to prevent future accidental commits

The symlink is a circular self-reference (`.githooks/` containing a symlink to itself) that serves no purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
