### PR TITLE
fix: guard against stale CDP session entry when session completes during Chrome launch

### DIFF
--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -180,6 +180,14 @@ export async function handleRideShotgunStart(
         cdpSession = await ensureChromeWithCdp({
           startUrl: targetDomain ? `https://${targetDomain}` : undefined,
         });
+        // If session completed while we were awaiting Chrome, skip storing to avoid a stale map entry
+        if (session.status !== "active") {
+          log.info(
+            { watchId, status: session.status },
+            "Session no longer active after CDP launch — skipping recording",
+          );
+          return;
+        }
         activeCdpSessions.set(watchId, cdpSession);
         log.info(
           {


### PR DESCRIPTION
Address reviewer feedback on PR #13151. When a ride-shotgun session completes (timeout or early stop) while ensureChromeWithCdp() is still awaiting, the resolved CDP session was stored in activeCdpSessions after completeSession() already ran, leaving a stale map entry. Now we check session.status before storing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
