### PR TITLE
feat: reuse bound notification conversations by channel and destination

### DIFF
--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -3,8 +3,8 @@
  *
  * Validates that pairDeliveryWithConversation materializes conversations
  * and messages according to the channel's conversation strategy, handles
- * thread reuse decisions, and that errors in pairing never break the
- * notification pipeline.
+ * thread reuse decisions, binding-key reuse for continue_existing channels,
+ * and that errors in pairing never break the notification pipeline.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -70,9 +70,36 @@ mock.module("../memory/conversation-store.js", () => ({
   getConversation: getConversationMock,
 }));
 
+/** Simulated bindings for external-conversation-store mock. */
+let mockBindings: Record<
+  string,
+  { conversationId: string; sourceChannel: string; externalChatId: string }
+> = {};
+
+const getBindingByChannelChatMock = mock(
+  (sourceChannel: string, externalChatId: string) => {
+    const key = `${sourceChannel}:${externalChatId}`;
+    return mockBindings[key] ?? null;
+  },
+);
+
+const upsertOutboundBindingMock = mock(
+  (_input: {
+    conversationId: string;
+    sourceChannel: string;
+    externalChatId: string;
+  }) => {},
+);
+
+mock.module("../memory/external-conversation-store.js", () => ({
+  getBindingByChannelChat: getBindingByChannelChatMock,
+  upsertOutboundBinding: upsertOutboundBindingMock,
+}));
+
 import { pairDeliveryWithConversation } from "../notifications/conversation-pairing.js";
 import type { NotificationSignal } from "../notifications/signal.js";
 import type {
+  DestinationBindingContext,
   NotificationChannel,
   RenderedChannelCopy,
   ThreadAction,
@@ -115,11 +142,14 @@ describe("pairDeliveryWithConversation", () => {
     createConversationMock.mockClear();
     addMessageMock.mockClear();
     getConversationMock.mockClear();
+    getBindingByChannelChatMock.mockClear();
+    upsertOutboundBindingMock.mockClear();
     mockConversationId = "conv-001";
     mockMessageId = "msg-001";
     createConversationShouldThrow = false;
     addMessageShouldThrow = false;
     mockExistingConversations = {};
+    mockBindings = {};
   });
 
   // ── start_new_conversation (vellum) ─────────────────────────────────
@@ -263,7 +293,7 @@ describe("pairDeliveryWithConversation", () => {
 
   // ── continue_existing_conversation (telegram) ─────────────────────
 
-  test("creates a conversation for continue_existing_conversation strategy", async () => {
+  test("creates a conversation for continue_existing_conversation without binding context", async () => {
     const signal = makeSignal();
     const copy = makeCopy();
 
@@ -273,8 +303,6 @@ describe("pairDeliveryWithConversation", () => {
       copy,
     );
 
-    // Currently creates a new conversation even for continue_existing_conversation
-    // (true continuation is planned for a future PR)
     expect(result.conversationId).toBe("conv-001");
     expect(result.messageId).toBe("msg-001");
     expect(result.strategy).toBe("continue_existing_conversation");
@@ -285,6 +313,228 @@ describe("pairDeliveryWithConversation", () => {
       unknown
     >;
     expect(callArgs.threadType).toBe("background");
+  });
+
+  // ── Binding-key reuse (continue_existing + bindingContext) ────────
+
+  test("reuses bound conversation when binding context matches an existing notification conversation", async () => {
+    mockExistingConversations["conv-bound"] = {
+      id: "conv-bound",
+      source: "notification",
+      title: "Telegram Thread",
+    };
+    mockBindings["telegram:chat-123"] = {
+      conversationId: "conv-bound",
+      sourceChannel: "telegram",
+      externalChatId: "chat-123",
+    };
+
+    const signal = makeSignal();
+    const copy = makeCopy({
+      threadSeedMessage: "Second notification to same chat",
+    });
+    const bindingContext: DestinationBindingContext = {
+      sourceChannel: "telegram" as NotificationChannel,
+      externalChatId: "chat-123",
+    };
+
+    const result = await pairDeliveryWithConversation(
+      signal,
+      "telegram" as NotificationChannel,
+      copy,
+      { bindingContext },
+    );
+
+    expect(result.conversationId).toBe("conv-bound");
+    expect(result.messageId).toBe("msg-001");
+    expect(result.createdNewConversation).toBe(false);
+    expect(result.threadDecisionFallbackUsed).toBe(false);
+    expect(result.strategy).toBe("continue_existing_conversation");
+    // Should append to existing, not create new
+    expect(createConversationMock).not.toHaveBeenCalled();
+    expect(addMessageMock).toHaveBeenCalledTimes(1);
+    expect(addMessageMock.mock.calls[0]![0]).toBe("conv-bound");
+    // Should touch the outbound binding
+    expect(upsertOutboundBindingMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("falls back to new conversation when bound conversation is stale (wrong source)", async () => {
+    mockExistingConversations["conv-user-owned"] = {
+      id: "conv-user-owned",
+      source: "user",
+      title: "User Thread",
+    };
+    mockBindings["sms:+15551234567"] = {
+      conversationId: "conv-user-owned",
+      sourceChannel: "sms",
+      externalChatId: "+15551234567",
+    };
+
+    const signal = makeSignal();
+    const copy = makeCopy();
+    const bindingContext: DestinationBindingContext = {
+      sourceChannel: "sms" as NotificationChannel,
+      externalChatId: "+15551234567",
+    };
+
+    const result = await pairDeliveryWithConversation(
+      signal,
+      "sms" as NotificationChannel,
+      copy,
+      { bindingContext },
+    );
+
+    expect(result.conversationId).toBe("conv-001");
+    expect(result.createdNewConversation).toBe(true);
+    expect(result.threadDecisionFallbackUsed).toBe(false);
+    expect(createConversationMock).toHaveBeenCalledTimes(1);
+    // Should upsert the binding for the new conversation
+    expect(upsertOutboundBindingMock).toHaveBeenCalledTimes(1);
+    const upsertArgs = upsertOutboundBindingMock.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(upsertArgs.conversationId).toBe("conv-001");
+    expect(upsertArgs.sourceChannel).toBe("sms");
+  });
+
+  test("falls back to new conversation when bound conversation no longer exists", async () => {
+    // Binding exists but conversation was deleted
+    mockBindings["telegram:chat-456"] = {
+      conversationId: "conv-deleted",
+      sourceChannel: "telegram",
+      externalChatId: "chat-456",
+    };
+
+    const signal = makeSignal();
+    const copy = makeCopy();
+    const bindingContext: DestinationBindingContext = {
+      sourceChannel: "telegram" as NotificationChannel,
+      externalChatId: "chat-456",
+    };
+
+    const result = await pairDeliveryWithConversation(
+      signal,
+      "telegram" as NotificationChannel,
+      copy,
+      { bindingContext },
+    );
+
+    expect(result.conversationId).toBe("conv-001");
+    expect(result.createdNewConversation).toBe(true);
+    expect(createConversationMock).toHaveBeenCalledTimes(1);
+    // Should upsert the new conversation binding
+    expect(upsertOutboundBindingMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("creates new conversation and upserts binding when no prior binding exists", async () => {
+    const signal = makeSignal();
+    const copy = makeCopy();
+    const bindingContext: DestinationBindingContext = {
+      sourceChannel: "slack" as NotificationChannel,
+      externalChatId: "C0123ABCDEF",
+    };
+
+    const result = await pairDeliveryWithConversation(
+      signal,
+      "slack" as NotificationChannel,
+      copy,
+      { bindingContext },
+    );
+
+    expect(result.conversationId).toBe("conv-001");
+    expect(result.createdNewConversation).toBe(true);
+    expect(createConversationMock).toHaveBeenCalledTimes(1);
+    // Should upsert so future deliveries reuse this conversation
+    expect(upsertOutboundBindingMock).toHaveBeenCalledTimes(1);
+    const upsertArgs = upsertOutboundBindingMock.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(upsertArgs.conversationId).toBe("conv-001");
+    expect(upsertArgs.sourceChannel).toBe("slack");
+    expect(upsertArgs.externalChatId).toBe("C0123ABCDEF");
+  });
+
+  test("explicit reuse_existing takes precedence over binding-key reuse", async () => {
+    // Both a binding and a reuse_existing target exist — reuse_existing wins
+    mockExistingConversations["conv-explicit"] = {
+      id: "conv-explicit",
+      source: "notification",
+      title: "Explicit Thread",
+    };
+    mockExistingConversations["conv-bound"] = {
+      id: "conv-bound",
+      source: "notification",
+      title: "Bound Thread",
+    };
+    mockBindings["telegram:chat-789"] = {
+      conversationId: "conv-bound",
+      sourceChannel: "telegram",
+      externalChatId: "chat-789",
+    };
+
+    const signal = makeSignal();
+    const copy = makeCopy({
+      threadSeedMessage: "Message for explicit reuse target",
+    });
+    const threadAction: ThreadAction = {
+      action: "reuse_existing",
+      conversationId: "conv-explicit",
+    };
+    const bindingContext: DestinationBindingContext = {
+      sourceChannel: "telegram" as NotificationChannel,
+      externalChatId: "chat-789",
+    };
+
+    const result = await pairDeliveryWithConversation(
+      signal,
+      "telegram" as NotificationChannel,
+      copy,
+      { threadAction, bindingContext },
+    );
+
+    // Should use the explicit target, not the binding
+    expect(result.conversationId).toBe("conv-explicit");
+    expect(result.createdNewConversation).toBe(false);
+    expect(createConversationMock).not.toHaveBeenCalled();
+    // Binding lookup should not even be attempted since reuse_existing matched first
+    expect(getBindingByChannelChatMock).not.toHaveBeenCalled();
+  });
+
+  test("binding context does not trigger reuse for start_new_conversation channels", async () => {
+    // vellum uses start_new_conversation — binding context should be ignored for reuse
+    mockExistingConversations["conv-bound-vellum"] = {
+      id: "conv-bound-vellum",
+      source: "notification",
+      title: "Vellum Thread",
+    };
+    mockBindings["vellum:device-1"] = {
+      conversationId: "conv-bound-vellum",
+      sourceChannel: "vellum",
+      externalChatId: "device-1",
+    };
+
+    const signal = makeSignal();
+    const copy = makeCopy();
+    const bindingContext: DestinationBindingContext = {
+      sourceChannel: "vellum" as NotificationChannel,
+      externalChatId: "device-1",
+    };
+
+    const result = await pairDeliveryWithConversation(
+      signal,
+      "vellum" as NotificationChannel,
+      copy,
+      { bindingContext },
+    );
+
+    // Should still create a new conversation — vellum is start_new_conversation
+    expect(result.conversationId).toBe("conv-001");
+    expect(result.createdNewConversation).toBe(true);
+    expect(createConversationMock).toHaveBeenCalledTimes(1);
+    // Binding lookup should not be called for non-continue_existing channels
+    expect(getBindingByChannelChatMock).not.toHaveBeenCalled();
   });
 
   // ── not_deliverable (voice) ───────────────────────────────────────

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -6,9 +6,12 @@
  * auditable conversation trail and enables the macOS/iOS client to
  * deep-link directly into the notification thread.
  *
- * When the decision engine selects `reuse_existing` for a channel and
- * the target conversation is valid, the seed message is appended to the
- * existing thread instead of creating a new one.
+ * Resolution order:
+ * 1. Explicit `reuse_existing` thread action — highest precedence.
+ * 2. Binding-key reuse — for `continue_existing_conversation` channels,
+ *    looks up a previously bound conversation by (sourceChannel, externalChatId).
+ * 3. Default — creates a fresh conversation and, when binding context is
+ *    present, upserts it into the external-conversation store for future reuse.
  */
 
 import type { ConversationStrategy } from "../channels/config.js";
@@ -19,6 +22,10 @@ import {
   createConversation,
   getConversation,
 } from "../memory/conversation-store.js";
+import {
+  getBindingByChannelChat,
+  upsertOutboundBinding,
+} from "../memory/external-conversation-store.js";
 import { getLogger } from "../util/logger.js";
 import type { NotificationSignal } from "./signal.js";
 import { composeThreadSeed, isThreadSeedSane } from "./thread-seed-composer.js";
@@ -54,11 +61,13 @@ export interface PairingOptions {
  * Looks up the channel's conversation strategy from the policy registry
  * and materializes a conversation + assistant message accordingly.
  *
- * When `options.threadAction` is `reuse_existing`, the function attempts
- * to look up the target conversation. If it exists and has the right source,
- * the seed message is appended to it. If the target is invalid or stale,
- * a new conversation is created instead (with `threadDecisionFallbackUsed`
- * set to true on the result).
+ * Resolution precedence:
+ * 1. `options.threadAction === "reuse_existing"` — reuse the explicit target.
+ * 2. `continue_existing_conversation` strategy with binding context —
+ *    look up a previously bound conversation by (sourceChannel, externalChatId).
+ * 3. Create a new conversation (and upsert the binding when context is present).
+ *
+ * Invalid/stale targets at any level fall through to the next.
  *
  * Errors are caught and logged — this function never throws so the
  * notification pipeline is not disrupted by pairing failures.
@@ -171,6 +180,77 @@ export async function pairDeliveryWithConversation(
       };
     }
 
+    // For channels with continue_existing_conversation strategy, try to
+    // reuse a previously bound conversation keyed by (sourceChannel, externalChatId)
+    // before falling through to create a new one.
+    const bindingContext = options?.bindingContext;
+    if (
+      strategy === "continue_existing_conversation" &&
+      bindingContext?.sourceChannel &&
+      bindingContext?.externalChatId
+    ) {
+      const existingBinding = getBindingByChannelChat(
+        bindingContext.sourceChannel,
+        bindingContext.externalChatId,
+      );
+
+      if (existingBinding) {
+        const boundConversation = getConversation(
+          existingBinding.conversationId,
+        );
+
+        if (boundConversation && boundConversation.source === "notification") {
+          const message = await addMessage(
+            boundConversation.id,
+            "assistant",
+            messageContent,
+            undefined,
+            { skipIndexing: true },
+          );
+
+          // Touch the outbound timestamp so the binding stays fresh.
+          upsertOutboundBinding({
+            conversationId: boundConversation.id,
+            sourceChannel: bindingContext.sourceChannel,
+            externalChatId: bindingContext.externalChatId,
+          });
+
+          log.info(
+            {
+              signalId: signal.signalId,
+              channel,
+              strategy,
+              conversationId: boundConversation.id,
+              messageId: message.id,
+              bindingKey: `${bindingContext.sourceChannel}:${bindingContext.externalChatId}`,
+            },
+            "Reused bound conversation for channel destination",
+          );
+
+          return {
+            conversationId: boundConversation.id,
+            messageId: message.id,
+            strategy,
+            createdNewConversation: false,
+            threadDecisionFallbackUsed: false,
+          };
+        }
+
+        // Binding exists but conversation is stale or wrong source — fall through
+        // to create a new one and re-bind below.
+        log.warn(
+          {
+            signalId: signal.signalId,
+            channel,
+            boundConversationId: existingBinding.conversationId,
+            boundConversationExists: !!boundConversation,
+            boundConversationSource: boundConversation?.source,
+          },
+          "Bound conversation stale or invalid — creating fresh conversation",
+        );
+      }
+    }
+
     // Default path: create a new conversation
     // Memory indexing is skipped on the seed message below to prevent
     // notification copy from polluting conversational recall.
@@ -189,6 +269,16 @@ export async function pairDeliveryWithConversation(
       undefined,
       { skipIndexing: true },
     );
+
+    // When binding context is available, record the new conversation so
+    // subsequent deliveries to the same destination reuse it.
+    if (bindingContext?.sourceChannel && bindingContext?.externalChatId) {
+      upsertOutboundBinding({
+        conversationId: conversation.id,
+        sourceChannel: bindingContext.sourceChannel,
+        externalChatId: bindingContext.externalChatId,
+      });
+    }
 
     log.info(
       {


### PR DESCRIPTION
## Summary
- Adds binding-key lookup in conversation pairing for channels with continue_existing_conversation strategy
- Reuses existing bound conversations for repeated notifications to the same SMS/Telegram/Slack destination
- Falls back to fresh conversation creation when bindings are stale or invalid
- Upserts new notification conversations into external-conversation-store for future reuse

Part of plan: notification-thread-continuation.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
