### PR TITLE
fix: add macOS usage panel discoverability, SidePanelType case, and stable store lifecycle

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindow.swift
@@ -218,6 +218,7 @@ public final class MainWindow {
     let threadManager: ThreadManager
     let appListManager = AppListManager()
     let traceStore = TraceStore()
+    let usageDashboardStore: UsageDashboardStore
     public let windowState = MainWindowState()
     let documentManager = DocumentManager()
     var onMicrophoneToggle: (() -> Void)?
@@ -263,6 +264,7 @@ public final class MainWindow {
             activityNotificationService: services.activityNotificationService,
             isFirstLaunch: isFirstLaunch
         )
+        self.usageDashboardStore = UsageDashboardStore(client: services.daemonClient)
         self.threadManager.ambientAgent = services.ambientAgent
         documentManager.daemonClient = daemonClient
         services.daemonClient.onTraceEvent = { [weak self] msg in
@@ -371,7 +373,7 @@ public final class MainWindow {
             }
         } : nil
 
-        let rootView = MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, conversationZoomManager: services.conversationZoomManager, traceStore: traceStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, documentManager: documentManager, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, onSendWakeUp: wakeUpCallback)
+        let rootView = MainWindowView(threadManager: threadManager, appListManager: appListManager, zoomManager: zoomManager, conversationZoomManager: services.conversationZoomManager, traceStore: traceStore, usageDashboardStore: usageDashboardStore, daemonClient: daemonClient, surfaceManager: surfaceManager, ambientAgent: ambientAgent, settingsStore: services.settingsStore, authManager: services.authManager, windowState: windowState, documentManager: documentManager, onMicrophoneToggle: onMicrophoneToggle ?? {}, voiceModeManager: voiceModeManager, onSendWakeUp: wakeUpCallback)
         let hostingController = NonDraggableHostingController(rootView: rootView)
 
         let screenFrame = NSScreen.main?.visibleFrame ?? NSScreen.screens.first?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -12,6 +12,7 @@ struct MainWindowView: View {
     /// TraceStore mutations when the DebugPanel isn't visible. DebugPanel
     /// itself uses `@ObservedObject` and is only instantiated when shown.
     let traceStore: TraceStore
+    let usageDashboardStore: UsageDashboardStore
     @ObservedObject var windowState: MainWindowState
     @State private var selectedThreadId: UUID?
     @State var sharing = SharingState()
@@ -58,12 +59,13 @@ struct MainWindowView: View {
     /// Whether the daemon-loading skeleton overlay is currently showing.
     @State var showDaemonLoading: Bool
 
-    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager, traceStore: TraceStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, onSendWakeUp: (() -> Void)? = nil) {
+    init(threadManager: ThreadManager, appListManager: AppListManager, zoomManager: ZoomManager, conversationZoomManager: ConversationZoomManager, traceStore: TraceStore, usageDashboardStore: UsageDashboardStore, daemonClient: DaemonClient, surfaceManager: SurfaceManager, ambientAgent: AmbientAgent, settingsStore: SettingsStore, authManager: AuthManager, windowState: MainWindowState, documentManager: DocumentManager, onMicrophoneToggle: @escaping () -> Void = {}, voiceModeManager: VoiceModeManager, onSendWakeUp: (() -> Void)? = nil) {
         self.threadManager = threadManager
         self.appListManager = appListManager
         self.zoomManager = zoomManager
         self.conversationZoomManager = conversationZoomManager
         self.traceStore = traceStore
+        self.usageDashboardStore = usageDashboardStore
         self.daemonClient = daemonClient
         self.surfaceManager = surfaceManager
         self.ambientAgent = ambientAgent
@@ -534,6 +536,10 @@ struct MainWindowView: View {
                             onSettings: {
                                 sidebar.showPreferencesDrawer = false
                                 windowState.selection = .panel(.settings)
+                            },
+                            onUsage: {
+                                sidebar.showPreferencesDrawer = false
+                                windowState.selection = .panel(.usageDashboard)
                             },
                             onDebug: {
                                 sidebar.showPreferencesDrawer = false

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -115,7 +115,7 @@ extension MainWindowView {
             )
         case .usageDashboard:
             UsageDashboardPanel(
-                daemonClient: daemonClient,
+                store: usageDashboardStore,
                 onClose: { windowState.selection = nil }
             )
         }
@@ -541,6 +541,12 @@ extension MainWindowView {
             )
             .overlay(alignment: .topTrailing) { panelDismissButton }
             .background(adaptiveColor(light: Moss._50, dark: Moss._950))
+        case .usageDashboard:
+            UsageDashboardPanel(
+                store: usageDashboardStore,
+                onClose: { windowState.dismissOverlay() }
+            )
+            .overlay(alignment: .topTrailing) { panelDismissButton }
         default:
             EmptyView()
         }
@@ -1109,7 +1115,7 @@ private struct AppLoadingView: View {
 struct MainWindowView_Previews: PreviewProvider {
     static var previews: some View {
         let dc = DaemonClient()
-        MainWindowView(threadManager: ThreadManager(daemonClient: dc), appListManager: AppListManager(), zoomManager: ZoomManager(), conversationZoomManager: ConversationZoomManager(), traceStore: TraceStore(), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: AmbientAgent(), settingsStore: SettingsStore(daemonClient: dc), authManager: AuthManager(), windowState: MainWindowState(), documentManager: DocumentManager(), voiceModeManager: VoiceModeManager())
+        MainWindowView(threadManager: ThreadManager(daemonClient: dc), appListManager: AppListManager(), zoomManager: ZoomManager(), conversationZoomManager: ConversationZoomManager(), traceStore: TraceStore(), usageDashboardStore: UsageDashboardStore(client: dc), daemonClient: dc, surfaceManager: SurfaceManager(), ambientAgent: AmbientAgent(), settingsStore: SettingsStore(daemonClient: dc), authManager: AuthManager(), windowState: MainWindowState(), documentManager: DocumentManager(), voiceModeManager: VoiceModeManager())
             .frame(width: 900, height: 600)
             .padding(.top, 36)
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -2,31 +2,19 @@ import SwiftUI
 import VellumAssistantShared
 
 struct UsageDashboardPanel: View {
-    let daemonClient: DaemonClient
+    let store: UsageDashboardStore
     var onClose: () -> Void
-
-    @State private var store: UsageDashboardStore?
 
     var body: some View {
         VSidePanel(title: "Usage", onClose: onClose, pinnedContent: {
-            if let store {
-                timeRangeStrip(store: store)
-                Divider().background(VColor.surfaceBorder)
-            }
+            timeRangeStrip(store: store)
+            Divider().background(VColor.surfaceBorder)
         }) {
-            if let store {
-                contentView(store: store)
-            } else {
-                ProgressView()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
+            contentView(store: store)
         }
         .onAppear {
-            if store == nil {
-                store = UsageDashboardStore(client: daemonClient)
-            }
             Task {
-                await store?.refresh()
+                await store.refresh()
             }
         }
     }
@@ -322,7 +310,7 @@ struct UsageDashboardPanel: View {
 #Preview {
     ZStack {
         VColor.background.ignoresSafeArea()
-        UsageDashboardPanel(daemonClient: DaemonClient(), onClose: {})
+        UsageDashboardPanel(store: UsageDashboardStore(client: DaemonClient()), onClose: {})
     }
     .frame(width: 400, height: 600)
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
@@ -7,6 +7,7 @@ enum SidePanelType: Hashable, CaseIterable {
     case avatarCustomization
     case apps
     case intelligence
+    case usageDashboard
 
     init?(rawValue: String) {
         switch rawValue {
@@ -18,6 +19,7 @@ enum SidePanelType: Hashable, CaseIterable {
         case "avatarCustomization": self = .avatarCustomization
         case "apps": self = .apps
         case "intelligence": self = .intelligence
+        case "usageDashboard": self = .usageDashboard
         // Legacy values from older builds — map to the unified Intelligence panel
         case "identity", "agent": self = .intelligence
         default: return nil

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -3,6 +3,7 @@ import VellumAssistantShared
 
 struct DrawerMenuView: View {
     let onSettings: () -> Void
+    let onUsage: () -> Void
     let onDebug: () -> Void
     let onLogOut: () -> Void
     var body: some View {
@@ -15,6 +16,11 @@ struct DrawerMenuView: View {
                 .padding(.vertical, VSpacing.xs)
 
             DrawerMenuItem(icon: "gearshape", label: String(localized: "Settings"), description: String(localized: "Ask the assistant to help you with any settings you wish to change"), action: onSettings)
+
+            VColor.surfaceBorder.frame(height: 1)
+                .padding(.vertical, VSpacing.xs)
+
+            DrawerMenuItem(icon: "chart.bar", label: String(localized: "Usage"), action: onUsage)
 
             VColor.surfaceBorder.frame(height: 1)
                 .padding(.vertical, VSpacing.xs)


### PR DESCRIPTION
## Summary
Fixes three related gaps from plan review for usage-cost-reporting.md.

**Gap 1:** macOS panel had no discoverable UI entry point — added "Usage" item to the drawer menu (alongside Settings and Debug).

**Gap 2:** SidePanelType enum was missing usageDashboard case — added the case and rawValue mapping so panel persistence and toggle work correctly.

**Gap 3:** UsageDashboardPanel created store lazily in onAppear, losing state on panel switch — lifted store creation to MainWindow and pass it through MainWindowView, matching the pattern used by TraceStore and SettingsStore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
