### PR TITLE
fix: propagate Ride Shotgun learn-mode bootstrap failures to client

### DIFF
--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1041,6 +1041,12 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     sessionId: "sess-routed-001",
     interactionType: "computer_use",
   },
+  ride_shotgun_error: {
+    type: "ride_shotgun_error",
+    watchId: "watch-shotgun-001",
+    sessionId: "sess-shotgun-001",
+    message: "Failed to start browser — Chrome CDP could not be launched.",
+  },
   ride_shotgun_progress: {
     type: "ride_shotgun_progress",
     watchId: "watch-shotgun-001",

--- a/assistant/src/__tests__/ride-shotgun-handler.test.ts
+++ b/assistant/src/__tests__/ride-shotgun-handler.test.ts
@@ -85,9 +85,10 @@ mock.module("../util/logger.js", () => ({
   }),
 }));
 
+const mockLastSummaryBySession = new Map<string, string>();
 mock.module("../daemon/watch-handler.js", () => ({
   generateSummary: async () => {},
-  lastSummaryBySession: new Map<string, string>(),
+  lastSummaryBySession: mockLastSummaryBySession,
 }));
 
 // ── Import under test (after mocks) ───────────────────────────────
@@ -141,6 +142,7 @@ describe("ride-shotgun-handler", () => {
       launchedByUs: false,
       userDataDir: "/tmp/cdp-test",
     };
+    mockLastSummaryBySession.clear();
     watchSessions.clear();
   });
 
@@ -366,4 +368,129 @@ describe("ride-shotgun-handler", () => {
       ctx,
     );
   });
+
+  test("sends ride_shotgun_error when ensureChromeWithCdp fails", async () => {
+    mockEnsureChromeShouldThrow = true;
+
+    const socket = makeMockSocket();
+    const ctx = makeMockCtx();
+
+    await handleRideShotgunStart(
+      {
+        type: "ride_shotgun_start",
+        durationSeconds: 60,
+        intervalSeconds: 5,
+        mode: "learn",
+        targetDomain: "example.com",
+        autoNavigate: false,
+      },
+      socket,
+      ctx,
+    );
+
+    // Give background task time to execute and complete session
+    await new Promise((r) => setTimeout(r, 500));
+
+    const errorMsg = ctx.sent.find(
+      (m: any) => m.type === "ride_shotgun_error",
+    ) as any;
+    expect(errorMsg).toBeDefined();
+    expect(errorMsg.watchId).toBeDefined();
+    expect(errorMsg.sessionId).toBeDefined();
+    expect(errorMsg.message).toContain("Chrome CDP");
+  });
+
+  test("cleans up session when ensureChromeWithCdp fails", async () => {
+    mockEnsureChromeShouldThrow = true;
+
+    const socket = makeMockSocket();
+    const ctx = makeMockCtx();
+
+    await handleRideShotgunStart(
+      {
+        type: "ride_shotgun_start",
+        durationSeconds: 60,
+        intervalSeconds: 5,
+        mode: "learn",
+        targetDomain: "example.com",
+        autoNavigate: false,
+      },
+      socket,
+      ctx,
+    );
+
+    // Give background task time to execute
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Session should be completed (not left hanging for the full duration)
+    const session = [...watchSessions.values()][0];
+    expect(session?.status).toBe("completed");
+  });
+
+  test("reports failure summary when no recorder ever started", async () => {
+    mockEnsureChromeShouldThrow = true;
+
+    const socket = makeMockSocket();
+    const ctx = makeMockCtx();
+
+    await handleRideShotgunStart(
+      {
+        type: "ride_shotgun_start",
+        durationSeconds: 60,
+        intervalSeconds: 5,
+        mode: "learn",
+        targetDomain: "example.com",
+        autoNavigate: false,
+      },
+      socket,
+      ctx,
+    );
+
+    // Give background task time to execute
+    await new Promise((r) => setTimeout(r, 500));
+
+    // The result message should indicate failure, not "recording saved"
+    const resultMsg = ctx.sent.find(
+      (m: any) => m.type === "ride_shotgun_result",
+    ) as any;
+    expect(resultMsg).toBeDefined();
+    expect(resultMsg.summary).toContain("failed");
+    expect(resultMsg.summary).not.toContain("recording saved");
+  });
+
+  test("sends ride_shotgun_error when all 10 recorder retries fail", async () => {
+    mockRecorderStartShouldThrow = true;
+    mockRecorderStartThrowCount = 10;
+
+    const socket = makeMockSocket();
+    const ctx = makeMockCtx();
+
+    await handleRideShotgunStart(
+      {
+        type: "ride_shotgun_start",
+        durationSeconds: 60,
+        intervalSeconds: 5,
+        mode: "learn",
+        targetDomain: "example.com",
+        autoNavigate: false,
+      },
+      socket,
+      ctx,
+    );
+
+    // Wait for all 10 retry attempts (each has a 2s delay except the last)
+    // 9 retries * 2s = 18s, but mock doesn't actually wait — it should complete quickly
+    // The mock delays are real setTimeout calls, so we need enough time
+    await new Promise((r) => setTimeout(r, 25000));
+
+    const errorMsg = ctx.sent.find(
+      (m: any) => m.type === "ride_shotgun_error",
+    ) as any;
+    expect(errorMsg).toBeDefined();
+    expect(errorMsg.message).toContain("10 attempts");
+
+    // Session should be completed
+    const session = [...watchSessions.values()][0];
+    expect(session?.status).toBe("completed");
+  }, 30000); // Extended timeout for retry delays
 });

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -278,6 +278,7 @@
     "recording_start",
     "recording_stop",
     "reminders_list_response",
+    "ride_shotgun_error",
     "ride_shotgun_progress",
     "ride_shotgun_result",
     "schedule_thread_created",

--- a/assistant/src/daemon/ipc-contract/computer-use.ts
+++ b/assistant/src/daemon/ipc-contract/computer-use.ts
@@ -217,6 +217,14 @@ export interface WatchCompleteRequest {
   watchId: string;
 }
 
+/** Server → Client: bootstrap failure during learn-mode recording setup. */
+export interface RideShotgunError {
+  type: "ride_shotgun_error";
+  watchId: string;
+  sessionId: string;
+  message: string;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
 export type _ComputerUseClientMessages =
@@ -236,6 +244,7 @@ export type _ComputerUseServerMessages =
   | TaskRouted
   | RideShotgunProgress
   | RideShotgunResult
+  | RideShotgunError
   | WatchStarted
   | WatchCompleteRequest
   | RecordingStart

--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -79,11 +79,15 @@ async function completeSession(session: WatchSession): Promise<void> {
 
   // In learn mode, stop recording and save — skip the LLM summary (not needed)
   if (session.isLearnMode && session.recordingId) {
-    session.savedRecordingPath = await finalizeLearnRecording(
-      watchId,
-      session,
-      session.recordingId,
-    );
+    const hasRecorder = activeRecorders.has(watchId);
+
+    if (hasRecorder) {
+      session.savedRecordingPath = await finalizeLearnRecording(
+        watchId,
+        session,
+        session.recordingId,
+      );
+    }
 
     // Clean up the CDP session — minimize if we launched Chrome, leave it alone otherwise
     const cdpSession = activeCdpSessions.get(watchId);
@@ -99,15 +103,17 @@ async function completeSession(session: WatchSession): Promise<void> {
       }
     }
 
-    lastSummaryBySession.set(
-      sessionId,
-      session.savedRecordingPath
+    // When no recorder ever started, the browser failed to launch — report failure
+    const summary = hasRecorder
+      ? session.savedRecordingPath
         ? "Learn session completed — recording saved."
-        : "Learn session completed — recording failed to save.",
-    );
+        : "Learn session completed — recording failed to save."
+      : "Learn session failed — browser could not be started.";
+
+    lastSummaryBySession.set(sessionId, summary);
     session.status = "completed";
     log.info(
-      { watchId, sessionId },
+      { watchId, sessionId, hasRecorder },
       "Learn session complete — firing completion notifier",
     );
     fireWatchCompletionNotifier(sessionId, session);
@@ -188,6 +194,15 @@ export async function handleRideShotgunStart(
           { err, watchId },
           "Failed to ensure Chrome with CDP — cannot start recording",
         );
+        ctx.send(socket, {
+          type: "ride_shotgun_error",
+          watchId,
+          sessionId,
+          message:
+            "Failed to start browser — Chrome CDP could not be launched.",
+        });
+        // Fail-fast: complete the session immediately instead of waiting for timeout
+        await completeSession(session);
         return;
       }
 
@@ -377,6 +392,13 @@ export async function handleRideShotgunStart(
               { err, watchId },
               "Failed to start network recording after 10 attempts",
             );
+            ctx.send(socket, {
+              type: "ride_shotgun_error",
+              watchId,
+              sessionId,
+              message: "Failed to start network recording after 10 attempts.",
+            });
+            await completeSession(session);
           }
         }
       }

--- a/clients/ios/App/RideShotgunSession.swift
+++ b/clients/ios/App/RideShotgunSession.swift
@@ -64,6 +64,12 @@ final class RideShotgunSession: ObservableObject, Identifiable {
                 switch message {
                 case .watchStarted(let msg):
                     await MainActor.run { self.handleWatchStarted(msg) }
+                case .rideShotgunError(let error):
+                    await MainActor.run {
+                        log.error("Ride shotgun bootstrap failure: \(error.message)")
+                        self.state = .failed(error.message)
+                        self.cleanup()
+                    }
                 case .rideShotgunProgress(let progress):
                     await MainActor.run {
                         if let count = progress.networkEntryCount {

--- a/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
@@ -69,6 +69,10 @@ public final class RideShotgunSession: ObservableObject {
                 switch message {
                 case .watchStarted(let started):
                     self.handleWatchStarted(started, daemonClient: daemonClient)
+                case .rideShotgunError(let error):
+                    log.error("Ride shotgun bootstrap failure: \(error.message)")
+                    self.state = .failed(error.message)
+                    self.cleanup()
                 case .rideShotgunProgress(let progress):
                     if let count = progress.networkEntryCount {
                         self.networkEntryCount = count

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -3389,6 +3389,21 @@ public struct IPCReorderThreadsRequestUpdate: Codable, Sendable {
     }
 }
 
+/// Server → Client: bootstrap failure during learn-mode recording setup.
+public struct IPCRideShotgunError: Codable, Sendable {
+    public let type: String
+    public let watchId: String
+    public let sessionId: String
+    public let message: String
+
+    public init(type: String, watchId: String, sessionId: String, message: String) {
+        self.type = type
+        self.watchId = watchId
+        self.sessionId = sessionId
+        self.message = message
+    }
+}
+
 public struct IPCRideShotgunProgress: Codable, Sendable {
     public let type: String
     public let watchId: String

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -894,6 +894,9 @@ extension IPCDictationRequest {
     }
 }
 
+/// Bootstrap failure during learn-mode recording setup.
+public typealias RideShotgunErrorMessage = IPCRideShotgunError
+
 /// Progress update from a ride shotgun auto-navigation session.
 public typealias RideShotgunProgressMessage = IPCRideShotgunProgress
 
@@ -2171,6 +2174,7 @@ public enum ServerMessage: Decodable, Sendable {
     case taskRouted(TaskRoutedMessage)
     case dictationResponse(DictationResponseMessage)
     case error(ErrorMessage)
+    case rideShotgunError(RideShotgunErrorMessage)
     case rideShotgunProgress(RideShotgunProgressMessage)
     case rideShotgunResult(RideShotgunResultMessage)
     case uiSurfaceShow(UiSurfaceShowMessage)
@@ -2365,6 +2369,9 @@ public enum ServerMessage: Decodable, Sendable {
         case "error":
             let message = try ErrorMessage(from: decoder)
             self = .error(message)
+        case "ride_shotgun_error":
+            let message = try RideShotgunErrorMessage(from: decoder)
+            self = .rideShotgunError(message)
         case "ride_shotgun_progress":
             let message = try RideShotgunProgressMessage(from: decoder)
             self = .rideShotgunProgress(message)


### PR DESCRIPTION
## Summary
- Add ride_shotgun_error IPC message type for daemon-to-client failure notification
- Make CDP bootstrap failures fail-fast: send error, clear timeout, clean up session
- Fix completeSession to not report 'recording saved' when no recorder started
- Update macOS client to handle bootstrap errors and enter .failed state
- Add tests verifying failure propagation, session cleanup, and error messaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
