### PR TITLE
fix: handle ride_shotgun_error in CLI learn-session consumers

### DIFF
--- a/assistant/src/cli/amazon.ts
+++ b/assistant/src/cli/amazon.ts
@@ -751,6 +751,13 @@ async function startLearnSession(
           continue;
         }
 
+        if (m.type === "ride_shotgun_error") {
+          clearTimeout(timeoutHandle);
+          socket.destroy();
+          reject(new Error((m as { message: string }).message));
+          continue;
+        }
+
         if (m.type === "ride_shotgun_result") {
           clearTimeout(timeoutHandle);
           socket.destroy();

--- a/assistant/src/cli/map.ts
+++ b/assistant/src/cli/map.ts
@@ -232,6 +232,13 @@ async function startLearnSession(
           continue;
         }
 
+        if (m.type === "ride_shotgun_error") {
+          clearTimeout(timeoutHandle);
+          socket.destroy();
+          reject(new Error((m as { message: string }).message));
+          continue;
+        }
+
         if (m.type === "ride_shotgun_result") {
           clearTimeout(timeoutHandle);
           socket.destroy();

--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -720,6 +720,13 @@ async function startLearnSession(
           continue;
         }
 
+        if (m.type === "ride_shotgun_error") {
+          clearTimeout(timeoutHandle);
+          socket.destroy();
+          reject(new Error((m as { message: string }).message));
+          continue;
+        }
+
         if (m.type === "ride_shotgun_result") {
           clearTimeout(timeoutHandle);
           socket.destroy();

--- a/assistant/src/config/bundled-skills/doordash/doordash-cli.ts
+++ b/assistant/src/config/bundled-skills/doordash/doordash-cli.ts
@@ -1174,6 +1174,13 @@ async function startLearnSession(
           continue;
         }
 
+        if (m.type === "ride_shotgun_error") {
+          clearTimeout(timeoutHandle);
+          socket.destroy();
+          reject(new Error((m as { message: string }).message));
+          continue;
+        }
+
         if (m.type === "ride_shotgun_result") {
           clearTimeout(timeoutHandle);
           socket.destroy();


### PR DESCRIPTION
## Summary
- Add ride_shotgun_error handling to amazon, twitter, map, and doordash CLI learn-session IPC listeners
- Bootstrap failures now reject with the actual error message instead of falling through to generic 'no recording path' errors
- Existing try/catch blocks surface the real failure reason via outputError()

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
