### PR TITLE
fix: sort imports in index.ts

### DIFF
--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -4,9 +4,6 @@ import { createRequire } from "node:module";
 
 import { Command } from "commander";
 
-const require = createRequire(import.meta.url);
-const { version } = require("../package.json") as { version: string };
-
 import { registerAmazonCommand } from "./cli/amazon.js";
 import { registerAuditCommand } from "./cli/audit.js";
 import { registerAutonomyCommand } from "./cli/autonomy.js";
@@ -31,6 +28,9 @@ import { registerSessionsCommand } from "./cli/sessions.js";
 import { registerTrustCommand } from "./cli/trust.js";
 import { registerTwitterCommand } from "./cli/twitter.js";
 import { registerHooksCommand } from "./hooks/cli.js";
+
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json") as { version: string };
 
 const program = new Command();
 


### PR DESCRIPTION
## Summary
- Moved `createRequire` usage below all import statements in `assistant/src/index.ts` to fix `simple-import-sort/imports` lint error

## Test plan
- [x] `bun run lint` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
