### PR TITLE
fix: align WhatsApp readiness and invite adapter with Meta credentials

### DIFF
--- a/assistant/src/__tests__/channel-readiness-routes.test.ts
+++ b/assistant/src/__tests__/channel-readiness-routes.test.ts
@@ -123,7 +123,7 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
   });
 
   // -------------------------------------------------------------------------
-  // WhatsApp probe
+  // WhatsApp probe — Meta WhatsApp Business API credentials
   // -------------------------------------------------------------------------
 
   describe("whatsapp", () => {
@@ -138,63 +138,80 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
       ).toBe(false);
     });
 
-    test("reports not ready when Twilio credentials are missing", async () => {
+    test("reports not ready when Meta credentials are missing", async () => {
       mockRawConfig = {};
       const service = createReadinessService();
       const [snapshot] = await service.getReadiness("whatsapp");
 
       expect(snapshot.ready).toBe(false);
       expect(
-        snapshot.reasons.some((r) => r.code === "twilio_credentials"),
+        snapshot.reasons.some((r) => r.code === "whatsapp_phone_number_id"),
+      ).toBe(true);
+      expect(
+        snapshot.reasons.some((r) => r.code === "whatsapp_access_token"),
       ).toBe(true);
     });
 
-    test("reports not ready when phone number is missing", async () => {
-      mockHasTwilioCredentials = true;
-      mockRawConfig = {};
+    test("reports ready when all Meta credentials are configured", async () => {
+      mockSecureKeys = {
+        "credential:whatsapp:phone_number_id": "123456789",
+        "credential:whatsapp:access_token": "EAAxxxxxx",
+        "credential:whatsapp:app_secret": "abc123",
+        "credential:whatsapp:webhook_verify_token": "my-verify-token",
+      };
+      mockRawConfig = {
+        ingress: { publicBaseUrl: "https://example.com", enabled: true },
+      };
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("whatsapp");
+
+      expect(snapshot.ready).toBe(true);
+      expect(snapshot.reasons).toHaveLength(0);
+    });
+
+    test("checks each Meta credential individually", async () => {
+      mockSecureKeys = {
+        "credential:whatsapp:phone_number_id": "123456789",
+        // access_token missing
+        "credential:whatsapp:app_secret": "abc123",
+        "credential:whatsapp:webhook_verify_token": "my-verify-token",
+      };
+      mockRawConfig = {
+        ingress: { publicBaseUrl: "https://example.com", enabled: true },
+      };
       const service = createReadinessService();
       const [snapshot] = await service.getReadiness("whatsapp");
 
       expect(snapshot.ready).toBe(false);
-      expect(snapshot.reasons.some((r) => r.code === "phone_number")).toBe(
-        true,
+
+      const phoneIdCheck = snapshot.localChecks.find(
+        (c) => c.name === "whatsapp_phone_number_id",
       );
-    });
+      expect(phoneIdCheck!.passed).toBe(true);
 
-    test("resolves phone number from whatsapp config", async () => {
-      mockHasTwilioCredentials = true;
-      mockRawConfig = {
-        whatsapp: { phoneNumber: "+15551234567" },
-        ingress: { publicBaseUrl: "https://example.com", enabled: true },
-      };
-      const service = createReadinessService();
-      const [snapshot] = await service.getReadiness("whatsapp");
-
-      const phoneCheck = snapshot.localChecks.find(
-        (c) => c.name === "phone_number",
+      const accessTokenCheck = snapshot.localChecks.find(
+        (c) => c.name === "whatsapp_access_token",
       );
-      expect(phoneCheck).toBeDefined();
-      expect(phoneCheck!.passed).toBe(true);
-    });
+      expect(accessTokenCheck!.passed).toBe(false);
 
-    test("falls back to sms config for phone number", async () => {
-      mockHasTwilioCredentials = true;
-      mockRawConfig = {
-        sms: { phoneNumber: "+15559876543" },
-        ingress: { publicBaseUrl: "https://example.com", enabled: true },
-      };
-      const service = createReadinessService();
-      const [snapshot] = await service.getReadiness("whatsapp");
-
-      const phoneCheck = snapshot.localChecks.find(
-        (c) => c.name === "phone_number",
+      const appSecretCheck = snapshot.localChecks.find(
+        (c) => c.name === "whatsapp_app_secret",
       );
-      expect(phoneCheck!.passed).toBe(true);
+      expect(appSecretCheck!.passed).toBe(true);
+
+      const webhookCheck = snapshot.localChecks.find(
+        (c) => c.name === "whatsapp_webhook_verify_token",
+      );
+      expect(webhookCheck!.passed).toBe(true);
     });
 
     test("checks invite policy", async () => {
-      mockHasTwilioCredentials = true;
-      mockTwilioPhoneNumberEnv = "+15551234567";
+      mockSecureKeys = {
+        "credential:whatsapp:phone_number_id": "123456789",
+        "credential:whatsapp:access_token": "EAAxxxxxx",
+        "credential:whatsapp:app_secret": "abc123",
+        "credential:whatsapp:webhook_verify_token": "my-verify-token",
+      };
       mockRawConfig = {
         ingress: { publicBaseUrl: "https://example.com", enabled: true },
       };
@@ -205,13 +222,16 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
         (c) => c.name === "invite_policy",
       );
       expect(inviteCheck).toBeDefined();
-      // WhatsApp has codeRedemptionEnabled: true in the channel policy registry
       expect(inviteCheck!.passed).toBe(true);
     });
 
     test("checks ingress configuration", async () => {
-      mockHasTwilioCredentials = true;
-      mockTwilioPhoneNumberEnv = "+15551234567";
+      mockSecureKeys = {
+        "credential:whatsapp:phone_number_id": "123456789",
+        "credential:whatsapp:access_token": "EAAxxxxxx",
+        "credential:whatsapp:app_secret": "abc123",
+        "credential:whatsapp:webhook_verify_token": "my-verify-token",
+      };
       mockRawConfig = {};
       const service = createReadinessService();
       const [snapshot] = await service.getReadiness("whatsapp");
@@ -221,19 +241,6 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
       );
       expect(ingressCheck).toBeDefined();
       expect(ingressCheck!.passed).toBe(false);
-    });
-
-    test("ready when all prerequisites are met", async () => {
-      mockHasTwilioCredentials = true;
-      mockTwilioPhoneNumberEnv = "+15551234567";
-      mockRawConfig = {
-        ingress: { publicBaseUrl: "https://example.com", enabled: true },
-      };
-      const service = createReadinessService();
-      const [snapshot] = await service.getReadiness("whatsapp");
-
-      expect(snapshot.ready).toBe(true);
-      expect(snapshot.reasons).toHaveLength(0);
     });
   });
 

--- a/assistant/src/__tests__/whatsapp-invite-adapter.test.ts
+++ b/assistant/src/__tests__/whatsapp-invite-adapter.test.ts
@@ -1,34 +1,11 @@
 /**
  * Tests for the WhatsApp channel invite adapter.
  *
- * Verifies handle resolution in both configured-handle and
- * generic-instruction (no handle) paths.
+ * WhatsApp uses Meta WhatsApp Business API, not Twilio. The adapter
+ * cannot resolve a user-facing phone number from Meta credentials
+ * alone, so it always returns undefined (triggering generic instructions).
  */
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-
-// ---------------------------------------------------------------------------
-// Mocks — must be set up before importing the adapter
-// ---------------------------------------------------------------------------
-
-let mockTwilioPhoneNumberEnv: string | undefined;
-let mockRawConfig: Record<string, unknown> | undefined;
-let mockSecureKeys: Record<string, string>;
-
-mock.module("../config/env.js", () => ({
-  getTwilioPhoneNumberEnv: () => mockTwilioPhoneNumberEnv,
-}));
-
-mock.module("../config/loader.js", () => ({
-  loadRawConfig: () => mockRawConfig,
-}));
-
-mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (key: string) => mockSecureKeys[key] ?? null,
-}));
-
-// ---------------------------------------------------------------------------
-// Import under test
-// ---------------------------------------------------------------------------
+import { describe, expect, test } from "bun:test";
 
 import { whatsappInviteAdapter } from "../runtime/channel-invite-transports/whatsapp.js";
 
@@ -37,83 +14,15 @@ import { whatsappInviteAdapter } from "../runtime/channel-invite-transports/what
 // ---------------------------------------------------------------------------
 
 describe("whatsapp invite adapter", () => {
-  beforeEach(() => {
-    mockTwilioPhoneNumberEnv = undefined;
-    mockRawConfig = undefined;
-    mockSecureKeys = {};
-  });
-
   test("adapter is registered for the whatsapp channel", () => {
     expect(whatsappInviteAdapter.channel).toBe("whatsapp");
   });
 
   // -------------------------------------------------------------------------
-  // Configured-handle path
+  // Handle resolution — always undefined for Meta WhatsApp
   // -------------------------------------------------------------------------
 
-  test("resolves handle from env override", () => {
-    mockTwilioPhoneNumberEnv = "+15551234567";
-
-    const handle = whatsappInviteAdapter.resolveChannelHandle!();
-    expect(handle).toBe("+15551234567");
-  });
-
-  test("resolves handle from whatsapp config phoneNumber", () => {
-    mockRawConfig = { whatsapp: { phoneNumber: "+15559876543" } };
-
-    const handle = whatsappInviteAdapter.resolveChannelHandle!();
-    expect(handle).toBe("+15559876543");
-  });
-
-  test("resolves handle from sms config phoneNumber as fallback", () => {
-    mockRawConfig = { sms: { phoneNumber: "+15550001111" } };
-
-    const handle = whatsappInviteAdapter.resolveChannelHandle!();
-    expect(handle).toBe("+15550001111");
-  });
-
-  test("prefers whatsapp config over sms config", () => {
-    mockRawConfig = {
-      whatsapp: { phoneNumber: "+15551111111" },
-      sms: { phoneNumber: "+15552222222" },
-    };
-
-    const handle = whatsappInviteAdapter.resolveChannelHandle!();
-    expect(handle).toBe("+15551111111");
-  });
-
-  test("resolves handle from secure key fallback", () => {
-    mockSecureKeys = { "credential:twilio:phone_number": "+15553334444" };
-    mockRawConfig = {};
-
-    const handle = whatsappInviteAdapter.resolveChannelHandle!();
-    expect(handle).toBe("+15553334444");
-  });
-
-  test("env override takes precedence over all other sources", () => {
-    mockTwilioPhoneNumberEnv = "+15550000000";
-    mockRawConfig = { whatsapp: { phoneNumber: "+15551111111" } };
-    mockSecureKeys = { "credential:twilio:phone_number": "+15552222222" };
-
-    const handle = whatsappInviteAdapter.resolveChannelHandle!();
-    expect(handle).toBe("+15550000000");
-  });
-
-  // -------------------------------------------------------------------------
-  // Generic-instruction path (no handle configured)
-  // -------------------------------------------------------------------------
-
-  test("returns undefined when no phone number is configured", () => {
-    mockRawConfig = {};
-
-    const handle = whatsappInviteAdapter.resolveChannelHandle!();
-    expect(handle).toBeUndefined();
-  });
-
-  test("returns undefined when no sources are available at all", () => {
-    // No env, no config, no secure keys — the adapter degrades gracefully
-    mockRawConfig = undefined;
-
+  test("returns undefined because Meta API has no displayable phone number", () => {
     const handle = whatsappInviteAdapter.resolveChannelHandle!();
     expect(handle).toBeUndefined();
   });

--- a/assistant/src/runtime/channel-invite-transports/sms.ts
+++ b/assistant/src/runtime/channel-invite-transports/sms.ts
@@ -19,20 +19,14 @@ import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
 
 /**
  * Keep Twilio-backed invite transports on a single secure-key reader so the
- * credential boundary stays narrow even as SMS and WhatsApp share resolution.
+ * credential boundary stays narrow.
  */
-export function resolveTwilioInvitePhoneNumber(options?: {
-  includeWhatsappOverride?: boolean;
-}): string | undefined {
+export function resolveTwilioInvitePhoneNumber(): string | undefined {
   try {
     const raw = loadRawConfig();
     const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
-    const whatsappConfig = options?.includeWhatsappOverride
-      ? ((raw?.whatsapp ?? {}) as Record<string, unknown>)
-      : undefined;
     return (
       getTwilioPhoneNumberEnv() ||
-      (whatsappConfig?.phoneNumber as string | undefined) ||
       (smsConfig.phoneNumber as string) ||
       getSecureKey("credential:twilio:phone_number") ||
       undefined

--- a/assistant/src/runtime/channel-invite-transports/whatsapp.ts
+++ b/assistant/src/runtime/channel-invite-transports/whatsapp.ts
@@ -1,22 +1,15 @@
 /**
  * WhatsApp channel invite adapter.
  *
- * Resolves the assistant's WhatsApp phone number for use in invite
- * instructions. WhatsApp invites use the universal 6-digit code path
- * for redemption, so this adapter only implements `resolveChannelHandle`
- * — no `buildShareLink` or `extractInboundToken` needed.
- *
- * WhatsApp shares the same Twilio phone number as SMS, so the
- * resolution strategy mirrors the SMS adapter.
+ * WhatsApp uses Meta WhatsApp Business API credentials, not Twilio.
+ * The Meta API identifies numbers by phone_number_id (a numeric string),
+ * which isn't a user-facing phone number. Since we can't resolve a
+ * display number from Meta credentials alone, the adapter returns
+ * `undefined` — triggering the generic instruction path for invites.
  */
 
 import type { ChannelId } from "../../channels/types.js";
 import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
-import { resolveTwilioInvitePhoneNumber } from "./sms.js";
-
-// ---------------------------------------------------------------------------
-// Phone number resolution
-// ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
 // Adapter implementation
@@ -26,6 +19,8 @@ export const whatsappInviteAdapter: ChannelInviteAdapter = {
   channel: "whatsapp" as ChannelId,
 
   resolveChannelHandle(): string | undefined {
-    return resolveTwilioInvitePhoneNumber({ includeWhatsappOverride: true });
+    // Meta WhatsApp Business API uses phone_number_id, not a displayable
+    // phone number. Return undefined to fall back to generic instructions.
+    return undefined;
   },
 };

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -26,22 +26,12 @@ function resolveSmsPhoneNumber(): string {
   return resolveTwilioPhoneNumber();
 }
 
-function resolveWhatsAppPhoneNumber(): string {
-  return resolveTwilioPhoneNumber({ includeWhatsappOverride: true });
-}
-
-function resolveTwilioPhoneNumber(options?: {
-  includeWhatsappOverride?: boolean;
-}): string {
+function resolveTwilioPhoneNumber(): string {
   try {
     const raw = loadRawConfig();
     const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
-    const whatsappConfig = options?.includeWhatsappOverride
-      ? ((raw?.whatsapp ?? {}) as Record<string, unknown>)
-      : undefined;
     return (
       getTwilioPhoneNumberEnv() ||
-      (whatsappConfig?.phoneNumber as string | undefined) ||
       (smsConfig.phoneNumber as string) ||
       getSecureKey("credential:twilio:phone_number") ||
       ""
@@ -309,23 +299,44 @@ const whatsappProbe: ChannelProbe = {
   runLocalChecks(): ReadinessCheckResult[] {
     const results: ReadinessCheckResult[] = [];
 
-    const hasCreds = hasTwilioCredentials();
+    const hasPhoneNumberId = !!getSecureKey(
+      "credential:whatsapp:phone_number_id",
+    );
     results.push({
-      name: "twilio_credentials",
-      passed: hasCreds,
-      message: hasCreds
-        ? "Twilio credentials are configured"
-        : "Twilio Account SID and Auth Token are not configured",
+      name: "whatsapp_phone_number_id",
+      passed: hasPhoneNumberId,
+      message: hasPhoneNumberId
+        ? "WhatsApp phone number ID is configured"
+        : "WhatsApp phone number ID is not configured",
     });
 
-    const resolvedNumber = resolveWhatsAppPhoneNumber();
-    const hasPhone = !!resolvedNumber;
+    const hasAccessToken = !!getSecureKey("credential:whatsapp:access_token");
     results.push({
-      name: "phone_number",
-      passed: hasPhone,
-      message: hasPhone
-        ? "WhatsApp phone number is assigned"
-        : "No WhatsApp phone number assigned",
+      name: "whatsapp_access_token",
+      passed: hasAccessToken,
+      message: hasAccessToken
+        ? "WhatsApp access token is configured"
+        : "WhatsApp access token is not configured",
+    });
+
+    const hasAppSecret = !!getSecureKey("credential:whatsapp:app_secret");
+    results.push({
+      name: "whatsapp_app_secret",
+      passed: hasAppSecret,
+      message: hasAppSecret
+        ? "WhatsApp app secret is configured"
+        : "WhatsApp app secret is not configured",
+    });
+
+    const hasWebhookVerifyToken = !!getSecureKey(
+      "credential:whatsapp:webhook_verify_token",
+    );
+    results.push({
+      name: "whatsapp_webhook_verify_token",
+      passed: hasWebhookVerifyToken,
+      message: hasWebhookVerifyToken
+        ? "WhatsApp webhook verify token is configured"
+        : "WhatsApp webhook verify token is not configured",
     });
 
     const invitePolicy = getChannelInvitePolicy("whatsapp");


### PR DESCRIPTION
## Summary
- WhatsApp readiness probe now checks Meta WhatsApp Business API credentials instead of Twilio
- WhatsApp invite adapter no longer returns incorrect Twilio phone numbers
- Removes incorrect resolveWhatsAppPhoneNumber from twilio-phone-resolution utility

Addresses feedback finding 1: WhatsApp path was implemented against wrong backend model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
