### PR TITLE
fix: remove consecutive failure tracking from CI workflows

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -126,46 +126,6 @@ jobs:
           path: assistant/.test-durations
           key: test-durations-${{ github.run_id }}
 
-  track-failures:
-    name: Track Consecutive Failures
-    needs: [lint, typecheck, test]
-    if: always()
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    steps:
-      - name: Track consecutive failures
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # github.workflow returns the display name, not the filename.
-          # Extract the filename from github.workflow_ref instead.
-          WORKFLOW_REF="${{ github.workflow_ref }}"
-          WORKFLOW_NAME="${WORKFLOW_REF%%@*}"
-          WORKFLOW_NAME="${WORKFLOW_NAME##*/}"
-
-          # Get the last 100 completed runs of this workflow on main (excluding current)
-          RUNS=$(gh api "/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_NAME}/runs?branch=main&status=completed&per_page=100" \
-            --jq '[.workflow_runs[] | select(.id != '${{ github.run_id }}') | .conclusion]')
-
-          # Count consecutive failures from most recent
-          CONSECUTIVE=0
-          for conclusion in $(echo "$RUNS" | jq -r '.[]'); do
-            if [ "$conclusion" = "failure" ]; then
-              CONSECUTIVE=$((CONSECUTIVE + 1))
-            else
-              break
-            fi
-          done
-
-          # Check all upstream job results instead of just job.status
-          if [[ "${{ needs.lint.result }}" == "failure" || "${{ needs.typecheck.result }}" == "failure" || "${{ needs.test.result }}" == "failure" ]]; then
-            CONSECUTIVE=$((CONSECUTIVE + 1))
-          else
-            CONSECUTIVE=0
-          fi
-
-          echo "Consecutive failures on main: $CONSECUTIVE"
-
   notify:
     name: Slack Notification
     needs: [lint, typecheck, test]

--- a/.github/workflows/ci-main-cli.yaml
+++ b/.github/workflows/ci-main-cli.yaml
@@ -40,41 +40,6 @@ jobs:
       - name: Test with coverage
         run: bun test --coverage
 
-      - name: Track consecutive failures
-        if: always()
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # github.workflow returns the display name, not the filename.
-          # Extract the filename from github.workflow_ref instead.
-          WORKFLOW_REF="${{ github.workflow_ref }}"
-          WORKFLOW_NAME="${WORKFLOW_REF%%@*}"
-          WORKFLOW_NAME="${WORKFLOW_NAME##*/}"
-
-          # Get the last 100 completed runs of this workflow on main (excluding current)
-          RUNS=$(gh api "/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_NAME}/runs?branch=main&status=completed&per_page=100" \
-            --jq '[.workflow_runs[] | select(.id != '${{ github.run_id }}') | .conclusion]')
-
-          # Count consecutive failures from most recent
-          CONSECUTIVE=0
-          for conclusion in $(echo "$RUNS" | jq -r '.[]'); do
-            if [ "$conclusion" = "failure" ]; then
-              CONSECUTIVE=$((CONSECUTIVE + 1))
-            else
-              break
-            fi
-          done
-
-          # Add current run result
-          if [ "${{ job.status }}" = "failure" ]; then
-            CONSECUTIVE=$((CONSECUTIVE + 1))
-          else
-            CONSECUTIVE=0
-          fi
-
-          echo "Consecutive failures on main: $CONSECUTIVE"
-
   notify:
     name: Slack Notification
     needs: [checks]

--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -38,41 +38,6 @@ jobs:
       - name: Test
         run: bun run test
 
-      - name: Track consecutive failures
-        if: always()
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # github.workflow returns the display name, not the filename.
-          # Extract the filename from github.workflow_ref instead.
-          WORKFLOW_REF="${{ github.workflow_ref }}"
-          WORKFLOW_NAME="${WORKFLOW_REF%%@*}"
-          WORKFLOW_NAME="${WORKFLOW_NAME##*/}"
-
-          # Get the last 100 completed runs of this workflow on main (excluding current)
-          RUNS=$(gh api "/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_NAME}/runs?branch=main&status=completed&per_page=100" \
-            --jq '[.workflow_runs[] | select(.id != '${{ github.run_id }}') | .conclusion]')
-
-          # Count consecutive failures from most recent
-          CONSECUTIVE=0
-          for conclusion in $(echo "$RUNS" | jq -r '.[]'); do
-            if [ "$conclusion" = "failure" ]; then
-              CONSECUTIVE=$((CONSECUTIVE + 1))
-            else
-              break
-            fi
-          done
-
-          # Add current run result
-          if [ "${{ job.status }}" = "failure" ]; then
-            CONSECUTIVE=$((CONSECUTIVE + 1))
-          else
-            CONSECUTIVE=0
-          fi
-
-          echo "Consecutive failures on main: $CONSECUTIVE"
-
   notify:
     name: Slack Notification
     needs: [checks]

--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -36,41 +36,6 @@ jobs:
         working-directory: clients/ios
         run: ./build.sh test
 
-      - name: Track consecutive failures
-        if: always()
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # github.workflow returns the display name, not the filename.
-          # Extract the filename from github.workflow_ref instead.
-          WORKFLOW_REF="${{ github.workflow_ref }}"
-          WORKFLOW_NAME="${WORKFLOW_REF%%@*}"
-          WORKFLOW_NAME="${WORKFLOW_NAME##*/}"
-
-          # Get the last 100 completed runs of this workflow on main (excluding current)
-          RUNS=$(gh api "/repos/${{ github.repository }}/actions/workflows/${WORKFLOW_NAME}/runs?branch=main&status=completed&per_page=100" \
-            --jq '[.workflow_runs[] | select(.id != '${{ github.run_id }}') | .conclusion]')
-
-          # Count consecutive failures from most recent
-          CONSECUTIVE=0
-          for conclusion in $(echo "$RUNS" | jq -r '.[]'); do
-            if [ "$conclusion" = "failure" ]; then
-              CONSECUTIVE=$((CONSECUTIVE + 1))
-            else
-              break
-            fi
-          done
-
-          # Add current run result
-          if [ "${{ job.status }}" = "failure" ]; then
-            CONSECUTIVE=$((CONSECUTIVE + 1))
-          else
-            CONSECUTIVE=0
-          fi
-
-          echo "Consecutive failures on main: $CONSECUTIVE"
-
   notify:
     name: Slack Notification
     needs: [build]


### PR DESCRIPTION
## Summary
- Removed the "Track consecutive failures" step/job from all 4 CI main workflows (assistant, gateway, ios, cli)
- The tracking only logged a count to stdout and didn't trigger any alerts or actions, making it dead code

## Test plan
- [ ] Verify CI workflows still run correctly without the tracking step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
