### PR TITLE
fix: harden Shift+Enter routing (review feedback from #13087 and #13091)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
@@ -128,15 +128,15 @@ struct ComposerFocusBridge: NSViewRepresentable {
                         self.parent.onSend()
                         return nil
                     case .bridgeInsertNewline:
-                        // Insert newline only if we can find the field editor;
-                        // otherwise let the event propagate normally.
+                        // Insert newline via the field editor. If the text view
+                        // can't be found, still consume the event to prevent
+                        // .onSubmit from firing (which would send the message).
                         let textView = (event.window?.firstResponder as? NSTextView)
                             ?? (NSApp.keyWindow?.firstResponder as? NSTextView)
                         if let textView {
                             textView.insertText("\n", replacementRange: textView.selectedRange())
-                            return nil
                         }
-                        return event
+                        return nil
                     case .deferToSubmit:
                         return event
                     }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerReturnKeyRouting.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerReturnKeyRouting.swift
@@ -12,8 +12,10 @@ enum ComposerReturnKeyRouting {
     }
 
     static func resolve(cmdEnterToSend: Bool, modifiers: NSEvent.ModifierFlags) -> Action {
-        // Strip device-independent modifier flags to compare only modifier keys
-        let keys = modifiers.intersection(.deviceIndependentFlagsMask)
+        // Mask to only the four modifier keys we care about so that
+        // incidental flags (capsLock, function, numericPad) don't break
+        // equality checks.
+        let keys = modifiers.intersection([.shift, .command, .control, .option])
 
         if !cmdEnterToSend && keys == .shift {
             return .bridgeInsertNewline

--- a/clients/macos/vellum-assistantTests/ComposerReturnKeyRoutingTests.swift
+++ b/clients/macos/vellum-assistantTests/ComposerReturnKeyRoutingTests.swift
@@ -47,5 +47,17 @@ final class ComposerReturnKeyRoutingTests: XCTestCase {
         let action = ComposerReturnKeyRouting.resolve(cmdEnterToSend: true, modifiers: [.option])
         XCTAssertEqual(action, .deferToSubmit)
     }
+
+    // MARK: - Extra modifier flags (capsLock, function, etc.)
+
+    func testDefaultMode_shiftReturnWithCapsLock_insertsNewline() {
+        let action = ComposerReturnKeyRouting.resolve(cmdEnterToSend: false, modifiers: [.shift, .capsLock])
+        XCTAssertEqual(action, .bridgeInsertNewline)
+    }
+
+    func testCmdEnterMode_cmdReturnWithCapsLock_sends() {
+        let action = ComposerReturnKeyRouting.resolve(cmdEnterToSend: true, modifiers: [.command, .capsLock])
+        XCTAssertEqual(action, .bridgeSend)
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- Fix modifier flag masking in `ComposerReturnKeyRouting.resolve()` — use `[.shift, .command, .control, .option]` instead of `.deviceIndependentFlagsMask` so capsLock/function/numericPad don't break equality checks
- Consume the Return event even when NSTextView lookup fails in the `.bridgeInsertNewline` path, preventing accidental sends via `.onSubmit`
- Add tests for Shift+Return and Cmd+Return with Caps Lock active

## Original prompt
Fix two review feedback items from PRs #13087 and #13091 in the Shift+Enter composer feature:

## Fix 1: Modifier flag masking in ComposerReturnKeyRouting.resolve() (#13087 Codex feedback)

In `clients/macos/vellum-assistant/Features/Chat/ComposerReturnKeyRouting.swift` line 16, change:
```swift
let keys = modifiers.intersection(.deviceIndependentFlagsMask)
```
to:
```swift
let keys = modifiers.intersection([.shift, .command, .control, .option])
```

This ensures extra flags like `.capsLock`, `.function`, `.numericPad` don't cause `==` comparisons to fail. Without this, Shift+Return with Caps Lock on misroutes to `.deferToSubmit` instead of `.bridgeInsertNewline`.

## Fix 2: Consume event when textView not found (#13091 Devin feedback)

In `clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift` line 139, change `return event` to `return nil` so the event is consumed even when NSTextView lookup fails, preventing `.onSubmit` from sending the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
