### PR TITLE
feat: add runtime HTTP routes for usage and cost summaries

### DIFF
--- a/assistant/src/__tests__/usage-routes.test.ts
+++ b/assistant/src/__tests__/usage-routes.test.ts
@@ -1,0 +1,339 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "usage-routes-test-"));
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getSocketPath: () => join(testDir, "test.sock"),
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
+import { recordUsageEvent } from "../memory/llm-usage-store.js";
+import { usageRouteDefinitions } from "../runtime/routes/usage-routes.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+function clearUsageEvents() {
+  getSqlite().run("DELETE FROM llm_usage_events");
+}
+
+// Build a simple dispatch helper from route definitions
+const routes = usageRouteDefinitions();
+
+function dispatch(method: string, path: string): Promise<Response> | Response {
+  const url = new URL(`http://localhost/v1/${path}`);
+  const req = new Request(url.toString(), { method });
+  const route = routes.find(
+    (r) =>
+      r.method === method &&
+      `usage/${url.pathname.split("/v1/usage/")[1]?.split("?")[0]}` ===
+        r.endpoint,
+  );
+  if (!route) throw new Error(`No route for ${method} /v1/${path}`);
+  return route.handler({
+    req,
+    url,
+    server: null as never,
+    authContext: {} as never,
+    params: {},
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Seed data helper
+// ---------------------------------------------------------------------------
+
+function seedEvents() {
+  const day1 = new Date("2025-01-15T10:00:00Z").getTime();
+  const day2 = new Date("2025-01-16T14:00:00Z").getTime();
+
+  // Two events on day 1, one on day 2
+  recordUsageEvent(
+    {
+      conversationId: "conv-1",
+      runId: "run-1",
+      requestId: "req-1",
+      actor: "main_agent",
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      inputTokens: 1000,
+      outputTokens: 200,
+      cacheCreationInputTokens: 50,
+      cacheReadInputTokens: 100,
+    },
+    { estimatedCostUsd: 0.005, pricingStatus: "priced" },
+  );
+  // Backdate the first event
+  getSqlite().run(
+    "UPDATE llm_usage_events SET created_at = ? WHERE request_id = 'req-1'",
+    [day1],
+  );
+
+  recordUsageEvent(
+    {
+      conversationId: "conv-1",
+      runId: "run-1",
+      requestId: "req-2",
+      actor: "context_compactor",
+      provider: "anthropic",
+      model: "claude-haiku-3",
+      inputTokens: 500,
+      outputTokens: 100,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+    },
+    { estimatedCostUsd: 0.001, pricingStatus: "priced" },
+  );
+  getSqlite().run(
+    "UPDATE llm_usage_events SET created_at = ? WHERE request_id = 'req-2'",
+    [day1 + 3600_000],
+  );
+
+  recordUsageEvent(
+    {
+      conversationId: "conv-2",
+      runId: "run-2",
+      requestId: "req-3",
+      actor: "main_agent",
+      provider: "openai",
+      model: "gpt-4o",
+      inputTokens: 2000,
+      outputTokens: 400,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+    },
+    { estimatedCostUsd: 0, pricingStatus: "unpriced" },
+  );
+  getSqlite().run(
+    "UPDATE llm_usage_events SET created_at = ? WHERE request_id = 'req-3'",
+    [day2],
+  );
+
+  return { day1, day2 };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("usage routes", () => {
+  beforeEach(clearUsageEvents);
+
+  // -- query parsing / validation --
+
+  describe("query parameter validation", () => {
+    test("returns 400 when from/to are missing", async () => {
+      const res = await dispatch("GET", "usage/totals");
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: { message: string } };
+      expect(body.error.message).toContain("from");
+    });
+
+    test("returns 400 when from is missing", async () => {
+      const res = await dispatch("GET", "usage/totals?to=1000");
+      expect(res.status).toBe(400);
+    });
+
+    test("returns 400 when to is missing", async () => {
+      const res = await dispatch("GET", "usage/totals?from=1000");
+      expect(res.status).toBe(400);
+    });
+
+    test("returns 400 when from/to are not numbers", async () => {
+      const res = await dispatch("GET", "usage/totals?from=abc&to=def");
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: { message: string } };
+      expect(body.error.message).toContain("valid numbers");
+    });
+
+    test("returns 400 when from > to", async () => {
+      const res = await dispatch("GET", "usage/totals?from=2000&to=1000");
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: { message: string } };
+      expect(body.error.message).toContain("less than or equal");
+    });
+  });
+
+  // -- totals --
+
+  describe("GET /v1/usage/totals", () => {
+    test("returns zeros for empty range", async () => {
+      const res = await dispatch("GET", "usage/totals?from=0&to=999999999999");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, number>;
+      expect(body.totalInputTokens).toBe(0);
+      expect(body.totalOutputTokens).toBe(0);
+      expect(body.totalEstimatedCostUsd).toBe(0);
+      expect(body.eventCount).toBe(0);
+    });
+
+    test("returns correct totals for seeded data", async () => {
+      const { day1, day2 } = seedEvents();
+      const from = day1 - 1000;
+      const to = day2 + 1000;
+
+      const res = await dispatch("GET", `usage/totals?from=${from}&to=${to}`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, number>;
+      expect(body.totalInputTokens).toBe(3500);
+      expect(body.totalOutputTokens).toBe(700);
+      expect(body.totalCacheCreationTokens).toBe(50);
+      expect(body.totalCacheReadTokens).toBe(100);
+      expect(body.eventCount).toBe(3);
+      expect(body.pricedEventCount).toBe(2);
+      expect(body.unpricedEventCount).toBe(1);
+    });
+
+    test("filters by time range", async () => {
+      const { day1 } = seedEvents();
+      // Only day 1 events
+      const from = day1 - 1000;
+      const to = day1 + 86400_000 - 1;
+
+      const res = await dispatch("GET", `usage/totals?from=${from}&to=${to}`);
+      const body = (await res.json()) as Record<string, number>;
+      expect(body.eventCount).toBe(2);
+      expect(body.totalInputTokens).toBe(1500);
+    });
+  });
+
+  // -- daily buckets --
+
+  describe("GET /v1/usage/daily", () => {
+    test("returns empty buckets array for empty range", async () => {
+      const res = await dispatch("GET", "usage/daily?from=0&to=999999999999");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { buckets: unknown[] };
+      expect(body.buckets).toEqual([]);
+    });
+
+    test("returns daily buckets for seeded data", async () => {
+      const { day1, day2 } = seedEvents();
+      const from = day1 - 1000;
+      const to = day2 + 1000;
+
+      const res = await dispatch("GET", `usage/daily?from=${from}&to=${to}`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        buckets: Array<{
+          date: string;
+          totalInputTokens: number;
+          eventCount: number;
+        }>;
+      };
+      expect(body.buckets).toHaveLength(2);
+      expect(body.buckets[0].date).toBe("2025-01-15");
+      expect(body.buckets[0].eventCount).toBe(2);
+      expect(body.buckets[1].date).toBe("2025-01-16");
+      expect(body.buckets[1].eventCount).toBe(1);
+    });
+  });
+
+  // -- breakdown --
+
+  describe("GET /v1/usage/breakdown", () => {
+    test("returns 400 when groupBy is missing", async () => {
+      const res = await dispatch(
+        "GET",
+        "usage/breakdown?from=0&to=999999999999",
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: { message: string } };
+      expect(body.error.message).toContain("groupBy");
+    });
+
+    test("returns 400 for invalid groupBy value", async () => {
+      const res = await dispatch(
+        "GET",
+        "usage/breakdown?from=0&to=999999999999&groupBy=invalid",
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: { message: string } };
+      expect(body.error.message).toContain("invalid");
+    });
+
+    test("groups by provider", async () => {
+      const { day1, day2 } = seedEvents();
+      const from = day1 - 1000;
+      const to = day2 + 1000;
+
+      const res = await dispatch(
+        "GET",
+        `usage/breakdown?from=${from}&to=${to}&groupBy=provider`,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        breakdown: Array<{
+          group: string;
+          totalInputTokens: number;
+          eventCount: number;
+        }>;
+      };
+      expect(body.breakdown).toHaveLength(2);
+      const groups = body.breakdown.map((b) => b.group).sort();
+      expect(groups).toEqual(["anthropic", "openai"]);
+    });
+
+    test("groups by actor", async () => {
+      const { day1, day2 } = seedEvents();
+      const from = day1 - 1000;
+      const to = day2 + 1000;
+
+      const res = await dispatch(
+        "GET",
+        `usage/breakdown?from=${from}&to=${to}&groupBy=actor`,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        breakdown: Array<{ group: string; eventCount: number }>;
+      };
+      expect(body.breakdown).toHaveLength(2);
+      const assistantGroup = body.breakdown.find(
+        (b) => b.group === "main_agent",
+      );
+      expect(assistantGroup?.eventCount).toBe(2);
+    });
+
+    test("groups by model", async () => {
+      const { day1, day2 } = seedEvents();
+      const from = day1 - 1000;
+      const to = day2 + 1000;
+
+      const res = await dispatch(
+        "GET",
+        `usage/breakdown?from=${from}&to=${to}&groupBy=model`,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        breakdown: Array<{ group: string; eventCount: number }>;
+      };
+      expect(body.breakdown).toHaveLength(3);
+    });
+  });
+});

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -130,6 +130,7 @@ import { surfaceActionRouteDefinitions } from "./routes/surface-action-routes.js
 import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.js";
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";
 import { twilioRouteDefinitions } from "./routes/twilio-routes.js";
+import { usageRouteDefinitions } from "./routes/usage-routes.js";
 
 // Re-export for consumers
 export { isPrivateAddress } from "./middleware/auth.js";
@@ -684,6 +685,7 @@ export class RuntimeHttpServer {
       ...secretRouteDefinitions(),
       ...identityRouteDefinitions(),
       ...debugRouteDefinitions(),
+      ...usageRouteDefinitions(),
 
       // Browser relay — not extracted into a domain module because
       // these two routes depend on the in-process extensionRelayServer

--- a/assistant/src/runtime/routes/usage-routes.ts
+++ b/assistant/src/runtime/routes/usage-routes.ts
@@ -1,0 +1,114 @@
+/**
+ * Route handlers for usage and cost summary endpoints.
+ *
+ * GET /v1/usage/totals?from=&to=              — aggregate totals for a time range
+ * GET /v1/usage/daily?from=&to=               — per-day buckets for a time range
+ * GET /v1/usage/breakdown?from=&to=&groupBy=  — grouped breakdown (actor, provider, model)
+ */
+
+import {
+  getUsageDayBuckets,
+  getUsageGroupBreakdown,
+  getUsageTotals,
+} from "../../memory/llm-usage-store.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+const VALID_GROUP_BY = new Set(["actor", "provider", "model"]);
+
+/**
+ * Parse and validate the `from` and `to` epoch-millis query parameters.
+ * Returns the parsed range or an error Response.
+ */
+function parseTimeRange(url: URL): { from: number; to: number } | Response {
+  const fromRaw = url.searchParams.get("from");
+  const toRaw = url.searchParams.get("to");
+
+  if (!fromRaw || !toRaw) {
+    return httpError(
+      "BAD_REQUEST",
+      'Missing required query parameters: "from" and "to" (epoch milliseconds)',
+      400,
+    );
+  }
+
+  const from = Number(fromRaw);
+  const to = Number(toRaw);
+
+  if (!Number.isFinite(from) || !Number.isFinite(to)) {
+    return httpError(
+      "BAD_REQUEST",
+      '"from" and "to" must be valid numbers (epoch milliseconds)',
+      400,
+    );
+  }
+
+  if (from > to) {
+    return httpError(
+      "BAD_REQUEST",
+      '"from" must be less than or equal to "to"',
+      400,
+    );
+  }
+
+  return { from, to };
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function usageRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "usage/totals",
+      method: "GET",
+      handler: ({ url }) => {
+        const range = parseTimeRange(url);
+        if (range instanceof Response) return range;
+        const totals = getUsageTotals(range);
+        return Response.json(totals);
+      },
+    },
+    {
+      endpoint: "usage/daily",
+      method: "GET",
+      handler: ({ url }) => {
+        const range = parseTimeRange(url);
+        if (range instanceof Response) return range;
+        const buckets = getUsageDayBuckets(range);
+        return Response.json({ buckets });
+      },
+    },
+    {
+      endpoint: "usage/breakdown",
+      method: "GET",
+      handler: ({ url }) => {
+        const range = parseTimeRange(url);
+        if (range instanceof Response) return range;
+
+        const groupBy = url.searchParams.get("groupBy");
+        if (!groupBy) {
+          return httpError(
+            "BAD_REQUEST",
+            'Missing required query parameter: "groupBy" (one of: actor, provider, model)',
+            400,
+          );
+        }
+        if (!VALID_GROUP_BY.has(groupBy)) {
+          return httpError(
+            "BAD_REQUEST",
+            `Invalid "groupBy" value: "${groupBy}". Must be one of: actor, provider, model`,
+            400,
+          );
+        }
+
+        const breakdown = getUsageGroupBreakdown(
+          range,
+          groupBy as "actor" | "provider" | "model",
+        );
+        return Response.json({ breakdown });
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add usage-routes.ts with HTTP endpoints for totals, daily buckets, and grouped breakdowns
- Register usage routes in http-server.ts
- Add tests covering query parsing, invalid ranges, and response shapes

Part of plan: usage-cost-reporting.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
