### PR TITLE
fix: conditional VButton accessibilityIdentifier and safe clipboard restore

### DIFF
--- a/clients/shared/DesignSystem/Core/Buttons/VButton.swift
+++ b/clients/shared/DesignSystem/Core/Buttons/VButton.swift
@@ -65,7 +65,7 @@ public struct VButton: View {
         .disabled(isDisabled)
         .opacity(isDisabled ? 0.5 : 1.0)
         .accessibilityHint(isDisabled ? "Button is currently disabled" : "")
-        .accessibilityIdentifier(accessibilityID ?? "")
+        .optionalAccessibilityIdentifier(accessibilityID)
     }
 
     private var iconSize: CGFloat {
@@ -209,6 +209,17 @@ private struct VButtonStyle: ButtonStyle {
             return .clear
         default:
             return .clear
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func optionalAccessibilityIdentifier(_ identifier: String?) -> some View {
+        if let identifier {
+            self.accessibilityIdentifier(identifier)
+        } else {
+            self
         }
     }
 }

--- a/playwright/agent/tools/fill-secure-credential.ts
+++ b/playwright/agent/tools/fill-secure-credential.ts
@@ -154,7 +154,11 @@ tell application "System Events"
     end repeat
 
     -- Restore the clipboard to its original value.
-    set the clipboard to savedClip
+    -- Only restore if we captured text; if the original clipboard was non-text
+    -- (image, file, etc.), savedClip is still "" and restoring would clobber it.
+    if savedClip is not "" then
+      set the clipboard to savedClip
+    end if
 
     if not foundField then
       error "Could not find or focus the text field in the Secure Credential panel"


### PR DESCRIPTION
## Summary
Fixes two review gaps from the phone-setup e2e fix plan:

- **VButton**: Only apply `.accessibilityIdentifier()` when `accessibilityID` is non-nil, avoiding setting empty-string identifiers on all 36+ VButton instances in the app
- **fill-secure-credential**: Skip clipboard restore when the original clipboard contained non-text data (image, file) to avoid clobbering it with an empty string

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
