### PR TITLE
feat: add readiness probes for Email and Slack channels

### DIFF
--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -275,6 +275,52 @@ const telegramProbe: ChannelProbe = {
   // Telegram has no remote checks currently
 };
 
+// ── Email Probe ─────────────────────────────────────────────────────────────
+
+const emailProbe: ChannelProbe = {
+  channel: "email",
+  runLocalChecks(): ReadinessCheckResult[] {
+    const hasApiKey = !!(
+      getSecureKey("agentmail") || getSecureKey("credential:agentmail:api_key")
+    );
+    return [
+      {
+        name: "agentmail_api_key",
+        passed: hasApiKey,
+        message: hasApiKey
+          ? "AgentMail API key is configured"
+          : "AgentMail API key is not configured",
+      },
+    ];
+  },
+};
+
+// ── Slack Probe ─────────────────────────────────────────────────────────────
+
+const slackProbe: ChannelProbe = {
+  channel: "slack",
+  runLocalChecks(): ReadinessCheckResult[] {
+    const hasBotToken = !!getSecureKey("credential:slack_channel:bot_token");
+    const hasAppToken = !!getSecureKey("credential:slack_channel:app_token");
+    return [
+      {
+        name: "bot_token",
+        passed: hasBotToken,
+        message: hasBotToken
+          ? "Slack bot token is configured"
+          : "Slack bot token is not configured",
+      },
+      {
+        name: "app_token",
+        passed: hasAppToken,
+        message: hasAppToken
+          ? "Slack app token is configured"
+          : "Slack app token is not configured",
+      },
+    ];
+  },
+};
+
 // ── Service ─────────────────────────────────────────────────────────────────
 
 export class ChannelReadinessService {
@@ -416,11 +462,13 @@ export class ChannelReadinessService {
 
 // ── Factory ─────────────────────────────────────────────────────────────────
 
-/** Create a service instance with built-in SMS, Voice, and Telegram probes registered. */
+/** Create a service instance with built-in SMS, Voice, Telegram, Email, and Slack probes registered. */
 export function createReadinessService(): ChannelReadinessService {
   const service = new ChannelReadinessService();
   service.registerProbe(smsProbe);
   service.registerProbe(voiceProbe);
   service.registerProbe(telegramProbe);
+  service.registerProbe(emailProbe);
+  service.registerProbe(slackProbe);
   return service;
 }


### PR DESCRIPTION
## Summary
- Add emailProbe checking for AgentMail API key via getSecureKey
- Add slackProbe checking for both bot_token and app_token credentials
- Register both in createReadinessService() (now 5 probes total: sms, voice, telegram, email, slack)

Part of plan: contacts-ui-fixes.md (PR 3 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
