### PR TITLE
feat: add WhatsApp invite adapter and enable invite-code redemption

### DIFF
--- a/assistant/src/__tests__/whatsapp-invite-adapter.test.ts
+++ b/assistant/src/__tests__/whatsapp-invite-adapter.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the WhatsApp channel invite adapter.
+ *
+ * Verifies handle resolution in both configured-handle and
+ * generic-instruction (no handle) paths.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the adapter
+// ---------------------------------------------------------------------------
+
+let mockTwilioPhoneNumberEnv: string | undefined;
+let mockRawConfig: Record<string, unknown> | undefined;
+let mockSecureKeys: Record<string, string>;
+
+mock.module("../config/env.js", () => ({
+  getTwilioPhoneNumberEnv: () => mockTwilioPhoneNumberEnv,
+}));
+
+mock.module("../config/loader.js", () => ({
+  loadRawConfig: () => mockRawConfig,
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKey: (key: string) => mockSecureKeys[key] ?? null,
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test
+// ---------------------------------------------------------------------------
+
+import { whatsappInviteAdapter } from "../runtime/channel-invite-transports/whatsapp.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("whatsapp invite adapter", () => {
+  beforeEach(() => {
+    mockTwilioPhoneNumberEnv = undefined;
+    mockRawConfig = undefined;
+    mockSecureKeys = {};
+  });
+
+  test("adapter is registered for the whatsapp channel", () => {
+    expect(whatsappInviteAdapter.channel).toBe("whatsapp");
+  });
+
+  // -------------------------------------------------------------------------
+  // Configured-handle path
+  // -------------------------------------------------------------------------
+
+  test("resolves handle from env override", () => {
+    mockTwilioPhoneNumberEnv = "+15551234567";
+
+    const handle = whatsappInviteAdapter.resolveChannelHandle!();
+    expect(handle).toBe("+15551234567");
+  });
+
+  test("resolves handle from whatsapp config phoneNumber", () => {
+    mockRawConfig = { whatsapp: { phoneNumber: "+15559876543" } };
+
+    const handle = whatsappInviteAdapter.resolveChannelHandle!();
+    expect(handle).toBe("+15559876543");
+  });
+
+  test("resolves handle from sms config phoneNumber as fallback", () => {
+    mockRawConfig = { sms: { phoneNumber: "+15550001111" } };
+
+    const handle = whatsappInviteAdapter.resolveChannelHandle!();
+    expect(handle).toBe("+15550001111");
+  });
+
+  test("prefers whatsapp config over sms config", () => {
+    mockRawConfig = {
+      whatsapp: { phoneNumber: "+15551111111" },
+      sms: { phoneNumber: "+15552222222" },
+    };
+
+    const handle = whatsappInviteAdapter.resolveChannelHandle!();
+    expect(handle).toBe("+15551111111");
+  });
+
+  test("resolves handle from secure key fallback", () => {
+    mockSecureKeys = { "credential:twilio:phone_number": "+15553334444" };
+    mockRawConfig = {};
+
+    const handle = whatsappInviteAdapter.resolveChannelHandle!();
+    expect(handle).toBe("+15553334444");
+  });
+
+  test("env override takes precedence over all other sources", () => {
+    mockTwilioPhoneNumberEnv = "+15550000000";
+    mockRawConfig = { whatsapp: { phoneNumber: "+15551111111" } };
+    mockSecureKeys = { "credential:twilio:phone_number": "+15552222222" };
+
+    const handle = whatsappInviteAdapter.resolveChannelHandle!();
+    expect(handle).toBe("+15550000000");
+  });
+
+  // -------------------------------------------------------------------------
+  // Generic-instruction path (no handle configured)
+  // -------------------------------------------------------------------------
+
+  test("returns undefined when no phone number is configured", () => {
+    mockRawConfig = {};
+
+    const handle = whatsappInviteAdapter.resolveChannelHandle!();
+    expect(handle).toBeUndefined();
+  });
+
+  test("returns undefined when no sources are available at all", () => {
+    // No env, no config, no secure keys — the adapter degrades gracefully
+    mockRawConfig = undefined;
+
+    const handle = whatsappInviteAdapter.resolveChannelHandle!();
+    expect(handle).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Adapter shape
+  // -------------------------------------------------------------------------
+
+  test("does not implement buildShareLink", () => {
+    expect(whatsappInviteAdapter.buildShareLink).toBeUndefined();
+  });
+
+  test("does not implement extractInboundToken", () => {
+    expect(whatsappInviteAdapter.extractInboundToken).toBeUndefined();
+  });
+});

--- a/assistant/src/channels/config.ts
+++ b/assistant/src/channels/config.ts
@@ -60,7 +60,7 @@ const CHANNEL_POLICIES = {
       conversationStrategy: "continue_existing_conversation",
     },
     invite: {
-      codeRedemptionEnabled: false,
+      codeRedemptionEnabled: true,
     },
   },
   slack: {

--- a/assistant/src/runtime/channel-invite-transport.ts
+++ b/assistant/src/runtime/channel-invite-transport.ts
@@ -140,6 +140,7 @@ import { slackInviteAdapter } from "./channel-invite-transports/slack.js";
 import { smsInviteAdapter } from "./channel-invite-transports/sms.js";
 import { telegramInviteAdapter } from "./channel-invite-transports/telegram.js";
 import { voiceInviteAdapter } from "./channel-invite-transports/voice.js";
+import { whatsappInviteAdapter } from "./channel-invite-transports/whatsapp.js";
 
 /** Create a registry instance with built-in adapters registered. */
 export function createInviteAdapterRegistry(): InviteAdapterRegistry {
@@ -149,6 +150,7 @@ export function createInviteAdapterRegistry(): InviteAdapterRegistry {
   registry.register(smsInviteAdapter);
   registry.register(telegramInviteAdapter);
   registry.register(voiceInviteAdapter);
+  registry.register(whatsappInviteAdapter);
   return registry;
 }
 

--- a/assistant/src/runtime/channel-invite-transports/whatsapp.ts
+++ b/assistant/src/runtime/channel-invite-transports/whatsapp.ts
@@ -1,0 +1,62 @@
+/**
+ * WhatsApp channel invite adapter.
+ *
+ * Resolves the assistant's WhatsApp phone number for use in invite
+ * instructions. WhatsApp invites use the universal 6-digit code path
+ * for redemption, so this adapter only implements `resolveChannelHandle`
+ * — no `buildShareLink` or `extractInboundToken` needed.
+ *
+ * WhatsApp shares the same Twilio phone number as SMS, so the
+ * resolution strategy mirrors the SMS adapter.
+ */
+
+import type { ChannelId } from "../../channels/types.js";
+import { getTwilioPhoneNumberEnv } from "../../config/env.js";
+import { loadRawConfig } from "../../config/loader.js";
+import { getSecureKey } from "../../security/secure-keys.js";
+import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
+
+// ---------------------------------------------------------------------------
+// Phone number resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the WhatsApp phone number with canonical precedence:
+ * env override -> config whatsapp.phoneNumber -> config sms.phoneNumber
+ * -> secure key fallback.
+ *
+ * WhatsApp typically shares the Twilio phone number with SMS, but
+ * allows a channel-specific override via config.
+ */
+function resolveWhatsAppPhoneNumber(): string | undefined {
+  try {
+    const raw = loadRawConfig();
+    const whatsappConfig = (raw?.whatsapp ?? {}) as Record<string, unknown>;
+    const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
+    return (
+      getTwilioPhoneNumberEnv() ||
+      (whatsappConfig.phoneNumber as string) ||
+      (smsConfig.phoneNumber as string) ||
+      getSecureKey("credential:twilio:phone_number") ||
+      undefined
+    );
+  } catch {
+    return (
+      getTwilioPhoneNumberEnv() ||
+      getSecureKey("credential:twilio:phone_number") ||
+      undefined
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Adapter implementation
+// ---------------------------------------------------------------------------
+
+export const whatsappInviteAdapter: ChannelInviteAdapter = {
+  channel: "whatsapp" as ChannelId,
+
+  resolveChannelHandle(): string | undefined {
+    return resolveWhatsAppPhoneNumber();
+  },
+};


### PR DESCRIPTION
## Summary
- Adds WhatsApp invite adapter following SMS guardian-instruction pattern
- Registers adapter in invite transport registry
- Enables WhatsApp invite code redemption in channel config

Part of plan: channel-gap-cleanup.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
