### PR TITLE
fix: use AXIdentifier attribute and positional fallback for Save button in fill-secure-credential

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -227,6 +227,7 @@ struct SecretPromptView: View {
                             onCancel()
                         }
                         .accessibilityIdentifier("secure-credential-cancel")
+                        .accessibilityLabel("Cancel")
                         VButton(label: "Save", style: .primary) {
                             let trimmed = secretValue.trimmingCharacters(in: .whitespacesAndNewlines)
                             guard !trimmed.isEmpty else { return }
@@ -236,6 +237,7 @@ struct SecretPromptView: View {
                         }
                         .disabled(secretValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                         .accessibilityIdentifier("secure-credential-save")
+                        .accessibilityLabel("Save")
                     }
 
                     if allowOneTimeSend {

--- a/playwright/agent/tools/fill-secure-credential.ts
+++ b/playwright/agent/tools/fill-secure-credential.ts
@@ -7,7 +7,13 @@
  *   1. Find the panel via its accessibility identifier
  *   2. Focus the SecureField
  *   3. Type the env var value
- *   4. Click Save
+ *   4. Click Save using a three-strategy cascade:
+ *      - Strategy 1: AXIdentifier — reads `value of attribute "AXIdentifier"` to
+ *        match the SwiftUI `.accessibilityIdentifier("secure-credential-save")`
+ *      - Strategy 2: Name/title — checks `name of elem` / `title of elem` for "Save",
+ *        backed by explicit `.accessibilityLabel("Save")` on the SwiftUI button
+ *      - Strategy 3: Positional fallback — clicks the last button in the scroll area,
+ *        since Save is always the rightmost button in the HStack
  *
  * The secret value is never returned in the tool result.
  */
@@ -145,13 +151,16 @@ tell application "System Events"
     -- We search entire contents for a button with the accessibility identifier or name "Save".
     set clickedSave to false
 
-    -- Strategy 1: Find button by accessibility identifier
+    -- Strategy 1: Find button by AXIdentifier (set by .accessibilityIdentifier() in SwiftUI)
     repeat with elem in allElems
       try
-        if class of elem is button and description of elem contains "secure-credential-save" then
-          click elem
-          set clickedSave to true
-          exit repeat
+        if class of elem is button then
+          set elemId to value of attribute "AXIdentifier" of elem
+          if elemId is "secure-credential-save" then
+            click elem
+            set clickedSave to true
+            exit repeat
+          end if
         end if
       end try
     end repeat
@@ -169,6 +178,22 @@ tell application "System Events"
           end if
         end try
       end repeat
+    end if
+
+    -- Strategy 3: Positional fallback — click the last button (Save is always rightmost)
+    if not clickedSave then
+      set lastButton to missing value
+      repeat with elem in allElems
+        try
+          if class of elem is button then
+            set lastButton to elem
+          end if
+        end try
+      end repeat
+      if lastButton is not missing value then
+        click lastButton
+        set clickedSave to true
+      end if
     end if
 
     if not clickedSave then


### PR DESCRIPTION
## Summary
- Fix Strategy 1 to use `value of attribute "AXIdentifier"` instead of `description` to correctly read SwiftUI `.accessibilityIdentifier()` from AppleScript
- Add explicit `.accessibilityLabel()` on Save/Cancel buttons in SecretPromptManager for defense-in-depth
- Add Strategy 3 positional fallback that clicks the last button (Save is always rightmost)

Part of plan: fix-fill-credential-save-button-detection.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
