### PR TITLE
fix: handle Shift+Enter newline in macOS chat composer (LUM-21)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
@@ -38,6 +38,8 @@ struct ComposerEditorHeightKey: PreferenceKey {
 /// - Intercepts Cmd+V when the pasteboard contains image content.
 /// - Intercepts Cmd+Return when `cmdEnterToSend` is enabled to trigger send
 ///   before SwiftUI's `.onSubmit` fires.
+/// - Intercepts Shift+Return in default send mode to insert a newline
+///   before SwiftUI's `.onSubmit` fires.
 struct ComposerFocusBridge: NSViewRepresentable {
     let isFocused: Bool
     let cmdEnterToSend: Bool
@@ -111,13 +113,33 @@ struct ComposerFocusBridge: NSViewRepresentable {
                     return nil
                 }
 
-                // Cmd+Return send when cmdEnterToSend is enabled.
-                // All other Return routing is handled by SwiftUI's .onSubmit
-                // on the TextField in ComposerView.
+                // Return-key routing. The bridge handles modifier-specific
+                // interception (Shift+Enter newline, Cmd+Enter send).
+                // Plain Enter flows through to SwiftUI's .onSubmit which
+                // calls performSendAction() — the canonical send path that
+                // handles slash-menu, ghost-text, and pending-confirmation.
                 let isReturn = event.keyCode == 36 || event.keyCode == 76
-                if isReturn, self.parent.cmdEnterToSend, modifiers == [.command] {
-                    self.parent.onSend()
-                    return nil
+                if isReturn {
+                    switch ComposerReturnKeyRouting.resolve(
+                        cmdEnterToSend: self.parent.cmdEnterToSend,
+                        modifiers: modifiers
+                    ) {
+                    case .bridgeSend:
+                        self.parent.onSend()
+                        return nil
+                    case .bridgeInsertNewline:
+                        // Insert newline only if we can find the field editor;
+                        // otherwise let the event propagate normally.
+                        let textView = (event.window?.firstResponder as? NSTextView)
+                            ?? (NSApp.keyWindow?.firstResponder as? NSTextView)
+                        if let textView {
+                            textView.insertText("\n", replacementRange: textView.selectedRange())
+                            return nil
+                        }
+                        return event
+                    case .deferToSubmit:
+                        return event
+                    }
                 }
 
                 // Let zoom shortcuts propagate instead of being consumed


### PR DESCRIPTION
## Summary
- Wires `ComposerReturnKeyRouting.resolve()` into ComposerBridge's event monitor to handle Return key + modifier combos
- Shift+Enter in default send mode now inserts a newline (consumed only when NSTextView is found)
- Cmd+Enter in cmd-enter mode continues to send (previously hardcoded, now via resolver)
- Plain Enter still flows through to `.onSubmit` → `performSendAction()` — no change to send orchestration

Apple refs checked (2026-03-05): `NSEvent.addLocalMonitorForEvents`, `NSTextView.insertText(_:replacementRange:)`, `NSEvent.window` — no deprecations for macOS 15.

Part of plan: shift-enter-newline.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
