### PR TITLE
fix: resolve 4 failing CI tests

### DIFF
--- a/assistant/src/__tests__/channel-readiness-routes.test.ts
+++ b/assistant/src/__tests__/channel-readiness-routes.test.ts
@@ -29,6 +29,12 @@ mock.module("../config/env.js", () => ({
 
 mock.module("../config/loader.js", () => ({
   loadRawConfig: () => mockRawConfig,
+  getConfig: () => {
+    const raw = mockRawConfig ?? {};
+    const wa = (raw.whatsapp ?? {}) as Record<string, unknown>;
+    return { whatsapp: { phoneNumber: (wa.phoneNumber as string) ?? "" } };
+  },
+  invalidateConfigCache: () => {},
 }));
 
 mock.module("../security/secure-keys.js", () => ({

--- a/assistant/src/__tests__/keychain-broker-client.test.ts
+++ b/assistant/src/__tests__/keychain-broker-client.test.ts
@@ -59,7 +59,11 @@ function createMockBroker(): {
     request: Record<string, unknown>,
   ) => Record<string, unknown> = () => ({ ok: true });
 
+  const connections = new Set<import("node:net").Socket>();
+
   const server = createServer((conn) => {
+    connections.add(conn);
+    conn.on("close", () => connections.delete(conn));
     let buffer = "";
     conn.on("data", (chunk) => {
       buffer += chunk.toString();
@@ -90,6 +94,9 @@ function createMockBroker(): {
       }),
     stop: () =>
       new Promise<void>((resolve) => {
+        // Destroy active connections so server.close() can complete
+        for (const conn of connections) conn.destroy();
+        connections.clear();
         server.close(() => resolve());
       }),
   };

--- a/assistant/src/__tests__/whatsapp-invite-adapter.test.ts
+++ b/assistant/src/__tests__/whatsapp-invite-adapter.test.ts
@@ -11,10 +11,16 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // Mocks — must be set up before importing the adapter
 // ---------------------------------------------------------------------------
 
-let mockRawConfig: Record<string, unknown> | undefined;
+let mockWhatsAppPhoneNumber: string | undefined;
+let mockGetConfigThrows = false;
 
 mock.module("../config/loader.js", () => ({
-  loadRawConfig: () => mockRawConfig,
+  loadRawConfig: () => ({}),
+  getConfig: () => {
+    if (mockGetConfigThrows) throw new Error("config not found");
+    return { whatsapp: { phoneNumber: mockWhatsAppPhoneNumber ?? "" } };
+  },
+  invalidateConfigCache: () => {},
 }));
 
 // ---------------------------------------------------------------------------
@@ -30,7 +36,8 @@ import { resolveWhatsAppDisplayNumber } from "../runtime/channel-invite-transpor
 
 describe("whatsapp invite adapter", () => {
   beforeEach(() => {
-    mockRawConfig = undefined;
+    mockWhatsAppPhoneNumber = undefined;
+    mockGetConfigThrows = false;
   });
 
   test("adapter is registered for the whatsapp channel", () => {
@@ -42,13 +49,13 @@ describe("whatsapp invite adapter", () => {
   // -------------------------------------------------------------------------
 
   test("returns configured phone number from workspace config", () => {
-    mockRawConfig = { whatsapp: { phoneNumber: "+15551234567" } };
+    mockWhatsAppPhoneNumber = "+15551234567";
     const handle = whatsappInviteAdapter.resolveChannelHandle!();
     expect(handle).toBe("+15551234567");
   });
 
   test("resolveWhatsAppDisplayNumber returns configured number", () => {
-    mockRawConfig = { whatsapp: { phoneNumber: "+15559876543" } };
+    mockWhatsAppPhoneNumber = "+15559876543";
     expect(resolveWhatsAppDisplayNumber()).toBe("+15559876543");
   });
 
@@ -57,21 +64,18 @@ describe("whatsapp invite adapter", () => {
   // -------------------------------------------------------------------------
 
   test("returns undefined when whatsapp config is missing", () => {
-    mockRawConfig = {};
     const handle = whatsappInviteAdapter.resolveChannelHandle!();
     expect(handle).toBeUndefined();
   });
 
   test("returns undefined when phoneNumber is empty string", () => {
-    mockRawConfig = { whatsapp: { phoneNumber: "" } };
+    mockWhatsAppPhoneNumber = "";
     const handle = whatsappInviteAdapter.resolveChannelHandle!();
     expect(handle).toBeUndefined();
   });
 
   test("returns undefined when config loading throws", () => {
-    mockRawConfig = undefined;
-    // Simulate loadRawConfig throwing by setting it to something that
-    // will cause our mock to return undefined (the try/catch handles this)
+    mockGetConfigThrows = true;
     const handle = whatsappInviteAdapter.resolveChannelHandle!();
     expect(handle).toBeUndefined();
   });

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -8,9 +8,15 @@
  */
 
 import * as encryptedStore from "./encrypted-store.js";
+import type { KeychainBrokerClient } from "./keychain-broker-client.js";
 import { createBrokerClient } from "./keychain-broker-client.js";
 
-const broker = createBrokerClient();
+let _broker: KeychainBrokerClient | undefined;
+
+function getBroker(): KeychainBrokerClient {
+  if (!_broker) _broker = createBrokerClient();
+  return _broker;
+}
 
 // ---------------------------------------------------------------------------
 // Sync variants — encrypted store only (startup / sync call sites)
@@ -57,7 +63,7 @@ export function listSecureKeys(): string[] {
  * Returns `"broker"` when the keychain broker is reachable, `"encrypted"` otherwise.
  */
 export function getBackendType(): "broker" | "encrypted" | null {
-  return broker.isAvailable() ? "broker" : "encrypted";
+  return getBroker().isAvailable() ? "broker" : "encrypted";
 }
 
 /**
@@ -80,6 +86,7 @@ export function isDowngradedFromKeychain(): boolean {
 export async function getSecureKeyAsync(
   account: string,
 ): Promise<string | undefined> {
+  const broker = getBroker();
   if (broker.isAvailable()) {
     const value = await broker.get(account);
     if (value !== undefined) return value;
@@ -96,6 +103,7 @@ export async function setSecureKeyAsync(
   account: string,
   value: string,
 ): Promise<boolean> {
+  const broker = getBroker();
   if (broker.isAvailable()) {
     const ok = await broker.set(account, value);
     if (ok) {
@@ -113,6 +121,7 @@ export async function setSecureKeyAsync(
  * as well so that sync callers have a consistent view.
  */
 export async function deleteSecureKeyAsync(account: string): Promise<boolean> {
+  const broker = getBroker();
   if (broker.isAvailable()) {
     const ok = await broker.del(account);
     if (ok) {
@@ -128,9 +137,9 @@ export async function deleteSecureKeyAsync(account: string): Promise<boolean> {
 // Test helpers
 // ---------------------------------------------------------------------------
 
-/** @internal Test-only: reset the cached backend so it's re-evaluated. */
+/** @internal Test-only: reset the cached broker so it's re-created. */
 export function _resetBackend(): void {
-  // No-op — backend selection is determined by broker availability at call time.
+  _broker = undefined;
 }
 
 /** @internal Test-only: force a specific backend. Pass `undefined` to reset. */


### PR DESCRIPTION
## Summary
- **whatsapp-invite-adapter.test.ts** / **channel-readiness-routes.test.ts**: Source was changed from `loadRawConfig()` to `getConfig()` but tests still mocked only `loadRawConfig`. Updated mocks to provide `getConfig`.
- **secure-keys.test.ts**: `createBrokerClient()` was called at module level, before bun's `mock.module` could intercept the transitive import. Changed to lazy initialization so the mock is applied on first use.
- **keychain-broker-client.test.ts**: `server.close()` in afterEach hung because persistent client connections were never destroyed. Track and destroy active connections before closing the server.

## Test plan
- [x] All 4 previously failing test files now pass locally
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
