### PR TITLE
Fix stale WhatsApp webhook CI assertion

### DIFF
--- a/gateway/src/http/routes/whatsapp-webhook.test.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.test.ts
@@ -365,6 +365,7 @@ describe("whatsapp-webhook", () => {
     expect(downloadWhatsAppFileMock).toHaveBeenCalledWith(
       baseConfig,
       "media-id-123",
+      expect.objectContaining({ mimeType: "image/jpeg" }),
     );
     expect(uploadAttachmentMock).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
## Summary
- update the WhatsApp webhook media attachment test to expect the MIME hint now passed into `downloadWhatsAppFile`
- keep the assertion focused on the metadata contract instead of an undefined filename field

## Testing
- `export PATH="$HOME/.bun/bin:$PATH"; cd gateway && bun test src/http/routes/whatsapp-webhook.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
