### PR TITLE
fix: auto-retry usage dashboard on reopen after partial failure

### DIFF
--- a/clients/ios/Views/UsageDashboardView.swift
+++ b/clients/ios/Views/UsageDashboardView.swift
@@ -15,7 +15,7 @@ struct UsageDashboardView: View {
                 .navigationTitle("Usage & Cost")
                 .navigationBarTitleDisplayMode(.inline)
                 .task {
-                    if store.totalsState == .idle || store.totalsState.isFailed {
+                    if store.needsRefresh {
                         await store.refresh()
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -14,7 +14,7 @@ struct UsageDashboardPanel: View {
         }
         .onAppear {
             Task {
-                if store.totalsState == .idle || store.totalsState.isFailed {
+                if store.needsRefresh {
                     await store.refresh()
                 }
             }

--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -87,6 +87,14 @@ public final class UsageDashboardStore {
         self.client = client
     }
 
+    /// Whether any section needs a (re)fetch — used by views to auto-refresh
+    /// on first appearance or after a partial/total failure.
+    public var needsRefresh: Bool {
+        totalsState == .idle || totalsState.isFailed ||
+        dailyState == .idle || dailyState.isFailed ||
+        breakdownState == .idle || breakdownState.isFailed
+    }
+
     // MARK: - Refresh
 
     /// Load all usage data (totals, daily, breakdown) for the currently selected range.


### PR DESCRIPTION
## Summary
The refresh guard only checked totalsState, so a partial failure (totals OK but daily/breakdown failed) was never retried on reopen. Now checks all three states via a shared needsRefresh property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
