### PR TITLE
fix: auto-retry usage dashboard refresh on reopen after failure

### DIFF
--- a/clients/ios/Views/UsageDashboardView.swift
+++ b/clients/ios/Views/UsageDashboardView.swift
@@ -15,7 +15,7 @@ struct UsageDashboardView: View {
                 .navigationTitle("Usage & Cost")
                 .navigationBarTitleDisplayMode(.inline)
                 .task {
-                    if store.totalsState == .idle {
+                    if store.totalsState == .idle || store.totalsState.isFailed {
                         await store.refresh()
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -14,7 +14,7 @@ struct UsageDashboardPanel: View {
         }
         .onAppear {
             Task {
-                if store.totalsState == .idle {
+                if store.totalsState == .idle || store.totalsState.isFailed {
                     await store.refresh()
                 }
             }

--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -42,6 +42,11 @@ public enum UsageLoadingState<T: Equatable>: Equatable {
     case loading
     case loaded(T)
     case failed(String)
+
+    public var isFailed: Bool {
+        if case .failed = self { return true }
+        return false
+    }
 }
 
 // MARK: - Group-By Dimension


### PR DESCRIPTION
## Summary
The idle-only guard prevented retry on reopen after a transient failure. Now both iOS and macOS dashboards also refresh when in a failed state, while still preserving loaded data across presentations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
