### PR TITLE
fix: unwrap IngressResult in invite CLI commands to match HTTP route shapes

### DIFF
--- a/assistant/src/cli/contacts.ts
+++ b/assistant/src/cli/contacts.ts
@@ -113,7 +113,11 @@ export function registerContactsCommand(program: Command): void {
             sourceChannel: opts.sourceChannel,
             status: opts.status,
           });
-          writeOutput(cmd, result);
+          if (result.ok) {
+            writeOutput(cmd, { ok: true, invites: result.data });
+          } else {
+            writeOutput(cmd, result);
+          }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           writeOutput(cmd, { ok: false, error: message });
@@ -173,7 +177,11 @@ export function registerContactsCommand(program: Command): void {
             friendName: opts.friendName,
             guardianName: opts.guardianName,
           });
-          writeOutput(cmd, result);
+          if (result.ok) {
+            writeOutput(cmd, { ok: true, invite: result.data });
+          } else {
+            writeOutput(cmd, result);
+          }
           if (!result.ok) {
             process.exitCode = 1;
           }
@@ -192,7 +200,11 @@ export function registerContactsCommand(program: Command): void {
       try {
         initializeDb();
         const result = revokeIngressInvite(inviteId);
-        writeOutput(cmd, result);
+        if (result.ok) {
+          writeOutput(cmd, { ok: true, invite: result.data });
+        } else {
+          writeOutput(cmd, result);
+        }
         if (!result.ok) process.exitCode = 1;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -245,8 +257,17 @@ export function registerContactsCommand(program: Command): void {
               sourceChannel: "voice",
               ...(opts.assistantId ? { assistantId: opts.assistantId } : {}),
             });
-            writeOutput(cmd, result);
-            if (!result.ok) {
+            if (result.ok) {
+              writeOutput(cmd, {
+                ok: true,
+                type: result.type,
+                memberId: result.memberId,
+                ...(result.type === "redeemed"
+                  ? { inviteId: result.inviteId }
+                  : {}),
+              });
+            } else {
+              writeOutput(cmd, { ok: false, error: result.reason });
               process.exitCode = 1;
             }
           } else {
@@ -260,7 +281,11 @@ export function registerContactsCommand(program: Command): void {
                 ? { externalChatId: opts.externalChatId }
                 : {}),
             });
-            writeOutput(cmd, result);
+            if (result.ok) {
+              writeOutput(cmd, { ok: true, invite: result.data });
+            } else {
+              writeOutput(cmd, result);
+            }
             if (!result.ok) {
               process.exitCode = 1;
             }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contacts-cli-invite-ops.md.

**Gap:** Invite CLI commands output raw IngressResult envelope with data key
**What was expected:** CLI output should match HTTP route shapes (invites/invite keys)
**What was found:** CLI output raw { ok, data } instead of { ok, invites/invite }

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
