### PR TITLE
fix: add missing ride_shotgun_error IPC snapshot

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1641,6 +1641,15 @@ exports[`IPC message snapshots ServerMessage types task_routed serializes to exp
 }
 `;
 
+exports[`IPC message snapshots ServerMessage types ride_shotgun_error serializes to expected JSON 1`] = `
+{
+  "message": "Failed to start browser — Chrome CDP could not be launched.",
+  "sessionId": "sess-shotgun-001",
+  "type": "ride_shotgun_error",
+  "watchId": "watch-shotgun-001",
+}
+`;
+
 exports[`IPC message snapshots ServerMessage types ride_shotgun_progress serializes to expected JSON 1`] = `
 {
   "message": "Observing user activity...",


### PR DESCRIPTION
Adds the missing snapshot for the `ride_shotgun_error` server message type, fixing the failing CI test in `ipc-snapshot.test.ts`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
