### PR TITLE
fix: Strategy 3 positional fallback skips Cancel to avoid clicking Send Once

### DIFF
--- a/playwright/agent/tools/fill-secure-credential.ts
+++ b/playwright/agent/tools/fill-secure-credential.ts
@@ -12,8 +12,8 @@
  *        match the SwiftUI `.accessibilityIdentifier("secure-credential-save")`
  *      - Strategy 2: Name/title — checks `name of elem` / `title of elem` for "Save",
  *        backed by explicit `.accessibilityLabel("Save")` on the SwiftUI button
- *      - Strategy 3: Positional fallback — clicks the last button in the scroll area,
- *        since Save is always the rightmost button in the HStack
+ *      - Strategy 3: Positional fallback — clicks the first non-Cancel button,
+ *        skipping buttons whose AXIdentifier is "secure-credential-cancel"
  *
  * The secret value is never returned in the tool result.
  */
@@ -180,20 +180,23 @@ tell application "System Events"
       end repeat
     end if
 
-    -- Strategy 3: Positional fallback — click the last button (Save is always rightmost)
+    -- Strategy 3: Positional fallback — click the first non-Cancel button.
+    -- The AX tree order is: Cancel, Save, [Send Once]. Taking the last button
+    -- would pick "Send Once" when allowOneTimeSend is true, so we skip Cancel
+    -- (identified by AXIdentifier) and take the first remaining button (Save).
     if not clickedSave then
-      set lastButton to missing value
       repeat with elem in allElems
         try
           if class of elem is button then
-            set lastButton to elem
+            set elemId to value of attribute "AXIdentifier" of elem
+            if elemId is not "secure-credential-cancel" then
+              click elem
+              set clickedSave to true
+              exit repeat
+            end if
           end if
         end try
       end repeat
-      if lastButton is not missing value then
-        click lastButton
-        set clickedSave to true
-      end if
     end if
 
     if not clickedSave then


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-fill-credential-save-button-detection.md.

**Gap:** Strategy 3 positional fallback clicks Send Once instead of Save when allowOneTimeSend is true
**What was expected:** Strategy 3 should click the Save button
**What was found:** Strategy 3 takes the last button in the AX tree, which is Send Once when that option is enabled

The fix changes Strategy 3 to skip buttons whose AXIdentifier is "secure-credential-cancel" and take the first remaining button (which is always Save).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
