### PR TITLE
fix: resolve assistant CI regressions on main

### DIFF
--- a/assistant/src/__tests__/recording-intent-handler.test.ts
+++ b/assistant/src/__tests__/recording-intent-handler.test.ts
@@ -342,8 +342,10 @@ mock.module("../providers/provider-send-message.js", () => ({
 // ── Mock external conversation store ───────────────────────────────────────
 
 mock.module("../memory/external-conversation-store.js", () => ({
+  getBindingByChannelChat: () => null,
   getBindingsForConversations: () => new Map(),
   upsertBinding: () => {},
+  upsertOutboundBinding: () => {},
 }));
 
 // ── Mock subagent manager ──────────────────────────────────────────────────

--- a/assistant/src/runtime/channel-invite-transports/sms.ts
+++ b/assistant/src/runtime/channel-invite-transports/sms.ts
@@ -18,16 +18,21 @@ import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the SMS phone number with canonical precedence:
- * env override -> config sms.phoneNumber -> secure key fallback.
- * Mirrors the resolution strategy in `channel-readiness-service.ts`.
+ * Keep Twilio-backed invite transports on a single secure-key reader so the
+ * credential boundary stays narrow even as SMS and WhatsApp share resolution.
  */
-function resolveSmsPhoneNumber(): string | undefined {
+export function resolveTwilioInvitePhoneNumber(options?: {
+  includeWhatsappOverride?: boolean;
+}): string | undefined {
   try {
     const raw = loadRawConfig();
     const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
+    const whatsappConfig = options?.includeWhatsappOverride
+      ? ((raw?.whatsapp ?? {}) as Record<string, unknown>)
+      : undefined;
     return (
       getTwilioPhoneNumberEnv() ||
+      (whatsappConfig?.phoneNumber as string | undefined) ||
       (smsConfig.phoneNumber as string) ||
       getSecureKey("credential:twilio:phone_number") ||
       undefined
@@ -49,6 +54,6 @@ export const smsInviteAdapter: ChannelInviteAdapter = {
   channel: "sms" as ChannelId,
 
   resolveChannelHandle(): string | undefined {
-    return resolveSmsPhoneNumber();
+    return resolveTwilioInvitePhoneNumber();
   },
 };

--- a/assistant/src/runtime/channel-invite-transports/whatsapp.ts
+++ b/assistant/src/runtime/channel-invite-transports/whatsapp.ts
@@ -11,43 +11,12 @@
  */
 
 import type { ChannelId } from "../../channels/types.js";
-import { getTwilioPhoneNumberEnv } from "../../config/env.js";
-import { loadRawConfig } from "../../config/loader.js";
-import { getSecureKey } from "../../security/secure-keys.js";
 import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
+import { resolveTwilioInvitePhoneNumber } from "./sms.js";
 
 // ---------------------------------------------------------------------------
 // Phone number resolution
 // ---------------------------------------------------------------------------
-
-/**
- * Resolve the WhatsApp phone number with canonical precedence:
- * env override -> config whatsapp.phoneNumber -> config sms.phoneNumber
- * -> secure key fallback.
- *
- * WhatsApp typically shares the Twilio phone number with SMS, but
- * allows a channel-specific override via config.
- */
-function resolveWhatsAppPhoneNumber(): string | undefined {
-  try {
-    const raw = loadRawConfig();
-    const whatsappConfig = (raw?.whatsapp ?? {}) as Record<string, unknown>;
-    const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
-    return (
-      getTwilioPhoneNumberEnv() ||
-      (whatsappConfig.phoneNumber as string) ||
-      (smsConfig.phoneNumber as string) ||
-      getSecureKey("credential:twilio:phone_number") ||
-      undefined
-    );
-  } catch {
-    return (
-      getTwilioPhoneNumberEnv() ||
-      getSecureKey("credential:twilio:phone_number") ||
-      undefined
-    );
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Adapter implementation
@@ -57,6 +26,6 @@ export const whatsappInviteAdapter: ChannelInviteAdapter = {
   channel: "whatsapp" as ChannelId,
 
   resolveChannelHandle(): string | undefined {
-    return resolveWhatsAppPhoneNumber();
+    return resolveTwilioInvitePhoneNumber({ includeWhatsappOverride: true });
   },
 };


### PR DESCRIPTION
## Summary
- keep Twilio invite phone number secure-key reads in the existing SMS transport helper and reuse that path for WhatsApp
- update the recording intent handler test mock to cover the external conversation store exports now used by notification pairing
- verify the previously failing assistant tests pass

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22738818665/job/65947001364

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
