### PR TITLE
fix: restore delegated assistant commands in CLI help text

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -77,7 +77,11 @@ async function main() {
     console.log("Usage: vellum <command> [options]");
     console.log("");
     console.log("Commands:");
+    console.log("  autonomy View and configure autonomy tiers");
     console.log("  client   Connect to a hatched assistant");
+    console.log("  config   Manage configuration");
+    console.log("  contacts Manage assistant contacts");
+    console.log("  email    Email operations (provider-agnostic)");
     console.log("  hatch    Create a new assistant instance");
     console.log("  login    Log in to the Vellum platform");
     console.log("  logout   Log out of the Vellum platform");


### PR DESCRIPTION
## Summary
- Add autonomy, config, contacts, and email back to the `vellum --help` output
- These commands were removed from help text when they were moved from the CLI package to the assistant CLI package, but they still work via the fallback routing mechanism
- Without this fix, users running `vellum --help` would not discover these commands

Addresses feedback on #13239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
