### PR TITLE
fix: replace fixed Task.sleep with predicate-based waiting in IPC test

### DIFF
--- a/clients/macos/vellum-assistantTests/RideShotgunSessionTests.swift
+++ b/clients/macos/vellum-assistantTests/RideShotgunSessionTests.swift
@@ -178,9 +178,11 @@ final class RideShotgunSessionTests: XCTestCase {
         )
         continuation.yield(.rideShotgunError(errorMessage))
 
-        // The subscription loop processes messages asynchronously on the main
-        // actor, so yield to let the Task pick up the emitted message.
-        try await Task.sleep(nanoseconds: 50_000_000)
+        // Poll until the subscription loop processes the message (up to 5s).
+        let deadline = ContinuousClock.now + .seconds(5)
+        while session.state == .starting, ContinuousClock.now < deadline {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
 
         XCTAssertEqual(session.state, .failed("CDP bootstrap timed out"))
         XCTAssertEqual(session.summary, "", "Summary should remain empty on error")


### PR DESCRIPTION
Replace the timing-sensitive Task.sleep(50_000_000) with a polling loop that checks for state transition, preventing flaky failures on slower CI.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
