### PR TITLE
test: update notification continuation docs and deep-link regressions

### DIFF
--- a/assistant/src/__tests__/notification-broadcaster.test.ts
+++ b/assistant/src/__tests__/notification-broadcaster.test.ts
@@ -486,6 +486,88 @@ describe("notification broadcaster", () => {
     });
   });
 
+  test("reused thread via binding-key continuation does NOT emit class-level onThreadCreated", async () => {
+    const vellumAdapter = new MockAdapter("vellum");
+    const broadcaster = new NotificationBroadcaster([vellumAdapter]);
+    const ipcCalls: ThreadCreatedInfo[] = [];
+    broadcaster.setOnThreadCreated((info) => ipcCalls.push(info));
+
+    // Simulate binding-key continuation: pairing reuses an existing bound
+    // conversation (createdNewConversation=false, strategy=continue_existing_conversation)
+    nextPairingResult = {
+      conversationId: "conv-bound-sms-001",
+      messageId: "msg-bound-sms-001",
+      strategy: "continue_existing_conversation" as const,
+      createdNewConversation: false,
+      threadDecisionFallbackUsed: false,
+    };
+
+    const signal = makeSignal();
+    const decision = makeDecision();
+
+    await broadcaster.broadcastDecision(signal, decision);
+
+    // The class-level IPC callback should NOT fire because
+    // createdNewConversation is false — the thread already exists
+    // in the external channel and the client already knows about it.
+    expect(ipcCalls).toHaveLength(0);
+  });
+
+  test("fresh conversation for continue_existing_conversation does NOT emit class-level onThreadCreated", async () => {
+    const vellumAdapter = new MockAdapter("vellum");
+    const broadcaster = new NotificationBroadcaster([vellumAdapter]);
+    const ipcCalls: ThreadCreatedInfo[] = [];
+    broadcaster.setOnThreadCreated((info) => ipcCalls.push(info));
+
+    // First delivery to a new destination: creates a fresh conversation but
+    // the strategy is continue_existing_conversation (not start_new_conversation),
+    // so the IPC event should NOT fire — these are background threads not
+    // meant to appear in the sidebar.
+    nextPairingResult = {
+      conversationId: "conv-new-telegram-dest",
+      messageId: "msg-new-telegram-dest",
+      strategy: "continue_existing_conversation" as const,
+      createdNewConversation: true,
+      threadDecisionFallbackUsed: false,
+    };
+
+    const signal = makeSignal();
+    const decision = makeDecision();
+
+    await broadcaster.broadcastDecision(signal, decision);
+
+    // Even though createdNewConversation is true, the strategy is
+    // continue_existing_conversation, so the IPC gate rejects it.
+    expect(ipcCalls).toHaveLength(0);
+  });
+
+  test("per-dispatch onThreadCreated fires for reused binding-key conversation", async () => {
+    const vellumAdapter = new MockAdapter("vellum");
+    const broadcaster = new NotificationBroadcaster([vellumAdapter]);
+    const dispatchCalls: ThreadCreatedInfo[] = [];
+
+    // Binding-key reuse: conversation already exists
+    nextPairingResult = {
+      conversationId: "conv-bound-telegram-456",
+      messageId: "msg-bound-telegram-789",
+      strategy: "continue_existing_conversation" as const,
+      createdNewConversation: false,
+      threadDecisionFallbackUsed: false,
+    };
+
+    const signal = makeSignal();
+    const decision = makeDecision();
+
+    await broadcaster.broadcastDecision(signal, decision, {
+      onThreadCreated: (info) => dispatchCalls.push(info),
+    });
+
+    // The per-dispatch callback SHOULD fire regardless of reuse
+    // (callers like dispatchGuardianQuestion need it for bookkeeping)
+    expect(dispatchCalls).toHaveLength(1);
+    expect(dispatchCalls[0].conversationId).toBe("conv-bound-telegram-456");
+  });
+
   test("vellum delivery does NOT carry binding context into pairing", async () => {
     const vellumAdapter = new MockAdapter("vellum");
     const broadcaster = new NotificationBroadcaster([vellumAdapter]);

--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -221,5 +221,121 @@ describe("notification deep-link metadata", () => {
       const metadata = msg.deepLinkMetadata as Record<string, unknown>;
       expect(metadata.conversationId).toBe("conv-reused-thread-042");
     });
+
+    // ── Reused thread deep-link stability regressions ─────────────────
+
+    test("reused thread preserves the same conversationId across follow-up notifications", async () => {
+      const messages: ServerMessage[] = [];
+      const adapter = new VellumAdapter((msg) => messages.push(msg));
+
+      const stableConversationId = "conv-bound-telegram-dest-001";
+
+      // First notification to a bound destination
+      await adapter.send(
+        {
+          sourceEventName: "guardian.question",
+          copy: { title: "Question 1", body: "Allow file read?" },
+          deepLinkTarget: {
+            conversationId: stableConversationId,
+            messageId: "msg-seed-1",
+          },
+        },
+        { channel: "vellum" },
+      );
+
+      // Follow-up notification reuses the same bound conversation
+      await adapter.send(
+        {
+          sourceEventName: "guardian.question",
+          copy: { title: "Question 2", body: "Allow network access?" },
+          deepLinkTarget: {
+            conversationId: stableConversationId,
+            messageId: "msg-seed-2",
+          },
+        },
+        { channel: "vellum" },
+      );
+
+      expect(messages).toHaveLength(2);
+
+      const meta1 = (messages[0] as unknown as Record<string, unknown>)
+        .deepLinkMetadata as Record<string, unknown>;
+      const meta2 = (messages[1] as unknown as Record<string, unknown>)
+        .deepLinkMetadata as Record<string, unknown>;
+
+      // Both deep links point to the same conversation
+      expect(meta1.conversationId).toBe(stableConversationId);
+      expect(meta2.conversationId).toBe(stableConversationId);
+
+      // But each has a distinct messageId for scroll-to-message targeting
+      expect(meta1.messageId).toBe("msg-seed-1");
+      expect(meta2.messageId).toBe("msg-seed-2");
+    });
+
+    test("reused thread deep-link messageId changes per delivery for scroll targeting", async () => {
+      const messages: ServerMessage[] = [];
+      const adapter = new VellumAdapter((msg) => messages.push(msg));
+
+      const conversationId = "conv-reused-scroll-test";
+
+      await adapter.send(
+        {
+          sourceEventName: "reminder.fired",
+          copy: { title: "Reminder", body: "First" },
+          deepLinkTarget: { conversationId, messageId: "msg-a" },
+        },
+        { channel: "vellum" },
+      );
+
+      await adapter.send(
+        {
+          sourceEventName: "reminder.fired",
+          copy: { title: "Reminder", body: "Second" },
+          deepLinkTarget: { conversationId, messageId: "msg-b" },
+        },
+        { channel: "vellum" },
+      );
+
+      const meta1 = (messages[0] as unknown as Record<string, unknown>)
+        .deepLinkMetadata as Record<string, unknown>;
+      const meta2 = (messages[1] as unknown as Record<string, unknown>)
+        .deepLinkMetadata as Record<string, unknown>;
+
+      // Same conversation but different message targets
+      expect(meta1.conversationId).toBe(conversationId);
+      expect(meta2.conversationId).toBe(conversationId);
+      expect(meta1.messageId).not.toBe(meta2.messageId);
+    });
+
+    test("deep-link metadata is stable when conversation is reused via binding-key continuation", async () => {
+      const messages: ServerMessage[] = [];
+      const adapter = new VellumAdapter((msg) => messages.push(msg));
+
+      // Simulates the binding-key continuation path: multiple notifications
+      // to the same SMS destination reuse the same bound conversation, and
+      // the deep-link metadata should reflect the bound conversation ID
+      // rather than creating a new one each time.
+      const boundConvId = "conv-sms-bound-+15551234567";
+
+      for (const body of ["Alert 1", "Alert 2", "Alert 3"]) {
+        await adapter.send(
+          {
+            sourceEventName: "activity.complete",
+            copy: { title: "Activity", body },
+            deepLinkTarget: { conversationId: boundConvId },
+          },
+          { channel: "vellum" },
+        );
+      }
+
+      expect(messages).toHaveLength(3);
+
+      // All three notifications deep-link to the same bound conversation
+      for (const msg of messages) {
+        const metadata = (msg as unknown as Record<string, unknown>)
+          .deepLinkMetadata as Record<string, unknown>;
+        expect(metadata.conversationId).toBe(boundConvId);
+      }
+    });
   });
 });

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -79,18 +79,18 @@ The broadcaster (`broadcaster.ts`) iterates over selected channels (vellum first
 
 Each policy defines:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `notification.deliveryEnabled` | `boolean` | Whether the channel can receive notification deliveries |
+| Field                               | Type                   | Description                                                       |
+| ----------------------------------- | ---------------------- | ----------------------------------------------------------------- |
+| `notification.deliveryEnabled`      | `boolean`              | Whether the channel can receive notification deliveries           |
 | `notification.conversationStrategy` | `ConversationStrategy` | How conversations are materialized for deliveries on this channel |
 
 ### Conversation Strategy Types
 
-| Strategy | Behavior | Used by |
-|----------|----------|---------|
-| `start_new_conversation` | Creates a fresh conversation per delivery. The thread is surfaced via IPC. | `vellum` |
-| `continue_existing_conversation` | Appends to an existing channel-scoped conversation (future: lookup by binding key). Currently materializes a background audit conversation per delivery and records the intended strategy. | `telegram`, `sms`, `whatsapp`, `slack`, `email` |
-| `not_deliverable` | Channel cannot receive notifications. Pairing returns null IDs. | `voice` |
+| Strategy                         | Behavior                                                                                                                                                                                                                                     | Used by                                         |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `start_new_conversation`         | Creates a fresh conversation per delivery. The thread is surfaced via IPC.                                                                                                                                                                   | `vellum`                                        |
+| `continue_existing_conversation` | Looks up a previously bound conversation by binding key (sourceChannel + externalChatId) and appends to it. When no bound conversation exists (first delivery to a destination), creates a new one and upserts the binding for future reuse. | `telegram`, `sms`, `whatsapp`, `slack`, `email` |
+| `not_deliverable`                | Channel cannot receive notifications. Pairing returns null IDs.                                                                                                                                                                              | `voice`                                         |
 
 ### Helper Functions
 
@@ -122,7 +122,7 @@ When the decision engine selects `reuse_existing` for a channel with a valid can
 ### New Thread Path (`start_new` / default)
 
 - **`start_new_conversation`**: Creates a new conversation with `threadType: 'standard'` and `source: 'notification'`, plus an assistant message containing the thread seed. Memory indexing is skipped on the seed message to prevent notification copy from polluting conversational recall. The result has `createdNewConversation: true`.
-- **`continue_existing_conversation`**: Currently materializes a background audit conversation per delivery (true continuation via binding key lookup is planned for a future PR). The audit trail records the intended strategy without adding visible sidebar threads.
+- **`continue_existing_conversation`**: Looks up a previously bound conversation by binding key (`sourceChannel` + `externalChatId` via `getBindingByChannelChat()`). When a valid bound conversation with `source: 'notification'` exists, the seed message is appended to it and the binding timestamp is refreshed. When no binding exists or the bound conversation is stale/invalid, a new conversation is created and the binding is upserted for future reuse. The result has `createdNewConversation: false` on reuse, `true` on fresh creation.
 - **`not_deliverable`**: Returns `{ conversationId: null, messageId: null }`.
 
 The pairing function is resilient -- errors are caught and logged. A pairing failure never breaks the delivery pipeline.
@@ -131,11 +131,11 @@ The pairing function is resilient -- errors are caught and logged. A pairing fai
 
 The system produces **three distinct copy outputs** per notification:
 
-| Output | Purpose | Verbosity |
-|--------|---------|-----------|
-| `title` + `body` | Native notification popup (macOS/iOS banner) | Short and glanceable |
-| `deliveryText` | Channel-native chat message text (Telegram) | Natural chat phrasing |
-| Thread seed message | Opening message in the notification thread | Richer and context-aware |
+| Output              | Purpose                                      | Verbosity                |
+| ------------------- | -------------------------------------------- | ------------------------ |
+| `title` + `body`    | Native notification popup (macOS/iOS banner) | Short and glanceable     |
+| `deliveryText`      | Channel-native chat message text (Telegram)  | Natural chat phrasing    |
+| Thread seed message | Opening message in the notification thread   | Richer and context-aware |
 
 ### How It Works
 
@@ -151,12 +151,13 @@ The system produces **three distinct copy outputs** per notification:
 
 The thread seed composer adapts verbosity to the delivery surface:
 
-| Channel | Default Interface | Verbosity | Style |
-|---------|-------------------|-----------|-------|
-| `vellum` | `macos` | Rich | 2-4 short sentences with context and next step |
-| `telegram` | `telegram` | Compact | 1-2 concise sentences |
+| Channel    | Default Interface | Verbosity | Style                                          |
+| ---------- | ----------------- | --------- | ---------------------------------------------- |
+| `vellum`   | `macos`           | Rich      | 2-4 short sentences with context and next step |
+| `telegram` | `telegram`        | Compact   | 1-2 concise sentences                          |
 
 Interface inference strategy:
+
 1. Explicit `interfaceHint` in the signal's `contextPayload` (if valid `InterfaceId`).
 2. `sourceInterface` from the originating conversation (if valid `InterfaceId`).
 3. Channel default mapping (`vellum` → `macos` → rich, `telegram` → `telegram` → compact).
@@ -164,17 +165,20 @@ Interface inference strategy:
 ### Example: Reminder Notification
 
 **Native popup (vellum/macos):**
+
 ```
 Title: Reminder
 Body:  Take out the trash
 ```
 
 **Telegram chat delivery (`deliveryText`):**
+
 ```
 Take out the trash
 ```
 
 **Thread seed on vellum/macos (rich):**
+
 ```
 Reminder. Take out the trash. Action required.
 ```
@@ -189,7 +193,10 @@ This is enforced in `broadcaster.ts` by gating the IPC emission on `pairing.crea
 // Emit notification_thread_created only when a NEW conversation was
 // actually created. Reusing an existing thread should not fire the IPC
 // event — the client already knows about the conversation.
-if (pairing.createdNewConversation && pairing.strategy === 'start_new_conversation') {
+if (
+  pairing.createdNewConversation &&
+  pairing.strategy === "start_new_conversation"
+) {
   // ... emit IPC event
 }
 ```
@@ -226,11 +233,11 @@ Reminders carry optional routing metadata that controls how notifications fan ou
 
 The `routing_intent` field on each reminder row specifies the desired channel coverage:
 
-| Intent | Behavior | When to use |
-|--------|----------|-------------|
-| `single_channel` | Default LLM-driven routing (no override) | Standard reminders where the decision engine picks the best channel |
-| `multi_channel` | Ensures delivery on 2+ channels when 2+ are connected | Important reminders the user wants on both desktop and phone |
-| `all_channels` | Forces delivery on every connected channel | Critical reminders that must reach the user everywhere |
+| Intent           | Behavior                                              | When to use                                                         |
+| ---------------- | ----------------------------------------------------- | ------------------------------------------------------------------- |
+| `single_channel` | Default LLM-driven routing (no override)              | Standard reminders where the decision engine picks the best channel |
+| `multi_channel`  | Ensures delivery on 2+ channels when 2+ are connected | Important reminders the user wants on both desktop and phone        |
+| `all_channels`   | Forces delivery on every connected channel            | Critical reminders that must reach the user everywhere              |
 
 The default is `single_channel`, preserving backward compatibility. Routing intent is persisted in the `reminders` table (`routing_intent` column) and carried through the notification signal as `routingIntent`.
 
@@ -342,10 +349,10 @@ When the decision is persisted, a `threadActions` summary is included in `valida
 
 Three columns on `notification_deliveries` record the per-channel thread decision:
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `thread_action` | TEXT | `'start_new'` or `'reuse_existing'` — what the model decided |
-| `thread_target_conversation_id` | TEXT | The candidate `conversationId` when action is `reuse_existing` |
+| Column                          | Type    | Description                                                                                                 |
+| ------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------- |
+| `thread_action`                 | TEXT    | `'start_new'` or `'reuse_existing'` — what the model decided                                                |
+| `thread_target_conversation_id` | TEXT    | The candidate `conversationId` when action is `reuse_existing`                                              |
 | `thread_decision_fallback_used` | INTEGER | `1` if `reuse_existing` was attempted but the target was invalid, so a new conversation was created instead |
 
 ### Query Examples
@@ -398,38 +405,38 @@ All three paths use the same pattern: look up pending deliveries by conversation
 
 All disambiguation messages are generated through `composeGuardianActionMessageGenerative()` in `guardian-action-message-composer.ts`, which uses a 2-tier priority chain (LLM generator with deterministic fallback). Three disambiguation scenarios exist:
 
-| Scenario | When triggered |
-|----------|---------------|
-| `guardian_disambiguation` | Multiple pending approval requests in a thread |
-| `guardian_expired_disambiguation` | Multiple expired requests with late replies |
+| Scenario                           | When triggered                                         |
+| ---------------------------------- | ------------------------------------------------------ |
+| `guardian_disambiguation`          | Multiple pending approval requests in a thread         |
+| `guardian_expired_disambiguation`  | Multiple expired requests with late replies            |
 | `guardian_followup_disambiguation` | Multiple follow-up deliveries awaiting guardian action |
 
 ## Key Files
 
-| File | Purpose |
-|------|---------|
-| `../channels/config.ts` | Channel policy registry -- single source of truth for per-channel notification behavior |
-| `emit-signal.ts` | Single entry point for producers; orchestrates the full pipeline |
-| `signal.ts` | `NotificationSignal` and `AttentionHints` type definitions |
-| `types.ts` | Channel adapter interfaces, delivery types, decision output contract, `ThreadAction` union |
-| `thread-candidates.ts` | Builds per-channel candidate set of recent notification conversations for the decision engine |
-| `conversation-pairing.ts` | Materializes conversation + message per delivery based on channel strategy |
-| `decision-engine.ts` | LLM-based routing with forced tool_choice; deterministic fallback |
-| `deterministic-checks.ts` | Pre-send gate checks (dedupe, source-active, channel availability) |
-| `runtime-dispatch.ts` | Dispatch gating (no-op decisions, empty channels) |
-| `broadcaster.ts` | Fan-out to channel adapters with delivery audit trail; emits `notification_thread_created` IPC |
-| `copy-composer.ts` | Template-based fallback notification copy when LLM copy is unavailable |
-| `thread-seed-composer.ts` | Surface-aware thread seed generation (richer than notification copy) |
-| `destination-resolver.ts` | Resolves per-channel endpoints (vellum IPC, Telegram chat ID) |
-| `adapters/macos.ts` | Vellum adapter -- broadcasts `notification_intent` via IPC with deep-link metadata |
-| `adapters/telegram.ts` | Telegram adapter -- POSTs to gateway `/deliver/telegram` |
-| `adapters/sms.ts` | SMS adapter -- POSTs to gateway `/deliver/sms` via Twilio Messages API |
-| `preference-extractor.ts` | Detects notification preferences in conversation messages |
-| `preference-summary.ts` | Builds preference context string for the decision engine prompt |
-| `preferences-store.ts` | CRUD for `notification_preferences` table |
-| `events-store.ts` | CRUD for `notification_events` table |
-| `decisions-store.ts` | CRUD for `notification_decisions` table |
-| `deliveries-store.ts` | CRUD for `notification_deliveries` table |
+| File                      | Purpose                                                                                        |
+| ------------------------- | ---------------------------------------------------------------------------------------------- |
+| `../channels/config.ts`   | Channel policy registry -- single source of truth for per-channel notification behavior        |
+| `emit-signal.ts`          | Single entry point for producers; orchestrates the full pipeline                               |
+| `signal.ts`               | `NotificationSignal` and `AttentionHints` type definitions                                     |
+| `types.ts`                | Channel adapter interfaces, delivery types, decision output contract, `ThreadAction` union     |
+| `thread-candidates.ts`    | Builds per-channel candidate set of recent notification conversations for the decision engine  |
+| `conversation-pairing.ts` | Materializes conversation + message per delivery based on channel strategy                     |
+| `decision-engine.ts`      | LLM-based routing with forced tool_choice; deterministic fallback                              |
+| `deterministic-checks.ts` | Pre-send gate checks (dedupe, source-active, channel availability)                             |
+| `runtime-dispatch.ts`     | Dispatch gating (no-op decisions, empty channels)                                              |
+| `broadcaster.ts`          | Fan-out to channel adapters with delivery audit trail; emits `notification_thread_created` IPC |
+| `copy-composer.ts`        | Template-based fallback notification copy when LLM copy is unavailable                         |
+| `thread-seed-composer.ts` | Surface-aware thread seed generation (richer than notification copy)                           |
+| `destination-resolver.ts` | Resolves per-channel endpoints (vellum IPC, Telegram chat ID)                                  |
+| `adapters/macos.ts`       | Vellum adapter -- broadcasts `notification_intent` via IPC with deep-link metadata             |
+| `adapters/telegram.ts`    | Telegram adapter -- POSTs to gateway `/deliver/telegram`                                       |
+| `adapters/sms.ts`         | SMS adapter -- POSTs to gateway `/deliver/sms` via Twilio Messages API                         |
+| `preference-extractor.ts` | Detects notification preferences in conversation messages                                      |
+| `preference-summary.ts`   | Builds preference context string for the decision engine prompt                                |
+| `preferences-store.ts`    | CRUD for `notification_preferences` table                                                      |
+| `events-store.ts`         | CRUD for `notification_events` table                                                           |
+| `decisions-store.ts`      | CRUD for `notification_decisions` table                                                        |
+| `deliveries-store.ts`     | CRUD for `notification_deliveries` table                                                       |
 
 ## How to Add a New Notification Producer
 
@@ -437,22 +444,24 @@ All disambiguation messages are generated through `composeGuardianActionMessageG
 2. Call it with the signal parameters:
 
 ```ts
-import { emitNotificationSignal } from '../notifications/emit-signal.js';
+import { emitNotificationSignal } from "../notifications/emit-signal.js";
 
 await emitNotificationSignal({
-  sourceEventName: 'your_event_name',
-  sourceChannel: 'scheduler',       // where the event originated
+  sourceEventName: "your_event_name",
+  sourceChannel: "scheduler", // where the event originated
   sourceSessionId: sessionId,
   attentionHints: {
     requiresAction: true,
-    urgency: 'high',
+    urgency: "high",
     isAsyncBackground: false,
     visibleInSourceNow: false,
   },
-  contextPayload: { /* arbitrary data for the decision engine */ },
+  contextPayload: {
+    /* arbitrary data for the decision engine */
+  },
   // Optional: control multi-channel fanout behavior
-  routingIntent: 'multi_channel',   // 'single_channel' | 'multi_channel' | 'all_channels'
-  routingHints: { preferredChannels: ['telegram', 'sms'] },
+  routingIntent: "multi_channel", // 'single_channel' | 'multi_channel' | 'all_channels'
+  routingHints: { preferredChannels: ["telegram", "sms"] },
 });
 ```
 
@@ -483,11 +492,11 @@ For vellum (macOS/iOS) deliveries, the audit trail now extends past the IPC broa
 
 The ack populates three columns on `notification_deliveries`:
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `client_delivery_status` | TEXT | `'delivered'` if the OS accepted the notification, `'client_failed'` otherwise |
-| `client_delivery_error` | TEXT | Error description when the post failed (e.g. authorization denied) |
-| `client_delivery_at` | INTEGER | Epoch ms timestamp of when the client reported the outcome |
+| Column                   | Type    | Description                                                                    |
+| ------------------------ | ------- | ------------------------------------------------------------------------------ |
+| `client_delivery_status` | TEXT    | `'delivered'` if the OS accepted the notification, `'client_failed'` otherwise |
+| `client_delivery_error`  | TEXT    | Error description when the post failed (e.g. authorization denied)             |
+| `client_delivery_at`     | INTEGER | Epoch ms timestamp of when the client reported the outcome                     |
 
 This means the audit trail can now answer three questions for each vellum delivery:
 
@@ -539,8 +548,8 @@ Preferences are sanitized against prompt injection (angle brackets replaced with
 
 All settings live under the `notifications` key in `config.json`:
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
+| Key                                 | Type   | Default               | Description                                                              |
+| ----------------------------------- | ------ | --------------------- | ------------------------------------------------------------------------ |
 | `notifications.decisionModelIntent` | string | `"latency-optimized"` | Model intent used for both the decision engine and preference extraction |
 
 The notification pipeline is always active -- signals are processed and dispatched as soon as the daemon is running. The audit trail (events, decisions, deliveries) is written for every signal.

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -93,10 +93,9 @@ export async function pairDeliveryWithConversation(
 
     const title = copy.threadTitle ?? copy.title ?? signal.sourceEventName;
 
-    // Only start_new_conversation threads should be user-visible. For channels
-    // that intend to continue an existing external conversation (e.g. Telegram),
-    // we still materialize an auditable row but keep it background-only until
-    // true continuation-by-key is implemented.
+    // Only start_new_conversation threads should be user-visible in the sidebar.
+    // Channels with continue_existing_conversation reuse bound external threads
+    // and mark them as background so they don't clutter the sidebar UI.
     const threadType =
       strategy === "start_new_conversation" ? "standard" : "background";
 


### PR DESCRIPTION
## Summary
- Rewrites continue_existing_conversation docs to describe real binding-key continuation
- Adds deep-link regression tests for reused notification threads
- Adds broadcaster regression ensuring reused threads don't emit thread-created events

Part of plan: notification-thread-continuation.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
