### PR TITLE
fix: surface channel readiness reasons in macOS contact detail

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -240,9 +240,9 @@ struct ContactDetailView: View {
             )
             let extraChannels = displayContact.channels.filter { !Self.allChannelTypes.contains($0.type) }
 
-            // Compute which standard types are visible (have channels or readiness==true)
+            // Compute which standard types are visible (have channels or readiness info)
             let visibleTypes = Self.allChannelTypes.filter { type in
-                channelsByType[type] != nil || channelReadiness[type]?.ready == true
+                channelsByType[type] != nil || channelReadiness[type] != nil
             }
             let lastVisibleType = visibleTypes.last
             let hasExtraChannels = !extraChannels.isEmpty
@@ -261,15 +261,19 @@ struct ContactDetailView: View {
                     if type != lastVisibleType || hasExtraChannels {
                         Divider().background(VColor.divider)
                     }
-                } else if channelReadiness[type]?.ready == true {
-                    // Unconfigured but assistant has this channel set up — show
-                    unconfiguredChannelRow(type: type)
+                } else if let readiness = channelReadiness[type] {
+                    if readiness.ready {
+                        // Unconfigured but assistant has this channel set up — show
+                        unconfiguredChannelRow(type: type)
+                    } else {
+                        // Channel exists but is not ready — show with reason
+                        unavailableChannelRow(type: type, reason: readiness.reasonSummary)
+                    }
 
                     if type != lastVisibleType || hasExtraChannels {
                         Divider().background(VColor.divider)
                     }
                 }
-                // else: channel not configured, hide entirely
             }
 
             ForEach(Array(extraChannels.enumerated()), id: \.element.id) { index, channel in
@@ -434,6 +438,37 @@ struct ContactDetailView: View {
 
             if inviteResult?.type == type {
                 inviteResultDisplay(for: type)
+            }
+        }
+    }
+
+    /// Row for a channel that the assistant knows about but is not ready.
+    /// Shows the channel name with an explanation of why it is unavailable.
+    @ViewBuilder
+    private func unavailableChannelRow(type: String, reason: String?) -> some View {
+        VStack(alignment: .leading, spacing: VSpacing.sm) {
+            HStack(spacing: VSpacing.sm) {
+                Image(systemName: channelIcon(for: type))
+                    .foregroundColor(VColor.textMuted)
+                    .font(.system(size: 14))
+                    .frame(width: 20, alignment: .center)
+
+                Text(channelLabel(for: type))
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textMuted)
+
+                Spacer()
+
+                Text("Unavailable")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
+
+            if let reason {
+                Text(reason)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1891,10 +1891,25 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         #endif
     }
 
+    /// A single readiness check result from the API.
+    public struct ReadinessCheck {
+        public let name: String
+        public let passed: Bool
+        public let message: String
+    }
+
     /// Rich channel readiness information returned by `fetchChannelReadiness()`.
     public struct ChannelReadinessInfo {
         public let ready: Bool
         public let channelHandle: String?
+        public let checks: [ReadinessCheck]
+
+        /// Human-readable reason why this channel is not ready, derived from
+        /// the first failing check. Returns `nil` when the channel is ready.
+        public var reasonSummary: String? {
+            guard !ready else { return nil }
+            return checks.first(where: { !$0.passed })?.message
+        }
     }
 
     /// Fetch per-channel readiness state from the gateway.
@@ -1919,14 +1934,24 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                 let channel: String
                 let ready: Bool
                 let channelHandle: String?
+                let localChecks: [CheckResult]?
+                let remoteChecks: [CheckResult]?
+            }
+            struct CheckResult: Decodable {
+                let name: String
+                let passed: Bool
+                let message: String
             }
         }
         let decoded = try JSONDecoder().decode(ReadinessResponse.self, from: data)
         var result: [String: ChannelReadinessInfo] = [:]
         for snapshot in decoded.snapshots {
+            let checks = ((snapshot.localChecks ?? []) + (snapshot.remoteChecks ?? []))
+                .map { ReadinessCheck(name: $0.name, passed: $0.passed, message: $0.message) }
             result[snapshot.channel] = ChannelReadinessInfo(
                 ready: snapshot.ready,
-                channelHandle: snapshot.channelHandle
+                channelHandle: snapshot.channelHandle,
+                checks: checks
             )
         }
         return result

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -1169,6 +1169,13 @@ public final class HTTPTransport {
             let channel: String
             let ready: Bool
             let channelHandle: String?
+            let localChecks: [CheckResult]?
+            let remoteChecks: [CheckResult]?
+        }
+        struct CheckResult: Decodable {
+            let name: String
+            let passed: Bool
+            let message: String
         }
     }
 
@@ -1320,9 +1327,12 @@ public final class HTTPTransport {
         let decoded = try decoder.decode(HTTPChannelReadinessResponse.self, from: data)
         var result: [String: DaemonClient.ChannelReadinessInfo] = [:]
         for snapshot in decoded.snapshots {
+            let checks = ((snapshot.localChecks ?? []) + (snapshot.remoteChecks ?? []))
+                .map { DaemonClient.ReadinessCheck(name: $0.name, passed: $0.passed, message: $0.message) }
             result[snapshot.channel] = DaemonClient.ChannelReadinessInfo(
                 ready: snapshot.ready,
-                channelHandle: snapshot.channelHandle
+                channelHandle: snapshot.channelHandle,
+                checks: checks
             )
         }
         return result


### PR DESCRIPTION
## Summary
- DaemonClient now parses readiness check results (reasons) from API response
- ContactDetailView shows non-ready channels with explanatory reasons instead of hiding them
- Users can now see why email/WhatsApp/Slack are unavailable

Addresses feedback finding 4: macOS surface honesty incomplete — readiness reasons thrown away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
