### PR TITLE
fix: defer session clearing until after summary dismissal in ride shotgun

### DIFF
--- a/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
+++ b/clients/macos/vellum-assistant/Ambient/AmbientAgent.swift
@@ -180,9 +180,7 @@ public final class AmbientAgent: ObservableObject {
             log.error("Ride shotgun session failed: \(reason)")
             progressWindow?.close()
             progressWindow = nil
-            let failureMessage = "The assistant failed to start the session:\n\n\(reason)"
-            setCurrentSession(nil)
-            showSummary(failureMessage)
+            showSummary("The assistant failed to start the session:\n\n\(reason)")
             sessionCancellable?.cancel()
             sessionCancellable = nil
 


### PR DESCRIPTION
Fixes the race condition where clearing the current session before showing the failure summary could allow a new session to start while the summary is still open. The summary window's onDismiss/onHelp callbacks already call setCurrentSession(nil), so the eager call was redundant and racy.

Addresses feedback from PR #13264.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
