### PR TITLE
fix: rebind UsageDashboardStore client after rebuildClient()

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -13,6 +13,10 @@ private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "Ap
 @MainActor
 final class ClientProvider: ObservableObject {
     @Published var client: any DaemonClientProtocol
+    /// Monotonically increasing counter bumped on each `rebuildClient()` call.
+    /// Views that cache the client can observe this to detect when the client
+    /// has been replaced.
+    @Published var clientGeneration: UInt = 0
     /// Mirrors the daemon client's `isConnected` state so views can observe a
     /// single source of truth. Automatically synced via Combine when the
     /// underlying client is a `DaemonClient`.
@@ -41,6 +45,7 @@ final class ClientProvider: ObservableObject {
         // Tear down the old client's connection, timers, and monitors before replacing.
         client.disconnect()
         self.client = DaemonClient(config: .fromUserDefaults())
+        self.clientGeneration &+= 1
         self.isConnected = false
         bindCombineBridge()
         bindTraceEvents()

--- a/clients/ios/Views/Settings/DeveloperSettingsSection.swift
+++ b/clients/ios/Views/Settings/DeveloperSettingsSection.swift
@@ -31,6 +31,7 @@ private struct DeveloperSettingsSectionContent: View {
     @State private var selectedSessionId: String?
     // Preserved across sheet presentations to avoid redundant network calls
     // and loading spinners each time the usage dashboard is opened.
+    // Updated via .onChange(of: clientGeneration) when rebuildClient() fires.
     @State private var usageDashboardStore: UsageDashboardStore
 
     init(clientProvider: ClientProvider, traceStore: TraceStore) {
@@ -93,6 +94,9 @@ private struct DeveloperSettingsSectionContent: View {
         }
         .sheet(isPresented: $showUsageDashboard) {
             UsageDashboardView(store: usageDashboardStore)
+        }
+        .onChange(of: clientProvider.clientGeneration) {
+            usageDashboardStore.updateClient(clientProvider.client)
         }
     }
 }

--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -91,7 +91,7 @@ public final class UsageDashboardStore {
 
     // MARK: - Dependencies
 
-    private let client: any DaemonClientProtocol
+    private var client: any DaemonClientProtocol
 
     /// Generation counters to discard results from stale in-flight requests
     /// when the user changes filters faster than fetches complete.
@@ -100,6 +100,15 @@ public final class UsageDashboardStore {
 
     public init(client: any DaemonClientProtocol) {
         self.client = client
+    }
+
+    /// Replace the underlying client and reset all loaded data so the next
+    /// `refresh()` fetches from the new client.
+    public func updateClient(_ newClient: any DaemonClientProtocol) {
+        client = newClient
+        totalsState = .idle
+        dailyState = .idle
+        breakdownState = .idle
     }
 
     /// Whether any section needs a (re)fetch — used by views to auto-refresh


### PR DESCRIPTION
## Summary
- Fixes stale client bug where `UsageDashboardStore` retained a disconnected client reference after `rebuildClient()` was called (e.g. after QR pairing)
- Adds `clientGeneration` counter to `ClientProvider` that increments on each `rebuildClient()` call
- Adds `updateClient(_:)` method to `UsageDashboardStore` to swap the client and reset loading states
- Uses `.onChange(of: clientProvider.clientGeneration)` in `DeveloperSettingsSectionContent` to rebind the store

Addresses review feedback on #13179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
