### PR TITLE
fix: prefer detected MIME over untrusted webhook hint in WhatsApp download

### DIFF
--- a/gateway/src/whatsapp/download.ts
+++ b/gateway/src/whatsapp/download.ts
@@ -62,11 +62,11 @@ export async function downloadWhatsAppFile(
 
   const detected = await fileTypeFromBuffer(new Uint8Array(buffer));
 
-  // Prefer the MIME type from Meta metadata, then hint, then detected, then Content-Type header
+  // Prefer the MIME type from Meta metadata, then detected (trusted), then hint (untrusted), then Content-Type header
   const mimeType =
     meta.mime_type ||
-    hint?.mimeType ||
     detected?.mime ||
+    hint?.mimeType ||
     response.headers.get("Content-Type")?.split(";")[0].trim() ||
     "application/octet-stream";
 


### PR DESCRIPTION
## Summary
- Reorder MIME type fallback in `downloadWhatsAppFile()` to prefer `fileTypeFromBuffer()` detection over untrusted webhook hints
- When Meta's `mime_type` is empty, a misreported client MIME could previously override the trusted detection result
- New order: Meta metadata > detected (trusted) > hint (untrusted) > Content-Type header > octet-stream

Addresses review feedback on #13177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
