### PR TITLE
feat: add keychain broker UDS server to macOS app using SecItem APIs

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -133,6 +133,13 @@ extension AppDelegate {
             setenv("RUNTIME_HTTP_PORT", "7821", 0)
         }
 
+        // Start the keychain broker before the daemon so it is listening
+        // when the daemon process launches and reads the socket path.
+        #if !DEBUG
+        keychainBroker = KeychainBrokerServer()
+        keychainBroker?.start()
+        #endif
+
         configureDaemonTransport(for: assistant)
 
         // Rebind the menu bar icon observer after transport reconfiguration
@@ -448,6 +455,9 @@ extension AppDelegate {
 
     func setupAutoUpdate() {
         updateManager.onWillInstallUpdate = { [weak self] in
+            #if !DEBUG
+            self?.keychainBroker?.stop()
+            #endif
             self?.assistantCli.stop()
         }
         updateManager.startAutomaticChecks()

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -89,6 +89,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     #if DEBUG
     var galleryWindow: ComponentGalleryWindow?
     #endif
+    #if !DEBUG
+    var keychainBroker: KeychainBrokerServer?
+    #endif
     var windowObserver: Any?
     weak var recordingViewModel: ChatViewModel?
     /// Text that was in the chat input before PTT voice recording started,
@@ -320,6 +323,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         recordingManager.forceStop()
         recordingHUDWindow?.dismiss()
         debugStateWriter.stop()
+        #if !DEBUG
+        keychainBroker?.stop()
+        #endif
         assistantCli.stop()
     }
 

--- a/clients/macos/vellum-assistant/App/AssistantCli.swift
+++ b/clients/macos/vellum-assistant/App/AssistantCli.swift
@@ -796,6 +796,18 @@ final class AssistantCli {
             if let port = fullEnv["RUNTIME_HTTP_PORT"] ?? getenv("RUNTIME_HTTP_PORT").flatMap({ String(cString: $0) }) {
                 env["RUNTIME_HTTP_PORT"] = port
             }
+            // Tell the daemon where the keychain broker socket is.
+            // Only set in release builds where the broker is running.
+            #if !DEBUG
+            let brokerBaseDir: String
+            if let baseDir = fullEnv["BASE_DATA_DIR"]?.trimmingCharacters(in: .whitespacesAndNewlines), !baseDir.isEmpty {
+                brokerBaseDir = (baseDir as NSString).appendingPathComponent(".vellum")
+            } else {
+                brokerBaseDir = (NSHomeDirectory() as NSString).appendingPathComponent(".vellum")
+            }
+            env["VELLUM_KEYCHAIN_BROKER_SOCKET"] = (brokerBaseDir as NSString)
+                .appendingPathComponent("keychain-broker.sock")
+            #endif
             // Fall back to UserDefaults for the Anthropic API key when
             // it's not in the process environment (e.g. app launched from
             // Finder, not a terminal with ANTHROPIC_API_KEY set).

--- a/clients/macos/vellum-assistant/Security/KeychainBrokerServer.swift
+++ b/clients/macos/vellum-assistant/Security/KeychainBrokerServer.swift
@@ -1,0 +1,367 @@
+#if os(macOS) && !DEBUG
+import Foundation
+import Network
+import os
+
+private let log = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant",
+    category: "KeychainBrokerServer"
+)
+
+/// UDS server that exposes keychain operations to the daemon process via
+/// newline-delimited JSON over a Unix domain socket.
+///
+/// The broker generates a random auth token on each launch and writes it
+/// to `~/.vellum/protected/keychain-broker.token` with `0o600` permissions.
+/// Only processes that can read that file (same user) can authenticate.
+///
+/// Only compiled for release builds (`!DEBUG`). Debug builds skip the broker
+/// entirely so developers never see the keychain authorization modal on rebuild.
+final class KeychainBrokerServer {
+
+    // MARK: - Paths
+
+    private var vellumDir: URL {
+        if let baseDir = ProcessInfo.processInfo.environment["BASE_DATA_DIR"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !baseDir.isEmpty {
+            return URL(fileURLWithPath: baseDir).appendingPathComponent(".vellum")
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".vellum")
+    }
+
+    private var socketPath: String {
+        vellumDir.appendingPathComponent("keychain-broker.sock").path
+    }
+
+    private var protectedDir: URL {
+        vellumDir.appendingPathComponent("protected")
+    }
+
+    private var tokenFileURL: URL {
+        protectedDir.appendingPathComponent("keychain-broker.token")
+    }
+
+    // MARK: - State
+
+    private var listener: NWListener?
+    private var connections: [NWConnection] = []
+    private var authToken: String?
+
+    /// Per-connection receive buffers keyed by object identity.
+    private var receiveBuffers: [ObjectIdentifier: Data] = [:]
+
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    // MARK: - Lifecycle
+
+    func start() {
+        // Generate auth token.
+        var bytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        let token = bytes.map { String(format: "%02x", $0) }.joined()
+        authToken = token
+
+        // Write token to protected directory.
+        let fm = FileManager.default
+        do {
+            if !fm.fileExists(atPath: protectedDir.path) {
+                try fm.createDirectory(at: protectedDir, withIntermediateDirectories: true)
+                // Set directory permissions to owner-only.
+                try fm.setAttributes(
+                    [.posixPermissions: 0o700],
+                    ofItemAtPath: protectedDir.path
+                )
+            }
+            try token.write(to: tokenFileURL, atomically: true, encoding: .utf8)
+            try fm.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: tokenFileURL.path
+            )
+        } catch {
+            log.error("Failed to write auth token: \(error.localizedDescription)")
+            return
+        }
+
+        // Remove stale socket from a previous unclean exit.
+        unlink(socketPath)
+
+        // Create NWListener on Unix domain socket.
+        let params = NWParameters()
+        params.defaultProtocolStack.transportProtocol = NWProtocolTCP.Options()
+        params.requiredLocalEndpoint = NWEndpoint.unix(path: socketPath)
+
+        do {
+            listener = try NWListener(using: params)
+        } catch {
+            log.error("Failed to create NWListener: \(error.localizedDescription)")
+            return
+        }
+
+        listener?.newConnectionHandler = { [weak self] conn in
+            self?.handleNewConnection(conn)
+        }
+
+        let path = socketPath
+        listener?.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                log.info("Keychain broker listening on \(path, privacy: .public)")
+            case .failed(let error):
+                log.error("Keychain broker listener failed: \(error.localizedDescription)")
+            case .cancelled:
+                log.info("Keychain broker listener cancelled")
+            default:
+                break
+            }
+        }
+
+        listener?.start(queue: .main)
+    }
+
+    func stop() {
+        // Cancel all client connections.
+        for conn in connections {
+            conn.cancel()
+        }
+        connections.removeAll()
+        receiveBuffers.removeAll()
+
+        // Cancel the listener.
+        listener?.cancel()
+        listener = nil
+
+        // Clean up socket and token files.
+        unlink(socketPath)
+        try? FileManager.default.removeItem(at: tokenFileURL)
+
+        authToken = nil
+        log.info("Keychain broker stopped")
+    }
+
+    // MARK: - Connection Handling
+
+    private func handleNewConnection(_ conn: NWConnection) {
+        connections.append(conn)
+        let connId = ObjectIdentifier(conn)
+        receiveBuffers[connId] = Data()
+
+        conn.stateUpdateHandler = { [weak self, weak conn] state in
+            guard let self, let conn else { return }
+            switch state {
+            case .ready:
+                log.debug("Broker client connected")
+            case .failed(let error):
+                log.error("Broker client connection failed: \(error.localizedDescription)")
+                self.removeConnection(conn)
+            case .cancelled:
+                self.removeConnection(conn)
+            default:
+                break
+            }
+        }
+
+        conn.start(queue: .main)
+        receiveData(on: conn)
+    }
+
+    private func removeConnection(_ conn: NWConnection) {
+        let connId = ObjectIdentifier(conn)
+        receiveBuffers.removeValue(forKey: connId)
+        connections.removeAll { $0 === conn }
+    }
+
+    // MARK: - Receive Loop
+
+    /// Newline-delimited JSON receive loop matching the DaemonConnection pattern.
+    private func receiveData(on conn: NWConnection) {
+        conn.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self, weak conn] content, _, isComplete, error in
+            guard let self, let conn else { return }
+
+            let connId = ObjectIdentifier(conn)
+
+            if let data = content, !data.isEmpty {
+                self.receiveBuffers[connId, default: Data()].append(data)
+
+                let newline = UInt8(0x0A)
+                while let buffer = self.receiveBuffers[connId],
+                      let newlineIndex = buffer.firstIndex(of: newline) {
+                    let lineData = buffer[buffer.startIndex..<newlineIndex]
+                    self.receiveBuffers[connId] = Data(buffer[(newlineIndex + 1)...])
+
+                    guard !lineData.isEmpty else { continue }
+
+                    self.handleLine(Data(lineData), on: conn)
+                }
+            }
+
+            if isComplete || error != nil {
+                self.removeConnection(conn)
+            } else {
+                self.receiveData(on: conn)
+            }
+        }
+    }
+
+    // MARK: - Request / Response Types
+
+    private struct Request: Decodable {
+        let v: Int
+        let id: String
+        let token: String
+        let method: String
+        let params: Params?
+
+        struct Params: Decodable {
+            let account: String?
+            let value: String?
+        }
+    }
+
+    private struct Response: Encodable {
+        let id: String
+        let ok: Bool
+        let result: AnyCodable?
+        let error: ErrorPayload?
+
+        struct ErrorPayload: Encodable {
+            let code: String
+            let message: String
+        }
+    }
+
+    /// Type-erased Encodable wrapper for response results.
+    private struct AnyCodable: Encodable {
+        private let _encode: (Encoder) throws -> Void
+
+        init<T: Encodable>(_ value: T) {
+            _encode = { encoder in try value.encode(to: encoder) }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            try _encode(encoder)
+        }
+    }
+
+    // MARK: - Dispatch
+
+    private func handleLine(_ data: Data, on conn: NWConnection) {
+        let request: Request
+        do {
+            request = try decoder.decode(Request.self, from: data)
+        } catch {
+            log.error("Failed to decode broker request: \(error.localizedDescription)")
+            // Cannot respond without an id, so just drop the malformed request.
+            return
+        }
+
+        // Validate protocol version.
+        guard request.v == 1 else {
+            sendError(id: request.id, code: "INVALID_REQUEST", message: "Unsupported protocol version: \(request.v)", on: conn)
+            return
+        }
+
+        // Validate auth token.
+        guard request.token == authToken else {
+            sendError(id: request.id, code: "UNAUTHORIZED", message: "Invalid auth token", on: conn)
+            return
+        }
+
+        switch request.method {
+        case "broker.ping":
+            sendSuccess(id: request.id, result: PingResult(pong: true), on: conn)
+
+        case "key.get":
+            guard let account = request.params?.account, !account.isEmpty else {
+                sendError(id: request.id, code: "INVALID_REQUEST", message: "Missing 'account' param", on: conn)
+                return
+            }
+            if let value = KeychainBrokerService.get(account: account) {
+                sendSuccess(id: request.id, result: GetResult(found: true, value: value), on: conn)
+            } else {
+                sendSuccess(id: request.id, result: GetResult(found: false, value: nil), on: conn)
+            }
+
+        case "key.set":
+            guard let account = request.params?.account, !account.isEmpty,
+                  let value = request.params?.value else {
+                sendError(id: request.id, code: "INVALID_REQUEST", message: "Missing 'account' or 'value' param", on: conn)
+                return
+            }
+            if KeychainBrokerService.set(account: account, value: value) {
+                sendSuccess(id: request.id, result: SetResult(stored: true), on: conn)
+            } else {
+                sendError(id: request.id, code: "KEYCHAIN_ERROR", message: "SecItemAdd failed", on: conn)
+            }
+
+        case "key.delete":
+            guard let account = request.params?.account, !account.isEmpty else {
+                sendError(id: request.id, code: "INVALID_REQUEST", message: "Missing 'account' param", on: conn)
+                return
+            }
+            if KeychainBrokerService.delete(account: account) {
+                sendSuccess(id: request.id, result: DeleteResult(deleted: true), on: conn)
+            } else {
+                sendError(id: request.id, code: "KEYCHAIN_ERROR", message: "SecItemDelete failed", on: conn)
+            }
+
+        case "key.list":
+            let accounts = KeychainBrokerService.list()
+            sendSuccess(id: request.id, result: ListResult(accounts: accounts), on: conn)
+
+        default:
+            sendError(id: request.id, code: "INVALID_REQUEST", message: "Unknown method: \(request.method)", on: conn)
+        }
+    }
+
+    // MARK: - Result Types
+
+    private struct PingResult: Encodable {
+        let pong: Bool
+    }
+
+    private struct GetResult: Encodable {
+        let found: Bool
+        let value: String?
+    }
+
+    private struct SetResult: Encodable {
+        let stored: Bool
+    }
+
+    private struct DeleteResult: Encodable {
+        let deleted: Bool
+    }
+
+    private struct ListResult: Encodable {
+        let accounts: [String]
+    }
+
+    // MARK: - Send Helpers
+
+    private func sendSuccess<T: Encodable>(id: String, result: T, on conn: NWConnection) {
+        let response = Response(id: id, ok: true, result: AnyCodable(result), error: nil)
+        send(response, on: conn)
+    }
+
+    private func sendError(id: String, code: String, message: String, on conn: NWConnection) {
+        let response = Response(id: id, ok: false, result: nil, error: .init(code: code, message: message))
+        send(response, on: conn)
+    }
+
+    private func send(_ response: Response, on conn: NWConnection) {
+        do {
+            var data = try encoder.encode(response)
+            data.append(0x0A) // newline delimiter
+            conn.send(content: data, completion: .contentProcessed { error in
+                if let error {
+                    log.error("Failed to send broker response: \(error.localizedDescription)")
+                }
+            })
+        } catch {
+            log.error("Failed to encode broker response: \(error.localizedDescription)")
+        }
+    }
+}
+#endif

--- a/clients/macos/vellum-assistant/Security/KeychainBrokerService.swift
+++ b/clients/macos/vellum-assistant/Security/KeychainBrokerService.swift
@@ -1,0 +1,100 @@
+#if os(macOS)
+import Foundation
+import Security
+
+/// SecItem wrapper that performs keychain CRUD operations scoped to the
+/// `vellum-assistant` service. All methods are synchronous and thread-safe
+/// (SecItem APIs are thread-safe by design).
+///
+/// Uses `kSecAttrAccessibleAfterFirstUnlock` so secrets survive screen lock
+/// without re-prompting the user. This differs from the iOS `APIKeyManager`
+/// which uses `kSecAttrAccessibleWhenUnlocked`.
+enum KeychainBrokerService {
+
+    private static let serviceName = "vellum-assistant"
+
+    // MARK: - Get
+
+    /// Retrieve the UTF-8 string value for a given account, or nil if not found.
+    static func get(account: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess, let data = result as? Data else {
+            return nil
+        }
+
+        return String(data: data, encoding: .utf8)
+    }
+
+    // MARK: - Set
+
+    /// Store a UTF-8 string value for a given account. Uses delete-then-add
+    /// to handle both insert and update cases.
+    @discardableResult
+    static func set(account: String, value: String) -> Bool {
+        // Delete any existing item first (ignore not-found errors).
+        delete(account: account)
+
+        guard let data = value.data(using: .utf8) else { return false }
+
+        let attributes: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+        ]
+
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+
+    // MARK: - Delete
+
+    /// Delete the keychain item for a given account. Returns true on success
+    /// or if the item was already absent.
+    @discardableResult
+    static func delete(account: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: account,
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+
+    // MARK: - List
+
+    /// Return the account names of all generic-password items scoped to the
+    /// `vellum-assistant` service.
+    static func list() -> [String] {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecMatchLimit as String: kSecMatchLimitAll,
+            kSecReturnAttributes as String: true,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+              let items = result as? [[String: Any]] else {
+            return []
+        }
+
+        return items.compactMap { $0[kSecAttrAccount as String] as? String }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add KeychainBrokerService: SecItem* wrapper for keychain CRUD operations with kSecAttrAccessibleAfterFirstUnlock
- Add KeychainBrokerServer: UDS server using NWListener with newline-delimited JSON protocol, auth token, and #if !DEBUG guard
- Wire broker into app lifecycle (start before daemon, stop on exit) and pass socket path to daemon via environment variable

Part of plan: app-embedded-keychain-broker.md (PR 1 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
