### PR TITLE
fix: add watchId guard on rideShotgunError and improve failure discrimination

### DIFF
--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -103,17 +103,24 @@ async function completeSession(session: WatchSession): Promise<void> {
       }
     }
 
-    // When no recorder ever started, report the specific bootstrap failure
-    const summary = hasRecorder
-      ? session.savedRecordingPath
+    // Use bootstrapFailureReason as the primary discriminator — hasRecorder
+    // alone can't distinguish "browser never launched" from "recorder failed
+    // after retries" since both leave activeRecorders empty.
+    const summary = session.bootstrapFailureReason
+      ? `Learn session failed — ${session.bootstrapFailureReason}`
+      : session.savedRecordingPath
         ? "Learn session completed — recording saved."
-        : "Learn session completed — recording failed to save."
-      : `Learn session failed — ${session.bootstrapFailureReason ?? "unknown error."}`;
+        : "Learn session completed — recording failed to save.";
 
     lastSummaryBySession.set(sessionId, summary);
     session.status = "completed";
     log.info(
-      { watchId, sessionId, hasRecorder },
+      {
+        watchId,
+        sessionId,
+        hasRecorder,
+        bootstrapFailureReason: session.bootstrapFailureReason,
+      },
       "Learn session complete — firing completion notifier",
     );
     fireWatchCompletionNotifier(sessionId, session);

--- a/clients/ios/App/RideShotgunSession.swift
+++ b/clients/ios/App/RideShotgunSession.swift
@@ -66,6 +66,7 @@ final class RideShotgunSession: ObservableObject, Identifiable {
                     await MainActor.run { self.handleWatchStarted(msg) }
                 case .rideShotgunError(let error):
                     await MainActor.run {
+                        guard error.watchId == self.expectedWatchId else { return }
                         log.error("Ride shotgun bootstrap failure: \(error.message)")
                         self.state = .failed(error.message)
                         self.cleanup()

--- a/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
@@ -70,6 +70,7 @@ public final class RideShotgunSession: ObservableObject {
                 case .watchStarted(let started):
                     self.handleWatchStarted(started, daemonClient: daemonClient)
                 case .rideShotgunError(let error):
+                    guard error.watchId == self.expectedWatchId else { break }
                     log.error("Ride shotgun bootstrap failure: \(error.message)")
                     self.state = .failed(error.message)
                     self.cleanup()


### PR DESCRIPTION
Adds watchId validation to rideShotgunError handlers on both macOS and iOS to prevent cross-session error interference. Improves failure reason discrimination in ride-shotgun-handler.ts by using bootstrapFailureReason as the primary discriminator instead of hasRecorder.

- **macOS** `RideShotgunSession.swift`: Added `guard error.watchId == self.expectedWatchId` before transitioning to `.failed`
- **iOS** `RideShotgunSession.swift`: Added same `guard error.watchId == self.expectedWatchId` inside MainActor.run block
- **ride-shotgun-handler.ts**: Changed failure summary logic to use `bootstrapFailureReason` as primary discriminator instead of `hasRecorder`, which couldn't distinguish "browser never launched" from "recorder failed after retries"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
