### PR TITLE
fix(google-oauth-setup): add People API to Path A and fix CLI install instructions

### DIFF
--- a/skills/google-oauth-setup/SKILL.md
+++ b/skills/google-oauth-setup/SKILL.md
@@ -58,14 +58,15 @@ Wait for confirmation. Note the project ID for subsequent steps.
 
 Tell the user:
 
-> **Step 2: Enable Gmail and Calendar APIs**
+> **Step 2: Enable Gmail, Calendar, and People APIs**
 >
 > Open each link below and click **Enable**:
 >
 > 1. Gmail API: `https://console.cloud.google.com/apis/library/gmail.googleapis.com?project=PROJECT_ID`
 > 2. Calendar API: `https://console.cloud.google.com/apis/library/calendar-json.googleapis.com?project=PROJECT_ID`
+> 3. People API: `https://console.cloud.google.com/apis/library/people.googleapis.com?project=PROJECT_ID`
 >
-> Let me know when both are enabled.
+> Let me know when all three are enabled.
 
 (Substitute the actual project ID into the URLs.)
 
@@ -218,9 +219,9 @@ Use `ui_show` with `surface_type: "confirmation"`:
 
 If the user declines, acknowledge and stop.
 
-## CLI Step 2: Install Prerequisites
+## CLI Step 2: Check Prerequisites
 
-Check for and install each prerequisite. If any installation fails (e.g., Homebrew not available, corporate restrictions), tell the user what went wrong and provide manual installation instructions.
+Check whether each prerequisite is installed. Do **not** install them yourself — if anything is missing, tell the user what they need and provide the commands for them to run manually.
 
 ### gcloud
 
@@ -228,13 +229,17 @@ Check for and install each prerequisite. If any installation fails (e.g., Homebr
 which gcloud
 ```
 
-If missing:
+If present, continue. If missing, tell the user:
 
-```bash
-brew install google-cloud-sdk
-```
+> **`gcloud` CLI not found.** Please install it and then let me know:
+>
+> ```
+> brew install google-cloud-sdk
+> ```
+>
+> Or see https://cloud.google.com/sdk/docs/install for other installation methods.
 
-After installation, verify it works:
+Wait for the user to confirm installation, then verify:
 
 ```bash
 gcloud --version
@@ -246,13 +251,15 @@ gcloud --version
 which gws
 ```
 
-If missing:
+If present, continue. If missing, tell the user:
 
-```bash
-npm install -g @googleworkspace/cli
-```
+> **`gws` CLI not found.** Please install it and then let me know:
+>
+> ```
+> npm install -g @googleworkspace/cli
+> ```
 
-After installation, verify it works:
+Wait for the user to confirm installation, then verify:
 
 ```bash
 gws --version


### PR DESCRIPTION
Two fixes from Devin review on #13099: (1) Add people.googleapis.com enablement to Path A (Channels) for consistency with CLI Path B. (2) Change CLI Step 2 to provide install commands as user-directed instructions instead of having the assistant run them directly, per skills/AGENTS.md.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
