### PR TITLE
fix: update stale legacy mode comment in computer-use test

### DIFF
--- a/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
+++ b/assistant/src/__tests__/computer-use-session-lifecycle.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, mock, test } from "bun:test";
 
 // Mock config before importing modules that depend on it.
-// The permissions mode must be 'legacy' so computer-use tools
-// (which have no trust rules in test) don't trigger approval prompts.
+// The permissions mode must be 'workspace' so computer-use tools
+// go through normal workspace trust evaluation instead of prompting.
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},


### PR DESCRIPTION
Updates the comment in computer-use-session-lifecycle.test.ts that still referenced 'legacy' mode after the mock was changed to 'workspace' mode.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
