### PR TITLE
feat: add shared client store for usage and cost summaries

### DIFF
--- a/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
@@ -1,0 +1,335 @@
+import Foundation
+import Testing
+@testable import VellumAssistantShared
+
+// MARK: - Mock Client
+
+@MainActor
+private final class MockUsageClient: DaemonClientProtocol {
+    var isConnected: Bool = true
+    var isBlobTransportAvailable: Bool = false
+
+    func subscribe() -> AsyncStream<ServerMessage> { AsyncStream { $0.finish() } }
+    func send<T: Encodable>(_ message: T) throws {}
+    func connect() async throws {}
+    func disconnect() {}
+    func startSSE() {}
+    func stopSSE() {}
+
+    var stubbedTotals: UsageTotalsResponse?
+    var stubbedDaily: UsageDailyResponse?
+    var stubbedBreakdown: UsageBreakdownResponse?
+
+    var lastTotalsFrom: Int?
+    var lastTotalsTo: Int?
+    var lastDailyFrom: Int?
+    var lastDailyTo: Int?
+    var lastBreakdownFrom: Int?
+    var lastBreakdownTo: Int?
+    var lastBreakdownGroupBy: String?
+
+    func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse? {
+        lastTotalsFrom = from
+        lastTotalsTo = to
+        return stubbedTotals
+    }
+
+    func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse? {
+        lastDailyFrom = from
+        lastDailyTo = to
+        return stubbedDaily
+    }
+
+    func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse? {
+        lastBreakdownFrom = from
+        lastBreakdownTo = to
+        lastBreakdownGroupBy = groupBy
+        return stubbedBreakdown
+    }
+}
+
+// MARK: - JSON Decoding Tests
+
+@Suite("UsageDashboardStore — JSON Decoding")
+struct UsageDashboardStoreDecodingTests {
+
+    @Test
+    func decodeTotalsResponse() throws {
+        let json = """
+        {
+            "totalInputTokens": 1000,
+            "totalOutputTokens": 500,
+            "totalCacheCreationTokens": 200,
+            "totalCacheReadTokens": 100,
+            "totalEstimatedCostUsd": 0.05,
+            "eventCount": 10,
+            "pricedEventCount": 8,
+            "unpricedEventCount": 2
+        }
+        """
+        let decoded = try JSONDecoder().decode(UsageTotalsResponse.self, from: Data(json.utf8))
+        #expect(decoded.totalInputTokens == 1000)
+        #expect(decoded.totalOutputTokens == 500)
+        #expect(decoded.totalCacheCreationTokens == 200)
+        #expect(decoded.totalCacheReadTokens == 100)
+        #expect(decoded.totalEstimatedCostUsd == 0.05)
+        #expect(decoded.eventCount == 10)
+        #expect(decoded.pricedEventCount == 8)
+        #expect(decoded.unpricedEventCount == 2)
+    }
+
+    @Test
+    func decodeDailyResponse() throws {
+        let json = """
+        {
+            "buckets": [
+                {
+                    "date": "2026-03-01",
+                    "totalInputTokens": 400,
+                    "totalOutputTokens": 200,
+                    "totalEstimatedCostUsd": 0.02,
+                    "eventCount": 3
+                },
+                {
+                    "date": "2026-03-02",
+                    "totalInputTokens": 600,
+                    "totalOutputTokens": 300,
+                    "totalEstimatedCostUsd": 0.03,
+                    "eventCount": 7
+                }
+            ]
+        }
+        """
+        let decoded = try JSONDecoder().decode(UsageDailyResponse.self, from: Data(json.utf8))
+        #expect(decoded.buckets.count == 2)
+        #expect(decoded.buckets[0].date == "2026-03-01")
+        #expect(decoded.buckets[0].totalInputTokens == 400)
+        #expect(decoded.buckets[1].date == "2026-03-02")
+        #expect(decoded.buckets[1].eventCount == 7)
+    }
+
+    @Test
+    func decodeBreakdownResponse() throws {
+        let json = """
+        {
+            "breakdown": [
+                {
+                    "group": "claude-sonnet-4-20250514",
+                    "totalInputTokens": 800,
+                    "totalOutputTokens": 400,
+                    "totalEstimatedCostUsd": 0.04,
+                    "eventCount": 5
+                },
+                {
+                    "group": "claude-haiku-3",
+                    "totalInputTokens": 200,
+                    "totalOutputTokens": 100,
+                    "totalEstimatedCostUsd": 0.01,
+                    "eventCount": 5
+                }
+            ]
+        }
+        """
+        let decoded = try JSONDecoder().decode(UsageBreakdownResponse.self, from: Data(json.utf8))
+        #expect(decoded.breakdown.count == 2)
+        #expect(decoded.breakdown[0].group == "claude-sonnet-4-20250514")
+        #expect(decoded.breakdown[0].totalInputTokens == 800)
+        #expect(decoded.breakdown[1].group == "claude-haiku-3")
+        #expect(decoded.breakdown[1].totalEstimatedCostUsd == 0.01)
+    }
+}
+
+// MARK: - Loading State Tests
+
+@Suite("UsageDashboardStore — Loading States")
+struct UsageDashboardStoreLoadingTests {
+
+    @Test @MainActor
+    func refreshTransitionsToLoadedOnSuccess() async {
+        let client = MockUsageClient()
+        client.stubbedTotals = UsageTotalsResponse(
+            totalInputTokens: 100, totalOutputTokens: 50,
+            totalCacheCreationTokens: 10, totalCacheReadTokens: 5,
+            totalEstimatedCostUsd: 0.01, eventCount: 3,
+            pricedEventCount: 2, unpricedEventCount: 1
+        )
+        client.stubbedDaily = UsageDailyResponse(buckets: [
+            UsageDayBucket(date: "2026-03-05", totalInputTokens: 100, totalOutputTokens: 50, totalEstimatedCostUsd: 0.01, eventCount: 3)
+        ])
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [
+            UsageGroupBreakdownEntry(group: "model-a", totalInputTokens: 100, totalOutputTokens: 50, totalEstimatedCostUsd: 0.01, eventCount: 3)
+        ])
+
+        let store = UsageDashboardStore(client: client)
+        #expect(store.totalsState == .idle)
+        #expect(store.dailyState == .idle)
+        #expect(store.breakdownState == .idle)
+
+        await store.refresh()
+
+        if case .loaded(let totals) = store.totalsState {
+            #expect(totals.totalInputTokens == 100)
+            #expect(totals.eventCount == 3)
+        } else {
+            Issue.record("Expected .loaded state for totals")
+        }
+
+        if case .loaded(let daily) = store.dailyState {
+            #expect(daily.buckets.count == 1)
+            #expect(daily.buckets[0].date == "2026-03-05")
+        } else {
+            Issue.record("Expected .loaded state for daily")
+        }
+
+        if case .loaded(let breakdown) = store.breakdownState {
+            #expect(breakdown.breakdown.count == 1)
+            #expect(breakdown.breakdown[0].group == "model-a")
+        } else {
+            Issue.record("Expected .loaded state for breakdown")
+        }
+    }
+
+    @Test @MainActor
+    func refreshTransitionsToFailedOnNilResponse() async {
+        let client = MockUsageClient()
+        // All stubs nil by default — simulates network failure.
+
+        let store = UsageDashboardStore(client: client)
+        await store.refresh()
+
+        if case .failed(let msg) = store.totalsState {
+            #expect(msg.contains("totals"))
+        } else {
+            Issue.record("Expected .failed state for totals")
+        }
+
+        if case .failed(let msg) = store.dailyState {
+            #expect(msg.contains("daily"))
+        } else {
+            Issue.record("Expected .failed state for daily")
+        }
+
+        if case .failed(let msg) = store.breakdownState {
+            #expect(msg.contains("breakdown"))
+        } else {
+            Issue.record("Expected .failed state for breakdown")
+        }
+    }
+
+    @Test @MainActor
+    func selectRangeChangesRangeAndRefreshes() async {
+        let client = MockUsageClient()
+        client.stubbedTotals = UsageTotalsResponse(
+            totalInputTokens: 0, totalOutputTokens: 0,
+            totalCacheCreationTokens: 0, totalCacheReadTokens: 0,
+            totalEstimatedCostUsd: 0, eventCount: 0,
+            pricedEventCount: 0, unpricedEventCount: 0
+        )
+        client.stubbedDaily = UsageDailyResponse(buckets: [])
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [])
+
+        let store = UsageDashboardStore(client: client)
+        #expect(store.selectedRange == .last7Days)
+
+        await store.selectRange(.last30Days)
+        #expect(store.selectedRange == .last30Days)
+
+        // Verify the client was called with non-nil range params
+        #expect(client.lastTotalsFrom != nil)
+        #expect(client.lastTotalsTo != nil)
+    }
+}
+
+// MARK: - Grouped Summary Derivation
+
+@Suite("UsageDashboardStore — Grouped Summaries")
+struct UsageDashboardStoreGroupTests {
+
+    @Test @MainActor
+    func selectGroupByRefreshesBreakdownOnly() async {
+        let client = MockUsageClient()
+        client.stubbedTotals = UsageTotalsResponse(
+            totalInputTokens: 100, totalOutputTokens: 50,
+            totalCacheCreationTokens: 0, totalCacheReadTokens: 0,
+            totalEstimatedCostUsd: 0.01, eventCount: 1,
+            pricedEventCount: 1, unpricedEventCount: 0
+        )
+        client.stubbedDaily = UsageDailyResponse(buckets: [])
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [
+            UsageGroupBreakdownEntry(group: "anthropic", totalInputTokens: 100, totalOutputTokens: 50, totalEstimatedCostUsd: 0.01, eventCount: 1)
+        ])
+
+        let store = UsageDashboardStore(client: client)
+
+        // Initial refresh to populate all states
+        await store.refresh()
+        #expect(client.lastBreakdownGroupBy == "model")
+
+        // Now change group-by — should only re-fetch breakdown
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [
+            UsageGroupBreakdownEntry(group: "provider-x", totalInputTokens: 50, totalOutputTokens: 25, totalEstimatedCostUsd: 0.005, eventCount: 1)
+        ])
+        await store.selectGroupBy(.provider)
+
+        #expect(store.selectedGroupBy == .provider)
+        #expect(client.lastBreakdownGroupBy == "provider")
+
+        if case .loaded(let breakdown) = store.breakdownState {
+            #expect(breakdown.breakdown[0].group == "provider-x")
+        } else {
+            Issue.record("Expected .loaded state for breakdown after selectGroupBy")
+        }
+    }
+
+    @Test @MainActor
+    func breakdownGroupedByActorPassesCorrectParam() async {
+        let client = MockUsageClient()
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [])
+
+        let store = UsageDashboardStore(client: client)
+        await store.selectGroupBy(.actor)
+
+        #expect(client.lastBreakdownGroupBy == "actor")
+    }
+}
+
+// MARK: - Time Range Bounds
+
+@Suite("UsageTimeRange — Epoch Bounds")
+struct UsageTimeRangeTests {
+
+    @Test
+    func todayRangeStartsAtMidnight() {
+        let now = Date(timeIntervalSince1970: 1709683200) // 2024-03-06 00:00:00 UTC
+        let range = UsageTimeRange.today.epochMillisRange(now: now)
+
+        let calendar = Calendar(identifier: .gregorian)
+        let startOfDay = calendar.startOfDay(for: now)
+        let expectedFrom = Int(startOfDay.timeIntervalSince1970 * 1000)
+
+        #expect(range.from == expectedFrom)
+        #expect(range.to == Int(now.timeIntervalSince1970 * 1000))
+    }
+
+    @Test
+    func last7DaysSpansSixDaysBack() {
+        let now = Date(timeIntervalSince1970: 1709683200) // 2024-03-06 00:00:00 UTC
+        let range = UsageTimeRange.last7Days.epochMillisRange(now: now)
+
+        let calendar = Calendar(identifier: .gregorian)
+        let startOfToday = calendar.startOfDay(for: now)
+        let sixDaysAgo = calendar.date(byAdding: .day, value: -6, to: startOfToday)!
+        let expectedFrom = Int(sixDaysAgo.timeIntervalSince1970 * 1000)
+
+        #expect(range.from == expectedFrom)
+        #expect(range.to == Int(now.timeIntervalSince1970 * 1000))
+    }
+
+    @Test
+    func fromIsAlwaysLessThanOrEqualToTo() {
+        for timeRange in UsageTimeRange.allCases {
+            let range = timeRange.epochMillisRange()
+            #expect(range.from <= range.to, "from should be <= to for \(timeRange.rawValue)")
+        }
+    }
+}

--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+// MARK: - Time Range Selection
+
+/// Predefined time ranges for the usage dashboard.
+public enum UsageTimeRange: String, CaseIterable, Sendable {
+    case today = "Today"
+    case last7Days = "Last 7 Days"
+    case last30Days = "Last 30 Days"
+    case last90Days = "Last 90 Days"
+
+    /// Compute the epoch-millisecond `from` and `to` bounds for this range.
+    /// `to` is always the current instant; `from` is midnight UTC of the starting day.
+    public func epochMillisRange(now: Date = Date()) -> (from: Int, to: Int) {
+        let to = Int(now.timeIntervalSince1970 * 1000)
+        let calendar = Calendar(identifier: .gregorian)
+        let startOfToday = calendar.startOfDay(for: now)
+
+        let startDate: Date
+        switch self {
+        case .today:
+            startDate = startOfToday
+        case .last7Days:
+            startDate = calendar.date(byAdding: .day, value: -6, to: startOfToday)!
+        case .last30Days:
+            startDate = calendar.date(byAdding: .day, value: -29, to: startOfToday)!
+        case .last90Days:
+            startDate = calendar.date(byAdding: .day, value: -89, to: startOfToday)!
+        }
+
+        let from = Int(startDate.timeIntervalSince1970 * 1000)
+        return (from: from, to: to)
+    }
+}
+
+// MARK: - Loading State
+
+/// Tri-state loading model for async fetches.
+public enum UsageLoadingState<T: Equatable>: Equatable {
+    case idle
+    case loading
+    case loaded(T)
+    case failed(String)
+}
+
+// MARK: - Group-By Dimension
+
+/// The dimension to group usage breakdown by.
+public enum UsageGroupByDimension: String, CaseIterable, Sendable {
+    case actor
+    case provider
+    case model
+}
+
+// MARK: - UsageDashboardStore
+
+/// Shared store that owns the selected time range, fetches usage data from the
+/// daemon client, and exposes loaded summaries for both macOS and iOS dashboards.
+@MainActor
+@Observable
+public final class UsageDashboardStore {
+
+    // MARK: - State
+
+    public var selectedRange: UsageTimeRange = .last7Days
+    public var totalsState: UsageLoadingState<UsageTotalsResponse> = .idle
+    public var dailyState: UsageLoadingState<UsageDailyResponse> = .idle
+    public var breakdownState: UsageLoadingState<UsageBreakdownResponse> = .idle
+    public var selectedGroupBy: UsageGroupByDimension = .model
+
+    // MARK: - Dependencies
+
+    private let client: any DaemonClientProtocol
+
+    public init(client: any DaemonClientProtocol) {
+        self.client = client
+    }
+
+    // MARK: - Refresh
+
+    /// Load all usage data (totals, daily, breakdown) for the currently selected range.
+    public func refresh() async {
+        let range = selectedRange.epochMillisRange()
+
+        totalsState = .loading
+        dailyState = .loading
+        breakdownState = .loading
+
+        async let totalsResult = client.fetchUsageTotals(from: range.from, to: range.to)
+        async let dailyResult = client.fetchUsageDaily(from: range.from, to: range.to)
+        async let breakdownResult = client.fetchUsageBreakdown(
+            from: range.from, to: range.to, groupBy: selectedGroupBy.rawValue
+        )
+
+        let totals = await totalsResult
+        let daily = await dailyResult
+        let breakdown = await breakdownResult
+
+        if let totals {
+            totalsState = .loaded(totals)
+        } else {
+            totalsState = .failed("Failed to load usage totals")
+        }
+
+        if let daily {
+            dailyState = .loaded(daily)
+        } else {
+            dailyState = .failed("Failed to load daily usage")
+        }
+
+        if let breakdown {
+            breakdownState = .loaded(breakdown)
+        } else {
+            breakdownState = .failed("Failed to load usage breakdown")
+        }
+    }
+
+    /// Convenience to change the selected range and immediately refresh.
+    public func selectRange(_ range: UsageTimeRange) async {
+        selectedRange = range
+        await refresh()
+    }
+
+    /// Convenience to change the group-by dimension and refresh the breakdown.
+    public func selectGroupBy(_ dimension: UsageGroupByDimension) async {
+        selectedGroupBy = dimension
+
+        let range = selectedRange.epochMillisRange()
+        breakdownState = .loading
+
+        let result = await client.fetchUsageBreakdown(
+            from: range.from, to: range.to, groupBy: dimension.rawValue
+        )
+        if let result {
+            breakdownState = .loaded(result)
+        } else {
+            breakdownState = .failed("Failed to load usage breakdown")
+        }
+    }
+}

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -115,11 +115,103 @@ public protocol DaemonClientProtocol {
     func startSSE()
     func stopSSE()
     func fetchSurfaceData(surfaceId: String, sessionId: String) async -> SurfaceData?
+    func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse?
+    func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse?
+    func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse?
 }
 
 extension DaemonClientProtocol {
     /// Default no-op implementation for clients that don't support HTTP surface fetches.
     public func fetchSurfaceData(surfaceId: String, sessionId: String) async -> SurfaceData? { nil }
+    public func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse? { nil }
+    public func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse? { nil }
+    public func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse? { nil }
+}
+
+// MARK: - Usage Response Models
+
+/// Aggregate totals for a time range from `GET /v1/usage/totals`.
+public struct UsageTotalsResponse: Decodable, Equatable, Sendable {
+    public let totalInputTokens: Int
+    public let totalOutputTokens: Int
+    public let totalCacheCreationTokens: Int
+    public let totalCacheReadTokens: Int
+    public let totalEstimatedCostUsd: Double
+    public let eventCount: Int
+    public let pricedEventCount: Int
+    public let unpricedEventCount: Int
+
+    public init(
+        totalInputTokens: Int,
+        totalOutputTokens: Int,
+        totalCacheCreationTokens: Int,
+        totalCacheReadTokens: Int,
+        totalEstimatedCostUsd: Double,
+        eventCount: Int,
+        pricedEventCount: Int,
+        unpricedEventCount: Int
+    ) {
+        self.totalInputTokens = totalInputTokens
+        self.totalOutputTokens = totalOutputTokens
+        self.totalCacheCreationTokens = totalCacheCreationTokens
+        self.totalCacheReadTokens = totalCacheReadTokens
+        self.totalEstimatedCostUsd = totalEstimatedCostUsd
+        self.eventCount = eventCount
+        self.pricedEventCount = pricedEventCount
+        self.unpricedEventCount = unpricedEventCount
+    }
+}
+
+/// A single day bucket from `GET /v1/usage/daily`.
+public struct UsageDayBucket: Decodable, Equatable, Sendable {
+    public let date: String
+    public let totalInputTokens: Int
+    public let totalOutputTokens: Int
+    public let totalEstimatedCostUsd: Double
+    public let eventCount: Int
+
+    public init(date: String, totalInputTokens: Int, totalOutputTokens: Int, totalEstimatedCostUsd: Double, eventCount: Int) {
+        self.date = date
+        self.totalInputTokens = totalInputTokens
+        self.totalOutputTokens = totalOutputTokens
+        self.totalEstimatedCostUsd = totalEstimatedCostUsd
+        self.eventCount = eventCount
+    }
+}
+
+/// Response wrapper for `GET /v1/usage/daily`.
+public struct UsageDailyResponse: Decodable, Equatable, Sendable {
+    public let buckets: [UsageDayBucket]
+
+    public init(buckets: [UsageDayBucket]) {
+        self.buckets = buckets
+    }
+}
+
+/// A single grouped breakdown row from `GET /v1/usage/breakdown`.
+public struct UsageGroupBreakdownEntry: Decodable, Equatable, Sendable {
+    public let group: String
+    public let totalInputTokens: Int
+    public let totalOutputTokens: Int
+    public let totalEstimatedCostUsd: Double
+    public let eventCount: Int
+
+    public init(group: String, totalInputTokens: Int, totalOutputTokens: Int, totalEstimatedCostUsd: Double, eventCount: Int) {
+        self.group = group
+        self.totalInputTokens = totalInputTokens
+        self.totalOutputTokens = totalOutputTokens
+        self.totalEstimatedCostUsd = totalEstimatedCostUsd
+        self.eventCount = eventCount
+    }
+}
+
+/// Response wrapper for `GET /v1/usage/breakdown`.
+public struct UsageBreakdownResponse: Decodable, Equatable, Sendable {
+    public let breakdown: [UsageGroupBreakdownEntry]
+
+    public init(breakdown: [UsageGroupBreakdownEntry]) {
+        self.breakdown = breakdown
+    }
 }
 
 extension Notification.Name {
@@ -785,6 +877,73 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             let (data, response) = try await URLSession.shared.data(for: request)
             guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else { return nil }
             return Surface.parseSurfaceDataFromResponse(data)
+        } catch {
+            return nil
+        }
+    }
+
+    // MARK: - Usage Reporting
+
+    /// Fetch aggregate usage totals for a time range (epoch milliseconds).
+    /// Delegates to HTTPTransport for remote connections, or calls the local daemon HTTP server.
+    public func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse? {
+        if let httpTransport {
+            return await httpTransport.fetchUsageTotals(from: from, to: to)
+        }
+
+        guard let request = buildLocalRequest(
+            target: .daemon,
+            path: "v1/usage/totals?from=\(from)&to=\(to)",
+            timeout: 10
+        ) else { return nil }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else { return nil }
+            return try JSONDecoder().decode(UsageTotalsResponse.self, from: data)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Fetch per-day usage buckets for a time range (epoch milliseconds).
+    public func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse? {
+        if let httpTransport {
+            return await httpTransport.fetchUsageDaily(from: from, to: to)
+        }
+
+        guard let request = buildLocalRequest(
+            target: .daemon,
+            path: "v1/usage/daily?from=\(from)&to=\(to)",
+            timeout: 10
+        ) else { return nil }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else { return nil }
+            return try JSONDecoder().decode(UsageDailyResponse.self, from: data)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Fetch grouped usage breakdown for a time range (epoch milliseconds).
+    public func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse? {
+        if let httpTransport {
+            return await httpTransport.fetchUsageBreakdown(from: from, to: to, groupBy: groupBy)
+        }
+
+        let encoded = groupBy.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? groupBy
+        guard let request = buildLocalRequest(
+            target: .daemon,
+            path: "v1/usage/breakdown?from=\(from)&to=\(to)&groupBy=\(encoded)",
+            timeout: 10
+        ) else { return nil }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else { return nil }
+            return try JSONDecoder().decode(UsageBreakdownResponse.self, from: data)
         } catch {
             return nil
         }

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -176,6 +176,9 @@ public final class HTTPTransport {
         case contactsInvitesCreate
         case channelsReadiness
         case surfaceContent(surfaceId: String, sessionId: String)
+        case usageTotals(from: Int, to: Int)
+        case usageDaily(from: Int, to: Int)
+        case usageBreakdown(from: Int, to: Int, groupBy: String)
     }
 
     /// Build a URL for the given endpoint using the current route mode.
@@ -278,6 +281,13 @@ public final class HTTPTransport {
             let sEncoded = surfaceId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? surfaceId
             let qEncoded = sessionId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? sessionId
             return ("/v1/surfaces/\(sEncoded)", "sessionId=\(qEncoded)")
+        case .usageTotals(let from, let to):
+            return ("/v1/usage/totals", "from=\(from)&to=\(to)")
+        case .usageDaily(let from, let to):
+            return ("/v1/usage/daily", "from=\(from)&to=\(to)")
+        case .usageBreakdown(let from, let to, let groupBy):
+            let encoded = groupBy.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? groupBy
+            return ("/v1/usage/breakdown", "from=\(from)&to=\(to)&groupBy=\(encoded)")
         }
     }
 
@@ -361,6 +371,13 @@ public final class HTTPTransport {
             let sEncoded = surfaceId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? surfaceId
             let qEncoded = sessionId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? sessionId
             return ("\(prefix)/surfaces/\(sEncoded)/", "sessionId=\(qEncoded)")
+        case .usageTotals(let from, let to):
+            return ("\(prefix)/usage/totals/", "from=\(from)&to=\(to)")
+        case .usageDaily(let from, let to):
+            return ("\(prefix)/usage/daily/", "from=\(from)&to=\(to)")
+        case .usageBreakdown(let from, let to, let groupBy):
+            let encoded = groupBy.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? groupBy
+            return ("\(prefix)/usage/breakdown/", "from=\(from)&to=\(to)&groupBy=\(encoded)")
         }
     }
 
@@ -1804,6 +1821,89 @@ public final class HTTPTransport {
             }
         } catch {
             log.error("fetchRemoteIdentity failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    // MARK: - Usage Reporting
+
+    /// Fetch aggregate usage totals from `GET /v1/usage/totals`.
+    func fetchUsageTotals(from: Int, to: Int, isRetry: Bool = false) async -> UsageTotalsResponse? {
+        guard let url = buildURL(for: .usageTotals(from: from, to: to)) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await fetchUsageTotals(from: from, to: to, isRetry: true)
+                    }
+                    return nil
+                }
+                guard (200...299).contains(http.statusCode) else { return nil }
+            }
+            return try decoder.decode(UsageTotalsResponse.self, from: data)
+        } catch {
+            log.error("fetchUsageTotals failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// Fetch per-day usage buckets from `GET /v1/usage/daily`.
+    func fetchUsageDaily(from: Int, to: Int, isRetry: Bool = false) async -> UsageDailyResponse? {
+        guard let url = buildURL(for: .usageDaily(from: from, to: to)) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await fetchUsageDaily(from: from, to: to, isRetry: true)
+                    }
+                    return nil
+                }
+                guard (200...299).contains(http.statusCode) else { return nil }
+            }
+            return try decoder.decode(UsageDailyResponse.self, from: data)
+        } catch {
+            log.error("fetchUsageDaily failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// Fetch grouped usage breakdown from `GET /v1/usage/breakdown`.
+    func fetchUsageBreakdown(from: Int, to: Int, groupBy: String, isRetry: Bool = false) async -> UsageBreakdownResponse? {
+        guard let url = buildURL(for: .usageBreakdown(from: from, to: to, groupBy: groupBy)) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await fetchUsageBreakdown(from: from, to: to, groupBy: groupBy, isRetry: true)
+                    }
+                    return nil
+                }
+                guard (200...299).contains(http.statusCode) else { return nil }
+            }
+            return try decoder.decode(UsageBreakdownResponse.self, from: data)
+        } catch {
+            log.error("fetchUsageBreakdown failed: \(error.localizedDescription)")
             return nil
         }
     }


### PR DESCRIPTION
## Summary
- Add fetch helpers to DaemonClient and HTTPDaemonClient for usage reporting routes
- Create UsageDashboardStore as shared source of truth for usage data
- Add tests for JSON decoding, loading states, and grouped summaries

Part of plan: usage-cost-reporting.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
