### PR TITLE
fix(google-oauth-setup): add contacts.readonly to Path A consent screen scopes

### DIFF
--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -88,6 +88,7 @@ Tell the user:
 >    - `https://www.googleapis.com/auth/calendar.readonly`
 >    - `https://www.googleapis.com/auth/calendar.events`
 >    - `https://www.googleapis.com/auth/userinfo.email`
+>    - `https://www.googleapis.com/auth/contacts.readonly`
 >    - Click **Update**, then **Save and Continue**
 > 5. On the Test users page, add **your email**, click **Save and Continue**
 > 6. On the Summary page, click **Back to Dashboard**

--- a/skills/google-oauth-setup/SKILL.md
+++ b/skills/google-oauth-setup/SKILL.md
@@ -90,6 +90,7 @@ Tell the user:
 >    - `https://www.googleapis.com/auth/calendar.readonly`
 >    - `https://www.googleapis.com/auth/calendar.events`
 >    - `https://www.googleapis.com/auth/userinfo.email`
+>    - `https://www.googleapis.com/auth/contacts.readonly`
 >    - Click **Update**, then **Save and Continue**
 > 5. On the Test users page, add **your email**, click **Save and Continue**
 > 6. On the Summary page, click **Back to Dashboard**


### PR DESCRIPTION
Adds the missing contacts.readonly scope to Path A (Channel setup) consent screen instructions in both bundled-skills and skills copies, matching the complete scope list already present in CLI Step 5b. Flagged by Devin review on #13098.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
