### PR TITLE
feat: collapsed thread switcher count badge and drawer

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/CollapsedThreadSwitcherPresentation.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/CollapsedThreadSwitcherPresentation.swift
@@ -3,8 +3,14 @@ import Foundation
 struct CollapsedThreadSwitcherPresentation {
     let switchTargets: [ThreadModel]
     let activeThreadTitle: String?
+    let totalRegularThreadCount: Int
 
-    var showsSwitcher: Bool { !switchTargets.isEmpty }
+    var showsSwitcher: Bool { totalRegularThreadCount > 0 }
+
+    var badgeText: String {
+        if totalRegularThreadCount > 99 { return "99+" }
+        return "\(totalRegularThreadCount)"
+    }
 
     var accessibilityLabel: String {
         if let title = activeThreadTitle {
@@ -14,10 +20,11 @@ struct CollapsedThreadSwitcherPresentation {
     }
 
     var accessibilityValue: String {
-        switchTargets.isEmpty ? "" : "\(switchTargets.count) threads"
+        totalRegularThreadCount == 0 ? "" : "\(totalRegularThreadCount) threads"
     }
 
     init(regularThreads: [ThreadModel], activeThreadId: UUID?) {
+        self.totalRegularThreadCount = regularThreads.count
         if let activeId = activeThreadId {
             self.switchTargets = regularThreads.filter { $0.id != activeId }
             self.activeThreadTitle = regularThreads.first(where: { $0.id == activeId })?.title

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -491,10 +491,18 @@ extension MainWindowView {
                     showThreadSwitcher.toggle()
                 } label: {
                     ZStack(alignment: .bottomTrailing) {
-                        Image(systemName: "ellipsis.message")
-                            .font(.system(size: 13, weight: .medium))
+                        Text(switcher.badgeText)
+                            .font(.system(size: 11, weight: .semibold))
                             .foregroundColor(adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400))
-                            .frame(width: 28, height: 28)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
+                            .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)
+                            .background(
+                                RoundedRectangle(cornerRadius: VRadius.md)
+                                    .fill(windowState.isShowingChat && threadManager.activeThread != nil
+                                        ? Color(hex: 0xD4DFD0)
+                                        : Color(hex: 0xE8E6DA))
+                            )
 
                         if switcher.switchTargets.contains(where: { $0.hasUnseenLatestAssistantMessage }) {
                             Circle()
@@ -505,85 +513,21 @@ extension MainWindowView {
                     }
                 }
                 .buttonStyle(.plain)
+                .padding(.horizontal, VSpacing.xs)
                 .accessibilityLabel(switcher.accessibilityLabel)
                 .accessibilityValue(switcher.accessibilityValue)
                 .onDisappear {
                     showThreadSwitcher = false
                 }
                 .pointerCursor()
-                .popover(isPresented: $showThreadSwitcher, arrowEdge: .trailing) {
-                    VStack(alignment: .leading, spacing: 0) {
-                        Text("\(switcher.switchTargets.count) threads")
-                            .font(VFont.body)
-                            .foregroundColor(VColor.textMuted)
-                            .padding(.leading, VSpacing.md)
-                            .padding(.trailing, VSpacing.sm)
-                            .padding(.top, VSpacing.md)
-                            .padding(.bottom, VSpacing.sm)
-
-                        VColor.divider
-                            .frame(height: 1)
-                            .padding(.horizontal, VSpacing.xs)
-                            .padding(.bottom, VSpacing.sm)
-
-                        ScrollView {
-                            VStack(spacing: 0) {
-                                ForEach(switcher.switchTargets) { thread in
-                                    SidebarThreadItem(
-                                        thread: thread,
-                                        threadManager: threadManager,
-                                        windowState: windowState,
-                                        sidebar: sidebar,
-                                        selectThread: { selectThread(thread) },
-                                        onSelect: { showThreadSwitcher = false }
-                                    )
-                                        .padding(.bottom, SidebarLayoutMetrics.listRowGap)
-                                        .overlay(alignment: sidebar.dropIndicatorAtBottom ? .bottom : .top) {
-                                            if sidebar.dropTargetThreadId == thread.id {
-                                                Rectangle()
-                                                    .fill(adaptiveColor(light: Forest._500, dark: Forest._400))
-                                                    .frame(height: 2)
-                                                    .transition(.opacity)
-                                            }
-                                        }
-                                        .dropDestination(for: String.self) { items, _ in
-                                            sidebar.dropTargetThreadId = nil
-                                            sidebar.draggingThreadId = nil
-                                            guard let droppedId = items.first,
-                                                  let sourceUUID = UUID(uuidString: droppedId),
-                                                  sourceUUID != thread.id else { return false }
-                                            return threadManager.moveThread(sourceId: sourceUUID, targetId: thread.id)
-                                        } isTargeted: { isTargeted in
-                                            if isTargeted && thread.id != sidebar.draggingThreadId {
-                                                sidebar.dropTargetThreadId = thread.id
-                                                if let dragId = sidebar.draggingThreadId {
-                                                    let visible = threadManager.visibleThreads
-                                                    let sIdx = visible.firstIndex(where: { $0.id == dragId }) ?? 0
-                                                    let tIdx = visible.firstIndex(where: { $0.id == thread.id }) ?? 0
-                                                    sidebar.dropIndicatorAtBottom = sIdx < tIdx
-                                                }
-                                            } else if !isTargeted && sidebar.dropTargetThreadId == thread.id {
-                                                sidebar.dropTargetThreadId = nil
-                                            }
-                                        }
-                                }
-                            }
-                        }
-                        .frame(maxHeight: 300)
+                .background(GeometryReader { proxy in
+                    Color.clear.onAppear {
+                        threadSwitcherTriggerFrame = proxy.frame(in: .named("coreLayout"))
                     }
-                    .frame(width: 220)
-                    .padding(.bottom, VSpacing.sm)
-                    .background(VColor.backgroundSubtle)
-                    .onChange(of: threadManager.activeThreadId) { _, _ in
-                        showThreadSwitcher = false
+                    .onChange(of: proxy.frame(in: .named("coreLayout"))) { _, newFrame in
+                        threadSwitcherTriggerFrame = newFrame
                     }
-                    .onDisappear {
-                        if sidebar.isHoveredThread != nil {
-                            sidebar.isHoveredThread = nil
-                        }
-                        sidebar.threadPendingDeletion = nil
-                    }
-                }
+                })
             }
 
             Spacer()

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -50,6 +50,7 @@ struct MainWindowView: View {
     let onSendWakeUp: (() -> Void)?
 
     @State var showThreadSwitcher = false
+    @State var threadSwitcherTriggerFrame: CGRect = .zero
     /// Whether the "coming alive" overlay is currently showing.
     @State private var showComingAlive: Bool
     /// Whether the daemon-loading skeleton overlay is currently showing.
@@ -552,6 +553,41 @@ struct MainWindowView: View {
                         .offset(x: drawerX, y: -28)
                         .zIndex(10)
                         .transition(.opacity)
+                    }
+                }
+                .overlay {
+                    if showThreadSwitcher {
+                        Color.clear
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                showThreadSwitcher = false
+                            }
+                    }
+                }
+                .overlay(alignment: .topLeading) {
+                    if showThreadSwitcher {
+                        ThreadSwitcherDrawer(
+                            regularThreads: regularThreads,
+                            activeThreadId: threadManager.activeThreadId,
+                            threadManager: threadManager,
+                            windowState: windowState,
+                            sidebar: sidebar,
+                            selectThread: { selectThread($0) },
+                            onDismiss: { showThreadSwitcher = false }
+                        )
+                        .frame(width: sidebarExpandedWidth - VSpacing.sm * 2)
+                        .offset(
+                            x: 16 + sidebarCollapsedWidth - VSpacing.xs,
+                            y: threadSwitcherTriggerFrame.minY
+                        )
+                        .zIndex(10)
+                        .transition(.opacity)
+                        .onChange(of: threadManager.activeThreadId) { _, _ in
+                            showThreadSwitcher = false
+                        }
+                        .onChange(of: sidebarExpanded) { _, expanded in
+                            if expanded { showThreadSwitcher = false }
+                        }
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ThreadSwitcherDrawer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/ThreadSwitcherDrawer.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import VellumAssistantShared
+
+struct ThreadSwitcherDrawer: View {
+    let regularThreads: [ThreadModel]
+    let activeThreadId: UUID?
+    @ObservedObject var threadManager: ThreadManager
+    @ObservedObject var windowState: MainWindowState
+    var sidebar: SidebarInteractionState
+    let selectThread: (ThreadModel) -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Text("\(regularThreads.count) threads")
+                .font(VFont.caption)
+                .foregroundColor(Color(hex: 0xA1A096))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.top, VSpacing.sm)
+                .padding(.bottom, VSpacing.xs)
+
+            VColor.surfaceBorder.frame(height: 1)
+                .padding(.horizontal, VSpacing.xs)
+                .padding(.bottom, VSpacing.xs)
+
+            ForEach(regularThreads) { thread in
+                SidebarThreadItem(
+                    thread: thread,
+                    threadManager: threadManager,
+                    windowState: windowState,
+                    sidebar: sidebar,
+                    selectThread: { selectThread(thread) },
+                    onSelect: onDismiss
+                )
+                .padding(.bottom, SidebarLayoutMetrics.listRowGap)
+            }
+        }
+        .padding(.vertical, VSpacing.sm)
+        .fixedSize(horizontal: false, vertical: true)
+        .background(VColor.surfaceSubtle)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.15), radius: 6, y: 2)
+        .onDisappear {
+            if sidebar.isHoveredThread != nil {
+                sidebar.isHoveredThread = nil
+            }
+            sidebar.threadPendingDeletion = nil
+        }
+    }
+}

--- a/clients/macos/vellum-assistantTests/CollapsedThreadSwitcherPresentationTests.swift
+++ b/clients/macos/vellum-assistantTests/CollapsedThreadSwitcherPresentationTests.swift
@@ -26,12 +26,13 @@ final class CollapsedThreadSwitcherPresentationTests: XCTestCase {
 
     // MARK: - Active thread
 
-    func testActiveThread_onlyThatThread_hidesSwitcher() {
+    func testActiveThread_onlyThatThread_showsSwitcherWithBadge() {
         let id = UUID()
         let threads = [makeThread(id: id)]
         let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: id)
 
-        XCTAssertFalse(sut.showsSwitcher)
+        XCTAssertTrue(sut.showsSwitcher)
+        XCTAssertEqual(sut.totalRegularThreadCount, 1)
         XCTAssertTrue(sut.switchTargets.isEmpty)
     }
 
@@ -44,6 +45,42 @@ final class CollapsedThreadSwitcherPresentationTests: XCTestCase {
         XCTAssertTrue(sut.showsSwitcher)
         XCTAssertEqual(sut.switchTargets.count, 1)
         XCTAssertEqual(sut.switchTargets.first?.id, otherId)
+    }
+
+    // MARK: - Total count and badge
+
+    func testTotalRegularThreadCount() {
+        let threads = [makeThread(), makeThread(), makeThread()]
+        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: nil)
+
+        XCTAssertEqual(sut.totalRegularThreadCount, 3)
+    }
+
+    func testBadgeText_normalCount() {
+        let threads = [makeThread(), makeThread()]
+        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: nil)
+
+        XCTAssertEqual(sut.badgeText, "2")
+    }
+
+    func testBadgeText_singleThread() {
+        let sut = CollapsedThreadSwitcherPresentation(regularThreads: [makeThread()], activeThreadId: nil)
+
+        XCTAssertEqual(sut.badgeText, "1")
+    }
+
+    func testBadgeText_capsAt99Plus() {
+        let threads = (0..<100).map { _ in makeThread() }
+        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: nil)
+
+        XCTAssertEqual(sut.badgeText, "99+")
+    }
+
+    func testBadgeText_99IsNotCapped() {
+        let threads = (0..<99).map { _ in makeThread() }
+        let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: nil)
+
+        XCTAssertEqual(sut.badgeText, "99")
     }
 
     // MARK: - Accessibility
@@ -62,14 +99,14 @@ final class CollapsedThreadSwitcherPresentationTests: XCTestCase {
         XCTAssertEqual(sut.accessibilityLabel, "Switch threads")
     }
 
-    func testAccessibilityValue_reflectsSwitchTargetCount() {
+    func testAccessibilityValue_reflectsTotalCount() {
         let threads = [makeThread(), makeThread(), makeThread()]
         let sut = CollapsedThreadSwitcherPresentation(regularThreads: threads, activeThreadId: nil)
 
         XCTAssertEqual(sut.accessibilityValue, "3 threads")
     }
 
-    func testAccessibilityValue_emptyWhenNoTargets() {
+    func testAccessibilityValue_emptyWhenNoThreads() {
         let sut = CollapsedThreadSwitcherPresentation(regularThreads: [], activeThreadId: nil)
 
         XCTAssertEqual(sut.accessibilityValue, "")


### PR DESCRIPTION
## Summary
- Replace collapsed sidebar thread icon with a numeric count badge (rounded square)
- Badge uses `#E8E6DA` by default, `#D4DFD0` active green when viewing a thread
- Replace native popover with custom drawer matching settings drawer style
- Shows all regular threads with "N threads" caption header
- Extract `ThreadSwitcherDrawer` component

## Test plan
- [ ] Collapsed sidebar shows thread count badge
- [ ] Badge is default color when on panels, active green when on a thread
- [ ] Clicking badge opens drawer with all threads and caption header
- [ ] Clicking outside dismisses drawer
- [ ] Selecting a thread switches and dismisses
- [ ] `swift test --filter CollapsedThreadSwitcherPresentationTests` — 13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
