### PR TITLE
Add organization header support to managed migration transport

### DIFF
--- a/assistant/src/__tests__/migration-transport.test.ts
+++ b/assistant/src/__tests__/migration-transport.test.ts
@@ -191,6 +191,55 @@ describe("Auth headers", () => {
     expect(headers["Authorization"]).toBeUndefined();
   });
 
+  test("managed request includes Vellum-Organization-Id from defaultHeaders", async () => {
+    const { fetchFn, captured } = capturingFetch(200, {
+      is_valid: true,
+      errors: [],
+      manifest: {},
+    });
+    await validateBundle(
+      managedConfig({
+        fetchFn,
+        defaultHeaders: { "Vellum-Organization-Id": "org-123" },
+      }),
+      sampleFileData,
+    );
+    const headers = captured[0].init.headers as Record<string, string>;
+    expect(headers["Vellum-Organization-Id"]).toBe("org-123");
+    // Managed auth header should still be present
+    expect(headers["X-Session-Token"]).toBe("test-session-token");
+  });
+
+  test("runtime request is unchanged when no defaultHeaders provided", async () => {
+    const { fetchFn, captured } = capturingFetch(200, {
+      is_valid: true,
+      errors: [],
+      manifest: {},
+    });
+    await validateBundle(runtimeConfig({ fetchFn }), sampleFileData);
+    const headers = captured[0].init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer test-jwt");
+    expect(headers["Vellum-Organization-Id"]).toBeUndefined();
+  });
+
+  test("auth header wins over same-named entry in defaultHeaders", async () => {
+    const { fetchFn, captured } = capturingFetch(200, {
+      is_valid: true,
+      errors: [],
+      manifest: {},
+    });
+    // defaultHeaders sets X-Session-Token, but authHeader should override it
+    await validateBundle(
+      managedConfig({
+        fetchFn,
+        defaultHeaders: { "X-Session-Token": "should-be-overridden" },
+      }),
+      sampleFileData,
+    );
+    const headers = captured[0].init.headers as Record<string, string>;
+    expect(headers["X-Session-Token"]).toBe("test-session-token");
+  });
+
   test("no auth header when authHeader is not provided", async () => {
     const { fetchFn, captured } = capturingFetch(200, {
       is_valid: true,

--- a/assistant/src/runtime/migrations/migration-transport.ts
+++ b/assistant/src/runtime/migrations/migration-transport.ts
@@ -40,6 +40,13 @@ export interface TransportConfig {
   authHeader?: string;
   /** Header name for auth. Defaults to "Authorization" for runtime, "X-Session-Token" for managed. */
   authHeaderName?: string;
+  /**
+   * Additional headers to include with every request.
+   * Merged after Content-Type but before auth-header injection,
+   * so an explicit auth header from the transport always wins
+   * over a same-named entry in defaultHeaders.
+   */
+  defaultHeaders?: Record<string, string>;
   /** Custom fetch implementation for testing or environments without global fetch. */
   fetchFn?: typeof fetch;
 }
@@ -277,6 +284,12 @@ function buildHeaders(
     headers["Content-Type"] = contentType;
   }
 
+  // Merge defaultHeaders after Content-Type but before auth injection
+  if (config.defaultHeaders) {
+    Object.assign(headers, config.defaultHeaders);
+  }
+
+  // Auth header is applied last so it always wins over defaultHeaders
   if (config.authHeader) {
     const headerName =
       config.authHeaderName ??


### PR DESCRIPTION
## Summary
- Extend `TransportConfig` with `defaultHeaders?: Record<string, string>` for generic header injection
- Update `buildHeaders` to merge `defaultHeaders` after `Content-Type` but before auth-header injection, ensuring auth headers always win
- Add tests verifying `Vellum-Organization-Id` header works in managed requests and runtime behavior is unchanged

Part of plan: managed-migration-live.md (PR 1 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
