### PR TITLE
fix: set bootstrapFailureReason on ride shotgun duration timeout

### DIFF
--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -427,6 +427,10 @@ export async function handleRideShotgunStart(
 
   // Set timeout for duration expiry
   session.timeoutHandle = setTimeout(() => {
+    if (!activeRecorders.has(watchId) && !session.bootstrapFailureReason) {
+      session.bootstrapFailureReason =
+        "session timed out before recording could start.";
+    }
     completeSession(session);
   }, durationSeconds * 1000);
 


### PR DESCRIPTION
Sets bootstrapFailureReason when the duration timeout fires during bootstrap, preventing the 'unknown error' fallthrough. If the duration timeout fires while bootstrap retries are still running, bootstrapFailureReason was never set, causing completeSession to produce 'Learn session failed — unknown error.' instead of a meaningful message.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
