### PR TITLE
fix: make telegram invite adapter test deterministic

### DIFF
--- a/assistant/src/__tests__/telegram-invite-adapter.test.ts
+++ b/assistant/src/__tests__/telegram-invite-adapter.test.ts
@@ -4,10 +4,15 @@
  * Covers `buildShareLink`, `extractInboundToken`, and
  * `resolveChannelHandle` on the real production adapter.
  */
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { ChannelId } from "../channels/types.js";
 import { telegramInviteAdapter } from "../runtime/channel-invite-transports/telegram.js";
+
+// Mock credential metadata so tests don't depend on local persisted state.
+mock.module("../tools/credentials/metadata-store.js", () => ({
+  getCredentialMetadata: () => undefined,
+}));
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
Fixes nondeterministic telegram invite adapter test by mocking credential metadata store in addition to env var, so the test doesn't depend on locally persisted Telegram metadata.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
