### PR TITLE
fix: correct readiness API response shape in contacts skill

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -209,13 +209,14 @@ curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/channels/readiness" \
   -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
 ```
 
-The response contains `{ ok: true, snapshots: [...] }` where each snapshot has:
+The response contains `{ success: true, snapshots: [...] }` where each snapshot has:
 
 - `channel` -- the channel type (e.g., `telegram`, `email`, `whatsapp`, `sms`, `slack`, `voice`)
 - `ready` -- boolean indicating whether the channel is fully operational
-- `checks` -- array of prerequisite checks, each with `name`, `passed` (boolean), and `detail` (human-readable explanation)
+- `localChecks` -- array of local prerequisite checks, each with `name`, `passed` (boolean), and `message` (human-readable explanation)
+- `remoteChecks` -- optional array of remote prerequisite checks (same shape: `name`, `passed`, `message`), present when the channel supports remote verification (e.g. confirming an email inbox exists)
 
-If the target channel's `ready` field is `false`, do **not** create the invite. Instead, tell the guardian which prerequisites are missing (from the `checks` array with `passed: false`) so they can resolve them first.
+If the target channel's `ready` field is `false`, do **not** create the invite. Instead, tell the guardian which prerequisites are missing (from the `localChecks` and `remoteChecks` arrays — look for entries with `passed: false`) so they can resolve them first.
 
 ## Invite Links
 


### PR DESCRIPTION
## Summary
- Fixes readiness API documentation in contacts SKILL.md to match actual response shape
- success instead of ok, localChecks/remoteChecks instead of checks, message instead of detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
