### PR TITLE
fix: cancel in-flight usage dashboard tasks on disappear and filter changes

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -5,6 +5,8 @@ struct UsageDashboardPanel: View {
     let store: UsageDashboardStore
     var onClose: () -> Void
 
+    @State private var activeTask: Task<Void, Never>?
+
     var body: some View {
         VSidePanel(title: "Usage", onClose: onClose, pinnedContent: {
             timeRangeStrip(store: store)
@@ -13,11 +15,15 @@ struct UsageDashboardPanel: View {
             contentView(store: store)
         }
         .onAppear {
-            Task {
+            activeTask = Task {
                 if store.needsRefresh {
                     await store.refresh()
                 }
             }
+        }
+        .onDisappear {
+            activeTask?.cancel()
+            activeTask = nil
         }
     }
 
@@ -29,7 +35,8 @@ struct UsageDashboardPanel: View {
             HStack(spacing: VSpacing.sm) {
                 ForEach(UsageTimeRange.allCases, id: \.rawValue) { range in
                     Button {
-                        Task { await store.selectRange(range) }
+                        activeTask?.cancel()
+                        activeTask = Task { await store.selectRange(range) }
                     } label: {
                         Text(range.rawValue)
                             .font(VFont.captionMedium)
@@ -171,7 +178,8 @@ struct UsageDashboardPanel: View {
         HStack(spacing: VSpacing.xs) {
             ForEach(UsageGroupByDimension.allCases, id: \.rawValue) { dimension in
                 Button {
-                    Task { await store.selectGroupBy(dimension) }
+                    activeTask?.cancel()
+                    activeTask = Task { await store.selectGroupBy(dimension) }
                 } label: {
                     Text(dimension.rawValue.capitalized)
                         .font(VFont.small)


### PR DESCRIPTION
## Summary
- Store the active async task in `@State` and cancel it in `.onDisappear` per `clients/AGENTS.md` lifecycle rules
- Cancel and replace the active task when time range or group-by filter changes, preventing wasted in-flight fetches
- The store already has generation counters to discard stale results; this change additionally cancels the underlying network work

Addresses review feedback on #13166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
