### PR TITLE
fix: reorder usage dashboard indexes to match query shape (created_at leading)

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -62,6 +62,7 @@ import {
   migrateNormalizePhoneIdentities,
   migrateNotificationDeliveryThreadDecision,
   migrateReminderRoutingIntent,
+  migrateReorderUsageDashboardIndexes,
   migrateSchemaIndexesAndColumns,
   migrateUsageDashboardIndexes,
   migrateVoiceInviteColumns,
@@ -296,6 +297,9 @@ export function initializeDb(): void {
 
   // 41. Indexes on llm_usage_events for usage dashboard time-range and breakdown queries
   migrateUsageDashboardIndexes(database);
+
+  // 42. Reorder usage dashboard composite indexes so created_at leads (matches query shape)
+  migrateReorderUsageDashboardIndexes(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/137-usage-dashboard-indexes.ts
+++ b/assistant/src/memory/migrations/137-usage-dashboard-indexes.ts
@@ -7,6 +7,10 @@ import type { DrizzleDb } from "../db-connection.js";
  * - Covering index on (created_at) for efficient time-range scans.
  * - Composite index on (actor, created_at) for per-actor breakdowns.
  * - Composite index on (provider, model, created_at) for provider/model grouping.
+ *
+ * NOTE: The two composite indexes created here are superseded by migration
+ * 138 which reorders them to lead with created_at, matching the actual
+ * query shapes (WHERE created_at range, GROUP BY dimension).
  */
 export function migrateUsageDashboardIndexes(database: DrizzleDb): void {
   database.run(

--- a/assistant/src/memory/migrations/138-reorder-usage-dashboard-indexes.ts
+++ b/assistant/src/memory/migrations/138-reorder-usage-dashboard-indexes.ts
@@ -1,0 +1,29 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Reorder the composite indexes from migration 137 so that `created_at`
+ * leads. All usage-dashboard queries filter by `created_at` range first,
+ * then GROUP BY a dimension column. With the dimension column leading,
+ * SQLite couldn't use the index for the time-range scan. Leading with
+ * `created_at` lets the index cover both the WHERE and GROUP BY.
+ *
+ * The plain `created_at`-only index is kept because other queries may rely
+ * on it (and it's smaller).
+ */
+export function migrateReorderUsageDashboardIndexes(database: DrizzleDb): void {
+  // Drop the old dimension-leading composites from migration 137
+  database.run(
+    /*sql*/ `DROP INDEX IF EXISTS idx_llm_usage_events_actor_created_at`,
+  );
+  database.run(
+    /*sql*/ `DROP INDEX IF EXISTS idx_llm_usage_events_provider_model_created_at`,
+  );
+
+  // Create new composites with created_at leading
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_created_at_actor ON llm_usage_events(created_at, actor)`,
+  );
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_llm_usage_events_created_at_provider_model ON llm_usage_events(created_at, provider, model)`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -80,6 +80,7 @@ export { migrateContactsNotesColumn } from "./134-contacts-notes-column.js";
 export { migrateBackfillContactInteractionStats } from "./135-backfill-contact-interaction-stats.js";
 export { migrateDropAssistantIdColumns } from "./136-drop-assistant-id-columns.js";
 export { migrateUsageDashboardIndexes } from "./137-usage-dashboard-indexes.js";
+export { migrateReorderUsageDashboardIndexes } from "./138-reorder-usage-dashboard-indexes.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,


### PR DESCRIPTION
## Summary
The original dashboard indexes led with dimension columns (actor, provider/model) but all queries filter by created_at first. SQLite couldn't use them for the time-range scan. This migration drops the old composites and creates new ones with created_at leading, so the index covers both the WHERE and GROUP BY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
