### PR TITLE
style: use compose icon for new thread button

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadsHeader.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadsHeader.swift
@@ -23,7 +23,7 @@ struct SidebarThreadsHeader: View {
                 )
                 .disabled(isLoading)
             }
-            VIconButton(label: "New thread", icon: "plus", iconOnly: true, action: onNewThread)
+            VIconButton(label: "New thread", icon: "square.and.pencil", iconOnly: true, action: onNewThread)
                 .disabled(isLoading)
                 .opacity(isLoading ? 0.4 : 1)
         }


### PR DESCRIPTION
## Summary
- Changes the expanded sidebar's new thread button from `+` to the compose icon (`square.and.pencil`)
- Matches the collapsed sidebar's existing new chat icon for consistency

## Test plan
- [ ] Expanded sidebar shows compose icon next to "Threads" header
- [ ] Collapsed sidebar still shows the same compose icon for "New Chat"
- [ ] Clicking either icon creates a new thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
