### PR TITLE
refactor: remove deprecated invite transport aliases and free functions

### DIFF
--- a/assistant/src/runtime/channel-invite-transport.ts
+++ b/assistant/src/runtime/channel-invite-transport.ts
@@ -66,16 +66,6 @@ export interface ChannelInviteAdapter {
 }
 
 // ---------------------------------------------------------------------------
-// Backward-compatible type aliases
-// ---------------------------------------------------------------------------
-
-/** @deprecated Use `ChannelInviteAdapter` instead. */
-export type ChannelInviteTransport = ChannelInviteAdapter;
-
-/** @deprecated Use `InviteShareLink` instead. */
-export type InviteSharePayload = InviteShareLink;
-
-// ---------------------------------------------------------------------------
 // Registry
 // ---------------------------------------------------------------------------
 
@@ -132,7 +122,7 @@ export async function resolveAdapterHandle(
 }
 
 // ---------------------------------------------------------------------------
-// Singleton registry + backward-compatible free functions
+// Singleton registry
 // ---------------------------------------------------------------------------
 
 import { emailInviteAdapter } from "./channel-invite-transports/email.js";
@@ -154,39 +144,10 @@ export function createInviteAdapterRegistry(): InviteAdapterRegistry {
   return registry;
 }
 
-/**
- * Module-level singleton registry, created eagerly so callers that
- * import the free functions continue to work without changes.
- */
+/** Module-level singleton registry, created eagerly at import time. */
 const defaultRegistry = createInviteAdapterRegistry();
 
 /** Return the module-level singleton registry. */
 export function getInviteAdapterRegistry(): InviteAdapterRegistry {
   return defaultRegistry;
-}
-
-/**
- * Register a channel invite adapter on the default registry.
- * @deprecated Prefer `getInviteAdapterRegistry().register(adapter)`.
- */
-export function registerTransport(transport: ChannelInviteAdapter): void {
-  defaultRegistry.register(transport);
-}
-
-/**
- * Look up the registered adapter for a channel on the default registry.
- * @deprecated Prefer `getInviteAdapterRegistry().get(channel)`.
- */
-export function getTransport(
-  channel: ChannelId,
-): ChannelInviteAdapter | undefined {
-  return defaultRegistry.get(channel);
-}
-
-/**
- * Reset the default registry. Intended for tests only.
- * @internal
- */
-export function _resetRegistry(): void {
-  defaultRegistry._reset();
 }

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -109,10 +109,3 @@ export const telegramInviteAdapter: ChannelInviteAdapter = {
     return undefined;
   },
 };
-
-// ---------------------------------------------------------------------------
-// Backward-compatible alias
-// ---------------------------------------------------------------------------
-
-/** @deprecated Use `telegramInviteAdapter` instead. */
-export const telegramInviteTransport = telegramInviteAdapter;

--- a/assistant/src/runtime/channel-invite-transports/voice.ts
+++ b/assistant/src/runtime/channel-invite-transports/voice.ts
@@ -49,10 +49,3 @@ export const voiceInviteAdapter: ChannelInviteAdapter = {
     return undefined;
   },
 };
-
-// ---------------------------------------------------------------------------
-// Backward-compatible alias
-// ---------------------------------------------------------------------------
-
-/** @deprecated Use `voiceInviteAdapter` instead. */
-export const voiceInviteTransport = voiceInviteAdapter;


### PR DESCRIPTION
## Summary
- Remove deprecated ChannelInviteTransport and InviteSharePayload type aliases
- Remove deprecated registerTransport() and getTransport() free functions
- Remove deprecated telegramInviteTransport and voiceInviteTransport alias exports
- Clean up stale comments referencing backward compatibility

Part of plan: compat-guardrails.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
