### PR TITLE
fix: revert locale pinning in usage cost formatting to preserve i18n

### DIFF
--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -66,7 +66,6 @@ public enum UsageFormatting {
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
         formatter.currencyCode = "USD"
-        formatter.locale = Locale(identifier: "en_US")
         formatter.minimumFractionDigits = 4
         formatter.maximumFractionDigits = 4
         return formatter.string(from: NSNumber(value: usd)) ?? String(format: "$%.4f", usd)
@@ -75,7 +74,6 @@ public enum UsageFormatting {
     public static func formatCount(_ n: Int) -> String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.locale = Locale(identifier: "en_US")
         return formatter.string(from: NSNumber(value: n)) ?? "\(n)"
     }
 }


### PR DESCRIPTION
Reverts the en_US locale pinning from PR #13291 while keeping the 4-digit precision fix. The locale pinning was flagged by both Codex and Devin as an i18n regression that forces US-style number formatting on all users.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
