### PR TITLE
fix(google-oauth-setup): add host_bash requirement and missing scopes to CLI path

### DIFF
--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -196,6 +196,8 @@ After the user authorizes (they'll come back and say so, or you can suggest they
 
 # Path B: CLI Setup (macOS Desktop App)
 
+**IMPORTANT: Always use `host_bash` (not `bash`) for all commands in this path.** The `gcloud` and `gws` CLIs need host access for Homebrew/npm installation, browser-based authentication, and interactive terminal prompts — none of which are available inside the sandbox.
+
 You will set up Google Cloud OAuth credentials using the `gcloud` and `gws` command-line tools. This avoids browser automation entirely — the user only needs to sign in once via the browser and copy-paste credentials from terminal output into secure prompts.
 
 ## CLI Step 1: Confirm
@@ -296,6 +298,29 @@ gcloud services enable people.googleapis.com --project=PROJECT_ID
 ```
 
 If either command reports the API is already enabled, that's fine — continue.
+
+## CLI Step 5b: Update OAuth Consent Screen Scopes
+
+`gws auth setup` configures the consent screen with Gmail scopes only. Vellum also needs Calendar, Contacts, and userinfo scopes. Tell the user to add the missing scopes:
+
+> **Update consent screen scopes**
+>
+> Open: `https://console.cloud.google.com/apis/credentials/consent/edit?project=PROJECT_ID`
+>
+> 1. Click through to the **Scopes** page (click **Save and Continue** on the first page)
+> 2. Click **Add or Remove Scopes** and ensure all of these are present:
+>    - `https://www.googleapis.com/auth/gmail.readonly`
+>    - `https://www.googleapis.com/auth/gmail.modify`
+>    - `https://www.googleapis.com/auth/gmail.send`
+>    - `https://www.googleapis.com/auth/calendar.readonly`
+>    - `https://www.googleapis.com/auth/calendar.events`
+>    - `https://www.googleapis.com/auth/userinfo.email`
+>    - `https://www.googleapis.com/auth/contacts.readonly`
+> 3. Click **Update**, then **Save and Continue** through the remaining pages
+
+(Substitute the actual project ID into the URL.)
+
+The Gmail scopes may already be present from `gws auth setup` — add any that are missing.
 
 ## CLI Step 6: Collect Credentials
 


### PR DESCRIPTION
## Summary
- Add explicit `host_bash` requirement to Path B (CLI Setup) so CLI commands run on the host, not in sandbox
- Add step to update OAuth consent screen with all required scopes (Calendar, Contacts, userinfo) after `gws auth setup`
- Addresses review feedback from PR #13086

## Test plan
- [ ] Verify SKILL.md renders correctly
- [ ] Verify host_bash instruction is clear and prominent at the top of Path B

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
