### PR TITLE
fix: replace DispatchQueue.main.asyncAfter with cancellable Task

### DIFF
--- a/clients/macos/vellum-assistant/Features/GuardianVerification/GuardianVerificationFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/GuardianVerification/GuardianVerificationFlowView.swift
@@ -30,6 +30,8 @@ struct GuardianVerificationFlowView: View {
 
     @State private var codeCopied: Bool = false
     @State private var commandCopied: Bool = false
+    @State private var codeCopyResetTask: Task<Void, Never>?
+    @State private var commandCopyResetTask: Task<Void, Never>?
 
     // MARK: - Body
 
@@ -175,10 +177,11 @@ struct GuardianVerificationFlowView: View {
                         Button {
                             NSPasteboard.general.clearContents()
                             NSPasteboard.general.setString(outboundCode, forType: .string)
+                            codeCopyResetTask?.cancel()
                             codeCopied = true
-                            // Use GCD instead of Task to avoid Swift concurrency executor
-                            // tracking issues when the countdown timer rebuilds this view.
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                            codeCopyResetTask = Task {
+                                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                                guard !Task.isCancelled else { return }
                                 codeCopied = false
                             }
                         } label: {
@@ -315,8 +318,11 @@ struct GuardianVerificationFlowView: View {
                     Button {
                         NSPasteboard.general.clearContents()
                         NSPasteboard.general.setString(command, forType: .string)
+                        commandCopyResetTask?.cancel()
                         commandCopied = true
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                        commandCopyResetTask = Task {
+                            try? await Task.sleep(nanoseconds: 2_000_000_000)
+                            guard !Task.isCancelled else { return }
                             commandCopied = false
                         }
                     } label: {


### PR DESCRIPTION
## Summary
- Replace two DispatchQueue.main.asyncAfter blocks with cancellable Task per AGENTS.md rules
- Prevents stale closures from firing after view teardown

Addresses feedback from #13079.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
