### PR TITLE
fix: simplify invite result display to complement LLM instructions

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -417,13 +417,7 @@ struct ContactDetailView: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
-                if let channelHandle = result.channelHandle {
-                    Text(channelHandle)
-                        .font(VFont.monoSmall)
-                        .foregroundColor(VColor.textMuted)
-                }
-
-                // When a share URL is available, show it prominently above the code
+                // When a share URL is available, show it as a copyable row below the instruction
                 if let shareUrl = result.shareUrl {
                     HStack(spacing: VSpacing.sm) {
                         let truncated = shareUrl.count > 30
@@ -451,12 +445,6 @@ struct ContactDetailView: View {
                             }
                         }
                     }
-
-                    Divider().background(VColor.divider)
-
-                    Text("Or use this code:")
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textMuted)
                 }
 
                 // Large monospaced invite code for readability


### PR DESCRIPTION
## Summary
- Remove separate channelHandle display (now embedded in LLM instruction)
- Remove 'Or use this code:' separator (instruction already frames the code)
- Instruction text shown first, followed by optional share URL, then invite code

Part of plan: contacts-ui-fixes.md (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
