### PR TITLE
style: reduce sidebar pin and archive icon size

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
@@ -51,7 +51,7 @@ struct SidebarThreadItem: View {
                         }
                     } label: {
                         Image(systemName: thread.isPinned ? "pin.fill" : "pin")
-                            .font(.system(size: 13, weight: .medium))
+                            .font(.system(size: 10, weight: .medium))
                             .foregroundColor(thread.isPinned ? VColor.textMuted : VColor.textSecondary)
                             .rotationEffect(.degrees(-45))
                             .frame(width: 20, height: 20)
@@ -85,7 +85,7 @@ struct SidebarThreadItem: View {
                                 .transition(.opacity)
                         } else if thread.isPinned {
                             Image(systemName: "pin.fill")
-                                .font(.system(size: 13, weight: .medium))
+                                .font(.system(size: 10, weight: .medium))
                                 .foregroundColor(VColor.textMuted)
                                 .rotationEffect(.degrees(-45))
                                 .frame(width: 20, height: 20)
@@ -150,7 +150,7 @@ struct SidebarThreadItem: View {
                     sidebar.threadPendingDeletion = thread.id
                 } label: {
                     Image(systemName: "archivebox")
-                        .font(.system(size: 13, weight: .medium))
+                        .font(.system(size: 10, weight: .medium))
                         .foregroundColor(VColor.textSecondary)
                         .frame(width: 20, height: 20)
                         .contentShape(Rectangle())


### PR DESCRIPTION
## Summary
- Shrinks pin and archive icons in the sidebar thread list from 13pt to 10pt
- Keeps the same 20x20 frame so the tap/click target remains unchanged
- Affects hover pin button, idle pinned indicator, and archive button

## Test plan
- [ ] Hover over a thread — pin and archive icons appear smaller but still easy to click
- [ ] Pinned threads show smaller pin indicator in idle state
- [ ] Click targets feel the same size as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
