### PR TITLE
fix: clear pendingAttachments on duplicate-send early return

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -1008,6 +1008,7 @@ public final class ChatViewModel: ObservableObject {
             }
             pendingSkillInvocation = nil
             inputText = ""
+            pendingAttachments = []
             return
         }
 


### PR DESCRIPTION
## Summary
- Clear `pendingAttachments` alongside `inputText` on the duplicate-send guard's early return path
- Prevents stale attachments from silently attaching to the next message

Addresses feedback from Devin on #13125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
