### PR TITLE
fix: eliminate macOS client build warnings

### DIFF
--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
                 .product(name: "Sentry", package: "sentry-cocoa"),
             ],
             path: "macos/vellum-assistant",
-            exclude: ["Resources/Info.plist", "Resources/bg.png"],
+            exclude: ["Resources/Info.plist", "Resources/bg.png", "Resources/VellumDocument.icns"],
             resources: [
                 .process("Resources/Assets.xcassets"),
                 .process("Resources/meadow.svg"),

--- a/clients/macos/vellum-assistant/Features/Settings/CrashReportView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CrashReportView.swift
@@ -149,13 +149,7 @@ extension AppDelegate {
 
     func showCrashReportWindow(url: URL, content: String) {
         let dismiss: () -> Void = { [weak self] in
-            if let observer = self?.crashReportWindowObserver {
-                NotificationCenter.default.removeObserver(observer)
-                self?.crashReportWindowObserver = nil
-            }
-            self?.crashReportWindow?.close()
-            self?.crashReportWindow = nil
-            self?.scheduleActivationPolicyRevert()
+            self?.dismissCrashReportWindow()
         }
 
         let view = CrashReportView(
@@ -189,12 +183,9 @@ extension AppDelegate {
             object: window,
             queue: .main
         ) { [weak self] _ in
-            if let observer = self?.crashReportWindowObserver {
-                NotificationCenter.default.removeObserver(observer)
+            MainActor.assumeIsolated {
+                self?.handleCrashReportWindowWillClose()
             }
-            self?.crashReportWindowObserver = nil
-            self?.crashReportWindow = nil
-            self?.scheduleActivationPolicyRevert()
         }
 
         NSApp.setActivationPolicy(.regular)
@@ -202,6 +193,25 @@ extension AppDelegate {
         NSApp.activate(ignoringOtherApps: true)
 
         crashReportWindow = window
+    }
+
+    private func dismissCrashReportWindow() {
+        if let observer = crashReportWindowObserver {
+            NotificationCenter.default.removeObserver(observer)
+            crashReportWindowObserver = nil
+        }
+        crashReportWindow?.close()
+        crashReportWindow = nil
+        scheduleActivationPolicyRevert()
+    }
+
+    private func handleCrashReportWindowWillClose() {
+        if let observer = crashReportWindowObserver {
+            NotificationCenter.default.removeObserver(observer)
+            crashReportWindowObserver = nil
+        }
+        crashReportWindow = nil
+        scheduleActivationPolicyRevert()
     }
 }
 

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -1,7 +1,7 @@
 import Foundation
 import MetricKit
 import os
-import Sentry
+@preconcurrency import Sentry
 
 @MainActor final class MetricKitManager: NSObject, ObservableObject {
     private let logger = Logger(


### PR DESCRIPTION
## Summary
- exclude `VellumDocument.icns` from the SwiftPM target so `build.sh` no longer reports it as an unhandled resource
- route crash report window cleanup through main-actor helpers so the NSWindow close observer no longer trips actor-isolation warnings
- import Sentry with `@preconcurrency` in MetricKitManager to suppress Sendable warnings from the SDK while keeping Sentry access serialized

## Original prompt
Fix these warnings from `VELLUM_ASSISTANT_PLATFORM_URL=https://platform.vellum.ai ./build.sh run` in `clients/macos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
