### PR TITLE
fix: composer collapses after send — reset all height state on clear

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -323,6 +323,13 @@ struct ComposerView: View {
         }
         .onChange(of: inputText) {
             if inputText.isEmpty {
+                // Reset all height state atomically so the ScrollView frame
+                // shrinks immediately. Without this, the GeometryReader
+                // re-measures the old (large) ScrollView frame and confirms
+                // the stale contentHeight, preventing collapse.
+                contentHeight = composerCompactHeight
+                editorContentHeight = composerCompactHeight
+                isComposerExpanded = false
                 withAnimation(VAnimation.fast) { showSlashMenu = false }
             } else {
                 updateSlashState()


### PR DESCRIPTION
## Summary
- Reset `contentHeight`, `editorContentHeight`, and `isComposerExpanded` atomically when `inputText` becomes empty
- Breaks the GeometryReader feedback loop that kept the composer expanded after sending

## Root cause
The ScrollView frame is driven by `contentHeight`, which is measured by a GeometryReader inside the ScrollView. When text clears after send, the GeometryReader re-measures the old (large) ScrollView frame and confirms the stale `contentHeight`, preventing collapse. Previous fix attempts only reset `editorContentHeight` from ChatView, but didn't reset `contentHeight` (local to ComposerView), so the ScrollView frame stayed large and the GeometryReader kept reporting the old size.

## Fix
In `onChange(of: inputText)`, when text becomes empty, reset all three state variables to compact values. The ScrollView frame shrinks immediately, the GeometryReader measures the new compact size, and the values stabilize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
