### PR TITLE
feat: add shared Chrome CDP helper for assistant-managed browser sessions

### DIFF
--- a/assistant/src/__tests__/chrome-cdp.test.ts
+++ b/assistant/src/__tests__/chrome-cdp.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  ensureChromeWithCdp,
+  isCdpReady,
+  minimizeChromeWindow,
+  restoreChromeWindow,
+} from "../tools/browser/chrome-cdp.js";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// We need to mock child_process.spawn and the global fetch / WebSocket so
+// tests don't need a real Chrome process.
+
+const spawnMock = mock(() => {
+  const proc = { unref: mock(() => {}) };
+  return proc;
+});
+
+mock.module("node:child_process", () => ({
+  spawn: spawnMock,
+}));
+
+// Track fetch calls so we can assert readiness-check behavior
+let fetchImpl: (url: string | URL | Request) => Promise<Response>;
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  // Default: CDP not ready
+  fetchImpl = async () => {
+    throw new Error("Connection refused");
+  };
+  globalThis.fetch = (async (
+    input: string | URL | Request,
+    _init?: RequestInit,
+  ) => {
+    return fetchImpl(input);
+  }) as typeof globalThis.fetch;
+  spawnMock.mockClear();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ---------------------------------------------------------------------------
+// isCdpReady
+// ---------------------------------------------------------------------------
+
+describe("isCdpReady", () => {
+  test("returns true when the endpoint responds with 200", async () => {
+    fetchImpl = async () => new Response("{}", { status: 200 });
+    expect(await isCdpReady()).toBe(true);
+  });
+
+  test("returns false when fetch throws (connection refused)", async () => {
+    fetchImpl = async () => {
+      throw new Error("Connection refused");
+    };
+    expect(await isCdpReady()).toBe(false);
+  });
+
+  test("returns false when the endpoint responds with non-ok status", async () => {
+    fetchImpl = async () => new Response("", { status: 500 });
+    expect(await isCdpReady()).toBe(false);
+  });
+
+  test("uses the provided base URL", async () => {
+    let calledUrl = "";
+    fetchImpl = async (url) => {
+      calledUrl = String(url);
+      return new Response("{}", { status: 200 });
+    };
+    await isCdpReady("http://localhost:9333");
+    expect(calledUrl).toBe("http://localhost:9333/json/version");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureChromeWithCdp
+// ---------------------------------------------------------------------------
+
+describe("ensureChromeWithCdp", () => {
+  test("returns immediately if CDP is already ready (launchedByUs=false)", async () => {
+    fetchImpl = async () => new Response("{}", { status: 200 });
+    const session = await ensureChromeWithCdp();
+    expect(session.launchedByUs).toBe(false);
+    expect(session.baseUrl).toBe("http://localhost:9222");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  test("spawns Chrome and retries when CDP is not initially ready", async () => {
+    let callCount = 0;
+    fetchImpl = async () => {
+      callCount++;
+      // Succeed on the 3rd call (1st check + 2 retries)
+      if (callCount >= 3) return new Response("{}", { status: 200 });
+      throw new Error("Connection refused");
+    };
+
+    const session = await ensureChromeWithCdp({
+      startUrl: "https://example.com/",
+    });
+    expect(session.launchedByUs).toBe(true);
+    expect(session.baseUrl).toBe("http://localhost:9222");
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    // Verify spawn was called with the right Chrome path and args
+    const spawnArgs = spawnMock.mock.calls[0] as unknown as [string, string[]];
+    expect(spawnArgs[0]).toContain("Google Chrome");
+    const flags = spawnArgs[1];
+    expect(flags).toContain("--remote-debugging-port=9222");
+    expect(flags).toContain("--force-renderer-accessibility");
+    expect(flags.some((f: string) => f.includes("Chrome-CDP"))).toBe(true);
+    expect(flags).toContain("https://example.com/");
+  });
+
+  test("uses custom port when specified", async () => {
+    fetchImpl = async () => new Response("{}", { status: 200 });
+    const session = await ensureChromeWithCdp({ port: 9333 });
+    expect(session.baseUrl).toBe("http://localhost:9333");
+  });
+
+  test("uses custom userDataDir when specified", async () => {
+    fetchImpl = async () => new Response("{}", { status: 200 });
+    const session = await ensureChromeWithCdp({
+      userDataDir: "/tmp/test-chrome",
+    });
+    expect(session.userDataDir).toBe("/tmp/test-chrome");
+  });
+
+  test("throws after exhausting retries", async () => {
+    // Never becomes ready
+    fetchImpl = async () => {
+      throw new Error("Connection refused");
+    };
+
+    // Override the retry delay so the test doesn't take 15 seconds.
+    // We can't easily do that without changing the implementation, so we
+    // test a shorter scenario: just verify it throws eventually.
+    // For CI speed, we rely on the error message check.
+    const promise = ensureChromeWithCdp();
+    await expect(promise).rejects.toThrow("CDP endpoint not responding");
+  }, 20_000);
+});
+
+// ---------------------------------------------------------------------------
+// Window management (minimize / restore)
+// ---------------------------------------------------------------------------
+
+describe("minimizeChromeWindow", () => {
+  test("does nothing when no page targets exist", async () => {
+    fetchImpl = async () => new Response("[]", { status: 200 });
+    // Should not throw
+    await minimizeChromeWindow();
+  });
+
+  test("sends minimize command via WebSocket", async () => {
+    // Track the WebSocket interactions
+    const sentMessages: string[] = [];
+    let wsOnOpen: (() => void) | undefined;
+    let wsOnMessage: ((event: { data: string }) => void) | undefined;
+
+    fetchImpl = async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes("/json/list")) {
+        return new Response(
+          JSON.stringify([
+            {
+              type: "page",
+              webSocketDebuggerUrl: "ws://localhost:9222/devtools/page/ABC",
+            },
+          ]),
+        );
+      }
+      return new Response("{}", { status: 200 });
+    };
+
+    const OriginalWebSocket = globalThis.WebSocket;
+    globalThis.WebSocket = class MockWebSocket {
+      constructor(_url: string) {}
+      addEventListener(event: string, handler: (...args: unknown[]) => void) {
+        if (event === "open") wsOnOpen = handler as () => void;
+        if (event === "message")
+          wsOnMessage = handler as (event: { data: string }) => void;
+      }
+      send(data: string) {
+        sentMessages.push(data);
+        const msg = JSON.parse(data);
+        if (msg.method === "Browser.getWindowForTarget") {
+          // Simulate response with windowId
+          setTimeout(() => {
+            wsOnMessage?.({
+              data: JSON.stringify({ id: 1, result: { windowId: 42 } }),
+            });
+          }, 0);
+        } else if (msg.method === "Browser.setWindowBounds") {
+          setTimeout(() => {
+            wsOnMessage?.({ data: JSON.stringify({ id: 2, result: {} }) });
+          }, 0);
+        }
+      }
+      close() {}
+    } as unknown as typeof WebSocket;
+
+    const promise = minimizeChromeWindow();
+
+    // Trigger the open event
+    await new Promise((r) => setTimeout(r, 10));
+    wsOnOpen?.();
+
+    await promise;
+
+    // Verify the setWindowBounds call had windowState: "minimized"
+    const boundsMsg = sentMessages.find((m) =>
+      m.includes("Browser.setWindowBounds"),
+    );
+    expect(boundsMsg).toBeDefined();
+    const parsed = JSON.parse(boundsMsg!);
+    expect(parsed.params.bounds.windowState).toBe("minimized");
+
+    globalThis.WebSocket = OriginalWebSocket;
+  });
+});
+
+describe("restoreChromeWindow", () => {
+  test("sends restore command via WebSocket", async () => {
+    const sentMessages: string[] = [];
+    let wsOnOpen: (() => void) | undefined;
+    let wsOnMessage: ((event: { data: string }) => void) | undefined;
+
+    fetchImpl = async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes("/json/list")) {
+        return new Response(
+          JSON.stringify([
+            {
+              type: "page",
+              webSocketDebuggerUrl: "ws://localhost:9222/devtools/page/ABC",
+            },
+          ]),
+        );
+      }
+      return new Response("{}", { status: 200 });
+    };
+
+    const OriginalWebSocket = globalThis.WebSocket;
+    globalThis.WebSocket = class MockWebSocket {
+      constructor(_url: string) {}
+      addEventListener(event: string, handler: (...args: unknown[]) => void) {
+        if (event === "open") wsOnOpen = handler as () => void;
+        if (event === "message")
+          wsOnMessage = handler as (event: { data: string }) => void;
+      }
+      send(data: string) {
+        sentMessages.push(data);
+        const msg = JSON.parse(data);
+        if (msg.method === "Browser.getWindowForTarget") {
+          setTimeout(() => {
+            wsOnMessage?.({
+              data: JSON.stringify({ id: 1, result: { windowId: 42 } }),
+            });
+          }, 0);
+        } else if (msg.method === "Browser.setWindowBounds") {
+          setTimeout(() => {
+            wsOnMessage?.({ data: JSON.stringify({ id: 2, result: {} }) });
+          }, 0);
+        }
+      }
+      close() {}
+    } as unknown as typeof WebSocket;
+
+    const promise = restoreChromeWindow();
+    await new Promise((r) => setTimeout(r, 10));
+    wsOnOpen?.();
+    await promise;
+
+    const boundsMsg = sentMessages.find((m) =>
+      m.includes("Browser.setWindowBounds"),
+    );
+    expect(boundsMsg).toBeDefined();
+    const parsed = JSON.parse(boundsMsg!);
+    expect(parsed.params.bounds.windowState).toBe("normal");
+
+    globalThis.WebSocket = OriginalWebSocket;
+  });
+});

--- a/assistant/src/tools/browser/chrome-cdp.ts
+++ b/assistant/src/tools/browser/chrome-cdp.ts
@@ -1,0 +1,204 @@
+/**
+ * Shared Chrome CDP session management.
+ *
+ * Consolidates the duplicated launch / readiness / window-management logic
+ * that was previously copy-pasted across the Amazon and DoorDash CLIs.
+ * Callers get back a {@link CdpSession} with structured metadata so they can
+ * make cleanup decisions (e.g. only kill Chrome if *we* launched it).
+ */
+
+import { spawn as spawnChild } from "node:child_process";
+import { homedir } from "node:os";
+import { join as pathJoin } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CDP_PORT = 9222;
+const DEFAULT_CDP_BASE = `http://localhost:${DEFAULT_CDP_PORT}`;
+const DEFAULT_USER_DATA_DIR = pathJoin(
+  homedir(),
+  "Library/Application Support/Google/Chrome-CDP",
+);
+const CHROME_APP_PATH =
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CdpSession {
+  /** Base URL for the CDP HTTP endpoints (e.g. `http://localhost:9222`). */
+  baseUrl: string;
+  /** Whether this helper launched Chrome (true) or it was already running (false). */
+  launchedByUs: boolean;
+  /** The `--user-data-dir` used for the Chrome instance. */
+  userDataDir: string;
+}
+
+export interface EnsureChromeOptions {
+  /** CDP port. Defaults to `9222`. */
+  port?: number;
+  /** User data directory for Chrome. Defaults to `~/Library/Application Support/Google/Chrome-CDP`. */
+  userDataDir?: string;
+  /** Initial URL to open when launching Chrome. */
+  startUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Readiness check
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns `true` when a CDP endpoint is responding at the given base URL.
+ */
+export async function isCdpReady(
+  cdpBase: string = DEFAULT_CDP_BASE,
+): Promise<boolean> {
+  try {
+    const res = await fetch(`${cdpBase}/json/version`);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Launch / ensure
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure a Chrome instance with CDP is available. If one is already listening
+ * on the target port, returns immediately. Otherwise spawns a new detached
+ * Chrome process and waits for the CDP endpoint to become ready.
+ *
+ * Returns a {@link CdpSession} with metadata about the running instance.
+ */
+export async function ensureChromeWithCdp(
+  options: EnsureChromeOptions = {},
+): Promise<CdpSession> {
+  const port = options.port ?? DEFAULT_CDP_PORT;
+  const baseUrl = `http://localhost:${port}`;
+  const userDataDir = options.userDataDir ?? DEFAULT_USER_DATA_DIR;
+
+  if (await isCdpReady(baseUrl)) {
+    return { baseUrl, launchedByUs: false, userDataDir };
+  }
+
+  const args = [
+    `--remote-debugging-port=${port}`,
+    `--force-renderer-accessibility`,
+    `--user-data-dir=${userDataDir}`,
+  ];
+  if (options.startUrl) {
+    args.push(options.startUrl);
+  }
+
+  spawnChild(CHROME_APP_PATH, args, {
+    detached: true,
+    stdio: "ignore",
+  }).unref();
+
+  // Poll until CDP responds (up to 15 s)
+  for (let i = 0; i < 30; i++) {
+    await new Promise((r) => setTimeout(r, 500));
+    if (await isCdpReady(baseUrl)) {
+      return { baseUrl, launchedByUs: true, userDataDir };
+    }
+  }
+
+  throw new Error("Chrome started but CDP endpoint not responding after 15s");
+}
+
+// ---------------------------------------------------------------------------
+// Window management helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up the first page target and return its WebSocket debugger URL.
+ */
+async function findPageTarget(cdpBase: string): Promise<string | null> {
+  const res = await fetch(`${cdpBase}/json/list`);
+  const targets = (await res.json()) as Array<{
+    type: string;
+    webSocketDebuggerUrl: string;
+  }>;
+  const page = targets.find((t) => t.type === "page");
+  return page?.webSocketDebuggerUrl ?? null;
+}
+
+/**
+ * Set the window state of the Chrome window owning the first page target.
+ * Used by both minimize and restore.
+ */
+async function setWindowState(
+  cdpBase: string,
+  windowState: "minimized" | "normal",
+): Promise<void> {
+  const wsUrl = await findPageTarget(cdpBase);
+  if (!wsUrl) return;
+
+  const ws = new WebSocket(wsUrl);
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error(`CDP ${windowState} timed out`));
+    }, 5000);
+
+    ws.addEventListener("open", () => {
+      ws.send(JSON.stringify({ id: 1, method: "Browser.getWindowForTarget" }));
+    });
+
+    ws.addEventListener("message", (event) => {
+      const msg = JSON.parse(String(event.data)) as {
+        id: number;
+        result?: { windowId: number };
+      };
+      if (msg.id === 1 && msg.result) {
+        ws.send(
+          JSON.stringify({
+            id: 2,
+            method: "Browser.setWindowBounds",
+            params: {
+              windowId: msg.result.windowId,
+              bounds: { windowState },
+            },
+          }),
+        );
+      } else if (msg.id === 1) {
+        clearTimeout(timeout);
+        ws.close();
+        reject(new Error("Browser.getWindowForTarget failed"));
+      } else if (msg.id === 2) {
+        clearTimeout(timeout);
+        ws.close();
+        resolve();
+      }
+    });
+
+    ws.addEventListener("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Minimize the Chrome window associated with the CDP session.
+ */
+export async function minimizeChromeWindow(
+  cdpBase: string = DEFAULT_CDP_BASE,
+): Promise<void> {
+  await setWindowState(cdpBase, "minimized");
+}
+
+/**
+ * Restore (un-minimize) the Chrome window associated with the CDP session.
+ */
+export async function restoreChromeWindow(
+  cdpBase: string = DEFAULT_CDP_BASE,
+): Promise<void> {
+  await setWindowState(cdpBase, "normal");
+}


### PR DESCRIPTION
## Summary
- Extract reusable Chrome CDP launcher and session management primitives into assistant/src/tools/browser/chrome-cdp.ts
- Add comprehensive tests with mocked fetch and process-spawn coverage
- Return structured session info (base URL, ownership, user-data dir) for caller cleanup decisions

Part of plan: ride-shotgun-cdp.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
