### PR TITLE
fix: propagate accessibility identifiers through VButton to native Button element

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -223,12 +223,11 @@ struct SecretPromptView: View {
                     // Buttons
                     HStack(spacing: VSpacing.lg) {
                         Spacer()
-                        VButton(label: "Cancel", style: .tertiary) {
+                        VButton(label: "Cancel", style: .tertiary, accessibilityID: "secure-credential-cancel") {
                             onCancel()
                         }
-                        .accessibilityIdentifier("secure-credential-cancel")
                         .accessibilityLabel("Cancel")
-                        VButton(label: "Save", style: .primary) {
+                        VButton(label: "Save", style: .primary, accessibilityID: "secure-credential-save") {
                             let trimmed = secretValue.trimmingCharacters(in: .whitespacesAndNewlines)
                             guard !trimmed.isEmpty else { return }
                             if onSave(trimmed) {
@@ -236,7 +235,6 @@ struct SecretPromptView: View {
                             }
                         }
                         .disabled(secretValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                        .accessibilityIdentifier("secure-credential-save")
                         .accessibilityLabel("Save")
                     }
 

--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -14,11 +14,12 @@ public struct VButton: View {
     public var size: Size = .small
     public var isFullWidth: Bool = false
     public var isDisabled: Bool = false
+    public var accessibilityID: String? = nil
     public let action: () -> Void
 
     @State private var isHovered = false
 
-    public init(label: String, icon: String? = nil, leftIcon: String? = nil, rightIcon: String? = nil, style: Style = .primary, size: Size = .small, isFullWidth: Bool = false, isDisabled: Bool = false, action: @escaping () -> Void) {
+    public init(label: String, icon: String? = nil, leftIcon: String? = nil, rightIcon: String? = nil, style: Style = .primary, size: Size = .small, isFullWidth: Bool = false, isDisabled: Bool = false, accessibilityID: String? = nil, action: @escaping () -> Void) {
         self.label = label
         self.leftIcon = leftIcon ?? icon
         self.rightIcon = rightIcon
@@ -26,6 +27,7 @@ public struct VButton: View {
         self.size = size
         self.isFullWidth = isFullWidth
         self.isDisabled = isDisabled
+        self.accessibilityID = accessibilityID
         self.action = action
     }
 
@@ -63,6 +65,7 @@ public struct VButton: View {
         .disabled(isDisabled)
         .opacity(isDisabled ? 0.5 : 1.0)
         .accessibilityHint(isDisabled ? "Button is currently disabled" : "")
+        .accessibilityIdentifier(accessibilityID ?? "")
     }
 
     private var iconSize: CGFloat {


### PR DESCRIPTION
## Summary
- Add optional `accessibilityID` parameter to VButton that applies `.accessibilityIdentifier()` directly on the internal Button element
- Update SecretPromptManager Cancel/Save buttons to use the new parameter instead of external modifiers
- Ensures AXIdentifier is properly exposed in the AX tree for AppleScript automation

Part of plan: fix-e2e-phone-setup.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
