### PR TITLE
feat: add aggregated usage queries and indexes for reporting

### DIFF
--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -26,6 +26,9 @@ mock.module("../util/logger.js", () => ({
 
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import {
+  getUsageDayBuckets,
+  getUsageGroupBreakdown,
+  getUsageTotals,
   listUsageEvents,
   recordUsageEvent,
 } from "../memory/llm-usage-store.js";
@@ -68,6 +71,19 @@ const unpricedResult: PricingResult = {
   estimatedCostUsd: null,
   pricingStatus: "unpriced",
 };
+
+/** Insert an event at a specific epoch-millis timestamp. */
+function insertEventAt(
+  timestamp: number,
+  inputOverrides?: Partial<UsageEventInput>,
+  pricing: PricingResult = pricedResult,
+): void {
+  const event = recordUsageEvent(makeInput(inputOverrides), pricing);
+  const db = getDb();
+  db.run(
+    `UPDATE llm_usage_events SET created_at = ${timestamp} WHERE id = '${event.id}'`,
+  );
+}
 
 describe("recordUsageEvent", () => {
   beforeEach(() => {
@@ -243,5 +259,333 @@ describe("listUsageEvents", () => {
     expect(typeof event.cacheReadInputTokens).toBe("number");
     expect(typeof event.estimatedCostUsd).toBe("number");
     expect(typeof event.pricingStatus).toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Aggregation query tests
+// ---------------------------------------------------------------------------
+
+describe("getUsageTotals", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+  });
+
+  test("returns zeros when no events exist in range", () => {
+    const totals = getUsageTotals({ from: 0, to: 99999 });
+    expect(totals.totalInputTokens).toBe(0);
+    expect(totals.totalOutputTokens).toBe(0);
+    expect(totals.totalCacheCreationTokens).toBe(0);
+    expect(totals.totalCacheReadTokens).toBe(0);
+    expect(totals.totalEstimatedCostUsd).toBe(0);
+    expect(totals.eventCount).toBe(0);
+    expect(totals.pricedEventCount).toBe(0);
+    expect(totals.unpricedEventCount).toBe(0);
+  });
+
+  test("sums tokens and cost across priced events", () => {
+    insertEventAt(
+      1000,
+      { inputTokens: 100, outputTokens: 50 },
+      {
+        estimatedCostUsd: 0.01,
+        pricingStatus: "priced",
+      },
+    );
+    insertEventAt(
+      2000,
+      { inputTokens: 200, outputTokens: 100 },
+      {
+        estimatedCostUsd: 0.02,
+        pricingStatus: "priced",
+      },
+    );
+
+    const totals = getUsageTotals({ from: 0, to: 5000 });
+    expect(totals.totalInputTokens).toBe(300);
+    expect(totals.totalOutputTokens).toBe(150);
+    expect(totals.totalEstimatedCostUsd).toBeCloseTo(0.03);
+    expect(totals.eventCount).toBe(2);
+    expect(totals.pricedEventCount).toBe(2);
+    expect(totals.unpricedEventCount).toBe(0);
+  });
+
+  test("counts priced and unpriced events separately", () => {
+    insertEventAt(1000, {}, pricedResult);
+    insertEventAt(
+      2000,
+      { provider: "ollama", model: "llama3" },
+      unpricedResult,
+    );
+
+    const totals = getUsageTotals({ from: 0, to: 5000 });
+    expect(totals.eventCount).toBe(2);
+    expect(totals.pricedEventCount).toBe(1);
+    expect(totals.unpricedEventCount).toBe(1);
+  });
+
+  test("respects time range boundaries (inclusive)", () => {
+    insertEventAt(1000);
+    insertEventAt(2000);
+    insertEventAt(3000);
+
+    // Only the middle event
+    const totals = getUsageTotals({ from: 2000, to: 2000 });
+    expect(totals.eventCount).toBe(1);
+  });
+
+  test("excludes events outside the time range", () => {
+    insertEventAt(500);
+    insertEventAt(5000);
+
+    const totals = getUsageTotals({ from: 1000, to: 4000 });
+    expect(totals.eventCount).toBe(0);
+  });
+
+  test("sums cache tokens including nulls", () => {
+    insertEventAt(1000, {
+      cacheCreationInputTokens: 50,
+      cacheReadInputTokens: 100,
+    });
+    insertEventAt(2000, {
+      cacheCreationInputTokens: null,
+      cacheReadInputTokens: null,
+    });
+
+    const totals = getUsageTotals({ from: 0, to: 5000 });
+    expect(totals.totalCacheCreationTokens).toBe(50);
+    expect(totals.totalCacheReadTokens).toBe(100);
+  });
+});
+
+describe("getUsageDayBuckets", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+  });
+
+  // Helper: epoch millis for a UTC date
+  function utcMs(year: number, month: number, day: number, hour = 0): number {
+    return Date.UTC(year, month - 1, day, hour);
+  }
+
+  test("returns empty array when no events exist", () => {
+    const buckets = getUsageDayBuckets({ from: 0, to: 99999999999 });
+    expect(buckets).toHaveLength(0);
+  });
+
+  test("groups events into correct day buckets", () => {
+    const day1Start = utcMs(2025, 3, 1, 0);
+    const day1Mid = utcMs(2025, 3, 1, 12);
+    const day2Start = utcMs(2025, 3, 2, 6);
+
+    insertEventAt(day1Start, { inputTokens: 100, outputTokens: 10 });
+    insertEventAt(day1Mid, { inputTokens: 200, outputTokens: 20 });
+    insertEventAt(day2Start, { inputTokens: 300, outputTokens: 30 });
+
+    const buckets = getUsageDayBuckets({
+      from: utcMs(2025, 3, 1),
+      to: utcMs(2025, 3, 3),
+    });
+
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0].date).toBe("2025-03-01");
+    expect(buckets[0].totalInputTokens).toBe(300);
+    expect(buckets[0].totalOutputTokens).toBe(30);
+    expect(buckets[0].eventCount).toBe(2);
+
+    expect(buckets[1].date).toBe("2025-03-02");
+    expect(buckets[1].totalInputTokens).toBe(300);
+    expect(buckets[1].totalOutputTokens).toBe(30);
+    expect(buckets[1].eventCount).toBe(1);
+  });
+
+  test("buckets are ordered by date ascending", () => {
+    insertEventAt(utcMs(2025, 3, 3));
+    insertEventAt(utcMs(2025, 3, 1));
+    insertEventAt(utcMs(2025, 3, 2));
+
+    const buckets = getUsageDayBuckets({
+      from: utcMs(2025, 3, 1),
+      to: utcMs(2025, 3, 4),
+    });
+    expect(buckets.map((b) => b.date)).toEqual([
+      "2025-03-01",
+      "2025-03-02",
+      "2025-03-03",
+    ]);
+  });
+
+  test("handles day boundary correctly (midnight UTC)", () => {
+    // Last millisecond of March 1 and first millisecond of March 2
+    const endOfDay1 = utcMs(2025, 3, 1, 23) + 59 * 60 * 1000 + 59 * 1000;
+    const startOfDay2 = utcMs(2025, 3, 2, 0);
+
+    insertEventAt(endOfDay1, { inputTokens: 111 });
+    insertEventAt(startOfDay2, { inputTokens: 222 });
+
+    const buckets = getUsageDayBuckets({
+      from: utcMs(2025, 3, 1),
+      to: utcMs(2025, 3, 3),
+    });
+
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0].date).toBe("2025-03-01");
+    expect(buckets[0].totalInputTokens).toBe(111);
+    expect(buckets[1].date).toBe("2025-03-02");
+    expect(buckets[1].totalInputTokens).toBe(222);
+  });
+
+  test("sums cost correctly with mixed priced/unpriced events", () => {
+    const day = utcMs(2025, 3, 1);
+    insertEventAt(day, {}, { estimatedCostUsd: 0.05, pricingStatus: "priced" });
+    insertEventAt(day + 1000, { provider: "ollama" }, unpricedResult);
+
+    const buckets = getUsageDayBuckets({
+      from: utcMs(2025, 3, 1),
+      to: utcMs(2025, 3, 2),
+    });
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].totalEstimatedCostUsd).toBeCloseTo(0.05);
+    expect(buckets[0].eventCount).toBe(2);
+  });
+});
+
+describe("getUsageGroupBreakdown", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+  });
+
+  test("returns empty array when no events exist", () => {
+    const groups = getUsageGroupBreakdown({ from: 0, to: 99999 }, "actor");
+    expect(groups).toHaveLength(0);
+  });
+
+  test("groups by actor", () => {
+    insertEventAt(
+      1000,
+      { actor: "main_agent", inputTokens: 100 },
+      {
+        estimatedCostUsd: 0.01,
+        pricingStatus: "priced",
+      },
+    );
+    insertEventAt(
+      2000,
+      { actor: "main_agent", inputTokens: 200 },
+      {
+        estimatedCostUsd: 0.02,
+        pricingStatus: "priced",
+      },
+    );
+    insertEventAt(
+      3000,
+      { actor: "title_generator", inputTokens: 50 },
+      {
+        estimatedCostUsd: 0.005,
+        pricingStatus: "priced",
+      },
+    );
+
+    const groups = getUsageGroupBreakdown({ from: 0, to: 5000 }, "actor");
+    expect(groups).toHaveLength(2);
+
+    // Ordered by cost descending
+    expect(groups[0].group).toBe("main_agent");
+    expect(groups[0].totalInputTokens).toBe(300);
+    expect(groups[0].totalEstimatedCostUsd).toBeCloseTo(0.03);
+    expect(groups[0].eventCount).toBe(2);
+
+    expect(groups[1].group).toBe("title_generator");
+    expect(groups[1].totalInputTokens).toBe(50);
+    expect(groups[1].eventCount).toBe(1);
+  });
+
+  test("groups by provider", () => {
+    insertEventAt(
+      1000,
+      { provider: "anthropic" },
+      {
+        estimatedCostUsd: 0.05,
+        pricingStatus: "priced",
+      },
+    );
+    insertEventAt(2000, { provider: "ollama" }, unpricedResult);
+
+    const groups = getUsageGroupBreakdown({ from: 0, to: 5000 }, "provider");
+    expect(groups).toHaveLength(2);
+    expect(groups[0].group).toBe("anthropic");
+    expect(groups[0].totalEstimatedCostUsd).toBeCloseTo(0.05);
+    expect(groups[1].group).toBe("ollama");
+    expect(groups[1].totalEstimatedCostUsd).toBe(0);
+  });
+
+  test("groups by model", () => {
+    insertEventAt(
+      1000,
+      { model: "claude-sonnet-4-20250514" },
+      {
+        estimatedCostUsd: 0.03,
+        pricingStatus: "priced",
+      },
+    );
+    insertEventAt(
+      2000,
+      { model: "claude-sonnet-4-20250514" },
+      {
+        estimatedCostUsd: 0.02,
+        pricingStatus: "priced",
+      },
+    );
+    insertEventAt(3000, { model: "llama3" }, unpricedResult);
+
+    const groups = getUsageGroupBreakdown({ from: 0, to: 5000 }, "model");
+    expect(groups).toHaveLength(2);
+    expect(groups[0].group).toBe("claude-sonnet-4-20250514");
+    expect(groups[0].totalEstimatedCostUsd).toBeCloseTo(0.05);
+    expect(groups[0].eventCount).toBe(2);
+    expect(groups[1].group).toBe("llama3");
+  });
+
+  test("respects time range", () => {
+    insertEventAt(1000, { actor: "main_agent" });
+    insertEventAt(5000, { actor: "title_generator" });
+
+    const groups = getUsageGroupBreakdown({ from: 2000, to: 4000 }, "actor");
+    expect(groups).toHaveLength(0);
+  });
+
+  test("orders groups by estimated cost descending", () => {
+    insertEventAt(
+      1000,
+      { actor: "main_agent" },
+      {
+        estimatedCostUsd: 0.01,
+        pricingStatus: "priced",
+      },
+    );
+    insertEventAt(
+      2000,
+      { actor: "title_generator" },
+      {
+        estimatedCostUsd: 0.05,
+        pricingStatus: "priced",
+      },
+    );
+    insertEventAt(
+      3000,
+      { actor: "context_compactor" },
+      {
+        estimatedCostUsd: 0.03,
+        pricingStatus: "priced",
+      },
+    );
+
+    const groups = getUsageGroupBreakdown({ from: 0, to: 5000 }, "actor");
+    expect(groups[0].group).toBe("title_generator");
+    expect(groups[1].group).toBe("context_compactor");
+    expect(groups[2].group).toBe("main_agent");
   });
 });

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -63,6 +63,7 @@ import {
   migrateNotificationDeliveryThreadDecision,
   migrateReminderRoutingIntent,
   migrateSchemaIndexesAndColumns,
+  migrateUsageDashboardIndexes,
   migrateVoiceInviteColumns,
   migrateVoiceInviteDisplayMetadata,
   recoverCrashedMigrations,
@@ -292,6 +293,9 @@ export function initializeDb(): void {
 
   // 40. Drop assistant_id columns from all 16 daemon tables
   migrateDropAssistantIdColumns(database);
+
+  // 41. Indexes on llm_usage_events for usage dashboard time-range and breakdown queries
+  migrateUsageDashboardIndexes(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -7,7 +7,12 @@ import type {
   UsageEventInput,
 } from "../usage/types.js";
 import { getDb } from "./db.js";
+import { rawAll } from "./raw-query.js";
 import { llmUsageEvents } from "./schema.js";
+
+// ---------------------------------------------------------------------------
+// Write
+// ---------------------------------------------------------------------------
 
 export function recordUsageEvent(
   input: UsageEventInput,
@@ -43,6 +48,10 @@ export function recordUsageEvent(
   return event;
 }
 
+// ---------------------------------------------------------------------------
+// Read — single-event listing
+// ---------------------------------------------------------------------------
+
 export function listUsageEvents(options?: { limit?: number }): UsageEvent[] {
   const db = getDb();
   const rows = db
@@ -66,5 +75,178 @@ export function listUsageEvents(options?: { limit?: number }): UsageEvent[] {
     cacheReadInputTokens: row.cacheReadInputTokens,
     estimatedCostUsd: row.estimatedCostUsd,
     pricingStatus: row.pricingStatus as "priced" | "unpriced",
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation — time-range queries for the usage dashboard
+// ---------------------------------------------------------------------------
+
+/** Epoch-millis time range (inclusive on both ends). */
+export interface UsageTimeRange {
+  from: number;
+  to: number;
+}
+
+/** Aggregate totals across a time range. */
+export interface UsageTotals {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheCreationTokens: number;
+  totalCacheReadTokens: number;
+  totalEstimatedCostUsd: number;
+  eventCount: number;
+  pricedEventCount: number;
+  unpricedEventCount: number;
+}
+
+/** A single day bucket with its aggregate totals. */
+export interface UsageDayBucket {
+  /** ISO date string (YYYY-MM-DD) in UTC. */
+  date: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalEstimatedCostUsd: number;
+  eventCount: number;
+}
+
+/** A grouped breakdown row (by actor, provider, or model). */
+export interface UsageGroupBreakdown {
+  group: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalEstimatedCostUsd: number;
+  eventCount: number;
+}
+
+// -- raw row shapes returned by SQLite aggregation queries --
+
+interface TotalsRow {
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cache_creation_tokens: number;
+  total_cache_read_tokens: number;
+  total_estimated_cost_usd: number | null;
+  event_count: number;
+  priced_event_count: number;
+  unpriced_event_count: number;
+}
+
+interface DayBucketRow {
+  date: string;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_estimated_cost_usd: number | null;
+  event_count: number;
+}
+
+interface GroupRow {
+  group_key: string;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_estimated_cost_usd: number | null;
+  event_count: number;
+}
+
+/**
+ * Return aggregate totals for all usage events within the given time range.
+ */
+export function getUsageTotals(range: UsageTimeRange): UsageTotals {
+  const rows = rawAll<TotalsRow>(
+    /*sql*/ `
+    SELECT
+      COALESCE(SUM(input_tokens), 0)                              AS total_input_tokens,
+      COALESCE(SUM(output_tokens), 0)                             AS total_output_tokens,
+      COALESCE(SUM(cache_creation_input_tokens), 0)               AS total_cache_creation_tokens,
+      COALESCE(SUM(cache_read_input_tokens), 0)                   AS total_cache_read_tokens,
+      COALESCE(SUM(estimated_cost_usd), 0)                        AS total_estimated_cost_usd,
+      COUNT(*)                                                     AS event_count,
+      COUNT(CASE WHEN pricing_status = 'priced' THEN 1 END)       AS priced_event_count,
+      COUNT(CASE WHEN pricing_status = 'unpriced' THEN 1 END)     AS unpriced_event_count
+    FROM llm_usage_events
+    WHERE created_at >= ?1 AND created_at <= ?2
+    `,
+    range.from,
+    range.to,
+  );
+  const row = rows[0];
+  return {
+    totalInputTokens: row.total_input_tokens,
+    totalOutputTokens: row.total_output_tokens,
+    totalCacheCreationTokens: row.total_cache_creation_tokens,
+    totalCacheReadTokens: row.total_cache_read_tokens,
+    totalEstimatedCostUsd: row.total_estimated_cost_usd ?? 0,
+    eventCount: row.event_count,
+    pricedEventCount: row.priced_event_count,
+    unpricedEventCount: row.unpriced_event_count,
+  };
+}
+
+/**
+ * Return per-day aggregates (UTC) within the given time range, ordered by date ascending.
+ *
+ * Each bucket key is a YYYY-MM-DD string derived by dividing the epoch-millis
+ * timestamp by 86400000 and formatting as a date.
+ */
+export function getUsageDayBuckets(range: UsageTimeRange): UsageDayBucket[] {
+  const rows = rawAll<DayBucketRow>(
+    /*sql*/ `
+    SELECT
+      strftime('%Y-%m-%d', created_at / 1000, 'unixepoch')  AS date,
+      COALESCE(SUM(input_tokens), 0)                         AS total_input_tokens,
+      COALESCE(SUM(output_tokens), 0)                        AS total_output_tokens,
+      COALESCE(SUM(estimated_cost_usd), 0)                   AS total_estimated_cost_usd,
+      COUNT(*)                                                AS event_count
+    FROM llm_usage_events
+    WHERE created_at >= ?1 AND created_at <= ?2
+    GROUP BY date
+    ORDER BY date ASC
+    `,
+    range.from,
+    range.to,
+  );
+  return rows.map((r) => ({
+    date: r.date,
+    totalInputTokens: r.total_input_tokens,
+    totalOutputTokens: r.total_output_tokens,
+    totalEstimatedCostUsd: r.total_estimated_cost_usd ?? 0,
+    eventCount: r.event_count,
+  }));
+}
+
+type GroupByDimension = "actor" | "provider" | "model";
+
+/**
+ * Return grouped breakdowns across the given time range, ordered by total
+ * estimated cost descending (most expensive group first).
+ */
+export function getUsageGroupBreakdown(
+  range: UsageTimeRange,
+  groupBy: GroupByDimension,
+): UsageGroupBreakdown[] {
+  // The column name matches the enum value exactly.
+  const column = groupBy;
+  const rows = rawAll<GroupRow>(
+    /*sql*/ `
+    SELECT
+      ${column}                                      AS group_key,
+      COALESCE(SUM(input_tokens), 0)                 AS total_input_tokens,
+      COALESCE(SUM(output_tokens), 0)                AS total_output_tokens,
+      COALESCE(SUM(estimated_cost_usd), 0)           AS total_estimated_cost_usd,
+      COUNT(*)                                        AS event_count
+    FROM llm_usage_events
+    WHERE created_at >= ?1 AND created_at <= ?2
+    GROUP BY ${column}
+    ORDER BY total_estimated_cost_usd DESC
+    `,
+    range.from,
+    range.to,
+  );
+  return rows.map((r) => ({
+    group: r.group_key,
+    totalInputTokens: r.total_input_tokens,
+    totalOutputTokens: r.total_output_tokens,
+    totalEstimatedCostUsd: r.total_estimated_cost_usd ?? 0,
+    eventCount: r.event_count,
   }));
 }

--- a/assistant/src/memory/migrations/137-usage-dashboard-indexes.ts
+++ b/assistant/src/memory/migrations/137-usage-dashboard-indexes.ts
@@ -1,0 +1,21 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Idempotent migration to add indexes on llm_usage_events for the
+ * time-range and breakdown queries the usage dashboard needs.
+ *
+ * - Covering index on (created_at) for efficient time-range scans.
+ * - Composite index on (actor, created_at) for per-actor breakdowns.
+ * - Composite index on (provider, model, created_at) for provider/model grouping.
+ */
+export function migrateUsageDashboardIndexes(database: DrizzleDb): void {
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_created_at ON llm_usage_events(created_at)`,
+  );
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_actor_created_at ON llm_usage_events(actor, created_at)`,
+  );
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_provider_model_created_at ON llm_usage_events(provider, model, created_at)`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -79,6 +79,7 @@ export { migrateAssistantContactMetadata } from "./133-assistant-contact-metadat
 export { migrateContactsNotesColumn } from "./134-contacts-notes-column.js";
 export { migrateBackfillContactInteractionStats } from "./135-backfill-contact-interaction-stats.js";
 export { migrateDropAssistantIdColumns } from "./136-drop-assistant-id-columns.js";
+export { migrateUsageDashboardIndexes } from "./137-usage-dashboard-indexes.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema-migration.ts
+++ b/assistant/src/memory/schema-migration.ts
@@ -28,6 +28,7 @@ export {
   migrateRemoveAssistantIdColumns,
   migrateSchemaIndexesAndColumns,
   migrateToolInvocationsFk,
+  migrateUsageDashboardIndexes,
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,
   type MigrationValidationResult,


### PR DESCRIPTION
## Summary
- Add migration with indexes on llm_usage_events for time-range and breakdown queries
- Extend LlmUsageStore with aggregation helpers for totals, daily buckets, and grouped breakdowns
- Add tests covering bucket boundaries, priced/unpriced events, and grouped totals

Part of plan: usage-cost-reporting.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
