### PR TITLE
fix: update SKILL.md invite CLI syntax to use list subcommand

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -496,22 +496,22 @@ If the Slack bot is not available (Slack credentials not configured), tell the g
 Use this to show the guardian their active (and optionally all) invite links.
 
 ```bash
-vellum contacts invites --source-channel telegram --json
+vellum contacts invites list --source-channel telegram --json
 ```
 
 For voice invites:
 
 ```bash
-vellum contacts invites --source-channel voice --json
+vellum contacts invites list --source-channel voice --json
 ```
 
 For email, WhatsApp, SMS, or Slack invites:
 
 ```bash
-vellum contacts invites --source-channel email --json
-vellum contacts invites --source-channel whatsapp --json
-vellum contacts invites --source-channel sms --json
-vellum contacts invites --source-channel slack --json
+vellum contacts invites list --source-channel email --json
+vellum contacts invites list --source-channel whatsapp --json
+vellum contacts invites list --source-channel sms --json
+vellum contacts invites list --source-channel slack --json
 ```
 
 Optional query parameters:


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contacts-cli-invite-ops.md.

**Gap:** SKILL.md references broken CLI syntax for invite listing
**What was expected:** SKILL.md uses the post-restructuring syntax with list subcommand
**What was found:** SKILL.md still referenced pre-restructuring syntax without list subcommand

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
