### PR TITLE
fix: register auth policies for usage endpoints

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -263,6 +263,11 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "apps/shared:DELETE", scopes: ["settings.write"] },
   { endpoint: "apps/shared/metadata", scopes: ["settings.read"] },
 
+  // Usage / cost telemetry
+  { endpoint: "usage/totals", scopes: ["settings.read"] },
+  { endpoint: "usage/daily", scopes: ["settings.read"] },
+  { endpoint: "usage/breakdown", scopes: ["settings.read"] },
+
   // Debug
   { endpoint: "debug", scopes: ["settings.read"] },
 


### PR DESCRIPTION
Address reviewer feedback on PR #13142. The usage routes (totals, daily, breakdown) were missing route policy registrations, allowing any authenticated principal to access cost/token telemetry regardless of scopes. Adds settings.read policy entries matching the pattern used by other informational endpoints.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
