### PR TITLE
fix: eliminate background FK errors in WhatsApp ingress attachment tests

### DIFF
--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -290,7 +290,18 @@ describe("WhatsApp channel ingress attachment resolution", () => {
     });
   }
 
-  const noopProcessMessage = mock(async () => ({ messageId: "msg-1" }));
+  // Create a real message in the DB so the background dispatch's
+  // linkMessage(eventId, userMessageId) FK constraint is satisfied.
+  const noopProcessMessage = mock(
+    async (conversationId: string, content: string) => {
+      const msg = await conversationStore.addMessage(
+        conversationId,
+        "user",
+        content,
+      );
+      return { messageId: msg.id };
+    },
+  );
 
   beforeEach(() => {
     resetIngressTables();


### PR DESCRIPTION
## Summary
- Fix noopProcessMessage mock to produce a real message so background dispatch succeeds
- Eliminates FOREIGN KEY constraint errors that silently fired after the 200 response
- Tests now prove attachment resolution through the full inbound path without background failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
