### PR TITLE
fix: skip commented-out code in assistant-id boundary guard signature scan

### DIFF
--- a/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
+++ b/assistant/src/__tests__/assistant-id-boundary-guard.test.ts
@@ -594,6 +594,18 @@ describe("assistant ID boundary", () => {
         match;
         match = exportFnStartRegex.exec(content)
       ) {
+        // Skip matches that fall inside comments. Find the beginning of
+        // the line containing the match and check for comment prefixes.
+        const lineStart = content.lastIndexOf("\n", match.index) + 1;
+        const linePrefix = content.slice(lineStart, match.index).trim();
+        if (
+          linePrefix.startsWith("//") ||
+          linePrefix.startsWith("*") ||
+          linePrefix.startsWith("/*")
+        ) {
+          continue;
+        }
+
         // Find the matching closing paren to extract the full parameter list,
         // which may span multiple lines.
         const parenStart = match.index + match[0].length - 1; // index of '('


### PR DESCRIPTION
## Summary
The multiline signature scan in the assistant-id boundary guard was matching
`export function` / `export const` patterns inside comments (e.g.,
`// export function demo(assistantId: string)`), causing false positive
guard failures. This adds a comment-prefix check before processing each
regex match, restoring the filtering that existed in the previous
line-based approach.

Addresses feedback on #13095

🤖 Generated with [Claude Code](https://claude.com/claude-code)