### PR TITLE
revert: undo ScrollView removal that broke composer layout

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -43,6 +43,7 @@ struct ComposerView: View {
     @Environment(\.cmdEnterToSend) private var cmdEnterToSend
     @FocusState private var composerFocus: Bool
     @State private var isComposerFocused = false
+    @State private var contentHeight: CGFloat = 34
 
     @State var showSlashMenu = false
     @State var slashFilter = ""
@@ -160,7 +161,8 @@ struct ComposerView: View {
         // visible text coloring.
         if hasSlashHighlight {
             Text(slashHighlightedText(font: font))
-                .lineLimit(1...11)
+                .lineLimit(1...)
+                .fixedSize(horizontal: false, vertical: true)
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
         }
@@ -173,7 +175,8 @@ struct ComposerView: View {
             + Text(ghostSuffix)
                 .font(font)
                 .foregroundColor(VColor.textSecondary.opacity(0.55)))
-                .lineLimit(1...11)
+                .lineLimit(1...)
+                .fixedSize(horizontal: false, vertical: true)
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
         }
@@ -188,7 +191,7 @@ struct ComposerView: View {
             text: $inputText,
             axis: .vertical
         )
-        .lineLimit(1...11)
+        .lineLimit(1...)
         .textFieldStyle(.plain)
         .font(font)
         .foregroundColor(hasSlashHighlight ? .clear : VColor.textPrimary)
@@ -248,32 +251,36 @@ struct ComposerView: View {
         let scaledBody = Font.custom("Inter", size: 13 * zoomScale)
         let hasSlashHighlight = slashCommandRange != nil
 
-        return ZStack(alignment: .leading) {
-            composerTextOverlays(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
-            composerInputField(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
-        }
-        // minHeight keeps single-line text vertically centered in the
-        // compact row; .leading alignment pins text to the left edge.
-        .frame(maxWidth: .infinity, minHeight: composerCompactHeight, alignment: .leading)
-        // Reserve trailing space so text wraps before reaching the
-        // overlaid action buttons (attach + send/mic ≈ 70pt wide).
-        .padding(.trailing, 70)
-        // Measure rendered height so ChatView can compute the bottom
-        // safe-area inset. With bounded lineLimit the TextField auto-grows
-        // and scrolls natively — no ScrollView or manual frame sizing needed.
-        .background(
-            GeometryReader { geo in
-                Color.clear.preference(key: ComposerEditorHeightKey.self, value: geo.size.height)
+        return ScrollView(.vertical, showsIndicators: false) {
+            ZStack(alignment: .leading) {
+                composerTextOverlays(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
+                composerInputField(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
             }
-        )
+            // minHeight keeps single-line text vertically centered in the
+            // compact row; .leading alignment pins text to the left edge.
+            .frame(maxWidth: .infinity, minHeight: composerCompactHeight, alignment: .leading)
+            // Reserve trailing space so text wraps before reaching the
+            // overlaid action buttons (attach + send/mic ≈ 70pt wide).
+            .padding(.trailing, 70)
+            // Measure content height BEFORE the conditional bottom padding
+            // so expansion state isn't inflated by its own padding.
+            .background(
+                GeometryReader { geo in
+                    Color.clear.preference(key: ComposerEditorHeightKey.self, value: geo.size.height)
+                }
+            )
+            // Reserve bottom space so the last visible line isn't hidden
+            // behind the buttons when the composer is expanded.
+            .padding(.bottom, isComposerExpanded ? composerActionButtonSize : 0)
+        }
         .onPreferenceChange(ComposerEditorHeightKey.self) { newHeight in
+            contentHeight = newHeight
             editorContentHeight = min(max(newHeight, composerCompactHeight), composerMaxHeight)
             isComposerExpanded = newHeight > composerCompactHeight
         }
-        // Reserve bottom space so the last visible line isn't hidden
-        // behind the buttons when the composer is expanded.
-        .padding(.bottom, isComposerExpanded ? composerActionButtonSize : 0)
+        .scrollBounceBehavior(.basedOnSize)
         .accessibilityLabel("Message")
+        .frame(height: min(max(contentHeight, composerCompactHeight), composerMaxHeight), alignment: .topLeading)
         .frame(maxWidth: .infinity)
         .background(
             ComposerFocusBridge(


### PR DESCRIPTION
## Summary
- Reverts #13108 which removed the ScrollView wrapper from the composer TextField
- The change caused the TextField to expand to fill all available vertical space instead of sizing to content
- Restores the previous ScrollView-based layout while a proper fix is developed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
