### PR TITLE
fix: use instance cdpBaseUrl in NetworkRecorder.startDirect() fallback

### DIFF
--- a/assistant/src/tools/browser/network-recorder.test.ts
+++ b/assistant/src/tools/browser/network-recorder.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { NetworkRecorder } from "./network-recorder.js";
+
+describe("NetworkRecorder", () => {
+  describe("startDirect CDP URL passthrough", () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCalls: string[];
+
+    beforeEach(() => {
+      fetchCalls = [];
+      // Mock fetch to capture the URL and return a valid CDP version response.
+      globalThis.fetch = (async (url: string | URL | Request) => {
+        fetchCalls.push(String(url));
+        return new Response(
+          JSON.stringify({
+            webSocketDebuggerUrl: "ws://localhost:1234/devtools/browser/fake",
+          }),
+          { status: 200 },
+        );
+      }) as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it("uses constructor-provided cdpBaseUrl when called without arguments", async () => {
+      const customBase = "http://custom-host:9333";
+      const recorder = new NetworkRecorder(undefined, customBase);
+
+      // startDirect will fail at the WebSocket connect step, but we only
+      // care that fetch was called with the correct URL.
+      try {
+        await recorder.startDirect();
+      } catch {
+        // Expected — WebSocket connection will fail in test environment
+      }
+
+      expect(fetchCalls.length).toBeGreaterThanOrEqual(1);
+      expect(fetchCalls[0]).toBe(`${customBase}/json/version`);
+      expect(fetchCalls[0]).not.toContain("undefined");
+    });
+
+    it("uses explicit cdpBaseUrl argument when provided", async () => {
+      const constructorBase = "http://constructor-host:9222";
+      const explicitBase = "http://explicit-host:9444";
+      const recorder = new NetworkRecorder(undefined, constructorBase);
+
+      try {
+        await recorder.startDirect(explicitBase);
+      } catch {
+        // Expected — WebSocket connection will fail in test environment
+      }
+
+      expect(fetchCalls.length).toBeGreaterThanOrEqual(1);
+      expect(fetchCalls[0]).toBe(`${explicitBase}/json/version`);
+    });
+  });
+});

--- a/assistant/src/tools/browser/network-recorder.ts
+++ b/assistant/src/tools/browser/network-recorder.ts
@@ -144,7 +144,7 @@ export class NetworkRecorder {
     if (cdpBaseUrl) this.cdpBaseUrl = cdpBaseUrl;
 
     // Discover the browser's WebSocket debugger URL
-    const versionRes = await fetch(`${cdpBaseUrl}/json/version`);
+    const versionRes = await fetch(`${this.cdpBaseUrl}/json/version`);
     const version = (await versionRes.json()) as {
       webSocketDebuggerUrl: string;
     };


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for ride-shotgun-cdp.md.

**Gap:** startDirect() uses undefined parameter instead of instance field for fetch URL
**What was expected:** startDirect() should fall back to the constructor-provided cdpBaseUrl
**What was found:** The method used the local parameter (undefined when not passed) instead of this.cdpBaseUrl

Also adds test coverage for CDP URL passthrough in startDirect().

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
