### PR TITLE
fix: add try/catch to contacts invites revoke subcommand

### DIFF
--- a/assistant/src/cli/contacts.ts
+++ b/assistant/src/cli/contacts.ts
@@ -189,10 +189,16 @@ export function registerContactsCommand(program: Command): void {
     .command("revoke <inviteId>")
     .description("Revoke an active invite")
     .action(async (inviteId: string, _opts: unknown, cmd: Command) => {
-      initializeDb();
-      const result = revokeIngressInvite(inviteId);
-      writeOutput(cmd, result);
-      if (!result.ok) process.exitCode = 1;
+      try {
+        initializeDb();
+        const result = revokeIngressInvite(inviteId);
+        writeOutput(cmd, result);
+        if (!result.ok) process.exitCode = 1;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeOutput(cmd, { ok: false, error: message });
+        process.exitCode = 1;
+      }
     });
 
   invites


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contacts-cli-invite-ops.md.

**Gap:** revoke subcommand missing try/catch error handling
**What was expected:** Consistent try/catch error handling matching all other subcommands
**What was found:** revoke had no try/catch, allowing raw stack traces on unexpected errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)