### PR TITLE
fix: prevent refresh() from overwriting breakdown set by concurrent selectGroupBy()

### DIFF
--- a/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
@@ -424,6 +424,56 @@ struct UsageDashboardStoreRaceTests {
     }
 
     @Test @MainActor
+    func refreshDoesNotOverwriteBreakdownFromConcurrentSelectGroupBy() async {
+        let client = DelayedMockUsageClient()
+        let store = UsageDashboardStore(client: client)
+
+        // Launch refresh() — it fetches totals, daily, and breakdown
+        let refreshTask = Task { @MainActor in await store.refresh() }
+        await Self.yieldUntil {
+            client.totalsContinuations.count >= 1
+            && client.dailyContinuations.count >= 1
+            && client.breakdownContinuations.count >= 1
+        }
+
+        // While refresh() is in flight, user changes group-by dimension
+        let groupByTask = Task { @MainActor in await store.selectGroupBy(.provider) }
+        await Self.yieldUntil { client.breakdownContinuations.count >= 2 }
+
+        // Complete selectGroupBy's breakdown first (the newer request)
+        client.breakdownContinuations[1].resume(returning: Self.makeBreakdown(group: "provider-fresh"))
+        await groupByTask.value
+
+        if case .loaded(let breakdown) = store.breakdownState {
+            #expect(breakdown.breakdown[0].group == "provider-fresh")
+        } else {
+            Issue.record("Expected .loaded state after selectGroupBy completes")
+        }
+
+        // Now complete refresh()'s fetches — its breakdown should be discarded
+        // because selectGroupBy() incremented breakdownGeneration
+        client.totalsContinuations[0].resume(returning: Self.makeTotals(inputTokens: 42))
+        client.dailyContinuations[0].resume(returning: Self.makeDaily())
+        client.breakdownContinuations[0].resume(returning: Self.makeBreakdown(group: "model-stale"))
+        await refreshTask.value
+
+        // Totals and daily from refresh() should still land (no newer refresh invalidated them)
+        if case .loaded(let totals) = store.totalsState {
+            #expect(totals.totalInputTokens == 42)
+        } else {
+            Issue.record("Expected totals to be loaded from refresh()")
+        }
+
+        // Breakdown must still be the selectGroupBy result, not overwritten by refresh()
+        if case .loaded(let breakdown) = store.breakdownState {
+            #expect(breakdown.breakdown[0].group == "provider-fresh",
+                    "refresh() must not overwrite breakdown set by concurrent selectGroupBy()")
+        } else {
+            Issue.record("Breakdown was overwritten by stale refresh()")
+        }
+    }
+
+    @Test @MainActor
     func staleSelectGroupByResultsAreDiscarded() async {
         let client = DelayedMockUsageClient()
         let store = UsageDashboardStore(client: client)

--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -87,7 +87,9 @@ public final class UsageDashboardStore {
     /// Load all usage data (totals, daily, breakdown) for the currently selected range.
     public func refresh() async {
         refreshGeneration &+= 1
-        let capturedGeneration = refreshGeneration
+        let capturedRefreshGen = refreshGeneration
+        breakdownGeneration &+= 1
+        let capturedBreakdownGen = breakdownGeneration
 
         let range = selectedRange.epochMillisRange()
 
@@ -105,24 +107,26 @@ public final class UsageDashboardStore {
         let daily = await dailyResult
         let breakdown = await breakdownResult
 
-        guard capturedGeneration == refreshGeneration else { return }
+        if capturedRefreshGen == refreshGeneration {
+            if let totals {
+                totalsState = .loaded(totals)
+            } else {
+                totalsState = .failed("Failed to load usage totals")
+            }
 
-        if let totals {
-            totalsState = .loaded(totals)
-        } else {
-            totalsState = .failed("Failed to load usage totals")
+            if let daily {
+                dailyState = .loaded(daily)
+            } else {
+                dailyState = .failed("Failed to load daily usage")
+            }
         }
 
-        if let daily {
-            dailyState = .loaded(daily)
-        } else {
-            dailyState = .failed("Failed to load daily usage")
-        }
-
-        if let breakdown {
-            breakdownState = .loaded(breakdown)
-        } else {
-            breakdownState = .failed("Failed to load usage breakdown")
+        if capturedBreakdownGen == breakdownGeneration {
+            if let breakdown {
+                breakdownState = .loaded(breakdown)
+            } else {
+                breakdownState = .failed("Failed to load usage breakdown")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
refresh() and selectGroupBy() both write breakdownState but used separate generation counters with no cross-coordination. Now refresh() also increments and checks breakdownGeneration for its breakdown write, so the two methods can't overwrite each other's results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
