### PR TITLE
fix: preserve 4-digit precision and pin locale in usage cost formatting

### DIFF
--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -66,7 +66,8 @@ public enum UsageFormatting {
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
         formatter.currencyCode = "USD"
-        formatter.minimumFractionDigits = 2
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.minimumFractionDigits = 4
         formatter.maximumFractionDigits = 4
         return formatter.string(from: NSNumber(value: usd)) ?? String(format: "$%.4f", usd)
     }
@@ -74,6 +75,7 @@ public enum UsageFormatting {
     public static func formatCount(_ n: Int) -> String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
+        formatter.locale = Locale(identifier: "en_US")
         return formatter.string(from: NSNumber(value: n)) ?? "\(n)"
     }
 }


### PR DESCRIPTION
Fixes formatCost to use minimumFractionDigits=4 (matching original String(format:) behavior) and pins locale to en_US on both formatCost and formatCount for consistent CI output across locales.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
