### PR TITLE
fix: hide bootstrap assistant names in macOS UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -97,7 +97,10 @@ final class AvatarAppearanceManager {
     private var assistantName: String = "V"
 
     func start() {
-        assistantName = IdentityInfo.load()?.name ?? "V"
+        assistantName = AssistantDisplayName.resolve(
+            IdentityInfo.load()?.name,
+            fallback: "V"
+        )
         loadCustomAvatar()
         watchAvatarFile()
 
@@ -111,7 +114,10 @@ final class AvatarAppearanceManager {
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                self.assistantName = IdentityInfo.load()?.name ?? "V"
+                self.assistantName = AssistantDisplayName.resolve(
+                    IdentityInfo.load()?.name,
+                    fallback: "V"
+                )
                 self.cachedFallbackAvatar = nil
                 self.cachedFallbackName = nil
                 self.cachedFullFallbackAvatar = nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -175,8 +175,10 @@ struct MainWindowView: View {
 
     /// Resolve display names for thread export.
     private func resolveParticipantNames() -> ChatTranscriptFormatter.ParticipantNames {
-        // Assistant name: IdentityInfo → UserDefaults → fallback
-        let assistantName = IdentityInfo.load()?.name ?? "Assistant"
+        let assistantName = AssistantDisplayName.resolve(
+            IdentityInfo.load()?.name,
+            fallback: AssistantDisplayName.placeholder
+        )
 
         // User name: stored profile → system name → fallback
         let userName: String = {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -94,6 +94,30 @@ enum AssistantHome {
     }
 }
 
+enum AssistantDisplayName {
+    static let placeholder = "Assistant"
+    private static let hiddenBootstrapPrefix = "_("
+
+    /// Freshly hatched assistants can briefly persist an internal bootstrap
+    /// instruction as the name. Mask that sentinel in all user-facing UI.
+    static func firstUserFacing(from candidates: [String?]) -> String? {
+        for candidate in candidates {
+            guard let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !trimmed.isEmpty else { continue }
+            if trimmed.hasPrefix(hiddenBootstrapPrefix) {
+                return placeholder
+            }
+            return trimmed
+        }
+
+        return nil
+    }
+
+    static func resolve(_ candidates: String?..., fallback: String = placeholder) -> String {
+        firstUserFacing(from: candidates) ?? fallback
+    }
+}
+
 // MARK: - Identity Info (parsed from IDENTITY.md)
 
 struct IdentityInfo {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityPanel.swift
@@ -21,6 +21,15 @@ struct IdentityPanel: View {
 
     private let panelPadding: CGFloat = VSpacing.xl
 
+    private var assistantDisplayName: String {
+        AssistantDisplayName.resolve(
+            remoteIdentity?.name.nilIfEmpty,
+            identity?.name,
+            lockfileAssistant?.assistantId,
+            fallback: "Unknown"
+        )
+    }
+
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
             // Left sidebar: title, avatar, ID card — hidden in fullscreen
@@ -28,7 +37,7 @@ struct IdentityPanel: View {
                 VStack(spacing: 0) {
                     VStack(spacing: 0) {
                         // "I'm [name]!" heading
-                        Text("I'm \(remoteIdentity?.name.nilIfEmpty ?? identity?.name ?? lockfileAssistant?.assistantId ?? "Unknown")!")
+                        Text("I'm \(assistantDisplayName)!")
                             .font(.system(size: 22, weight: .regular, design: .rounded))
                             .foregroundColor(VColor.textPrimary)
                             .multilineTextAlignment(.center)
@@ -182,7 +191,11 @@ struct IdentityPanel: View {
             }
 
             // Given name: remote > local > assistantId
-            let name = remoteIdentity?.name.nilIfEmpty ?? identity?.name ?? lockfileAssistant?.assistantId
+            let name = AssistantDisplayName.firstUserFacing(from: [
+                remoteIdentity?.name.nilIfEmpty,
+                identity?.name,
+                lockfileAssistant?.assistantId,
+            ])
             if let name {
                 idRow(label: "Given name", value: name)
             }

--- a/clients/macos/vellum-assistant/Features/Session/ThinkingIndicatorWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Session/ThinkingIndicatorWindow.swift
@@ -14,7 +14,8 @@ struct ThinkingIndicatorView: View {
         if let statusText, !statusText.isEmpty {
             return "\(statusText)..."
         }
-        if completedConversationCount <= 5, let name = IdentityInfo.load()?.name {
+        if completedConversationCount <= 5,
+           let name = AssistantDisplayName.firstUserFacing(from: [IdentityInfo.load()?.name]) {
             return "\(name) is thinking..."
         }
         return "Thinking..."


### PR DESCRIPTION
## Summary
- add a shared macOS assistant display-name helper that replaces hidden bootstrap names starting with `_(` with the placeholder `Assistant`
- route the Intelligence identity panel, thinking indicator, transcript export name, and fallback avatar label through the helper so freshly hatched assistants do not expose internal bootstrap text
- Apple refs checked (2026-03-05): existing Swift/Foundation string handling only; no new Apple platform APIs introduced

## Original prompt
On hatching a new assistant, this shouldn't show up (lol). Let's use some placeholder if the name starts with `_(`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
