### PR TITLE
fix: clear failed Ride Shotgun session to prevent stale state

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -180,7 +180,9 @@ public final class AmbientAgent: ObservableObject {
             log.error("Ride shotgun session failed: \(reason)")
             progressWindow?.close()
             progressWindow = nil
-            showSummary("The assistant failed to start the session:\n\n\(reason)")
+            let failureMessage = "The assistant failed to start the session:\n\n\(reason)"
+            setCurrentSession(nil)
+            showSummary(failureMessage)
             sessionCancellable?.cancel()
             sessionCancellable = nil
 


### PR DESCRIPTION
## Summary
- Clear `currentSession` in the `.failed` handler of `handleSessionStateChange` to prevent a stale session from blocking new sessions and from showing a progress window after failure
- When `session.start()` fails synchronously, `showProgress()` was still running because `currentSession` remained set. Now it's cleared before `showSummary`, matching the `.cancelled` path behavior

Addresses feedback from PR #13170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
