### PR TITLE
test: exercise Ride Shotgun IPC error delivery path in macOS tests

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
@@ -38,7 +38,7 @@ public final class RideShotgunSession: ObservableObject {
     public var isLearnMode: Bool { mode == "learn" }
 
     private var watchSession: WatchSession?
-    private var daemonClient: DaemonClient?
+    private var daemonClient: (any DaemonClientProtocol)?
     private var messageSubscription: Task<Void, Never>?
     private var watchSessionObserver: Task<Void, Never>?
     private var expectedWatchId: String?
@@ -51,7 +51,7 @@ public final class RideShotgunSession: ObservableObject {
         self.targetDomain = targetDomain
     }
 
-    public func start(daemonClient: DaemonClient) {
+    public func start(daemonClient: any DaemonClientProtocol) {
         guard state == .idle else {
             log.warning("Cannot start ride shotgun session: already in state \(String(describing: self.state))")
             return
@@ -135,7 +135,7 @@ public final class RideShotgunSession: ObservableObject {
 
     // MARK: - Private
 
-    private func handleWatchStarted(_ message: WatchStartedMessage, daemonClient: DaemonClient) {
+    private func handleWatchStarted(_ message: WatchStartedMessage, daemonClient: any DaemonClientProtocol) {
         guard state == .starting else {
             log.warning("Received watch_started but state is \(String(describing: self.state)), ignoring")
             return

--- a/clients/macos/vellum-assistantTests/RideShotgunSessionTests.swift
+++ b/clients/macos/vellum-assistantTests/RideShotgunSessionTests.swift
@@ -153,4 +153,37 @@ final class RideShotgunSessionTests: XCTestCase {
         agent.cancelRideShotgun()
         XCTAssertNil(agent.currentSession)
     }
+
+    // MARK: - IPC Message Delivery Path
+
+    @MainActor
+    func testRideShotgunErrorMessageTransitionsSessionToFailed() async throws {
+        // Exercises the actual subscription loop in RideShotgunSession.start():
+        // a rideShotgunError message delivered through the DaemonClient stream
+        // should transition the session from .starting to .failed with the error
+        // message from the IPC payload.
+        let mockClient = MockDaemonClient()
+        let continuation = mockClient.setupTestStream()
+
+        let session = RideShotgunSession(durationSeconds: 60)
+        session.start(daemonClient: mockClient)
+        XCTAssertEqual(session.state, .starting)
+
+        // Deliver the error through the IPC subscription
+        let errorMessage = RideShotgunErrorMessage(
+            type: "ride_shotgun_error",
+            watchId: "w-1",
+            sessionId: "s-1",
+            message: "CDP bootstrap timed out"
+        )
+        continuation.yield(.rideShotgunError(errorMessage))
+
+        // The subscription loop processes messages asynchronously on the main
+        // actor, so yield to let the Task pick up the emitted message.
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(session.state, .failed("CDP bootstrap timed out"))
+        XCTAssertEqual(session.summary, "", "Summary should remain empty on error")
+        XCTAssertEqual(session.observationCount, 0, "Observation count should remain zero on error")
+    }
 }


### PR DESCRIPTION
## Summary
- Add test that exercises the rideShotgunError IPC message delivery through RideShotgunSession's subscription loop
- Verifies the session transitions to .failed state with the correct error message when bootstrap fails
- Widen RideShotgunSession.start() to accept DaemonClientProtocol (matching WatchSession pattern) to enable MockDaemonClient injection in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
