### PR TITLE
fix: target first group text field in send-chat-message to avoid auxiliary fields

### DIFF
--- a/playwright/agent/tools/send-chat-message.ts
+++ b/playwright/agent/tools/send-chat-message.ts
@@ -80,18 +80,25 @@ tell application "System Events"
       error "Could not find the app window"
     end if
 
-    -- Find the text field (chat input) in the main window.
-    -- Use entire contents to find it regardless of nesting.
+    -- Find the chat input text field.
+    -- Primary: direct path (text field 1 of the main group)
     set chatField to missing value
-    set allElems to entire contents of appWindow
-    repeat with elem in allElems
-      try
-        if class of elem is text field then
-          -- The chat input is in the main group, not in a scroll area popup
-          set chatField to elem
-        end if
-      end try
-    end repeat
+    try
+      set chatField to text field 1 of group 1 of appWindow
+    end try
+
+    -- Fallback: scan entire contents for first text field
+    if chatField is missing value then
+      set allElems to entire contents of appWindow
+      repeat with elem in allElems
+        try
+          if class of elem is text field then
+            set chatField to elem
+            exit repeat
+          end if
+        end try
+      end repeat
+    end if
 
     if chatField is missing value then
       error "Could not find the chat text field"


### PR DESCRIPTION
## Summary
- Change text field discovery to try direct path first (text field 1 of group 1 of appWindow)
- Add fallback scan that takes the FIRST text field found instead of the last
- Prevents the tool from targeting auxiliary text fields instead of the chat input

Part of plan: fix-e2e-phone-setup.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
