### PR TITLE
fix: preserve UsageDashboardStore across iOS sheet presentations

### DIFF
--- a/clients/ios/Views/Settings/DeveloperSettingsSection.swift
+++ b/clients/ios/Views/Settings/DeveloperSettingsSection.swift
@@ -29,6 +29,15 @@ private struct DeveloperSettingsSectionContent: View {
     // Captured once when the sheet opens so the panel stays on the same session
     // even if newer trace events arrive while the sheet is visible.
     @State private var selectedSessionId: String?
+    // Preserved across sheet presentations to avoid redundant network calls
+    // and loading spinners each time the usage dashboard is opened.
+    @State private var usageDashboardStore: UsageDashboardStore
+
+    init(clientProvider: ClientProvider, traceStore: TraceStore) {
+        self.clientProvider = clientProvider
+        self.traceStore = traceStore
+        _usageDashboardStore = State(initialValue: UsageDashboardStore(client: clientProvider.client))
+    }
 
     private var sessionCount: Int {
         traceStore.eventsBySession.count
@@ -83,9 +92,7 @@ private struct DeveloperSettingsSectionContent: View {
             )
         }
         .sheet(isPresented: $showUsageDashboard) {
-            UsageDashboardView(
-                store: UsageDashboardStore(client: clientProvider.client)
-            )
+            UsageDashboardView(store: usageDashboardStore)
         }
     }
 }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for usage-cost-reporting.md.

**Gap:** iOS created a new UsageDashboardStore on every sheet presentation, causing redundant network calls.
**What was expected:** Store preserved across sheet open/close cycles.
**What was found:** Store created inline in .sheet modifier.

Lifts the `UsageDashboardStore` into a `@State` property initialized once in the view's `init`, so it persists across sheet dismiss/re-present cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
