### PR TITLE
M4: Enhance CI to post PR comment with performance regression table (#13133)

### DIFF
--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -70,7 +70,7 @@ jobs:
           fi
 
       - name: Comment on PR with performance results
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && hashFiles('.perf-baselines/summary.md') != ''
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           path: .perf-baselines/summary.md

--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -62,6 +62,19 @@ jobs:
           UPDATE_BASELINE: ${{ github.event_name == 'push' && 'true' || 'false' }}
         run: bash scripts/compare-perf-baselines.sh
 
+      - name: Performance summary
+        if: always()
+        run: |
+          if [ -f .perf-baselines/summary.md ]; then
+            cat .perf-baselines/summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Comment on PR with performance results
+        if: always() && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: .perf-baselines/summary.md
+
       - name: Upload new baselines
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Comment on PR with performance results
         if: always() && github.event_name == 'pull_request' && hashFiles('.perf-baselines/summary.md') != ''
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           path: .perf-baselines/summary.md

--- a/scripts/compare-perf-baselines.sh
+++ b/scripts/compare-perf-baselines.sh
@@ -54,10 +54,14 @@ with open(results_log) as f:
             if test_name not in results:  # first match wins (wall-time before CPU-cycles lines)
                 results[test_name] = float(m.group(3))
 
+summary_file = os.path.join(baseline_dir, "summary.md")
+
 if not results:
     print("ERROR: No XCTest performance measurements found in log.")
     print("This likely means the performance tests did not run or produced no output.")
     print("Check that MarkdownPerformanceTests executed successfully.")
+    with open(summary_file, "w") as sf:
+        sf.write("## Performance Baselines\n\nNo performance measurements found in test output.\n")
     sys.exit(1)
 
 print("=== Performance Results ===")
@@ -79,6 +83,8 @@ if not os.path.exists(baseline_file):
         print("WARNING: No baseline found and this is a PR run (UPDATE_BASELINE=false).")
         print("Run the workflow on main to establish a baseline before regressions can be detected.")
         print("Skipping regression check for this PR run.")
+    with open(summary_file, "w") as sf:
+        sf.write("## Performance Baselines\n\nNo baseline available yet. Run the workflow on `main` to establish baselines.\n")
     sys.exit(0)
 
 # Load and compare against stored baseline.
@@ -102,6 +108,28 @@ for name, actual in sorted(results.items()):
         regressions.append(name)
 
 print()
+
+# Write summary.md with a formatted table for PR comments and step summaries.
+rows = []
+for name, actual in sorted(results.items()):
+    if name not in baselines:
+        rows.append(f"| {name} | — | {actual:.4f}s | — | 🆕 NEW |")
+        continue
+    baseline = baselines[name]
+    if baseline == 0:
+        dp = float('inf') if actual > 0 else 0.0
+    else:
+        dp = (actual - baseline) / baseline * 100
+    status = "❌ REGRESSED" if dp > threshold else "✅ ok"
+    rows.append(f"| {name} | {baseline:.4f}s | {actual:.4f}s | {dp:+.1f}% | {status} |")
+
+with open(summary_file, "w") as sf:
+    sf.write("## Performance Baselines\n\n")
+    sf.write("| Test | Baseline | Actual | Delta | Status |\n")
+    sf.write("|------|----------|--------|-------|--------|\n")
+    for row in rows:
+        sf.write(row + "\n")
+    sf.write(f"\n**Threshold**: {int(threshold)}%\n")
 
 if regressions:
     print(f"FAIL: {len(regressions)} regression(s) exceed {threshold:.0f}% threshold: {', '.join(regressions)}")


### PR DESCRIPTION
## Summary
- Modify compare-perf-baselines.sh to output a markdown summary table
- Add GitHub Actions step summary for all runs
- Add sticky PR comment with performance results on pull_request events
- Table shows test name, baseline, actual, delta %, and pass/fail status

Part of #13128

Closes #13133
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
