### PR TITLE
fix: add missing iOS app target import in UsageDashboardViewTests

### DIFF
--- a/clients/ios/Tests/UsageDashboardViewTests.swift
+++ b/clients/ios/Tests/UsageDashboardViewTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 #if canImport(UIKit)
 import SwiftUI
+@testable import vellum_assistant_ios
 #endif
 
 /// Tests for the UsageDashboardStore states used by the iOS UsageDashboardView.


### PR DESCRIPTION
## Summary
- `UsageDashboardViewTests.swift` references `UsageDashboardView` which is defined in the iOS app target (`vellum_assistant_ios`), but only imports `VellumAssistantShared`
- Adds `@testable import vellum_assistant_ios` inside the `#if canImport(UIKit)` block so the view type is in scope

## Test plan
- [x] CI iOS build should now resolve `UsageDashboardView` and compile successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
