### PR TITLE
fix: normalize unrecognized permissions mode to workspace in checker

### DIFF
--- a/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
+++ b/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
@@ -8,7 +8,7 @@ mock.module("../config/loader.js", () => ({
     ui: {},
 
     provider: "mock-provider",
-    permissions: { mode: "legacy" },
+    permissions: { mode: "workspace" },
     apiKeys: {},
     sandbox: { enabled: false },
     timeouts: { toolExecutionTimeoutSec: 30, permissionTimeoutSec: 5 },

--- a/assistant/src/__tests__/computer-use-skill-lifecycle-cleanup.test.ts
+++ b/assistant/src/__tests__/computer-use-skill-lifecycle-cleanup.test.ts
@@ -6,7 +6,7 @@ mock.module("../config/loader.js", () => ({
     ui: {},
 
     provider: "mock-provider",
-    permissions: { mode: "legacy" },
+    permissions: { mode: "workspace" },
     apiKeys: {},
     sandbox: { enabled: false },
     timeouts: { toolExecutionTimeoutSec: 30, permissionTimeoutSec: 5 },

--- a/assistant/src/__tests__/ephemeral-permissions.test.ts
+++ b/assistant/src/__tests__/ephemeral-permissions.test.ts
@@ -36,7 +36,7 @@ mock.module("../util/logger.js", () => ({
 }));
 
 const testConfig: Record<string, any> = {
-  permissions: { mode: "legacy" as "legacy" | "strict" | "workspace" },
+  permissions: { mode: "workspace" as "strict" | "workspace" },
   skills: { load: { extraDirs: [] as string[] } },
   sandbox: { enabled: false },
 };
@@ -263,7 +263,7 @@ describe("ephemeral-permissions", () => {
   describe("check() with ephemeral rules", () => {
     beforeEach(() => {
       clearCache();
-      testConfig.permissions.mode = "legacy";
+      testConfig.permissions.mode = "workspace";
     });
 
     test("ephemeral allow rule auto-allows non-high-risk tool", async () => {
@@ -327,7 +327,7 @@ describe("ephemeral-permissions", () => {
     });
 
     afterEach(() => {
-      testConfig.permissions.mode = "legacy";
+      testConfig.permissions.mode = "workspace";
     });
 
     test("workspace mode auto-allows workspace-scoped file_write (medium risk)", async () => {

--- a/assistant/src/__tests__/handlers-add-trust-rule-metadata.test.ts
+++ b/assistant/src/__tests__/handlers-add-trust-rule-metadata.test.ts
@@ -40,7 +40,7 @@ mock.module("../util/logger.js", () => ({
 }));
 
 const testConfig: Record<string, any> = {
-  permissions: { mode: "legacy" as "legacy" | "strict" | "workspace" },
+  permissions: { mode: "workspace" as "strict" | "workspace" },
   skills: { load: { extraDirs: [] as string[] } },
   sandbox: { enabled: true },
 };

--- a/assistant/src/__tests__/proxy-approval-callback.test.ts
+++ b/assistant/src/__tests__/proxy-approval-callback.test.ts
@@ -26,7 +26,7 @@ mock.module("../config/loader.js", () => ({
 
     provider: "mock-provider",
     timeouts: { permissionTimeoutSec: 5 },
-    permissions: { mode: "legacy" },
+    permissions: { mode: "workspace" },
     skills: { load: { extraDirs: [] } },
   }),
 }));

--- a/assistant/src/__tests__/recording-handler.test.ts
+++ b/assistant/src/__tests__/recording-handler.test.ts
@@ -24,7 +24,7 @@ mock.module("../config/loader.js", () => ({
 
     daemon: { standaloneRecording: true },
     provider: "mock-provider",
-    permissions: { mode: "legacy" },
+    permissions: { mode: "workspace" },
     apiKeys: {},
     sandbox: { enabled: false },
     timeouts: { toolExecutionTimeoutSec: 30, permissionTimeoutSec: 5 },

--- a/assistant/src/__tests__/recording-intent-handler.test.ts
+++ b/assistant/src/__tests__/recording-intent-handler.test.ts
@@ -34,7 +34,7 @@ mock.module("../config/loader.js", () => ({
     daemon: { standaloneRecording: true },
     provider: "mock-provider",
     model: "mock-model",
-    permissions: { mode: "legacy" },
+    permissions: { mode: "workspace" },
     apiKeys: {},
     sandbox: { enabled: false },
     timeouts: { toolExecutionTimeoutSec: 30, permissionTimeoutSec: 5 },

--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -24,7 +24,7 @@ mock.module("../config/loader.js", () => ({
 
     daemon: { standaloneRecording: true },
     provider: "mock-provider",
-    permissions: { mode: "legacy" },
+    permissions: { mode: "workspace" },
     apiKeys: {},
     sandbox: { enabled: false },
     timeouts: { toolExecutionTimeoutSec: 30, permissionTimeoutSec: 5 },

--- a/assistant/src/__tests__/session-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/session-confirmation-signals.test.ts
@@ -85,7 +85,7 @@ mock.module("../config/loader.js", () => ({
     apiKeys: {},
     skills: { entries: {}, allowBundled: true },
     memory: { retrieval: { injectionStrategy: "inline" } },
-    permissions: { mode: "legacy" },
+    permissions: { mode: "workspace" },
   }),
   loadRawConfig: () => ({}),
   saveRawConfig: () => {},

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -76,7 +76,7 @@ mock.module("../config/loader.js", () => ({
     apiKeys: {},
     skills: { entries: {}, allowBundled: true },
     memory: { retrieval: { injectionStrategy: "inline" } },
-    permissions: { mode: "legacy" },
+    permissions: { mode: "workspace" },
     daemon: {
       startupSocketWaitMs: 5000,
       stopTimeoutMs: 5000,

--- a/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
+++ b/assistant/src/__tests__/tool-execution-pipeline.benchmark.test.ts
@@ -63,7 +63,7 @@ mock.module("../config/loader.js", () => ({
 
     provider: "mock-provider",
     timeouts: { permissionTimeoutSec: 5, toolExecutionTimeoutSec: 120 },
-    permissions: { mode: "legacy" },
+    permissions: { mode: "workspace" },
     skills: { load: { extraDirs: [] } },
     secretDetection: { enabled: true, entropyThreshold: 4.0, action: "warn" },
     sandbox: { enabled: false },

--- a/assistant/src/__tests__/tool-permission-simulate-handler.test.ts
+++ b/assistant/src/__tests__/tool-permission-simulate-handler.test.ts
@@ -39,7 +39,7 @@ mock.module("../util/logger.js", () => ({
 }));
 
 const testConfig: Record<string, any> = {
-  permissions: { mode: "legacy" as "legacy" | "strict" | "workspace" },
+  permissions: { mode: "workspace" as "strict" | "workspace" },
   skills: { load: { extraDirs: [] as string[] } },
   sandbox: { enabled: true },
 };
@@ -111,7 +111,7 @@ describe("tool_permission_simulate handler", () => {
   beforeEach(() => {
     clearAllRules();
     clearCache();
-    testConfig.permissions.mode = "legacy";
+    testConfig.permissions.mode = "workspace";
   });
 
   test("validation: returns error when toolName is missing", async () => {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -806,6 +806,26 @@ export async function check(
     }
   }
 
+  // Any unrecognized mode (including raw "legacy" that somehow bypassed loader
+  // migration) is treated as workspace mode — fail-closed relative to the old
+  // risk-only fallthrough that would auto-allow low-risk operations everywhere.
+  if (
+    permissionsMode !== "strict" &&
+    permissionsMode !== "workspace" &&
+    !matchedRule &&
+    risk !== RiskLevel.High
+  ) {
+    if (toolName === "bash" && !getConfig().sandbox.enabled) {
+      // Fall through to risk-based policy below
+    } else if (isWorkspaceScopedInvocation(toolName, input, workingDir)) {
+      return {
+        decision: "allow",
+        reason:
+          "Workspace mode (normalized): workspace-scoped operation auto-allowed",
+      };
+    }
+  }
+
   // Auto-allow low-risk bundled skill tools even without explicit trust rules.
   // These are first-party tools with a vetted risk declaration — applying the
   // same policy as the per-tool default allow rules for browser tools, but


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for compat-guardrails.md.

**Gap:** Invalid permissions.mode still falls through to legacy-style behavior
**What was expected:** Legacy mode narrowed to migration-only — checker should not have a de facto third mode
**What was found:** checker.ts falls through to risk-based auto-allow for any non-strict/non-workspace mode, and tests still inject legacy directly

- Add guard in checker.ts to normalize unrecognized modes to workspace behavior
- Update tests to use workspace instead of legacy for permissions.mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
