### PR TITLE
fix: fall back to configured email.address when provider inbox unavailable

### DIFF
--- a/assistant/src/__tests__/email-invite-adapter.test.ts
+++ b/assistant/src/__tests__/email-invite-adapter.test.ts
@@ -65,4 +65,14 @@ describe("emailInviteAdapter", () => {
     expect(emailInviteAdapter.buildShareLink).toBeUndefined();
     expect(emailInviteAdapter.extractInboundToken).toBeUndefined();
   });
+
+  test("returns config fallback address when provider has no inboxes", async () => {
+    // Simulates the config fallback: provider returns no inboxes, but
+    // email.address is set in workspace config. The service's
+    // getPrimaryInboxAddress() should return the configured address.
+    mockPrimaryAddress = "configured@example.com";
+
+    const handle = await resolveAdapterHandle(emailInviteAdapter);
+    expect(handle).toBe("configured@example.com");
+  });
 });

--- a/assistant/src/__tests__/email-service-config-fallback.test.ts
+++ b/assistant/src/__tests__/email-service-config-fallback.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests that getPrimaryInboxAddress() falls back to the workspace config's
+ * email.address when the provider can't list inboxes.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock dependencies before importing the service
+// ---------------------------------------------------------------------------
+
+let mockProviderThrows = false;
+let mockProviderInboxes: { address: string }[] = [];
+
+mock.module("../email/providers/index.js", () => ({
+  createProvider: async () => ({
+    name: "mock",
+    health: async () => {
+      if (mockProviderThrows) throw new Error("provider unavailable");
+      return { inboxes: mockProviderInboxes, domains: [] };
+    },
+  }),
+  getActiveProviderName: () => "mock",
+}));
+
+let mockRawConfig: Record<string, unknown> = {};
+
+mock.module("../config/loader.js", () => ({
+  loadRawConfig: () => mockRawConfig,
+  getNestedValue: (obj: Record<string, unknown>, path: string) => {
+    const keys = path.split(".");
+    let current: unknown = obj;
+    for (const key of keys) {
+      if (current == null || typeof current !== "object") return undefined;
+      current = (current as Record<string, unknown>)[key];
+    }
+    return current;
+  },
+  saveRawConfig: () => {},
+  setNestedValue: () => {},
+}));
+
+// Stub guardrails (imported by service.ts but not relevant here)
+mock.module("../cli/email-guardrails.js", () => ({
+  addAddressRule: () => ({}),
+  checkSendGuardrails: () => null,
+  getGuardrailsStatus: () => ({}),
+  incrementDailySendCount: () => 0,
+  listRules: () => [],
+  removeAddressRule: () => false,
+  setDailySendCap: () => {},
+  setOutboundPaused: () => {},
+}));
+
+// Now import the service under test
+const { EmailService } = await import("../email/service.js");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("getPrimaryInboxAddress — config fallback", () => {
+  afterEach(() => {
+    mockProviderThrows = false;
+    mockProviderInboxes = [];
+    mockRawConfig = {};
+  });
+
+  test("returns provider inbox address when available", async () => {
+    mockProviderInboxes = [{ address: "inbox@provider.example" }];
+    const svc = new EmailService();
+
+    const addr = await svc.getPrimaryInboxAddress();
+    expect(addr).toBe("inbox@provider.example");
+  });
+
+  test("falls back to email.address from config when provider returns no inboxes", async () => {
+    mockProviderInboxes = [];
+    mockRawConfig = { email: { address: "configured@example.com" } };
+    const svc = new EmailService();
+
+    const addr = await svc.getPrimaryInboxAddress();
+    expect(addr).toBe("configured@example.com");
+  });
+
+  test("falls back to email.address from config when provider throws", async () => {
+    mockProviderThrows = true;
+    mockRawConfig = { email: { address: "fallback@example.com" } };
+    const svc = new EmailService();
+
+    const addr = await svc.getPrimaryInboxAddress();
+    expect(addr).toBe("fallback@example.com");
+  });
+
+  test("returns undefined when neither provider nor config has an address", async () => {
+    mockProviderThrows = true;
+    mockRawConfig = {};
+    const svc = new EmailService();
+
+    const addr = await svc.getPrimaryInboxAddress();
+    expect(addr).toBeUndefined();
+  });
+});

--- a/assistant/src/email/service.ts
+++ b/assistant/src/email/service.ts
@@ -17,6 +17,7 @@ import {
   setOutboundPaused,
 } from "../cli/email-guardrails.js";
 import {
+  getNestedValue,
   loadRawConfig,
   saveRawConfig,
   setNestedValue,
@@ -134,6 +135,20 @@ export class EmailService {
         health.inboxes.length > 0 ? health.inboxes[0].address : undefined;
     } catch {
       this.cachedPrimaryAddress = undefined;
+    }
+
+    // Fall back to the statically configured email address in workspace config
+    // when the provider can't list inboxes (e.g. provider temporarily unavailable).
+    if (this.cachedPrimaryAddress === undefined) {
+      try {
+        const raw = loadRawConfig();
+        const configured = getNestedValue(raw, "email.address");
+        if (typeof configured === "string" && configured.length > 0) {
+          this.cachedPrimaryAddress = configured;
+        }
+      } catch {
+        // Config unavailable — leave as undefined
+      }
     }
     // Only cache positive results so a missing inbox is retried on next call
     // (e.g. user sets up email after initial miss).


### PR DESCRIPTION
## Summary
- getPrimaryInboxAddress() now falls back to email.address from workspace config
- Handles case where provider health can't list inboxes but address is configured

Addresses feedback: email handle work incomplete, missing config fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
