### PR TITLE
fix: replace undefined isTerminalMediaFailure with isAuthError check

### DIFF
--- a/gateway/src/whatsapp/api.ts
+++ b/gateway/src/whatsapp/api.ts
@@ -432,10 +432,10 @@ async function retryableWhatsAppRawFetch(
           ? `WhatsApp ${operation} failed with status ${response.status}: ${body}`
           : `WhatsApp ${operation} failed with status ${response.status}`;
 
-      if (isTerminalMediaFailure(response.status)) {
-        throw new WhatsAppNonRetryableError(message);
+      if (isAuthError(response.status)) {
+        throw new Error(message);
       }
-      throw new Error(message);
+      throw new WhatsAppNonRetryableError(message);
     }
 
     if (isRetryable(response.status)) {


### PR DESCRIPTION
## Summary

- Fix TS2304 build error: `isTerminalMediaFailure` was used in `retryableWhatsAppRawFetch` but never defined
- Replace with `isAuthError` check to match the pattern in `retryableWhatsAppFetch`: auth errors (401/403) throw regular errors (retryable by Meta), all other non-OK/non-retryable statuses throw `WhatsAppNonRetryableError`

## Test plan

- [ ] CI type-check passes (was failing with `TS2304: Cannot find name 'isTerminalMediaFailure'`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
