### PR TITLE
feat: route secure-keys through keychain broker when available, encrypted fallback

### DIFF
--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -23,16 +23,53 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+// ---------------------------------------------------------------------------
+// Broker client mock — set up before importing secure-keys so the
+// module-level `createBrokerClient()` call picks up our mock.
+// ---------------------------------------------------------------------------
+
+let mockBrokerAvailable = false;
+let mockBrokerStore: Map<string, string> = new Map();
+let mockBrokerGetError = false;
+let mockBrokerSetError = false;
+let mockBrokerDelError = false;
+
+mock.module("../security/keychain-broker-client.js", () => ({
+  createBrokerClient: () => ({
+    isAvailable: () => mockBrokerAvailable,
+    ping: async () => (mockBrokerAvailable ? { version: "test" } : null),
+    get: async (account: string) => {
+      if (mockBrokerGetError) return undefined;
+      return mockBrokerStore.get(account);
+    },
+    set: async (account: string, value: string) => {
+      if (mockBrokerSetError) return false;
+      mockBrokerStore.set(account, value);
+      return true;
+    },
+    del: async (account: string) => {
+      if (mockBrokerDelError) return false;
+      const existed = mockBrokerStore.has(account);
+      mockBrokerStore.delete(account);
+      return existed;
+    },
+    list: async () => Array.from(mockBrokerStore.keys()),
+  }),
+}));
+
 import { _setStorePath } from "../security/encrypted-store.js";
 import {
   _resetBackend,
   _setBackend,
   deleteSecureKey,
+  deleteSecureKeyAsync,
   getBackendType,
   getSecureKey,
+  getSecureKeyAsync,
   isDowngradedFromKeychain,
   listSecureKeys,
   setSecureKey,
+  setSecureKeyAsync,
 } from "../security/secure-keys.js";
 
 // ---------------------------------------------------------------------------
@@ -48,6 +85,13 @@ const STORE_PATH = join(TEST_DIR, "keys.enc");
 describe("secure-keys", () => {
   beforeEach(() => {
     _resetBackend();
+
+    // Reset broker mock state
+    mockBrokerAvailable = false;
+    mockBrokerStore = new Map();
+    mockBrokerGetError = false;
+    mockBrokerSetError = false;
+    mockBrokerDelError = false;
 
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true });
@@ -71,8 +115,13 @@ describe("secure-keys", () => {
   // Backend selection
   // -----------------------------------------------------------------------
   describe("backend selection", () => {
-    test("always uses encrypted backend", () => {
+    test("returns encrypted when broker is unavailable", () => {
       expect(getBackendType()).toBe("encrypted");
+    });
+
+    test("returns broker when broker is available", () => {
+      mockBrokerAvailable = true;
+      expect(getBackendType()).toBe("broker");
     });
 
     test("isDowngradedFromKeychain always returns false", () => {
@@ -81,9 +130,9 @@ describe("secure-keys", () => {
   });
 
   // -----------------------------------------------------------------------
-  // CRUD operations (via encrypted store backend)
+  // CRUD operations (via encrypted store backend — sync)
   // -----------------------------------------------------------------------
-  describe("CRUD with encrypted backend", () => {
+  describe("CRUD with encrypted backend (sync)", () => {
     test("set and get a key", () => {
       setSecureKey("openai", "sk-openai-789");
       expect(getSecureKey("openai")).toBe("sk-openai-789");
@@ -110,6 +159,129 @@ describe("secure-keys", () => {
       expect(keys).toContain("anthropic");
       expect(keys).toContain("openai");
       expect(keys.length).toBe(2);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Sync variants always use encrypted store even when broker is available
+  // -----------------------------------------------------------------------
+  describe("sync variants ignore broker", () => {
+    test("getSecureKey uses encrypted store even when broker is available", () => {
+      mockBrokerAvailable = true;
+      mockBrokerStore.set("api-key", "broker-value");
+      // Sync getter should not see broker-only keys
+      expect(getSecureKey("api-key")).toBeUndefined();
+      // But encrypted store keys should work
+      setSecureKey("api-key", "encrypted-value");
+      expect(getSecureKey("api-key")).toBe("encrypted-value");
+    });
+
+    test("setSecureKey uses encrypted store even when broker is available", () => {
+      mockBrokerAvailable = true;
+      setSecureKey("api-key", "encrypted-value");
+      expect(getSecureKey("api-key")).toBe("encrypted-value");
+      // Should not have written to broker
+      expect(mockBrokerStore.has("api-key")).toBe(false);
+    });
+
+    test("deleteSecureKey uses encrypted store even when broker is available", () => {
+      mockBrokerAvailable = true;
+      mockBrokerStore.set("api-key", "broker-value");
+      setSecureKey("api-key", "encrypted-value");
+      deleteSecureKey("api-key");
+      expect(getSecureKey("api-key")).toBeUndefined();
+      // Broker value should be untouched
+      expect(mockBrokerStore.has("api-key")).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Async variants — broker available path
+  // -----------------------------------------------------------------------
+  describe("async variants with broker available", () => {
+    test("getSecureKeyAsync returns broker value when available", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerStore.set("api-key", "broker-value");
+      setSecureKey("api-key", "encrypted-value");
+      expect(await getSecureKeyAsync("api-key")).toBe("broker-value");
+    });
+
+    test("getSecureKeyAsync falls back to encrypted store when broker returns undefined", async () => {
+      mockBrokerAvailable = true;
+      // Broker has nothing for this key
+      setSecureKey("api-key", "encrypted-value");
+      expect(await getSecureKeyAsync("api-key")).toBe("encrypted-value");
+    });
+
+    test("getSecureKeyAsync falls back to encrypted store on broker error", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerGetError = true;
+      setSecureKey("api-key", "encrypted-value");
+      expect(await getSecureKeyAsync("api-key")).toBe("encrypted-value");
+    });
+
+    test("setSecureKeyAsync writes to broker and encrypted store", async () => {
+      mockBrokerAvailable = true;
+      const result = await setSecureKeyAsync("api-key", "new-value");
+      expect(result).toBe(true);
+      expect(mockBrokerStore.get("api-key")).toBe("new-value");
+      // Also persisted to encrypted store for sync callers
+      expect(getSecureKey("api-key")).toBe("new-value");
+    });
+
+    test("setSecureKeyAsync falls back to encrypted store on broker error", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerSetError = true;
+      const result = await setSecureKeyAsync("api-key", "new-value");
+      expect(result).toBe(true);
+      expect(mockBrokerStore.has("api-key")).toBe(false);
+      expect(getSecureKey("api-key")).toBe("new-value");
+    });
+
+    test("deleteSecureKeyAsync deletes from broker and encrypted store", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerStore.set("api-key", "broker-value");
+      setSecureKey("api-key", "encrypted-value");
+      const result = await deleteSecureKeyAsync("api-key");
+      expect(result).toBe(true);
+      expect(mockBrokerStore.has("api-key")).toBe(false);
+      expect(getSecureKey("api-key")).toBeUndefined();
+    });
+
+    test("deleteSecureKeyAsync falls back to encrypted store on broker error", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerDelError = true;
+      setSecureKey("api-key", "encrypted-value");
+      const result = await deleteSecureKeyAsync("api-key");
+      expect(result).toBe(true);
+      expect(getSecureKey("api-key")).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Async variants — broker unavailable path
+  // -----------------------------------------------------------------------
+  describe("async variants with broker unavailable", () => {
+    test("getSecureKeyAsync uses encrypted store", async () => {
+      setSecureKey("api-key", "encrypted-value");
+      expect(await getSecureKeyAsync("api-key")).toBe("encrypted-value");
+    });
+
+    test("getSecureKeyAsync returns undefined for missing key", async () => {
+      expect(await getSecureKeyAsync("missing")).toBeUndefined();
+    });
+
+    test("setSecureKeyAsync uses encrypted store", async () => {
+      const result = await setSecureKeyAsync("api-key", "new-value");
+      expect(result).toBe(true);
+      expect(getSecureKey("api-key")).toBe("new-value");
+    });
+
+    test("deleteSecureKeyAsync uses encrypted store", async () => {
+      setSecureKey("api-key", "value");
+      const result = await deleteSecureKeyAsync("api-key");
+      expect(result).toBe(true);
+      expect(getSecureKey("api-key")).toBeUndefined();
     });
   });
 

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -1,13 +1,23 @@
 /**
- * Unified secure key storage — encrypted-at-rest file storage.
+ * Unified secure key storage — routes through the keychain broker when
+ * available (macOS app embedded), with transparent fallback to the
+ * encrypted-at-rest file store.
  *
- * Provides get/set/delete/list interface backed by the encrypted store.
+ * Async variants try the broker first; sync variants always use the
+ * encrypted store (startup code paths cannot do async I/O).
  */
 
 import * as encryptedStore from "./encrypted-store.js";
+import { createBrokerClient } from "./keychain-broker-client.js";
+
+const broker = createBrokerClient();
+
+// ---------------------------------------------------------------------------
+// Sync variants — encrypted store only (startup / sync call sites)
+// ---------------------------------------------------------------------------
 
 /**
- * Retrieve a secret from secure storage.
+ * Retrieve a secret from secure storage (sync — encrypted store only).
  * Returns `undefined` if the key doesn't exist or on error.
  */
 export function getSecureKey(account: string): string | undefined {
@@ -15,7 +25,7 @@ export function getSecureKey(account: string): string | undefined {
 }
 
 /**
- * Store a secret in secure storage.
+ * Store a secret in secure storage (sync — encrypted store only).
  * Returns `true` on success, `false` on failure.
  */
 export function setSecureKey(account: string, value: string): boolean {
@@ -23,7 +33,7 @@ export function setSecureKey(account: string, value: string): boolean {
 }
 
 /**
- * Delete a secret from secure storage.
+ * Delete a secret from secure storage (sync — encrypted store only).
  * Returns `true` on success, `false` if not found or on error.
  */
 export function deleteSecureKey(account: string): boolean {
@@ -31,19 +41,23 @@ export function deleteSecureKey(account: string): boolean {
 }
 
 /**
- * List all account names in secure storage.
- * Throws if the store file exists but cannot be read (encrypted backend).
+ * List all account names in secure storage (sync — encrypted store only).
+ * Throws if the store file exists but cannot be read.
  */
 export function listSecureKeys(): string[] {
   return encryptedStore.listKeys();
 }
 
+// ---------------------------------------------------------------------------
+// Backend introspection
+// ---------------------------------------------------------------------------
+
 /**
  * Return the currently resolved backend type.
- * Always returns "encrypted" now that keychain CLI is removed.
+ * Returns `"broker"` when the keychain broker is reachable, `"encrypted"` otherwise.
  */
-export function getBackendType(): "keychain" | "encrypted" | null {
-  return "encrypted";
+export function getBackendType(): "broker" | "encrypted" | null {
+  return broker.isAvailable() ? "broker" : "encrypted";
 }
 
 /**
@@ -55,44 +69,73 @@ export function isDowngradedFromKeychain(): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Async variants — thin wrappers around sync calls since the encrypted
-// store uses synchronous file I/O.
+// Async variants — try broker first, fall back to encrypted store
 // ---------------------------------------------------------------------------
 
 /**
- * Async version of `getSecureKey` — retrieve a secret without blocking.
+ * Async version of `getSecureKey`. When the broker is available it is
+ * queried first; if it returns `undefined` (not found *or* error) the
+ * encrypted store is consulted as a fallback.
  */
 export async function getSecureKeyAsync(
   account: string,
 ): Promise<string | undefined> {
-  return getSecureKey(account);
+  if (broker.isAvailable()) {
+    const value = await broker.get(account);
+    if (value !== undefined) return value;
+  }
+  return encryptedStore.getKey(account);
 }
 
 /**
- * Async version of `setSecureKey` — store a secret without blocking.
+ * Async version of `setSecureKey`. When the broker is available the key
+ * is written there first; the encrypted store is always updated as well
+ * so that sync callers have a consistent view.
  */
 export async function setSecureKeyAsync(
   account: string,
   value: string,
 ): Promise<boolean> {
-  return setSecureKey(account, value);
+  if (broker.isAvailable()) {
+    const ok = await broker.set(account, value);
+    if (ok) {
+      // Also persist to encrypted store so sync callers stay consistent.
+      encryptedStore.setKey(account, value);
+      return true;
+    }
+  }
+  return encryptedStore.setKey(account, value);
 }
 
 /**
- * Async version of `deleteSecureKey` — delete a secret without blocking.
+ * Async version of `deleteSecureKey`. When the broker is available the
+ * key is deleted there first; the encrypted store entry is always removed
+ * as well so that sync callers have a consistent view.
  */
 export async function deleteSecureKeyAsync(account: string): Promise<boolean> {
-  return deleteSecureKey(account);
+  if (broker.isAvailable()) {
+    const ok = await broker.del(account);
+    if (ok) {
+      // Also remove from encrypted store so sync callers stay consistent.
+      encryptedStore.deleteKey(account);
+      return true;
+    }
+  }
+  return encryptedStore.deleteKey(account);
 }
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
 
 /** @internal Test-only: reset the cached backend so it's re-evaluated. */
 export function _resetBackend(): void {
-  // No-op — encrypted store is always the backend.
+  // No-op — backend selection is determined by broker availability at call time.
 }
 
 /** @internal Test-only: force a specific backend. Pass `undefined` to reset. */
 export function _setBackend(
-  _backend: "keychain" | "encrypted" | null | undefined,
+  _backend: "keychain" | "encrypted" | "broker" | null | undefined,
 ): void {
   // No-op — kept for test compatibility.
 }


### PR DESCRIPTION
## Summary
- Wire keychain broker client into secure-keys.ts async paths (getSecureKeyAsync, setSecureKeyAsync, deleteSecureKeyAsync)
- Broker is tried first when available; undefined results fall through to encrypted store
- Sync variants remain encrypted-store-only (startup code can't do async I/O)
- getBackendType() returns 'broker' when broker is available, 'encrypted' otherwise
- Add broker integration tests with mock client

Part of plan: app-embedded-keychain-broker.md (PR 6 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
