### PR TITLE
feat: restyle Preferences row to match sidebar nav items

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -105,7 +105,9 @@ extension MainWindowView {
                 collapsedSidebarContent
             }
         }
-        .padding(VSpacing.xs)
+        .padding(.horizontal, VSpacing.xs)
+        .padding(.top, VSpacing.md)
+        .padding(.bottom, sidebarExpanded ? VSpacing.md : VSpacing.sm)
         .frame(width: sidebarExpanded ? sidebarExpandedWidth : sidebarCollapsedWidth, alignment: .leading)
         .background(adaptiveColor(light: Moss._50, dark: Moss._950))
         .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
@@ -439,8 +441,12 @@ extension MainWindowView {
 
             Spacer(minLength: VSpacing.sm)
 
+            sidebarSectionDivider(isExpanded: true)
+
             // Preferences row (fixed)
             PreferencesRow(
+                isActive: sidebar.showPreferencesDrawer,
+                isExpanded: true,
                 onToggle: {
                     withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
                         sidebar.showPreferencesDrawer.toggle()
@@ -532,11 +538,17 @@ extension MainWindowView {
 
             Spacer()
 
-            SidebarNavRow(icon: "slider.horizontal.3", label: "Preferences", isActive: false, isExpanded: false) {
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
-                    sidebar.showPreferencesDrawer.toggle()
+            sidebarSectionDivider(isExpanded: false)
+
+            PreferencesRow(
+                isActive: sidebar.showPreferencesDrawer,
+                isExpanded: false,
+                onToggle: {
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                        sidebar.showPreferencesDrawer.toggle()
+                    }
                 }
-            }
+            )
 
             Spacer().frame(height: 0)
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -528,9 +528,8 @@ struct MainWindowView: View {
                     // Preferences drawer rendered at top level so it floats above all content
                     if sidebar.showPreferencesDrawer {
                         let drawerWidth = sidebarExpandedWidth - VSpacing.sm * 2
-                        let drawerX = sidebarExpanded
-                            ? 16 + VSpacing.sm
-                            : 16 + sidebarCollapsedWidth - VSpacing.xs
+                        let sidebarWidth = sidebarExpanded ? sidebarExpandedWidth : sidebarCollapsedWidth
+                        let drawerX = 16 + sidebarWidth - VSpacing.xs
                         DrawerMenuView(
                             onSettings: {
                                 sidebar.showPreferencesDrawer = false

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/PreferencesRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/PreferencesRow.swift
@@ -2,19 +2,18 @@ import SwiftUI
 import VellumAssistantShared
 
 struct PreferencesRow: View {
+    let isActive: Bool
+    let isExpanded: Bool
     let onToggle: () -> Void
 
     var body: some View {
-        VButton(
+        SidebarPrimaryRow(
+            icon: "slider.horizontal.3",
             label: "Preferences",
-            leftIcon: "slider.horizontal.3",
-            rightIcon: "chevron.up",
-            style: .secondary,
-            size: .medium,
-            isFullWidth: true,
+            isActive: isActive,
+            trailingIcon: isActive ? "chevron.down" : "chevron.up",
+            isExpanded: isExpanded,
             action: onToggle
         )
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.bottom, VSpacing.sm)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift
@@ -9,6 +9,7 @@ struct SidebarPrimaryRow: View {
     let icon: String
     let label: String
     var isActive: Bool = false
+    var trailingIcon: String? = nil
     var isExpanded: Bool = true
     let action: () -> Void
     @State private var isHovered = false
@@ -31,6 +32,11 @@ struct SidebarPrimaryRow: View {
                     .allowsHitTesting(false)
                 if isExpanded {
                     Spacer()
+                    if let trailingIcon {
+                        Image(systemName: trailingIcon)
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400))
+                    }
                 }
             }
             .padding(.leading, isExpanded ? VSpacing.xs : 0)


### PR DESCRIPTION
## Summary
- Replace VButton-based PreferencesRow with SidebarPrimaryRow for consistent nav item styling
- Add active green highlight when preferences drawer is open
- Add trailing chevron indicator (up/down based on drawer state)
- Add section divider above Preferences in both expanded and collapsed modes
- Position preferences drawer to the right of sidebar in expanded mode (matching collapsed behavior)
- Add optional `trailingIcon` support to SidebarPrimaryRow
- Adjust sidebar container vertical padding (md top, md/sm bottom for expanded/collapsed)

## Test plan
- [x] Preferences row matches nav item style in both expanded and collapsed sidebar
- [x] Active green shows when drawer is open
- [x] Chevron flips direction based on drawer state
- [x] Divider appears above Preferences
- [x] Drawer opens to the right of sidebar in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
