### PR TITLE
fix: email readiness probe checks for configured inbox address

### DIFF
--- a/assistant/src/__tests__/channel-readiness-routes.test.ts
+++ b/assistant/src/__tests__/channel-readiness-routes.test.ts
@@ -15,6 +15,7 @@ let mockTwilioPhoneNumberEnv: string | undefined;
 let mockRawConfig: Record<string, unknown> | undefined;
 let mockSecureKeys: Record<string, string>;
 let mockHasTwilioCredentials: boolean;
+let mockPrimaryInboxAddress: string | undefined;
 
 mock.module("../calls/twilio-rest.js", () => ({
   hasTwilioCredentials: () => mockHasTwilioCredentials,
@@ -34,6 +35,12 @@ mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (key: string) => mockSecureKeys[key] ?? null,
 }));
 
+mock.module("../email/service.js", () => ({
+  getEmailService: () => ({
+    getPrimaryInboxAddress: async () => mockPrimaryInboxAddress,
+  }),
+}));
+
 // ---------------------------------------------------------------------------
 // Import under test
 // ---------------------------------------------------------------------------
@@ -50,6 +57,7 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
     mockRawConfig = undefined;
     mockSecureKeys = {};
     mockHasTwilioCredentials = false;
+    mockPrimaryInboxAddress = undefined;
   });
 
   // -------------------------------------------------------------------------
@@ -109,16 +117,45 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
       expect(ingressCheck!.passed).toBe(false);
     });
 
-    test("ready when all prerequisites are met", async () => {
+    test("ready when all prerequisites are met (including inbox)", async () => {
       mockSecureKeys = { agentmail: "test-key" };
       mockRawConfig = {
         ingress: { publicBaseUrl: "https://example.com", enabled: true },
       };
+      mockPrimaryInboxAddress = "hello@example.agentmail.to";
       const service = createReadinessService();
-      const [snapshot] = await service.getReadiness("email");
+      const [snapshot] = await service.getReadiness("email", true);
 
       expect(snapshot.ready).toBe(true);
       expect(snapshot.reasons).toHaveLength(0);
+    });
+
+    test("not ready when inbox is missing (remote check)", async () => {
+      mockSecureKeys = { agentmail: "test-key" };
+      mockRawConfig = {
+        ingress: { publicBaseUrl: "https://example.com", enabled: true },
+      };
+      mockPrimaryInboxAddress = undefined;
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("email", true);
+
+      expect(snapshot.ready).toBe(false);
+      expect(snapshot.reasons.some((r) => r.code === "inbox_configured")).toBe(
+        true,
+      );
+    });
+
+    test("local-only readiness still passes without inbox check", async () => {
+      mockSecureKeys = { agentmail: "test-key" };
+      mockRawConfig = {
+        ingress: { publicBaseUrl: "https://example.com", enabled: true },
+      };
+      // No inbox configured, but local-only check (no includeRemote)
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("email");
+
+      // Local checks pass — remote inbox check is not included
+      expect(snapshot.ready).toBe(true);
     });
   });
 

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -9,6 +9,7 @@ import {
 } from "../calls/twilio-rest.js";
 import { getChannelInvitePolicy } from "../channels/config.js";
 import { loadRawConfig } from "../config/loader.js";
+import { getEmailService } from "../email/service.js";
 import { getSecureKey } from "../security/secure-keys.js";
 import type {
   ChannelId,
@@ -267,6 +268,36 @@ const emailProbe: ChannelProbe = {
     });
 
     return results;
+  },
+  async runRemoteChecks(): Promise<ReadinessCheckResult[]> {
+    // Only worth checking if the API key is present
+    const hasApiKey = !!(
+      getSecureKey("agentmail") || getSecureKey("credential:agentmail:api_key")
+    );
+    if (!hasApiKey) return [];
+
+    try {
+      const address = await getEmailService().getPrimaryInboxAddress();
+      const hasInbox = !!address;
+      return [
+        {
+          name: "inbox_configured",
+          passed: hasInbox,
+          message: hasInbox
+            ? `Inbox address is configured (${address})`
+            : "No inbox address configured — create one with: vellum email setup inboxes",
+        },
+      ];
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return [
+        {
+          name: "inbox_configured",
+          passed: false,
+          message: `Failed to check inbox configuration: ${message}`,
+        },
+      ];
+    }
   },
 };
 

--- a/assistant/src/runtime/routes/channel-readiness-routes.ts
+++ b/assistant/src/runtime/routes/channel-readiness-routes.ts
@@ -21,7 +21,9 @@ import type { RouteDefinition } from "../http-router.js";
 export async function handleGetChannelReadiness(url: URL): Promise<Response> {
   const channel =
     (url.searchParams.get("channel") as ChannelId | null) ?? undefined;
-  const includeRemote = url.searchParams.get("includeRemote") === "true";
+  // Default to including remote checks — they're cached for 5 minutes and
+  // required for accurate readiness (e.g. email inbox existence).
+  const includeRemote = url.searchParams.get("includeRemote") !== "false";
 
   const service = getReadinessService();
   const snapshots = await service.getReadiness(channel, includeRemote);


### PR DESCRIPTION
## Summary
- Email readiness probe now verifies an inbox address is available via a remote check against the email provider, not just API key/policy/ingress
- GET /v1/channels/readiness now defaults to includeRemote=true (cached 5min) so clients get accurate readiness without needing to opt in
- Prevents dead-end invite flows where email shows ready but has no address

Addresses feedback finding 2: email readiness overstates support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
