### PR TITLE
fix: use received value in onReceive to avoid stale @Published willSet timing

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -74,8 +74,9 @@ struct ContactsContainerView: View {
                 .background(VColor.background)
             }
         }
-        .onReceive(viewModel.$contacts) { _ in
-            if selectedContactId == nil, let guardian = viewModel.guardianContact {
+        .onReceive(viewModel.$contacts) { newContacts in
+            if selectedContactId == nil,
+               let guardian = newContacts.first(where: { $0.role == "guardian" }) {
                 selectedContactId = guardian.id
             }
         }


### PR DESCRIPTION
Address reviewer feedback on PR #13074.

The `.onReceive(viewModel.$contacts)` closure was ignoring the received value and reading `viewModel.guardianContact`, which traverses `contacts`. Since `@Published` emits during `willSet` (before the property is stored), the closure would read stale data on first load, causing the guardian contact to not be auto-selected.

Fix: use the received `newContacts` value directly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
