### PR TITLE
fix: don't permanently cache missing email inbox address

### DIFF
--- a/assistant/src/email/service.ts
+++ b/assistant/src/email/service.ts
@@ -135,7 +135,11 @@ export class EmailService {
     } catch {
       this.cachedPrimaryAddress = undefined;
     }
-    this.primaryAddressResolved = true;
+    // Only cache positive results so a missing inbox is retried on next call
+    // (e.g. user sets up email after initial miss).
+    if (this.cachedPrimaryAddress !== undefined) {
+      this.primaryAddressResolved = true;
+    }
     return this.cachedPrimaryAddress;
   }
 
@@ -168,7 +172,10 @@ export class EmailService {
     displayName?: string,
   ): Promise<EmailInbox> {
     const p = await this.provider();
-    return p.createInbox({ username, domain, displayName });
+    const inbox = await p.createInbox({ username, domain, displayName });
+    this.primaryAddressResolved = false;
+    this.cachedPrimaryAddress = undefined;
+    return inbox;
   }
 
   async listInboxes(): Promise<EmailInbox[]> {
@@ -178,7 +185,10 @@ export class EmailService {
 
   async ensureInboxes(domain: string): Promise<EmailInbox[]> {
     const p = await this.provider();
-    return p.ensureInboxes({ domain });
+    const inboxes = await p.ensureInboxes({ domain });
+    this.primaryAddressResolved = false;
+    this.cachedPrimaryAddress = undefined;
+    return inboxes;
   }
 
   // =========================================================================


### PR DESCRIPTION
## Summary
- Email service no longer permanently caches negative inbox lookups
- Setting up email after initial miss now works without restart
- resetProvider() and inbox creation properly invalidate the cache

Addresses feedback finding 3: email handle resolution negatively caches 'no inbox' forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
