### PR TITLE
fix: align broker IPC protocol between Swift server and TypeScript clients

### DIFF
--- a/assistant/src/__tests__/keychain-broker-client.test.ts
+++ b/assistant/src/__tests__/keychain-broker-client.test.ts
@@ -199,44 +199,78 @@ describe("keychain-broker-client", () => {
       await broker.stop();
     });
 
-    test("ping returns version from broker", async () => {
+    test("ping returns pong from broker", async () => {
       broker.setHandler((req) => {
-        if (req.method === "ping") {
-          return { ok: true, version: "1.0.0" };
+        expect(req.v).toBe(1);
+        if (req.method === "broker.ping") {
+          return { ok: true, result: { pong: true } };
         }
-        return { ok: false, error: "unknown method" };
+        return {
+          ok: false,
+          error: { code: "INVALID_REQUEST", message: "unknown method" },
+        };
       });
       await broker.start();
 
       const client = createBrokerClient();
       const result = await client.ping();
-      expect(result).toEqual({ version: "1.0.0" });
+      expect(result).toEqual({ pong: true });
     });
 
-    test("get returns value from broker", async () => {
+    test("get returns found result from broker", async () => {
       broker.setHandler((req) => {
-        if (req.method === "get" && req.account === "my-key") {
-          return { ok: true, value: "secret-value" };
+        expect(req.v).toBe(1);
+        const params = req.params as { account?: string } | undefined;
+        if (req.method === "key.get" && params?.account === "my-key") {
+          return { ok: true, result: { found: true, value: "secret-value" } };
         }
-        return { ok: false, error: "not found" };
+        return {
+          ok: false,
+          error: { code: "INVALID_REQUEST", message: "not found" },
+        };
       });
       await broker.start();
 
       const client = createBrokerClient();
       const result = await client.get("my-key");
-      expect(result).toBe("secret-value");
+      expect(result).toEqual({ found: true, value: "secret-value" });
+    });
+
+    test("get returns not-found result from broker", async () => {
+      broker.setHandler((req) => {
+        expect(req.v).toBe(1);
+        if (req.method === "key.get") {
+          return { ok: true, result: { found: false } };
+        }
+        return {
+          ok: false,
+          error: { code: "INVALID_REQUEST", message: "bad" },
+        };
+      });
+      await broker.start();
+
+      const client = createBrokerClient();
+      const result = await client.get("missing-key");
+      expect(result).toEqual({ found: false, value: undefined });
     });
 
     test("set returns true on success", async () => {
       broker.setHandler((req) => {
+        expect(req.v).toBe(1);
+        const params = req.params as
+          | { account?: string; value?: string }
+          | undefined;
         if (
-          req.method === "set" &&
-          req.account === "my-key" &&
-          req.value === "new-value"
+          req.method === "key.set" &&
+          params?.account === "my-key" &&
+          params?.value === "new-value"
         ) {
-          return { ok: true };
+          return { ok: true, result: { stored: true } };
         }
-        return { ok: false, error: "failed" };
+        return {
+          ok: false,
+          error: { code: "INVALID_REQUEST", message: "failed" },
+        };
       });
       await broker.start();
 
@@ -247,10 +281,15 @@ describe("keychain-broker-client", () => {
 
     test("del returns true on success", async () => {
       broker.setHandler((req) => {
-        if (req.method === "del" && req.account === "my-key") {
-          return { ok: true };
+        expect(req.v).toBe(1);
+        const params = req.params as { account?: string } | undefined;
+        if (req.method === "key.delete" && params?.account === "my-key") {
+          return { ok: true, result: { deleted: true } };
         }
-        return { ok: false, error: "not found" };
+        return {
+          ok: false,
+          error: { code: "INVALID_REQUEST", message: "not found" },
+        };
       });
       await broker.start();
 
@@ -261,10 +300,17 @@ describe("keychain-broker-client", () => {
 
     test("list returns account names", async () => {
       broker.setHandler((req) => {
-        if (req.method === "list") {
-          return { ok: true, accounts: ["key-a", "key-b", "key-c"] };
+        expect(req.v).toBe(1);
+        if (req.method === "key.list") {
+          return {
+            ok: true,
+            result: { accounts: ["key-a", "key-b", "key-c"] },
+          };
         }
-        return { ok: false, error: "failed" };
+        return {
+          ok: false,
+          error: { code: "INVALID_REQUEST", message: "failed" },
+        };
       });
       await broker.start();
 
@@ -273,17 +319,20 @@ describe("keychain-broker-client", () => {
       expect(result).toEqual(["key-a", "key-b", "key-c"]);
     });
 
-    test("sends auth token with every request", async () => {
+    test("sends auth token and v:1 with every request", async () => {
       let receivedToken: unknown;
+      let receivedVersion: unknown;
       broker.setHandler((req) => {
         receivedToken = req.token;
-        return { ok: true, version: "1.0.0" };
+        receivedVersion = req.v;
+        return { ok: true, result: { pong: true } };
       });
       await broker.start();
 
       const client = createBrokerClient();
       await client.ping();
       expect(receivedToken).toBe(TEST_TOKEN);
+      expect(receivedVersion).toBe(1);
     });
   });
 
@@ -319,9 +368,9 @@ describe("keychain-broker-client", () => {
 
       const client = createBrokerClient();
 
-      // get should return undefined on timeout
+      // get should return null on timeout (broker error)
       const result = await client.get("test-key");
-      expect(result).toBeUndefined();
+      expect(result).toBeNull();
     }, 10_000);
   });
 
@@ -346,9 +395,12 @@ describe("keychain-broker-client", () => {
       broker.setHandler((req) => {
         callCount++;
         if (req.token === "new-token") {
-          return { ok: true, version: "2.0.0" };
+          return { ok: true, result: { pong: true } };
         }
-        return { ok: false, error: "UNAUTHORIZED" };
+        return {
+          ok: false,
+          error: { code: "UNAUTHORIZED", message: "Invalid auth token" },
+        };
       });
       await broker.start();
 
@@ -363,18 +415,24 @@ describe("keychain-broker-client", () => {
         if (callCount === 1) {
           // First request with old token — write new token file and return UNAUTHORIZED
           writeFileSync(TOKEN_PATH, "new-token");
-          return { ok: false, error: "UNAUTHORIZED" };
+          return {
+            ok: false,
+            error: { code: "UNAUTHORIZED", message: "Invalid auth token" },
+          };
         }
         // Retry with re-read token
         if (req.token === "new-token") {
-          return { ok: true, version: "2.0.0" };
+          return { ok: true, result: { pong: true } };
         }
-        return { ok: false, error: "UNAUTHORIZED" };
+        return {
+          ok: false,
+          error: { code: "UNAUTHORIZED", message: "Invalid auth token" },
+        };
       });
       callCount = 0;
 
       const result = await client.ping();
-      expect(result).toEqual({ version: "2.0.0" });
+      expect(result).toEqual({ pong: true });
       expect(callCount).toBe(2);
     });
   });
@@ -383,12 +441,12 @@ describe("keychain-broker-client", () => {
   // Graceful degradation
   // -----------------------------------------------------------------------
   describe("graceful degradation", () => {
-    test("get returns undefined when broker is not running", async () => {
+    test("get returns null when broker is not running", async () => {
       process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = SOCKET_PATH;
       writeFileSync(TOKEN_PATH, TEST_TOKEN);
       const client = createBrokerClient();
       const result = await client.get("test-key");
-      expect(result).toBeUndefined();
+      expect(result).toBeNull();
     });
 
     test("set returns false when broker is not running", async () => {
@@ -427,7 +485,7 @@ describe("keychain-broker-client", () => {
       delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
       writeFileSync(TOKEN_PATH, TEST_TOKEN);
       const client = createBrokerClient();
-      expect(await client.get("key")).toBeUndefined();
+      expect(await client.get("key")).toBeNull();
       expect(await client.set("key", "val")).toBe(false);
       expect(await client.del("key")).toBe(false);
       expect(await client.list()).toEqual([]);
@@ -442,7 +500,7 @@ describe("keychain-broker-client", () => {
         /* ignore */
       }
       const client = createBrokerClient();
-      expect(await client.get("key")).toBeUndefined();
+      expect(await client.get("key")).toBeNull();
       expect(await client.set("key", "val")).toBe(false);
       expect(await client.del("key")).toBe(false);
       expect(await client.list()).toEqual([]);
@@ -471,7 +529,7 @@ describe("keychain-broker-client", () => {
       broker.server.on("connection", () => {
         connectionCount++;
       });
-      broker.setHandler(() => ({ ok: true, version: "1.0.0" }));
+      broker.setHandler(() => ({ ok: true, result: { pong: true } }));
       await broker.start();
 
       const client = createBrokerClient();

--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -37,10 +37,13 @@ let mockBrokerDelError = false;
 mock.module("../security/keychain-broker-client.js", () => ({
   createBrokerClient: () => ({
     isAvailable: () => mockBrokerAvailable,
-    ping: async () => (mockBrokerAvailable ? { version: "test" } : null),
+    ping: async () => (mockBrokerAvailable ? { pong: true } : null),
     get: async (account: string) => {
-      if (mockBrokerGetError) return undefined;
-      return mockBrokerStore.get(account);
+      // null = broker error (fall back to encrypted store)
+      if (mockBrokerGetError) return null;
+      const value = mockBrokerStore.get(account);
+      if (value !== undefined) return { found: true, value };
+      return { found: false };
     },
     set: async (account: string, value: string) => {
       if (mockBrokerSetError) return false;
@@ -206,11 +209,12 @@ describe("secure-keys", () => {
       expect(await getSecureKeyAsync("api-key")).toBe("broker-value");
     });
 
-    test("getSecureKeyAsync falls back to encrypted store when broker returns undefined", async () => {
+    test("getSecureKeyAsync returns undefined when broker reports not-found (no fallback)", async () => {
       mockBrokerAvailable = true;
-      // Broker has nothing for this key
+      // Broker has nothing for this key — returns { found: false }.
+      // The new behaviour trusts the broker answer and does NOT fall back.
       setSecureKey("api-key", "encrypted-value");
-      expect(await getSecureKeyAsync("api-key")).toBe("encrypted-value");
+      expect(await getSecureKeyAsync("api-key")).toBeUndefined();
     });
 
     test("getSecureKeyAsync falls back to encrypted store on broker error", async () => {

--- a/assistant/src/security/keychain-broker-client.ts
+++ b/assistant/src/security/keychain-broker-client.ts
@@ -29,27 +29,32 @@ const REQUEST_TIMEOUT_MS = 5_000;
 // Types
 // ---------------------------------------------------------------------------
 
+/** Result of a `get()` call. `null` means broker error (caller should fall
+ *  back); `{ found: false }` means the key doesn't exist in the keychain. */
+export type BrokerGetResult = { found: boolean; value?: string } | null;
+
 export interface KeychainBrokerClient {
   isAvailable(): boolean;
-  ping(): Promise<{ version: string } | null>;
-  get(account: string): Promise<string | undefined>;
+  ping(): Promise<{ pong: boolean } | null>;
+  get(account: string): Promise<BrokerGetResult>;
   set(account: string, value: string): Promise<boolean>;
   del(account: string): Promise<boolean>;
   list(): Promise<string[]>;
 }
 
 interface BrokerRequest {
+  v: number;
   id: string;
   method: string;
   token: string;
-  [key: string]: unknown;
+  params?: Record<string, unknown>;
 }
 
 interface BrokerResponse {
   id: string;
   ok: boolean;
-  error?: string;
-  [key: string]: unknown;
+  result?: Record<string, unknown>;
+  error?: { code: string; message: string };
 }
 
 interface PendingRequest {
@@ -149,7 +154,11 @@ export function createBrokerClient(): KeychainBrokerClient {
     // Reject all pending requests
     for (const [id, entry] of pending) {
       clearTimeout(entry.timer);
-      entry.resolve({ id, ok: false, error: "disconnected" });
+      entry.resolve({
+        id,
+        ok: false,
+        error: { code: "DISCONNECTED", message: "disconnected" },
+      });
     }
     pending.clear();
   }
@@ -222,13 +231,21 @@ export function createBrokerClient(): KeychainBrokerClient {
   function sendRequest(request: BrokerRequest): Promise<BrokerResponse> {
     return new Promise((resolve) => {
       if (!socket || socket.destroyed) {
-        resolve({ id: request.id, ok: false, error: "not connected" });
+        resolve({
+          id: request.id,
+          ok: false,
+          error: { code: "NOT_CONNECTED", message: "not connected" },
+        });
         return;
       }
 
       const timer = setTimeout(() => {
         pending.delete(request.id);
-        resolve({ id: request.id, ok: false, error: "timeout" });
+        resolve({
+          id: request.id,
+          ok: false,
+          error: { code: "TIMEOUT", message: "timeout" },
+        });
       }, REQUEST_TIMEOUT_MS);
 
       pending.set(request.id, { resolve, timer });
@@ -238,7 +255,11 @@ export function createBrokerClient(): KeychainBrokerClient {
         if (err) {
           clearTimeout(timer);
           pending.delete(request.id);
-          resolve({ id: request.id, ok: false, error: "write error" });
+          resolve({
+            id: request.id,
+            ok: false,
+            error: { code: "WRITE_ERROR", message: "write error" },
+          });
         }
       });
     });
@@ -255,20 +276,25 @@ export function createBrokerClient(): KeychainBrokerClient {
     if (!token) return null;
 
     const id = randomUUID();
-    const request: BrokerRequest = { id, method, token, ...params };
+    const request: BrokerRequest = {
+      v: 1,
+      id,
+      method,
+      token,
+      ...(Object.keys(params).length > 0 ? { params } : {}),
+    };
     const response = await sendRequest(request);
 
     // On UNAUTHORIZED, re-read the token once and retry. This handles
     // the case where the app restarted with a new token while the daemon
     // is still running with the old cached one.
-    if (response.error === "UNAUTHORIZED") {
+    if (response.error?.code === "UNAUTHORIZED") {
       const newToken = refreshToken();
       if (!newToken || newToken === request.token) return response;
 
-      const retryId = randomUUID();
       const retryRequest: BrokerRequest = {
         ...request,
-        id: retryId,
+        id: randomUUID(),
         token: newToken,
       };
       return await sendRequest(retryRequest);
@@ -289,29 +315,37 @@ export function createBrokerClient(): KeychainBrokerClient {
       return pathExists(getTokenPath());
     },
 
-    async ping(): Promise<{ version: string } | null> {
+    async ping(): Promise<{ pong: boolean } | null> {
       try {
-        const response = await doRequest("ping");
+        const response = await doRequest("broker.ping");
         if (!response || !response.ok) return null;
-        return { version: (response.version as string) ?? "unknown" };
+        return {
+          pong: !!(response.result as Record<string, unknown> | undefined)
+            ?.pong,
+        };
       } catch {
         return null;
       }
     },
 
-    async get(account: string): Promise<string | undefined> {
+    async get(account: string): Promise<BrokerGetResult> {
       try {
-        const response = await doRequest("get", { account });
-        if (!response || !response.ok) return undefined;
-        return (response.value as string) ?? undefined;
+        const response = await doRequest("key.get", { account });
+        if (!response) return null;
+        if (!response.ok) return null;
+        const result = response.result as
+          | { found?: boolean; value?: string }
+          | undefined;
+        if (!result) return null;
+        return { found: !!result.found, value: result.value };
       } catch {
-        return undefined;
+        return null;
       }
     },
 
     async set(account: string, value: string): Promise<boolean> {
       try {
-        const response = await doRequest("set", { account, value });
+        const response = await doRequest("key.set", { account, value });
         return response?.ok === true;
       } catch {
         return false;
@@ -320,7 +354,7 @@ export function createBrokerClient(): KeychainBrokerClient {
 
     async del(account: string): Promise<boolean> {
       try {
-        const response = await doRequest("del", { account });
+        const response = await doRequest("key.delete", { account });
         return response?.ok === true;
       } catch {
         return false;
@@ -329,9 +363,10 @@ export function createBrokerClient(): KeychainBrokerClient {
 
     async list(): Promise<string[]> {
       try {
-        const response = await doRequest("list");
+        const response = await doRequest("key.list");
         if (!response || !response.ok) return [];
-        return (response.accounts as string[]) ?? [];
+        const result = response.result as { accounts?: string[] } | undefined;
+        return result?.accounts ?? [];
       } catch {
         return [];
       }

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -80,16 +80,20 @@ export function isDowngradedFromKeychain(): boolean {
 
 /**
  * Async version of `getSecureKey`. When the broker is available it is
- * queried first; if it returns `undefined` (not found *or* error) the
- * encrypted store is consulted as a fallback.
+ * queried first. A `null` return from the broker means error (fall back
+ * to encrypted store). A `{ found: false }` means the key definitively
+ * does not exist in the keychain — no fall-through needed.
  */
 export async function getSecureKeyAsync(
   account: string,
 ): Promise<string | undefined> {
   const broker = getBroker();
   if (broker.isAvailable()) {
-    const value = await broker.get(account);
-    if (value !== undefined) return value;
+    const result = await broker.get(account);
+    // null = broker error, fall back to encrypted store
+    if (result === null) return encryptedStore.getKey(account);
+    // Broker responded — trust its answer
+    return result.found ? result.value : undefined;
   }
   return encryptedStore.getKey(account);
 }

--- a/gateway/src/__tests__/credential-reader.test.ts
+++ b/gateway/src/__tests__/credential-reader.test.ts
@@ -297,7 +297,12 @@ describe("readCredential broker integration", () => {
 
     mockSpawnSyncImpl = (cmd, args, opts) => {
       expect(cmd).toBe("node");
-      expect(args).toEqual(["-e", expect.stringContaining("BROKER_SOCKET")]);
+      // Verify the inline script uses the correct protocol format
+      const script = (args as string[])[1];
+      expect(script).toContain("v: 1");
+      expect(script).toContain('"key.get"');
+      expect(script).toContain("params:");
+      expect(script).toContain("resp.result");
       const env = opts.env as Record<string, string>;
       expect(env.BROKER_SOCKET).toBe(BROKER_SOCKET_PLACEHOLDER);
       expect(env.BROKER_TOKEN).toBe(TEST_TOKEN);
@@ -320,7 +325,9 @@ describe("readCredential broker integration", () => {
 
     mockSpawnSyncImpl = (cmd, args, opts) => {
       expect(cmd).toBe("node");
-      expect(args).toEqual(["-e", expect.stringContaining("BROKER_SOCKET")]);
+      const script = (args as string[])[1];
+      expect(script).toContain("v: 1");
+      expect(script).toContain('"key.get"');
       const env = opts.env as Record<string, string>;
       expect(env.BROKER_SOCKET).toBe(BROKER_SOCKET_PLACEHOLDER);
       expect(env.BROKER_TOKEN).toBe(TEST_TOKEN);
@@ -341,10 +348,13 @@ describe("readCredential broker integration", () => {
       "credential:test:key": "encrypted-value",
     });
 
-    // Mock returns empty stdout, simulating broker returning no value
+    // Mock returns empty stdout, simulating broker responding with
+    // { ok: true, result: { found: false } } — the inline script
+    // only writes to stdout when result.found is true.
     mockSpawnSyncImpl = (cmd, args, opts) => {
       expect(cmd).toBe("node");
-      expect(args).toEqual(["-e", expect.stringContaining("BROKER_SOCKET")]);
+      const script = (args as string[])[1];
+      expect(script).toContain("resp.result.found");
       const env = opts.env as Record<string, string>;
       expect(env.BROKER_SOCKET).toBe(BROKER_SOCKET_PLACEHOLDER);
       expect(env.BROKER_TOKEN).toBe(TEST_TOKEN);

--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -162,10 +162,11 @@ const socket = net.createConnection({ path: process.env.BROKER_SOCKET });
 let buf = "";
 socket.on("connect", () => {
   const req = JSON.stringify({
+    v: 1,
     id: process.env.BROKER_REQ_ID,
-    method: "get",
+    method: "key.get",
     token: process.env.BROKER_TOKEN,
-    account: process.env.BROKER_ACCOUNT,
+    params: { account: process.env.BROKER_ACCOUNT },
   }) + "\\n";
   socket.write(req);
 });
@@ -175,8 +176,8 @@ socket.on("data", (chunk) => {
   if (idx !== -1) {
     try {
       const resp = JSON.parse(buf.slice(0, idx));
-      if (resp.ok && typeof resp.value === "string") {
-        process.stdout.write(resp.value);
+      if (resp.ok && resp.result && resp.result.found && typeof resp.result.value === "string") {
+        process.stdout.write(resp.result.value);
       }
     } catch {}
     socket.destroy();


### PR DESCRIPTION
## Summary
Fixes protocol mismatch between the Swift keychain broker server and TypeScript clients that made the broker integration non-functional:
- Add `v: 1` protocol version to all requests
- Nest params in `params` field instead of spreading at top level
- Use namespaced method names (`key.get`, `key.set`, etc.)
- Fix error response type (object with `code`/`message`, not string)
- Read response values from `result` wrapper
- Distinguish broker not-found from error in `get()` return type
- Update all test mocks to match actual server protocol

Part of plan: app-embedded-keychain-broker.md (review fix round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
