### PR TITLE
refactor: rename .vellumapp extension to .vellum (#13123)

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -495,7 +495,7 @@ exports[`IPC message snapshots ClientMessage types fork_shared_app serializes to
 
 exports[`IPC message snapshots ClientMessage types open_bundle serializes to expected JSON 1`] = `
 {
-  "filePath": "/tmp/My_App.vellumapp",
+  "filePath": "/tmp/My_App.vellum",
   "type": "open_bundle",
 }
 `;
@@ -1988,7 +1988,7 @@ exports[`IPC message snapshots ServerMessage types reminders_list_response seria
 
 exports[`IPC message snapshots ServerMessage types bundle_app_response serializes to expected JSON 1`] = `
 {
-  "bundlePath": "/tmp/My_App-abc12345.vellumapp",
+  "bundlePath": "/tmp/My_App-abc12345.vellum",
   "manifest": {
     "capabilities": [],
     "content_id": "a1b2c3d4e5f6a7b8",

--- a/assistant/src/__tests__/bundle-scanner.test.ts
+++ b/assistant/src/__tests__/bundle-scanner.test.ts
@@ -49,7 +49,7 @@ async function createBundle(
   const data = await zip.generateAsync({ type: "uint8array" });
   const path = join(
     tempDir,
-    `test-${Date.now()}-${Math.random().toString(36).slice(2)}.vellumapp`,
+    `test-${Date.now()}-${Math.random().toString(36).slice(2)}.vellum`,
   );
   await Bun.write(path, data);
   return path;

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -315,7 +315,7 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
   },
   open_bundle: {
     type: "open_bundle",
-    filePath: "/tmp/My_App.vellumapp",
+    filePath: "/tmp/My_App.vellum",
   },
   sign_bundle_payload_response: {
     type: "sign_bundle_payload_response",
@@ -1266,7 +1266,7 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
   },
   bundle_app_response: {
     type: "bundle_app_response",
-    bundlePath: "/tmp/My_App-abc12345.vellumapp",
+    bundlePath: "/tmp/My_App-abc12345.vellum",
     manifest: {
       format_version: 1,
       name: "My App",

--- a/assistant/src/bundler/app-bundler.ts
+++ b/assistant/src/bundler/app-bundler.ts
@@ -1,5 +1,5 @@
 /**
- * Core packaging logic for .vellumapp zip archives.
+ * Core packaging logic for .vellum zip archives.
  *
  * Reads an app from the app-store, generates a manifest, and produces a
  * zip archive written to a temp file.
@@ -176,12 +176,12 @@ export interface BundleResult {
 }
 
 /**
- * Package an app into a .vellumapp zip archive.
+ * Package an app into a .vellum zip archive.
  *
  * @param appId - The ID of the app to package (from the app-store).
  * @param requestSignature - Optional callback to request an Ed25519 signature from the Swift client.
  *                           If provided, the bundle will be signed and include a signature.json.
- * @returns The path to the created .vellumapp file and the manifest.
+ * @returns The path to the created .vellum file and the manifest.
  * @throws If the app is not found, or the bundle exceeds the size limit.
  */
 export async function packageApp(
@@ -239,7 +239,7 @@ export async function packageApp(
   const bundleFilename = `${app.name.replace(
     /[^a-zA-Z0-9_-]/g,
     "_",
-  )}-${randomUUID().slice(0, SHORT_HASH_LENGTH)}.vellumapp`;
+  )}-${randomUUID().slice(0, SHORT_HASH_LENGTH)}.vellum`;
   const bundlePath = join(tmpdir(), bundleFilename);
 
   await new Promise<void>((resolve, reject) => {

--- a/assistant/src/bundler/bundle-scanner.ts
+++ b/assistant/src/bundler/bundle-scanner.ts
@@ -1,5 +1,5 @@
 /**
- * BundleScanner — Security validation and static analysis for .vellumapp bundles.
+ * BundleScanner — Security validation and static analysis for .vellum bundles.
  *
  * Validates zip bundles before they are opened, returning structured results
  * with block-level (reject) and warn-level (flag) findings.

--- a/assistant/src/bundler/bundle-signer.ts
+++ b/assistant/src/bundler/bundle-signer.ts
@@ -1,5 +1,5 @@
 /**
- * Bundle signing for .vellumapp archives.
+ * Bundle signing for .vellum archives.
  *
  * Computes content hashes, constructs a canonical signing payload,
  * and requests an Ed25519 signature from the Swift client via IPC.
@@ -78,9 +78,9 @@ async function computeContentHashes(
 }
 
 /**
- * Sign a .vellumapp bundle.
+ * Sign a .vellum bundle.
  *
- * @param bundlePath - Path to the .vellumapp zip archive.
+ * @param bundlePath - Path to the .vellum zip archive.
  * @param requestSignature - Callback to request a signature from the Swift client.
  * @returns The SignatureJson to embed in the archive.
  */

--- a/assistant/src/bundler/manifest.ts
+++ b/assistant/src/bundler/manifest.ts
@@ -1,5 +1,5 @@
 /**
- * Types and serialization for .vellumapp manifest files.
+ * Types and serialization for .vellum manifest files.
  */
 
 export interface AppManifest {

--- a/assistant/src/bundler/signature-verifier.ts
+++ b/assistant/src/bundler/signature-verifier.ts
@@ -1,5 +1,5 @@
 /**
- * Signature verification for .vellumapp archives.
+ * Signature verification for .vellum archives.
  *
  * Checks bundle integrity and Ed25519 signature validity.
  */
@@ -39,9 +39,9 @@ function sortKeysDeep(obj: unknown): unknown {
 }
 
 /**
- * Verify the signature and integrity of a .vellumapp bundle.
+ * Verify the signature and integrity of a .vellum bundle.
  *
- * @param zipPath - Path to the .vellumapp zip archive.
+ * @param zipPath - Path to the .vellum zip archive.
  * @param trustedPublicKeys - Optional map of keyId -> base64-encoded public key for verification.
  *                            If not provided, signature is checked structurally but returns 'signed' at best.
  * @returns The verification result with trust tier and signer info.

--- a/assistant/src/memory/shared-app-links-store.ts
+++ b/assistant/src/memory/shared-app-links-store.ts
@@ -1,7 +1,7 @@
 /**
  * Store for cloud-shared app link records.
  *
- * Each record holds a .vellumapp zip bundle keyed by a short, shareable token.
+ * Each record holds a .vellum zip bundle keyed by a short, shareable token.
  */
 
 import { randomBytes, randomUUID } from "node:crypto";

--- a/assistant/src/runtime/routes/app-routes.ts
+++ b/assistant/src/runtime/routes/app-routes.ts
@@ -167,7 +167,7 @@ export function handleDownloadSharedApp(shareToken: string): Response {
   return new Response(new Uint8Array(record.bundleData), {
     headers: {
       "Content-Type": "application/zip",
-      "Content-Disposition": 'attachment; filename="app.vellumapp"',
+      "Content-Disposition": 'attachment; filename="app.vellum"',
     },
   });
 }

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -639,10 +639,10 @@ cat > "$CONTENTS/Info.plist" <<PLIST
             <dict>
                 <key>public.filename-extension</key>
                 <array>
-                    <string>vellumapp</string>
+                    <string>vellum</string>
                 </array>
                 <key>public.mime-type</key>
-                <string>application/x-vellumapp</string>
+                <string>application/x-vellum</string>
             </dict>
         </dict>
     </array>
@@ -651,7 +651,7 @@ cat > "$CONTENTS/Info.plist" <<PLIST
         <dict>
             <key>CFBundleTypeExtensions</key>
             <array>
-                <string>vellumapp</string>
+                <string>vellum</string>
             </array>
             <key>CFBundleTypeRole</key>
             <string>Viewer</string>

--- a/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
@@ -10,8 +10,8 @@ extension AppDelegate {
 
     public func application(_ application: NSApplication, open urls: [URL]) {
         for url in urls {
-            guard url.pathExtension == "vellumapp" else { continue }
-            log.info("Opening .vellumapp file: \(url.path, privacy: .private)")
+            guard url.pathExtension == "vellum" else { continue }
+            log.info("Opening .vellum file: \(url.path, privacy: .private)")
 
             guard daemonClient.isConnected else {
                 log.warning("Cannot open bundle: daemon not connected")

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -79,7 +79,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var bootstrapFailureKind: BootstrapFailureKind = .unknown
     /// Background task that retries actor-token bootstrap until success.
     var actorTokenBootstrapTask: Task<Void, Never>?
-    /// Tracks file paths of .vellumapp bundles awaiting daemon responses (FIFO).
+    /// Tracks file paths of .vellum bundles awaiting daemon responses (FIFO).
     /// Each call to sendOpenBundle appends a path; handleOpenBundleResponse
     /// pops the first entry so concurrent opens are correctly paired.
     var pendingBundleFilePaths: [String] = []

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "BundleSandbox")
 
-/// Manages unpacking shared .vellumapp bundles into a sandboxed directory.
+/// Manages unpacking shared .vellum bundles into a sandboxed directory.
 enum BundleSandbox {
 
     /// Base directory for all shared apps.
@@ -34,7 +34,7 @@ enum BundleSandbox {
         let installedAt: String
     }
 
-    /// Unpacks a `.vellumapp` zip file into the sandbox and writes metadata.
+    /// Unpacks a `.vellum` zip file into the sandbox and writes metadata.
     /// Returns the UUID and the directory URL where the contents were extracted.
     static func unpack(
         filePath: String,

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1099,7 +1099,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(BundleAppRequestMessage(appId: appId))
     }
 
-    /// Request opening and scanning a .vellumapp bundle.
+    /// Request opening and scanning a .vellum bundle.
     public func sendOpenBundle(filePath: String) throws {
         try send(OpenBundleMessage(filePath: filePath))
     }

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -529,7 +529,7 @@ extension IPCBundleAppRequest {
     }
 }
 
-/// Sent to open and scan a .vellumapp bundle.
+/// Sent to open and scan a .vellum bundle.
 /// Backed by generated `IPCOpenBundleRequest`.
 public typealias OpenBundleMessage = IPCOpenBundleRequest
 
@@ -1687,7 +1687,7 @@ extension IPCToolNamesListRequest {
 /// Backed by generated `IPCToolNamesListResponse`.
 public typealias ToolNamesListResponseMessage = IPCToolNamesListResponse
 
-/// Response from opening and scanning a .vellumapp bundle.
+/// Response from opening and scanning a .vellum bundle.
 /// Backed by generated `IPCOpenBundleResponse`.
 public typealias OpenBundleResponseMessage = IPCOpenBundleResponse
 


### PR DESCRIPTION
Renames the .vellumapp file extension to .vellum across all code, comments, tests, and build configuration. The vellumapp:// URL scheme is left unchanged as it's internal.

Part of #13051
Closes #13123
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
