### PR TITLE
fix: update docs and skill guidance to match actual channel implementations

### DIFF
--- a/assistant/README.md
+++ b/assistant/README.md
@@ -382,7 +382,7 @@ All endpoints are bearer-authenticated. Skills and clients should call the gatew
 - **Voice**: Checks Twilio credentials, phone number assignment, and public ingress URL.
 - **Telegram**: Checks bot token, webhook secret, and public ingress URL.
 - **Email**: Checks AgentMail API key, invite policy, and public ingress URL.
-- **WhatsApp**: Checks Twilio credentials, phone number assignment, invite policy, and public ingress URL.
+- **WhatsApp**: Checks Meta WhatsApp Business API credentials (phoneNumberId, accessToken, appSecret, webhookVerifyToken), invite policy, and public ingress URL.
 - **Slack**: Checks bot token and app token.
 
 ### Key modules
@@ -419,16 +419,8 @@ The `iv_` prefix distinguishes invite tokens from `gv_` (guardian verification) 
 The invite redemption system uses a three-layer architecture:
 
 - **Core redemption engine** (`invite-redemption-service.ts`) — Channel-agnostic business logic that validates tokens, enforces expiry/use-count/channel-match constraints, handles member reactivation, and returns a discriminated-union `InviteRedemptionOutcome`. Deterministic reply templates (`invite-redemption-templates.ts`) map each outcome to a user-facing message without passing through the LLM.
-- **Channel transport adapters** (`channel-invite-transport.ts` + `channel-invite-transports/`) — A registry of per-channel adapters that know how to build shareable deep links (`buildShareableInvite`) and extract inbound tokens (`extractInboundToken`). Currently only the Telegram adapter is implemented.
+- **Channel transport adapters** (`channel-invite-transport.ts` + `channel-invite-transports/`) — A registry of per-channel adapters that know how to build shareable links (`buildShareLink`) and extract inbound tokens (`extractInboundToken`). Adapters are implemented for Telegram, SMS, Voice, Email, WhatsApp, and Slack.
 - **Conversational orchestration** (`guardian-invite-intent.ts`) — Pattern-based intent detection that intercepts guardian invite management requests (create, list, revoke) in the session pipeline and forces immediate entry into the `contacts` skill, bypassing the normal agent loop.
-
-#### Deferred Channel Support
-
-The transport adapter registry is architecturally extensible to additional channels. The following are not yet implemented:
-
-- **SMS** — Requires a deep-link strategy compatible with SMS (e.g., a short URL that redirects to an SMS reply flow or web-based redemption page). The core redemption engine is channel-agnostic and ready.
-- **Slack** — Requires DM-safe ingress (Socket Mode currently handles channel messages but DM-initiated invite flows need additional routing). The adapter would build Slack deep links or slash-command payloads.
-- **Voice** — Requires DTMF or speech-based token capture during an inbound call. The adapter would need to integrate with the voice relay state machine for token entry.
 
 Redemption auto-creates a **member** record with an access policy:
 

--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -406,7 +406,7 @@ The response contains `{ ok: true, invite: { id, token, inviteCode, guardianInst
 >
 > This code can be used <maxUses> time(s)<and expires in X hours/days if applicable>.
 
-If the assistant's WhatsApp number is not available (Twilio not configured for WhatsApp), tell the guardian they need to set up WhatsApp integration first.
+If the assistant's WhatsApp number is not available (Meta WhatsApp Business API credentials not configured), tell the guardian they need to set up WhatsApp integration first.
 
 ### Create an SMS invite
 
@@ -429,6 +429,37 @@ The response follows the same shape as email and WhatsApp invites (`inviteCode`,
 
 **Presenting to the guardian**: Give the guardian the invite code and the assistant's phone number, with instructions for the invitee to text the code.
 
+### Create a Slack invite
+
+Use this when the guardian wants to invite someone to message the assistant on Slack. Slack invites use a 6-digit code -- the invitee sends the code as a direct message to the assistant's Slack bot to redeem access.
+
+```bash
+INVITE_JSON=$(curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/contacts/invites" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
+  -d '{
+    "sourceChannel": "slack",
+    "contactName": "<invitee display name>",
+    "maxUses": 1,
+    "note": "<optional note, e.g. the person it is for>"
+  }')
+printf '%s\n' "$INVITE_JSON"
+```
+
+The response follows the same shape as email, WhatsApp, and SMS invites (`inviteCode`, `guardianInstruction`, `channelHandle`).
+
+**Presenting to the guardian**: Give the guardian the invite code and instructions for the invitee to send the code as a DM to the assistant's Slack bot.
+
+> Slack invite created for **<contact_name>**:
+>
+> **Invite code: `<inviteCode>`**
+>
+> Tell them to send a direct message to the assistant's Slack bot with the code **<inviteCode>**. Once verified, they will be added as a trusted contact and can message the assistant on Slack directly.
+>
+> This code can be used <maxUses> time(s)<and expires in X hours/days if applicable>.
+
+If the Slack bot is not available (Slack credentials not configured), tell the guardian they need to set up Slack integration first.
+
 ### List invites
 
 Use this to show the guardian their active (and optionally all) invite links.
@@ -443,12 +474,13 @@ For voice invites:
 vellum contacts invites --source-channel voice --json
 ```
 
-For email, WhatsApp, or SMS invites:
+For email, WhatsApp, SMS, or Slack invites:
 
 ```bash
 vellum contacts invites --source-channel email --json
 vellum contacts invites --source-channel whatsapp --json
 vellum contacts invites --source-channel sms --json
+vellum contacts invites --source-channel slack --json
 ```
 
 Optional query parameters:
@@ -509,7 +541,7 @@ Each channel has:
 
 ## Confirmation Requirements
 
-**All mutating actions (allow, revoke, block, revoke invite) require explicit user confirmation before execution.** This is a safety measure -- modifying who can access the assistant should always be a deliberate choice. Creating an invite (Telegram link or voice invite) does not require confirmation since it does not grant access until the invitee redeems it.
+**All mutating actions (allow, revoke, block, revoke invite) require explicit user confirmation before execution.** This is a safety measure -- modifying who can access the assistant should always be a deliberate choice. Creating an invite (Telegram link, voice invite, email invite, WhatsApp invite, SMS invite, or Slack invite) does not require confirmation since it does not grant access until the invitee redeems it.
 
 - Clearly state what action you are about to take and who it affects.
 - Wait for the user to confirm before running the curl command.
@@ -555,6 +587,8 @@ Each channel has:
 **"Invite someone on WhatsApp"** -- Create an invite with `sourceChannel: "whatsapp"`. Present the 6-digit invite code and the assistant's WhatsApp number. Tell the guardian to share both with the invitee.
 
 **"Invite someone via SMS"** / **"Send a text invite"** -- Create an invite with `sourceChannel: "sms"`. Present the 6-digit invite code and the assistant's phone number. Tell the guardian to share both with the invitee.
+
+**"Invite someone on Slack"** -- Create an invite with `sourceChannel: "slack"`. Present the 6-digit invite code and tell the guardian to have the invitee DM the code to the assistant's Slack bot.
 
 **"Show my invites"** / **"List active invite links"** -- List invites filtered by `sourceChannel=telegram`, present active invites with uses remaining and expiration info. Use the appropriate `--source-channel` value for other channels.
 


### PR DESCRIPTION
## Summary
- README: WhatsApp probe documented with Meta credentials instead of Twilio
- README: channel adapter list updated to reflect all implemented adapters
- SKILL.md: WhatsApp guidance uses Meta model, no-confirmation rule covers all code-invite channels
- SKILL.md: adds Slack invite workflow

Addresses feedback finding 5: doc/skill updates not executed faithfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
