### PR TITLE
fix: increment generation counters on usage dashboard client rebind

### DIFF
--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -111,6 +111,8 @@ public final class UsageDashboardStore {
     /// `refresh()` fetches from the new client.
     public func updateClient(_ newClient: any DaemonClientProtocol) {
         client = newClient
+        refreshGeneration &+= 1
+        breakdownGeneration &+= 1
         totalsState = .idle
         dailyState = .idle
         breakdownState = .idle


### PR DESCRIPTION
Increments refreshGeneration and breakdownGeneration in updateClient() to invalidate in-flight fetches from the old client.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
