### PR TITLE
fix: pass filename hints through WhatsApp media download to preserve original names

### DIFF
--- a/gateway/src/__tests__/whatsapp-download.test.ts
+++ b/gateway/src/__tests__/whatsapp-download.test.ts
@@ -404,6 +404,73 @@ describe("downloadWhatsAppFile", () => {
     );
   });
 
+  test("uses hint.fileName when provided instead of inferred name", async () => {
+    fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.includes("graph.facebook.com")) {
+        return new Response(
+          JSON.stringify({
+            url: MEDIA_URL,
+            mime_type: "application/pdf",
+            sha256: "abc",
+            file_size: 4,
+            id: MEDIA_ID,
+          }),
+        );
+      }
+
+      return new Response(new Uint8Array([0x25, 0x50, 0x44, 0x46]), {
+        headers: { "Content-Type": "application/pdf" },
+      });
+    });
+
+    const result = await downloadWhatsAppFile(makeConfig(), MEDIA_ID, {
+      fileName: "invoice.pdf",
+    });
+
+    expect(result.filename).toBe("invoice.pdf");
+    expect(result.mimeType).toBe("application/pdf");
+  });
+
+  test("uses hint.mimeType when Meta metadata is empty", async () => {
+    fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.includes("graph.facebook.com")) {
+        return new Response(
+          JSON.stringify({
+            url: MEDIA_URL,
+            mime_type: "",
+            sha256: "abc",
+            file_size: 3,
+            id: MEDIA_ID,
+          }),
+        );
+      }
+
+      // Unrecognizable bytes so file-type detection fails
+      return new Response(new Uint8Array([0x01, 0x02, 0x03]));
+    });
+
+    const result = await downloadWhatsAppFile(makeConfig(), MEDIA_ID, {
+      mimeType: "application/pdf",
+    });
+
+    expect(result.mimeType).toBe("application/pdf");
+    expect(result.filename).toBe("1234567890.pdf");
+  });
+
   test("throws when WhatsApp credentials are not configured", async () => {
     const config = makeConfig({
       whatsappAccessToken: undefined,

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -258,6 +258,10 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
                 const downloaded = await downloadWhatsAppFile(
                   config,
                   att.fileId,
+                  {
+                    fileName: att.fileName,
+                    mimeType: att.mimeType,
+                  },
                 );
                 return uploadAttachment(config, downloaded);
               }),

--- a/gateway/src/whatsapp/download.ts
+++ b/gateway/src/whatsapp/download.ts
@@ -46,6 +46,7 @@ function inferFilename(mediaId: string, mimeType: string): string {
 export async function downloadWhatsAppFile(
   config: GatewayConfig,
   mediaId: string,
+  hint?: { fileName?: string; mimeType?: string },
 ): Promise<DownloadedFile> {
   const meta = await getWhatsAppMediaMetadata(config, mediaId);
 
@@ -54,14 +55,15 @@ export async function downloadWhatsAppFile(
 
   const detected = await fileTypeFromBuffer(new Uint8Array(buffer));
 
-  // Prefer the MIME type from Meta metadata, then detected, then Content-Type header
+  // Prefer the MIME type from Meta metadata, then hint, then detected, then Content-Type header
   const mimeType =
     meta.mime_type ||
+    hint?.mimeType ||
     detected?.mime ||
     response.headers.get("Content-Type")?.split(";")[0].trim() ||
     "application/octet-stream";
 
-  const filename = inferFilename(mediaId, mimeType);
+  const filename = hint?.fileName || inferFilename(mediaId, mimeType);
   const data = Buffer.from(buffer).toString("base64");
 
   return { filename, mimeType, data };


### PR DESCRIPTION
## Summary
- Add hint parameter to downloadWhatsAppFile() mirroring Telegram's downloadTelegramFile() pattern
- Pass fileName and mimeType from normalized attachments in the webhook handler
- Preserves original filenames so the runtime's dangerous-extension guard works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
