### PR TITLE
fix: correct contacts SKILL.md readiness API documentation

### DIFF
--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -195,6 +195,24 @@ export async function runRead(
   }
 }
 
+export function registerChannelsCommand(program: Command): void {
+  const channels = program
+    .command("channels")
+    .description("Query channel status")
+    .option("--json", "Machine-readable compact JSON output");
+
+  channels
+    .command("readiness")
+    .description("Check channel readiness for accepting messages")
+    .option("--channel <channel>", "Filter by channel type")
+    .action(async (opts: { channel?: string }, cmd: Command) => {
+      const query = toQueryString({ channel: opts.channel });
+      await runRead(cmd, async () =>
+        gatewayGet(`/v1/channels/readiness${query}`),
+      );
+    });
+}
+
 export function registerIntegrationsCommand(program: Command): void {
   const integrations = program
     .command("integrations")

--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -205,18 +205,21 @@ Replace `<channel_id>` with the channel's `id` from the contact's `channels` arr
 Before creating an invite for any channel, check whether that channel is ready to accept messages. Creating an invite for an unready channel produces an unusable invite — the invitee redeems the code but cannot actually reach the assistant.
 
 ```bash
-curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/channels/readiness" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum channels readiness --json
 ```
 
 The response contains `{ success: true, snapshots: [...] }` where each snapshot has:
 
 - `channel` -- the channel type (e.g., `telegram`, `email`, `whatsapp`, `sms`, `slack`, `voice`)
 - `ready` -- boolean indicating whether the channel is fully operational
+- `checkedAt` -- timestamp (ms since epoch) of when readiness was evaluated
+- `stale` -- boolean indicating whether cached remote check data is outdated
+- `reasons` -- array of `{ code, text }` objects summarizing why the channel is not ready (empty when ready)
 - `localChecks` -- array of local prerequisite checks, each with `name`, `passed` (boolean), and `message` (human-readable explanation)
 - `remoteChecks` -- optional array of remote prerequisite checks (same shape: `name`, `passed`, `message`), present when the channel supports remote verification (e.g. confirming an email inbox exists)
+- `channelHandle` -- optional human-readable channel identifier (e.g. bot username, phone number, email address)
 
-If the target channel's `ready` field is `false`, do **not** create the invite. Instead, tell the guardian which prerequisites are missing (from the `localChecks` and `remoteChecks` arrays — look for entries with `passed: false`) so they can resolve them first.
+If the target channel's `ready` field is `false`, do **not** create the invite. Instead, tell the guardian which prerequisites are missing (from `reasons` or from the `localChecks`/`remoteChecks` arrays — look for entries with `passed: false`) so they can resolve them first.
 
 ## Invite Links
 

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -26,7 +26,10 @@ import {
 import { registerEmailCommand } from "./cli/email.js";
 import { registerInfluencerCommand } from "./cli/influencer.js";
 import { registerContactsCommand } from "./cli/contacts.js";
-import { registerIntegrationsCommand } from "./cli/integrations.js";
+import {
+  registerChannelsCommand,
+  registerIntegrationsCommand,
+} from "./cli/integrations.js";
 import { registerMapCommand } from "./cli/map.js";
 import { registerMcpCommand } from "./cli/mcp.js";
 import { registerSequenceCommand } from "./cli/sequence.js";
@@ -51,6 +54,7 @@ registerMcpCommand(program);
 registerEmailCommand(program);
 registerIntegrationsCommand(program);
 registerContactsCommand(program);
+registerChannelsCommand(program);
 registerAmazonCommand(program);
 registerAutonomyCommand(program);
 registerCompletionsCommand(program);


### PR DESCRIPTION
Fixes contacts SKILL.md to match actual readiness API contract:

- Replace curl + GATEWAY_AUTH_TOKEN with `vellum channels readiness --json` CLI command (per SKILL.md retrieval contract)
- Add `vellum channels readiness` CLI command that calls the gateway readiness endpoint
- Document all response fields: checkedAt, stale, reasons, channelHandle (previously missing)
- Reference reasons array in the guidance for unready channels

Addresses review feedback on #13221.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
