### PR TITLE
fix: add @preconcurrency import Sentry to CrashReportView and AppDelegate

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -3,7 +3,7 @@ import Carbon
 import VellumAssistantShared
 import Combine
 import CoreText
-import Sentry
+@preconcurrency import Sentry
 import SwiftUI
 import UserNotifications
 import os

--- a/clients/macos/vellum-assistant/Features/Settings/CrashReportView.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/CrashReportView.swift
@@ -1,5 +1,5 @@
 import AppKit
-import Sentry
+@preconcurrency import Sentry
 import SwiftUI
 import VellumAssistantShared
 


### PR DESCRIPTION
## Summary
- Adds `@preconcurrency import Sentry` to `CrashReportView.swift` and `AppDelegate.swift` to suppress Sendable warnings when Sentry types cross isolation boundaries
- Addresses review feedback from PR #13172

## Test plan
- [ ] Verify macOS client builds without Sendable warnings for Sentry types