### PR TITLE
refactor: extract contacts CLI into contacts.ts

### DIFF
--- a/assistant/src/cli/contacts.ts
+++ b/assistant/src/cli/contacts.ts
@@ -1,0 +1,81 @@
+import type { Command } from "commander";
+
+import {
+  gatewayGet,
+  gatewayPost,
+  runRead,
+  toQueryString,
+} from "./integrations.js";
+
+type IngressChannel = "telegram" | "voice" | "sms";
+
+export function registerContactsCommand(program: Command): void {
+  const contacts = program
+    .command("contacts")
+    .description("Manage and query the contact graph")
+    .option("--json", "Machine-readable compact JSON output");
+
+  contacts
+    .command("list")
+    .description("List contacts (calls /v1/contacts)")
+    .option("--role <role>", "Filter by role (default: contact)", "contact")
+    .option("--limit <limit>", "Maximum number of contacts to return")
+    .option("--query <query>", "Search query to filter contacts")
+    .action(
+      async (
+        opts: {
+          role?: string;
+          limit?: string;
+          query?: string;
+        },
+        cmd: Command,
+      ) => {
+        const query = toQueryString({
+          role: opts.role,
+          limit: opts.limit,
+          query: opts.query,
+        });
+        await runRead(cmd, async () => gatewayGet(`/v1/contacts${query}`));
+      },
+    );
+
+  contacts
+    .command("get <id>")
+    .description("Get a contact by ID")
+    .action(async (id: string, _opts: unknown, cmd: Command) => {
+      await runRead(cmd, async () =>
+        gatewayGet(`/v1/contacts/${encodeURIComponent(id)}`),
+      );
+    });
+
+  contacts
+    .command("merge <keepId> <mergeId>")
+    .description("Merge two contacts")
+    .action(
+      async (keepId: string, mergeId: string, _opts: unknown, cmd: Command) => {
+        await runRead(cmd, async () =>
+          gatewayPost("/v1/contacts/merge", { keepId, mergeId }),
+        );
+      },
+    );
+
+  contacts
+    .command("invites")
+    .description("List contact invites")
+    .option("--source-channel <sourceChannel>", "Filter by source channel")
+    .option("--status <status>", "Filter by invite status")
+    .action(
+      async (
+        opts: { sourceChannel?: IngressChannel; status?: string },
+        cmd: Command,
+      ) => {
+        const query = toQueryString({
+          sourceChannel: opts.sourceChannel,
+          status: opts.status,
+        });
+        await runRead(cmd, async () =>
+          gatewayGet(`/v1/contacts/invites${query}`),
+        );
+      },
+    );
+}

--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -10,7 +10,6 @@ import {
   mintEdgeRelayToken,
 } from "../runtime/auth/token-service.js";
 
-type IngressChannel = "telegram" | "voice" | "sms";
 type GuardianChannel = "telegram" | "voice" | "sms";
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -20,7 +19,7 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function shouldOutputJson(cmd: Command): boolean {
+export function shouldOutputJson(cmd: Command): boolean {
   let current: Command | null = cmd;
   while (current) {
     if ((current.opts() as { json?: boolean }).json) return true;
@@ -29,7 +28,7 @@ function shouldOutputJson(cmd: Command): boolean {
   return false;
 }
 
-function writeOutput(cmd: Command, payload: unknown): void {
+export function writeOutput(cmd: Command, payload: unknown): void {
   const compact = shouldOutputJson(cmd);
   process.stdout.write(
     compact
@@ -49,7 +48,9 @@ function getGatewayToken(): string {
   return mintEdgeRelayToken();
 }
 
-function toQueryString(params: Record<string, string | undefined>): string {
+export function toQueryString(
+  params: Record<string, string | undefined>,
+): string {
   const query = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
     if (value) query.set(key, value);
@@ -107,7 +108,7 @@ function readVoiceConfig(): {
 // CLI-specific gateway helper — uses GATEWAY_AUTH_TOKEN env var for out-of-process
 // access. See runtime/gateway-internal-client.ts for daemon-internal usage which
 // mints fresh tokens.
-async function gatewayGet(path: string): Promise<unknown> {
+export async function gatewayGet(path: string): Promise<unknown> {
   const gatewayBase = getGatewayInternalBaseUrl();
   const token = getGatewayToken();
 
@@ -141,7 +142,10 @@ async function gatewayGet(path: string): Promise<unknown> {
   return parsed;
 }
 
-async function gatewayPost(path: string, body: unknown): Promise<unknown> {
+export async function gatewayPost(
+  path: string,
+  body: unknown,
+): Promise<unknown> {
   const gatewayBase = getGatewayInternalBaseUrl();
   const token = getGatewayToken();
 
@@ -177,7 +181,7 @@ async function gatewayPost(path: string, body: unknown): Promise<unknown> {
   return parsed;
 }
 
-async function runRead(
+export async function runRead(
   cmd: Command,
   reader: () => Promise<unknown>,
 ): Promise<void> {
@@ -189,77 +193,6 @@ async function runRead(
     writeOutput(cmd, { ok: false, error: message });
     process.exitCode = 1;
   }
-}
-
-export function registerContactsCommand(program: Command): void {
-  const contacts = program
-    .command("contacts")
-    .description("Manage and query the contact graph")
-    .option("--json", "Machine-readable compact JSON output");
-
-  contacts
-    .command("list")
-    .description("List contacts (calls /v1/contacts)")
-    .option("--role <role>", "Filter by role (default: contact)", "contact")
-    .option("--limit <limit>", "Maximum number of contacts to return")
-    .option("--query <query>", "Search query to filter contacts")
-    .action(
-      async (
-        opts: {
-          role?: string;
-          limit?: string;
-          query?: string;
-        },
-        cmd: Command,
-      ) => {
-        const query = toQueryString({
-          role: opts.role,
-          limit: opts.limit,
-          query: opts.query,
-        });
-        await runRead(cmd, async () => gatewayGet(`/v1/contacts${query}`));
-      },
-    );
-
-  contacts
-    .command("get <id>")
-    .description("Get a contact by ID")
-    .action(async (id: string, _opts: unknown, cmd: Command) => {
-      await runRead(cmd, async () =>
-        gatewayGet(`/v1/contacts/${encodeURIComponent(id)}`),
-      );
-    });
-
-  contacts
-    .command("merge <keepId> <mergeId>")
-    .description("Merge two contacts")
-    .action(
-      async (keepId: string, mergeId: string, _opts: unknown, cmd: Command) => {
-        await runRead(cmd, async () =>
-          gatewayPost("/v1/contacts/merge", { keepId, mergeId }),
-        );
-      },
-    );
-
-  contacts
-    .command("invites")
-    .description("List contact invites")
-    .option("--source-channel <sourceChannel>", "Filter by source channel")
-    .option("--status <status>", "Filter by invite status")
-    .action(
-      async (
-        opts: { sourceChannel?: IngressChannel; status?: string },
-        cmd: Command,
-      ) => {
-        const query = toQueryString({
-          sourceChannel: opts.sourceChannel,
-          status: opts.status,
-        });
-        await runRead(cmd, async () =>
-          gatewayGet(`/v1/contacts/invites${query}`),
-        );
-      },
-    );
 }
 
 export function registerIntegrationsCommand(program: Command): void {

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -25,10 +25,8 @@ import {
 } from "./cli/core-commands.js";
 import { registerEmailCommand } from "./cli/email.js";
 import { registerInfluencerCommand } from "./cli/influencer.js";
-import {
-  registerContactsCommand,
-  registerIntegrationsCommand,
-} from "./cli/integrations.js";
+import { registerContactsCommand } from "./cli/contacts.js";
+import { registerIntegrationsCommand } from "./cli/integrations.js";
 import { registerMapCommand } from "./cli/map.js";
 import { registerMcpCommand } from "./cli/mcp.js";
 import { registerSequenceCommand } from "./cli/sequence.js";


### PR DESCRIPTION
Moves `registerContactsCommand` out of `integrations.ts` into a dedicated `contacts.ts` file under `assistant/src/cli/`.

- Created `assistant/src/cli/contacts.ts` with the contacts command and its `IngressChannel` type
- Exported shared gateway helpers (`gatewayGet`, `gatewayPost`, `runRead`, `toQueryString`, `shouldOutputJson`, `writeOutput`) from `integrations.ts` so both modules can use them
- Updated `assistant/src/index.ts` to import `registerContactsCommand` from the new file
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
