### PR TITLE
fix: default includeRemote=true on readiness refresh endpoint

### DIFF
--- a/assistant/src/__tests__/channel-readiness-routes.test.ts
+++ b/assistant/src/__tests__/channel-readiness-routes.test.ts
@@ -150,9 +150,9 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
       mockRawConfig = {
         ingress: { publicBaseUrl: "https://example.com", enabled: true },
       };
-      // No inbox configured, but local-only check (no includeRemote)
+      // No inbox configured — explicitly opt out of remote checks
       const service = createReadinessService();
-      const [snapshot] = await service.getReadiness("email");
+      const [snapshot] = await service.getReadiness("email", false);
 
       // Local checks pass — remote inbox check is not included
       expect(snapshot.ready).toBe(true);

--- a/assistant/src/runtime/routes/channel-readiness-routes.ts
+++ b/assistant/src/runtime/routes/channel-readiness-routes.ts
@@ -78,7 +78,7 @@ export async function handleRefreshChannelReadiness(
 
   const snapshots = await service.getReadiness(
     body.channel,
-    body.includeRemote,
+    body.includeRemote ?? true,
   );
   const adapterRegistry = getInviteAdapterRegistry();
 


### PR DESCRIPTION
## Summary
- POST /v1/channels/readiness/refresh now defaults includeRemote to true
- Consistent with GET endpoint behavior
- Prevents stale local-only email readiness snapshots on refresh

Addresses feedback: readiness API internally inconsistent on refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
