### PR TITLE
feat: add WhatsApp media metadata and download helpers

### DIFF
--- a/gateway/src/__tests__/whatsapp-download.test.ts
+++ b/gateway/src/__tests__/whatsapp-download.test.ts
@@ -1,0 +1,461 @@
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(
+  async () => new Response(),
+);
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { downloadWhatsAppFile } = await import("../whatsapp/download.js");
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    telegramBotToken: undefined,
+    telegramWebhookSecret: undefined,
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    whatsappPhoneNumberId: "123456789",
+    whatsappAccessToken: "test-access-token",
+    whatsappAppSecret: undefined,
+    whatsappWebhookVerifyToken: undefined,
+    whatsappDeliverAuthBypass: false,
+    whatsappTimeoutMs: 15000,
+    whatsappMaxRetries: 0, // no retries in tests for speed
+    whatsappInitialBackoffMs: 1000,
+    slackChannelBotToken: undefined,
+    slackChannelAppToken: undefined,
+    slackDeliverAuthBypass: false,
+    trustProxy: false,
+    ...overrides,
+  };
+}
+
+const MEDIA_ID = "1234567890";
+const MEDIA_URL =
+  "https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=1234567890";
+
+// Minimal valid PNG: 1x1 pixel transparent
+const PNG_BYTES = new Uint8Array([
+  0x89,
+  0x50,
+  0x4e,
+  0x47,
+  0x0d,
+  0x0a,
+  0x1a,
+  0x0a, // PNG signature
+  0x00,
+  0x00,
+  0x00,
+  0x0d,
+  0x49,
+  0x48,
+  0x44,
+  0x52, // IHDR chunk
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x00,
+  0x01, // 1x1
+  0x08,
+  0x06,
+  0x00,
+  0x00,
+  0x00,
+  0x1f,
+  0x15,
+  0xc4, // RGBA
+  0x89,
+  0x00,
+  0x00,
+  0x00,
+  0x0a,
+  0x49,
+  0x44,
+  0x41, // IDAT chunk
+  0x54,
+  0x78,
+  0x9c,
+  0x62,
+  0x00,
+  0x00,
+  0x00,
+  0x02,
+  0x00,
+  0x01,
+  0xe5,
+  0x27,
+  0xde,
+  0xfc,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x49,
+  0x45,
+  0x4e,
+  0x44,
+  0xae,
+  0x42, // IEND chunk
+  0x60,
+  0x82,
+]);
+
+describe("downloadWhatsAppFile", () => {
+  afterEach(() => {
+    fetchMock = mock(async () => new Response());
+  });
+
+  test("successfully downloads media and returns filename, mimeType, data", async () => {
+    const urls: string[] = [];
+
+    fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      urls.push(url);
+
+      // Metadata endpoint
+      if (url.includes(MEDIA_ID) && url.includes("graph.facebook.com")) {
+        return new Response(
+          JSON.stringify({
+            url: MEDIA_URL,
+            mime_type: "image/png",
+            sha256: "abc123",
+            file_size: PNG_BYTES.length,
+            id: MEDIA_ID,
+          }),
+        );
+      }
+
+      // Download endpoint
+      if (url.includes("lookaside.fbsbx.com")) {
+        return new Response(PNG_BYTES, {
+          headers: { "Content-Type": "image/png" },
+        });
+      }
+
+      return new Response("unexpected", { status: 500 });
+    });
+
+    const config = makeConfig();
+    const result = await downloadWhatsAppFile(config, MEDIA_ID);
+
+    expect(urls).toHaveLength(2);
+    expect(result.mimeType).toBe("image/png");
+    expect(result.filename).toBe("1234567890.png");
+    expect(result.data).toBe(Buffer.from(PNG_BYTES).toString("base64"));
+  });
+
+  test("infers filename from MIME type when Meta omits it", async () => {
+    fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.includes("graph.facebook.com")) {
+        return new Response(
+          JSON.stringify({
+            url: MEDIA_URL,
+            mime_type: "application/pdf",
+            sha256: "def456",
+            file_size: 4,
+            id: MEDIA_ID,
+          }),
+        );
+      }
+
+      return new Response(new Uint8Array([0x25, 0x50, 0x44, 0x46]), {
+        headers: { "Content-Type": "application/pdf" },
+      });
+    });
+
+    const result = await downloadWhatsAppFile(makeConfig(), MEDIA_ID);
+
+    expect(result.filename).toBe("1234567890.pdf");
+    expect(result.mimeType).toBe("application/pdf");
+  });
+
+  test("falls back to detected MIME when Meta metadata is empty", async () => {
+    fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.includes("graph.facebook.com")) {
+        return new Response(
+          JSON.stringify({
+            url: MEDIA_URL,
+            mime_type: "",
+            sha256: "abc",
+            file_size: PNG_BYTES.length,
+            id: MEDIA_ID,
+          }),
+        );
+      }
+
+      return new Response(PNG_BYTES, {
+        headers: { "Content-Type": "image/png" },
+      });
+    });
+
+    const result = await downloadWhatsAppFile(makeConfig(), MEDIA_ID);
+
+    // file-type should detect PNG from magic bytes
+    expect(result.mimeType).toBe("image/png");
+    expect(result.filename).toBe("1234567890.png");
+  });
+
+  test("falls back to application/octet-stream for unknown MIME", async () => {
+    fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.includes("graph.facebook.com")) {
+        return new Response(
+          JSON.stringify({
+            url: MEDIA_URL,
+            mime_type: "",
+            sha256: "abc",
+            file_size: 3,
+            id: MEDIA_ID,
+          }),
+        );
+      }
+
+      // Unrecognizable bytes with no Content-Type
+      return new Response(new Uint8Array([0x01, 0x02, 0x03]));
+    });
+
+    const result = await downloadWhatsAppFile(makeConfig(), MEDIA_ID);
+
+    expect(result.mimeType).toBe("application/octet-stream");
+    // No extension mapping for octet-stream, so filename is just the truncated ID
+    expect(result.filename).toBe("1234567890");
+  });
+
+  test("throws on non-retryable 4xx metadata response", async () => {
+    fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.includes("graph.facebook.com")) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              message: "Invalid media ID",
+              type: "OAuthException",
+              code: 100,
+            },
+          }),
+          { status: 400 },
+        );
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+
+    await expect(downloadWhatsAppFile(makeConfig(), MEDIA_ID)).rejects.toThrow(
+      "Invalid media ID",
+    );
+  });
+
+  test("throws on non-retryable 4xx download response", async () => {
+    fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.includes("graph.facebook.com")) {
+        return new Response(
+          JSON.stringify({
+            url: MEDIA_URL,
+            mime_type: "image/png",
+            sha256: "abc",
+            file_size: 100,
+            id: MEDIA_ID,
+          }),
+        );
+      }
+
+      // Download returns 404
+      return new Response("Not Found", { status: 404 });
+    });
+
+    await expect(downloadWhatsAppFile(makeConfig(), MEDIA_ID)).rejects.toThrow(
+      "WhatsApp downloadMedia failed with status 404",
+    );
+  });
+
+  test("retries on 500 and eventually succeeds", async () => {
+    let metadataAttempt = 0;
+
+    fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.includes("graph.facebook.com")) {
+        metadataAttempt++;
+        if (metadataAttempt === 1) {
+          return new Response(
+            JSON.stringify({ error: { message: "Internal error" } }),
+            { status: 500 },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            url: MEDIA_URL,
+            mime_type: "image/jpeg",
+            sha256: "abc",
+            file_size: 3,
+            id: MEDIA_ID,
+          }),
+        );
+      }
+
+      return new Response(new Uint8Array([0xff, 0xd8, 0xff]), {
+        headers: { "Content-Type": "image/jpeg" },
+      });
+    });
+
+    // Allow 1 retry
+    const config = makeConfig({
+      whatsappMaxRetries: 1,
+      whatsappInitialBackoffMs: 1,
+    });
+    const result = await downloadWhatsAppFile(config, MEDIA_ID);
+
+    expect(metadataAttempt).toBe(2);
+    expect(result.mimeType).toBe("image/jpeg");
+  });
+
+  test("exhausts retries on persistent 500 and throws", async () => {
+    fetchMock = mock(async () => {
+      return new Response(
+        JSON.stringify({ error: { message: "Service unavailable" } }),
+        { status: 500 },
+      );
+    });
+
+    const config = makeConfig({
+      whatsappMaxRetries: 1,
+      whatsappInitialBackoffMs: 1,
+    });
+
+    await expect(downloadWhatsAppFile(config, MEDIA_ID)).rejects.toThrow(
+      "Service unavailable",
+    );
+  });
+
+  test("throws when WhatsApp credentials are not configured", async () => {
+    const config = makeConfig({
+      whatsappAccessToken: undefined,
+    });
+
+    await expect(downloadWhatsAppFile(config, MEDIA_ID)).rejects.toThrow(
+      "WhatsApp credentials not configured",
+    );
+  });
+
+  test("passes Authorization header to both metadata and download requests", async () => {
+    const headers: Record<string, string | null>[] = [];
+
+    fetchMock = mock(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+
+        const authHeader =
+          init?.headers instanceof Headers
+            ? init.headers.get("Authorization")
+            : Array.isArray(init?.headers)
+              ? (init.headers.find(([k]) => k === "Authorization")?.[1] ?? null)
+              : ((init?.headers as Record<string, string>)?.Authorization ??
+                null);
+
+        headers.push({ url: url.slice(0, 50), auth: authHeader });
+
+        if (url.includes("graph.facebook.com")) {
+          return new Response(
+            JSON.stringify({
+              url: MEDIA_URL,
+              mime_type: "image/png",
+              sha256: "abc",
+              file_size: PNG_BYTES.length,
+              id: MEDIA_ID,
+            }),
+          );
+        }
+
+        return new Response(PNG_BYTES);
+      },
+    );
+
+    await downloadWhatsAppFile(makeConfig(), MEDIA_ID);
+
+    expect(headers).toHaveLength(2);
+    expect(headers[0].auth).toBe("Bearer test-access-token");
+    expect(headers[1].auth).toBe("Bearer test-access-token");
+  });
+});

--- a/gateway/src/whatsapp/api.ts
+++ b/gateway/src/whatsapp/api.ts
@@ -306,6 +306,129 @@ export async function sendWhatsAppInteractiveMessage(
  * Mark an incoming WhatsApp message as read.
  * Best-effort — callers should not propagate errors from this.
  */
+export interface WhatsAppMediaMetadata {
+  url: string;
+  mime_type: string;
+  sha256: string;
+  file_size: number;
+  id: string;
+}
+
+/**
+ * Resolve media metadata (download URL, MIME type, size) from a WhatsApp media ID.
+ * The returned URL is short-lived and requires the access token as a Bearer header.
+ */
+export async function getWhatsAppMediaMetadata(
+  config: GatewayConfig,
+  mediaId: string,
+): Promise<WhatsAppMediaMetadata> {
+  if (!config.whatsappAccessToken) {
+    throw new Error("WhatsApp credentials not configured");
+  }
+
+  return retryableWhatsAppFetch<WhatsAppMediaMetadata>(
+    config,
+    "getMediaMetadata",
+    () =>
+      fetchImpl(`${WHATSAPP_API_BASE}/${mediaId}`, {
+        headers: {
+          Authorization: `Bearer ${config.whatsappAccessToken}`,
+        },
+        signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+      }),
+  );
+}
+
+/**
+ * Download the raw bytes of a WhatsApp media object given its CDN URL.
+ * The URL comes from getWhatsAppMediaMetadata and requires the access token.
+ * Returns the raw Response so callers can stream or buffer as needed.
+ */
+export async function downloadWhatsAppMediaBytes(
+  config: GatewayConfig,
+  mediaUrl: string,
+): Promise<Response> {
+  if (!config.whatsappAccessToken) {
+    throw new Error("WhatsApp credentials not configured");
+  }
+
+  return retryableWhatsAppRawFetch(config, "downloadMedia", () =>
+    fetchImpl(mediaUrl, {
+      headers: {
+        Authorization: `Bearer ${config.whatsappAccessToken}`,
+      },
+      signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+    }),
+  );
+}
+
+/**
+ * Like retryableWhatsAppFetch but returns the raw Response instead of parsing JSON.
+ * Used for binary downloads where the response body is not JSON.
+ */
+async function retryableWhatsAppRawFetch(
+  config: GatewayConfig,
+  operation: string,
+  doFetch: () => Promise<Response>,
+): Promise<Response> {
+  let lastError: Error | null = null;
+  let lastRetryAfter: string | null = null;
+
+  for (let attempt = 0; attempt <= config.whatsappMaxRetries; attempt++) {
+    if (attempt > 0) {
+      const delay = computeDelay(
+        attempt,
+        config.whatsappInitialBackoffMs,
+        lastRetryAfter,
+      );
+      log.debug({ attempt, delay, operation }, "Retrying WhatsApp API call");
+      await new Promise((r) => setTimeout(r, delay));
+    }
+
+    lastRetryAfter = null;
+
+    let response: Response;
+    try {
+      response = await doFetch();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      lastError = new Error(`WhatsApp ${operation} request failed: ${message}`);
+      log.warn(
+        { error: message, attempt, operation },
+        "WhatsApp API fetch failed",
+      );
+      continue;
+    }
+
+    if (!isRetryable(response.status) && !response.ok) {
+      throw new Error(
+        `WhatsApp ${operation} failed with status ${response.status}`,
+      );
+    }
+
+    if (isRetryable(response.status)) {
+      lastRetryAfter = response.headers.get("retry-after");
+      lastError = new Error(
+        `WhatsApp ${operation} failed with status ${response.status}`,
+      );
+      log.warn(
+        {
+          status: response.status,
+          attempt,
+          operation,
+          retryAfter: lastRetryAfter,
+        },
+        "WhatsApp API returned retryable error",
+      );
+      continue;
+    }
+
+    return response;
+  }
+
+  throw lastError ?? new Error(`WhatsApp ${operation} failed after retries`);
+}
+
 export async function markWhatsAppMessageRead(
   config: GatewayConfig,
   messageId: string,

--- a/gateway/src/whatsapp/download.ts
+++ b/gateway/src/whatsapp/download.ts
@@ -1,0 +1,68 @@
+import { fileTypeFromBuffer } from "file-type";
+import type { GatewayConfig } from "../config.js";
+import { getWhatsAppMediaMetadata, downloadWhatsAppMediaBytes } from "./api.js";
+
+export interface DownloadedFile {
+  filename: string;
+  mimeType: string;
+  data: string; // base64-encoded
+}
+
+/** Common MIME-to-extension map for when Meta omits a filename. */
+const MIME_EXTENSIONS: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "video/mp4": "mp4",
+  "video/3gpp": "3gp",
+  "audio/aac": "aac",
+  "audio/mp4": "m4a",
+  "audio/mpeg": "mp3",
+  "audio/amr": "amr",
+  "audio/ogg": "ogg",
+  "application/pdf": "pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    "docx",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+    "pptx",
+  "application/vnd.ms-excel": "xls",
+  "application/msword": "doc",
+  "text/plain": "txt",
+};
+
+function inferFilename(mediaId: string, mimeType: string): string {
+  const ext = MIME_EXTENSIONS[mimeType];
+  const base = mediaId.slice(0, 12);
+  return ext ? `${base}.${ext}` : base;
+}
+
+/**
+ * Download a WhatsApp media object by its media ID.
+ * Resolves metadata from Meta's Graph API, downloads the binary, and returns
+ * the same shape used by uploadAttachment() in the runtime.
+ */
+export async function downloadWhatsAppFile(
+  config: GatewayConfig,
+  mediaId: string,
+): Promise<DownloadedFile> {
+  const meta = await getWhatsAppMediaMetadata(config, mediaId);
+
+  const response = await downloadWhatsAppMediaBytes(config, meta.url);
+  const buffer = await response.arrayBuffer();
+
+  const detected = await fileTypeFromBuffer(new Uint8Array(buffer));
+
+  // Prefer the MIME type from Meta metadata, then detected, then Content-Type header
+  const mimeType =
+    meta.mime_type ||
+    detected?.mime ||
+    response.headers.get("Content-Type")?.split(";")[0].trim() ||
+    "application/octet-stream";
+
+  const filename = inferFilename(mediaId, mimeType);
+  const data = Buffer.from(buffer).toString("base64");
+
+  return { filename, mimeType, data };
+}


### PR DESCRIPTION
## Summary
- Add WhatsApp media metadata resolution and download helpers to the gateway API layer
- Create a download primitive mirroring the Telegram pattern for consistent media handling
- Add comprehensive tests covering success, retryable failures, and MIME/filename inference

Part of plan: whatsapp-media-ingestion.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
