### PR TITLE
fix: forward VELLUM_KEYCHAIN_BROKER_SOCKET env var to daemon process

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -701,6 +701,7 @@ export async function startLocalDaemon(watch: boolean = false): Promise<void> {
         "VELLUM_DAEMON_TCP_PORT",
         "VELLUM_DAEMON_TCP_HOST",
         "VELLUM_DAEMON_SOCKET",
+        "VELLUM_KEYCHAIN_BROKER_SOCKET",
         "VELLUM_DEBUG",
         "SENTRY_DSN",
         "TMPDIR",


### PR DESCRIPTION
## Summary
The daemon process was not receiving the `VELLUM_KEYCHAIN_BROKER_SOCKET` environment variable because the CLI's `startLocalDaemon()` uses a minimal env allowlist that omitted it. This meant the keychain broker integration was silently inert for the daemon — all operations fell back to the encrypted store.

Added the env var to the daemon's forwarded environment allowlist so the broker client can discover and connect to the broker socket.

Part of plan: app-embedded-keychain-broker.md (review fix round 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
