### PR TITLE
fix: allow rideShotgunError through when expectedWatchId is nil

### DIFF
--- a/clients/ios/App/RideShotgunSession.swift
+++ b/clients/ios/App/RideShotgunSession.swift
@@ -66,7 +66,7 @@ final class RideShotgunSession: ObservableObject, Identifiable {
                     await MainActor.run { self.handleWatchStarted(msg) }
                 case .rideShotgunError(let error):
                     await MainActor.run {
-                        guard error.watchId == self.expectedWatchId else { return }
+                        guard self.expectedWatchId == nil || error.watchId == self.expectedWatchId else { return }
                         log.error("Ride shotgun bootstrap failure: \(error.message)")
                         self.state = .failed(error.message)
                         self.cleanup()

--- a/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
+++ b/clients/macos/vellum-assistant/Ambient/RideShotgunSession.swift
@@ -70,7 +70,7 @@ public final class RideShotgunSession: ObservableObject {
                 case .watchStarted(let started):
                     self.handleWatchStarted(started, daemonClient: daemonClient)
                 case .rideShotgunError(let error):
-                    guard error.watchId == self.expectedWatchId else { break }
+                    guard self.expectedWatchId == nil || error.watchId == self.expectedWatchId else { break }
                     log.error("Ride shotgun bootstrap failure: \(error.message)")
                     self.state = .failed(error.message)
                     self.cleanup()


### PR DESCRIPTION
The watchId guard added in #13289 silently drops errors when expectedWatchId is nil (before watchStarted arrives). This fix only enforces watchId matching after expectedWatchId has been set, so bootstrap errors during startup are still surfaced.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
