### PR TITLE
refactor: extract channels CLI into channels.ts

### DIFF
--- a/assistant/src/cli/channels.ts
+++ b/assistant/src/cli/channels.ts
@@ -1,0 +1,21 @@
+import type { Command } from "commander";
+
+import { gatewayGet, runRead, toQueryString } from "./integrations.js";
+
+export function registerChannelsCommand(program: Command): void {
+  const channels = program
+    .command("channels")
+    .description("Query channel status")
+    .option("--json", "Machine-readable compact JSON output");
+
+  channels
+    .command("readiness")
+    .description("Check channel readiness for accepting messages")
+    .option("--channel <channel>", "Filter by channel type")
+    .action(async (opts: { channel?: string }, cmd: Command) => {
+      const query = toQueryString({ channel: opts.channel });
+      await runRead(cmd, async () =>
+        gatewayGet(`/v1/channels/readiness${query}`),
+      );
+    });
+}

--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -195,24 +195,6 @@ export async function runRead(
   }
 }
 
-export function registerChannelsCommand(program: Command): void {
-  const channels = program
-    .command("channels")
-    .description("Query channel status")
-    .option("--json", "Machine-readable compact JSON output");
-
-  channels
-    .command("readiness")
-    .description("Check channel readiness for accepting messages")
-    .option("--channel <channel>", "Filter by channel type")
-    .action(async (opts: { channel?: string }, cmd: Command) => {
-      const query = toQueryString({ channel: opts.channel });
-      await runRead(cmd, async () =>
-        gatewayGet(`/v1/channels/readiness${query}`),
-      );
-    });
-}
-
 export function registerIntegrationsCommand(program: Command): void {
   const integrations = program
     .command("integrations")

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -15,10 +15,8 @@ import { registerDevCommand } from "./cli/dev.js";
 import { registerDoctorCommand } from "./cli/doctor.js";
 import { registerEmailCommand } from "./cli/email.js";
 import { registerInfluencerCommand } from "./cli/influencer.js";
-import {
-  registerChannelsCommand,
-  registerIntegrationsCommand,
-} from "./cli/integrations.js";
+import { registerChannelsCommand } from "./cli/channels.js";
+import { registerIntegrationsCommand } from "./cli/integrations.js";
 import { registerKeysCommand } from "./cli/keys.js";
 import { registerMapCommand } from "./cli/map.js";
 import { registerMcpCommand } from "./cli/mcp.js";


### PR DESCRIPTION
## Summary
- Extract `registerChannelsCommand` from `integrations.ts` into a dedicated `channels.ts` file
- Update `index.ts` to import from the new module
- Shared gateway helpers (`gatewayGet`, `runRead`, `toQueryString`, etc.) remain in `integrations.ts`

## Original prompt
split this one up too:
import {
  registerChannelsCommand,
  registerIntegrationsCommand,
} from "./cli/integrations.js";

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
