### PR TITLE
feat: add `contacts invites redeem` CLI subcommand

### DIFF
--- a/assistant/src/cli/contacts.ts
+++ b/assistant/src/cli/contacts.ts
@@ -8,7 +8,11 @@ import {
 } from "../contacts/contact-store.js";
 import type { ContactRole } from "../contacts/types.js";
 import { initializeDb } from "../memory/db.js";
-import { listIngressInvites } from "../runtime/invite-service.js";
+import {
+  listIngressInvites,
+  redeemIngressInvite,
+  redeemVoiceInviteCode,
+} from "../runtime/invite-service.js";
 import { writeOutput } from "./integrations.js";
 
 export function registerContactsCommand(program: Command): void {
@@ -108,6 +112,78 @@ export function registerContactsCommand(program: Command): void {
             status: opts.status,
           });
           writeOutput(cmd, result);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
+          process.exitCode = 1;
+        }
+      },
+    );
+
+  invites
+    .command("redeem")
+    .description("Redeem an invite via token or voice code")
+    .option("--token <token>", "Invite token")
+    .option("--source-channel <channel>", "Channel for redemption")
+    .option("--external-user-id <id>", "External user ID")
+    .option("--external-chat-id <id>", "External chat ID")
+    .option("--code <code>", "6-digit voice code")
+    .option(
+      "--caller-external-user-id <phone>",
+      "E.164 phone number for voice code redemption",
+    )
+    .option("--assistant-id <id>", "Assistant ID for voice code redemption")
+    .action(
+      async (
+        opts: {
+          token?: string;
+          sourceChannel?: string;
+          externalUserId?: string;
+          externalChatId?: string;
+          code?: string;
+          callerExternalUserId?: string;
+          assistantId?: string;
+        },
+        cmd: Command,
+      ) => {
+        try {
+          initializeDb();
+          if (opts.code) {
+            if (!opts.callerExternalUserId) {
+              writeOutput(cmd, {
+                ok: false,
+                error:
+                  "--caller-external-user-id is required for voice code redemption",
+              });
+              process.exitCode = 1;
+              return;
+            }
+            const result = redeemVoiceInviteCode({
+              code: opts.code,
+              callerExternalUserId: opts.callerExternalUserId,
+              sourceChannel: "voice",
+              ...(opts.assistantId ? { assistantId: opts.assistantId } : {}),
+            });
+            writeOutput(cmd, result);
+            if (!result.ok) {
+              process.exitCode = 1;
+            }
+          } else {
+            const result = redeemIngressInvite({
+              token: opts.token,
+              sourceChannel: opts.sourceChannel,
+              ...(opts.externalUserId
+                ? { externalUserId: opts.externalUserId }
+                : {}),
+              ...(opts.externalChatId
+                ? { externalChatId: opts.externalChatId }
+                : {}),
+            });
+            writeOutput(cmd, result);
+            if (!result.ok) {
+              process.exitCode = 1;
+            }
+          }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           writeOutput(cmd, { ok: false, error: message });


### PR DESCRIPTION
## Summary
- Added redeem subcommand to contacts invites with dual-mode support
- Token-based redemption via --token and --source-channel
- Voice-code redemption via --code and --caller-external-user-id
- Calls service functions directly (no gateway proxy)

Part of plan: contacts-cli-invite-ops.md (PR 6 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
