### PR TITLE
refactor: reuse shared Chrome CDP helper in amazon CLI flows

### DIFF
--- a/assistant/src/__tests__/amazon-cdp-integration.test.ts
+++ b/assistant/src/__tests__/amazon-cdp-integration.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Verify that the Amazon CLI delegates CDP management to the shared
+ * chrome-cdp helper instead of owning its own launch/window logic.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const AMAZON_CLI_PATH = join(
+  import.meta.dirname ?? __dirname,
+  "..",
+  "cli",
+  "amazon.ts",
+);
+const amazonSource = readFileSync(AMAZON_CLI_PATH, "utf-8");
+
+describe("Amazon CLI CDP integration", () => {
+  test("imports shared CDP helpers instead of defining its own", () => {
+    // Should import from the shared module
+    expect(amazonSource).toContain('from "../tools/browser/chrome-cdp.js"');
+
+    // Should import the key entrypoints
+    expect(amazonSource).toContain("ensureChromeWithCdp");
+    expect(amazonSource).toContain("minimizeChromeWindow");
+    expect(amazonSource).toContain("restoreChromeWindow");
+  });
+
+  test("does not define its own CDP_BASE constant", () => {
+    // The old inline constant was: const CDP_BASE = "http://localhost:9222";
+    expect(amazonSource).not.toMatch(/const\s+CDP_BASE\s*=/);
+  });
+
+  test("does not define its own Chrome data dir constant", () => {
+    expect(amazonSource).not.toMatch(/const\s+CHROME_DATA_DIR\s*=/);
+  });
+
+  test("does not define a local isCdpReady function", () => {
+    expect(amazonSource).not.toMatch(/async\s+function\s+isCdpReady\s*\(/);
+  });
+
+  test("does not define a local ensureChromeWithCDP function", () => {
+    expect(amazonSource).not.toMatch(
+      /async\s+function\s+ensureChromeWithCDP\s*\(/,
+    );
+  });
+
+  test("does not define local minimize/restore window functions", () => {
+    expect(amazonSource).not.toMatch(
+      /async\s+function\s+minimizeChromeWindow\s*\(/,
+    );
+    expect(amazonSource).not.toMatch(
+      /async\s+function\s+restoreChromeWindow\s*\(/,
+    );
+  });
+
+  test("does not spawn Chrome directly", () => {
+    // The old code imported spawn and called it with the Chrome app path.
+    // After migration, spawn should not be imported or used.
+    expect(amazonSource).not.toMatch(/spawn\s+as\s+spawnChild/);
+    expect(amazonSource).not.toContain(
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    );
+  });
+
+  test("still calls ensureChromeWithCdp in the learn session flow", () => {
+    // The learn session helper should delegate to the shared entrypoint
+    expect(amazonSource).toMatch(/await\s+ensureChromeWithCdp\s*\(/);
+  });
+
+  test("passes amazon.com as the start URL", () => {
+    expect(amazonSource).toContain("https://www.amazon.com/");
+  });
+});

--- a/assistant/src/cli/amazon.ts
+++ b/assistant/src/cli/amazon.ts
@@ -490,10 +490,10 @@ export function registerAmazonCommand(program: Command): void {
 }
 
 // ---------------------------------------------------------------------------
-// Chrome CDP restart helper
+// Chrome CDP helpers (delegated to shared module)
 // ---------------------------------------------------------------------------
 
-import { execSync, spawn as spawnChild } from "node:child_process";
+import { execSync } from "node:child_process";
 import * as crypto from "node:crypto";
 import {
   copyFileSync,
@@ -503,156 +503,11 @@ import {
 import { homedir, tmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
 
-const CDP_BASE = "http://localhost:9222";
-const CHROME_DATA_DIR = pathJoin(
-  homedir(),
-  "Library/Application Support/Google/Chrome-CDP",
-);
-
-async function isCdpReady(): Promise<boolean> {
-  try {
-    const res = await fetch(`${CDP_BASE}/json/version`);
-    return res.ok;
-  } catch {
-    return false;
-  }
-}
-
-async function ensureChromeWithCDP(): Promise<void> {
-  if (await isCdpReady()) return;
-
-  const chromeApp =
-    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
-  spawnChild(
-    chromeApp,
-    [
-      `--remote-debugging-port=9222`,
-      `--force-renderer-accessibility`,
-      `--user-data-dir=${CHROME_DATA_DIR}`,
-      `https://www.amazon.com/`,
-    ],
-    {
-      detached: true,
-      stdio: "ignore",
-    },
-  ).unref();
-
-  for (let i = 0; i < 30; i++) {
-    await new Promise((r) => setTimeout(r, 500));
-    if (await isCdpReady()) return;
-  }
-  throw new Error("Chrome started but CDP endpoint not responding after 15s");
-}
-
-async function minimizeChromeWindow(): Promise<void> {
-  const res = await fetch(`${CDP_BASE}/json/list`);
-  const targets = (await res.json()) as Array<{
-    type: string;
-    webSocketDebuggerUrl: string;
-  }>;
-  const pageTarget = targets.find((t) => t.type === "page");
-  if (!pageTarget) return;
-
-  const ws = new WebSocket(pageTarget.webSocketDebuggerUrl);
-
-  await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      ws.close();
-      reject(new Error("CDP minimize timed out"));
-    }, 5000);
-
-    ws.addEventListener("open", () => {
-      ws.send(JSON.stringify({ id: 1, method: "Browser.getWindowForTarget" }));
-    });
-
-    ws.addEventListener("message", (event) => {
-      const msg = JSON.parse(String(event.data)) as {
-        id: number;
-        result?: { windowId: number };
-      };
-      if (msg.id === 1 && msg.result) {
-        ws.send(
-          JSON.stringify({
-            id: 2,
-            method: "Browser.setWindowBounds",
-            params: {
-              windowId: msg.result.windowId,
-              bounds: { windowState: "minimized" },
-            },
-          }),
-        );
-      } else if (msg.id === 1) {
-        clearTimeout(timeout);
-        ws.close();
-        reject(new Error("Browser.getWindowForTarget failed"));
-      } else if (msg.id === 2) {
-        clearTimeout(timeout);
-        ws.close();
-        resolve();
-      }
-    });
-
-    ws.addEventListener("error", (err) => {
-      clearTimeout(timeout);
-      reject(err);
-    });
-  });
-}
-
-async function restoreChromeWindow(): Promise<void> {
-  const res = await fetch(`${CDP_BASE}/json/list`);
-  const targets = (await res.json()) as Array<{
-    type: string;
-    webSocketDebuggerUrl: string;
-  }>;
-  const pageTarget = targets.find((t) => t.type === "page");
-  if (!pageTarget) return;
-
-  const ws = new WebSocket(pageTarget.webSocketDebuggerUrl);
-
-  await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      ws.close();
-      reject(new Error("CDP restore timed out"));
-    }, 5000);
-
-    ws.addEventListener("open", () => {
-      ws.send(JSON.stringify({ id: 1, method: "Browser.getWindowForTarget" }));
-    });
-
-    ws.addEventListener("message", (event) => {
-      const msg = JSON.parse(String(event.data)) as {
-        id: number;
-        result?: { windowId: number };
-      };
-      if (msg.id === 1 && msg.result) {
-        ws.send(
-          JSON.stringify({
-            id: 2,
-            method: "Browser.setWindowBounds",
-            params: {
-              windowId: msg.result.windowId,
-              bounds: { windowState: "normal" },
-            },
-          }),
-        );
-      } else if (msg.id === 1) {
-        clearTimeout(timeout);
-        ws.close();
-        reject(new Error("Browser.getWindowForTarget failed"));
-      } else if (msg.id === 2) {
-        clearTimeout(timeout);
-        ws.close();
-        resolve();
-      }
-    });
-
-    ws.addEventListener("error", (err) => {
-      clearTimeout(timeout);
-      reject(err);
-    });
-  });
-}
+import {
+  ensureChromeWithCdp,
+  minimizeChromeWindow,
+  restoreChromeWindow,
+} from "../tools/browser/chrome-cdp.js";
 
 // ---------------------------------------------------------------------------
 // Headless cookie extraction from Chrome's SQLite database
@@ -834,7 +689,7 @@ interface LearnResult {
 async function startLearnSession(
   durationSeconds: number,
 ): Promise<LearnResult> {
-  await ensureChromeWithCDP();
+  await ensureChromeWithCdp({ startUrl: "https://www.amazon.com/" });
 
   return new Promise((resolve, reject) => {
     const socketPath = getSocketPath();


### PR DESCRIPTION
## Summary
- Replace inline CDP launch/window-management code in amazon.ts with imports from shared chrome-cdp.ts helper
- Delete duplicate CDP_BASE, launch loop, and minimize/restore logic
- Add integration tests for Amazon refresh flows using the shared helper

Part of plan: ride-shotgun-cdp.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
