### PR TITLE
fix: remove non-existent whatsapp.phoneNumber config reference from docs

### DIFF
--- a/assistant/README.md
+++ b/assistant/README.md
@@ -382,7 +382,7 @@ All endpoints are bearer-authenticated. Skills and clients should call the gatew
 - **Voice**: Checks Twilio credentials, phone number assignment, and public ingress URL.
 - **Telegram**: Checks bot token, webhook secret, and public ingress URL.
 - **Email**: Checks AgentMail API key, invite policy, public ingress URL, and verifies an inbox address is available (remote check).
-- **WhatsApp**: Checks Meta WhatsApp Business API credentials (phoneNumberId, accessToken, appSecret, webhookVerifyToken), display phone number (`whatsapp.phoneNumber`), invite policy, and public ingress URL.
+- **WhatsApp**: Checks Meta WhatsApp Business API credentials (phoneNumberId, accessToken, appSecret, webhookVerifyToken), invite policy, and public ingress URL.
 - **Slack**: Checks bot token and app token.
 
 ### Key modules

--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -416,7 +416,7 @@ The response contains `{ ok: true, invite: { id, token, inviteCode, guardianInst
 
 - `inviteCode` is the 6-digit code the invitee must send to redeem the invite.
 - `guardianInstruction` is a generated instruction telling the guardian how to share the invite.
-- `channelHandle` (optional) is the assistant's WhatsApp display phone number. It is only present when a display number is configured via `whatsapp.phoneNumber` in workspace config.
+- `channelHandle` (optional) is the assistant's WhatsApp display phone number. It is not currently available because the Meta WhatsApp Business API identifies numbers by `phone_number_id`, which is not a user-facing phone number.
 
 **Presenting to the guardian**: If `channelHandle` is present, give the guardian the invite code and the assistant's WhatsApp number:
 


### PR DESCRIPTION
Removes references to `whatsapp.phoneNumber` config key that doesn't exist in AssistantConfigSchema from SKILL.md and README.md. The Meta WhatsApp Business API uses `phone_number_id` internally, so the display phone number config path was misleading.

Addresses review feedback on #13213.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
