### PR TITLE
fix: add whatsapp.phoneNumber to AssistantConfigSchema

### DIFF
--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -252,6 +252,12 @@ export const SmsConfigSchema = z.object({
     .optional(),
 });
 
+export const WhatsAppConfigSchema = z.object({
+  phoneNumber: z
+    .string({ error: "whatsapp.phoneNumber must be a string" })
+    .default(""),
+});
+
 export const IngressWebhookConfigSchema = z.object({
   secret: z
     .string({ error: "ingress.webhook.secret must be a string" })
@@ -392,6 +398,7 @@ export type ContextOverflowRecoveryConfig = z.infer<
 export type ContextWindowConfig = z.infer<typeof ContextWindowConfigSchema>;
 export type ModelPricingOverride = z.infer<typeof ModelPricingOverrideSchema>;
 export type SmsConfig = z.infer<typeof SmsConfigSchema>;
+export type WhatsAppConfig = z.infer<typeof WhatsAppConfigSchema>;
 export type IngressWebhookConfig = z.infer<typeof IngressWebhookConfigSchema>;
 export type IngressRateLimitConfig = z.infer<
   typeof IngressRateLimitConfigSchema

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -49,6 +49,7 @@ export type {
   ThinkingConfig,
   TimeoutConfig,
   UiConfig,
+  WhatsAppConfig,
 } from "./core-schema.js";
 export {
   AuditLogConfigSchema,
@@ -69,6 +70,7 @@ export {
   ThinkingConfigSchema,
   TimeoutConfigSchema,
   UiConfigSchema,
+  WhatsAppConfigSchema,
 } from "./core-schema.js";
 export type { ElevenLabsConfig } from "./elevenlabs-schema.js";
 export {
@@ -161,6 +163,7 @@ import {
   ThinkingConfigSchema,
   TimeoutConfigSchema,
   UiConfigSchema,
+  WhatsAppConfigSchema,
 } from "./core-schema.js";
 import { ElevenLabsConfigSchema } from "./elevenlabs-schema.js";
 import { McpConfigSchema } from "./mcp-schema.js";
@@ -261,6 +264,7 @@ export const AssistantConfigSchema = z
       ElevenLabsConfigSchema.parse({}),
     ),
     sms: SmsConfigSchema.default(SmsConfigSchema.parse({})),
+    whatsapp: WhatsAppConfigSchema.default(WhatsAppConfigSchema.parse({})),
     ingress: IngressConfigSchema,
     platform: PlatformConfigSchema.default(PlatformConfigSchema.parse({})),
     daemon: DaemonConfigSchema.default(DaemonConfigSchema.parse({})),

--- a/assistant/src/runtime/channel-invite-transports/whatsapp.ts
+++ b/assistant/src/runtime/channel-invite-transports/whatsapp.ts
@@ -9,7 +9,7 @@
  */
 
 import type { ChannelId } from "../../channels/types.js";
-import { loadRawConfig } from "../../config/loader.js";
+import { getConfig } from "../../config/loader.js";
 import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
 
 // ---------------------------------------------------------------------------
@@ -23,9 +23,8 @@ import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
  */
 export function resolveWhatsAppDisplayNumber(): string | undefined {
   try {
-    const raw = loadRawConfig();
-    const waConfig = (raw?.whatsapp ?? {}) as Record<string, unknown>;
-    return (waConfig.phoneNumber as string) || undefined;
+    const config = getConfig();
+    return config.whatsapp.phoneNumber || undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
Adds whatsapp.phoneNumber to the config schema so it is properly validated when used by the WhatsApp display phone resolver. Previously the resolver read from raw config which bypassed schema validation, meaning the value could be silently stripped during config round-trips.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
