### PR TITLE
feat: upload inbound WhatsApp media to the runtime attachment store

### DIFF
--- a/gateway/src/http/routes/whatsapp-webhook.test.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.test.ts
@@ -5,13 +5,30 @@ const handleInboundMock = mock(() =>
   Promise.resolve({ forwarded: true, rejected: false }),
 );
 const resetConversationMock = mock(() => Promise.resolve());
+const uploadAttachmentMock = mock(() =>
+  Promise.resolve({ id: "att-uploaded-1" }),
+);
 const sendWhatsAppReplyMock = mock(() => Promise.resolve());
 const markWhatsAppMessageReadMock = mock(() => Promise.resolve());
+const downloadWhatsAppFileMock = mock(() =>
+  Promise.resolve({
+    filename: "photo.jpg",
+    mimeType: "image/jpeg",
+    data: "base64data",
+  }),
+);
 const normalizeWhatsAppWebhookMock = mock(
   () =>
     [] as Array<{ event: Record<string, unknown>; whatsappMessageId: string }>,
 );
 const verifyWhatsAppWebhookSignatureMock = mock(() => true);
+
+class MockAttachmentValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AttachmentValidationError";
+  }
+}
 
 mock.module("../../handlers/handle-inbound.js", () => ({
   handleInbound: handleInboundMock,
@@ -19,7 +36,13 @@ mock.module("../../handlers/handle-inbound.js", () => ({
 
 mock.module("../../runtime/client.js", () => ({
   resetConversation: resetConversationMock,
+  uploadAttachment: uploadAttachmentMock,
+  AttachmentValidationError: MockAttachmentValidationError,
   CircuitBreakerOpenError: class extends Error {},
+}));
+
+mock.module("../../whatsapp/download.js", () => ({
+  downloadWhatsAppFile: downloadWhatsAppFileMock,
 }));
 
 mock.module("../../whatsapp/send.js", () => ({
@@ -103,6 +126,18 @@ describe("whatsapp-webhook", () => {
       Promise.resolve({ forwarded: true, rejected: false }),
     );
     resetConversationMock.mockClear();
+    uploadAttachmentMock.mockClear();
+    uploadAttachmentMock.mockImplementation(() =>
+      Promise.resolve({ id: "att-uploaded-1" }),
+    );
+    downloadWhatsAppFileMock.mockClear();
+    downloadWhatsAppFileMock.mockImplementation(() =>
+      Promise.resolve({
+        filename: "photo.jpg",
+        mimeType: "image/jpeg",
+        data: "base64data",
+      }),
+    );
     sendWhatsAppReplyMock.mockClear();
     markWhatsAppMessageReadMock.mockClear();
     normalizeWhatsAppWebhookMock.mockClear();
@@ -269,5 +304,295 @@ describe("whatsapp-webhook", () => {
     expect(res.status).toBe(500);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.error).toBe("Internal error");
+  });
+
+  it("downloads and uploads media attachments, passing attachmentIds to handleInbound", async () => {
+    const { handler } = createWhatsAppWebhookHandler(baseConfig);
+
+    uploadAttachmentMock.mockImplementation(() =>
+      Promise.resolve({ id: "att-img-1" }),
+    );
+
+    normalizeWhatsAppWebhookMock.mockImplementation(() => [
+      {
+        whatsappMessageId: "wamid-media-1",
+        mediaType: "image",
+        event: {
+          version: "v1",
+          sourceChannel: "whatsapp",
+          receivedAt: new Date().toISOString(),
+          message: {
+            content: "check this out",
+            conversationExternalId: "15551230000",
+            externalMessageId: "wamid-media-1",
+            attachments: [
+              {
+                type: "image",
+                fileId: "media-id-123",
+                mimeType: "image/jpeg",
+                fileSize: 1024,
+              },
+            ],
+          },
+          actor: {
+            actorExternalId: "15551230000",
+            displayName: "Alice",
+          },
+          source: {
+            updateId: "wamid-media-1",
+            messageId: "wamid-media-1",
+            chatType: "private",
+          },
+          raw: {},
+        },
+      },
+    ]);
+
+    const res = await handler(
+      buildPostReq({ object: "whatsapp_business_account", entry: [] }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(downloadWhatsAppFileMock).toHaveBeenCalledTimes(1);
+    expect(downloadWhatsAppFileMock).toHaveBeenCalledWith(
+      baseConfig,
+      "media-id-123",
+    );
+    expect(uploadAttachmentMock).toHaveBeenCalledTimes(1);
+
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+    const [, , options] = handleInboundMock.mock.calls[0] as unknown as [
+      GatewayConfig,
+      Record<string, unknown>,
+      { attachmentIds?: string[] },
+    ];
+    expect(options.attachmentIds).toEqual(["att-img-1"]);
+  });
+
+  it("forwards media-only messages (no caption) when attachment upload succeeds", async () => {
+    const { handler } = createWhatsAppWebhookHandler(baseConfig);
+
+    uploadAttachmentMock.mockImplementation(() =>
+      Promise.resolve({ id: "att-img-2" }),
+    );
+
+    normalizeWhatsAppWebhookMock.mockImplementation(() => [
+      {
+        whatsappMessageId: "wamid-media-only",
+        mediaType: "image",
+        event: {
+          version: "v1",
+          sourceChannel: "whatsapp",
+          receivedAt: new Date().toISOString(),
+          message: {
+            content: "",
+            conversationExternalId: "15551230000",
+            externalMessageId: "wamid-media-only",
+            attachments: [
+              {
+                type: "image",
+                fileId: "media-id-456",
+                mimeType: "image/png",
+                fileSize: 2048,
+              },
+            ],
+          },
+          actor: {
+            actorExternalId: "15551230000",
+            displayName: "Alice",
+          },
+          source: {
+            updateId: "wamid-media-only",
+            messageId: "wamid-media-only",
+            chatType: "private",
+          },
+          raw: {},
+        },
+      },
+    ]);
+
+    const res = await handler(
+      buildPostReq({ object: "whatsapp_business_account", entry: [] }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+    const [, , options] = handleInboundMock.mock.calls[0] as unknown as [
+      GatewayConfig,
+      Record<string, unknown>,
+      { attachmentIds?: string[] },
+    ];
+    expect(options.attachmentIds).toEqual(["att-img-2"]);
+  });
+
+  it("skips validation errors for one attachment without dropping the message", async () => {
+    const { handler } = createWhatsAppWebhookHandler(baseConfig);
+
+    let callCount = 0;
+    uploadAttachmentMock.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        throw new MockAttachmentValidationError("Unsupported MIME type");
+      }
+      return Promise.resolve({ id: "att-good" });
+    });
+
+    normalizeWhatsAppWebhookMock.mockImplementation(() => [
+      {
+        whatsappMessageId: "wamid-mixed",
+        mediaType: "image",
+        event: {
+          version: "v1",
+          sourceChannel: "whatsapp",
+          receivedAt: new Date().toISOString(),
+          message: {
+            content: "two attachments",
+            conversationExternalId: "15551230000",
+            externalMessageId: "wamid-mixed",
+            attachments: [
+              {
+                type: "image",
+                fileId: "bad-media-id",
+                mimeType: "image/tiff",
+                fileSize: 1024,
+              },
+              {
+                type: "document",
+                fileId: "good-media-id",
+                mimeType: "application/pdf",
+                fileSize: 2048,
+              },
+            ],
+          },
+          actor: {
+            actorExternalId: "15551230000",
+            displayName: "Alice",
+          },
+          source: {
+            updateId: "wamid-mixed",
+            messageId: "wamid-mixed",
+            chatType: "private",
+          },
+          raw: {},
+        },
+      },
+    ]);
+
+    const res = await handler(
+      buildPostReq({ object: "whatsapp_business_account", entry: [] }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+    const [, , options] = handleInboundMock.mock.calls[0] as unknown as [
+      GatewayConfig,
+      Record<string, unknown>,
+      { attachmentIds?: string[] },
+    ];
+    expect(options.attachmentIds).toEqual(["att-good"]);
+  });
+
+  it("returns 500 on transient download failure so Meta retries", async () => {
+    const { handler } = createWhatsAppWebhookHandler(baseConfig);
+
+    downloadWhatsAppFileMock.mockImplementation(() => {
+      throw new Error("Network timeout");
+    });
+
+    normalizeWhatsAppWebhookMock.mockImplementation(() => [
+      {
+        whatsappMessageId: "wamid-transient",
+        mediaType: "image",
+        event: {
+          version: "v1",
+          sourceChannel: "whatsapp",
+          receivedAt: new Date().toISOString(),
+          message: {
+            content: "photo",
+            conversationExternalId: "15551230000",
+            externalMessageId: "wamid-transient",
+            attachments: [
+              {
+                type: "image",
+                fileId: "media-transient",
+                mimeType: "image/jpeg",
+                fileSize: 1024,
+              },
+            ],
+          },
+          actor: {
+            actorExternalId: "15551230000",
+            displayName: "Alice",
+          },
+          source: {
+            updateId: "wamid-transient",
+            messageId: "wamid-transient",
+            chatType: "private",
+          },
+          raw: {},
+        },
+      },
+    ]);
+
+    const res = await handler(
+      buildPostReq({ object: "whatsapp_business_account", entry: [] }),
+    );
+
+    expect(res.status).toBe(500);
+    expect(handleInboundMock).not.toHaveBeenCalled();
+  });
+
+  it("skips oversized attachments without failing the message", async () => {
+    const { handler } = createWhatsAppWebhookHandler(baseConfig);
+
+    normalizeWhatsAppWebhookMock.mockImplementation(() => [
+      {
+        whatsappMessageId: "wamid-oversize",
+        mediaType: "video",
+        event: {
+          version: "v1",
+          sourceChannel: "whatsapp",
+          receivedAt: new Date().toISOString(),
+          message: {
+            content: "big video",
+            conversationExternalId: "15551230000",
+            externalMessageId: "wamid-oversize",
+            attachments: [
+              {
+                type: "video",
+                fileId: "media-big",
+                mimeType: "video/mp4",
+                fileSize: 100 * 1024 * 1024, // 100 MB — over limit
+              },
+            ],
+          },
+          actor: {
+            actorExternalId: "15551230000",
+            displayName: "Alice",
+          },
+          source: {
+            updateId: "wamid-oversize",
+            messageId: "wamid-oversize",
+            chatType: "private",
+          },
+          raw: {},
+        },
+      },
+    ]);
+
+    const res = await handler(
+      buildPostReq({ object: "whatsapp_business_account", entry: [] }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(downloadWhatsAppFileMock).not.toHaveBeenCalled();
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+    const [, , options] = handleInboundMock.mock.calls[0] as unknown as [
+      GatewayConfig,
+      Record<string, unknown>,
+      { attachmentIds?: string[] },
+    ];
+    // No attachmentIds since the only attachment was oversized
+    expect(options.attachmentIds).toEqual([]);
   });
 });

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -10,12 +10,17 @@ import {
   isRejection,
 } from "../../routing/resolve-assistant.js";
 import {
+  AttachmentValidationError,
+  uploadAttachment,
+} from "../../runtime/client.js";
+import {
   handleCircuitBreakerError,
   handleNewCommand,
   isNewCommand,
   processInboundResult,
 } from "../../webhook-pipeline.js";
 import { ROUTING_REJECTION_NOTICE } from "../../webhook-copy.js";
+import { downloadWhatsAppFile } from "../../whatsapp/download.js";
 import { markWhatsAppMessageRead } from "../../whatsapp/api.js";
 import { normalizeWhatsAppWebhook } from "../../whatsapp/normalize.js";
 import { sendWhatsAppReply } from "../../whatsapp/send.js";
@@ -147,29 +152,6 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
         "WhatsApp webhook received",
       );
 
-      if (mediaType) {
-        tlog.warn(
-          {
-            whatsappMessageId,
-            mediaType,
-            hasCaption: event.message.content.length > 0,
-          },
-          "WhatsApp media attachment not processed — media download not yet supported",
-        );
-
-        // No caption and no text — nothing to forward to the assistant
-        if (event.message.content.length === 0) {
-          markWhatsAppMessageRead(config, whatsappMessageId).catch((err) => {
-            tlog.debug(
-              { err, messageId: whatsappMessageId },
-              "Failed to mark WhatsApp message as read",
-            );
-          });
-          dedupCache.mark(whatsappMessageId);
-          continue;
-        }
-      }
-
       // Mark message as read (best-effort, do not await)
       markWhatsAppMessageRead(config, whatsappMessageId).catch((err) => {
         tlog.debug(
@@ -231,8 +213,95 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
         continue;
       }
 
+      // Download and upload attachments if present
+      let attachmentIds: string[] | undefined;
+      const eventAttachments = event.message.attachments;
+      if (eventAttachments && eventAttachments.length > 0) {
+        try {
+          attachmentIds = [];
+
+          // Filter oversized attachments
+          const eligible = eventAttachments.filter((att) => {
+            if (
+              att.fileSize !== undefined &&
+              att.fileSize > config.maxAttachmentBytes
+            ) {
+              tlog.warn(
+                {
+                  fileId: att.fileId,
+                  fileSize: att.fileSize,
+                  limit: config.maxAttachmentBytes,
+                },
+                "Skipping oversized WhatsApp attachment",
+              );
+              return false;
+            }
+            return true;
+          });
+
+          // Process with bounded concurrency. Validation errors (unsupported
+          // MIME type, dangerous extension) are skipped so that a bad attachment
+          // doesn't drop the user's message. Transient errors (download timeout,
+          // upload 5xx, network failures) are propagated so that Meta retries
+          // the webhook delivery.
+          for (
+            let i = 0;
+            i < eligible.length;
+            i += config.maxAttachmentConcurrency
+          ) {
+            const batch = eligible.slice(
+              i,
+              i + config.maxAttachmentConcurrency,
+            );
+            const results = await Promise.allSettled(
+              batch.map(async (att) => {
+                const downloaded = await downloadWhatsAppFile(
+                  config,
+                  att.fileId,
+                );
+                return uploadAttachment(config, downloaded);
+              }),
+            );
+            for (const result of results) {
+              if (result.status === "fulfilled") {
+                attachmentIds.push(result.value.id);
+              } else if (result.reason instanceof AttachmentValidationError) {
+                tlog.warn(
+                  { err: result.reason },
+                  "Skipping WhatsApp attachment with validation error",
+                );
+              } else {
+                // Transient failure — propagate so the webhook returns 500 and
+                // Meta retries the update delivery.
+                throw result.reason;
+              }
+            }
+          }
+        } catch (err) {
+          // Transient attachment failure — return 500 so Meta retries.
+          tlog.error(
+            { err },
+            "WhatsApp attachment processing failed with transient error",
+          );
+          dedupCache.unreserve(whatsappMessageId);
+          hasFailure = true;
+          continue;
+        }
+      }
+
+      // Media-only messages with no successfully uploaded attachments have
+      // nothing to forward — skip silently.
+      if (
+        event.message.content.length === 0 &&
+        (!attachmentIds || attachmentIds.length === 0)
+      ) {
+        dedupCache.mark(whatsappMessageId);
+        continue;
+      }
+
       try {
         const result = await handleInbound(config, event, {
+          attachmentIds,
           transportMetadata: buildWhatsAppTransportMetadata(),
           replyCallbackUrl: `${config.gatewayInternalBaseUrl}/deliver/whatsapp`,
           traceId,


### PR DESCRIPTION
## Summary
- Wire WhatsApp webhook to download and upload inbound media attachments using the same bounded-concurrency pattern as Telegram
- Remove the 'media download not yet supported' early-drop so media-only messages are forwarded
- Handle validation errors gracefully (skip bad attachments) while making transient failures retryable (500)

Part of plan: whatsapp-media-ingestion.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
