### PR TITLE
fix: demote Copy Code button to tertiary when channelHandle is present

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -562,7 +562,7 @@ struct ContactDetailView: View {
                 VButton(
                     label: inviteCopiedType == type ? "Copied!" : "Copy Code",
                     icon: "doc.on.doc",
-                    style: result.shareUrl != nil ? .tertiary : .secondary,
+                    style: (result.shareUrl != nil || result.channelHandle != nil) ? .tertiary : .secondary,
                     size: .medium
                 ) {
                     NSPasteboard.general.clearContents()


### PR DESCRIPTION
When a channelHandle is present (email, WhatsApp, SMS invites), the Copy Address button uses .secondary style. The Copy Code button should be demoted to .tertiary for visual consistency, matching the existing behavior when a shareUrl is present (Telegram).

Addresses feedback from PR #13156.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
