### PR TITLE
refactor: restructure contacts invites as parent command with list subcommand

### DIFF
--- a/assistant/src/cli/contacts.ts
+++ b/assistant/src/cli/contacts.ts
@@ -87,9 +87,13 @@ export function registerContactsCommand(program: Command): void {
       },
     );
 
-  contacts
+  const invites = contacts
     .command("invites")
-    .description("List contact invites")
+    .description("Manage contact invites");
+
+  invites
+    .command("list")
+    .description("List invites")
     .option("--source-channel <sourceChannel>", "Filter by source channel")
     .option("--status <status>", "Filter by invite status")
     .action(


### PR DESCRIPTION
## Summary
- Converted contacts invites from a leaf command into a parent command with subcommands
- Moved the existing list behavior into invites list subcommand
- Prepares for adding create, revoke, redeem subcommands in subsequent PRs

Part of plan: contacts-cli-invite-ops.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
