### PR TITLE
fix: clean up stale keychain references in test files

### DIFF
--- a/assistant/src/__tests__/credential-vault.test.ts
+++ b/assistant/src/__tests__/credential-vault.test.ts
@@ -29,7 +29,7 @@ mock.module("../util/logger.js", () => ({
 // ---------------------------------------------------------------------------
 
 import { _setStorePath } from "../security/encrypted-store.js";
-import { _resetBackend, _setBackend } from "../security/secure-keys.js";
+import { _resetBackend } from "../security/secure-keys.js";
 
 const TEST_DIR = join(
   tmpdir(),
@@ -489,7 +489,7 @@ describe("credential_store tool", () => {
       expect(gmail.injection_templates).toBeUndefined();
     });
 
-    test("works with keychain backend (reads from metadata store)", async () => {
+    test("works with metadata store fallback when listing secrets", async () => {
       // Store a credential first (on encrypted backend)
       await credentialStoreTool.execute(
         {
@@ -500,9 +500,6 @@ describe("credential_store tool", () => {
         },
         _ctx,
       );
-
-      // Switch to keychain backend — list should still work via metadata
-      _setBackend("keychain");
 
       const result = await credentialStoreTool.execute(
         { action: "list" },

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -37,7 +37,7 @@ mock.module("../security/secure-keys.js", () => ({
   },
   deleteSecureKey: (key: string) => storedKeys.delete(key),
   listSecureKeys: () => [],
-  getBackendType: () => "keychain",
+  getBackendType: () => "encrypted",
   isDowngradedFromKeychain: () => false,
 }));
 


### PR DESCRIPTION
## Summary
- Rename misleading 'works with keychain backend' test in credential-vault.test.ts and remove no-op `_setBackend('keychain')` call
- Fix stale `getBackendType` mock returning `'keychain'` in secret-onetime-send.test.ts (now returns `'encrypted'`)
- Remove unused `_setBackend` import (dead code cleanup)

Part of plan: app-embedded-keychain-broker.md (review fix round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)