### PR TITLE
fix: correct whatsapp channelHandle and phoneNumber documentation

### DIFF
--- a/assistant/README.md
+++ b/assistant/README.md
@@ -382,7 +382,7 @@ All endpoints are bearer-authenticated. Skills and clients should call the gatew
 - **Voice**: Checks Twilio credentials, phone number assignment, and public ingress URL.
 - **Telegram**: Checks bot token, webhook secret, and public ingress URL.
 - **Email**: Checks AgentMail API key, invite policy, public ingress URL, and verifies an inbox address is available (remote check).
-- **WhatsApp**: Checks Meta WhatsApp Business API credentials (phoneNumberId, accessToken, appSecret, webhookVerifyToken), invite policy, and public ingress URL.
+- **WhatsApp**: Checks Meta WhatsApp Business API credentials (phoneNumberId, accessToken, appSecret, webhookVerifyToken), display phone number (`whatsapp.phoneNumber`), invite policy, and public ingress URL.
 - **Slack**: Checks bot token and app token.
 
 ### Key modules

--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -419,7 +419,7 @@ The response contains `{ ok: true, invite: { id, token, inviteCode, guardianInst
 
 - `inviteCode` is the 6-digit code the invitee must send to redeem the invite.
 - `guardianInstruction` is a generated instruction telling the guardian how to share the invite.
-- `channelHandle` (optional) is the assistant's WhatsApp display phone number. It is not currently available because the Meta WhatsApp Business API identifies numbers by `phone_number_id`, which is not a user-facing phone number.
+- `channelHandle` (optional) is the assistant's WhatsApp display phone number. It is only present when a display number is configured via `whatsapp.phoneNumber` in workspace config.
 
 **Presenting to the guardian**: If `channelHandle` is present, give the guardian the invite code and the assistant's WhatsApp number:
 


### PR DESCRIPTION
Fixes documentation to accurately reflect that whatsapp.phoneNumber is actively used and channelHandle IS available when configured. Addresses feedback from PR #13280.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
