### PR TITLE
fix: inline config helpers in cli ngrok.ts after config.ts removal

### DIFF
--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -1,7 +1,30 @@
 import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 
-import { loadRawConfig, saveRawConfig } from "./config";
 import { GATEWAY_PORT } from "./constants";
+
+function getConfigPath(): string {
+  const root = join(process.env.BASE_DATA_DIR?.trim() || homedir(), ".vellum");
+  return join(root, "workspace", "config.json");
+}
+
+function loadRawConfig(): Record<string, unknown> {
+  const configPath = getConfigPath();
+  if (!existsSync(configPath)) return {};
+  return JSON.parse(readFileSync(configPath, "utf-8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+function saveRawConfig(config: Record<string, unknown>): void {
+  const configPath = getConfigPath();
+  const dir = dirname(configPath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+}
 
 const NGROK_API_URL = "http://127.0.0.1:4040/api/tunnels";
 const NGROK_POLL_INTERVAL_MS = 500;


### PR DESCRIPTION
## Summary
- `cli/src/lib/config.ts` was deleted in #13243, breaking the `./config` import in `cli/src/lib/ngrok.ts`
- Inlined the three needed helpers (`getConfigPath`, `loadRawConfig`, `saveRawConfig`) directly into `ngrok.ts`
- Fixes 3 consecutive CI failures on `ci-main-cli.yaml`

## Test plan
- [ ] `ci-main-cli.yaml` type check step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
