### PR TITLE
fix: reject on CDP window state error responses

### DIFF
--- a/assistant/src/__tests__/chrome-cdp.test.ts
+++ b/assistant/src/__tests__/chrome-cdp.test.ts
@@ -112,6 +112,7 @@ async function setWindowState(
       const msg = JSON.parse(String(event.data)) as {
         id: number;
         result?: { windowId: number };
+        error?: { message: string };
       };
       if (msg.id === 1 && msg.result) {
         ws.send(
@@ -131,7 +132,13 @@ async function setWindowState(
       } else if (msg.id === 2) {
         clearTimeout(timeout);
         ws.close();
-        resolve();
+        if (msg.error) {
+          reject(
+            new Error(`Browser.setWindowBounds failed: ${msg.error.message}`),
+          );
+        } else {
+          resolve();
+        }
       }
     });
 
@@ -366,6 +373,66 @@ describe("minimizeChromeWindow", () => {
     expect(boundsMsg).toBeDefined();
     const parsed = JSON.parse(boundsMsg!);
     expect(parsed.params.bounds.windowState).toBe("minimized");
+
+    globalThis.WebSocket = OriginalWebSocket;
+  });
+});
+
+describe("setWindowState error handling", () => {
+  test("rejects when Browser.setWindowBounds returns an error", async () => {
+    let wsOnOpen: (() => void) | undefined;
+    let wsOnMessage: ((event: { data: string }) => void) | undefined;
+
+    fetchImpl = async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes("/json/list")) {
+        return new Response(
+          JSON.stringify([
+            {
+              type: "page",
+              webSocketDebuggerUrl: "ws://localhost:9222/devtools/page/ABC",
+            },
+          ]),
+        );
+      }
+      return new Response("{}", { status: 200 });
+    };
+
+    const OriginalWebSocket = globalThis.WebSocket;
+    globalThis.WebSocket = class MockWebSocket {
+      constructor(_url: string) {}
+      addEventListener(event: string, handler: (...args: unknown[]) => void) {
+        if (event === "open") wsOnOpen = handler as () => void;
+        if (event === "message")
+          wsOnMessage = handler as (event: { data: string }) => void;
+      }
+      send(data: string) {
+        const msg = JSON.parse(data);
+        if (msg.method === "Browser.getWindowForTarget") {
+          setTimeout(() => {
+            wsOnMessage?.({
+              data: JSON.stringify({ id: 1, result: { windowId: 42 } }),
+            });
+          }, 0);
+        } else if (msg.method === "Browser.setWindowBounds") {
+          setTimeout(() => {
+            wsOnMessage?.({
+              data: JSON.stringify({
+                id: 2,
+                error: { message: "No window with given id" },
+              }),
+            });
+          }, 0);
+        }
+      }
+      close() {}
+    } as unknown as typeof WebSocket;
+
+    const promise = minimizeChromeWindow();
+    await new Promise((r) => setTimeout(r, 10));
+    wsOnOpen?.();
+
+    await expect(promise).rejects.toThrow("Browser.setWindowBounds failed");
 
     globalThis.WebSocket = OriginalWebSocket;
   });

--- a/assistant/src/tools/browser/chrome-cdp.ts
+++ b/assistant/src/tools/browser/chrome-cdp.ts
@@ -155,6 +155,7 @@ async function setWindowState(
       const msg = JSON.parse(String(event.data)) as {
         id: number;
         result?: { windowId: number };
+        error?: { message: string };
       };
       if (msg.id === 1 && msg.result) {
         ws.send(
@@ -174,7 +175,13 @@ async function setWindowState(
       } else if (msg.id === 2) {
         clearTimeout(timeout);
         ws.close();
-        resolve();
+        if (msg.error) {
+          reject(
+            new Error(`Browser.setWindowBounds failed: ${msg.error.message}`),
+          );
+        } else {
+          resolve();
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- Address reviewer feedback on PR #13138: the `id === 2` branch in `setWindowState` now checks for CDP error payloads and rejects the promise instead of silently resolving.
- Added test covering the error response case.

## Test plan
- [x] Existing chrome-cdp tests pass (13/13)
- [x] New test verifies `Browser.setWindowBounds` error responses cause rejection
- [x] Type-check passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
