### PR TITLE
fix: distinguish non-retryable WhatsApp media errors from transient failures

### DIFF
--- a/gateway/src/__tests__/whatsapp-download.test.ts
+++ b/gateway/src/__tests__/whatsapp-download.test.ts
@@ -14,6 +14,7 @@ mock.module("../fetch.js", () => ({
 }));
 
 const { downloadWhatsAppFile } = await import("../whatsapp/download.js");
+const { WhatsAppNonRetryableError } = await import("../whatsapp/api.js");
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return {
@@ -281,7 +282,7 @@ describe("downloadWhatsAppFile", () => {
     expect(result.filename).toBe("1234567890");
   });
 
-  test("throws on non-retryable 4xx metadata response", async () => {
+  test("throws WhatsAppNonRetryableError on non-retryable 4xx metadata response", async () => {
     fetchMock = mock(async (input: string | URL | Request) => {
       const url =
         typeof input === "string"
@@ -305,12 +306,12 @@ describe("downloadWhatsAppFile", () => {
       return new Response("unexpected", { status: 500 });
     });
 
-    await expect(downloadWhatsAppFile(makeConfig(), MEDIA_ID)).rejects.toThrow(
-      "Invalid media ID",
-    );
+    const promise = downloadWhatsAppFile(makeConfig(), MEDIA_ID);
+    await expect(promise).rejects.toThrow("Invalid media ID");
+    await expect(promise).rejects.toBeInstanceOf(WhatsAppNonRetryableError);
   });
 
-  test("throws on non-retryable 4xx download response", async () => {
+  test("throws WhatsAppNonRetryableError on non-retryable 4xx download response", async () => {
     fetchMock = mock(async (input: string | URL | Request) => {
       const url =
         typeof input === "string"
@@ -335,9 +336,11 @@ describe("downloadWhatsAppFile", () => {
       return new Response("Not Found", { status: 404 });
     });
 
-    await expect(downloadWhatsAppFile(makeConfig(), MEDIA_ID)).rejects.toThrow(
+    const promise = downloadWhatsAppFile(makeConfig(), MEDIA_ID);
+    await expect(promise).rejects.toThrow(
       "WhatsApp downloadMedia failed with status 404",
     );
+    await expect(promise).rejects.toBeInstanceOf(WhatsAppNonRetryableError);
   });
 
   test("retries on 500 and eventually succeeds", async () => {

--- a/gateway/src/http/routes/whatsapp-webhook.test.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.test.ts
@@ -30,6 +30,13 @@ class MockAttachmentValidationError extends Error {
   }
 }
 
+class MockWhatsAppNonRetryableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WhatsAppNonRetryableError";
+  }
+}
+
 mock.module("../../handlers/handle-inbound.js", () => ({
   handleInbound: handleInboundMock,
 }));
@@ -54,6 +61,7 @@ mock.module("../../whatsapp/send.js", () => ({
 
 mock.module("../../whatsapp/api.js", () => ({
   markWhatsAppMessageRead: markWhatsAppMessageReadMock,
+  WhatsAppNonRetryableError: MockWhatsAppNonRetryableError,
 }));
 
 mock.module("../../whatsapp/normalize.js", () => ({
@@ -540,6 +548,67 @@ describe("whatsapp-webhook", () => {
 
     expect(res.status).toBe(500);
     expect(handleInboundMock).not.toHaveBeenCalled();
+  });
+
+  it("skips non-retryable 4xx download errors and forwards message with empty attachments", async () => {
+    const { handler, dedupCache } = createWhatsAppWebhookHandler(baseConfig);
+
+    downloadWhatsAppFileMock.mockImplementation(() => {
+      throw new MockWhatsAppNonRetryableError(
+        "WhatsApp downloadMedia failed with status 404: Not Found",
+      );
+    });
+
+    normalizeWhatsAppWebhookMock.mockImplementation(() => [
+      {
+        whatsappMessageId: "wamid-nonretryable",
+        mediaType: "image",
+        event: {
+          version: "v1",
+          sourceChannel: "whatsapp",
+          receivedAt: new Date().toISOString(),
+          message: {
+            content: "check this photo",
+            conversationExternalId: "15551230000",
+            externalMessageId: "wamid-nonretryable",
+            attachments: [
+              {
+                type: "image",
+                fileId: "media-expired",
+                mimeType: "image/jpeg",
+                fileSize: 1024,
+              },
+            ],
+          },
+          actor: {
+            actorExternalId: "15551230000",
+            displayName: "Alice",
+          },
+          source: {
+            updateId: "wamid-nonretryable",
+            messageId: "wamid-nonretryable",
+            chatType: "private",
+          },
+          raw: {},
+        },
+      },
+    ]);
+
+    const res = await handler(
+      buildPostReq({ object: "whatsapp_business_account", entry: [] }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(handleInboundMock).toHaveBeenCalledTimes(1);
+    const [, , options] = handleInboundMock.mock.calls[0] as unknown as [
+      GatewayConfig,
+      Record<string, unknown>,
+      { attachmentIds?: string[] },
+    ];
+    expect(options.attachmentIds).toEqual([]);
+
+    // Dedup cache should be marked (not unreserved)
+    expect(dedupCache.reserve("wamid-nonretryable")).toBe(false);
   });
 
   it("deduplicates messages with the same WhatsApp message ID", async () => {

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -21,7 +21,10 @@ import {
 } from "../../webhook-pipeline.js";
 import { ROUTING_REJECTION_NOTICE } from "../../webhook-copy.js";
 import { downloadWhatsAppFile } from "../../whatsapp/download.js";
-import { markWhatsAppMessageRead } from "../../whatsapp/api.js";
+import {
+  markWhatsAppMessageRead,
+  WhatsAppNonRetryableError,
+} from "../../whatsapp/api.js";
 import { normalizeWhatsAppWebhook } from "../../whatsapp/normalize.js";
 import { sendWhatsAppReply } from "../../whatsapp/send.js";
 import { verifyWhatsAppWebhookSignature } from "../../whatsapp/verify.js";
@@ -269,6 +272,11 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
                 tlog.warn(
                   { err: result.reason },
                   "Skipping WhatsApp attachment with validation error",
+                );
+              } else if (result.reason instanceof WhatsAppNonRetryableError) {
+                tlog.warn(
+                  { err: result.reason },
+                  "Skipping WhatsApp attachment with non-retryable error",
                 );
               } else {
                 // Transient failure — propagate so the webhook returns 500 and

--- a/gateway/src/whatsapp/api.ts
+++ b/gateway/src/whatsapp/api.ts
@@ -4,6 +4,13 @@ import { getLogger } from "../logger.js";
 
 const log = getLogger("whatsapp-api");
 
+export class WhatsAppNonRetryableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WhatsAppNonRetryableError";
+  }
+}
+
 // Meta Cloud API v20 endpoint template
 const WHATSAPP_API_BASE = "https://graph.facebook.com/v20.0";
 
@@ -84,7 +91,7 @@ async function retryableWhatsAppFetch<T>(
       const data = (await response
         .json()
         .catch(() => ({}))) as WhatsAppApiErrorResponse;
-      throw new Error(
+      throw new WhatsAppNonRetryableError(
         data.error?.message
           ? `WhatsApp ${operation} failed: ${data.error.message}`
           : `WhatsApp ${operation} failed with status ${response.status}`,
@@ -409,7 +416,7 @@ async function retryableWhatsAppRawFetch(
       } catch {
         // Response body is not JSON — include raw text if available
       }
-      throw new Error(
+      throw new WhatsAppNonRetryableError(
         errorMessage
           ? `WhatsApp ${operation} failed: ${errorMessage}`
           : body


### PR DESCRIPTION
## Summary
- Add WhatsAppNonRetryableError class for 4xx media API failures
- Skip non-retryable errors in webhook handler instead of treating them as transient (returning 500)
- Prevents pointless Meta webhook retries for invalid/deleted/expired media IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
