### PR TITLE
fix: use UTC timezone for usage dashboard time range computation

### DIFF
--- a/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
@@ -299,24 +299,29 @@ struct UsageDashboardStoreGroupTests {
 struct UsageTimeRangeTests {
 
     @Test
-    func todayRangeStartsAtMidnight() {
-        let now = Date(timeIntervalSince1970: 1709683200) // 2024-03-06 00:00:00 UTC
+    func todayRangeStartsAtMidnightUTC() {
+        // Use a mid-day timestamp so UTC midnight differs from most local timezones
+        let now = Date(timeIntervalSince1970: 1709733600) // 2024-03-06 14:00:00 UTC
         let range = UsageTimeRange.today.epochMillisRange(now: now)
 
-        let calendar = Calendar(identifier: .gregorian)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
         let startOfDay = calendar.startOfDay(for: now)
         let expectedFrom = Int(startOfDay.timeIntervalSince1970 * 1000)
 
         #expect(range.from == expectedFrom)
+        // Verify we get UTC midnight (2024-03-06 00:00:00 UTC = 1709683200)
+        #expect(range.from == 1709683200 * 1000)
         #expect(range.to == Int(now.timeIntervalSince1970 * 1000))
     }
 
     @Test
     func last7DaysSpansSixDaysBack() {
-        let now = Date(timeIntervalSince1970: 1709683200) // 2024-03-06 00:00:00 UTC
+        let now = Date(timeIntervalSince1970: 1709733600) // 2024-03-06 14:00:00 UTC
         let range = UsageTimeRange.last7Days.epochMillisRange(now: now)
 
-        let calendar = Calendar(identifier: .gregorian)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
         let startOfToday = calendar.startOfDay(for: now)
         let sixDaysAgo = calendar.date(byAdding: .day, value: -6, to: startOfToday)!
         let expectedFrom = Int(sixDaysAgo.timeIntervalSince1970 * 1000)

--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -13,7 +13,8 @@ public enum UsageTimeRange: String, CaseIterable, Sendable {
     /// `to` is always the current instant; `from` is midnight UTC of the starting day.
     public func epochMillisRange(now: Date = Date()) -> (from: Int, to: Int) {
         let to = Int(now.timeIntervalSince1970 * 1000)
-        let calendar = Calendar(identifier: .gregorian)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
         let startOfToday = calendar.startOfDay(for: now)
 
         let startDate: Date


### PR DESCRIPTION
## Summary
Fixes timezone mismatch identified during plan review for usage-cost-reporting.md.

**Gap:** Client used local timezone for date boundaries while server uses UTC for day bucketing.
**What was expected:** Consistent UTC usage on both sides.
**What was found:** Calendar used device locale instead of UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
