### PR TITLE
feat: add `contacts invites revoke` CLI subcommand

### DIFF
--- a/assistant/src/cli/contacts.ts
+++ b/assistant/src/cli/contacts.ts
@@ -8,7 +8,10 @@ import {
 } from "../contacts/contact-store.js";
 import type { ContactRole } from "../contacts/types.js";
 import { initializeDb } from "../memory/db.js";
-import { listIngressInvites } from "../runtime/invite-service.js";
+import {
+  listIngressInvites,
+  revokeIngressInvite,
+} from "../runtime/invite-service.js";
 import { writeOutput } from "./integrations.js";
 
 export function registerContactsCommand(program: Command): void {
@@ -115,4 +118,14 @@ export function registerContactsCommand(program: Command): void {
         }
       },
     );
+
+  invites
+    .command("revoke <inviteId>")
+    .description("Revoke an active invite")
+    .action(async (inviteId: string, _opts: unknown, cmd: Command) => {
+      initializeDb();
+      const result = revokeIngressInvite(inviteId);
+      writeOutput(cmd, result);
+      if (!result.ok) process.exitCode = 1;
+    });
 }


### PR DESCRIPTION
## Summary
- Added revoke subcommand to contacts invites
- Calls revokeIngressInvite() service function directly (no gateway proxy)
- Accepts invite ID as positional argument

Part of plan: contacts-cli-invite-ops.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
