### PR TITLE
feat: show guardian verification flow for unconfigured channels

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -382,24 +382,47 @@ struct ContactDetailView: View {
                 Text("Not set up")
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)
+            }
 
+            // Guardian contacts get the full verification flow; others get invite button
+            if displayContact.role == "guardian" {
+                if Self.guardianSupportedChannels.contains(type), let store {
+                    let state = store.guardianChannelState(for: type)
+                    let destinationBinding = Binding<String>(
+                        get: { guardianDestinationTexts[type] ?? "" },
+                        set: { guardianDestinationTexts[type] = $0 }
+                    )
+                    GuardianVerificationFlowView(
+                        state: state,
+                        countdownNow: $guardianCountdownNow,
+                        destinationText: destinationBinding,
+                        onStartOutbound: { dest in store.startOutboundGuardianVerification(channel: type, destination: dest) },
+                        onResend: { store.resendOutboundGuardian(channel: type) },
+                        onCancelOutbound: { store.cancelOutboundGuardian(channel: type) },
+                        onRevoke: { store.revokeChannelGuardian(channel: type) },
+                        onStartChallenge: { rebind in store.startChannelGuardianVerification(channel: type, rebind: rebind) },
+                        onCancelChallenge: { store.cancelGuardianChallenge(channel: type) },
+                        botUsername: store.telegramBotUsername,
+                        phoneNumber: store.twilioPhoneNumber,
+                        showLabel: false
+                    )
+                }
+            } else if type != "voice" {
                 // Voice invites require additional fields (phone number, friend/guardian
                 // names) that aren't available in this context, so hide the button.
                 // Row visibility is already gated on channelReadiness[type]?.ready == true,
                 // so no additional readiness check is needed here.
-                if displayContact.role != "guardian" && type != "voice" {
-                    if inviteInProgress == type {
-                        ProgressView()
-                            .controlSize(.small)
-                    } else {
-                        VButton(
-                            label: "Invite",
-                            style: .secondary,
-                            size: .medium,
-                            isDisabled: inviteInProgress != nil
-                        ) {
-                            createInviteForChannel(type: type)
-                        }
+                if inviteInProgress == type {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    VButton(
+                        label: "Invite",
+                        style: .secondary,
+                        size: .medium,
+                        isDisabled: inviteInProgress != nil
+                    ) {
+                        createInviteForChannel(type: type)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Add GuardianVerificationFlowView to unconfigured channel rows when the contact is a guardian
- Guardians can now initiate verification directly from the contact card for channels not yet set up
- Non-guardian contacts continue to see the Invite button (unchanged)

Part of plan: contacts-ui-fixes.md (PR 7 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
