### PR TITLE
feat: add iOS view for usage and cost reporting

### DIFF
--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -97,6 +97,11 @@ let package = Package(
             name: "VellumAssistantSharedTests",
             dependencies: ["VellumAssistantShared"],
             path: "shared/Tests"
+        ),
+        .testTarget(
+            name: "VellumAssistantIOSTests",
+            dependencies: ["VellumAssistantShared"],
+            path: "ios/Tests"
         )
     ]
 )

--- a/clients/ios/Tests/UsageDashboardViewTests.swift
+++ b/clients/ios/Tests/UsageDashboardViewTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import VellumAssistantShared
+
+/// Tests for the UsageDashboardStore states used by the iOS UsageDashboardView.
+/// Covers idle/empty, loading, and populated summary states.
+@MainActor
+final class UsageDashboardViewTests: XCTestCase {
+
+    private var mockClient: MockDaemonClient!
+    private var store: UsageDashboardStore!
+
+    override func setUp() {
+        super.setUp()
+        mockClient = MockDaemonClient()
+        store = UsageDashboardStore(client: mockClient)
+    }
+
+    override func tearDown() {
+        store = nil
+        mockClient = nil
+        super.tearDown()
+    }
+
+    // MARK: - Initial / Empty State
+
+    func testInitialStateIsIdle() {
+        XCTAssertEqual(store.totalsState, .idle)
+        XCTAssertEqual(store.dailyState, .idle)
+        XCTAssertEqual(store.breakdownState, .idle)
+    }
+
+    func testDefaultTimeRangeIsLast7Days() {
+        XCTAssertEqual(store.selectedRange, .last7Days)
+    }
+
+    func testDefaultGroupByIsModel() {
+        XCTAssertEqual(store.selectedGroupBy, .model)
+    }
+
+    // MARK: - Loading → Failed (mock returns nil)
+
+    func testRefreshTransitionsToFailedWhenClientReturnsNil() async {
+        // MockDaemonClient's default protocol extensions return nil for all
+        // usage fetches, so refresh should transition to .failed.
+        await store.refresh()
+
+        if case .failed(let msg) = store.totalsState {
+            XCTAssertFalse(msg.isEmpty, "Expected a non-empty failure message for totals")
+        } else {
+            XCTFail("Expected totalsState to be .failed, got \(store.totalsState)")
+        }
+
+        if case .failed(let msg) = store.dailyState {
+            XCTAssertFalse(msg.isEmpty, "Expected a non-empty failure message for daily")
+        } else {
+            XCTFail("Expected dailyState to be .failed, got \(store.dailyState)")
+        }
+
+        if case .failed(let msg) = store.breakdownState {
+            XCTAssertFalse(msg.isEmpty, "Expected a non-empty failure message for breakdown")
+        } else {
+            XCTFail("Expected breakdownState to be .failed, got \(store.breakdownState)")
+        }
+    }
+
+    // MARK: - Populated State
+
+    func testRefreshPopulatesLoadedStateWithStubClient() async {
+        let stubClient = StubUsageDaemonClient()
+        let populatedStore = UsageDashboardStore(client: stubClient)
+
+        await populatedStore.refresh()
+
+        if case .loaded(let totals) = populatedStore.totalsState {
+            XCTAssertEqual(totals.totalInputTokens, 1000)
+            XCTAssertEqual(totals.totalOutputTokens, 500)
+            XCTAssertEqual(totals.totalEstimatedCostUsd, 0.0042, accuracy: 0.0001)
+            XCTAssertEqual(totals.eventCount, 3)
+        } else {
+            XCTFail("Expected totalsState to be .loaded, got \(populatedStore.totalsState)")
+        }
+
+        if case .loaded(let daily) = populatedStore.dailyState {
+            XCTAssertEqual(daily.buckets.count, 2)
+            XCTAssertEqual(daily.buckets[0].date, "2026-03-04")
+            XCTAssertEqual(daily.buckets[1].date, "2026-03-05")
+        } else {
+            XCTFail("Expected dailyState to be .loaded, got \(populatedStore.dailyState)")
+        }
+
+        if case .loaded(let breakdown) = populatedStore.breakdownState {
+            XCTAssertEqual(breakdown.breakdown.count, 2)
+            XCTAssertEqual(breakdown.breakdown[0].group, "claude-sonnet-4-20250514")
+        } else {
+            XCTFail("Expected breakdownState to be .loaded, got \(populatedStore.breakdownState)")
+        }
+    }
+
+    // MARK: - Range Selection
+
+    func testSelectRangeUpdatesSelectedRange() async {
+        await store.selectRange(.last30Days)
+        XCTAssertEqual(store.selectedRange, .last30Days)
+    }
+
+    // MARK: - Group By Selection
+
+    func testSelectGroupByUpdatesSelectedGroupBy() async {
+        await store.selectGroupBy(.provider)
+        XCTAssertEqual(store.selectedGroupBy, .provider)
+    }
+
+    func testTimeRangeEpochMillisRangeProducesValidBounds() {
+        let referenceDate = Date(timeIntervalSince1970: 1_709_600_000)
+        let range = UsageTimeRange.today.epochMillisRange(now: referenceDate)
+        XCTAssertGreaterThan(range.to, range.from, "to should be after from")
+        XCTAssertEqual(range.to, Int(referenceDate.timeIntervalSince1970 * 1000))
+    }
+}
+
+// MARK: - Stub Client
+
+/// A stub that returns canned usage data for populated-state tests.
+/// Implements `DaemonClientProtocol` directly since `MockDaemonClient` is final.
+@MainActor
+private final class StubUsageDaemonClient: DaemonClientProtocol {
+    var isConnected: Bool = false
+    var isBlobTransportAvailable: Bool = false
+
+    func subscribe() -> AsyncStream<ServerMessage> {
+        AsyncStream { $0.finish() }
+    }
+
+    func send<T: Encodable>(_ message: T) throws {}
+    func connect() async throws {}
+    func disconnect() {}
+    func startSSE() {}
+    func stopSSE() {}
+
+    func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse? {
+        UsageTotalsResponse(
+            totalInputTokens: 1000,
+            totalOutputTokens: 500,
+            totalCacheCreationTokens: 200,
+            totalCacheReadTokens: 100,
+            totalEstimatedCostUsd: 0.0042,
+            eventCount: 3,
+            pricedEventCount: 2,
+            unpricedEventCount: 1
+        )
+    }
+
+    func fetchUsageDaily(from: Int, to: Int) async -> UsageDailyResponse? {
+        UsageDailyResponse(buckets: [
+            UsageDayBucket(date: "2026-03-04", totalInputTokens: 600, totalOutputTokens: 300, totalEstimatedCostUsd: 0.0025, eventCount: 2),
+            UsageDayBucket(date: "2026-03-05", totalInputTokens: 400, totalOutputTokens: 200, totalEstimatedCostUsd: 0.0017, eventCount: 1),
+        ])
+    }
+
+    func fetchUsageBreakdown(from: Int, to: Int, groupBy: String) async -> UsageBreakdownResponse? {
+        UsageBreakdownResponse(breakdown: [
+            UsageGroupBreakdownEntry(group: "claude-sonnet-4-20250514", totalInputTokens: 700, totalOutputTokens: 350, totalEstimatedCostUsd: 0.003, eventCount: 2),
+            UsageGroupBreakdownEntry(group: "claude-haiku-3-20240307", totalInputTokens: 300, totalOutputTokens: 150, totalEstimatedCostUsd: 0.0012, eventCount: 1),
+        ])
+    }
+}

--- a/clients/ios/Views/Settings/DeveloperSettingsSection.swift
+++ b/clients/ios/Views/Settings/DeveloperSettingsSection.swift
@@ -25,6 +25,7 @@ private struct DeveloperSettingsSectionContent: View {
     let clientProvider: ClientProvider
     @ObservedObject var traceStore: TraceStore
     @State private var showDebugPanel = false
+    @State private var showUsageDashboard = false
     // Captured once when the sheet opens so the panel stays on the same session
     // even if newer trace events arrive while the sheet is visible.
     @State private var selectedSessionId: String?
@@ -60,6 +61,14 @@ private struct DeveloperSettingsSectionContent: View {
                 }
             }
 
+            Section("Usage & Cost") {
+                Button {
+                    showUsageDashboard = true
+                } label: {
+                    Label("Usage Dashboard", systemImage: "chart.bar")
+                }
+            }
+
             Section("Connection") {
                 LabeledContent("Status", value: clientProvider.isConnected ? "Connected" : "Disconnected")
             }
@@ -71,6 +80,11 @@ private struct DeveloperSettingsSectionContent: View {
                 traceStore: traceStore,
                 sessionId: selectedSessionId,
                 onClose: { showDebugPanel = false }
+            )
+        }
+        .sheet(isPresented: $showUsageDashboard) {
+            UsageDashboardView(
+                store: UsageDashboardStore(client: clientProvider.client)
             )
         }
     }

--- a/clients/ios/Views/UsageDashboardView.swift
+++ b/clients/ios/Views/UsageDashboardView.swift
@@ -1,0 +1,186 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+/// iOS sheet presenting aggregated usage and cost data.
+///
+/// Reuses the shared `UsageDashboardStore` to show totals, daily trend buckets,
+/// and grouped breakdowns in an iOS-friendly layout.
+struct UsageDashboardView: View {
+    @State var store: UsageDashboardStore
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Usage & Cost")
+                .navigationBarTitleDisplayMode(.inline)
+                .task { await store.refresh() }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        List {
+            timeRangeSection
+            totalsSection
+            dailyTrendSection
+            breakdownSection
+        }
+    }
+
+    // MARK: - Time Range
+
+    private var timeRangeSection: some View {
+        Section {
+            Picker("Time Range", selection: Binding(
+                get: { store.selectedRange },
+                set: { newRange in
+                    Task { await store.selectRange(newRange) }
+                }
+            )) {
+                ForEach(UsageTimeRange.allCases, id: \.self) { range in
+                    Text(range.rawValue).tag(range)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
+    // MARK: - Totals
+
+    @ViewBuilder
+    private var totalsSection: some View {
+        Section("Totals") {
+            switch store.totalsState {
+            case .idle, .loading:
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+            case .loaded(let totals):
+                LabeledContent("Estimated Cost", value: Self.formatCost(totals.totalEstimatedCostUsd))
+                LabeledContent("Input Tokens", value: Self.formatCount(totals.totalInputTokens))
+                LabeledContent("Output Tokens", value: Self.formatCount(totals.totalOutputTokens))
+                LabeledContent("Cache Creation", value: Self.formatCount(totals.totalCacheCreationTokens))
+                LabeledContent("Cache Read", value: Self.formatCount(totals.totalCacheReadTokens))
+                LabeledContent("Events", value: "\(totals.eventCount)")
+            case .failed(let message):
+                Text(message)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Daily Trend
+
+    @ViewBuilder
+    private var dailyTrendSection: some View {
+        Section("Daily Trend") {
+            switch store.dailyState {
+            case .idle, .loading:
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+            case .loaded(let daily):
+                if daily.buckets.isEmpty {
+                    Text("No data for selected range")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(daily.buckets, id: \.date) { bucket in
+                        HStack {
+                            Text(bucket.date)
+                                .font(.footnote.monospaced())
+                            Spacer()
+                            Text(Self.formatCost(bucket.totalEstimatedCostUsd))
+                                .font(.footnote)
+                            Text("\(bucket.eventCount) events")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            case .failed(let message):
+                Text(message)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Breakdown
+
+    @ViewBuilder
+    private var breakdownSection: some View {
+        Section {
+            Picker("Group By", selection: Binding(
+                get: { store.selectedGroupBy },
+                set: { dimension in
+                    Task { await store.selectGroupBy(dimension) }
+                }
+            )) {
+                ForEach(UsageGroupByDimension.allCases, id: \.self) { dim in
+                    Text(dim.rawValue.capitalized).tag(dim)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            switch store.breakdownState {
+            case .idle, .loading:
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+            case .loaded(let breakdown):
+                if breakdown.breakdown.isEmpty {
+                    Text("No data for selected range")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(breakdown.breakdown, id: \.group) { entry in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(entry.group)
+                                .font(.subheadline.weight(.medium))
+                            HStack {
+                                Text(Self.formatCost(entry.totalEstimatedCostUsd))
+                                    .font(.footnote)
+                                Text("\(entry.eventCount) events")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Spacer()
+                                Text("\(Self.formatCount(entry.totalInputTokens)) in / \(Self.formatCount(entry.totalOutputTokens)) out")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            case .failed(let message):
+                Text(message)
+                    .foregroundStyle(.secondary)
+            }
+        } header: {
+            Text("Breakdown")
+        }
+    }
+
+    // MARK: - Formatting Helpers
+
+    static func formatCost(_ usd: Double) -> String {
+        String(format: "$%.4f", usd)
+    }
+
+    static func formatCount(_ n: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter.string(from: NSNumber(value: n)) ?? "\(n)"
+    }
+}
+
+#Preview {
+    UsageDashboardView(
+        store: UsageDashboardStore(client: MockDaemonClient())
+    )
+}
+#endif


### PR DESCRIPTION
## Summary
- Add UsageDashboardView with totals, daily trend, and grouped breakdowns in iOS sheet layout
- Add entry point from DeveloperSettingsSection
- Add tests for empty, loading, and populated states
- Add SPM test target for iOS tests so `swift test --filter` works

Part of plan: usage-cost-reporting.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
