### PR TITLE
fix: auto-select guardian contact on Contacts tab load

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -34,9 +34,20 @@ struct ContactsContainerView: View {
             Divider()
                 .background(VColor.surfaceBorder)
 
-            // Right pane: detail or placeholder
-            if let contactId = selectedContactId,
-               let contact = viewModel.contacts.first(where: { $0.id == contactId }) {
+            // Right pane: detail, loading, or placeholder
+            if viewModel.isLoading && viewModel.contacts.isEmpty {
+                // Loading state — contacts are being fetched
+                VStack(spacing: VSpacing.md) {
+                    ProgressView()
+                        .controlSize(.regular)
+                    Text("Loading contacts...")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(VColor.background)
+            } else if let contactId = selectedContactId,
+                      let contact = viewModel.contacts.first(where: { $0.id == contactId }) {
                 ContactDetailView(
                     contact: contact,
                     daemonClient: daemonClient,
@@ -45,6 +56,7 @@ struct ContactsContainerView: View {
                 .id(contactId)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             } else {
+                // True empty state — contacts loaded but none selected
                 VStack(spacing: VSpacing.md) {
                     Image(systemName: "person.2.fill")
                         .font(.system(size: 36))


### PR DESCRIPTION
## Summary
- Show loading spinner in right pane while contacts are being fetched instead of empty placeholder
- Guardian contact is auto-selected once contacts load (existing logic preserved)
- 'Select a contact' placeholder only shown after loading completes with no selection

Part of plan: contacts-ui-fixes.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)