### PR TITLE
fix: collapsed sidebar thread switcher visibility and trigger mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/CollapsedThreadSwitcherPresentation.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/CollapsedThreadSwitcherPresentation.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct CollapsedThreadSwitcherPresentation {
+    let switchTargets: [ThreadModel]
+    let activeThreadTitle: String?
+
+    var showsSwitcher: Bool { !switchTargets.isEmpty }
+
+    var accessibilityLabel: String {
+        if let title = activeThreadTitle {
+            return "Switch threads: \(title)"
+        }
+        return "Switch threads"
+    }
+
+    var accessibilityValue: String {
+        switchTargets.isEmpty ? "" : "\(switchTargets.count) threads"
+    }
+
+    init(regularThreads: [ThreadModel], activeThreadId: UUID?) {
+        if let activeId = activeThreadId {
+            self.switchTargets = regularThreads.filter { $0.id != activeId }
+            self.activeThreadTitle = regularThreads.first(where: { $0.id == activeId })?.title
+        } else {
+            self.switchTargets = regularThreads
+            self.activeThreadTitle = nil
+        }
+    }
+}

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -482,22 +482,21 @@ extension MainWindowView {
             }
 
             // MARK: Thread Section (collapsed)
-            if let activeThread = threadManager.activeThread {
+            let switcher = CollapsedThreadSwitcherPresentation(
+                regularThreads: regularThreads,
+                activeThreadId: threadManager.activeThreadId
+            )
+            if switcher.showsSwitcher {
                 Button {
-                    guard regularThreads.count > 1 else { return }
-                    threadSwitcherHoverTask?.cancel()
-                    threadSwitcherHoverTask = nil
                     showThreadSwitcher.toggle()
                 } label: {
                     ZStack(alignment: .bottomTrailing) {
-                        // Active thread icon — SF Symbol chat bubble matching SidebarNavRow style
                         Image(systemName: "ellipsis.message")
                             .font(.system(size: 13, weight: .medium))
                             .foregroundColor(adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400))
                             .frame(width: 28, height: 28)
 
-                        // Unseen dot overlay (bottom-right) — shows when any thread has unseen messages
-                        if regularThreads.contains(where: { $0.hasUnseenLatestAssistantMessage }) {
+                        if switcher.switchTargets.contains(where: { $0.hasUnseenLatestAssistantMessage }) {
                             Circle()
                                 .fill(Color(hex: 0xE86B40))
                                 .frame(width: 8, height: 8)
@@ -506,48 +505,15 @@ extension MainWindowView {
                     }
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Switch threads: \(activeThread.title)")
-                .accessibilityValue(regularThreads.count > 1 ? "\(regularThreads.count) threads" : "")
+                .accessibilityLabel(switcher.accessibilityLabel)
+                .accessibilityValue(switcher.accessibilityValue)
                 .onDisappear {
-                    threadSwitcherHoverTask?.cancel()
-                    threadSwitcherHoverTask = nil
-                    threadSwitcherDismissTask?.cancel()
-                    threadSwitcherDismissTask = nil
                     showThreadSwitcher = false
                 }
-                .if(regularThreads.count > 1) { view in
-                    view.pointerCursor()
-                }
-                .onHover { hovering in
-                    guard regularThreads.count > 1 else { return }
-                    if hovering {
-                        // Cancel any pending dismiss
-                        threadSwitcherDismissTask?.cancel()
-                        threadSwitcherDismissTask = nil
-                        // Start open timer
-                        threadSwitcherHoverTask?.cancel()
-                        threadSwitcherHoverTask = Task { @MainActor in
-                            try? await Task.sleep(for: .milliseconds(300))
-                            guard !Task.isCancelled else { return }
-                            showThreadSwitcher = true
-                        }
-                    } else {
-                        threadSwitcherHoverTask?.cancel()
-                        threadSwitcherHoverTask = nil
-                        // Schedule dismiss — gives time to move mouse into the popover
-                        if showThreadSwitcher {
-                            threadSwitcherDismissTask = Task { @MainActor in
-                                try? await Task.sleep(for: .milliseconds(300))
-                                guard !Task.isCancelled else { return }
-                                showThreadSwitcher = false
-                            }
-                        }
-                    }
-                }
+                .pointerCursor()
                 .popover(isPresented: $showThreadSwitcher, arrowEdge: .trailing) {
                     VStack(alignment: .leading, spacing: 0) {
-                        // Header
-                        Text("\(regularThreads.count) threads")
+                        Text("\(switcher.switchTargets.count) threads")
                             .font(VFont.body)
                             .foregroundColor(VColor.textMuted)
                             .padding(.leading, VSpacing.md)
@@ -560,10 +526,9 @@ extension MainWindowView {
                             .padding(.horizontal, VSpacing.xs)
                             .padding(.bottom, VSpacing.sm)
 
-                        // Thread list
                         ScrollView {
                             VStack(spacing: 0) {
-                                ForEach(regularThreads) { thread in
+                                ForEach(switcher.switchTargets) { thread in
                                     SidebarThreadItem(
                                         thread: thread,
                                         threadManager: threadManager,
@@ -613,29 +578,10 @@ extension MainWindowView {
                         showThreadSwitcher = false
                     }
                     .onDisappear {
-                        // Clean up hover state when popover dismisses —
-                        // onHover(false) may not fire if the view is removed.
-                        // Cursor cleanup is handled by PointerCursorModifier.
                         if sidebar.isHoveredThread != nil {
                             sidebar.isHoveredThread = nil
                         }
                         sidebar.threadPendingDeletion = nil
-                    }
-                    // Hover→pending-deletion invariant is now owned by
-                    // SidebarInteractionState.setThreadHover(threadId:hovering:)
-                    .onHover { hovering in
-                        if hovering {
-                            // Mouse entered popover — cancel pending dismiss
-                            threadSwitcherDismissTask?.cancel()
-                            threadSwitcherDismissTask = nil
-                        } else {
-                            // Mouse left popover — dismiss after short delay
-                            threadSwitcherDismissTask = Task { @MainActor in
-                                try? await Task.sleep(for: .milliseconds(300))
-                                guard !Task.isCancelled else { return }
-                                showThreadSwitcher = false
-                            }
-                        }
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -50,10 +50,6 @@ struct MainWindowView: View {
     let onSendWakeUp: (() -> Void)?
 
     @State var showThreadSwitcher = false
-    /// Cancellable task for the delayed hover trigger on the collapsed thread section.
-    @State var threadSwitcherHoverTask: Task<Void, Never>?
-    /// Cancellable task that dismisses the thread switcher popover after leaving the hover area.
-    @State var threadSwitcherDismissTask: Task<Void, Never>?
     /// Whether the "coming alive" overlay is currently showing.
     @State private var showComingAlive: Bool
     /// Whether the daemon-loading skeleton overlay is currently showing.

--- a/clients/macos/vellum-assistantTests/CollapsedThreadSwitcherPresentationTests.swift
+++ b/clients/macos/vellum-assistantTests/CollapsedThreadSwitcherPresentationTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import VellumAssistantLib
+
+final class CollapsedThreadSwitcherPresentationTests: XCTestCase {
+
+    private func makeThread(id: UUID = UUID(), title: String = "Thread") -> ThreadModel {
+        ThreadModel(id: id, title: title)
+    }
+
+    // MARK: - Draft mode (no active thread)
+
+    func testDraftMode_withExistingThreads_showsSwitcher() {
+        let threads = [makeThread(), makeThread()]
+        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: nil)
+
+        XCTAssertTrue(sut.showsSwitcher)
+        XCTAssertEqual(sut.switchTargets.count, 2)
+    }
+
+    func testDraftMode_withNoThreads_hidesSwitcher() {
+        let sut = CollapsedThreadSwitcherPresentation(regularThreads: [], activeThreadId: nil)
+
+        XCTAssertFalse(sut.showsSwitcher)
+        XCTAssertTrue(sut.switchTargets.isEmpty)
+    }
+
+    // MARK: - Active thread
+
+    func testActiveThread_onlyThatThread_hidesSwitcher() {
+        let id = UUID()
+        let threads = [makeThread(id: id)]
+        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: id)
+
+        XCTAssertFalse(sut.showsSwitcher)
+        XCTAssertTrue(sut.switchTargets.isEmpty)
+    }
+
+    func testActiveThread_withOtherThreads_showsSwitcherAndExcludesActive() {
+        let activeId = UUID()
+        let otherId = UUID()
+        let threads = [makeThread(id: activeId, title: "Active"), makeThread(id: otherId, title: "Other")]
+        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: activeId)
+
+        XCTAssertTrue(sut.showsSwitcher)
+        XCTAssertEqual(sut.switchTargets.count, 1)
+        XCTAssertEqual(sut.switchTargets.first?.id, otherId)
+    }
+
+    // MARK: - Accessibility
+
+    func testAccessibilityLabel_withActiveThread() {
+        let id = UUID()
+        let threads = [makeThread(id: id, title: "My Chat"), makeThread()]
+        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: id)
+
+        XCTAssertEqual(sut.accessibilityLabel, "Switch threads: My Chat")
+    }
+
+    func testAccessibilityLabel_draftMode() {
+        let sut = CollapsedThreadSwitcherPresentation(regularThreads: [makeThread()], activeThreadId: nil)
+
+        XCTAssertEqual(sut.accessibilityLabel, "Switch threads")
+    }
+
+    func testAccessibilityValue_reflectsSwitchTargetCount() {
+        let threads = [makeThread(), makeThread(), makeThread()]
+        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: nil)
+
+        XCTAssertEqual(sut.accessibilityValue, "3 threads")
+    }
+
+    func testAccessibilityValue_emptyWhenNoTargets() {
+        let sut = CollapsedThreadSwitcherPresentation(regularThreads: [], activeThreadId: nil)
+
+        XCTAssertEqual(sut.accessibilityValue, "")
+    }
+}


### PR DESCRIPTION
## Summary
- Thread switcher icon now visible in draft/new-thread state when switch targets exist
- Popover opens on click only (removed hover-based open/dismiss behavior)
- Active thread excluded from switch targets in popover
- Added `CollapsedThreadSwitcherPresentation` model with unit tests

## Test plan
- [ ] Collapse sidebar in draft/new thread with existing threads — switcher icon visible
- [ ] Hovering icon does not open popover
- [ ] Clicking icon opens popover with correct thread list
- [ ] Active thread excluded from popover list
- [ ] No threads → no switcher icon
- [ ] `swift test --filter CollapsedThreadSwitcherPresentationTests` — 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
