### PR TITLE
test: cover WhatsApp attachment ingestion end to end

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -340,7 +340,7 @@ The WhatsApp channel enables inbound and outbound messaging via the Meta WhatsAp
 
 1. **Webhook verification**: Meta sends a `GET` with `hub.mode=subscribe`, `hub.verify_token`, and `hub.challenge`. The gateway compares `hub.verify_token` against `WHATSAPP_WEBHOOK_VERIFY_TOKEN` and echoes `hub.challenge` as plain text.
 2. On `POST`, the gateway verifies the `X-Hub-Signature-256` header (HMAC-SHA256 of the raw request body using `WHATSAPP_APP_SECRET`) when the app secret is configured. Fail-closed: requests are rejected when the secret is set but the signature fails.
-3. **Normalization**: Only `type=text` messages from `messages` change fields are forwarded. Delivery receipts, read receipts, and non-text message types (image, audio, video, document, sticker) are silently acknowledged with `{ ok: true }`.
+3. **Normalization**: Text and media messages (image, audio, video, document) from `messages` change fields are forwarded. Delivery receipts, read receipts, and unsupported message types (sticker, contacts, location) are silently acknowledged with `{ ok: true }`. Media attachments are downloaded from the WhatsApp Cloud API, uploaded to the runtime attachment store, and their IDs are passed alongside the message content.
 4. **`/new` command**: When the message body is `/new` (case-insensitive), the gateway resolves routing, resets the conversation, and sends a confirmation message without forwarding to the runtime.
 5. The payload is normalized into a `GatewayInboundEvent` with `sourceChannel: "whatsapp"` and `conversationExternalId` set to the sender's WhatsApp phone number (E.164).
 6. WhatsApp message IDs are deduplicated via `StringDedupCache` (24-hour TTL).
@@ -363,7 +363,7 @@ The WhatsApp channel enables inbound and outbound messaging via the Meta WhatsAp
 
 These can be set via environment variables or stored in the credential vault (keychain / encrypted store) under the `whatsapp` service prefix.
 
-**Limitations (v1)**: Text-only — non-text message types are acknowledged but not forwarded; rich approval UI (inline buttons) is not supported.
+**Limitations (v1)**: Rich approval UI (inline buttons) is not supported. Sticker, contacts, and location message types are acknowledged but not forwarded.
 
 **Channel Readiness**: The channel readiness HTTP endpoints (`GET /v1/channels/readiness`, `POST /v1/channels/readiness/refresh`) backed by `ChannelReadinessService` in `src/runtime/channel-readiness-service.ts` provide a unified readiness subsystem for all channels. Each channel registers a `ChannelProbe` that runs synchronous local checks (credential presence, phone number, ingress config) and optional async remote checks with a 5-minute TTL cache. Built-in probes: SMS (Twilio credentials, phone number, ingress; remote checks query Twilio toll-free verification status for toll-free numbers) and Telegram (bot token, webhook secret, ingress). The GET endpoint returns cached snapshots; the refresh endpoint invalidates the cache first. Unknown channels return `unsupported_channel`. Route handlers live in `src/runtime/routes/channel-readiness-routes.ts`.
 

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -50,6 +50,7 @@ mock.module("../config/loader.js", () => ({
 }));
 
 import {
+  getAttachmentsByIds,
   linkAttachmentToMessage,
   uploadAttachment,
 } from "../memory/attachments-store.js";
@@ -225,5 +226,112 @@ describe("Runtime attachment metadata", () => {
 
     expect(res.status).toBe(404);
     expect(body.error.message).toBe("Attachment not found");
+  });
+});
+
+describe("WhatsApp channel ingress attachment resolution", () => {
+  let server: RuntimeHttpServer;
+  let port: number;
+
+  beforeEach(async () => {
+    const db = getDb();
+    db.run("DELETE FROM message_attachments");
+    db.run("DELETE FROM attachments");
+    db.run("DELETE FROM messages");
+    db.run("DELETE FROM conversations");
+    db.run("DELETE FROM conversation_keys");
+
+    port = 18000 + Math.floor(Math.random() * 1000);
+    server = new RuntimeHttpServer({ port, bearerToken: TEST_TOKEN });
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server?.stop();
+  });
+
+  test("uploaded attachment IDs from channel ingress resolve via GET /attachments/:id", async () => {
+    // Simulate what the gateway does: upload an attachment (downloaded from
+    // WhatsApp) to the runtime attachment store before forwarding the inbound
+    // event. The runtime must be able to resolve these IDs.
+    const img = uploadAttachment(
+      "whatsapp-photo.jpg",
+      "image/jpeg",
+      "/9j/4AAQ",
+    );
+    const doc = uploadAttachment("receipt.pdf", "application/pdf", "JVBERi0x");
+
+    // Both attachments should be individually retrievable
+    const imgRes = await fetch(
+      `http://127.0.0.1:${port}/v1/attachments/${img.id}`,
+      { headers: AUTH_HEADERS },
+    );
+    expect(imgRes.status).toBe(200);
+    const imgBody = (await imgRes.json()) as {
+      id: string;
+      filename: string;
+      mimeType: string;
+      kind: string;
+      data: string;
+    };
+    expect(imgBody.id).toBe(img.id);
+    expect(imgBody.filename).toBe("whatsapp-photo.jpg");
+    expect(imgBody.mimeType).toBe("image/jpeg");
+    expect(imgBody.kind).toBe("image");
+    expect(imgBody.data).toBe("/9j/4AAQ");
+
+    const docRes = await fetch(
+      `http://127.0.0.1:${port}/v1/attachments/${doc.id}`,
+      { headers: AUTH_HEADERS },
+    );
+    expect(docRes.status).toBe(200);
+    const docBody = (await docRes.json()) as {
+      id: string;
+      filename: string;
+      mimeType: string;
+      kind: string;
+    };
+    expect(docBody.id).toBe(doc.id);
+    expect(docBody.filename).toBe("receipt.pdf");
+    expect(docBody.mimeType).toBe("application/pdf");
+    expect(docBody.kind).toBe("document");
+  });
+
+  test("batch-uploaded WhatsApp attachment IDs resolve via getAttachmentsByIds", async () => {
+    // The inbound message handler calls getAttachmentsByIds to validate that
+    // all IDs exist before processing. This test proves that pattern works
+    // for WhatsApp-originated uploads.
+    const a1 = uploadAttachment("photo1.jpg", "image/jpeg", "base64img1");
+    const a2 = uploadAttachment("photo2.png", "image/png", "base64img2");
+    const a3 = uploadAttachment("voice.ogg", "audio/ogg", "base64audio");
+
+    const resolved = getAttachmentsByIds([a1.id, a2.id, a3.id]);
+    expect(resolved).toHaveLength(3);
+
+    const resolvedIds = resolved.map((a) => a.id);
+    expect(resolvedIds).toContain(a1.id);
+    expect(resolvedIds).toContain(a2.id);
+    expect(resolvedIds).toContain(a3.id);
+
+    // Each resolved attachment carries the correct metadata
+    const photo1 = resolved.find((a) => a.id === a1.id)!;
+    expect(photo1.originalFilename).toBe("photo1.jpg");
+    expect(photo1.mimeType).toBe("image/jpeg");
+
+    const audio = resolved.find((a) => a.id === a3.id)!;
+    expect(audio.originalFilename).toBe("voice.ogg");
+    expect(audio.mimeType).toBe("audio/ogg");
+  });
+
+  test("partially missing attachment IDs are detected (mixed valid/invalid)", async () => {
+    // When one attachment upload fails at the gateway, the remaining IDs
+    // still need to resolve. The inbound handler detects missing IDs by
+    // comparing resolved count to requested count.
+    const valid = uploadAttachment("ok.jpg", "image/jpeg", "base64ok");
+    const ids = [valid.id, "nonexistent-whatsapp-att"];
+
+    const resolved = getAttachmentsByIds(ids);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].id).toBe(valid.id);
   });
 });

--- a/gateway/src/http/routes/whatsapp-webhook.test.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.test.ts
@@ -542,6 +542,221 @@ describe("whatsapp-webhook", () => {
     expect(handleInboundMock).not.toHaveBeenCalled();
   });
 
+  it("deduplicates messages with the same WhatsApp message ID", async () => {
+    const { handler } = createWhatsAppWebhookHandler(baseConfig);
+
+    normalizeWhatsAppWebhookMock.mockImplementation(() => [
+      {
+        whatsappMessageId: "wamid-dedup-1",
+        event: {
+          version: "v1",
+          sourceChannel: "whatsapp",
+          receivedAt: new Date().toISOString(),
+          message: {
+            content: "first delivery",
+            conversationExternalId: "15551230000",
+            externalMessageId: "wamid-dedup-1",
+          },
+          actor: {
+            actorExternalId: "15551230000",
+            displayName: "Alice",
+          },
+          source: {
+            updateId: "wamid-dedup-1",
+            messageId: "wamid-dedup-1",
+            chatType: "private",
+          },
+          raw: {},
+        },
+      },
+    ]);
+
+    // First delivery succeeds
+    const res1 = await handler(
+      buildPostReq({ object: "whatsapp_business_account", entry: [] }),
+    );
+    expect(res1.status).toBe(200);
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+
+    // Second delivery of same message ID is silently ignored
+    const res2 = await handler(
+      buildPostReq({ object: "whatsapp_business_account", entry: [] }),
+    );
+    expect(res2.status).toBe(200);
+    expect(handleInboundMock).toHaveBeenCalledTimes(1); // still 1
+  });
+
+  it("marks each message as read even for media-only messages", async () => {
+    const { handler } = createWhatsAppWebhookHandler(baseConfig);
+
+    uploadAttachmentMock.mockImplementation(() =>
+      Promise.resolve({ id: "att-read-1" }),
+    );
+
+    normalizeWhatsAppWebhookMock.mockImplementation(() => [
+      {
+        whatsappMessageId: "wamid-read-media",
+        mediaType: "image",
+        event: {
+          version: "v1",
+          sourceChannel: "whatsapp",
+          receivedAt: new Date().toISOString(),
+          message: {
+            content: "",
+            conversationExternalId: "15551230000",
+            externalMessageId: "wamid-read-media",
+            attachments: [
+              {
+                type: "image",
+                fileId: "media-read-1",
+                mimeType: "image/jpeg",
+                fileSize: 1024,
+              },
+            ],
+          },
+          actor: {
+            actorExternalId: "15551230000",
+            displayName: "Alice",
+          },
+          source: {
+            updateId: "wamid-read-media",
+            messageId: "wamid-read-media",
+            chatType: "private",
+          },
+          raw: {},
+        },
+      },
+    ]);
+
+    const res = await handler(
+      buildPostReq({ object: "whatsapp_business_account", entry: [] }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(markWhatsAppMessageReadMock).toHaveBeenCalledWith(
+      baseConfig,
+      "wamid-read-media",
+    );
+  });
+
+  it("handles multiple attachments in a single message", async () => {
+    const { handler } = createWhatsAppWebhookHandler(baseConfig);
+
+    let uploadCount = 0;
+    uploadAttachmentMock.mockImplementation(() => {
+      uploadCount++;
+      return Promise.resolve({ id: `att-multi-${uploadCount}` });
+    });
+
+    normalizeWhatsAppWebhookMock.mockImplementation(() => [
+      {
+        whatsappMessageId: "wamid-multi-attach",
+        mediaType: "document",
+        event: {
+          version: "v1",
+          sourceChannel: "whatsapp",
+          receivedAt: new Date().toISOString(),
+          message: {
+            content: "here are some files",
+            conversationExternalId: "15551230000",
+            externalMessageId: "wamid-multi-attach",
+            attachments: [
+              {
+                type: "image",
+                fileId: "media-multi-1",
+                mimeType: "image/jpeg",
+                fileSize: 1024,
+              },
+              {
+                type: "document",
+                fileId: "media-multi-2",
+                mimeType: "application/pdf",
+                fileSize: 2048,
+              },
+            ],
+          },
+          actor: {
+            actorExternalId: "15551230000",
+            displayName: "Alice",
+          },
+          source: {
+            updateId: "wamid-multi-attach",
+            messageId: "wamid-multi-attach",
+            chatType: "private",
+          },
+          raw: {},
+        },
+      },
+    ]);
+
+    const res = await handler(
+      buildPostReq({ object: "whatsapp_business_account", entry: [] }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(downloadWhatsAppFileMock).toHaveBeenCalledTimes(2);
+    expect(uploadAttachmentMock).toHaveBeenCalledTimes(2);
+
+    const [, , options] = handleInboundMock.mock.calls[0] as unknown as [
+      GatewayConfig,
+      Record<string, unknown>,
+      { attachmentIds?: string[] },
+    ];
+    expect(options.attachmentIds).toEqual(["att-multi-1", "att-multi-2"]);
+  });
+
+  it("unreserves dedup cache on transient failure so retries can succeed", async () => {
+    const { handler, dedupCache } = createWhatsAppWebhookHandler(baseConfig);
+
+    downloadWhatsAppFileMock.mockImplementation(() => {
+      throw new Error("Transient network error");
+    });
+
+    normalizeWhatsAppWebhookMock.mockImplementation(() => [
+      {
+        whatsappMessageId: "wamid-retry-ok",
+        mediaType: "image",
+        event: {
+          version: "v1",
+          sourceChannel: "whatsapp",
+          receivedAt: new Date().toISOString(),
+          message: {
+            content: "photo",
+            conversationExternalId: "15551230000",
+            externalMessageId: "wamid-retry-ok",
+            attachments: [
+              {
+                type: "image",
+                fileId: "media-retry",
+                mimeType: "image/jpeg",
+                fileSize: 1024,
+              },
+            ],
+          },
+          actor: {
+            actorExternalId: "15551230000",
+            displayName: "Alice",
+          },
+          source: {
+            updateId: "wamid-retry-ok",
+            messageId: "wamid-retry-ok",
+            chatType: "private",
+          },
+          raw: {},
+        },
+      },
+    ]);
+
+    // First attempt fails with 500
+    const res1 = await handler(
+      buildPostReq({ object: "whatsapp_business_account", entry: [] }),
+    );
+    expect(res1.status).toBe(500);
+
+    // The dedup cache should have unreserved the ID so a retry can proceed
+    expect(dedupCache.reserve("wamid-retry-ok")).toBe(true);
+  });
+
   it("skips oversized attachments without failing the message", async () => {
     const { handler } = createWhatsAppWebhookHandler(baseConfig);
 


### PR DESCRIPTION
## Summary
- Add regression tests for media-only, caption-plus-media, and mixed-success WhatsApp attachment scenarios
- Add assistant-side test proving channel ingress attachment IDs resolve correctly in the runtime
- Update README to reflect WhatsApp inbound media support

Part of plan: whatsapp-media-ingestion.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
