### PR TITLE
fix: strengthen formatCount grouping assertion in usage dashboard tests

### DIFF
--- a/clients/ios/Tests/UsageDashboardViewTests.swift
+++ b/clients/ios/Tests/UsageDashboardViewTests.swift
@@ -177,9 +177,11 @@ final class UsageDashboardViewTests: XCTestCase {
 
     func testFormatCountUsesDecimalGrouping() {
         let result = UsageFormatting.formatCount(1_000_000)
-        // NumberFormatter with .decimal style uses locale-specific grouping.
-        XCTAssertTrue(result.contains("1"), "Formatted count should contain the digit 1")
-        XCTAssertTrue(result.count > 1, "Formatted count should have grouping separators or multiple digits")
+        // The raw digit string without grouping would be "1000000".
+        // Verify the formatter actually inserts grouping separators.
+        XCTAssertNotEqual(result, "1000000", "formatCount should insert grouping separators, not return raw digits")
+        let groupingSeparator = Locale.current.groupingSeparator ?? ","
+        XCTAssertTrue(result.contains(groupingSeparator), "Formatted count should contain the locale grouping separator (\(groupingSeparator))")
     }
 }
 


### PR DESCRIPTION
Strengthens `testFormatCountUsesDecimalGrouping` to verify actual grouping separator presence, not just string containment.

- Asserts formatted result differs from raw digits ("1000000")
- Asserts locale grouping separator is present in the output
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
