### PR TITLE
feat: add readiness probes for email and WhatsApp invite flows

### DIFF
--- a/assistant/README.md
+++ b/assistant/README.md
@@ -379,15 +379,19 @@ All endpoints are bearer-authenticated. Skills and clients should call the gatew
 ### Built-in Channel Probes
 
 - **SMS**: Checks Twilio credentials, phone number assignment, and public ingress URL.
+- **Voice**: Checks Twilio credentials, phone number assignment, and public ingress URL.
 - **Telegram**: Checks bot token, webhook secret, and public ingress URL.
+- **Email**: Checks AgentMail API key, invite policy, and public ingress URL.
+- **WhatsApp**: Checks Twilio credentials, phone number assignment, invite policy, and public ingress URL.
+- **Slack**: Checks bot token and app token.
 
 ### Key modules
 
-| File                                             | Purpose                                                                                              |
-| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| `src/runtime/channel-readiness-types.ts`         | Shared types: `ChannelId`, `ReadinessCheckResult`, `ChannelReadinessSnapshot`, `ChannelProbe`        |
-| `src/runtime/channel-readiness-service.ts`       | Service class with probe registration, cached readiness evaluation, and built-in SMS/Telegram probes |
-| `src/runtime/routes/channel-readiness-routes.ts` | HTTP route handlers for `/v1/channels/readiness` and `/v1/channels/readiness/refresh`                |
+| File                                             | Purpose                                                                                         |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| `src/runtime/channel-readiness-types.ts`         | Shared types: `ChannelId`, `ReadinessCheckResult`, `ChannelReadinessSnapshot`, `ChannelProbe`   |
+| `src/runtime/channel-readiness-service.ts`       | Service class with probe registration, cached readiness evaluation, and built-in channel probes |
+| `src/runtime/routes/channel-readiness-routes.ts` | HTTP route handlers for `/v1/channels/readiness` and `/v1/channels/readiness/refresh`           |
 
 ## Ingress Membership + Escalation
 

--- a/assistant/src/__tests__/channel-readiness-routes.test.ts
+++ b/assistant/src/__tests__/channel-readiness-routes.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests that the channel readiness service returns real readiness snapshots
+ * for email and WhatsApp channels (not unsupported placeholders).
+ *
+ * Uses the same mock approach as channel-readiness-service.test.ts but
+ * exercises the createReadinessService factory to verify probe registration.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before importing the service
+// ---------------------------------------------------------------------------
+
+let mockTwilioPhoneNumberEnv: string | undefined;
+let mockRawConfig: Record<string, unknown> | undefined;
+let mockSecureKeys: Record<string, string>;
+let mockHasTwilioCredentials: boolean;
+
+mock.module("../calls/twilio-rest.js", () => ({
+  hasTwilioCredentials: () => mockHasTwilioCredentials,
+  getPhoneNumberSid: async () => null,
+  getTollFreeVerificationStatus: async () => null,
+}));
+
+mock.module("../config/env.js", () => ({
+  getTwilioPhoneNumberEnv: () => mockTwilioPhoneNumberEnv,
+}));
+
+mock.module("../config/loader.js", () => ({
+  loadRawConfig: () => mockRawConfig,
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKey: (key: string) => mockSecureKeys[key] ?? null,
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test
+// ---------------------------------------------------------------------------
+
+import { createReadinessService } from "../runtime/channel-readiness-service.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("channel readiness routes — email and WhatsApp probes", () => {
+  beforeEach(() => {
+    mockTwilioPhoneNumberEnv = undefined;
+    mockRawConfig = undefined;
+    mockSecureKeys = {};
+    mockHasTwilioCredentials = false;
+  });
+
+  // -------------------------------------------------------------------------
+  // Email probe
+  // -------------------------------------------------------------------------
+
+  describe("email", () => {
+    test("returns real readiness snapshot (not unsupported)", async () => {
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("email");
+
+      expect(snapshot.channel).toBe("email");
+      // Should have real local checks, not the unsupported placeholder
+      expect(snapshot.localChecks.length).toBeGreaterThan(0);
+      expect(
+        snapshot.reasons.some((r) => r.code === "unsupported_channel"),
+      ).toBe(false);
+    });
+
+    test("reports not ready when AgentMail API key is missing", async () => {
+      mockRawConfig = {};
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("email");
+
+      expect(snapshot.ready).toBe(false);
+      expect(snapshot.reasons.some((r) => r.code === "agentmail_api_key")).toBe(
+        true,
+      );
+    });
+
+    test("checks invite policy", async () => {
+      mockSecureKeys = { agentmail: "test-key" };
+      mockRawConfig = {
+        ingress: { publicBaseUrl: "https://example.com", enabled: true },
+      };
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("email");
+
+      const inviteCheck = snapshot.localChecks.find(
+        (c) => c.name === "invite_policy",
+      );
+      expect(inviteCheck).toBeDefined();
+      // Email has codeRedemptionEnabled: true in the channel policy registry
+      expect(inviteCheck!.passed).toBe(true);
+    });
+
+    test("checks ingress configuration", async () => {
+      mockSecureKeys = { agentmail: "test-key" };
+      mockRawConfig = {};
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("email");
+
+      const ingressCheck = snapshot.localChecks.find(
+        (c) => c.name === "ingress",
+      );
+      expect(ingressCheck).toBeDefined();
+      expect(ingressCheck!.passed).toBe(false);
+    });
+
+    test("ready when all prerequisites are met", async () => {
+      mockSecureKeys = { agentmail: "test-key" };
+      mockRawConfig = {
+        ingress: { publicBaseUrl: "https://example.com", enabled: true },
+      };
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("email");
+
+      expect(snapshot.ready).toBe(true);
+      expect(snapshot.reasons).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // WhatsApp probe
+  // -------------------------------------------------------------------------
+
+  describe("whatsapp", () => {
+    test("returns real readiness snapshot (not unsupported)", async () => {
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("whatsapp");
+
+      expect(snapshot.channel).toBe("whatsapp");
+      expect(snapshot.localChecks.length).toBeGreaterThan(0);
+      expect(
+        snapshot.reasons.some((r) => r.code === "unsupported_channel"),
+      ).toBe(false);
+    });
+
+    test("reports not ready when Twilio credentials are missing", async () => {
+      mockRawConfig = {};
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("whatsapp");
+
+      expect(snapshot.ready).toBe(false);
+      expect(
+        snapshot.reasons.some((r) => r.code === "twilio_credentials"),
+      ).toBe(true);
+    });
+
+    test("reports not ready when phone number is missing", async () => {
+      mockHasTwilioCredentials = true;
+      mockRawConfig = {};
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("whatsapp");
+
+      expect(snapshot.ready).toBe(false);
+      expect(snapshot.reasons.some((r) => r.code === "phone_number")).toBe(
+        true,
+      );
+    });
+
+    test("resolves phone number from whatsapp config", async () => {
+      mockHasTwilioCredentials = true;
+      mockRawConfig = {
+        whatsapp: { phoneNumber: "+15551234567" },
+        ingress: { publicBaseUrl: "https://example.com", enabled: true },
+      };
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("whatsapp");
+
+      const phoneCheck = snapshot.localChecks.find(
+        (c) => c.name === "phone_number",
+      );
+      expect(phoneCheck).toBeDefined();
+      expect(phoneCheck!.passed).toBe(true);
+    });
+
+    test("falls back to sms config for phone number", async () => {
+      mockHasTwilioCredentials = true;
+      mockRawConfig = {
+        sms: { phoneNumber: "+15559876543" },
+        ingress: { publicBaseUrl: "https://example.com", enabled: true },
+      };
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("whatsapp");
+
+      const phoneCheck = snapshot.localChecks.find(
+        (c) => c.name === "phone_number",
+      );
+      expect(phoneCheck!.passed).toBe(true);
+    });
+
+    test("checks invite policy", async () => {
+      mockHasTwilioCredentials = true;
+      mockTwilioPhoneNumberEnv = "+15551234567";
+      mockRawConfig = {
+        ingress: { publicBaseUrl: "https://example.com", enabled: true },
+      };
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("whatsapp");
+
+      const inviteCheck = snapshot.localChecks.find(
+        (c) => c.name === "invite_policy",
+      );
+      expect(inviteCheck).toBeDefined();
+      // WhatsApp has codeRedemptionEnabled: true in the channel policy registry
+      expect(inviteCheck!.passed).toBe(true);
+    });
+
+    test("checks ingress configuration", async () => {
+      mockHasTwilioCredentials = true;
+      mockTwilioPhoneNumberEnv = "+15551234567";
+      mockRawConfig = {};
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("whatsapp");
+
+      const ingressCheck = snapshot.localChecks.find(
+        (c) => c.name === "ingress",
+      );
+      expect(ingressCheck).toBeDefined();
+      expect(ingressCheck!.passed).toBe(false);
+    });
+
+    test("ready when all prerequisites are met", async () => {
+      mockHasTwilioCredentials = true;
+      mockTwilioPhoneNumberEnv = "+15551234567";
+      mockRawConfig = {
+        ingress: { publicBaseUrl: "https://example.com", enabled: true },
+      };
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("whatsapp");
+
+      expect(snapshot.ready).toBe(true);
+      expect(snapshot.reasons).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Factory coverage — all channels registered
+  // -------------------------------------------------------------------------
+
+  describe("createReadinessService factory", () => {
+    test("registers probes for all deliverable channels including email and whatsapp", async () => {
+      const service = createReadinessService();
+      const snapshots = await service.getReadiness();
+
+      const channels = snapshots.map((s) => s.channel).sort();
+      expect(channels).toContain("email");
+      expect(channels).toContain("whatsapp");
+
+      // None should be unsupported placeholders
+      for (const s of snapshots) {
+        expect(s.reasons.some((r) => r.code === "unsupported_channel")).toBe(
+          false,
+        );
+      }
+    });
+  });
+});

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -3,6 +3,7 @@ import {
   getTollFreeVerificationStatus,
   hasTwilioCredentials,
 } from "../calls/twilio-rest.js";
+import { getChannelInvitePolicy } from "../channels/config.js";
 import { getTwilioPhoneNumberEnv } from "../config/env.js";
 import { loadRawConfig } from "../config/loader.js";
 import { getSecureKey } from "../security/secure-keys.js";
@@ -280,18 +281,115 @@ const telegramProbe: ChannelProbe = {
 const emailProbe: ChannelProbe = {
   channel: "email",
   runLocalChecks(): ReadinessCheckResult[] {
+    const results: ReadinessCheckResult[] = [];
+
     const hasApiKey = !!(
       getSecureKey("agentmail") || getSecureKey("credential:agentmail:api_key")
     );
-    return [
-      {
-        name: "agentmail_api_key",
-        passed: hasApiKey,
-        message: hasApiKey
-          ? "AgentMail API key is configured"
-          : "AgentMail API key is not configured",
-      },
-    ];
+    results.push({
+      name: "agentmail_api_key",
+      passed: hasApiKey,
+      message: hasApiKey
+        ? "AgentMail API key is configured"
+        : "AgentMail API key is not configured",
+    });
+
+    const invitePolicy = getChannelInvitePolicy("email");
+    results.push({
+      name: "invite_policy",
+      passed: invitePolicy.codeRedemptionEnabled,
+      message: invitePolicy.codeRedemptionEnabled
+        ? "Email invite code redemption is enabled"
+        : "Email invite code redemption is disabled",
+    });
+
+    const hasIngress = hasIngressConfigured();
+    results.push({
+      name: "ingress",
+      passed: hasIngress,
+      message: hasIngress
+        ? "Public ingress URL is configured"
+        : "Public ingress URL is not configured or disabled",
+    });
+
+    return results;
+  },
+};
+
+// ── WhatsApp Probe ──────────────────────────────────────────────────────────
+
+/**
+ * Resolve the WhatsApp phone number with canonical precedence:
+ * env override -> config whatsapp.phoneNumber -> config sms.phoneNumber
+ * -> secure key fallback.
+ *
+ * WhatsApp typically shares the Twilio phone number with SMS, but
+ * allows a channel-specific override via config.
+ */
+function resolveWhatsAppPhoneNumber(): string {
+  try {
+    const raw = loadRawConfig();
+    const whatsappConfig = (raw?.whatsapp ?? {}) as Record<string, unknown>;
+    const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
+    return (
+      getTwilioPhoneNumberEnv() ||
+      (whatsappConfig.phoneNumber as string) ||
+      (smsConfig.phoneNumber as string) ||
+      getSecureKey("credential:twilio:phone_number") ||
+      ""
+    );
+  } catch {
+    return (
+      getTwilioPhoneNumberEnv() ||
+      getSecureKey("credential:twilio:phone_number") ||
+      ""
+    );
+  }
+}
+
+const whatsappProbe: ChannelProbe = {
+  channel: "whatsapp",
+  runLocalChecks(): ReadinessCheckResult[] {
+    const results: ReadinessCheckResult[] = [];
+
+    const hasCreds = hasTwilioCredentials();
+    results.push({
+      name: "twilio_credentials",
+      passed: hasCreds,
+      message: hasCreds
+        ? "Twilio credentials are configured"
+        : "Twilio Account SID and Auth Token are not configured",
+    });
+
+    const resolvedNumber = resolveWhatsAppPhoneNumber();
+    const hasPhone = !!resolvedNumber;
+    results.push({
+      name: "phone_number",
+      passed: hasPhone,
+      message: hasPhone
+        ? "WhatsApp phone number is assigned"
+        : "No WhatsApp phone number assigned",
+    });
+
+    const invitePolicy = getChannelInvitePolicy("whatsapp");
+    results.push({
+      name: "invite_policy",
+      passed: invitePolicy.codeRedemptionEnabled,
+      message: invitePolicy.codeRedemptionEnabled
+        ? "WhatsApp invite code redemption is enabled"
+        : "WhatsApp invite code redemption is disabled",
+    });
+
+    const hasIngress = hasIngressConfigured();
+    results.push({
+      name: "ingress",
+      passed: hasIngress,
+      message: hasIngress
+        ? "Public ingress URL is configured"
+        : "Public ingress URL is not configured or disabled",
+    });
+
+    return results;
   },
 };
 
@@ -462,13 +560,14 @@ export class ChannelReadinessService {
 
 // ── Factory ─────────────────────────────────────────────────────────────────
 
-/** Create a service instance with built-in SMS, Voice, Telegram, Email, and Slack probes registered. */
+/** Create a service instance with built-in SMS, Voice, Telegram, Email, WhatsApp, and Slack probes registered. */
 export function createReadinessService(): ChannelReadinessService {
   const service = new ChannelReadinessService();
   service.registerProbe(smsProbe);
   service.registerProbe(voiceProbe);
   service.registerProbe(telegramProbe);
   service.registerProbe(emailProbe);
+  service.registerProbe(whatsappProbe);
   service.registerProbe(slackProbe);
   return service;
 }


### PR DESCRIPTION
## Summary
- Adds WhatsApp readiness probe checking Twilio credentials, phone number, invite policy, and ingress
- Enhances existing email probe with invite policy and ingress checks (previously only checked AgentMail API key)
- Registers WhatsApp probe in the factory so it returns real snapshots instead of unsupported placeholders
- Adds comprehensive test coverage for both email and WhatsApp readiness probes
- Updates README to document all built-in channel probes

Part of plan: channel-gap-cleanup.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
