### PR TITLE
fix: strip MIME parameters in inferFilename for sane fallback filenames

### DIFF
--- a/gateway/src/__tests__/whatsapp-download.test.ts
+++ b/gateway/src/__tests__/whatsapp-download.test.ts
@@ -474,6 +474,38 @@ describe("downloadWhatsAppFile", () => {
     expect(result.filename).toBe("1234567890.pdf");
   });
 
+  test("strips MIME parameters when inferring filename extension", async () => {
+    fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.includes("graph.facebook.com")) {
+        return new Response(
+          JSON.stringify({
+            url: MEDIA_URL,
+            mime_type: "audio/ogg; codecs=opus",
+            sha256: "abc",
+            file_size: 3,
+            id: MEDIA_ID,
+          }),
+        );
+      }
+
+      return new Response(new Uint8Array([0x01, 0x02, 0x03]), {
+        headers: { "Content-Type": "audio/ogg; codecs=opus" },
+      });
+    });
+
+    const result = await downloadWhatsAppFile(makeConfig(), MEDIA_ID);
+
+    expect(result.mimeType).toBe("audio/ogg; codecs=opus");
+    expect(result.filename).toBe("1234567890.ogg");
+  });
+
   test("throws when WhatsApp credentials are not configured", async () => {
     const config = makeConfig({
       whatsappAccessToken: undefined,

--- a/gateway/src/whatsapp/download.ts
+++ b/gateway/src/whatsapp/download.ts
@@ -33,7 +33,8 @@ const MIME_EXTENSIONS: Record<string, string> = {
 };
 
 function inferFilename(mediaId: string, mimeType: string): string {
-  const ext = MIME_EXTENSIONS[mimeType];
+  const baseMime = mimeType.split(";")[0].trim();
+  const ext = MIME_EXTENSIONS[baseMime];
   const base = mediaId.slice(0, 12);
   return ext ? `${base}.${ext}` : base;
 }


### PR DESCRIPTION
## Summary
- Strip MIME parameters (e.g. `; codecs=opus`) before looking up extension in inferFilename()
- Ensures parameterized MIME types like `audio/ogg; codecs=opus` produce `.ogg` filenames instead of bare media IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
