### PR TITLE
fix: show clean app name in share sheet instead of hash filename

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
@@ -121,7 +121,7 @@ extension MainWindowView {
             let previousHandler = daemonClient.onBundleAppResponse
             daemonClient.onBundleAppResponse = { response in
                 daemonClient.onBundleAppResponse = previousHandler
-                sharing.shareFileURL = URL(fileURLWithPath: response.bundlePath)
+                sharing.shareFileURL = Self.cleanBundleURL(bundlePath: response.bundlePath, appName: response.manifest.name)
                 sharing.isBundling = false
                 sharing.showSharePicker = true
             }
@@ -132,6 +132,26 @@ extension MainWindowView {
                 sharing.isBundling = false
                 daemonClient.onBundleAppResponse = previousHandler
             }
+        }
+    }
+
+    /// Creates a hardlink with a clean display name for the share sheet.
+    /// Falls back to the original path if linking fails.
+    static func cleanBundleURL(bundlePath: String, appName: String) -> URL {
+        let originalURL = URL(fileURLWithPath: bundlePath)
+        let cleanName = appName
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: ":", with: "_")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanName.isEmpty else { return originalURL }
+
+        let cleanURL = originalURL.deletingLastPathComponent().appendingPathComponent("\(cleanName).vellum")
+        try? FileManager.default.removeItem(at: cleanURL)
+        do {
+            try FileManager.default.linkItem(at: originalURL, to: cleanURL)
+            return cleanURL
+        } catch {
+            return originalURL
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -286,7 +286,7 @@ struct AppsGridView: View {
         let previousHandler = daemonClient.onBundleAppResponse
         daemonClient.onBundleAppResponse = { response in
             daemonClient.onBundleAppResponse = previousHandler
-            shareFileURL = URL(fileURLWithPath: response.bundlePath)
+            shareFileURL = MainWindowView.cleanBundleURL(bundlePath: response.bundlePath, appName: response.manifest.name)
             isBundling = false
             showShareSheet = true
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -726,9 +726,10 @@ struct GeneratedPanel: View {
         isBundling = true
 
         Task { @MainActor in
+            let previousHandler = daemonClient.onBundleAppResponse
             daemonClient.onBundleAppResponse = { response in
-                let url = URL(fileURLWithPath: response.bundlePath)
-                self.shareFileURL = url
+                daemonClient.onBundleAppResponse = previousHandler
+                self.shareFileURL = MainWindowView.cleanBundleURL(bundlePath: response.bundlePath, appName: response.manifest.name)
                 self.isBundling = false
                 self.showShareSheet = true
             }
@@ -738,6 +739,7 @@ struct GeneratedPanel: View {
             } catch {
                 isBundling = false
                 sharingAppId = nil
+                daemonClient.onBundleAppResponse = previousHandler
             }
         }
     }


### PR DESCRIPTION
## Summary
- Share sheet was showing the internal temp filename with hash suffix (e.g. `Pax Voice Terminal v2 - Hex 6-Display-a84fee5a.vellum`) instead of a clean name
- Add `cleanBundleURL` helper that hardlinks the temp bundle to `App Name.vellum` before passing to the share sheet
- Apply to all three share paths: MainWindowView toolbar, AppsGridView grid menu, GeneratedPanel
- Also fix GeneratedPanel missing save/restore of `onBundleAppResponse` handler (same bug previously fixed in the other two paths)

## Test plan
- [ ] Share an app from the workspace toolbar — verify AirDrop/share sheet shows clean name like `Pax Voice Terminal v2.vellum`
- [ ] Share from the Things grid ellipsis menu — same clean name
- [ ] Share from GeneratedPanel — same clean name

Part of #13051

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
