### PR TITLE
fix: skip redundant index reorder migration before composite drop

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -63,7 +63,6 @@ import {
   migrateNormalizePhoneIdentities,
   migrateNotificationDeliveryThreadDecision,
   migrateReminderRoutingIntent,
-  migrateReorderUsageDashboardIndexes,
   migrateSchemaIndexesAndColumns,
   migrateUsageDashboardIndexes,
   migrateVoiceInviteColumns,
@@ -299,8 +298,8 @@ export function initializeDb(): void {
   // 41. Indexes on llm_usage_events for usage dashboard time-range and breakdown queries
   migrateUsageDashboardIndexes(database);
 
-  // 42. Reorder usage dashboard composite indexes so created_at leads (matches query shape)
-  migrateReorderUsageDashboardIndexes(database);
+  // 42. (skipped) migrateReorderUsageDashboardIndexes — superseded by 43 which drops
+  // all composite indexes that 42 would create, so running it is wasted work.
 
   // 43. Drop all composite usage indexes — they don't eliminate temp B-trees for GROUP BY
   migrateDropUsageCompositeIndexes(database);


### PR DESCRIPTION
Gate migrateReorderUsageDashboardIndexes so it's skipped since migrateDropUsageCompositeIndexes drops those indexes anyway.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
