### PR TITLE
fix: make ComputerUseSession.surfaceState public to match Session visibility

### DIFF
--- a/assistant/src/daemon/computer-use-session.ts
+++ b/assistant/src/daemon/computer-use-session.ts
@@ -103,7 +103,7 @@ export class ComputerUseSession {
       resolve: (result: ToolExecutionResult) => void;
     }
   >();
-  private surfaceState = new Map<
+  /** @internal */ surfaceState = new Map<
     string,
     { surfaceType: SurfaceType; data: SurfaceData; title?: string }
   >();


### PR DESCRIPTION
## Summary
- Changed `ComputerUseSession.surfaceState` from `private` to public (with `@internal` annotation) to match `Session.surfaceState` visibility
- Fixes TypeScript error in `lifecycle.ts` where `findSession` return type requires public `surfaceState`

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22736372083

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
