### PR TITLE
fix: guard resolveAdapterHandle from async failures and restore Telegram adapter tests

### DIFF
--- a/assistant/src/__tests__/channel-invite-transport.test.ts
+++ b/assistant/src/__tests__/channel-invite-transport.test.ts
@@ -77,6 +77,30 @@ describe("resolveAdapterHandle", () => {
     const handle = await resolveAdapterHandle(adapter);
     expect(handle).toBeUndefined();
   });
+
+  test("returns undefined when async resolveChannelHandleAsync rejects", async () => {
+    const adapter: ChannelInviteAdapter = {
+      channel: "email",
+      resolveChannelHandleAsync: async () => {
+        throw new Error("transient API failure");
+      },
+    };
+
+    const handle = await resolveAdapterHandle(adapter);
+    expect(handle).toBeUndefined();
+  });
+
+  test("returns undefined when sync resolveChannelHandle throws", async () => {
+    const adapter: ChannelInviteAdapter = {
+      channel: "telegram",
+      resolveChannelHandle: () => {
+        throw new Error("credential lookup failed");
+      },
+    };
+
+    const handle = await resolveAdapterHandle(adapter);
+    expect(handle).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/telegram-invite-adapter.test.ts
+++ b/assistant/src/__tests__/telegram-invite-adapter.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for the Telegram channel invite adapter.
+ *
+ * Covers `buildShareLink`, `extractInboundToken`, and
+ * `resolveChannelHandle` on the real production adapter.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { ChannelId } from "../channels/types.js";
+import { telegramInviteAdapter } from "../runtime/channel-invite-transports/telegram.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CHANNEL: ChannelId = "telegram" as ChannelId;
+
+function setEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// buildShareLink
+// ---------------------------------------------------------------------------
+
+describe("telegramInviteAdapter.buildShareLink", () => {
+  let originalBotUsername: string | undefined;
+
+  beforeEach(() => {
+    originalBotUsername = process.env.TELEGRAM_BOT_USERNAME;
+  });
+
+  afterEach(() => {
+    setEnv("TELEGRAM_BOT_USERNAME", originalBotUsername);
+  });
+
+  test("builds a deep link with iv_ prefix", () => {
+    setEnv("TELEGRAM_BOT_USERNAME", "TestBot");
+
+    const link = telegramInviteAdapter.buildShareLink!({
+      rawToken: "abc123",
+      sourceChannel: CHANNEL,
+    });
+
+    expect(link.url).toBe("https://t.me/TestBot?start=iv_abc123");
+    expect(link.displayText).toContain("https://t.me/TestBot?start=iv_abc123");
+  });
+
+  test("throws when bot username is not configured", () => {
+    setEnv("TELEGRAM_BOT_USERNAME", undefined);
+
+    expect(() =>
+      telegramInviteAdapter.buildShareLink!({
+        rawToken: "abc123",
+        sourceChannel: CHANNEL,
+      }),
+    ).toThrow(/bot username/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractInboundToken
+// ---------------------------------------------------------------------------
+
+describe("telegramInviteAdapter.extractInboundToken", () => {
+  test("extracts token from structured commandIntent", () => {
+    const token = telegramInviteAdapter.extractInboundToken!({
+      commandIntent: { type: "start", payload: "iv_tok123" },
+      content: "/start iv_tok123",
+    });
+
+    expect(token).toBe("tok123");
+  });
+
+  test("returns undefined for non-invite commandIntent payload", () => {
+    const token = telegramInviteAdapter.extractInboundToken!({
+      commandIntent: { type: "start", payload: "gv_guardian_token" },
+      content: "/start gv_guardian_token",
+    });
+
+    expect(token).toBeUndefined();
+  });
+
+  test("returns undefined for commandIntent with empty payload after prefix", () => {
+    const token = telegramInviteAdapter.extractInboundToken!({
+      commandIntent: { type: "start", payload: "iv_" },
+      content: "/start iv_",
+    });
+
+    expect(token).toBeUndefined();
+  });
+
+  test("falls back to raw content parsing when no commandIntent", () => {
+    const token = telegramInviteAdapter.extractInboundToken!({
+      content: "/start iv_fallback_token",
+    });
+
+    expect(token).toBe("fallback_token");
+  });
+
+  test("returns undefined for non-invite raw content", () => {
+    const token = telegramInviteAdapter.extractInboundToken!({
+      content: "/start gv_something",
+    });
+
+    expect(token).toBeUndefined();
+  });
+
+  test("returns undefined for plain text content", () => {
+    const token = telegramInviteAdapter.extractInboundToken!({
+      content: "hello world",
+    });
+
+    expect(token).toBeUndefined();
+  });
+
+  test("returns undefined for commandIntent with non-start type", () => {
+    const token = telegramInviteAdapter.extractInboundToken!({
+      commandIntent: { type: "help", payload: "iv_tok" },
+      content: "/help iv_tok",
+    });
+
+    expect(token).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveChannelHandle
+// ---------------------------------------------------------------------------
+
+describe("telegramInviteAdapter.resolveChannelHandle", () => {
+  let originalBotUsername: string | undefined;
+
+  beforeEach(() => {
+    originalBotUsername = process.env.TELEGRAM_BOT_USERNAME;
+  });
+
+  afterEach(() => {
+    setEnv("TELEGRAM_BOT_USERNAME", originalBotUsername);
+  });
+
+  test("returns @-prefixed bot username from env", () => {
+    setEnv("TELEGRAM_BOT_USERNAME", "MyBot");
+
+    const handle = telegramInviteAdapter.resolveChannelHandle!();
+    expect(handle).toBe("@MyBot");
+  });
+
+  test("returns undefined when bot username is not configured", () => {
+    setEnv("TELEGRAM_BOT_USERNAME", undefined);
+
+    const handle = telegramInviteAdapter.resolveChannelHandle!();
+    expect(handle).toBeUndefined();
+  });
+});

--- a/assistant/src/runtime/channel-invite-transport.ts
+++ b/assistant/src/runtime/channel-invite-transport.ts
@@ -115,10 +115,16 @@ export class InviteAdapterRegistry {
 export async function resolveAdapterHandle(
   adapter: ChannelInviteAdapter,
 ): Promise<string | undefined> {
-  if (adapter.resolveChannelHandleAsync) {
-    return adapter.resolveChannelHandleAsync();
+  try {
+    if (adapter.resolveChannelHandleAsync) {
+      return await adapter.resolveChannelHandleAsync();
+    }
+    return adapter.resolveChannelHandle?.();
+  } catch {
+    // Handle resolution is optional metadata — degrade gracefully so
+    // callers (e.g. readiness endpoints) don't fail on transient errors.
+    return undefined;
   }
-  return adapter.resolveChannelHandle?.();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Address reviewer feedback on PR #13137:

- Wrap resolveAdapterHandle in try/catch so async rejections degrade gracefully to undefined instead of failing readiness endpoints with 500
- Add tests for error swallowing behavior (both sync throw and async rejection)
- Restore Telegram adapter test coverage (buildShareLink, extractInboundToken, resolveChannelHandle) that was removed in the refactor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
