### PR TITLE
fix: add src/cli/ to assistant/AGENTS.md subdirectory index

### DIFF
--- a/assistant/AGENTS.md
+++ b/assistant/AGENTS.md
@@ -2,4 +2,4 @@
 
 For error handling conventions (throw vs result objects vs null), see [docs/error-handling.md](docs/error-handling.md).
 
-Subdirectory-scoped rules live in local AGENTS.md files: `src/runtime/`, `src/approvals/`, `src/notifications/`.
+Subdirectory-scoped rules live in local AGENTS.md files: `src/cli/`, `src/runtime/`, `src/approvals/`, `src/notifications/`.


### PR DESCRIPTION
## Summary
- Add `src/cli/` to the list of subdirectory-scoped AGENTS.md files in `assistant/AGENTS.md`
- The new `assistant/src/cli/AGENTS.md` added in #13260 was not listed in the parent index

Addresses feedback on #13260

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
