### PR TITLE
fix: composer stays expanded after send — break height/padding feedback loop

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -262,14 +262,16 @@ struct ComposerView: View {
             // Reserve trailing space so text wraps before reaching the
             // overlaid action buttons (attach + send/mic ≈ 70pt wide).
             .padding(.trailing, 70)
-            // Reserve bottom space so the last visible line isn't hidden
-            // behind the buttons when the composer is expanded.
-            .padding(.bottom, isComposerExpanded ? composerActionButtonSize : 0)
+            // Measure content height BEFORE the conditional bottom padding
+            // so expansion state isn't inflated by its own padding.
             .background(
                 GeometryReader { geo in
                     Color.clear.preference(key: ComposerEditorHeightKey.self, value: geo.size.height)
                 }
             )
+            // Reserve bottom space so the last visible line isn't hidden
+            // behind the buttons when the composer is expanded.
+            .padding(.bottom, isComposerExpanded ? composerActionButtonSize : 0)
         }
         .onPreferenceChange(ComposerEditorHeightKey.self) { newHeight in
             contentHeight = newHeight


### PR DESCRIPTION
## Summary
- Moves GeometryReader measurement **before** the conditional `.padding(.bottom, isComposerExpanded ? composerActionButtonSize : 0)` so it measures only text content height
- Fixes feedback loop where the 34pt expansion padding inflated the measured height, keeping `isComposerExpanded = true` even after text cleared
- Both Codex and Devin independently identified this exact issue on #13100

The fix is a single reorder: `.background(GeometryReader)` now comes before `.padding(.bottom)` instead of after it.

Apple refs checked (2026-03-05): SwiftUI modifier ordering determines measurement scope — measuring before conditional padding is the correct pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
