### PR TITLE
fix: read guardianStoreRevision in view body and refresh Slack guardian on Contacts appear

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -50,6 +50,11 @@ struct ContactDetailView: View {
     }
 
     var body: some View {
+        // Read guardianStoreRevision so SwiftUI tracks it; the .onReceive
+        // below increments it whenever SettingsStore publishes, forcing
+        // re-evaluation of guardian verification state.
+        let _ = guardianStoreRevision
+
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
                 headerSection

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -687,6 +687,7 @@ public final class SettingsStore: ObservableObject {
         refreshChannelGuardianStatus(channel: "telegram")
         refreshChannelGuardianStatus(channel: "sms")
         refreshChannelGuardianStatus(channel: "voice")
+        refreshChannelGuardianStatus(channel: "slack")
 
         // Ingress config is refreshed by onAppear in SettingsPanel,
         // not here, to avoid duplicate get requests whose


### PR DESCRIPTION
## Summary
- Fix guardianStoreRevision @State never being read in the view body, so SwiftUI re-renders when SettingsStore publishes guardian state changes
- Add Slack to SettingsStore init guardian status refresh so Slack guardian state is available from app startup, not only when the Channels tab appears

Addresses feedback from #13081.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
