### PR TITLE
fix: scope bootstrapFailureReason to learn-mode sessions only

### DIFF
--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -442,7 +442,11 @@ export async function handleRideShotgunStart(
 
   // Set timeout for duration expiry
   session.timeoutHandle = setTimeout(() => {
-    if (!activeRecorders.has(watchId) && !session.bootstrapFailureReason) {
+    if (
+      session.isLearnMode &&
+      !activeRecorders.has(watchId) &&
+      !session.bootstrapFailureReason
+    ) {
       session.bootstrapFailureReason =
         "session timed out before recording could start.";
     }


### PR DESCRIPTION
Adds isLearnMode guard to the bootstrapFailureReason timeout check, preventing non-learn-mode sessions from incorrectly getting a failure reason set. Addresses Devin feedback on PR #13295.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
