### PR TITLE
feat: route gateway credential reading through keychain broker when available

### DIFF
--- a/gateway/src/__tests__/credential-reader.test.ts
+++ b/gateway/src/__tests__/credential-reader.test.ts
@@ -3,6 +3,8 @@ import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { hostname, tmpdir, userInfo } from "node:os";
 import { createCipheriv, pbkdf2Sync, randomBytes } from "node:crypto";
+import type { Server } from "node:net";
+import { createServer } from "node:net";
 
 // ---------------------------------------------------------------------------
 // Mock logger — capture log calls to verify no secrets leak
@@ -21,7 +23,10 @@ mock.module("../logger.js", () => ({
     }),
 }));
 
-import { readTelegramCredentials } from "../credential-reader.js";
+import {
+  readCredential,
+  readTelegramCredentials,
+} from "../credential-reader.js";
 
 // ---------------------------------------------------------------------------
 // Temp directory for metadata / encrypted store fixtures
@@ -113,13 +118,93 @@ function writeEncryptedStore(entries: Record<string, string>): void {
   writeFileSync(storePath, JSON.stringify(store));
 }
 
+// ---------------------------------------------------------------------------
+// Broker test helpers
+// ---------------------------------------------------------------------------
+
+const SOCKET_PATH = join(testDir, "broker.sock");
+const TEST_TOKEN = "test-auth-token-abc123";
+
+function writeBrokerToken(token: string): void {
+  const tokenDir = join(testDir, ".vellum", "protected");
+  mkdirSync(tokenDir, { recursive: true });
+  writeFileSync(join(tokenDir, "keychain-broker.token"), token);
+}
+
+function createMockBroker(): {
+  server: Server;
+  setHandler: (
+    fn: (request: Record<string, unknown>) => Record<string, unknown>,
+  ) => void;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+} {
+  let handler: (
+    request: Record<string, unknown>,
+  ) => Record<string, unknown> = () => ({ ok: true });
+
+  const server = createServer((conn) => {
+    let buffer = "";
+    conn.on("data", (chunk) => {
+      buffer += chunk.toString();
+      let idx: number;
+      while ((idx = buffer.indexOf("\n")) !== -1) {
+        const line = buffer.slice(0, idx).trim();
+        buffer = buffer.slice(idx + 1);
+        if (!line) continue;
+        try {
+          const request = JSON.parse(line);
+          const response = handler(request);
+          conn.write(JSON.stringify({ id: request.id, ...response }) + "\n");
+        } catch {
+          // Malformed request — ignore
+        }
+      }
+    });
+  });
+
+  return {
+    server,
+    setHandler: (fn) => {
+      handler = fn;
+    },
+    start: () =>
+      new Promise<void>((resolve) => {
+        server.listen(SOCKET_PATH, () => resolve());
+      }),
+    stop: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let savedBrokerSocket: string | undefined;
+
 beforeEach(() => {
   process.env.BASE_DATA_DIR = testDir;
+  savedBrokerSocket = process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
+  delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
   logCalls.length = 0;
+  // Clean up socket file from prior test
+  try {
+    rmSync(SOCKET_PATH, { force: true });
+  } catch {
+    /* ignore */
+  }
 });
 
 afterEach(() => {
   delete process.env.BASE_DATA_DIR;
+  if (savedBrokerSocket === undefined) {
+    delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
+  } else {
+    process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = savedBrokerSocket;
+  }
   try {
     rmSync(testDir, { recursive: true, force: true });
   } catch {
@@ -128,7 +213,7 @@ afterEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests
+// Tests: encrypted store (existing)
 // ---------------------------------------------------------------------------
 
 describe("readTelegramCredentials", () => {
@@ -194,5 +279,127 @@ describe("log output: no plaintext secrets", () => {
     const allLogText = JSON.stringify(logCalls);
     expect(allLogText).not.toContain("SUPER_SECRET_TOKEN_123");
     expect(allLogText).not.toContain("SUPER_SECRET_WEBHOOK_456");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: broker credential reading
+// ---------------------------------------------------------------------------
+
+describe("readCredential broker integration", () => {
+  test("returns undefined when broker env var is unset", () => {
+    delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
+    const result = readCredential("credential:test:key");
+    expect(result).toBeUndefined();
+  });
+
+  test("falls back to encrypted store when broker is unavailable", () => {
+    // No broker socket configured — should fall through to encrypted store
+    delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
+
+    writeEncryptedStore({
+      "credential:test:key": "encrypted-value",
+    });
+
+    const result = readCredential("credential:test:key");
+    expect(result).toBe("encrypted-value");
+  });
+
+  test("falls back to encrypted store when broker socket path is set but no server", () => {
+    process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = "/tmp/nonexistent-broker.sock";
+    writeBrokerToken(TEST_TOKEN);
+
+    writeEncryptedStore({
+      "credential:test:key": "encrypted-value",
+    });
+
+    const result = readCredential("credential:test:key");
+    expect(result).toBe("encrypted-value");
+  });
+
+  test("falls back to encrypted store when broker token file is missing", () => {
+    process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
+    // Don't write a token file
+
+    writeEncryptedStore({
+      "credential:test:key": "encrypted-value",
+    });
+
+    const result = readCredential("credential:test:key");
+    expect(result).toBe("encrypted-value");
+  });
+
+  test("reads credential from broker when available", async () => {
+    process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
+    writeBrokerToken(TEST_TOKEN);
+
+    const broker = createMockBroker();
+    broker.setHandler((req) => {
+      if (
+        req.method === "get" &&
+        req.account === "credential:test:key" &&
+        req.token === TEST_TOKEN
+      ) {
+        return { ok: true, value: "broker-secret-value" };
+      }
+      return { ok: false, error: "not found" };
+    });
+    await broker.start();
+
+    try {
+      const result = readCredential("credential:test:key");
+      expect(result).toBe("broker-secret-value");
+    } finally {
+      await broker.stop();
+    }
+  });
+
+  test("broker result takes priority over encrypted store", async () => {
+    process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
+    writeBrokerToken(TEST_TOKEN);
+
+    // Write a value to the encrypted store
+    writeEncryptedStore({
+      "credential:test:key": "encrypted-value",
+    });
+
+    // Also set up broker to return a different value
+    const broker = createMockBroker();
+    broker.setHandler((req) => {
+      if (req.method === "get" && req.account === "credential:test:key") {
+        return { ok: true, value: "broker-value" };
+      }
+      return { ok: false, error: "not found" };
+    });
+    await broker.start();
+
+    try {
+      const result = readCredential("credential:test:key");
+      expect(result).toBe("broker-value");
+    } finally {
+      await broker.stop();
+    }
+  });
+
+  test("falls back to encrypted store when broker returns not found", async () => {
+    process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
+    writeBrokerToken(TEST_TOKEN);
+
+    writeEncryptedStore({
+      "credential:test:key": "encrypted-value",
+    });
+
+    const broker = createMockBroker();
+    broker.setHandler(() => {
+      return { ok: false, error: "not found" };
+    });
+    await broker.start();
+
+    try {
+      const result = readCredential("credential:test:key");
+      expect(result).toBe("encrypted-value");
+    } finally {
+      await broker.stop();
+    }
   });
 });

--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -1,10 +1,12 @@
 /**
  * Read-only reader for the assistant's credential stores.
  *
- * Reads secrets from the encrypted-at-rest file (~/.vellum/protected/keys.enc).
+ * Tries the keychain broker (UDS) first, then falls back to the
+ * encrypted-at-rest file (~/.vellum/protected/keys.enc).
  */
 
-import { createDecipheriv, pbkdf2Sync } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { createDecipheriv, pbkdf2Sync, randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { hostname, userInfo } from "node:os";
 import { join } from "node:path";
@@ -114,12 +116,16 @@ export function getMetadataPath(): string {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Encrypted store reader
+// ---------------------------------------------------------------------------
+
 /**
  * Read a single credential from the encrypted store.
  * Returns `undefined` if the store doesn't exist, the key is missing,
  * or decryption fails.
  */
-export function readCredential(account: string): string | undefined {
+function readEncryptedCredential(account: string): string | undefined {
   try {
     const store = readStore(getEncryptedStorePath());
     if (!store) return undefined;
@@ -134,6 +140,109 @@ export function readCredential(account: string): string | undefined {
     log.debug({ err, account }, "Failed to read from encrypted store");
     return undefined;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Keychain broker reader (UDS)
+// ---------------------------------------------------------------------------
+
+/**
+ * Inline Node script executed via spawnSync to perform a synchronous UDS
+ * round-trip to the keychain broker. Communicates via newline-delimited JSON.
+ *
+ * Environment variables consumed:
+ *   BROKER_SOCKET  — path to the Unix domain socket
+ *   BROKER_TOKEN   — auth token
+ *   BROKER_ACCOUNT — credential account key
+ *   BROKER_REQ_ID  — unique request ID
+ */
+const BROKER_INLINE_SCRIPT = `
+const net = require("net");
+const socket = net.createConnection({ path: process.env.BROKER_SOCKET });
+let buf = "";
+socket.on("connect", () => {
+  const req = JSON.stringify({
+    id: process.env.BROKER_REQ_ID,
+    method: "get",
+    token: process.env.BROKER_TOKEN,
+    account: process.env.BROKER_ACCOUNT,
+  }) + "\\n";
+  socket.write(req);
+});
+socket.on("data", (chunk) => {
+  buf += chunk.toString();
+  const idx = buf.indexOf("\\n");
+  if (idx !== -1) {
+    try {
+      const resp = JSON.parse(buf.slice(0, idx));
+      if (resp.ok && typeof resp.value === "string") {
+        process.stdout.write(resp.value);
+      }
+    } catch {}
+    socket.destroy();
+  }
+});
+socket.on("error", () => process.exit(0));
+setTimeout(() => process.exit(0), 4000);
+`;
+
+function getBrokerTokenPath(): string {
+  return join(getRootDir(), "protected", "keychain-broker.token");
+}
+
+/**
+ * Try to read a credential from the keychain broker over its Unix domain socket.
+ * Returns `undefined` if the broker is unavailable, the socket env var is unset,
+ * the token file is missing, or the broker doesn't have the requested key.
+ */
+function readBrokerCredential(account: string): string | undefined {
+  const socketPath = process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
+  if (!socketPath) return undefined;
+
+  const tokenPath = getBrokerTokenPath();
+  let token: string;
+  try {
+    if (!existsSync(tokenPath)) return undefined;
+    token = readFileSync(tokenPath, "utf-8").trim();
+    if (!token) return undefined;
+  } catch {
+    return undefined;
+  }
+
+  try {
+    const result = spawnSync("node", ["-e", BROKER_INLINE_SCRIPT], {
+      env: {
+        ...process.env,
+        BROKER_SOCKET: socketPath,
+        BROKER_TOKEN: token,
+        BROKER_ACCOUNT: account,
+        BROKER_REQ_ID: randomUUID(),
+      },
+      timeout: 5_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const value = result.stdout?.toString();
+    if (!value) return undefined;
+    return value;
+  } catch (err) {
+    log.debug({ err, account }, "Failed to read from keychain broker");
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public credential reader — tries broker, then encrypted store
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a single credential by account key.
+ * Tries the keychain broker first (when available), then falls back
+ * to the encrypted-at-rest store.
+ */
+export function readCredential(account: string): string | undefined {
+  const brokerValue = readBrokerCredential(account);
+  if (brokerValue !== undefined) return brokerValue;
+  return readEncryptedCredential(account);
 }
 
 export type TelegramCredentials = {


### PR DESCRIPTION
## Summary
- Add readBrokerCredential() to gateway credential-reader using UDS connection to keychain broker
- Rename existing readCredential to readEncryptedCredential (private)
- New readCredential tries broker first, falls back to encrypted store
- All credential readers (Telegram, Twilio, Slack, WhatsApp) benefit transparently

Part of plan: app-embedded-keychain-broker.md (PR 7 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
