### PR TITLE
fix: namespace notification bindings to avoid clobbering messaging adapter bindings

### DIFF
--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -323,9 +323,9 @@ describe("pairDeliveryWithConversation", () => {
       source: "notification",
       title: "Telegram Thread",
     };
-    mockBindings["telegram:chat-123"] = {
+    mockBindings["notification:telegram:chat-123"] = {
       conversationId: "conv-bound",
-      sourceChannel: "telegram",
+      sourceChannel: "notification:telegram",
       externalChatId: "chat-123",
     };
 
@@ -364,9 +364,9 @@ describe("pairDeliveryWithConversation", () => {
       source: "user",
       title: "User Thread",
     };
-    mockBindings["sms:+15551234567"] = {
+    mockBindings["notification:sms:+15551234567"] = {
       conversationId: "conv-user-owned",
-      sourceChannel: "sms",
+      sourceChannel: "notification:sms",
       externalChatId: "+15551234567",
     };
 
@@ -395,14 +395,14 @@ describe("pairDeliveryWithConversation", () => {
       unknown
     >;
     expect(upsertArgs.conversationId).toBe("conv-001");
-    expect(upsertArgs.sourceChannel).toBe("sms");
+    expect(upsertArgs.sourceChannel).toBe("notification:sms");
   });
 
   test("falls back to new conversation when bound conversation no longer exists", async () => {
     // Binding exists but conversation was deleted
-    mockBindings["telegram:chat-456"] = {
+    mockBindings["notification:telegram:chat-456"] = {
       conversationId: "conv-deleted",
-      sourceChannel: "telegram",
+      sourceChannel: "notification:telegram",
       externalChatId: "chat-456",
     };
 
@@ -452,7 +452,7 @@ describe("pairDeliveryWithConversation", () => {
       unknown
     >;
     expect(upsertArgs.conversationId).toBe("conv-001");
-    expect(upsertArgs.sourceChannel).toBe("slack");
+    expect(upsertArgs.sourceChannel).toBe("notification:slack");
     expect(upsertArgs.externalChatId).toBe("C0123ABCDEF");
   });
 
@@ -468,9 +468,9 @@ describe("pairDeliveryWithConversation", () => {
       source: "notification",
       title: "Bound Thread",
     };
-    mockBindings["telegram:chat-789"] = {
+    mockBindings["notification:telegram:chat-789"] = {
       conversationId: "conv-bound",
-      sourceChannel: "telegram",
+      sourceChannel: "notification:telegram",
       externalChatId: "chat-789",
     };
 
@@ -509,9 +509,9 @@ describe("pairDeliveryWithConversation", () => {
       source: "notification",
       title: "Vellum Thread",
     };
-    mockBindings["vellum:device-1"] = {
+    mockBindings["notification:vellum:device-1"] = {
       conversationId: "conv-bound-vellum",
-      sourceChannel: "vellum",
+      sourceChannel: "notification:vellum",
       externalChatId: "device-1",
     };
 

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -38,6 +38,18 @@ import type { RenderedChannelCopy } from "./types.js";
 
 const log = getLogger("notification-conversation-pairing");
 
+/**
+ * Prefix applied to sourceChannel values in notification bindings so they
+ * occupy a separate namespace from messaging adapter bindings in the
+ * external_conversation_bindings table.  Without this, notification pairing
+ * and messaging adapters (Telegram, SMS, etc.) would destructively overwrite
+ * each other's bindings since both use (sourceChannel, externalChatId) as key.
+ */
+const NOTIFICATION_CHANNEL_PREFIX = "notification:";
+function notificationChannel(sourceChannel: string): string {
+  return `${NOTIFICATION_CHANNEL_PREFIX}${sourceChannel}`;
+}
+
 export interface PairingResult {
   conversationId: string | null;
   messageId: string | null;
@@ -189,7 +201,7 @@ export async function pairDeliveryWithConversation(
       bindingContext?.externalChatId
     ) {
       const existingBinding = getBindingByChannelChat(
-        bindingContext.sourceChannel,
+        notificationChannel(bindingContext.sourceChannel),
         bindingContext.externalChatId,
       );
 
@@ -210,7 +222,7 @@ export async function pairDeliveryWithConversation(
           // Touch the outbound timestamp so the binding stays fresh.
           upsertOutboundBinding({
             conversationId: boundConversation.id,
-            sourceChannel: bindingContext.sourceChannel,
+            sourceChannel: notificationChannel(bindingContext.sourceChannel),
             externalChatId: bindingContext.externalChatId,
           });
 
@@ -274,7 +286,7 @@ export async function pairDeliveryWithConversation(
     if (bindingContext?.sourceChannel && bindingContext?.externalChatId) {
       upsertOutboundBinding({
         conversationId: conversation.id,
-        sourceChannel: bindingContext.sourceChannel,
+        sourceChannel: notificationChannel(bindingContext.sourceChannel),
         externalChatId: bindingContext.externalChatId,
       });
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for notification-thread-continuation.md.

**Gap:** Notification and messaging adapters destructively clobber each other's external_conversation_bindings
**What was expected:** Notification thread continuation should work independently of messaging adapter bindings
**What was found:** Both systems use the same (sourceChannel, externalChatId) binding key, causing a destructive ping-pong overwrite cycle

Prefixes the sourceChannel with `notification:` in notification pairing lookups and upserts so notification bindings live in a separate namespace from messaging bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
