### PR TITLE
fix: add runtime column allowlist to getUsageGroupBreakdown

### DIFF
--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -224,7 +224,11 @@ export function getUsageGroupBreakdown(
   range: UsageTimeRange,
   groupBy: GroupByDimension,
 ): UsageGroupBreakdown[] {
-  // The column name matches the enum value exactly.
+  // Runtime allowlist — defense-in-depth against SQL injection via type assertions.
+  const ALLOWED_COLUMNS = new Set<string>(["actor", "provider", "model"]);
+  if (!ALLOWED_COLUMNS.has(groupBy)) {
+    throw new Error(`Invalid groupBy column: ${groupBy}`);
+  }
   const column = groupBy;
   const rows = rawAll<GroupRow>(
     /*sql*/ `


### PR DESCRIPTION
## Summary
Fixes defense-in-depth gap identified during plan review for usage-cost-reporting.md.

**Gap:** getUsageGroupBreakdown interpolated column names into SQL without runtime validation.
**What was expected:** Runtime allowlist check regardless of TypeScript type constraints.
**What was found:** Only compile-time type restriction, no runtime guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
