### PR TITLE
fix: address review feedback from PR #13127

### DIFF
--- a/gateway/src/whatsapp/api.ts
+++ b/gateway/src/whatsapp/api.ts
@@ -309,10 +309,7 @@ export async function sendWhatsAppInteractiveMessage(
   );
 }
 
-/**
- * Mark an incoming WhatsApp message as read.
- * Best-effort — callers should not propagate errors from this.
- */
+/** Metadata returned by the WhatsApp media endpoint. */
 export interface WhatsAppMediaMetadata {
   url: string;
   mime_type: string;
@@ -458,6 +455,10 @@ async function retryableWhatsAppRawFetch(
   throw lastError ?? new Error(`WhatsApp ${operation} failed after retries`);
 }
 
+/**
+ * Mark an incoming WhatsApp message as read.
+ * Best-effort — callers should not propagate errors from this.
+ */
 export async function markWhatsAppMessageRead(
   config: GatewayConfig,
   messageId: string,

--- a/gateway/src/whatsapp/download.ts
+++ b/gateway/src/whatsapp/download.ts
@@ -51,6 +51,12 @@ export async function downloadWhatsAppFile(
 ): Promise<DownloadedFile> {
   const meta = await getWhatsAppMediaMetadata(config, mediaId);
 
+  if (meta.file_size > config.maxAttachmentBytes) {
+    throw new Error(
+      `WhatsApp media ${mediaId} exceeds size limit (${meta.file_size} > ${config.maxAttachmentBytes} bytes)`,
+    );
+  }
+
   const response = await downloadWhatsAppMediaBytes(config, meta.url);
   const buffer = await response.arrayBuffer();
 


### PR DESCRIPTION
Address reviewer feedback on PR #13127.

- Fix displaced JSDoc: move markWhatsAppMessageRead docs back to the function, add proper docs for WhatsAppMediaMetadata interface
- Add maxAttachmentBytes enforcement in downloadWhatsAppFile before downloading media
- MIME normalization for codec-parameterized types was already handled by inferFilename
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
