### PR TITLE
docs: update AGENTS.md for Shift+Enter and composer layout lessons

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -67,9 +67,9 @@ Prefer built-in SwiftUI primitives over custom `NSViewRepresentable` / AppKit wr
 |------|----------|----------|
 | Multi-line text input | `TextField(axis: .vertical)` + `.lineLimit(1...N)` | Custom `NSTextView` in `NSScrollView` |
 | Vertical centering in text field | Native `TextField` behavior | Custom `NSClipView` subclass |
-| Auto-growing height | `.lineLimit(1...N)` | Manual height sync + frame clamping |
+| Auto-growing height | `.lineLimit(1...N)` for simple cases | Manual height sync + frame clamping (exception: the chat composer uses ScrollView + GeometryReader because `.lineLimit` truncates instead of scrolling on macOS when content exceeds max lines) |
 | Return-to-send in chat input | `.onSubmit { sendAction() }` (native SwiftUI) | `.onKeyPress(.return)` (returning `.ignored` doesn't fall back to TextField's newline behavior) |
-| Newline in chat input | Option+Return (native macOS convention, free with `.onSubmit`) | Custom Shift+Return handling (`.onSubmit` fires on Shift+Return too and cannot distinguish modifiers) |
+| Newline in chat input | Shift+Return via AppKit bridge (intercepts before `.onSubmit`); Option+Return also works natively | Relying solely on `.onSubmit` modifier detection (SwiftUI's `.onSubmit` cannot distinguish Shift+Return from plain Return) |
 | Keyboard shortcuts | `.onKeyPress()` modifiers | `keyDown(with:)` / `performKeyEquivalent` overrides |
 | Attributed/colored text display | `AttributedString` + `Text` overlay | `layoutManager.addTemporaryAttributes` |
 | File drag-drop | `.onDrop(of: [.fileURL])` | `performDragOperation` override |
@@ -79,6 +79,7 @@ Prefer built-in SwiftUI primitives over custom `NSViewRepresentable` / AppKit wr
 **When AppKit bridges are still needed** (keep them minimal — only AppKit-specific logic, no business logic or layout):
 - Intercepting `Cmd+V` for image paste detection (pasteboard inspection not available in SwiftUI)
 - Intercepting `Cmd+Enter` as a key equivalent before the field editor consumes it
+- Intercepting `Shift+Return` to insert a newline before `.onSubmit` fires (SwiftUI cannot distinguish modifier+Return combos)
 - Registering window-level event monitors (`NSEvent.addLocalMonitorForEvents`)
 - Accessing `NSWindow` properties (e.g., typing redirect handlers, container view registration)
 
@@ -136,6 +137,7 @@ Swift's type checker has quadratic complexity with chained view modifiers. Compl
 | `.scrollPosition(id:)` with unmanaged binding | Nil binding fights SwiftUI's internal tracking, crashes on re-layout | Use `ScrollViewReader` + `proxy.scrollTo()`, or fully manage the binding |
 | Strong closure capture on window | Retain cycle if window outlives view | Use `[weak coordinator]` or clear in `dismantleNSView` |
 | `@Observable` dictionary as per-entity store | Any key mutation invalidates all views reading the dictionary | Use per-entity `@Observable` wrapper objects; mutate their properties instead of the dictionary |
+| GeometryReader on ScrollView `.background` measuring parent frame | Measures the ScrollView's proposed size (parent frame), not content intrinsic height — creates feedback loop where state derived from the measurement drives the frame that's being measured | Place GeometryReader on the *inner content* (inside the ScrollView), and reset all derived state (`contentHeight`, `isExpanded`) atomically when content clears |
 
 ## Non-Apple clients
 - Follow platform-specific best practices for the target (for example, Chrome extension guidelines).


### PR DESCRIPTION
## Summary
- Update auto-growing height guidance to note the ScrollView + GeometryReader exception for the chat composer (`.lineLimit` truncates instead of scrolling on macOS)
- Replace outdated "Option+Return only" newline guidance with the shipped Shift+Return via AppKit bridge pattern (LUM-21)
- Add Shift+Return interception to the AppKit bridge exceptions list
- Add GeometryReader-on-ScrollView-background feedback loop to the pitfalls table

## Original prompt
Update clients/AGENTS.md to fix three incorrect/outdated entries discovered during today's Shift+Enter and composer height work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
