### PR TITLE
fix: replace refactoring-history docstring in GuardianVerificationModels

### DIFF
--- a/clients/macos/vellum-assistant/Features/GuardianVerification/GuardianVerificationModels.swift
+++ b/clients/macos/vellum-assistant/Features/GuardianVerification/GuardianVerificationModels.swift
@@ -2,9 +2,8 @@ import Foundation
 
 // MARK: - Guardian Channel State
 
-/// Bundles all per-channel guardian verification state into a single value type.
-/// This replaces the giant switch-statement blocks in SettingsChannelsTab.guardianStatusRow
-/// by providing a single struct that can be built from SettingsStore's @Published properties.
+/// Bundles all per-channel guardian verification state into a single value type,
+/// built from SettingsStore's @Published properties for use in guardian verification UI.
 struct GuardianChannelState {
     let channel: String
     let identity: String?


### PR DESCRIPTION
## Summary
- Replace breadcrumb docstring with intent-focused description per AGENTS.md comment quality rules

Addresses feedback from #13075.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13093" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
