### PR TITLE
feat: resolve configured assistant email addresses in invite flows

### DIFF
--- a/assistant/src/__tests__/email-invite-adapter.test.ts
+++ b/assistant/src/__tests__/email-invite-adapter.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the email invite adapter.
+ *
+ * Verifies that the email adapter resolves the assistant's real inbox
+ * address when one is configured and falls back to `undefined` (triggering
+ * generic invite instructions) when no inbox exists.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { resolveAdapterHandle } from "../runtime/channel-invite-transport.js";
+import { emailInviteAdapter } from "../runtime/channel-invite-transports/email.js";
+
+// ---------------------------------------------------------------------------
+// Mock the EmailService singleton
+// ---------------------------------------------------------------------------
+
+let mockPrimaryAddress: string | undefined;
+
+mock.module("../email/service.js", () => ({
+  getEmailService: () => ({
+    getPrimaryInboxAddress: async () => mockPrimaryAddress,
+  }),
+  // Re-export other symbols that callers might need
+  EmailService: class {},
+  _resetEmailService: () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("emailInviteAdapter", () => {
+  beforeEach(() => {
+    mockPrimaryAddress = undefined;
+  });
+
+  afterEach(() => {
+    mockPrimaryAddress = undefined;
+  });
+
+  test("returns configured email address via resolveChannelHandleAsync", async () => {
+    mockPrimaryAddress = "hello@mycompany.agentmail.to";
+
+    const handle = await resolveAdapterHandle(emailInviteAdapter);
+    expect(handle).toBe("hello@mycompany.agentmail.to");
+  });
+
+  test("returns undefined when no inbox is configured", async () => {
+    mockPrimaryAddress = undefined;
+
+    const handle = await resolveAdapterHandle(emailInviteAdapter);
+    expect(handle).toBeUndefined();
+  });
+
+  test("adapter channel is email", () => {
+    expect(emailInviteAdapter.channel).toBe("email");
+  });
+
+  test("does not define sync resolveChannelHandle", () => {
+    // The email adapter uses the async path exclusively
+    expect(emailInviteAdapter.resolveChannelHandle).toBeUndefined();
+  });
+
+  test("does not define buildShareLink or extractInboundToken", () => {
+    expect(emailInviteAdapter.buildShareLink).toBeUndefined();
+    expect(emailInviteAdapter.extractInboundToken).toBeUndefined();
+  });
+});

--- a/assistant/src/email/service.ts
+++ b/assistant/src/email/service.ts
@@ -74,6 +74,8 @@ export class EmailService {
   /** Force re-creation of the provider (e.g. after `provider set`). */
   resetProvider(): void {
     this.providerInstance = null;
+    this.primaryAddressResolved = false;
+    this.cachedPrimaryAddress = undefined;
   }
 
   // =========================================================================
@@ -107,6 +109,34 @@ export class EmailService {
       health,
       guardrails: getGuardrailsStatus(),
     };
+  }
+
+  // =========================================================================
+  // Primary inbox address (cached)
+  // =========================================================================
+
+  private primaryAddressResolved = false;
+  private cachedPrimaryAddress: string | undefined;
+
+  /**
+   * Return the assistant's primary inbox email address, caching the result
+   * for the lifetime of this service instance. Returns `undefined` when no
+   * inboxes are configured or the provider is unavailable.
+   */
+  async getPrimaryInboxAddress(): Promise<string | undefined> {
+    if (this.primaryAddressResolved) {
+      return this.cachedPrimaryAddress;
+    }
+    try {
+      const p = await this.provider();
+      const health = await p.health();
+      this.cachedPrimaryAddress =
+        health.inboxes.length > 0 ? health.inboxes[0].address : undefined;
+    } catch {
+      this.cachedPrimaryAddress = undefined;
+    }
+    this.primaryAddressResolved = true;
+    return this.cachedPrimaryAddress;
   }
 
   // =========================================================================

--- a/assistant/src/runtime/channel-invite-transports/email.ts
+++ b/assistant/src/runtime/channel-invite-transports/email.ts
@@ -2,24 +2,18 @@
  * Email channel invite adapter.
  *
  * Resolves the assistant's email address for use in invite instructions.
+ * Uses the EmailService's cached primary inbox lookup so the real address
+ * is returned when an inbox is configured. Falls back to `undefined` when
+ * no inbox exists, which causes the invite instruction generator to emit
+ * generic "on Email" wording instead of a misleading stub address.
+ *
  * Email invites use the universal 6-digit code path for redemption, so
- * this adapter only implements `resolveChannelHandle` — no `buildShareLink`
- * or `extractInboundToken` needed.
+ * this adapter only implements `resolveChannelHandleAsync` — no
+ * `buildShareLink` or `extractInboundToken` needed.
  */
 
+import { getEmailService } from "../../email/service.js";
 import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
-
-// ---------------------------------------------------------------------------
-// Email address resolution
-// ---------------------------------------------------------------------------
-
-// TODO: resolve from AgentMail provider (async — needs caching or pre-resolution)
-// The real implementation requires async inbox lookup via
-// `getActiveEmailProvider().health()` which doesn't fit the sync adapter
-// interface.
-function resolveAssistantEmailAddress(): string | undefined {
-  return undefined;
-}
 
 // ---------------------------------------------------------------------------
 // Adapter implementation
@@ -28,7 +22,7 @@ function resolveAssistantEmailAddress(): string | undefined {
 export const emailInviteAdapter: ChannelInviteAdapter = {
   channel: "email",
 
-  resolveChannelHandle(): string | undefined {
-    return resolveAssistantEmailAddress();
+  async resolveChannelHandleAsync(): Promise<string | undefined> {
+    return getEmailService().getPrimaryInboxAddress();
   },
 };

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -25,7 +25,10 @@ import {
 } from "../memory/invite-store.js";
 import { isValidE164 } from "../util/phone.js";
 import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
-import { getInviteAdapterRegistry } from "./channel-invite-transport.js";
+import {
+  getInviteAdapterRegistry,
+  resolveAdapterHandle,
+} from "./channel-invite-transport.js";
 import { generateInviteInstruction } from "./invite-instruction-generator.js";
 import {
   type InviteRedemptionOutcome,
@@ -231,7 +234,7 @@ export async function createIngressInvite(params: {
     const adapter = channelId
       ? getInviteAdapterRegistry().get(channelId)
       : undefined;
-    channelHandle = adapter?.resolveChannelHandle?.();
+    channelHandle = adapter ? await resolveAdapterHandle(adapter) : undefined;
     const share = buildSharePayload(params.sourceChannel, rawToken);
     guardianInstruction = await generateInviteInstruction({
       contactName: params.contactName,


### PR DESCRIPTION
## Summary
- Adds cached `getPrimaryInboxAddress()` accessor to `EmailService` for the assistant's primary inbox address
- Updates email invite adapter to use `resolveChannelHandleAsync` with the real address from the email provider
- Updates invite service to use `resolveAdapterHandle()` (async path) instead of sync `resolveChannelHandle()`
- Falls back to `undefined` (generic instructions) when no email inbox is configured

Part of plan: channel-gap-cleanup.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)