### PR TITLE
refactor: remove deprecated skill feature-flag wrapper

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -672,8 +672,7 @@ The assistant feature-flag resolver (`src/config/assistant-feature-flags.ts`) is
 **Public API:**
 
 - `isAssistantFeatureFlagEnabled(key, config)` — full resolver with the canonical key
-- `isAssistantSkillEnabled(skillId, config)` — convenience wrapper that constructs `feature_flags.<skillId>.enabled` and delegates
-- `isSkillFeatureEnabled(skillId, config)` — deprecated legacy wrapper in `config/skill-state.ts`
+- `skillFlagKey(skillId)` — derives the canonical flag key for a skill, respecting overrides (in `config/skill-state.ts`)
 
 **Skill-gating guarantee:** For skills that are explicitly mapped to declared assistant flags, when the flag is OFF the skill is unavailable everywhere — it cannot appear in client UIs, model context, or runtime tool execution. This is enforced at five independent points:
 
@@ -685,24 +684,24 @@ The assistant feature-flag resolver (`src/config/assistant-feature-flags.ts`) is
 | **4. Runtime tool projection**     | `projectSkillTools()` in `daemon/session-skill-tools.ts` | Even if a skill was previously active in a session (has `<loaded_skill>` markers in history), the per-turn projection drops it when the flag is OFF. Already-registered tools are unregistered.             |
 | **5. Included child skills**       | `executeSkillLoad()` in `tools/skills/load.ts`           | When a parent skill includes children via the `includes` directive, each child is independently checked against its feature flag. Flagged-off children are silently excluded from the loaded skill content. |
 
-All five enforcement points use `isAssistantSkillEnabled()` from `config/assistant-feature-flags.ts` for consistency.
+All five enforcement points use `isAssistantFeatureFlagEnabled(skillFlagKey(skillId), config)` for consistency.
 
 **Migration path:** The legacy `skills.<id>.enabled` key format is no longer supported. All code must use the canonical `feature_flags.<id>.enabled` format. Guard tests enforce canonical key usage and declaration coverage for literal key references in the unified registry.
 
 **Key source files:**
 
-| File                                            | Purpose                                                                                                                                  |
-| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `src/config/assistant-feature-flags.ts`         | Canonical resolver: `isAssistantFeatureFlagEnabled()`, `isAssistantSkillEnabled()`, `getAssistantFeatureFlagDefaults()`, registry loader |
-| `src/config/skill-state.ts`                     | `isSkillFeatureEnabled()` (deprecated wrapper) — delegates to canonical resolver; `resolveSkillStates()` — enforcement point 1           |
-| `src/config/system-prompt.ts`                   | `appendSkillsCatalog()` — enforcement point 2                                                                                            |
-| `src/tools/skills/load.ts`                      | `executeSkillLoad()` — enforcement points 3 and 5                                                                                        |
-| `src/daemon/session-skill-tools.ts`             | `projectSkillTools()` — enforcement point 4                                                                                              |
-| `src/config/schema.ts`                          | `featureFlags` and `assistantFeatureFlagValues` field definitions in `AssistantConfig` (Zod schema)                                      |
-| `src/config/types.ts`                           | Type definitions for `FeatureFlags` (legacy) and `AssistantFeatureFlagValues` (canonical)                                                |
-| `src/daemon/handlers/skills.ts`                 | `handleSkillsList()` — uses `resolveSkillStates()` for IPC client responses                                                              |
-| `meta/feature-flags/feature-flag-registry.json` | Unified feature flag registry (repo root) — all declared flags with scope, label, default values, and descriptions                       |
-| `src/config/feature-flag-registry.json`         | Bundled copy of the unified registry for compiled binary resolution                                                                      |
+| File                                            | Purpose                                                                                                            |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `src/config/assistant-feature-flags.ts`         | Canonical resolver: `isAssistantFeatureFlagEnabled()`, `getAssistantFeatureFlagDefaults()`, registry loader        |
+| `src/config/skill-state.ts`                     | `skillFlagKey()` — derives canonical flag key for skills; `resolveSkillStates()` — enforcement point 1             |
+| `src/config/system-prompt.ts`                   | `appendSkillsCatalog()` — enforcement point 2                                                                      |
+| `src/tools/skills/load.ts`                      | `executeSkillLoad()` — enforcement points 3 and 5                                                                  |
+| `src/daemon/session-skill-tools.ts`             | `projectSkillTools()` — enforcement point 4                                                                        |
+| `src/config/schema.ts`                          | `featureFlags` and `assistantFeatureFlagValues` field definitions in `AssistantConfig` (Zod schema)                |
+| `src/config/types.ts`                           | Type definitions for `FeatureFlags` (legacy) and `AssistantFeatureFlagValues` (canonical)                          |
+| `src/daemon/handlers/skills.ts`                 | `handleSkillsList()` — uses `resolveSkillStates()` for IPC client responses                                        |
+| `meta/feature-flags/feature-flag-registry.json` | Unified feature flag registry (repo root) — all declared flags with scope, label, default values, and descriptions |
+| `src/config/feature-flag-registry.json`         | Bundled copy of the unified registry for compiled binary resolution                                                |
 
 ---
 

--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -90,7 +90,7 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 const { buildSystemPrompt } = await import("../config/system-prompt.js");
 const { isAssistantFeatureFlagEnabled } =
   await import("../config/assistant-feature-flags.js");
-const { isSkillFeatureEnabled } = await import("../config/skill-state.js");
+const { skillFlagKey } = await import("../config/skill-state.js");
 
 // ---------------------------------------------------------------------------
 // Setup / Teardown
@@ -301,18 +301,22 @@ describe("isAssistantFeatureFlagEnabled", () => {
   });
 });
 
-describe("legacy isSkillFeatureEnabled backward compat", () => {
-  test("delegates to the canonical resolver", () => {
+describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
+  test("resolves skill flag via canonical path", () => {
     const config = {
       assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: false },
     } as any;
 
-    expect(isSkillFeatureEnabled(DECLARED_SKILL_ID, config)).toBe(false);
+    expect(
+      isAssistantFeatureFlagEnabled(skillFlagKey(DECLARED_SKILL_ID), config),
+    ).toBe(false);
   });
 
   test("disabled when no override set (registry default is false)", () => {
     const config = {} as any;
 
-    expect(isSkillFeatureEnabled(DECLARED_SKILL_ID, config)).toBe(false);
+    expect(
+      isAssistantFeatureFlagEnabled(skillFlagKey(DECLARED_SKILL_ID), config),
+    ).toBe(false);
   });
 });

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../config/schema.js";
-import {
-  isSkillFeatureEnabled,
-  resolveSkillStates,
-} from "../config/skill-state.js";
+import { resolveSkillStates, skillFlagKey } from "../config/skill-state.js";
 import type { SkillSummary } from "../config/skills.js";
 
 const DECLARED_FLAG_KEY = "feature_flags.hatch-new-assistant.enabled";
@@ -55,27 +52,33 @@ function makeSkill(
 }
 
 // ---------------------------------------------------------------------------
-// isSkillFeatureEnabled (legacy wrapper — backward compat)
+// isAssistantFeatureFlagEnabled with skillFlagKey (canonical path)
 // ---------------------------------------------------------------------------
 
-describe("isSkillFeatureEnabled", () => {
+describe("isAssistantFeatureFlagEnabled with skillFlagKey", () => {
   test("returns false when no flag overrides (registry default is false)", () => {
     const config = makeConfig();
-    expect(isSkillFeatureEnabled(DECLARED_SKILL_ID, config)).toBe(false);
+    expect(
+      isAssistantFeatureFlagEnabled(skillFlagKey(DECLARED_SKILL_ID), config),
+    ).toBe(false);
   });
 
   test("returns true when skill key is explicitly true", () => {
     const config = makeConfig({
       assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: true },
     });
-    expect(isSkillFeatureEnabled(DECLARED_SKILL_ID, config)).toBe(true);
+    expect(
+      isAssistantFeatureFlagEnabled(skillFlagKey(DECLARED_SKILL_ID), config),
+    ).toBe(true);
   });
 
   test("returns false when skill key is explicitly false", () => {
     const config = makeConfig({
       assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: false },
     });
-    expect(isSkillFeatureEnabled(DECLARED_SKILL_ID, config)).toBe(false);
+    expect(
+      isAssistantFeatureFlagEnabled(skillFlagKey(DECLARED_SKILL_ID), config),
+    ).toBe(false);
   });
 });
 

--- a/assistant/src/__tests__/skill-projection.benchmark.test.ts
+++ b/assistant/src/__tests__/skill-projection.benchmark.test.ts
@@ -69,7 +69,6 @@ mock.module("../config/skills.js", () => ({
 // only needs skillFlagKey and doesn't exercise resolveSkillStates.
 mock.module("../config/skill-state.js", () => ({
   skillFlagKey: (id: string) => `feature_flags.${id}.enabled`,
-  isSkillFeatureEnabled: () => true,
   resolveSkillStates: () => [],
 }));
 

--- a/assistant/src/config/skill-state.ts
+++ b/assistant/src/config/skill-state.ts
@@ -33,19 +33,6 @@ export function skillFlagKey(skillId: string): string {
   );
 }
 
-/**
- * @deprecated Use `isAssistantFeatureFlagEnabled` from `./assistant-feature-flags.js` instead.
- *
- * Thin backward-compatible wrapper that delegates to the canonical resolver.
- * Kept to avoid breaking existing call sites during migration.
- */
-export function isSkillFeatureEnabled(
-  skillId: string,
-  config: AssistantConfig,
-): boolean {
-  return isAssistantFeatureFlagEnabled(skillFlagKey(skillId), config);
-}
-
 export function resolveSkillStates(
   catalog: SkillSummary[],
   config: AssistantConfig,


### PR DESCRIPTION
## Summary
- Remove deprecated isSkillFeatureEnabled() wrapper from skill-state.ts
- Update tests to use isAssistantFeatureFlagEnabled() with skillFlagKey() directly
- Clean up ARCHITECTURE.md references to the deprecated wrapper

Part of plan: compat-guardrails.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
