### PR TITLE
fix: differentiate learn-mode failure summaries for CDP vs recorder failures

### DIFF
--- a/assistant/src/__tests__/ride-shotgun-handler.test.ts
+++ b/assistant/src/__tests__/ride-shotgun-handler.test.ts
@@ -451,12 +451,13 @@ describe("ride-shotgun-handler", () => {
     // Give background task time to execute
     await new Promise((r) => setTimeout(r, 500));
 
-    // The result message should indicate failure, not "recording saved"
+    // The result message should indicate the specific CDP failure
     const resultMsg = ctx.sent.find(
       (m: any) => m.type === "ride_shotgun_result",
     ) as any;
     expect(resultMsg).toBeDefined();
     expect(resultMsg.summary).toContain("failed");
+    expect(resultMsg.summary).toContain("browser could not be started");
     expect(resultMsg.summary).not.toContain("recording saved");
   });
 

--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -103,12 +103,12 @@ async function completeSession(session: WatchSession): Promise<void> {
       }
     }
 
-    // When no recorder ever started, the browser failed to launch — report failure
+    // When no recorder ever started, report the specific bootstrap failure
     const summary = hasRecorder
       ? session.savedRecordingPath
         ? "Learn session completed — recording saved."
         : "Learn session completed — recording failed to save."
-      : "Learn session failed — browser could not be started.";
+      : `Learn session failed — ${session.bootstrapFailureReason ?? "unknown error."}`;
 
     lastSummaryBySession.set(sessionId, summary);
     session.status = "completed";
@@ -202,6 +202,7 @@ export async function handleRideShotgunStart(
             "Failed to start browser — Chrome CDP could not be launched.",
         });
         // Fail-fast: complete the session immediately instead of waiting for timeout
+        session.bootstrapFailureReason = "browser could not be started.";
         await completeSession(session);
         return;
       }
@@ -398,6 +399,8 @@ export async function handleRideShotgunStart(
               sessionId,
               message: "Failed to start network recording after 10 attempts.",
             });
+            session.bootstrapFailureReason =
+              "network recording could not be started after 10 attempts.";
             await completeSession(session);
           }
         }

--- a/assistant/src/tools/watch/watch-state.ts
+++ b/assistant/src/tools/watch/watch-state.ts
@@ -34,6 +34,8 @@ export interface WatchSession {
   recordingId?: string;
   /** Path where the learn recording was successfully saved (undefined if save failed) */
   savedRecordingPath?: string;
+  /** Reason the learn-mode bootstrap failed (CDP launch vs recorder attach) */
+  bootstrapFailureReason?: string;
 }
 
 /** Module-level map of watch sessions keyed by watchId. */


### PR DESCRIPTION
## Summary
- Add bootstrapFailureReason field to WatchSession for distinct failure messages
- CDP launch failure: 'browser could not be started'
- Recorder attach failure: 'network recording could not be started after 10 attempts'
- completeSession now uses the specific failure reason instead of a generic message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
