### PR TITLE
fix: restore notification thread handling with pre-namespace compatibility

### DIFF
--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -358,6 +358,47 @@ describe("pairDeliveryWithConversation", () => {
     expect(upsertOutboundBindingMock).toHaveBeenCalledTimes(1);
   });
 
+  test("reuses pre-namespace binding when namespaced binding is absent", async () => {
+    // Simulate a binding created before the notification: prefix was introduced
+    mockExistingConversations["conv-legacy"] = {
+      id: "conv-legacy",
+      source: "notification",
+      title: "Legacy Telegram Thread",
+    };
+    mockBindings["telegram:chat-legacy"] = {
+      conversationId: "conv-legacy",
+      sourceChannel: "telegram",
+      externalChatId: "chat-legacy",
+    };
+
+    const signal = makeSignal();
+    const copy = makeCopy({
+      threadSeedMessage: "Delivery to legacy binding",
+    });
+    const bindingContext: DestinationBindingContext = {
+      sourceChannel: "telegram" as NotificationChannel,
+      externalChatId: "chat-legacy",
+    };
+
+    const result = await pairDeliveryWithConversation(
+      signal,
+      "telegram" as NotificationChannel,
+      copy,
+      { bindingContext },
+    );
+
+    expect(result.conversationId).toBe("conv-legacy");
+    expect(result.createdNewConversation).toBe(false);
+    expect(createConversationMock).not.toHaveBeenCalled();
+    // The upsert should write with the new namespaced sourceChannel
+    expect(upsertOutboundBindingMock).toHaveBeenCalledTimes(1);
+    const upsertArgs = upsertOutboundBindingMock.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(upsertArgs.sourceChannel).toBe("notification:telegram");
+  });
+
   test("falls back to new conversation when bound conversation is stale (wrong source)", async () => {
     mockExistingConversations["conv-user-owned"] = {
       id: "conv-user-owned",

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -61,6 +61,23 @@ import {
 export { handleUserMessage } from "./session-user-message.js";
 import { handleUserMessage } from "./session-user-message.js";
 
+/**
+ * Extract a valid ChannelId from a binding's sourceChannel, which may carry a
+ * `notification:` namespace prefix (e.g. `"notification:telegram"` -> `"telegram"`).
+ * Returns the ChannelId if valid, or null otherwise.
+ */
+function parseBindingSourceChannel(
+  sourceChannel: string,
+): import("../../channels/types.js").ChannelId | null {
+  if (isChannelId(sourceChannel)) return sourceChannel;
+  const NOTIFICATION_PREFIX = "notification:";
+  if (sourceChannel.startsWith(NOTIFICATION_PREFIX)) {
+    const inner = sourceChannel.slice(NOTIFICATION_PREFIX.length);
+    if (isChannelId(inner)) return inner;
+  }
+  return null;
+}
+
 export function syncCanonicalStatusFromIpcConfirmationDecision(
   requestId: string,
   decision: ConfirmationResponse["decision"],
@@ -283,10 +300,12 @@ export function handleSessionList(
         updatedAt: c.updatedAt,
         threadType: normalizeThreadType(c.threadType),
         source: c.source ?? "user",
-        ...(binding && isChannelId(binding.sourceChannel)
+        ...(binding && parseBindingSourceChannel(binding.sourceChannel)
           ? {
               channelBinding: {
-                sourceChannel: binding.sourceChannel,
+                sourceChannel: parseBindingSourceChannel(
+                  binding.sourceChannel,
+                )!,
                 externalChatId: binding.externalChatId,
                 externalUserId: binding.externalUserId,
                 displayName: binding.displayName,

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -220,10 +220,17 @@ export async function pairDeliveryWithConversation(
       bindingContext?.sourceChannel &&
       bindingContext?.externalChatId
     ) {
-      const existingBinding = getBindingByChannelChat(
-        notificationChannel(bindingContext.sourceChannel),
-        bindingContext.externalChatId,
-      );
+      // Look up by namespaced key first; fall back to pre-namespace key for
+      // bindings created before the notification: prefix was introduced.
+      const existingBinding =
+        getBindingByChannelChat(
+          notificationChannel(bindingContext.sourceChannel),
+          bindingContext.externalChatId,
+        ) ??
+        getBindingByChannelChat(
+          bindingContext.sourceChannel,
+          bindingContext.externalChatId,
+        );
 
       if (existingBinding) {
         const boundConversation = getConversation(


### PR DESCRIPTION
Keep notification: namespacing, restore thread lane/session handling, add compatibility for pre-namespace bindings.

- Add fallback lookup for pre-namespace bindings in conversation pairing so existing unprefixed bindings are found and reused instead of creating orphan threads
- Add parseBindingSourceChannel helper in sessions handler to strip notification: prefix before isChannelId check, ensuring channelBinding is correctly exposed for notification threads
- Add test for pre-namespace binding compatibility
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
