### PR TITLE
fix: use locale-aware currency formatting in usage dashboard

### DIFF
--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -63,7 +63,12 @@ public enum UsageGroupByDimension: String, CaseIterable, Sendable {
 /// Formatting helpers for usage dashboard values, shared across platforms.
 public enum UsageFormatting {
     public static func formatCost(_ usd: Double) -> String {
-        String(format: "$%.4f", usd)
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = "USD"
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 4
+        return formatter.string(from: NSNumber(value: usd)) ?? String(format: "$%.4f", usd)
     }
 
     public static func formatCount(_ n: Int) -> String {


### PR DESCRIPTION
## Summary
- Replace `String(format:)` with `NumberFormatter` using `.currency` style in `UsageFormatting.formatCost`
- Ensures consistent locale-aware formatting alongside `formatCount` which already uses `NumberFormatter`
- Addresses review feedback on PR #13167

## Test plan
- Existing usage dashboard tests continue to pass
- Currency values now respect user locale (decimal/grouping separators, currency symbol placement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
