### PR TITLE
fix: add missing sandbox config to session-queue test mock

### DIFF
--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -77,6 +77,7 @@ mock.module("../config/loader.js", () => ({
     skills: { entries: {}, allowBundled: true },
     memory: { retrieval: { injectionStrategy: "inline" } },
     permissions: { mode: "workspace" },
+    sandbox: { enabled: false },
     daemon: {
       startupSocketWaitMs: 5000,
       stopTimeoutMs: 5000,


### PR DESCRIPTION
## Summary
- Add `sandbox: { enabled: false }` to the mock config in `session-queue.test.ts`
- Fixes two host attachment tests that were failing because `check()` in workspace mode accesses `getConfig().sandbox.enabled`, which threw when `sandbox` was undefined

## Test plan
- [x] Both host attachment tests now pass locally
- [x] All 35 tests in session-queue.test.ts pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
