### PR TITLE
fix: refactor autoNavigate/navigateXPages to use options object for optional params

### DIFF
--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -295,7 +295,7 @@ export async function handleRideShotgunStart(
                 clearInterval(checkInterval);
               }
             }, 1000);
-            navigateXPages(abortSignal, cdpBaseUrl)
+            navigateXPages({ abortSignal, cdpBaseUrl })
               .then((completed) => {
                 clearInterval(checkInterval);
                 log.info(
@@ -322,10 +322,9 @@ export async function handleRideShotgunStart(
                 clearInterval(checkInterval);
               }
             }, 1000);
-            autoNavigate(
-              navDomain,
+            autoNavigate(navDomain, {
               abortSignal,
-              (progress) => {
+              onProgress: (progress) => {
                 // Send progress to connected client
                 if (progress.type === "visiting" && progress.url) {
                   const shortUrl = progress.url.replace(/^https?:\/\//, "");
@@ -337,7 +336,7 @@ export async function handleRideShotgunStart(
                 }
               },
               cdpBaseUrl,
-            )
+            })
               .then((visited) => {
                 clearInterval(checkInterval);
                 log.info(

--- a/assistant/src/tools/browser/auto-navigate.ts
+++ b/assistant/src/tools/browser/auto-navigate.ts
@@ -80,21 +80,29 @@ export interface AutoNavProgress {
   visitedCount?: number;
 }
 
+export interface AutoNavOptions {
+  abortSignal?: { aborted: boolean };
+  onProgress?: (p: AutoNavProgress) => void;
+  cdpBaseUrl?: string;
+}
+
 /**
  * Navigate Chrome through a domain's pages to trigger API calls.
  * Discovers internal links from the DOM and visits up to ~15 unique paths.
  *
  * @param domain The domain to crawl (e.g. "example.com").
- * @param abortSignal Optional signal to stop navigation early.
- * @param onProgress Optional callback for live progress updates.
+ * @param options Optional configuration for abort, progress, and CDP base URL.
  * @returns List of visited page URLs.
  */
 export async function autoNavigate(
   domain: string,
-  abortSignal?: { aborted: boolean },
-  onProgress?: (p: AutoNavProgress) => void,
-  cdpBaseUrl: string = DEFAULT_CDP_BASE,
+  options?: AutoNavOptions,
 ): Promise<string[]> {
+  const {
+    abortSignal,
+    onProgress,
+    cdpBaseUrl = DEFAULT_CDP_BASE,
+  } = options ?? {};
   let wsUrl: string | null = null;
   try {
     const res = await fetch(`${cdpBaseUrl}/json/list`);

--- a/assistant/src/tools/browser/x-auto-navigate.ts
+++ b/assistant/src/tools/browser/x-auto-navigate.ts
@@ -71,17 +71,22 @@ class MiniCDP {
   }
 }
 
+export interface NavigateXPagesOptions {
+  abortSignal?: { aborted: boolean };
+  cdpBaseUrl?: string;
+}
+
 /**
  * Navigate Chrome through X.com pages to trigger GraphQL calls.
  * The NetworkRecorder should already be attached and capturing.
  *
- * @param abortSignal Optional signal to stop navigation early.
+ * @param options Optional configuration for abort and CDP base URL.
  * @returns List of step labels that completed successfully.
  */
 export async function navigateXPages(
-  abortSignal?: { aborted: boolean },
-  cdpBaseUrl: string = DEFAULT_CDP_BASE,
+  options?: NavigateXPagesOptions,
 ): Promise<string[]> {
+  const { abortSignal, cdpBaseUrl = DEFAULT_CDP_BASE } = options ?? {};
   let wsUrl: string | null = null;
   try {
     const res = await fetch(`${cdpBaseUrl}/json/list`);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for ride-shotgun-cdp.md.

**Gap:** autoNavigate has cdpBaseUrl parameter positioned after optional callbacks
**What was expected:** Clean API where callers don't need to pass undefined for unused optional params
**What was found:** cdpBaseUrl was appended as the last positional parameter after two other optionals

- Refactored `autoNavigate()` to accept `(domain, options?)` with `AutoNavOptions` interface
- Refactored `navigateXPages()` to accept `(options?)` with `NavigateXPagesOptions` interface
- Updated the sole caller in `ride-shotgun-handler.ts` for both functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
