### PR TITLE
fix: stop sending share URL tokens to LLM in invite instruction generation

### DIFF
--- a/assistant/src/runtime/invite-instruction-generator.ts
+++ b/assistant/src/runtime/invite-instruction-generator.ts
@@ -81,6 +81,13 @@ export async function generateInviteInstruction(params: {
   contactName?: string;
   channelType: string;
   channelHandle?: string;
+  /** Whether a share URL is available (shown separately in the UI). */
+  hasShareUrl?: boolean;
+  /**
+   * Actual share URL for the deterministic fallback only. Never sent to the
+   * LLM — the URL contains the raw invite token which is a redemption
+   * credential.
+   */
   shareUrl?: string;
 }): Promise<string> {
   const channelLabel = channelDisplayLabel(params.channelType);
@@ -113,15 +120,15 @@ export async function generateInviteInstruction(params: {
     if (params.channelHandle) {
       parts.push(`Channel handle: ${params.channelHandle}`);
     }
-    if (params.shareUrl) {
-      parts.push(`Share URL: ${params.shareUrl}`);
+    if (params.hasShareUrl) {
+      parts.push("A share link is available (displayed separately in the UI).");
     }
     parts.push(
       "",
       "Requirements:",
       '- Write from the assistant\'s perspective using first person ("message me"), NOT third person ("message the assistant").',
       "- Do NOT include the invite code — it is displayed separately in the UI.",
-      "- When a share URL is available, lead with the link.",
+      "- When a share link is available, mention that the user can share the link.",
       "- Keep the instruction concise (1–2 sentences, under 500 characters).",
       '- Refer to the invite code as "the code below" since it is shown beneath this instruction.',
       "",

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -240,6 +240,7 @@ export async function createIngressInvite(params: {
       contactName: params.contactName,
       channelType: params.sourceChannel,
       channelHandle,
+      hasShareUrl: !!share?.url,
       shareUrl: share?.url,
     });
   }


### PR DESCRIPTION
## Summary
- Share URLs contain raw invite redemption tokens (e.g. `https://t.me/bot?start=iv_<token>`). Previously these were passed directly into the LLM prompt via `generateInviteInstruction`, exposing live credentials to the external LLM provider.
- Replace `shareUrl` in the LLM prompt with a boolean `hasShareUrl` flag so the LLM knows a share link exists without seeing the actual token-bearing URL.
- The deterministic fallback still uses the real URL (rendered locally, never sent to an LLM).

Addresses feedback on #13116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
