### PR TITLE
Expand performance regression detection tooling

### DIFF
--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -53,7 +53,7 @@ jobs:
         run: |
           set -o pipefail
           mkdir -p .perf-baselines
-          swift test --package-path clients --filter MarkdownPerformanceTests 2>&1 | tee .perf-baselines/results.log
+          swift test --package-path clients --filter 'MarkdownPerformanceTests|MessageListAnchorPerformanceTests' 2>&1 | tee .perf-baselines/results.log
 
       - name: Compare baselines
         env:

--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -62,6 +62,20 @@ jobs:
           UPDATE_BASELINE: ${{ github.event_name == 'push' && 'true' || 'false' }}
         run: bash scripts/compare-perf-baselines.sh
 
+      - name: Performance summary
+        if: always()
+        run: |
+          if [ -f .perf-baselines/summary.md ]; then
+            cat .perf-baselines/summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Comment on PR with performance results
+        if: always() && github.event_name == 'pull_request' && hashFiles('.perf-baselines/summary.md') != ''
+        continue-on-error: true
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: .perf-baselines/summary.md
+
       - name: Upload new baselines
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -53,7 +53,7 @@ jobs:
         run: |
           set -o pipefail
           mkdir -p .perf-baselines
-          swift test --package-path clients --filter 'MarkdownPerformanceTests|MessageListAnchorPerformanceTests' 2>&1 | tee .perf-baselines/results.log
+          swift test --package-path clients --filter 'MarkdownPerformanceTests|MessageListAnchorPerformanceTests|AXTreeDiffPerformanceTests' 2>&1 | tee .perf-baselines/results.log
 
       - name: Compare baselines
         env:

--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -53,6 +53,9 @@ jobs:
         run: |
           set -o pipefail
           mkdir -p .perf-baselines
+          # Remove stale summary from artifact download so a failed test run
+          # doesn't cause the PR comment step to post outdated results.
+          rm -f .perf-baselines/summary.md
           swift test --package-path clients --filter 'MarkdownPerformanceTests|MessageListAnchorPerformanceTests|AXTreeDiffPerformanceTests' 2>&1 | tee .perf-baselines/results.log
 
       - name: Compare baselines

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -9,7 +9,7 @@ private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "Me
 /// Holds the last-known anchor minY without triggering SwiftUI re-renders.
 /// Only `isVisible` is @Published so re-renders happen only when the
 /// visible/invisible boundary is crossed — not on every scroll tick.
-@MainActor private final class AnchorVisibilityTracker: ObservableObject {
+@MainActor final class AnchorVisibilityTracker: ObservableObject {
     var lastMinY: CGFloat = .infinity  // NOT @Published — no re-render on scroll
     @Published var isVisible: Bool = true
 

--- a/clients/macos/vellum-assistantTests/AXTreeDiffPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/AXTreeDiffPerformanceTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+@testable import VellumAssistantLib
+
+// MARK: - AXTreeDiff Performance Baselines
+//
+// These tests establish XCTest performance baselines for AXTreeDiff.diff()
+// computation across representative scenarios. On the first run XCTest records
+// a baseline; subsequent runs fail if wall-clock time regresses by more than
+// the default XCTest allowance (~10 %).
+//
+// Run manually with:
+//   swift test --filter AXTreeDiffPerformanceTests  (from clients/macos/)
+// or via Xcode's Test navigator.
+
+final class AXTreeDiffPerformanceTests: XCTestCase {
+
+    // MARK: - Synthetic Element Generation
+
+    /// Creates a flat array of synthetic AXElement instances.
+    /// Each element has a unique id and deterministic frame/role/title values
+    /// derived from the index so that StableKey matching behaves realistically.
+    private static func makeElements(
+        count: Int,
+        idOffset: Int = 0,
+        prefix: String = "el"
+    ) -> [AXElement] {
+        let roles = [
+            "AXButton", "AXTextField", "AXStaticText", "AXGroup",
+            "AXCheckBox", "AXLink", "AXTextArea", "AXMenuItem"
+        ]
+        return (0..<count).map { i in
+            let id = idOffset + i + 1
+            let role = roles[i % roles.count]
+            let x = CGFloat((i % 20) * 40)
+            let y = CGFloat((i / 20) * 30)
+            return AXElement(
+                id: id,
+                role: role,
+                title: "\(prefix)-\(i)",
+                value: i % 3 == 0 ? "value-\(i)" : nil,
+                frame: CGRect(x: x, y: y, width: 100, height: 24),
+                isEnabled: true,
+                isFocused: i == 0,
+                children: [],
+                roleDescription: nil,
+                identifier: "id-\(prefix)-\(i)",
+                url: nil,
+                placeholderValue: nil
+            )
+        }
+    }
+
+    /// Returns a copy of `elements` with `count` elements mutated (title changed).
+    /// Mutations are spread evenly across the array.
+    private static func mutateElements(
+        _ elements: [AXElement],
+        count: Int
+    ) -> [AXElement] {
+        guard count > 0, !elements.isEmpty else { return elements }
+        let step = max(1, elements.count / count)
+        var result = elements
+        for i in stride(from: 0, to: elements.count, by: step) {
+            let old = result[i]
+            result[i] = AXElement(
+                id: old.id,
+                role: old.role,
+                title: (old.title ?? "") + "-changed",
+                value: old.value,
+                frame: old.frame,
+                isEnabled: old.isEnabled,
+                isFocused: old.isFocused,
+                children: old.children,
+                roleDescription: old.roleDescription,
+                identifier: old.identifier,
+                url: old.url,
+                placeholderValue: old.placeholderValue
+            )
+        }
+        return result
+    }
+
+    // MARK: - Benchmarks
+
+    /// Small tree (~50 elements), ~5 elements changed.
+    /// Simulates a typical session step where the UI has minimal changes.
+    func testSmallTreeSmallDiff() {
+        let previous = Self.makeElements(count: 50, prefix: "s")
+        let current = Self.mutateElements(previous, count: 5)
+
+        measure(metrics: [XCTClockMetric()]) {
+            for _ in 0..<200 {
+                _ = AXTreeDiff.diff(previousFlat: previous, currentFlat: current)
+            }
+        }
+    }
+
+    /// Medium tree (~200 elements), ~50 elements changed.
+    /// Simulates switching between app views with substantial UI changes.
+    func testMediumTreeManyChanges() {
+        let previous = Self.makeElements(count: 200, prefix: "m")
+        let current = Self.mutateElements(previous, count: 50)
+
+        measure(metrics: [XCTClockMetric()]) {
+            for _ in 0..<50 {
+                _ = AXTreeDiff.diff(previousFlat: previous, currentFlat: current)
+            }
+        }
+    }
+
+    /// Large tree (~500 elements), identical previous and current.
+    /// This is the no-op fast path when the UI hasn't changed between session steps.
+    func testLargeTreeIdentical() {
+        let elements = Self.makeElements(count: 500, prefix: "l")
+
+        measure(metrics: [XCTClockMetric()]) {
+            for _ in 0..<50 {
+                _ = AXTreeDiff.diff(previousFlat: elements, currentFlat: elements)
+            }
+        }
+    }
+
+    /// Large tree (~200 elements), complete replacement — previous and current
+    /// share no structural keys. Worst case: forces full multimap rebuild with
+    /// no matches.
+    func testLargeTreeCompleteReplacement() {
+        let previous = Self.makeElements(count: 200, idOffset: 0, prefix: "old")
+        let current = Self.makeElements(count: 200, idOffset: 1000, prefix: "new")
+
+        measure(metrics: [XCTClockMetric()]) {
+            for _ in 0..<50 {
+                _ = AXTreeDiff.diff(previousFlat: previous, currentFlat: current)
+            }
+        }
+    }
+}

--- a/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
@@ -79,35 +79,13 @@ final class MessageListAnchorPerformanceTests: XCTestCase {
 
     // MARK: - 1. AnchorVisibilityTracker Rapid-Update Stress Test
 
-    /// The real AnchorVisibilityTracker is @MainActor private, so we create a
-    /// minimal replica that mirrors the exact same O(1) logic. The goal is to
-    /// guard against regressions in the hot path's algorithmic complexity —
-    /// these methods are called on every scroll frame via SwiftUI preference keys.
-    @MainActor
-    private final class AnchorVisibilityTrackerReplica {
-        var lastMinY: CGFloat = .infinity
-        var isVisible: Bool = true
-
-        func update(minY: CGFloat, viewportHeight: CGFloat) {
-            lastMinY = minY
-            let newVisible = minY >= -20 && minY <= viewportHeight + 20
-            if isVisible != newVisible { isVisible = newVisible }
-        }
-
-        func updateViewport(height: CGFloat, storedViewportHeight: inout CGFloat) {
-            storedViewportHeight = height
-            let newVisible = lastMinY >= -20 && lastMinY <= height + 20
-            if isVisible != newVisible { isVisible = newVisible }
-        }
-    }
-
     /// Benchmarks calling update(minY:viewportHeight:) and
     /// updateViewport(height:storedViewportHeight:) 10,000 times each in a
     /// tight loop. While individually trivial (O(1)), they are called on EVERY
     /// scroll frame. This test detects if any future refactoring adds overhead.
     @MainActor
     func testAnchorVisibilityTrackerRapidUpdateStress() {
-        let tracker = AnchorVisibilityTrackerReplica()
+        let tracker = AnchorVisibilityTracker()
         let viewportHeight: CGFloat = 800.0
 
         measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {

--- a/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MessageListAnchorPerformanceTests.swift
@@ -1,0 +1,288 @@
+import XCTest
+@testable import VellumAssistantLib
+@testable import VellumAssistantShared
+
+// MARK: - MessageListView Anchor & Rendering Performance Baselines
+//
+// These tests establish XCTest performance baselines for:
+//   1. AnchorVisibilityTracker hot-path stress (called on every scroll frame)
+//   2. Large conversation markdown pipeline throughput (cold cache)
+//   3. Attributed string cache hit performance (hot cache)
+//
+// Run manually with:
+//   swift test --filter MessageListAnchorPerformanceTests  (from clients/macos/)
+// or via Xcode's Test navigator.
+
+final class MessageListAnchorPerformanceTests: XCTestCase {
+
+    // MARK: - Sample Data
+
+    // Realistic markdown similar to MarkdownPerformanceTests — used to build
+    // a 50-message conversation with alternating user/assistant messages.
+    private static let sampleAssistantMarkdown: String = """
+    # Getting Started with Swift Concurrency
+
+    Swift 5.5 introduced structured concurrency — a model that makes asynchronous \
+    code as readable as synchronous code.  At its core are two primitives: \
+    `async`/`await` and `Task`.
+
+    ## Why Structured Concurrency?
+
+    Before Swift 5.5, asynchronous work was expressed through completion handlers, \
+    combine pipelines, or DispatchQueue callbacks.  These approaches are hard to \
+    reason about, especially when multiple asynchronous operations depend on each \
+    other.
+
+    Structured concurrency solves this by tying the lifetime of every child task to \
+    a parent scope.  When the parent scope exits, all child tasks are automatically \
+    cancelled and awaited.
+
+    ## Core APIs
+
+    ### async / await
+
+    Mark a function `async` to indicate it can suspend:
+
+    ```swift
+    func fetchUser(id: String) async throws -> User {
+        let url = URL(string: "https://api.example.com/users/\\(id)")!
+        let (data, _) = try await URLSession.shared.data(from: url)
+        return try JSONDecoder().decode(User.self, from: data)
+    }
+    ```
+
+    - Audit every `DispatchQueue.async` call and determine whether it can become `await`
+    - Replace `DispatchGroup` fan-out patterns with `withTaskGroup`
+    - Mark view models and data-layer types with `@MainActor` where appropriate
+
+    | Approach            | Cancellation | Structured | Readable |
+    |---------------------|:------------:|:----------:|:--------:|
+    | Completion handlers | Manual       | No         | Low      |
+    | async/await         | Automatic    | Yes        | High     |
+    """
+
+    private static let sampleUserMarkdown: String = """
+    Can you explain how `Task.sleep(nanoseconds:)` works and when I should use \
+    `Task.checkCancellation()` vs `Task.isCancelled`?
+
+    I'm also curious about `TaskLocal` — when would I use that instead of a \
+    regular property on an actor?
+
+    ```swift
+    let task = Task {
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        print("Done")
+    }
+    task.cancel()
+    ```
+    """
+
+    // MARK: - 1. AnchorVisibilityTracker Rapid-Update Stress Test
+
+    /// The real AnchorVisibilityTracker is @MainActor private, so we create a
+    /// minimal replica that mirrors the exact same O(1) logic. The goal is to
+    /// guard against regressions in the hot path's algorithmic complexity —
+    /// these methods are called on every scroll frame via SwiftUI preference keys.
+    @MainActor
+    private final class AnchorVisibilityTrackerReplica {
+        var lastMinY: CGFloat = .infinity
+        var isVisible: Bool = true
+
+        func update(minY: CGFloat, viewportHeight: CGFloat) {
+            lastMinY = minY
+            let newVisible = minY >= -20 && minY <= viewportHeight + 20
+            if isVisible != newVisible { isVisible = newVisible }
+        }
+
+        func updateViewport(height: CGFloat, storedViewportHeight: inout CGFloat) {
+            storedViewportHeight = height
+            let newVisible = lastMinY >= -20 && lastMinY <= height + 20
+            if isVisible != newVisible { isVisible = newVisible }
+        }
+    }
+
+    /// Benchmarks calling update(minY:viewportHeight:) and
+    /// updateViewport(height:storedViewportHeight:) 10,000 times each in a
+    /// tight loop. While individually trivial (O(1)), they are called on EVERY
+    /// scroll frame. This test detects if any future refactoring adds overhead.
+    @MainActor
+    func testAnchorVisibilityTrackerRapidUpdateStress() {
+        let tracker = AnchorVisibilityTrackerReplica()
+        let viewportHeight: CGFloat = 800.0
+
+        measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
+            var storedViewportHeight: CGFloat = 800.0
+            for i in 0..<10_000 {
+                // Simulate scrolling: minY varies from well above to well below
+                // the viewport, crossing the visibility boundary frequently.
+                let minY = CGFloat(i % 1600) - 400.0
+                tracker.update(minY: minY, viewportHeight: viewportHeight)
+            }
+            for i in 0..<10_000 {
+                // Simulate viewport resizes mixed with position changes.
+                let height = 600.0 + CGFloat(i % 400)
+                tracker.updateViewport(height: height, storedViewportHeight: &storedViewportHeight)
+            }
+        }
+    }
+
+    // MARK: - 2. Large Conversation Markdown Pipeline Throughput
+
+    /// Builds 50 alternating user/assistant messages and measures the full
+    /// parse + group + build attributed string pipeline. This simulates the
+    /// work done when scrolling through a large conversation where the
+    /// attributed string cache is cold.
+    func testLargeConversationMarkdownPipelineThroughput() {
+        // Build 50 messages alternating user/assistant content.
+        let messages: [String] = (0..<50).map { i in
+            i.isMultiple(of: 2) ? Self.sampleUserMarkdown : Self.sampleAssistantMarkdown
+        }
+
+        measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
+            for markdown in messages {
+                let segments = parseMarkdownSegments(markdown)
+                let groups = groupSegments(segments)
+                for group in groups {
+                    if case .selectableRun(let run) = group {
+                        _ = makeAttributedString(from: run)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - 3. Attributed String Cache Hit Performance
+
+    /// Pre-warms a set of parsed segments, then measures how fast 200
+    /// repeated cache lookups are. This benchmarks the LRU cache hot path
+    /// using the same makeAttributedString helper (which mirrors the real
+    /// cache-less build path from MarkdownPerformanceTests).
+    ///
+    /// Because the real MarkdownSegmentView cache is private and requires a
+    /// SwiftUI view instance, we benchmark the attributed string construction
+    /// path with a local dictionary cache to validate that caching itself
+    /// does not regress.
+    func testAttributedStringCacheHitPerformance() {
+        // Parse a representative set of segments once.
+        let markdowns = [Self.sampleAssistantMarkdown, Self.sampleUserMarkdown]
+        let allRuns: [[MarkdownSegment]] = markdowns.flatMap { md -> [[MarkdownSegment]] in
+            let segments = parseMarkdownSegments(md)
+            let groups = groupSegments(segments)
+            return groups.compactMap { group -> [MarkdownSegment]? in
+                if case .selectableRun(let run) = group { return run }
+                return nil
+            }
+        }
+
+        // Pre-warm: build each attributed string once and store in a local cache.
+        var cache: [Int: AttributedString] = [:]
+        for (index, run) in allRuns.enumerated() {
+            cache[index] = makeAttributedString(from: run)
+        }
+
+        // Measure 200 repeated cache lookups.
+        measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
+            for _ in 0..<200 {
+                for (index, _) in allRuns.enumerated() {
+                    _ = cache[index]
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Test Helpers (shared with MarkdownPerformanceTests)
+
+/// Mirrors `MarkdownSegmentView.computeGroupedSegments()` — duplicated here
+/// as a pure function so the performance test can call it without constructing
+/// a SwiftUI view.
+private enum SegmentGroup {
+    case selectableRun([MarkdownSegment])
+    case heading(level: Int, text: String)
+    case codeBlock(language: String?, code: String)
+    case list(items: [ListItem], ordered: Bool)
+    case table(headers: [String], rows: [[String]])
+    case image(alt: String, url: String)
+    case horizontalRule
+}
+
+private func groupSegments(_ segments: [MarkdownSegment]) -> [SegmentGroup] {
+    var groups: [SegmentGroup] = []
+    var currentRun: [MarkdownSegment] = []
+
+    func flushRun() {
+        if !currentRun.isEmpty {
+            groups.append(.selectableRun(currentRun))
+            currentRun = []
+        }
+    }
+
+    for segment in segments {
+        switch segment {
+        case .text:
+            currentRun.append(segment)
+        case .heading(let level, let text):
+            flushRun()
+            groups.append(.heading(level: level, text: text))
+        case .list(let items):
+            flushRun()
+            let hasOrdered = items.contains { $0.ordered }
+            groups.append(.list(items: items, ordered: hasOrdered))
+        case .codeBlock(let language, let code):
+            flushRun()
+            groups.append(.codeBlock(language: language, code: code))
+        case .table(let headers, let rows):
+            flushRun()
+            groups.append(.table(headers: headers, rows: rows))
+        case .image(let alt, let url):
+            flushRun()
+            groups.append(.image(alt: alt, url: url))
+        case .horizontalRule:
+            flushRun()
+            groups.append(.horizontalRule)
+        }
+    }
+    flushRun()
+    return groups
+}
+
+/// Builds a combined `AttributedString` from a selectable run by parsing each
+/// text segment's inline markdown. Mirrors the hot path in
+/// `MarkdownSegmentView.buildAttributedStringUncached(from:…)`.
+private func makeAttributedString(from segments: [MarkdownSegment]) -> AttributedString {
+    let options = AttributedString.MarkdownParsingOptions(
+        interpretedSyntax: .inlineOnlyPreservingWhitespace
+    )
+    var result = AttributedString()
+    for (index, segment) in segments.enumerated() {
+        if index > 0 {
+            result += AttributedString("\n\n")
+        }
+        if case .text(let text) = segment {
+            let attributed = (try? AttributedString(markdown: text, options: options))
+                ?? AttributedString(text)
+            result += attributed
+        }
+    }
+
+    // Apply background, text color, and padding to inline code spans —
+    // mirrors the pass in buildAttributedStringUncached.
+    var codeRanges: [Range<AttributedString.Index>] = []
+    for run in result.runs {
+        if let intent = run.inlinePresentationIntent, intent.contains(.code) {
+            codeRanges.append(run.range)
+        }
+    }
+    for range in codeRanges.reversed() {
+        result[range].foregroundColor = VColor.codeText
+        result[range].backgroundColor = VColor.codeBackground
+        var trailing = AttributedString("\u{2009}")
+        trailing.backgroundColor = VColor.codeBackground
+        result.insert(trailing, at: range.upperBound)
+        var leading = AttributedString("\u{2009}")
+        leading.backgroundColor = VColor.codeBackground
+        result.insert(leading, at: range.lowerBound)
+    }
+
+    return result
+}

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -716,6 +716,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
 
         // Route through HTTP transport when active (remote assistants).
+        // Note: httpTransport.send() dispatches the actual HTTP request
+        // asynchronously (Task { ... }), so the signpost only captures the
+        // synchronous dispatch overhead, not the full network round-trip.
+        // Full HTTP latency instrumentation belongs in HTTPDaemonClient.
         if let httpTransport {
             guard httpTransport.isConnected else {
                 os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
@@ -1930,12 +1934,19 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
         #if os(macOS)
         if let httpTransport = self.httpTransport, !Self.isLocalBaseURL(httpTransport.baseURL) {
+            let sid = OSSignpostID(log: ipcLog)
+            os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
+            defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
             return try await httpTransport.fetchAssistantFeatureFlags(featureFlagToken: token)
         }
 
         guard let request = buildLocalRequest(target: .gateway, path: "v1/feature-flags", tokenOverride: token) else {
             throw FeatureFlagError.invalidURL
         }
+
+        let sid = OSSignpostID(log: ipcLog)
+        os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
+        defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
 
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
@@ -1949,6 +1960,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         guard let httpTransport else {
             throw FeatureFlagError.requestFailed(0)
         }
+        let sid = OSSignpostID(log: ipcLog)
+        os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
+        defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
         return try await httpTransport.fetchAssistantFeatureFlags(featureFlagToken: token)
         #endif
     }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -706,10 +706,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Throws `SendError.notConnected` when the connection is nil so callers can
     /// distinguish a silently-dropped message from a successful write.
     public func send<T: Encodable>(_ message: T) throws {
-        os_signpost(.begin, log: ipcLog, name: "daemonIPCSend")
-        defer { os_signpost(.end, log: ipcLog, name: "daemonIPCSend") }
+        let sendID = OSSignpostID(log: ipcLog)
+        os_signpost(.begin, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
 
         if let override = sendOverride {
+            os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
             try override(message)
             return
         }
@@ -717,18 +718,22 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         // Route through HTTP transport when active (remote assistants).
         if let httpTransport {
             guard httpTransport.isConnected else {
+                os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
                 throw SendError.notConnected
             }
+            os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
             try httpTransport.send(message)
             return
         }
 
         guard let conn = connection else {
+            os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
             log.warning("Cannot send: not connected")
             throw SendError.notConnected
         }
 
         if !isAuthenticated, !(message is AuthMessage) {
+            os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
             log.warning("Cannot send: authentication not complete")
             throw SendError.notAuthenticated
         }
@@ -750,6 +755,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
 
         conn.send(content: data, completion: .contentProcessed { error in
+            os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
             if let error {
                 log.error("Send failed: \(error.localizedDescription)")
             }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -721,8 +721,13 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                 os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
                 throw SendError.notConnected
             }
-            os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
-            try httpTransport.send(message)
+            do {
+                try httpTransport.send(message)
+                os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
+            } catch {
+                os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
+                throw error
+            }
             return
         }
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -738,8 +738,15 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             throw SendError.notAuthenticated
         }
 
-        var data = try encoder.encode(message)
-        data.append(contentsOf: [0x0A]) // newline byte
+        let data: Data
+        do {
+            var encoded = try encoder.encode(message)
+            encoded.append(contentsOf: [0x0A]) // newline byte
+            data = encoded
+        } catch {
+            os_signpost(.end, log: ipcLog, name: "daemonIPCSend", signpostID: sendID)
+            throw error
+        }
 
         if let observation = message as? CuObservationMessage {
             let previousSequence = cuObservationSequenceBySession[observation.sessionId] ?? 0

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -4,6 +4,12 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "DaemonClient")
 
+/// Shared signpost log for IPC instrumentation (Points of Interest lane in Instruments).
+private let ipcLog = OSLog(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
+    category: .pointsOfInterest
+)
+
 #if os(macOS)
 private func expandHomePath(_ path: String) -> String {
     if path == "~" {
@@ -700,6 +706,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Throws `SendError.notConnected` when the connection is nil so callers can
     /// distinguish a silently-dropped message from a successful write.
     public func send<T: Encodable>(_ message: T) throws {
+        os_signpost(.begin, log: ipcLog, name: "daemonIPCSend")
+        defer { os_signpost(.end, log: ipcLog, name: "daemonIPCSend") }
+
         if let override = sendOverride {
             try override(message)
             return
@@ -1936,6 +1945,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
         #if os(macOS)
         if let httpTransport = self.httpTransport, !Self.isLocalBaseURL(httpTransport.baseURL) {
+            let sid = OSSignpostID(log: ipcLog)
+            os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
+            defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
             return try await httpTransport.getFeatureFlags(featureFlagToken: token)
         }
 
@@ -1943,6 +1955,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         guard let request = buildLocalRequest(target: .gateway, path: "v1/feature-flags", tokenOverride: token) else {
             throw FeatureFlagError.invalidURL
         }
+
+        let sid = OSSignpostID(log: ipcLog)
+        os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
+        defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
 
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
@@ -1956,6 +1972,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         guard let httpTransport else {
             throw FeatureFlagError.requestFailed(0)
         }
+        let sid = OSSignpostID(log: ipcLog)
+        os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
+        defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
         return try await httpTransport.getFeatureFlags(featureFlagToken: token)
         #endif
     }
@@ -1980,6 +1999,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         // points at localhost (the runtime), which does NOT serve feature-flag
         // routes — so we must fall through to the local gateway path below.
         if let httpTransport = self.httpTransport, !Self.isLocalBaseURL(httpTransport.baseURL) {
+            let sid = OSSignpostID(log: ipcLog)
+            os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
+            defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
             try await httpTransport.setFeatureFlag(key: key, enabled: enabled, featureFlagToken: token)
             return
         }
@@ -1994,6 +2016,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         let body: [String: Any] = ["enabled": enabled]
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
+        let sid = OSSignpostID(log: ipcLog)
+        os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
+        defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
+
         let (_, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
@@ -2004,6 +2030,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         guard let httpTransport else {
             throw FeatureFlagError.requestFailed(0)
         }
+        let sid = OSSignpostID(log: ipcLog)
+        os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)
+        defer { os_signpost(.end, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid) }
         try await httpTransport.setFeatureFlag(key: key, enabled: enabled, featureFlagToken: token)
         #endif
     }

--- a/scripts/compare-perf-baselines.sh
+++ b/scripts/compare-perf-baselines.sh
@@ -79,12 +79,14 @@ if not os.path.exists(baseline_file):
         with open(baseline_file, "w") as f:
             json.dump(results, f, indent=2)
         print(f"No baseline found. Recorded current results as baseline ({baseline_file}).")
+        with open(summary_file, "w") as sf:
+            sf.write("## Performance Baselines\n\nBaseline recorded for the first time. Future runs will compare against these values.\n")
     else:
         print("WARNING: No baseline found and this is a PR run (UPDATE_BASELINE=false).")
         print("Run the workflow on main to establish a baseline before regressions can be detected.")
         print("Skipping regression check for this PR run.")
-    with open(summary_file, "w") as sf:
-        sf.write("## Performance Baselines\n\nNo baseline available yet. Run the workflow on `main` to establish baselines.\n")
+        with open(summary_file, "w") as sf:
+            sf.write("## Performance Baselines\n\nNo baseline available yet. Run the workflow on `main` to establish baselines.\n")
     sys.exit(0)
 
 # Load and compare against stored baseline.

--- a/scripts/compare-perf-baselines.sh
+++ b/scripts/compare-perf-baselines.sh
@@ -54,10 +54,14 @@ with open(results_log) as f:
             if test_name not in results:  # first match wins (wall-time before CPU-cycles lines)
                 results[test_name] = float(m.group(3))
 
+summary_file = os.path.join(baseline_dir, "summary.md")
+
 if not results:
     print("ERROR: No XCTest performance measurements found in log.")
     print("This likely means the performance tests did not run or produced no output.")
     print("Check that MarkdownPerformanceTests executed successfully.")
+    with open(summary_file, "w") as sf:
+        sf.write("## Performance Baselines\n\nNo performance measurements found in test output.\n")
     sys.exit(1)
 
 print("=== Performance Results ===")
@@ -79,6 +83,8 @@ if not os.path.exists(baseline_file):
         print("WARNING: No baseline found and this is a PR run (UPDATE_BASELINE=false).")
         print("Run the workflow on main to establish a baseline before regressions can be detected.")
         print("Skipping regression check for this PR run.")
+    with open(summary_file, "w") as sf:
+        sf.write("## Performance Baselines\n\nNo baseline available yet. Run the workflow on `main` to establish baselines.\n")
     sys.exit(0)
 
 # Load and compare against stored baseline.
@@ -102,6 +108,28 @@ for name, actual in sorted(results.items()):
         regressions.append(name)
 
 print()
+
+# Write summary.md with a formatted table for PR comments and step summaries.
+rows = []
+for name, actual in sorted(results.items()):
+    if name not in baselines:
+        rows.append(f"| {name} | — | {actual:.4f}s | — | 🆕 NEW |")
+        continue
+    baseline = baselines[name]
+    if baseline == 0:
+        dp = float('inf') if actual > 0 else 0.0
+    else:
+        dp = (actual - baseline) / baseline * 100
+    status = "❌ REGRESSED" if dp > threshold else "✅ ok"
+    rows.append(f"| {name} | {baseline:.4f}s | {actual:.4f}s | {dp:+.1f}% | {status} |")
+
+with open(summary_file, "w") as sf:
+    sf.write("## Performance Baselines\n\n")
+    sf.write("| Test | Baseline | Actual | Delta | Status |\n")
+    sf.write("|------|----------|--------|-------|--------|\n")
+    for row in rows:
+        sf.write(row + "\n")
+    sf.write(f"\n**Threshold**: {int(threshold)}%\n")
 
 if regressions:
     print(f"FAIL: {len(regressions)} regression(s) exceed {threshold:.0f}% threshold: {', '.join(regressions)}")


### PR DESCRIPTION
## Summary
Expand CI performance baselines and runtime telemetry to catch more classes of performance regressions before they reach users. Adds new XCTest benchmarks, os_signpost instrumentation, and CI workflow enhancements.

## Changes
- **MessageListView benchmarks**: Anchor tracker stress test, large conversation markdown throughput, attributed string cache hit performance
- **AXTreeDiff benchmarks**: Small diff, medium diff, identical tree, and complete replacement scenarios
- **DaemonClient os_signpost instrumentation**: `daemonIPCSend` signpost on all outbound IPC, `daemonHTTPRequest` signpost on HTTP request-response methods (getFeatureFlags, setFeatureFlag)
- **CI PR comments**: Compare script now outputs summary.md; workflow posts sticky PR comment with performance table and writes GitHub step summary

## Milestone PRs (merged into feature branch)
- #13145: M1 — MessageListView anchor tracking XCTest benchmark
- #13154: M2 — AXTreeDiff computation XCTest benchmark
- #13163: M3 — os_signpost instrumentation for DaemonClient IPC
- #13182: M4 — CI PR comment with performance regression table

## Project issue
Closes #13128

## Test plan
- [ ] `swift test --package-path clients --filter 'MarkdownPerformanceTests|MessageListAnchorPerformanceTests|AXTreeDiffPerformanceTests'` passes
- [ ] Instruments profiling shows new signpost names (daemonIPCSend, daemonHTTPRequest) in Points of Interest
- [ ] CI perf workflow posts performance table as PR comment on pull_request events
- [ ] CI perf workflow writes step summary on push events

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
