### PR TITLE
fix: only auto-refresh usage dashboard on first load, not every appearance

### DIFF
--- a/clients/ios/Views/UsageDashboardView.swift
+++ b/clients/ios/Views/UsageDashboardView.swift
@@ -14,7 +14,11 @@ struct UsageDashboardView: View {
             content
                 .navigationTitle("Usage & Cost")
                 .navigationBarTitleDisplayMode(.inline)
-                .task { await store.refresh() }
+                .task {
+                    if store.totalsState == .idle {
+                        await store.refresh()
+                    }
+                }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -14,7 +14,9 @@ struct UsageDashboardPanel: View {
         }
         .onAppear {
             Task {
-                await store.refresh()
+                if store.totalsState == .idle {
+                    await store.refresh()
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
The iOS sheet and macOS panel unconditionally called store.refresh() on every appearance, resetting the preserved store to loading state. Now only refreshes when the store is idle (first load), preserving existing data across panel/sheet toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13209" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
