### PR TITLE
feat: generate invite instructions via LLM instead of static templates

### DIFF
--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -32,19 +32,20 @@ import {
   renderHistoryContent,
 } from "./shared.js";
 
-export function handleContactsInvite(
+export async function handleContactsInvite(
   msg: ContactsInviteRequest,
   socket: net.Socket,
   ctx: HandlerContext,
-): void {
+): Promise<void> {
   try {
     switch (msg.action) {
       case "create": {
-        const result = createIngressInvite({
+        const result = await createIngressInvite({
           sourceChannel: msg.sourceChannel,
           note: msg.note,
           maxUses: msg.maxUses,
           expiresInMs: msg.expiresInMs,
+          contactName: msg.contactName,
           friendName: msg.friendName,
           guardianName: msg.guardianName,
         });

--- a/assistant/src/daemon/ipc-contract/inbox.ts
+++ b/assistant/src/daemon/ipc-contract/inbox.ts
@@ -25,6 +25,8 @@ export interface ContactsInviteRequest {
   status?: string;
   /** Invitee's first name (voice invite create only). */
   friendName?: string;
+  /** Contact display name for personalizing invite instructions (create only). */
+  contactName?: string;
   /** Guardian's first name (voice invite create only). */
   guardianName?: string;
 }

--- a/assistant/src/runtime/channel-invite-transport.ts
+++ b/assistant/src/runtime/channel-invite-transport.ts
@@ -2,15 +2,14 @@
  * Channel invite adapter abstraction.
  *
  * Defines an adapter interface for building shareable invite links,
- * extracting inbound invite tokens, and generating guardian instructions
+ * extracting inbound invite tokens, and resolving channel handles
  * from channel-specific payloads. Each channel (Telegram, voice, etc.)
  * registers an adapter that knows how to handle invite flows for that
  * channel.
  *
- * All methods are optional: a channel that only provides
- * `buildGuardianInstruction` (e.g. SMS) is a valid adapter. The adapter
- * layer is intentionally thin — redemption logic lives in
- * `invite-redemption-service.ts`.
+ * All methods are optional — the adapter layer is intentionally thin.
+ * Redemption logic lives in `invite-redemption-service.ts` and invite
+ * instruction generation lives in `invite-instruction-generator.ts`.
  */
 
 import type { ChannelId } from "../channels/types.js";
@@ -24,13 +23,6 @@ export interface InviteShareLink {
   url: string;
   /** Human-readable text suitable for display alongside the link. */
   displayText: string;
-}
-
-export interface GuardianInstruction {
-  /** Human-readable instruction text for the guardian. */
-  instruction: string;
-  /** Channel-specific handle to reach the assistant (e.g. "@botName", "+15551234567", "hello@domain.agentmail.to"). */
-  channelHandle?: string;
 }
 
 export interface ChannelInviteAdapter {
@@ -56,16 +48,6 @@ export interface ChannelInviteAdapter {
     content: string;
     sourceMetadata?: Record<string, unknown>;
   }): string | undefined;
-
-  /**
-   * Build guardian instruction for this channel. Returns structured data
-   * with the instruction text and an optional channel-specific handle.
-   * Optional — falls back to generic instruction if not implemented.
-   */
-  buildGuardianInstruction?(params: {
-    inviteCode: string;
-    contactName?: string;
-  }): GuardianInstruction;
 
   /**
    * Resolve the channel-specific handle to reach the assistant (e.g.

--- a/assistant/src/runtime/channel-invite-transports/email.ts
+++ b/assistant/src/runtime/channel-invite-transports/email.ts
@@ -1,16 +1,13 @@
 /**
  * Email channel invite adapter.
  *
- * Provides guardian instruction text for email-based invites. Email invites
- * use the universal 6-digit code path for redemption, so this adapter only
- * implements `buildGuardianInstruction` — no `buildShareLink` or
- * `extractInboundToken` needed.
+ * Resolves the assistant's email address for use in invite instructions.
+ * Email invites use the universal 6-digit code path for redemption, so
+ * this adapter only implements `resolveChannelHandle` — no `buildShareLink`
+ * or `extractInboundToken` needed.
  */
 
-import type {
-  ChannelInviteAdapter,
-  GuardianInstruction,
-} from "../channel-invite-transport.js";
+import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
 
 // ---------------------------------------------------------------------------
 // Email address resolution
@@ -30,23 +27,6 @@ function resolveAssistantEmailAddress(): string | undefined {
 
 export const emailInviteAdapter: ChannelInviteAdapter = {
   channel: "email",
-
-  buildGuardianInstruction(params: {
-    inviteCode: string;
-    contactName?: string;
-  }): GuardianInstruction {
-    const address = resolveAssistantEmailAddress();
-    const contactLabel = params.contactName || "the contact";
-    if (!address) {
-      return {
-        instruction: `Tell ${contactLabel} to email the assistant and include the code ${params.inviteCode} in the message.`,
-      };
-    }
-    return {
-      instruction: `Tell ${contactLabel} to email ${address} and include the code ${params.inviteCode} in the message.`,
-      channelHandle: address,
-    };
-  },
 
   resolveChannelHandle(): string | undefined {
     return resolveAssistantEmailAddress();

--- a/assistant/src/runtime/channel-invite-transports/slack.ts
+++ b/assistant/src/runtime/channel-invite-transports/slack.ts
@@ -1,19 +1,15 @@
 /**
  * Slack channel invite adapter.
  *
- * Provides guardian instruction text that includes the assistant's Slack
- * bot @username and workspace name when available. Slack invites use the
- * universal 6-digit code path for redemption, so this adapter only
- * implements `buildGuardianInstruction` — no `buildShareLink` or
- * `extractInboundToken` needed.
+ * Resolves the assistant's Slack bot @username for use in invite
+ * instructions. Slack invites use the universal 6-digit code path for
+ * redemption, so this adapter only implements `resolveChannelHandle` —
+ * no `buildShareLink` or `extractInboundToken` needed.
  */
 
 import type { ChannelId } from "../../channels/types.js";
 import { getCredentialMetadata } from "../../tools/credentials/metadata-store.js";
-import type {
-  ChannelInviteAdapter,
-  GuardianInstruction,
-} from "../channel-invite-transport.js";
+import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
 
 // ---------------------------------------------------------------------------
 // Slack bot info resolution
@@ -53,31 +49,6 @@ function resolveSlackBotInfo(): SlackBotInfo | undefined {
 
 export const slackInviteAdapter: ChannelInviteAdapter = {
   channel: "slack" as ChannelId,
-
-  buildGuardianInstruction(params: {
-    inviteCode: string;
-    contactName?: string;
-  }): GuardianInstruction {
-    const botInfo = resolveSlackBotInfo();
-    const contactLabel = params.contactName || "the contact";
-
-    if (!botInfo) {
-      return {
-        instruction: `Tell ${contactLabel} to message the assistant on Slack and provide the code ${params.inviteCode}.`,
-      };
-    }
-
-    let instruction = `Tell ${contactLabel} to message @${botInfo.botUsername} on Slack and provide the code ${params.inviteCode}`;
-    if (botInfo.teamName) {
-      instruction += ` (workspace: ${botInfo.teamName})`;
-    }
-    instruction += ".";
-
-    return {
-      instruction,
-      channelHandle: `@${botInfo.botUsername}`,
-    };
-  },
 
   resolveChannelHandle(): string | undefined {
     const botInfo = resolveSlackBotInfo();

--- a/assistant/src/runtime/channel-invite-transports/sms.ts
+++ b/assistant/src/runtime/channel-invite-transports/sms.ts
@@ -1,9 +1,9 @@
 /**
  * SMS channel invite adapter.
  *
- * Provides guardian instruction text that includes the assistant's Twilio
- * phone number. SMS invites use the universal 6-digit code path for
- * redemption, so this adapter only implements `buildGuardianInstruction` —
+ * Resolves the assistant's Twilio phone number for use in invite
+ * instructions. SMS invites use the universal 6-digit code path for
+ * redemption, so this adapter only implements `resolveChannelHandle` —
  * no `buildShareLink` or `extractInboundToken` needed.
  */
 
@@ -11,10 +11,7 @@ import type { ChannelId } from "../../channels/types.js";
 import { getTwilioPhoneNumberEnv } from "../../config/env.js";
 import { loadRawConfig } from "../../config/loader.js";
 import { getSecureKey } from "../../security/secure-keys.js";
-import type {
-  ChannelInviteAdapter,
-  GuardianInstruction,
-} from "../channel-invite-transport.js";
+import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
 
 // ---------------------------------------------------------------------------
 // Phone number resolution
@@ -50,23 +47,6 @@ function resolveSmsPhoneNumber(): string | undefined {
 
 export const smsInviteAdapter: ChannelInviteAdapter = {
   channel: "sms" as ChannelId,
-
-  buildGuardianInstruction(params: {
-    inviteCode: string;
-    contactName?: string;
-  }): GuardianInstruction {
-    const phoneNumber = resolveSmsPhoneNumber();
-    const contactLabel = params.contactName || "the contact";
-    if (!phoneNumber) {
-      return {
-        instruction: `Tell ${contactLabel} to text the assistant and provide the code ${params.inviteCode}.`,
-      };
-    }
-    return {
-      instruction: `Tell ${contactLabel} to text ${phoneNumber} and provide the code ${params.inviteCode}.`,
-      channelHandle: phoneNumber,
-    };
-  },
 
   resolveChannelHandle(): string | undefined {
     return resolveSmsPhoneNumber();

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -1,8 +1,9 @@
 /**
  * Telegram channel invite adapter.
  *
- * Builds `https://t.me/<botUsername>?start=iv_<token>` deep links and
- * extracts invite tokens from `/start iv_<token>` command payloads.
+ * Builds `https://t.me/<botUsername>?start=iv_<token>` deep links,
+ * extracts invite tokens from `/start iv_<token>` command payloads,
+ * and resolves the bot's channel handle for invite instructions.
  *
  * The `iv_` prefix distinguishes invite tokens from `gv_` (guardian
  * verification) tokens that use the same `/start` deep-link mechanism.
@@ -12,7 +13,6 @@ import type { ChannelId } from "../../channels/types.js";
 import { getCredentialMetadata } from "../../tools/credentials/metadata-store.js";
 import type {
   ChannelInviteAdapter,
-  GuardianInstruction,
   InviteShareLink,
 } from "../channel-invite-transport.js";
 
@@ -65,23 +65,6 @@ export const telegramInviteAdapter: ChannelInviteAdapter = {
     return {
       url,
       displayText: `Open in Telegram: ${url}`,
-    };
-  },
-
-  buildGuardianInstruction(params: {
-    inviteCode: string;
-    contactName?: string;
-  }): GuardianInstruction {
-    const botUsername = getTelegramBotUsername();
-    const contactLabel = params.contactName || "the contact";
-    if (!botUsername) {
-      return {
-        instruction: `Tell ${contactLabel} to message the assistant on Telegram and provide the code ${params.inviteCode}.`,
-      };
-    }
-    return {
-      instruction: `Tell ${contactLabel} to message @${botUsername} on Telegram and provide the code ${params.inviteCode}.`,
-      channelHandle: `@${botUsername}`,
     };
   },
 

--- a/assistant/src/runtime/invite-instruction-generator.ts
+++ b/assistant/src/runtime/invite-instruction-generator.ts
@@ -1,0 +1,161 @@
+/**
+ * Generative invite instructions.
+ *
+ * Uses the configured provider to generate a short, first-person instruction
+ * telling the guardian how to invite a contact via a specific channel. Falls
+ * back to a deterministic template when the provider is unavailable or
+ * generation fails/times out.
+ */
+
+import {
+  createTimeout,
+  extractText,
+  resolveConfiguredProvider,
+  userMessage,
+} from "../providers/provider-send-message.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("invite-instruction-generator");
+
+/** Timeout for the generative instruction call (ms). */
+const GENERATION_TIMEOUT_MS = 5_000;
+
+/** Maximum allowed length for a generated instruction. */
+const MAX_INSTRUCTION_LENGTH = 500;
+
+// ---------------------------------------------------------------------------
+// Channel display label
+// ---------------------------------------------------------------------------
+
+/** Human-readable label for a channel type. */
+export function channelDisplayLabel(type: string): string {
+  switch (type) {
+    case "telegram":
+      return "Telegram";
+    case "sms":
+      return "SMS";
+    case "email":
+      return "Email";
+    case "slack":
+      return "Slack";
+    case "voice":
+      return "Voice";
+    default:
+      return type.charAt(0).toUpperCase() + type.slice(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic fallback
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a deterministic fallback instruction when the LLM is unavailable.
+ */
+export function buildFallbackInstruction(params: {
+  contactName?: string;
+  channelLabel: string;
+  channelHandle?: string;
+  shareUrl?: string;
+}): string {
+  const contact = params.contactName || "the contact";
+  const handle = params.channelHandle
+    ? ` at ${params.channelHandle}`
+    : ` on ${params.channelLabel}`;
+  if (params.shareUrl) {
+    return `Send ${contact} this link: ${params.shareUrl} — or tell them to message me${handle} with the code below.`;
+  }
+  return `Tell ${contact} to message me${handle} with the code below.`;
+}
+
+// ---------------------------------------------------------------------------
+// LLM-powered generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate an invite instruction via the configured LLM provider. Returns a
+ * deterministic fallback when the provider is unavailable, generation times
+ * out (5s), or the output fails validation.
+ */
+export async function generateInviteInstruction(params: {
+  contactName?: string;
+  channelType: string;
+  channelHandle?: string;
+  shareUrl?: string;
+}): Promise<string> {
+  const channelLabel = channelDisplayLabel(params.channelType);
+  const fallback = buildFallbackInstruction({
+    contactName: params.contactName,
+    channelLabel,
+    channelHandle: params.channelHandle,
+    shareUrl: params.shareUrl,
+  });
+
+  const resolved = resolveConfiguredProvider();
+  if (!resolved) {
+    log.debug(
+      "No provider available for invite instruction generation, using fallback",
+    );
+    return fallback;
+  }
+
+  const { signal, cleanup } = createTimeout(GENERATION_TIMEOUT_MS);
+
+  try {
+    const parts: string[] = [
+      "Generate a 1–2 sentence instruction from the assistant's perspective telling the user how to invite a contact.",
+      "",
+      `Channel: ${channelLabel}`,
+    ];
+    if (params.contactName) {
+      parts.push(`Contact name: ${params.contactName}`);
+    }
+    if (params.channelHandle) {
+      parts.push(`Channel handle: ${params.channelHandle}`);
+    }
+    if (params.shareUrl) {
+      parts.push(`Share URL: ${params.shareUrl}`);
+    }
+    parts.push(
+      "",
+      "Requirements:",
+      '- Write from the assistant\'s perspective using first person ("message me"), NOT third person ("message the assistant").',
+      "- Do NOT include the invite code — it is displayed separately in the UI.",
+      "- When a share URL is available, lead with the link.",
+      "- Keep the instruction concise (1–2 sentences, under 500 characters).",
+      '- Refer to the invite code as "the code below" since it is shown beneath this instruction.',
+      "",
+      "Respond with the instruction text only — no labels, no extra formatting.",
+    );
+
+    const prompt = parts.join("\n");
+
+    const response = await resolved.provider.sendMessage(
+      [userMessage(prompt)],
+      undefined,
+      undefined,
+      { signal, config: { modelIntent: "latency-optimized" } },
+    );
+
+    const text = extractText(response).trim();
+
+    if (!text || text.length > MAX_INSTRUCTION_LENGTH) {
+      log.warn(
+        { length: text.length },
+        "Generated invite instruction failed validation, using fallback",
+      );
+      return fallback;
+    }
+
+    return text;
+  } catch (err) {
+    if (signal.aborted) {
+      log.warn("Invite instruction generation timed out, using fallback");
+    } else {
+      log.warn({ err }, "Invite instruction generation failed, using fallback");
+    }
+    return fallback;
+  } finally {
+    cleanup();
+  }
+}

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -26,6 +26,7 @@ import {
 import { isValidE164 } from "../util/phone.js";
 import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
 import { getInviteAdapterRegistry } from "./channel-invite-transport.js";
+import { generateInviteInstruction } from "./invite-instruction-generator.js";
 import {
   type InviteRedemptionOutcome,
   redeemInvite as redeemInviteTyped,
@@ -140,19 +141,19 @@ export type IngressResult<T> =
 // Invite operations
 // ---------------------------------------------------------------------------
 
-export function createIngressInvite(params: {
+export async function createIngressInvite(params: {
   sourceChannel?: string;
   note?: string;
   maxUses?: number;
   expiresInMs?: number;
-  // Contact display name for personalizing guardian instructions
+  // Contact display name for personalizing invite instructions
   contactName?: string;
   // Voice invite parameters
   expectedExternalUserId?: string;
   voiceCodeDigits?: number;
   friendName?: string;
   guardianName?: string;
-}): IngressResult<InviteResponseData> {
+}): Promise<IngressResult<InviteResponseData>> {
   if (!params.sourceChannel) {
     return { ok: false, error: "sourceChannel is required for create" };
   }
@@ -220,7 +221,7 @@ export function createIngressInvite(params: {
       : { inviteCodeHash }),
   });
 
-  // Build guardian instruction for non-voice invites
+  // Build invite instruction for non-voice invites via LLM generation
   let guardianInstruction: string | undefined;
   let channelHandle: string | undefined;
   if (!isVoice && inviteCode) {
@@ -230,27 +231,14 @@ export function createIngressInvite(params: {
     const adapter = channelId
       ? getInviteAdapterRegistry().get(channelId)
       : undefined;
-
-    if (adapter?.buildGuardianInstruction) {
-      try {
-        const adapterResult = adapter.buildGuardianInstruction({
-          inviteCode,
-          contactName: params.contactName,
-        });
-        if (adapterResult) {
-          guardianInstruction = adapterResult.instruction;
-          channelHandle = adapterResult.channelHandle;
-        }
-      } catch {
-        // Fall through to generic instruction if adapter fails
-      }
-    }
-
-    if (!guardianInstruction) {
-      const contactLabel = params.contactName || "the contact";
-      const channelLabel = params.sourceChannel;
-      guardianInstruction = `Tell ${contactLabel} to contact the assistant on ${channelLabel} and provide the code ${inviteCode}.`;
-    }
+    channelHandle = adapter?.resolveChannelHandle?.();
+    const share = buildSharePayload(params.sourceChannel, rawToken);
+    guardianInstruction = await generateInviteInstruction({
+      contactName: params.contactName,
+      channelType: params.sourceChannel,
+      channelHandle,
+      shareUrl: share?.url,
+    });
   }
 
   // Voice invites must not expose the token — callers must redeem via the

--- a/assistant/src/runtime/routes/invite-routes.ts
+++ b/assistant/src/runtime/routes/invite-routes.ts
@@ -47,7 +47,7 @@ export function handleListInvites(url: URL): Response {
 export async function handleCreateInvite(req: Request): Promise<Response> {
   const body = (await req.json()) as Record<string, unknown>;
 
-  const result = createIngressInvite({
+  const result = await createIngressInvite({
     sourceChannel: body.sourceChannel as string | undefined,
     note: body.note as string | undefined,
     maxUses: body.maxUses as number | undefined,

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -916,10 +916,12 @@ public struct IPCContactsInviteRequest: Codable, Sendable {
     public let status: String?
     /// Invitee's first name (voice invite create only).
     public let friendName: String?
+    /// Contact display name for personalizing invite instructions (create only).
+    public let contactName: String?
     /// Guardian's first name (voice invite create only).
     public let guardianName: String?
 
-    public init(type: String, action: String, sourceChannel: String? = nil, note: String? = nil, maxUses: Double? = nil, expiresInMs: Double? = nil, inviteId: String? = nil, token: String? = nil, externalUserId: String? = nil, externalChatId: String? = nil, status: String? = nil, friendName: String? = nil, guardianName: String? = nil) {
+    public init(type: String, action: String, sourceChannel: String? = nil, note: String? = nil, maxUses: Double? = nil, expiresInMs: Double? = nil, inviteId: String? = nil, token: String? = nil, externalUserId: String? = nil, externalChatId: String? = nil, status: String? = nil, friendName: String? = nil, contactName: String? = nil, guardianName: String? = nil) {
         self.type = type
         self.action = action
         self.sourceChannel = sourceChannel
@@ -932,6 +934,7 @@ public struct IPCContactsInviteRequest: Codable, Sendable {
         self.externalChatId = externalChatId
         self.status = status
         self.friendName = friendName
+        self.contactName = contactName
         self.guardianName = guardianName
     }
 }


### PR DESCRIPTION
## Summary
- Create invite-instruction-generator.ts with LLM-powered instruction generation and deterministic fallback
- Make createIngressInvite async, replace static adapter instructions with LLM generation
- Remove dead buildGuardianInstruction from all channel adapters
- Add contactName pass-through from IPC to invite service
- Regenerate IPC Swift types

Part of plan: contacts-ui-fixes.md (PR 5 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
