### PR TITLE
fix: throw WhatsAppNonRetryableError for attachment size limit

### DIFF
--- a/gateway/src/whatsapp/download.ts
+++ b/gateway/src/whatsapp/download.ts
@@ -1,6 +1,10 @@
 import { fileTypeFromBuffer } from "file-type";
 import type { GatewayConfig } from "../config.js";
-import { getWhatsAppMediaMetadata, downloadWhatsAppMediaBytes } from "./api.js";
+import {
+  getWhatsAppMediaMetadata,
+  downloadWhatsAppMediaBytes,
+  WhatsAppNonRetryableError,
+} from "./api.js";
 
 export interface DownloadedFile {
   filename: string;
@@ -52,7 +56,7 @@ export async function downloadWhatsAppFile(
   const meta = await getWhatsAppMediaMetadata(config, mediaId);
 
   if (meta.file_size > config.maxAttachmentBytes) {
-    throw new Error(
+    throw new WhatsAppNonRetryableError(
       `WhatsApp media ${mediaId} exceeds size limit (${meta.file_size} > ${config.maxAttachmentBytes} bytes)`,
     );
   }


### PR DESCRIPTION
Changes the attachment size-limit check to throw WhatsAppNonRetryableError instead of plain Error, preventing infinite Meta webhook retries.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
