### PR TITLE
fix(ci): use gh CLI for perf baseline artifact download

### DIFF
--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -38,15 +38,30 @@ jobs:
             macos-spm-
 
       - name: Download previous baseline artifact
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          name: perf-baselines
-          path: .perf-baselines
-          # Always pull the baseline from the last successful main-branch run so
-          # PR runs compare against a known-good reference, not their own history.
-          workflow: ci-perf-macos.yaml
-          branch: main
-          if_no_artifact_found: warn
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Find the latest successful run of this workflow on main and download
+          # its perf-baselines artifact.  The gh CLI natively supports v4 artifacts,
+          # avoiding compatibility issues with third-party download actions.
+          RUN_ID=$(gh run list \
+            --repo "${{ github.repository }}" \
+            --workflow ci-perf-macos.yaml \
+            --branch main \
+            --status success \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
+          if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ]; then
+            echo "Downloading perf-baselines from run $RUN_ID"
+            gh run download "$RUN_ID" \
+              --repo "${{ github.repository }}" \
+              --name perf-baselines \
+              --dir .perf-baselines \
+            || echo "Warning: Could not download baseline artifact from run $RUN_ID"
+          else
+            echo "Warning: No previous successful run found on main — first run will establish the baseline"
+          fi
         continue-on-error: true
 
       - name: Run performance tests

--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -83,4 +83,5 @@ jobs:
         with:
           name: perf-baselines
           path: .perf-baselines/
+          include-hidden-files: true
           retention-days: 90


### PR DESCRIPTION
## Summary
- Replace `dawidd6/action-download-artifact@v6` with `gh run download` in the perf baselines CI workflow
- The third-party action couldn't find v4-format artifacts despite finding the correct workflow run — the gh CLI handles this natively
- Gracefully handles the first-run case when no previous baseline exists

## Original prompt
seen it running on main, however never seen an artifact getting downloaded/uploaded. need it to be fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
