### PR TITLE
Move thread title to centered top bar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -19,6 +19,9 @@ struct MainWindowView: View {
     @AppStorage("isAppChatOpen") var isAppChatOpen: Bool = false
     @State private var jitPermissionManager = JITPermissionManager()
     @State var showThreadActionsDrawer = false
+    /// Frame of the thread title button in the coordinate space of coreLayoutView,
+    /// used to position the actions drawer directly below it.
+    @State private var threadTitleFrame: CGRect = .zero
     /// Stores the thread ID the user was on before entering temporary chat,
     /// so we can restore it when they exit instead of jumping to visibleThreads.first
     /// (which may be a pinned thread unrelated to what they were doing).
@@ -208,6 +211,20 @@ struct MainWindowView: View {
         windowState.showToast(message: "Thread copied to clipboard", style: .success)
     }
 
+    private var threadHeaderPresentation: ThreadHeaderPresentation {
+        ThreadHeaderPresentation(
+            activeThread: threadManager.activeThread,
+            activeViewModel: threadManager.activeViewModel,
+            isConversationVisible: windowState.isShowingChat || isChatBubbleActive
+        )
+    }
+
+    func dismissThreadDrawer() {
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+            showThreadActionsDrawer = false
+        }
+    }
+
     func startRenameActiveThread() {
         guard let id = threadManager.activeThreadId,
               let thread = threadManager.activeThread else { return }
@@ -365,6 +382,38 @@ struct MainWindowView: View {
                 .help("Search (\u{2318}K)")
             }
             Spacer()
+            if windowState.isShowingChat || isChatBubbleActive {
+                ThreadTitleActionsControl(
+                    presentation: threadHeaderPresentation,
+                    onCopy: { copyActiveThreadToClipboard(); dismissThreadDrawer() },
+                    onPin: {
+                        guard let id = threadManager.activeThreadId else { return }
+                        threadManager.pinThread(id: id)
+                        dismissThreadDrawer()
+                    },
+                    onUnpin: {
+                        guard let id = threadManager.activeThreadId else { return }
+                        threadManager.unpinThread(id: id)
+                        dismissThreadDrawer()
+                    },
+                    onArchive: {
+                        guard let id = threadManager.activeThreadId else { return }
+                        threadManager.archiveThread(id: id)
+                        dismissThreadDrawer()
+                    },
+                    onRename: { startRenameActiveThread(); dismissThreadDrawer() },
+                    showDrawer: $showThreadActionsDrawer
+                )
+                .background(GeometryReader { proxy in
+                    Color.clear.onAppear {
+                        threadTitleFrame = proxy.frame(in: .named("coreLayout"))
+                    }
+                    .onChange(of: proxy.frame(in: .named("coreLayout"))) { _, newFrame in
+                        threadTitleFrame = newFrame
+                    }
+                })
+            }
+            Spacer()
             PTTKeyIndicator {
                 settingsStore.pendingSettingsTab = .voice
                 windowState.selection = .panel(.settings)
@@ -426,6 +475,7 @@ struct MainWindowView: View {
                     }
                     .padding(16)
                 }
+                .coordinateSpace(name: "coreLayout")
                 .overlay {
                     // Click-outside-to-dismiss background for preferences drawer
                     if sidebar.showPreferencesDrawer {
@@ -436,6 +486,41 @@ struct MainWindowView: View {
                                     sidebar.showPreferencesDrawer = false
                                 }
                             }
+                    }
+                }
+                .overlay {
+                    // Click-outside-to-dismiss background for thread actions drawer
+                    if showThreadActionsDrawer {
+                        Color.clear
+                            .contentShape(Rectangle())
+                            .onTapGesture { dismissThreadDrawer() }
+                    }
+                }
+                .overlay(alignment: .topLeading) {
+                    if showThreadActionsDrawer {
+                        let presentation = threadHeaderPresentation
+                        ThreadActionsDrawer(
+                            presentation: presentation,
+                            onCopy: { copyActiveThreadToClipboard(); dismissThreadDrawer() },
+                            onPin: {
+                                guard let id = threadManager.activeThreadId else { return }
+                                threadManager.pinThread(id: id)
+                                dismissThreadDrawer()
+                            },
+                            onUnpin: {
+                                guard let id = threadManager.activeThreadId else { return }
+                                threadManager.unpinThread(id: id)
+                                dismissThreadDrawer()
+                            },
+                            onArchive: {
+                                guard let id = threadManager.activeThreadId else { return }
+                                threadManager.archiveThread(id: id)
+                                dismissThreadDrawer()
+                            },
+                            onRename: { startRenameActiveThread(); dismissThreadDrawer() }
+                        )
+                        .offset(x: threadTitleFrame.minX, y: threadTitleFrame.maxY)
+                        .zIndex(10)
                     }
                 }
                 .overlay(alignment: .bottomLeading) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -436,110 +436,35 @@ extension MainWindowView {
         )
     }
 
-    private var threadHeaderPresentation: ThreadHeaderPresentation {
-        ThreadHeaderPresentation(
-            activeThread: threadManager.activeThread,
-            activeViewModel: threadManager.activeViewModel,
-            isConversationVisible: windowState.isShowingChat || isChatBubbleActive
-        )
-    }
-
-    private func dismissThreadDrawer() {
-        withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
-            showThreadActionsDrawer = false
-        }
-    }
-
     @ViewBuilder
     var chatView: some View {
         if let viewModel = threadManager.activeViewModel {
             let activeThread = threadManager.activeThread
-            let presentation = threadHeaderPresentation
-            VStack(spacing: 0) {
-                // Thread title header
-                HStack {
-                    ThreadTitleActionsControl(
-                        presentation: presentation,
-                        onCopy: { copyActiveThreadToClipboard(); dismissThreadDrawer() },
-                        onPin: {
-                            guard let id = threadManager.activeThreadId else { return }
-                            threadManager.pinThread(id: id)
-                            dismissThreadDrawer()
-                        },
-                        onUnpin: {
-                            guard let id = threadManager.activeThreadId else { return }
-                            threadManager.unpinThread(id: id)
-                            dismissThreadDrawer()
-                        },
-                        onArchive: {
-                            guard let id = threadManager.activeThreadId else { return }
-                            threadManager.archiveThread(id: id)
-                            dismissThreadDrawer()
-                        },
-                        onRename: { startRenameActiveThread(); dismissThreadDrawer() },
-                        showDrawer: $showThreadActionsDrawer
-                    )
-                    Spacer()
-                }
-
-                ActiveChatViewWrapper(
-                    viewModel: viewModel,
-                    windowState: windowState,
-                    daemonClient: daemonClient,
-                    ambientAgent: ambientAgent,
-                    settingsStore: settingsStore,
-                    onMicrophoneToggle: onMicrophoneToggle,
-                    isTemporaryChat: activeThread?.kind == .private,
-                    voiceModeManager: voiceModeManager,
-                    voiceService: voiceModeManager.openAIVoiceService,
-                    onEndVoiceMode: {
-                        voiceModeManager.deactivate()
-                    },
-                    threadId: threadManager.activeThreadId,
-                    anchorMessageId: $threadManager.pendingAnchorMessageId
-                )
-                .environment(\.conversationZoomScale, conversationZoomManager.zoomLevel)
-                .overlay(alignment: .top) {
-                    if conversationZoomManager.showZoomIndicator {
-                        ZoomIndicatorView(percentage: conversationZoomManager.zoomPercentage, label: "Text")
-                            .transition(.move(edge: .top).combined(with: .opacity))
-                            .padding(.top, VSpacing.xl)
-                    }
-                }
-                .animation(VAnimation.fast, value: conversationZoomManager.showZoomIndicator)
-            }
-            .overlay {
-                if showThreadActionsDrawer {
-                    Color.clear
-                        .contentShape(Rectangle())
-                        .onTapGesture { dismissThreadDrawer() }
+            ActiveChatViewWrapper(
+                viewModel: viewModel,
+                windowState: windowState,
+                daemonClient: daemonClient,
+                ambientAgent: ambientAgent,
+                settingsStore: settingsStore,
+                onMicrophoneToggle: onMicrophoneToggle,
+                isTemporaryChat: activeThread?.kind == .private,
+                voiceModeManager: voiceModeManager,
+                voiceService: voiceModeManager.openAIVoiceService,
+                onEndVoiceMode: {
+                    voiceModeManager.deactivate()
+                },
+                threadId: threadManager.activeThreadId,
+                anchorMessageId: $threadManager.pendingAnchorMessageId
+            )
+            .environment(\.conversationZoomScale, conversationZoomManager.zoomLevel)
+            .overlay(alignment: .top) {
+                if conversationZoomManager.showZoomIndicator {
+                    ZoomIndicatorView(percentage: conversationZoomManager.zoomPercentage, label: "Text")
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                        .padding(.top, VSpacing.xl)
                 }
             }
-            .overlay(alignment: .topLeading) {
-                if showThreadActionsDrawer {
-                    ThreadActionsDrawer(
-                        presentation: presentation,
-                        onCopy: { copyActiveThreadToClipboard(); dismissThreadDrawer() },
-                        onPin: {
-                            guard let id = threadManager.activeThreadId else { return }
-                            threadManager.pinThread(id: id)
-                            dismissThreadDrawer()
-                        },
-                        onUnpin: {
-                            guard let id = threadManager.activeThreadId else { return }
-                            threadManager.unpinThread(id: id)
-                            dismissThreadDrawer()
-                        },
-                        onArchive: {
-                            guard let id = threadManager.activeThreadId else { return }
-                            threadManager.archiveThread(id: id)
-                            dismissThreadDrawer()
-                        },
-                        onRename: { startRenameActiveThread(); dismissThreadDrawer() }
-                    )
-                    .offset(x: VSpacing.lg, y: 32)
-                }
-            }
+            .animation(VAnimation.fast, value: conversationZoomManager.showZoomIndicator)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTitleActionsControl.swift
@@ -36,7 +36,7 @@ struct ThreadTitleActionsControl: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.leading, VSpacing.lg)
+        .padding(.leading, VSpacing.sm)
         .padding(.vertical, VSpacing.sm)
     }
 }
@@ -81,6 +81,6 @@ struct ThreadActionsDrawer: View {
         )
         .shadow(color: .black.opacity(0.15), radius: 6, y: 2)
         .frame(width: 200)
-        .transition(.opacity.combined(with: .scale(scale: 0.95, anchor: .topLeading)))
+        .transition(.opacity.combined(with: .scale(scale: 0.95, anchor: .top)))
     }
 }


### PR DESCRIPTION
## Summary
- Moves `ThreadTitleActionsControl` from the chat content area (`PanelCoordinator.chatView`) to the global top bar (`MainWindowView.topBarView`), centered between the left and right controls
- Actions drawer renders at the outer VStack level so it floats above all content (sidebar, chat, panels)
- Removes thread title header, drawer overlay, and related helpers from `PanelCoordinator.chatView`

## Test plan
- [ ] Thread title appears centered in the top bar
- [ ] Clicking title opens actions drawer directly below it
- [ ] Clicking outside dismisses drawer
- [ ] All actions (copy, pin/unpin, rename, archive) work correctly
- [ ] Title updates when switching threads
- [ ] Title hidden when settings panel is open
- [ ] Drawer floats above sidebar and chat content
- [ ] Drawer animates straight down (not from the side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
