### PR TITLE
refactor: remove keychain CLI reading from gateway, encrypted-only fallback

### DIFF
--- a/gateway/src/__tests__/credential-reader.test.ts
+++ b/gateway/src/__tests__/credential-reader.test.ts
@@ -21,23 +21,7 @@ mock.module("../logger.js", () => ({
     }),
 }));
 
-// ---------------------------------------------------------------------------
-// Mock execFileSync — intercept keychain CLI calls
-// ---------------------------------------------------------------------------
-
-let execFileSyncMock: ReturnType<typeof mock>;
-
-mock.module("node:child_process", () => {
-  execFileSyncMock = mock(() => {
-    throw new Error("not found");
-  });
-  return { execFileSync: execFileSyncMock };
-});
-
-import {
-  readTelegramCredentials,
-  readKeychainCredential,
-} from "../credential-reader.js";
+import { readTelegramCredentials } from "../credential-reader.js";
 
 // ---------------------------------------------------------------------------
 // Temp directory for metadata / encrypted store fixtures
@@ -129,18 +113,9 @@ function writeEncryptedStore(entries: Record<string, string>): void {
   writeFileSync(storePath, JSON.stringify(store));
 }
 
-const originalPlatform = process.platform;
-
 beforeEach(() => {
   process.env.BASE_DATA_DIR = testDir;
   logCalls.length = 0;
-  execFileSyncMock.mockReset();
-  // Default: execFileSync throws with exit code 44 (errSecItemNotFound)
-  execFileSyncMock.mockImplementation(() => {
-    const err = new Error("not found") as Error & { status: number };
-    err.status = 44;
-    throw err;
-  });
 });
 
 afterEach(() => {
@@ -150,18 +125,13 @@ afterEach(() => {
   } catch {
     // best-effort cleanup
   }
-  // Restore platform in case a test changed it
-  Object.defineProperty(process, "platform", {
-    value: originalPlatform,
-    writable: true,
-  });
 });
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("readTelegramCredentials: encrypted store only (existing behavior)", () => {
+describe("readTelegramCredentials", () => {
   test("returns null when metadata file does not exist", () => {
     const result = readTelegramCredentials();
     expect(result).toBeNull();
@@ -173,79 +143,22 @@ describe("readTelegramCredentials: encrypted store only (existing behavior)", ()
     expect(result).toBeNull();
   });
 
-  test("returns null when metadata exists but secrets are missing from both backends", () => {
+  test("returns null when metadata exists but secrets are missing from encrypted store", () => {
     writeMetadata([
       { service: "telegram", field: "bot_token" },
       { service: "telegram", field: "webhook_secret" },
     ]);
 
-    // Keychain returns nothing (throws), encrypted store has no file
     const result = readTelegramCredentials();
     expect(result).toBeNull();
   });
-});
 
-describe("readTelegramCredentials: keychain on macOS", () => {
-  beforeEach(() => {
-    Object.defineProperty(process, "platform", {
-      value: "darwin",
-      writable: true,
-    });
-  });
-
-  test("returns credentials from keychain when available on macOS", () => {
+  test("returns credentials from encrypted store", () => {
     writeMetadata([
       { service: "telegram", field: "bot_token" },
       { service: "telegram", field: "webhook_secret" },
     ]);
 
-    // Simulate keychain returning credentials
-    execFileSyncMock.mockImplementation((_cmd: string, args: string[]) => {
-      const aIdx = (args as string[]).indexOf("-a");
-      const account = (args as string[])[aIdx + 1];
-      if (account === "credential:telegram:bot_token") return "kc-bot-token\n";
-      if (account === "credential:telegram:webhook_secret")
-        return "kc-webhook-secret\n";
-      throw new Error("not found");
-    });
-
-    const result = readTelegramCredentials();
-    expect(result).toEqual({
-      botToken: "kc-bot-token",
-      webhookSecret: "kc-webhook-secret",
-    });
-  });
-
-  test("prefers keychain over encrypted store on macOS", () => {
-    writeMetadata([
-      { service: "telegram", field: "bot_token" },
-      { service: "telegram", field: "webhook_secret" },
-    ]);
-
-    // Keychain returns credentials — encrypted store should not be consulted
-    execFileSyncMock.mockImplementation((_cmd: string, args: string[]) => {
-      const aIdx = (args as string[]).indexOf("-a");
-      const account = (args as string[])[aIdx + 1];
-      if (account === "credential:telegram:bot_token")
-        return "keychain-token\n";
-      if (account === "credential:telegram:webhook_secret")
-        return "keychain-secret\n";
-      throw new Error("not found");
-    });
-
-    const result = readTelegramCredentials();
-    expect(result).not.toBeNull();
-    expect(result!.botToken).toBe("keychain-token");
-    expect(result!.webhookSecret).toBe("keychain-secret");
-  });
-
-  test("falls back to encrypted store when keychain has no credentials", () => {
-    writeMetadata([
-      { service: "telegram", field: "bot_token" },
-      { service: "telegram", field: "webhook_secret" },
-    ]);
-
-    // Keychain throws (credential not found) — fall through to encrypted store.
     writeEncryptedStore({
       "credential:telegram:bot_token": "enc-bot-token",
       "credential:telegram:webhook_secret": "enc-webhook-secret",
@@ -259,142 +172,21 @@ describe("readTelegramCredentials: keychain on macOS", () => {
   });
 });
 
-describe("readTelegramCredentials: non-macOS platforms", () => {
-  test("skips keychain on non-macOS and uses encrypted store", () => {
-    Object.defineProperty(process, "platform", {
-      value: "linux",
-      writable: true,
-    });
-
-    writeMetadata([
-      { service: "telegram", field: "bot_token" },
-      { service: "telegram", field: "webhook_secret" },
-    ]);
-
-    // readKeychainCredential should return undefined on linux
-    const keychainResult = readKeychainCredential(
-      "credential:telegram:bot_token",
-    );
-    expect(keychainResult).toBeUndefined();
-
-    // execFileSync should NOT have been called since platform is not darwin
-    expect(execFileSyncMock).not.toHaveBeenCalled();
-  });
-});
-
-describe("readTelegramCredentials: neither backend has credentials", () => {
-  test("returns null when both keychain and encrypted store have nothing", () => {
-    writeMetadata([
-      { service: "telegram", field: "bot_token" },
-      { service: "telegram", field: "webhook_secret" },
-    ]);
-
-    // Keychain throws, encrypted store file doesn't exist
-    const result = readTelegramCredentials();
-    expect(result).toBeNull();
-  });
-});
-
-describe("readKeychainCredential", () => {
-  beforeEach(() => {
-    Object.defineProperty(process, "platform", {
-      value: "darwin",
-      writable: true,
-    });
-  });
-
-  test("returns credential value from keychain on macOS", () => {
-    execFileSyncMock.mockImplementation(() => "my-secret-value\n");
-
-    const result = readKeychainCredential("credential:telegram:bot_token");
-    expect(result).toBe("my-secret-value");
-  });
-
-  test("returns undefined when keychain item not found (exit code 44)", () => {
-    execFileSyncMock.mockImplementation(() => {
-      const err = new Error(
-        "security: SecKeychainSearchCopyNext: The specified item could not be found",
-      ) as Error & { status: number };
-      err.status = 44;
-      throw err;
-    });
-
-    const result = readKeychainCredential("credential:telegram:bot_token");
-    expect(result).toBeUndefined();
-  });
-
-  test("returns undefined for transient keychain errors (non-44 exit code)", () => {
-    execFileSyncMock.mockImplementation(() => {
-      const err = new Error(
-        "security: The user name or passphrase you entered is not correct.",
-      ) as Error & { status: number };
-      err.status = 51;
-      throw err;
-    });
-
-    // Should still return undefined (graceful fallback), but logs a warning
-    const result = readKeychainCredential("credential:telegram:bot_token");
-    expect(result).toBeUndefined();
-  });
-
-  test("returns undefined on non-darwin platforms", () => {
-    Object.defineProperty(process, "platform", {
-      value: "linux",
-      writable: true,
-    });
-
-    const result = readKeychainCredential("credential:telegram:bot_token");
-    expect(result).toBeUndefined();
-    expect(execFileSyncMock).not.toHaveBeenCalled();
-  });
-
-  test("passes correct service name and account to security CLI", () => {
-    execFileSyncMock.mockImplementation(() => "value\n");
-
-    readKeychainCredential("credential:telegram:bot_token");
-
-    expect(execFileSyncMock).toHaveBeenCalledWith(
-      "security",
-      [
-        "find-generic-password",
-        "-s",
-        "vellum-assistant",
-        "-a",
-        "credential:telegram:bot_token",
-        "-w",
-      ],
-      expect.objectContaining({ encoding: "utf-8", timeout: 5000 }),
-    );
-  });
-});
-
 describe("log output: no plaintext secrets", () => {
-  beforeEach(() => {
-    Object.defineProperty(process, "platform", {
-      value: "darwin",
-      writable: true,
-    });
-  });
-
   test("log messages never contain secret values", () => {
     writeMetadata([
       { service: "telegram", field: "bot_token" },
       { service: "telegram", field: "webhook_secret" },
     ]);
 
-    execFileSyncMock.mockImplementation((_cmd: string, args: string[]) => {
-      const aIdx = (args as string[]).indexOf("-a");
-      const account = (args as string[])[aIdx + 1];
-      if (account === "credential:telegram:bot_token")
-        return "SUPER_SECRET_TOKEN_123\n";
-      if (account === "credential:telegram:webhook_secret")
-        return "SUPER_SECRET_WEBHOOK_456\n";
-      throw new Error("not found");
+    writeEncryptedStore({
+      "credential:telegram:bot_token": "SUPER_SECRET_TOKEN_123",
+      "credential:telegram:webhook_secret": "SUPER_SECRET_WEBHOOK_456",
     });
 
     const result = readTelegramCredentials();
 
-    // Verify credentials were actually returned (mock is working)
+    // Verify credentials were actually returned
     expect(result).not.toBeNull();
     expect(result!.botToken).toBe("SUPER_SECRET_TOKEN_123");
 

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -3,7 +3,6 @@ import { join } from "node:path";
 import { getLogger, type LogFileConfig } from "./logger.js";
 import {
   getRootDir,
-  readKeychainCredential,
   readCredential,
   readTwilioCredentials,
   readWhatsAppCredentials,
@@ -301,7 +300,7 @@ export function loadConfig(): GatewayConfig {
     );
   }
 
-  // Twilio credentials: env var > credential store (keychain / encrypted file)
+  // Twilio credentials: env var > credential store (encrypted file)
   const twilioCreds = readTwilioCredentials();
   const twilioAuthToken =
     process.env.TWILIO_AUTH_TOKEN || twilioCreds?.authToken || undefined;
@@ -344,12 +343,10 @@ export function loadConfig(): GatewayConfig {
   }
   if (!twilioPhoneNumber) {
     twilioPhoneNumber =
-      readKeychainCredential("credential:twilio:phone_number") ||
-      readCredential("credential:twilio:phone_number") ||
-      undefined;
+      readCredential("credential:twilio:phone_number") || undefined;
   }
 
-  // WhatsApp credentials: env var > credential store (keychain / encrypted file)
+  // WhatsApp credentials: env var > credential store (encrypted file)
   const whatsappCreds = readWhatsAppCredentials();
   const whatsappPhoneNumberId =
     process.env.WHATSAPP_PHONE_NUMBER_ID ||
@@ -407,7 +404,7 @@ export function loadConfig(): GatewayConfig {
     );
   }
 
-  // Slack channel credentials: env var > credential store (keychain / encrypted file)
+  // Slack channel credentials: env var > credential store (encrypted file)
   const slackChannelCreds = readSlackChannelCredentials();
   const slackChannelBotToken =
     process.env.SLACK_CHANNEL_BOT_TOKEN ||

--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -1,15 +1,9 @@
 /**
  * Read-only reader for the assistant's credential stores.
  *
- * The assistant persists secrets in either:
- * 1. macOS Keychain (via `security` CLI) — preferred on darwin
- * 2. Encrypted-at-rest file (~/.vellum/protected/keys.enc) — fallback
- *
- * This module tries the OS keychain first on macOS, then falls back to
- * the encrypted store, mirroring the assistant's own secure-keys module.
+ * Reads secrets from the encrypted-at-rest file (~/.vellum/protected/keys.enc).
  */
 
-import { execFileSync } from "node:child_process";
 import { createDecipheriv, pbkdf2Sync } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { hostname, userInfo } from "node:os";
@@ -17,9 +11,6 @@ import { join } from "node:path";
 import { getLogger } from "./logger.js";
 
 const log = getLogger("credential-reader");
-
-/** Service name matching the assistant's keychain module. */
-const KEYCHAIN_SERVICE = "vellum-assistant";
 
 const ALGORITHM = "aes-256-gcm";
 const AUTH_TAG_LENGTH = 16;
@@ -124,46 +115,6 @@ export function getMetadataPath(): string {
 }
 
 /**
- * Read a single credential from the macOS Keychain.
- * Returns `undefined` on non-macOS platforms, when the credential
- * doesn't exist, or on any error.
- *
- * Exit code 44 from `security` means errSecItemNotFound — the credential
- * genuinely doesn't exist. Other non-zero exit codes indicate transient
- * errors (locked keychain, timeout, etc.) and are logged as warnings so
- * operators have visibility into keychain health.
- */
-export function readKeychainCredential(account: string): string | undefined {
-  if (process.platform !== "darwin") return undefined;
-
-  try {
-    const result = execFileSync(
-      "security",
-      ["find-generic-password", "-s", KEYCHAIN_SERVICE, "-a", account, "-w"],
-      {
-        stdio: ["ignore", "pipe", "ignore"],
-        timeout: 5000,
-        encoding: "utf-8",
-      },
-    );
-    const value = result.replace(/\n$/, "");
-    if (!value) return undefined;
-    log.debug({ account }, "Credential found in keychain");
-    return value;
-  } catch (err: unknown) {
-    // Exit code 44 = errSecItemNotFound — credential genuinely missing
-    const exitCode = (err as { status?: number }).status;
-    if (exitCode !== 44) {
-      log.warn(
-        { account, exitCode },
-        "Keychain lookup failed with unexpected error",
-      );
-    }
-    return undefined;
-  }
-}
-
-/**
  * Read a single credential from the encrypted store.
  * Returns `undefined` if the store doesn't exist, the key is missing,
  * or decryption fails.
@@ -196,27 +147,13 @@ export type TwilioCredentials = {
 };
 
 /**
- * Read a credential by trying keychain first (on macOS), then encrypted store.
- */
-function readCredentialWithFallback(account: string): string | undefined {
-  const keychainValue = readKeychainCredential(account);
-  if (keychainValue !== undefined) return keychainValue;
-
-  const encValue = readCredential(account);
-  if (encValue !== undefined) {
-    log.debug({ account }, "Credential found in encrypted store");
-  }
-  return encValue;
-}
-
-/**
  * Check the credential metadata file for Telegram credentials and read
- * them from secure storage (keychain on macOS, then encrypted store).
+ * them from the encrypted store.
  *
  * Returns `null` if:
  * - The metadata file doesn't exist or can't be parsed
  * - Telegram bot_token or webhook_secret entries are missing from metadata
- * - The actual secret values can't be read from any backend
+ * - The actual secret values can't be read from the encrypted store
  */
 export function readTelegramCredentials(): TelegramCredentials | null {
   try {
@@ -238,16 +175,12 @@ export function readTelegramCredentials(): TelegramCredentials | null {
 
     if (!hasBotToken || !hasWebhookSecret) return null;
 
-    const botToken = readCredentialWithFallback(
-      "credential:telegram:bot_token",
-    );
-    const webhookSecret = readCredentialWithFallback(
-      "credential:telegram:webhook_secret",
-    );
+    const botToken = readCredential("credential:telegram:bot_token");
+    const webhookSecret = readCredential("credential:telegram:webhook_secret");
 
     if (!botToken || !webhookSecret) {
       log.warn(
-        "Telegram credential metadata exists but secrets could not be read from any backend",
+        "Telegram credential metadata exists but secrets could not be read from encrypted store",
       );
       return null;
     }
@@ -261,12 +194,12 @@ export function readTelegramCredentials(): TelegramCredentials | null {
 
 /**
  * Check the credential metadata file for Twilio credentials and read
- * them from secure storage (keychain on macOS, then encrypted store).
+ * them from the encrypted store.
  *
  * Returns `null` if:
  * - The metadata file doesn't exist or can't be parsed
  * - Twilio account_sid or auth_token entries are missing from metadata
- * - The actual secret values can't be read from any backend
+ * - The actual secret values can't be read from the encrypted store
  */
 export function readTwilioCredentials(): TwilioCredentials | null {
   try {
@@ -288,16 +221,12 @@ export function readTwilioCredentials(): TwilioCredentials | null {
 
     if (!hasAccountSid || !hasAuthToken) return null;
 
-    const accountSid = readCredentialWithFallback(
-      "credential:twilio:account_sid",
-    );
-    const authToken = readCredentialWithFallback(
-      "credential:twilio:auth_token",
-    );
+    const accountSid = readCredential("credential:twilio:account_sid");
+    const authToken = readCredential("credential:twilio:auth_token");
 
     if (!accountSid || !authToken) {
       log.warn(
-        "Twilio credential metadata exists but secrets could not be read from any backend",
+        "Twilio credential metadata exists but secrets could not be read from encrypted store",
       );
       return null;
     }
@@ -318,12 +247,12 @@ export type SlackChannelCredentials = {
 
 /**
  * Check the credential metadata file for Slack channel credentials and read
- * them from secure storage (keychain on macOS, then encrypted store).
+ * them from the encrypted store.
  *
  * Returns `null` if:
  * - The metadata file doesn't exist or can't be parsed
  * - Slack channel bot_token or app_token entries are missing from metadata
- * - The actual secret values can't be read from any backend
+ * - The actual secret values can't be read from the encrypted store
  */
 export function readSlackChannelCredentials(): SlackChannelCredentials | null {
   try {
@@ -345,16 +274,12 @@ export function readSlackChannelCredentials(): SlackChannelCredentials | null {
 
     if (!hasBotToken || !hasAppToken) return null;
 
-    const botToken = readCredentialWithFallback(
-      "credential:slack_channel:bot_token",
-    );
-    const appToken = readCredentialWithFallback(
-      "credential:slack_channel:app_token",
-    );
+    const botToken = readCredential("credential:slack_channel:bot_token");
+    const appToken = readCredential("credential:slack_channel:app_token");
 
     if (!botToken || !appToken) {
       log.warn(
-        "Slack channel credential metadata exists but secrets could not be read from any backend",
+        "Slack channel credential metadata exists but secrets could not be read from encrypted store",
       );
       return null;
     }
@@ -379,12 +304,12 @@ export type WhatsAppCredentials = {
 
 /**
  * Check the credential metadata file for WhatsApp credentials and read
- * them from secure storage (keychain on macOS, then encrypted store).
+ * them from the encrypted store.
  *
  * Returns `null` if:
  * - The metadata file doesn't exist or can't be parsed
  * - Required WhatsApp entries are missing from metadata
- * - The actual secret values can't be read from any backend
+ * - The actual secret values can't be read from the encrypted store
  */
 export function readWhatsAppCredentials(): WhatsAppCredentials | null {
   try {
@@ -420,22 +345,16 @@ export function readWhatsAppCredentials(): WhatsAppCredentials | null {
     )
       return null;
 
-    const phoneNumberId = readCredentialWithFallback(
-      "credential:whatsapp:phone_number_id",
-    );
-    const accessToken = readCredentialWithFallback(
-      "credential:whatsapp:access_token",
-    );
-    const appSecret = readCredentialWithFallback(
-      "credential:whatsapp:app_secret",
-    );
-    const webhookVerifyToken = readCredentialWithFallback(
+    const phoneNumberId = readCredential("credential:whatsapp:phone_number_id");
+    const accessToken = readCredential("credential:whatsapp:access_token");
+    const appSecret = readCredential("credential:whatsapp:app_secret");
+    const webhookVerifyToken = readCredential(
       "credential:whatsapp:webhook_verify_token",
     );
 
     if (!phoneNumberId || !accessToken || !appSecret || !webhookVerifyToken) {
       log.warn(
-        "WhatsApp credential metadata exists but secrets could not be read from any backend",
+        "WhatsApp credential metadata exists but secrets could not be read from encrypted store",
       );
       return null;
     }


### PR DESCRIPTION
## Summary
- Remove readKeychainCredential() and readCredentialWithFallback() from gateway credential-reader
- Update all credential readers (Telegram, Twilio, Slack, WhatsApp) to use readCredential() directly
- Remove keychain import from config.ts, simplify to readCredential() only
- Remove keychain mocking infrastructure from credential-reader tests

Part of plan: app-embedded-keychain-broker.md (PR 4 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
