### PR TITLE
test: add regression coverage for canonical invite registry APIs

### DIFF
--- a/assistant/src/__tests__/channel-invite-transport.test.ts
+++ b/assistant/src/__tests__/channel-invite-transport.test.ts
@@ -1,14 +1,21 @@
 /**
- * Tests for channel invite adapter handle resolution.
+ * Tests for channel invite adapter resolution and registry wiring.
  *
  * Verifies that `resolveAdapterHandle()` correctly prefers the async
  * path when available and falls back to the sync path for adapters
- * that only implement `resolveChannelHandle`.
+ * that only implement `resolveChannelHandle`. Also covers the
+ * canonical registry APIs (`createInviteAdapterRegistry`,
+ * `getInviteAdapterRegistry`) that replaced the deprecated shims.
  */
 import { describe, expect, test } from "bun:test";
 
-import type { ChannelInviteAdapter } from "../runtime/channel-invite-transport.js";
-import { resolveAdapterHandle } from "../runtime/channel-invite-transport.js";
+import {
+  type ChannelInviteAdapter,
+  createInviteAdapterRegistry,
+  getInviteAdapterRegistry,
+  InviteAdapterRegistry,
+  resolveAdapterHandle,
+} from "../runtime/channel-invite-transport.js";
 
 describe("resolveAdapterHandle", () => {
   test("returns sync handle when only resolveChannelHandle is defined", async () => {
@@ -69,5 +76,91 @@ describe("resolveAdapterHandle", () => {
 
     const handle = await resolveAdapterHandle(adapter);
     expect(handle).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registry APIs
+// ---------------------------------------------------------------------------
+
+describe("createInviteAdapterRegistry", () => {
+  const builtInChannels = [
+    "email",
+    "slack",
+    "sms",
+    "telegram",
+    "voice",
+    "whatsapp",
+  ] as const;
+
+  test("returns a registry with all built-in adapters registered", () => {
+    const registry = createInviteAdapterRegistry();
+
+    for (const channel of builtInChannels) {
+      const adapter = registry.get(channel);
+      expect(adapter).toBeDefined();
+      expect(adapter!.channel).toBe(channel);
+    }
+  });
+
+  test("getAll returns exactly the built-in adapters", () => {
+    const registry = createInviteAdapterRegistry();
+    const all = registry.getAll();
+
+    expect(all).toHaveLength(builtInChannels.length);
+    const channels = new Set(all.map((a) => a.channel));
+    for (const ch of builtInChannels) {
+      expect(channels.has(ch)).toBe(true);
+    }
+  });
+
+  test("returns a new registry instance on each call", () => {
+    const a = createInviteAdapterRegistry();
+    const b = createInviteAdapterRegistry();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("getInviteAdapterRegistry", () => {
+  test("returns the singleton registry", () => {
+    const registry = getInviteAdapterRegistry();
+    expect(registry).toBeInstanceOf(InviteAdapterRegistry);
+  });
+
+  test("returns the same instance on repeated calls", () => {
+    const first = getInviteAdapterRegistry();
+    const second = getInviteAdapterRegistry();
+    expect(first).toBe(second);
+  });
+});
+
+describe("InviteAdapterRegistry register / get", () => {
+  test("register stores and get retrieves a custom adapter", () => {
+    const registry = new InviteAdapterRegistry();
+    const custom: ChannelInviteAdapter = {
+      channel: "telegram",
+      resolveChannelHandle: () => "@custom",
+    };
+
+    registry.register(custom);
+    expect(registry.get("telegram")).toBe(custom);
+  });
+
+  test("register overwrites a previously registered adapter", () => {
+    const registry = new InviteAdapterRegistry();
+    const first: ChannelInviteAdapter = { channel: "email" };
+    const second: ChannelInviteAdapter = {
+      channel: "email",
+      resolveChannelHandle: () => "new@example.com",
+    };
+
+    registry.register(first);
+    registry.register(second);
+    expect(registry.get("email")).toBe(second);
+  });
+
+  test("get returns undefined for an unregistered channel", () => {
+    const registry = new InviteAdapterRegistry();
+    expect(registry.get("slack")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for compat-guardrails.md.

**Gap:** Canonical invite registry APIs lost their planned regression coverage
**What was expected:** Tests covering createInviteAdapterRegistry() and getInviteAdapterRegistry()
**What was found:** Test file only exercises resolveAdapterHandle(), no coverage for registry wiring

- Add tests for createInviteAdapterRegistry() verifying all built-in adapters are registered
- Add test for getInviteAdapterRegistry() singleton behavior
- Add tests for register() and get() on the registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
