### PR TITLE
fix: include Meta error body in WhatsApp raw fetch failures

### DIFF
--- a/gateway/src/whatsapp/api.ts
+++ b/gateway/src/whatsapp/api.ts
@@ -401,15 +401,37 @@ async function retryableWhatsAppRawFetch(
     }
 
     if (!isRetryable(response.status) && !response.ok) {
+      const body = await response.text().catch(() => "");
+      let errorMessage: string | undefined;
+      try {
+        const data = JSON.parse(body) as WhatsAppApiErrorResponse;
+        errorMessage = data.error?.message;
+      } catch {
+        // Response body is not JSON — include raw text if available
+      }
       throw new Error(
-        `WhatsApp ${operation} failed with status ${response.status}`,
+        errorMessage
+          ? `WhatsApp ${operation} failed: ${errorMessage}`
+          : body
+            ? `WhatsApp ${operation} failed with status ${response.status}: ${body}`
+            : `WhatsApp ${operation} failed with status ${response.status}`,
       );
     }
 
     if (isRetryable(response.status)) {
       lastRetryAfter = response.headers.get("retry-after");
+      const body = await response.text().catch(() => "");
+      let errorMessage: string | undefined;
+      try {
+        const data = JSON.parse(body) as WhatsAppApiErrorResponse;
+        errorMessage = data.error?.message;
+      } catch {
+        // Response body is not JSON
+      }
       lastError = new Error(
-        `WhatsApp ${operation} failed with status ${response.status}`,
+        errorMessage
+          ? `WhatsApp ${operation} failed: ${errorMessage}`
+          : `WhatsApp ${operation} failed with status ${response.status}`,
       );
       log.warn(
         {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for whatsapp-media-ingestion.md.

**Gap:** retryableWhatsAppRawFetch discards error response body on non-retryable failures
**What was expected:** Error messages should include actionable diagnostics from Meta's error envelope
**What was found:** The raw fetch variant threw generic status-only errors while the JSON variant included Meta's error.message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
