### PR TITLE
fix: rebind destination after explicit reuse_existing in notification pairing

### DIFF
--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -456,6 +456,80 @@ describe("pairDeliveryWithConversation", () => {
     expect(upsertArgs.externalChatId).toBe("C0123ABCDEF");
   });
 
+  test("reuse_existing rebinds destination when binding context is present", async () => {
+    mockExistingConversations["conv-explicit"] = {
+      id: "conv-explicit",
+      source: "notification",
+      title: "Explicit Thread",
+    };
+
+    const signal = makeSignal();
+    const copy = makeCopy({
+      threadSeedMessage: "Follow-up to explicit reuse target",
+    });
+    const threadAction: ThreadAction = {
+      action: "reuse_existing",
+      conversationId: "conv-explicit",
+    };
+    const bindingContext: DestinationBindingContext = {
+      sourceChannel: "telegram" as NotificationChannel,
+      externalChatId: "chat-rebind",
+    };
+
+    const result = await pairDeliveryWithConversation(
+      signal,
+      "telegram" as NotificationChannel,
+      copy,
+      { threadAction, bindingContext },
+    );
+
+    expect(result.conversationId).toBe("conv-explicit");
+    expect(result.createdNewConversation).toBe(false);
+    // Should rebind the destination to the reused conversation
+    expect(upsertOutboundBindingMock).toHaveBeenCalledTimes(1);
+    const upsertArgs = upsertOutboundBindingMock.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(upsertArgs.conversationId).toBe("conv-explicit");
+    expect(upsertArgs.sourceChannel).toBe("notification:telegram");
+    expect(upsertArgs.externalChatId).toBe("chat-rebind");
+  });
+
+  test("reuse_existing fallback rebinds destination when binding context is present", async () => {
+    // Target does not exist — falls back to new conversation
+    const signal = makeSignal();
+    const copy = makeCopy();
+    const threadAction: ThreadAction = {
+      action: "reuse_existing",
+      conversationId: "conv-gone",
+    };
+    const bindingContext: DestinationBindingContext = {
+      sourceChannel: "sms" as NotificationChannel,
+      externalChatId: "+15559876543",
+    };
+
+    const result = await pairDeliveryWithConversation(
+      signal,
+      "sms" as NotificationChannel,
+      copy,
+      { threadAction, bindingContext },
+    );
+
+    expect(result.conversationId).toBe("conv-001");
+    expect(result.createdNewConversation).toBe(true);
+    expect(result.threadDecisionFallbackUsed).toBe(true);
+    // Should bind the new conversation to the destination
+    expect(upsertOutboundBindingMock).toHaveBeenCalledTimes(1);
+    const upsertArgs = upsertOutboundBindingMock.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(upsertArgs.conversationId).toBe("conv-001");
+    expect(upsertArgs.sourceChannel).toBe("notification:sms");
+    expect(upsertArgs.externalChatId).toBe("+15559876543");
+  });
+
   test("explicit reuse_existing takes precedence over binding-key reuse", async () => {
     // Both a binding and a reuse_existing target exist — reuse_existing wins
     mockExistingConversations["conv-explicit"] = {

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -119,6 +119,7 @@ export async function pairDeliveryWithConversation(
       : composeThreadSeed(signal, channel, copy);
 
     const threadAction = options?.threadAction;
+    const bindingContext = options?.bindingContext;
 
     // Attempt to reuse an existing conversation when the model requests it
     if (threadAction?.action === "reuse_existing") {
@@ -134,6 +135,16 @@ export async function pairDeliveryWithConversation(
           undefined,
           { skipIndexing: true },
         );
+
+        // Rebind the destination so subsequent deliveries to the same
+        // (sourceChannel, externalChatId) resolve to this conversation.
+        if (bindingContext?.sourceChannel && bindingContext?.externalChatId) {
+          upsertOutboundBinding({
+            conversationId: existing.id,
+            sourceChannel: notificationChannel(bindingContext.sourceChannel),
+            externalChatId: bindingContext.externalChatId,
+          });
+        }
 
         log.info(
           {
@@ -182,6 +193,16 @@ export async function pairDeliveryWithConversation(
         { skipIndexing: true },
       );
 
+      // Bind the new conversation to the destination so subsequent
+      // deliveries reuse it instead of creating yet another conversation.
+      if (bindingContext?.sourceChannel && bindingContext?.externalChatId) {
+        upsertOutboundBinding({
+          conversationId: conversation.id,
+          sourceChannel: notificationChannel(bindingContext.sourceChannel),
+          externalChatId: bindingContext.externalChatId,
+        });
+      }
+
       return {
         conversationId: conversation.id,
         messageId: message.id,
@@ -194,7 +215,6 @@ export async function pairDeliveryWithConversation(
     // For channels with continue_existing_conversation strategy, try to
     // reuse a previously bound conversation keyed by (sourceChannel, externalChatId)
     // before falling through to create a new one.
-    const bindingContext = options?.bindingContext;
     if (
       strategy === "continue_existing_conversation" &&
       bindingContext?.sourceChannel &&


### PR DESCRIPTION
## Summary
- Adds upsertOutboundBinding() calls to both the successful reuse_existing path and the invalid-reuse fallback path in conversation-pairing.ts
- Ensures the destination binding always points to the conversation that was actually used, maintaining the 'one destination, one continued conversation' invariant
- Adds test coverage for both rebinding scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
