### PR TITLE
fix: drop composite usage indexes that don't accelerate grouped queries

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -47,6 +47,7 @@ import {
   migrateConversationsThreadTypeIndex,
   migrateDropAssistantIdColumns,
   migrateDropLegacyMemberGuardianTables,
+  migrateDropUsageCompositeIndexes,
   migrateFkCascadeRebuilds,
   migrateGuardianActionFollowup,
   migrateGuardianActionSupersession,
@@ -300,6 +301,9 @@ export function initializeDb(): void {
 
   // 42. Reorder usage dashboard composite indexes so created_at leads (matches query shape)
   migrateReorderUsageDashboardIndexes(database);
+
+  // 43. Drop all composite usage indexes — they don't eliminate temp B-trees for GROUP BY
+  migrateDropUsageCompositeIndexes(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/137-usage-dashboard-indexes.ts
+++ b/assistant/src/memory/migrations/137-usage-dashboard-indexes.ts
@@ -8,9 +8,10 @@ import type { DrizzleDb } from "../db-connection.js";
  * - Composite index on (actor, created_at) for per-actor breakdowns.
  * - Composite index on (provider, model, created_at) for provider/model grouping.
  *
- * NOTE: The two composite indexes created here are superseded by migration
- * 138 which reorders them to lead with created_at, matching the actual
- * query shapes (WHERE created_at range, GROUP BY dimension).
+ * SUPERSEDED: The two composite indexes are dropped by migration 139.
+ * They don't accelerate grouped queries — SQLite still uses temp B-trees
+ * for GROUP BY regardless of index column order. Only the plain
+ * created_at index (kept) provides value for range scans.
  */
 export function migrateUsageDashboardIndexes(database: DrizzleDb): void {
   database.run(

--- a/assistant/src/memory/migrations/138-reorder-usage-dashboard-indexes.ts
+++ b/assistant/src/memory/migrations/138-reorder-usage-dashboard-indexes.ts
@@ -9,6 +9,10 @@ import type { DrizzleDb } from "../db-connection.js";
  *
  * The plain `created_at`-only index is kept because other queries may rely
  * on it (and it's smaller).
+ *
+ * SUPERSEDED: The reordered composite indexes are also dropped by
+ * migration 139 — EXPLAIN QUERY PLAN shows they still don't eliminate
+ * the temp B-tree for GROUP BY.
  */
 export function migrateReorderUsageDashboardIndexes(database: DrizzleDb): void {
   // Drop the old dimension-leading composites from migration 137

--- a/assistant/src/memory/migrations/139-drop-usage-composite-indexes.ts
+++ b/assistant/src/memory/migrations/139-drop-usage-composite-indexes.ts
@@ -1,0 +1,30 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Drop all composite indexes on llm_usage_events added by migrations 137
+ * and 138. EXPLAIN QUERY PLAN shows they provide no benefit: SQLite uses
+ * the created_at prefix for the range scan but still needs a temp B-tree
+ * for GROUP BY because the grouping column isn't contiguous after a range
+ * filter. For a local SQLite DB with typical usage volumes, the plain
+ * created_at index is sufficient and the temp B-tree overhead is negligible.
+ *
+ * The plain idx_llm_usage_events_created_at index (from migration 137)
+ * is intentionally kept — it genuinely helps range scans.
+ */
+export function migrateDropUsageCompositeIndexes(database: DrizzleDb): void {
+  // Migration 137 composites (may already be dropped by 138, hence IF EXISTS)
+  database.run(
+    /*sql*/ `DROP INDEX IF EXISTS idx_llm_usage_events_actor_created_at`,
+  );
+  database.run(
+    /*sql*/ `DROP INDEX IF EXISTS idx_llm_usage_events_provider_model_created_at`,
+  );
+
+  // Migration 138 composites
+  database.run(
+    /*sql*/ `DROP INDEX IF EXISTS idx_llm_usage_events_created_at_actor`,
+  );
+  database.run(
+    /*sql*/ `DROP INDEX IF EXISTS idx_llm_usage_events_created_at_provider_model`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -81,6 +81,7 @@ export { migrateBackfillContactInteractionStats } from "./135-backfill-contact-i
 export { migrateDropAssistantIdColumns } from "./136-drop-assistant-id-columns.js";
 export { migrateUsageDashboardIndexes } from "./137-usage-dashboard-indexes.js";
 export { migrateReorderUsageDashboardIndexes } from "./138-reorder-usage-dashboard-indexes.js";
+export { migrateDropUsageCompositeIndexes } from "./139-drop-usage-composite-indexes.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,


### PR DESCRIPTION
## Summary
The composite indexes on llm_usage_events (both original and reordered) don't help with the dashboard's GROUP BY queries — SQLite still uses temp B-trees regardless. For a local SQLite DB, the plain created_at index is sufficient for range scans and the temp B-tree overhead is negligible. Drops all composite indexes to remove dead weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)