### PR TITLE
feat: move twilio-setup skill to top-level skills directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,7 +58,7 @@ assistant/src/tools/system/voice-config.ts @alex-nork
 assistant/src/config/calls-schema.ts @alex-nork
 assistant/src/config/bundled-skills/phone-calls/ @alex-nork
 assistant/src/config/bundled-skills/voice-setup/ @alex-nork
-assistant/src/config/bundled-skills/twilio-setup/ @alex-nork
+skills/twilio-setup/ @alex-nork
 assistant/src/runtime/routes/call-routes.ts @alex-nork
 assistant/src/runtime/middleware/twilio-validation.ts @alex-nork
 assistant/src/runtime/channel-invite-transports/voice.ts @alex-nork

--- a/assistant/src/__tests__/bundled-skill-retrieval-guard.test.ts
+++ b/assistant/src/__tests__/bundled-skill-retrieval-guard.test.ts
@@ -67,13 +67,6 @@ const GATEWAY_RETRIEVAL_BANLIST: Array<{
     ],
   },
   {
-    skillPath: "twilio-setup/SKILL.md",
-    bannedSnippets: [
-      'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/config"',
-      'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/numbers"',
-    ],
-  },
-  {
     skillPath: "phone-calls/SKILL.md",
     bannedSnippets: [
       'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/config"',

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -13,7 +13,6 @@
       "id": "twilio-setup",
       "name": "twilio-setup",
       "description": "Configure Twilio credentials and phone numbers for voice calls and SMS messaging",
-      "emoji": "📱",
       "compatibility": "Requires public ingress for Twilio webhooks (voice, SMS, status callbacks)"
     },
     {

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -14,6 +14,13 @@
       "name": "weather",
       "description": "Get current weather conditions and forecasts for any location",
       "emoji": "🌤️"
+    },
+    {
+      "id": "twilio-setup",
+      "name": "twilio-setup",
+      "description": "Configure Twilio credentials and phone numbers for voice calls and SMS messaging",
+      "emoji": "📱",
+      "compatibility": "Requires public ingress for Twilio webhooks (voice, SMS, status callbacks)"
     }
   ]
 }

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -13,6 +13,7 @@
       "id": "twilio-setup",
       "name": "twilio-setup",
       "description": "Configure Twilio credentials and phone numbers for voice calls and SMS messaging",
+      "emoji": "📱",
       "compatibility": "Requires public ingress for Twilio webhooks (voice, SMS, status callbacks)"
     },
     {

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -10,17 +10,17 @@
       "compatibility": "Desktop: requires gcloud and gws CLI tools. Channels: requires public ingress for OAuth callback"
     },
     {
-      "id": "weather",
-      "name": "weather",
-      "description": "Get current weather conditions and forecasts for any location",
-      "emoji": "🌤️"
-    },
-    {
       "id": "twilio-setup",
       "name": "twilio-setup",
       "description": "Configure Twilio credentials and phone numbers for voice calls and SMS messaging",
       "emoji": "📱",
       "compatibility": "Requires public ingress for Twilio webhooks (voice, SMS, status callbacks)"
+    },
+    {
+      "id": "weather",
+      "name": "weather",
+      "description": "Get current weather conditions and forecasts for any location",
+      "emoji": "🌤️"
     }
   ]
 }

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -2,11 +2,9 @@
 name: "twilio-setup"
 description: "Configure Twilio credentials and phone numbers for voice calls and SMS messaging"
 compatibility: "Requires public ingress for Twilio webhooks (voice, SMS, status callbacks)"
-metadata:
-  emoji: "\ud83d\udcf1"
-  vellum:
-    user-invocable: true
-    credential-setup-for: "twilio"
+user-invocable: true
+credential-setup-for: "twilio"
+metadata: { "vellum": { "emoji": "\ud83d\udcf1" } }
 ---
 
 You are helping your user configure Twilio for voice calls and SMS messaging. Twilio is the shared telephony provider for both the **phone-calls** and **SMS messaging** capabilities. When this skill is invoked, walk through each step below using the Twilio HTTP control-plane endpoints and existing tools.

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -2,9 +2,11 @@
 name: "twilio-setup"
 description: "Configure Twilio credentials and phone numbers for voice calls and SMS messaging"
 compatibility: "Requires public ingress for Twilio webhooks (voice, SMS, status callbacks)"
-user-invocable: true
-credential-setup-for: "twilio"
-metadata: { "vellum": { "emoji": "\ud83d\udcf1" } }
+metadata:
+  emoji: "\ud83d\udcf1"
+  vellum:
+    user-invocable: true
+    credential-setup-for: "twilio"
 ---
 
 You are helping your user configure Twilio for voice calls and SMS messaging. Twilio is the shared telephony provider for both the **phone-calls** and **SMS messaging** capabilities. When this skill is invoked, walk through each step below using the Twilio HTTP control-plane endpoints and existing tools.

--- a/skills/twilio-setup/SKILL.md
+++ b/skills/twilio-setup/SKILL.md
@@ -1,29 +1,15 @@
 ---
-name: "Twilio Setup"
+name: "twilio-setup"
 description: "Configure Twilio credentials and phone numbers for voice calls and SMS messaging"
-user-invocable: true
-includes: ["public-ingress"]
-metadata: { "vellum": { "emoji": "\ud83d\udcf1" } }
+compatibility: "Requires public ingress for Twilio webhooks (voice, SMS, status callbacks)"
+metadata:
+  emoji: "\ud83d\udcf1"
+  vellum:
+    user-invocable: true
+    credential-setup-for: "twilio"
 ---
 
 You are helping your user configure Twilio for voice calls and SMS messaging. Twilio is the shared telephony provider for both the **phone-calls** and **SMS messaging** capabilities. When this skill is invoked, walk through each step below using the Twilio HTTP control-plane endpoints and existing tools.
-
-## Quick Start
-
-```bash
-# 1. Check current status
-vellum integrations twilio config --json
-# 2. Store credentials (after collecting via credential_store prompt)
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/credentials" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" -H "Content-Type: application/json" \
-  -d '{"accountSid":"ACxxx","authToken":"xxx"}'
-# 3. Provision or assign a number
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/numbers/provision" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" -H "Content-Type: application/json" \
-  -d '{"country":"US","areaCode":"415"}'
-```
-
-For voice call setup after Twilio is configured, use `phone-calls` + `call_start`.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- Move `twilio-setup` skill from `assistant/src/config/bundled-skills/` to top-level `skills/` directory as a first-party Vellum skill
- Refactor SKILL.md frontmatter to follow the Agent Skills spec (kebab-case name, `compatibility` field, `metadata.vellum.credential-setup-for`, structured YAML). Remove duplicative Quick Start section.
- Add `twilio-setup` entry to `skills/catalog.json`
- Update `.github/CODEOWNERS` path from bundled-skills to skills directory
- Remove bundled-skill retrieval guard test entry (skill no longer lives in bundled-skills)

## Original prompt
move-twilio-setup-skill.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
