### PR TITLE
feat: add macOS dashboard for usage and cost trends

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/LayoutConfig.swift
@@ -4,7 +4,7 @@ import VellumAssistantShared
 // MARK: - Domain Types
 
 public enum NativePanelId: String, Equatable, Sendable {
-    case chat, threadList, settings, debug, directory, generated, avatarCustomization, apps, intelligence
+    case chat, threadList, settings, debug, directory, generated, avatarCustomization, apps, intelligence, usageDashboard
 }
 
 extension NativePanelId: Codable {

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -113,6 +113,11 @@ extension MainWindowView {
                 },
                 daemonClient: daemonClient
             )
+        case .usageDashboard:
+            UsageDashboardPanel(
+                daemonClient: daemonClient,
+                onClose: { windowState.selection = nil }
+            )
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -1,0 +1,328 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct UsageDashboardPanel: View {
+    let daemonClient: DaemonClient
+    var onClose: () -> Void
+
+    @State private var store: UsageDashboardStore?
+
+    var body: some View {
+        VSidePanel(title: "Usage", onClose: onClose, pinnedContent: {
+            if let store {
+                timeRangeStrip(store: store)
+                Divider().background(VColor.surfaceBorder)
+            }
+        }) {
+            if let store {
+                contentView(store: store)
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .onAppear {
+            if store == nil {
+                store = UsageDashboardStore(client: daemonClient)
+            }
+            Task {
+                await store?.refresh()
+            }
+        }
+    }
+
+    // MARK: - Time Range Strip
+
+    @ViewBuilder
+    private func timeRangeStrip(store: UsageDashboardStore) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: VSpacing.sm) {
+                ForEach(UsageTimeRange.allCases, id: \.rawValue) { range in
+                    Button {
+                        Task { await store.selectRange(range) }
+                    } label: {
+                        Text(range.rawValue)
+                            .font(VFont.captionMedium)
+                            .foregroundColor(store.selectedRange == range ? VColor.textPrimary : VColor.textMuted)
+                            .padding(.horizontal, VSpacing.sm)
+                            .padding(.vertical, VSpacing.xs)
+                            .background(
+                                store.selectedRange == range
+                                    ? VColor.surfaceBorder.opacity(0.5)
+                                    : Color.clear
+                            )
+                            .cornerRadius(6)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, VSpacing.lg)
+            .padding(.vertical, VSpacing.sm)
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private func contentView(store: UsageDashboardStore) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xl) {
+            totalsSection(store: store)
+            dailySection(store: store)
+            breakdownSection(store: store)
+        }
+    }
+
+    // MARK: - Totals Section
+
+    @ViewBuilder
+    private func totalsSection(store: UsageDashboardStore) -> some View {
+        sectionHeader("Totals", icon: "chart.bar.fill")
+
+        switch store.totalsState {
+        case .idle, .loading:
+            loadingRow()
+        case .loaded(let totals):
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: VSpacing.md) {
+                statCard(label: "Estimated Cost", value: formatCost(totals.totalEstimatedCostUsd))
+                statCard(label: "LLM Calls", value: formatCount(totals.eventCount))
+                statCard(label: "Input Tokens", value: formatTokenCount(totals.totalInputTokens))
+                statCard(label: "Output Tokens", value: formatTokenCount(totals.totalOutputTokens))
+                statCard(label: "Cache Created", value: formatTokenCount(totals.totalCacheCreationTokens))
+                statCard(label: "Cache Read", value: formatTokenCount(totals.totalCacheReadTokens))
+            }
+        case .failed(let message):
+            errorRow(message)
+        }
+    }
+
+    // MARK: - Daily Trend Section
+
+    @ViewBuilder
+    private func dailySection(store: UsageDashboardStore) -> some View {
+        sectionHeader("Daily Trend", icon: "chart.line.uptrend.xyaxis")
+
+        switch store.dailyState {
+        case .idle, .loading:
+            loadingRow()
+        case .loaded(let daily):
+            if daily.buckets.isEmpty {
+                VEmptyState(
+                    title: "No daily data",
+                    subtitle: "No usage recorded in this time range",
+                    icon: "calendar"
+                )
+            } else {
+                dailyTrendList(daily.buckets)
+            }
+        case .failed(let message):
+            errorRow(message)
+        }
+    }
+
+    @ViewBuilder
+    private func dailyTrendList(_ buckets: [UsageDayBucket]) -> some View {
+        let maxCost = buckets.map(\.totalEstimatedCostUsd).max() ?? 1.0
+
+        VStack(spacing: VSpacing.xs) {
+            ForEach(buckets, id: \.date) { bucket in
+                HStack(spacing: VSpacing.sm) {
+                    Text(bucket.date)
+                        .font(VFont.small)
+                        .foregroundColor(VColor.textMuted)
+                        .frame(width: 80, alignment: .leading)
+
+                    GeometryReader { geo in
+                        let fraction = maxCost > 0 ? bucket.totalEstimatedCostUsd / maxCost : 0
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(Emerald._400)
+                            .frame(width: max(2, geo.size.width * fraction))
+                    }
+                    .frame(height: 12)
+
+                    Text(formatCost(bucket.totalEstimatedCostUsd))
+                        .font(VFont.small)
+                        .foregroundColor(VColor.textSecondary)
+                        .frame(width: 60, alignment: .trailing)
+                }
+            }
+        }
+    }
+
+    // MARK: - Breakdown Section
+
+    @ViewBuilder
+    private func breakdownSection(store: UsageDashboardStore) -> some View {
+        HStack {
+            sectionHeader("Breakdown", icon: "rectangle.3.group")
+            Spacer()
+            groupByPicker(store: store)
+        }
+
+        switch store.breakdownState {
+        case .idle, .loading:
+            loadingRow()
+        case .loaded(let breakdown):
+            if breakdown.breakdown.isEmpty {
+                VEmptyState(
+                    title: "No breakdown data",
+                    subtitle: "No usage recorded for this grouping",
+                    icon: "rectangle.3.group"
+                )
+            } else {
+                breakdownList(breakdown.breakdown)
+            }
+        case .failed(let message):
+            errorRow(message)
+        }
+    }
+
+    @ViewBuilder
+    private func groupByPicker(store: UsageDashboardStore) -> some View {
+        HStack(spacing: VSpacing.xs) {
+            ForEach(UsageGroupByDimension.allCases, id: \.rawValue) { dimension in
+                Button {
+                    Task { await store.selectGroupBy(dimension) }
+                } label: {
+                    Text(dimension.rawValue.capitalized)
+                        .font(VFont.small)
+                        .foregroundColor(store.selectedGroupBy == dimension ? VColor.textPrimary : VColor.textMuted)
+                        .padding(.horizontal, VSpacing.xs)
+                        .padding(.vertical, 2)
+                        .background(
+                            store.selectedGroupBy == dimension
+                                ? VColor.surfaceBorder.opacity(0.5)
+                                : Color.clear
+                        )
+                        .cornerRadius(4)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func breakdownList(_ entries: [UsageGroupBreakdownEntry]) -> some View {
+        VStack(spacing: VSpacing.sm) {
+            // Header row
+            HStack {
+                Text("Group")
+                    .font(VFont.small)
+                    .foregroundColor(VColor.textMuted)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Text("Tokens")
+                    .font(VFont.small)
+                    .foregroundColor(VColor.textMuted)
+                    .frame(width: 70, alignment: .trailing)
+                Text("Cost")
+                    .font(VFont.small)
+                    .foregroundColor(VColor.textMuted)
+                    .frame(width: 60, alignment: .trailing)
+            }
+            .padding(.bottom, VSpacing.xxs)
+
+            ForEach(entries, id: \.group) { entry in
+                HStack {
+                    Text(entry.group)
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textPrimary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .lineLimit(1)
+                    Text(formatTokenCount(entry.totalInputTokens + entry.totalOutputTokens))
+                        .font(VFont.small)
+                        .foregroundColor(VColor.textSecondary)
+                        .frame(width: 70, alignment: .trailing)
+                    Text(formatCost(entry.totalEstimatedCostUsd))
+                        .font(VFont.small)
+                        .foregroundColor(VColor.textSecondary)
+                        .frame(width: 60, alignment: .trailing)
+                }
+            }
+        }
+    }
+
+    // MARK: - Shared Components
+
+    @ViewBuilder
+    private func sectionHeader(_ title: String, icon: String) -> some View {
+        HStack(spacing: VSpacing.xs) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+                .foregroundColor(Emerald._400)
+            Text(title)
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.textPrimary)
+        }
+    }
+
+    @ViewBuilder
+    private func statCard(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.xxs) {
+            Text(value)
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.textPrimary)
+            Text(label)
+                .font(VFont.small)
+                .foregroundColor(VColor.textMuted)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(VSpacing.sm)
+        .background(VColor.surfaceBorder.opacity(0.15))
+        .cornerRadius(8)
+    }
+
+    @ViewBuilder
+    private func loadingRow() -> some View {
+        HStack {
+            ProgressView()
+                .controlSize(.small)
+            Text("Loading...")
+                .font(VFont.small)
+                .foregroundColor(VColor.textMuted)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .padding(.vertical, VSpacing.md)
+    }
+
+    @ViewBuilder
+    private func errorRow(_ message: String) -> some View {
+        HStack(spacing: VSpacing.xs) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(Amber._400)
+            Text(message)
+                .font(VFont.small)
+                .foregroundColor(VColor.textMuted)
+        }
+        .padding(.vertical, VSpacing.sm)
+    }
+
+    // MARK: - Formatters
+
+    private func formatCost(_ usd: Double) -> String {
+        if usd < 0.01 {
+            return String(format: "$%.4f", usd)
+        }
+        return String(format: "$%.2f", usd)
+    }
+
+    private func formatTokenCount(_ count: Int) -> String {
+        if count >= 1_000_000 {
+            return String(format: "%.1fM", Double(count) / 1_000_000)
+        }
+        if count >= 1_000 {
+            return String(format: "%.1fk", Double(count) / 1_000)
+        }
+        return "\(count)"
+    }
+
+    private func formatCount(_ count: Int) -> String {
+        "\(count)"
+    }
+}
+
+#Preview {
+    ZStack {
+        VColor.background.ignoresSafeArea()
+        UsageDashboardPanel(daemonClient: DaemonClient(), onClose: {})
+    }
+    .frame(width: 400, height: 600)
+}

--- a/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
@@ -1,0 +1,224 @@
+import Foundation
+import Testing
+@testable import VellumAssistantShared
+
+// MARK: - UsageDashboardPanel Rendering Logic Tests
+
+/// These tests verify the rendering logic paths for the UsageDashboardPanel
+/// by exercising the UsageDashboardStore states that drive each section.
+/// The panel renders three sections: totals, daily trend, and grouped breakdown.
+
+@Suite("UsageDashboardPanel — Empty / Idle State")
+struct UsageDashboardPanelEmptyTests {
+
+    @Test @MainActor
+    func storeStartsInIdleState() {
+        let client = MockPanelClient()
+        let store = UsageDashboardStore(client: client)
+
+        #expect(store.totalsState == .idle)
+        #expect(store.dailyState == .idle)
+        #expect(store.breakdownState == .idle)
+        #expect(store.selectedRange == .last7Days)
+        #expect(store.selectedGroupBy == .model)
+    }
+
+    @Test @MainActor
+    func emptyResponsesProduceLoadedWithEmptyData() async {
+        let client = MockPanelClient()
+        client.stubbedTotals = UsageTotalsResponse(
+            totalInputTokens: 0, totalOutputTokens: 0,
+            totalCacheCreationTokens: 0, totalCacheReadTokens: 0,
+            totalEstimatedCostUsd: 0, eventCount: 0,
+            pricedEventCount: 0, unpricedEventCount: 0
+        )
+        client.stubbedDaily = UsageDailyResponse(buckets: [])
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [])
+
+        let store = UsageDashboardStore(client: client)
+        await store.refresh()
+
+        if case .loaded(let totals) = store.totalsState {
+            #expect(totals.eventCount == 0)
+            #expect(totals.totalEstimatedCostUsd == 0)
+        } else {
+            Issue.record("Expected .loaded for totals with zero values")
+        }
+
+        if case .loaded(let daily) = store.dailyState {
+            #expect(daily.buckets.isEmpty)
+        } else {
+            Issue.record("Expected .loaded for daily with empty buckets")
+        }
+
+        if case .loaded(let breakdown) = store.breakdownState {
+            #expect(breakdown.breakdown.isEmpty)
+        } else {
+            Issue.record("Expected .loaded for breakdown with empty entries")
+        }
+    }
+}
+
+@Suite("UsageDashboardPanel — Loading State")
+struct UsageDashboardPanelLoadingTests {
+
+    @Test @MainActor
+    func failedFetchesShowErrorMessages() async {
+        let client = MockPanelClient()
+        // All stubs nil — simulates fetch failure.
+
+        let store = UsageDashboardStore(client: client)
+        await store.refresh()
+
+        if case .failed(let msg) = store.totalsState {
+            #expect(msg.contains("totals"))
+        } else {
+            Issue.record("Expected .failed for totals")
+        }
+
+        if case .failed(let msg) = store.dailyState {
+            #expect(msg.contains("daily"))
+        } else {
+            Issue.record("Expected .failed for daily")
+        }
+
+        if case .failed(let msg) = store.breakdownState {
+            #expect(msg.contains("breakdown"))
+        } else {
+            Issue.record("Expected .failed for breakdown")
+        }
+    }
+}
+
+@Suite("UsageDashboardPanel — Populated State")
+struct UsageDashboardPanelPopulatedTests {
+
+    @Test @MainActor
+    func populatedStoreHasCorrectTotals() async {
+        let client = MockPanelClient()
+        client.stubbedTotals = UsageTotalsResponse(
+            totalInputTokens: 50_000, totalOutputTokens: 25_000,
+            totalCacheCreationTokens: 5_000, totalCacheReadTokens: 2_000,
+            totalEstimatedCostUsd: 1.23, eventCount: 42,
+            pricedEventCount: 40, unpricedEventCount: 2
+        )
+        client.stubbedDaily = UsageDailyResponse(buckets: [
+            UsageDayBucket(date: "2026-03-04", totalInputTokens: 20_000, totalOutputTokens: 10_000, totalEstimatedCostUsd: 0.50, eventCount: 15),
+            UsageDayBucket(date: "2026-03-05", totalInputTokens: 30_000, totalOutputTokens: 15_000, totalEstimatedCostUsd: 0.73, eventCount: 27)
+        ])
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [
+            UsageGroupBreakdownEntry(group: "claude-sonnet-4-20250514", totalInputTokens: 30_000, totalOutputTokens: 15_000, totalEstimatedCostUsd: 0.80, eventCount: 25),
+            UsageGroupBreakdownEntry(group: "claude-haiku-3", totalInputTokens: 20_000, totalOutputTokens: 10_000, totalEstimatedCostUsd: 0.43, eventCount: 17)
+        ])
+
+        let store = UsageDashboardStore(client: client)
+        await store.refresh()
+
+        if case .loaded(let totals) = store.totalsState {
+            #expect(totals.totalInputTokens == 50_000)
+            #expect(totals.totalOutputTokens == 25_000)
+            #expect(totals.totalEstimatedCostUsd == 1.23)
+            #expect(totals.eventCount == 42)
+        } else {
+            Issue.record("Expected .loaded for totals")
+        }
+
+        if case .loaded(let daily) = store.dailyState {
+            #expect(daily.buckets.count == 2)
+            #expect(daily.buckets[0].date == "2026-03-04")
+            #expect(daily.buckets[1].date == "2026-03-05")
+        } else {
+            Issue.record("Expected .loaded for daily")
+        }
+
+        if case .loaded(let breakdown) = store.breakdownState {
+            #expect(breakdown.breakdown.count == 2)
+            #expect(breakdown.breakdown[0].group == "claude-sonnet-4-20250514")
+            #expect(breakdown.breakdown[1].group == "claude-haiku-3")
+        } else {
+            Issue.record("Expected .loaded for breakdown")
+        }
+    }
+
+    @Test @MainActor
+    func groupByDimensionAffectsBreakdownHeadings() async {
+        let client = MockPanelClient()
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [
+            UsageGroupBreakdownEntry(group: "anthropic", totalInputTokens: 100, totalOutputTokens: 50, totalEstimatedCostUsd: 0.01, eventCount: 1)
+        ])
+
+        let store = UsageDashboardStore(client: client)
+
+        // Default is .model
+        #expect(store.selectedGroupBy == .model)
+
+        await store.selectGroupBy(.provider)
+        #expect(store.selectedGroupBy == .provider)
+        #expect(client.lastBreakdownGroupBy == "provider")
+
+        await store.selectGroupBy(.actor)
+        #expect(store.selectedGroupBy == .actor)
+        #expect(client.lastBreakdownGroupBy == "actor")
+    }
+
+    @Test @MainActor
+    func timeRangeSelectionRefreshesAllData() async {
+        let client = MockPanelClient()
+        client.stubbedTotals = UsageTotalsResponse(
+            totalInputTokens: 0, totalOutputTokens: 0,
+            totalCacheCreationTokens: 0, totalCacheReadTokens: 0,
+            totalEstimatedCostUsd: 0, eventCount: 0,
+            pricedEventCount: 0, unpricedEventCount: 0
+        )
+        client.stubbedDaily = UsageDailyResponse(buckets: [])
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [])
+
+        let store = UsageDashboardStore(client: client)
+        await store.selectRange(.last30Days)
+
+        #expect(store.selectedRange == .last30Days)
+        #expect(client.lastTotalsFrom != nil)
+        #expect(client.lastDailyFrom != nil)
+        #expect(client.lastBreakdownFrom != nil)
+    }
+}
+
+// MARK: - Mock Client
+
+@MainActor
+private final class MockPanelClient: DaemonClientProtocol {
+    var isConnected: Bool = true
+    var isBlobTransportAvailable: Bool = false
+
+    func subscribe() -> AsyncStream<ServerMessage> { AsyncStream { $0.finish() } }
+    func send<T: Encodable>(_ message: T) throws {}
+    func connect() async throws {}
+    func disconnect() {}
+    func startSSE() {}
+    func stopSSE() {}
+
+    var stubbedTotals: UsageTotalsResponse?
+    var stubbedDaily: UsageDailyResponse?
+    var stubbedBreakdown: UsageBreakdownResponse?
+
+    var lastTotalsFrom: Int?
+    var lastDailyFrom: Int?
+    var lastBreakdownFrom: Int?
+    var lastBreakdownGroupBy: String?
+
+    func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse? {
+        lastTotalsFrom = from
+        return stubbedTotals
+    }
+
+    func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse? {
+        lastDailyFrom = from
+        return stubbedDaily
+    }
+
+    func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse? {
+        lastBreakdownFrom = from
+        lastBreakdownGroupBy = groupBy
+        return stubbedBreakdown
+    }
+}


### PR DESCRIPTION
## Summary
- Add UsageDashboardPanel with headline totals, daily trend, and grouped breakdowns
- Register panel in PanelCoordinator for side-panel access
- Add tests for empty, loading, and populated states

Part of plan: usage-cost-reporting.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
