### PR TITLE
fix: simplify composer layout — remove GeometryReader feedback loop

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -25,8 +25,6 @@ struct ChatEmptyStateView: View {
     var onDropImageData: ((Data, String?) -> Void)? = nil
     let onMicrophoneToggle: () -> Void
     let onDismissError: () -> Void
-    @Binding var editorContentHeight: CGFloat
-    @Binding var isComposerExpanded: Bool
 
     @State private var visible = false
     @State private var title: String = titles.randomElement()!
@@ -119,8 +117,6 @@ struct ChatEmptyStateView: View {
                     onDropImageData: onDropImageData,
                     onMicrophoneToggle: onMicrophoneToggle,
                     placeholderText: placeholder,
-                    editorContentHeight: $editorContentHeight,
-                    isComposerExpanded: $isComposerExpanded
                 )
             }
             .frame(maxWidth: 500)
@@ -166,8 +162,6 @@ struct ChatTemporaryChatEmptyStateView: View {
     var onDropImageData: ((Data, String?) -> Void)? = nil
     let onMicrophoneToggle: () -> Void
     let onDismissError: () -> Void
-    @Binding var editorContentHeight: CGFloat
-    @Binding var isComposerExpanded: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -228,8 +222,6 @@ struct ChatTemporaryChatEmptyStateView: View {
                     onDropImageData: onDropImageData,
                     onMicrophoneToggle: onMicrophoneToggle,
                     placeholderText: "Ask anything...",
-                    editorContentHeight: $editorContentHeight,
-                    isComposerExpanded: $isComposerExpanded
                 )
             }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -92,29 +92,10 @@ struct ChatView: View {
 
     @State private var isNearBottom = true
     @State private var isDropTargeted = false
-    @State private var editorContentHeight: CGFloat = 20
-    @State private var isComposerExpanded = false
     @State private var containerWidth: CGFloat = 0
 
     private var isEmptyState: Bool {
         messages.isEmpty && isHistoryLoaded
-    }
-
-    private let composerMinHeight: CGFloat = 34
-
-    /// Height reserved at the bottom of the scroll view so the last message isn't hidden behind the composer.
-    private var composerReservedHeight: CGFloat {
-        let editorClamped = min(max(editorContentHeight, 34), 200)
-        let contentHeight = max(editorClamped, 34)
-        let expanded = isComposerExpanded
-        let topPad: CGFloat = expanded ? VSpacing.md : VSpacing.sm
-        let bottomPad: CGFloat = VSpacing.sm
-        // Buttons are overlaid on the text area, so they don't add to height.
-        let base: CGFloat = VSpacing.sm + topPad + bottomPad + contentHeight
-        let attachments: CGFloat = pendingAttachments.isEmpty ? 0 : 48
-        let error: CGFloat = (sessionError == nil && errorText != nil) ? 36 : 0
-        let sessionErrorToast: CGFloat = sessionError != nil ? 52 : 0
-        return base + attachments + error + sessionErrorToast
     }
 
     var body: some View {
@@ -157,9 +138,7 @@ struct ChatView: View {
                             onFileDrop: onDropFiles,
                             onDropImageData: onDropImageData,
                             onMicrophoneToggle: onMicrophoneToggle,
-                            onDismissError: onDismissError,
-                            editorContentHeight: $editorContentHeight,
-                            isComposerExpanded: $isComposerExpanded
+                            onDismissError: onDismissError
                         )
                     } else {
                         ChatEmptyStateView(
@@ -180,13 +159,11 @@ struct ChatView: View {
                             onFileDrop: onDropFiles,
                             onDropImageData: onDropImageData,
                             onMicrophoneToggle: onMicrophoneToggle,
-                            onDismissError: onDismissError,
-                            editorContentHeight: $editorContentHeight,
-                            isComposerExpanded: $isComposerExpanded
+                            onDismissError: onDismissError
                         )
                     }
                 } else {
-                    ZStack(alignment: .bottom) {
+                    VStack(spacing: 0) {
                         MessageListView(
                             messages: messages,
                             isSending: isSending,
@@ -224,10 +201,6 @@ struct ChatView: View {
                             isNearBottom: $isNearBottom,
                             containerWidth: containerWidth
                         )
-                        .safeAreaInset(edge: .bottom) {
-                            Color.clear.frame(height: composerReservedHeight)
-                                .animation(VAnimation.fast, value: editorContentHeight)
-                        }
 
                         let composerMessages: [ChatMessage] = {
                             let all = messages.filter { !$0.isSubagentNotification }
@@ -278,9 +251,7 @@ struct ChatView: View {
                             idleHint: idleHint,
                             voiceModeManager: voiceModeManager,
                             voiceService: voiceService,
-                            onEndVoiceMode: onEndVoiceMode,
-                            editorContentHeight: $editorContentHeight,
-                            isComposerExpanded: $isComposerExpanded
+                            onEndVoiceMode: onEndVoiceMode
                         )
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
@@ -17,17 +17,6 @@ extension EnvironmentValues {
     }
 }
 
-// MARK: - Composer Editor Height Preference Key
-
-/// PreferenceKey used to measure the natural height of the TextField composer
-/// so that ChatView can compute the correct bottom safe-area inset.
-struct ComposerEditorHeightKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
-}
-
 // MARK: - Composer Focus Bridge
 
 /// Minimal NSViewRepresentable that provides AppKit integration for the

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -41,8 +41,6 @@ struct ComposerSection: View {
     var voiceModeManager: VoiceModeManager? = nil
     var voiceService: OpenAIVoiceService? = nil
     var onEndVoiceMode: (() -> Void)? = nil
-    @Binding var editorContentHeight: CGFloat
-    @Binding var isComposerExpanded: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -97,9 +95,7 @@ struct ComposerSection: View {
                 voiceModeManager: voiceModeManager,
                 voiceService: voiceService,
                 onEndVoiceMode: onEndVoiceMode,
-                placeholderText: "What would you like to do?",
-                editorContentHeight: $editorContentHeight,
-                isComposerExpanded: $isComposerExpanded
+                placeholderText: "What would you like to do?"
             )
         }
         .background(

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -32,18 +32,11 @@ struct ComposerView: View {
     var onEndVoiceMode: (() -> Void)? = nil
     var placeholderText: String = "What would you like to do?"
     var composerCompactHeight: CGFloat = 34
-    /// Bound to ChatView's state so it can compute composerReservedHeight for safe area insets.
-    @Binding var editorContentHeight: CGFloat
-
-    /// Exposed to ChatView so composerReservedHeight stays in sync with the
-    /// sticky expansion state (set true when text wraps, reset when text clears).
-    @Binding var isComposerExpanded: Bool
 
     @Environment(\.conversationZoomScale) private var zoomScale
     @Environment(\.cmdEnterToSend) private var cmdEnterToSend
     @FocusState private var composerFocus: Bool
     @State private var isComposerFocused = false
-    @State private var contentHeight: CGFloat = 34
 
     @State var showSlashMenu = false
     @State var slashFilter = ""
@@ -94,18 +87,14 @@ struct ComposerView: View {
                     }
                     .frame(height: compactRowHeight, alignment: .center)
                 } else {
-                    // Text field with action buttons pinned to trailing edge.
-                    // In compact (single-line) mode buttons are vertically centered;
-                    // in expanded (multi-line) mode they pin to the bottom-right.
                     composerTextField
                         .frame(minHeight: composerCompactHeight)
-                        .overlay(alignment: isComposerExpanded ? .bottomTrailing : .trailing) {
+                        .overlay(alignment: .bottomTrailing) {
                             composerActionButtons
-                                .padding(.bottom, isComposerExpanded ? VSpacing.xs : 0)
                         }
                 }
             }
-            .padding(.top, isComposerExpanded ? VSpacing.md : VSpacing.sm)
+            .padding(.top, VSpacing.sm)
             .padding(.bottom, VSpacing.sm)
             .padding(.leading, VSpacing.lg)
             .padding(.trailing, VSpacing.lg)
@@ -133,7 +122,6 @@ struct ComposerView: View {
         .padding(.top, VSpacing.sm)
         .frame(maxWidth: 700)
         .frame(maxWidth: .infinity)
-        .animation(VAnimation.fast, value: isComposerExpanded)
         .animation(VAnimation.fast, value: isComposerFocused)
         .onAppear {
             composerFocus = true
@@ -142,12 +130,8 @@ struct ComposerView: View {
         }
     }
 
-    private var clampedComposerHeight: CGFloat {
-        min(max(editorContentHeight, composerCompactHeight), composerMaxHeight)
-    }
-
     private var compactRowHeight: CGFloat {
-        max(clampedComposerHeight, composerActionButtonSize)
+        composerActionButtonSize
     }
 
     /// The text overlays (slash highlighting, ghost text) rendered behind / on
@@ -162,7 +146,6 @@ struct ComposerView: View {
         if hasSlashHighlight {
             Text(slashHighlightedText(font: font))
                 .lineLimit(1...)
-                .fixedSize(horizontal: false, vertical: true)
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
         }
@@ -176,7 +159,6 @@ struct ComposerView: View {
                 .font(font)
                 .foregroundColor(VColor.textSecondary.opacity(0.55)))
                 .lineLimit(1...)
-                .fixedSize(horizontal: false, vertical: true)
                 .allowsHitTesting(false)
                 .accessibilityHidden(true)
         }
@@ -256,31 +238,12 @@ struct ComposerView: View {
                 composerTextOverlays(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
                 composerInputField(font: scaledBody, hasSlashHighlight: hasSlashHighlight)
             }
-            // minHeight keeps single-line text vertically centered in the
-            // compact row; .leading alignment pins text to the left edge.
             .frame(maxWidth: .infinity, minHeight: composerCompactHeight, alignment: .leading)
-            // Reserve trailing space so text wraps before reaching the
-            // overlaid action buttons (attach + send/mic ≈ 70pt wide).
             .padding(.trailing, 70)
-            // Measure content height BEFORE the conditional bottom padding
-            // so expansion state isn't inflated by its own padding.
-            .background(
-                GeometryReader { geo in
-                    Color.clear.preference(key: ComposerEditorHeightKey.self, value: geo.size.height)
-                }
-            )
-            // Reserve bottom space so the last visible line isn't hidden
-            // behind the buttons when the composer is expanded.
-            .padding(.bottom, isComposerExpanded ? composerActionButtonSize : 0)
-        }
-        .onPreferenceChange(ComposerEditorHeightKey.self) { newHeight in
-            contentHeight = newHeight
-            editorContentHeight = min(max(newHeight, composerCompactHeight), composerMaxHeight)
-            isComposerExpanded = newHeight > composerCompactHeight
         }
         .scrollBounceBehavior(.basedOnSize)
+        .frame(minHeight: composerCompactHeight, maxHeight: inputText.isEmpty ? composerCompactHeight : composerMaxHeight)
         .accessibilityLabel("Message")
-        .frame(height: min(max(contentHeight, composerCompactHeight), composerMaxHeight), alignment: .topLeading)
         .frame(maxWidth: .infinity)
         .background(
             ComposerFocusBridge(
@@ -305,15 +268,8 @@ struct ComposerView: View {
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            // Auto-focus the composer on app reactivation so the user can
-            // start typing immediately after cmd+tab or Dock click.
             guard !hasPendingConfirmation else { return }
-            // Only claim focus when the main window is key. If a floating
-            // panel or other window is frontmost, skip to avoid intercepting
-            // shortcuts (Cmd+V, Cmd+Enter) in the wrong context.
             guard let window = NSApp.keyWindow as? TitleBarZoomableWindow else { return }
-            // Preserve focus if another input (NSTextView, WKWebView, etc.)
-            // already owns first-responder status in split-panel mode.
             if let responder = window.firstResponder as? NSView,
                responder != window.contentView,
                window.composerContainerView.map({ !responder.isDescendant(of: $0) }) ?? false {
@@ -323,13 +279,6 @@ struct ComposerView: View {
         }
         .onChange(of: inputText) {
             if inputText.isEmpty {
-                // Reset all height state atomically so the ScrollView frame
-                // shrinks immediately. Without this, the GeometryReader
-                // re-measures the old (large) ScrollView frame and confirms
-                // the stale contentHeight, preventing collapse.
-                contentHeight = composerCompactHeight
-                editorContentHeight = composerCompactHeight
-                isComposerExpanded = false
                 withAnimation(VAnimation.fast) { showSlashMenu = false }
             } else {
                 updateSlashState()


### PR DESCRIPTION
## Summary
- Move composer from ZStack overlay to VStack sibling of MessageListView — SwiftUI handles layout naturally
- Remove ScrollView + GeometryReader + PreferenceKey height measurement chain that caused the feedback loop
- Remove `editorContentHeight` and `isComposerExpanded` bindings flowing from ComposerView → ComposerSection → ChatView
- Remove manual `composerReservedHeight` safe-area inset calculation
- Remove `ComposerEditorHeightKey` PreferenceKey (no longer needed)
- Composer now uses a simple ScrollView with conditional frame: compact (34pt) when empty, up to 200pt when typing

**Net: -112 lines, +9 lines across 5 files.**

## What was wrong
After sending a message, the composer stayed expanded because a GeometryReader on the ScrollView's `.background` measured the ScrollView frame (parent-proposed size), not the content intrinsic height. This created a circular dependency where state derived from the measurement drove the frame being measured. Multiple attempts to fix with atomic resets and onChange hacks didn't fully resolve the issue.

## What changed
The root cause was architectural: the composer was in a ZStack overlay on top of the message list, requiring a manual height calculation to reserve space. That calculation required GeometryReader measurements, which required the ScrollView, which created the feedback loop.

Moving the composer to a VStack sibling eliminates the need for any height measurement — SwiftUI allocates space naturally. The TextField grows via `.lineLimit(1...)` inside a ScrollView capped at 200pt. When text clears, the frame collapses to 34pt via a conditional `maxHeight`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
