### PR TITLE
fix: update credential security invariants allowlist for cli/keys.ts

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -219,11 +219,10 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "calls/twilio-provider.ts", // call infrastructure credential lookup
       "calls/twilio-rest.ts", // Twilio REST API credential lookup
       "runtime/channel-invite-transports/sms.ts", // SMS invite transport phone number lookup
-      "cli/config-commands.ts", // CLI credential management commands
+      "cli/keys.ts", // CLI credential management commands
       "runtime/http-server.ts", // HTTP server credential lookup
       "daemon/handlers/twitter-auth.ts", // Twitter OAuth token storage
       "twitter/oauth-client.ts", // Twitter OAuth API client (reads access token for API calls)
-      "cli/config-commands.ts", // CLI config management
       "messaging/providers/telegram-bot/adapter.ts", // Telegram bot token lookup for connectivity check
       "messaging/providers/sms/adapter.ts", // Twilio credential lookup for SMS connectivity check
       "runtime/channel-readiness-service.ts", // channel readiness probes for SMS/Telegram connectivity


### PR DESCRIPTION
## Summary
- PR #13297 split `cli/config-commands.ts` into per-command files, creating `cli/keys.ts` for key management
- The `credential-security-invariants` test's `ALLOWED_IMPORTERS` set still referenced the deleted `cli/config-commands.ts`, causing `cli/keys.ts` to be flagged as unauthorized
- Replace both stale `cli/config-commands.ts` entries with a single `cli/keys.ts` entry

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22742067195

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
