### PR TITLE
fix: make WhatsApp display phone number a readiness requirement

### DIFF
--- a/assistant/src/__tests__/channel-readiness-routes.test.ts
+++ b/assistant/src/__tests__/channel-readiness-routes.test.ts
@@ -189,7 +189,25 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
       ).toBe(true);
     });
 
-    test("reports ready when all Meta credentials are configured", async () => {
+    test("reports ready when all Meta credentials and display number are configured", async () => {
+      mockSecureKeys = {
+        "credential:whatsapp:phone_number_id": "123456789",
+        "credential:whatsapp:access_token": "EAAxxxxxx",
+        "credential:whatsapp:app_secret": "abc123",
+        "credential:whatsapp:webhook_verify_token": "my-verify-token",
+      };
+      mockRawConfig = {
+        whatsapp: { phoneNumber: "+15551234567" },
+        ingress: { publicBaseUrl: "https://example.com", enabled: true },
+      };
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("whatsapp");
+
+      expect(snapshot.ready).toBe(true);
+      expect(snapshot.reasons).toHaveLength(0);
+    });
+
+    test("reports not ready when display phone number is missing", async () => {
       mockSecureKeys = {
         "credential:whatsapp:phone_number_id": "123456789",
         "credential:whatsapp:access_token": "EAAxxxxxx",
@@ -202,8 +220,12 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
       const service = createReadinessService();
       const [snapshot] = await service.getReadiness("whatsapp");
 
-      expect(snapshot.ready).toBe(true);
-      expect(snapshot.reasons).toHaveLength(0);
+      expect(snapshot.ready).toBe(false);
+      expect(
+        snapshot.reasons.some(
+          (r) => r.code === "whatsapp_display_phone_number",
+        ),
+      ).toBe(true);
     });
 
     test("checks each Meta credential individually", async () => {
@@ -250,6 +272,7 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
         "credential:whatsapp:webhook_verify_token": "my-verify-token",
       };
       mockRawConfig = {
+        whatsapp: { phoneNumber: "+15551234567" },
         ingress: { publicBaseUrl: "https://example.com", enabled: true },
       };
       const service = createReadinessService();
@@ -269,7 +292,9 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
         "credential:whatsapp:app_secret": "abc123",
         "credential:whatsapp:webhook_verify_token": "my-verify-token",
       };
-      mockRawConfig = {};
+      mockRawConfig = {
+        whatsapp: { phoneNumber: "+15551234567" },
+      };
       const service = createReadinessService();
       const [snapshot] = await service.getReadiness("whatsapp");
 

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -371,15 +371,14 @@ const whatsappProbe: ChannelProbe = {
         : "WhatsApp webhook verify token is not configured",
     });
 
-    // Display phone number is optional — invites still work without it
-    // (falling back to generic instructions), but we surface the status.
     const displayNumber = resolveWhatsAppDisplayNumber();
+    const hasDisplayNumber = !!displayNumber;
     results.push({
       name: "whatsapp_display_phone_number",
-      passed: true, // informational, never blocks readiness
-      message: displayNumber
+      passed: hasDisplayNumber,
+      message: hasDisplayNumber
         ? `WhatsApp display phone number is configured (${displayNumber})`
-        : "WhatsApp display phone number is not configured — invite instructions will be generic",
+        : "WhatsApp display phone number is not configured — set whatsapp.phoneNumber in workspace config",
     });
 
     const invitePolicy = getChannelInvitePolicy("whatsapp");


### PR DESCRIPTION
## Summary
- WhatsApp display phone number is now a readiness requirement, not informational
- Channels without a configured display number show as unavailable
- Prevents dead-end invites with codes but no destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
