### PR TITLE
fix: restore lockfile sync after config set in assistant CLI

### DIFF
--- a/assistant/src/cli/config.ts
+++ b/assistant/src/cli/config.ts
@@ -5,6 +5,7 @@ import {
   loadRawConfig,
   saveRawConfig,
   setNestedValue,
+  syncConfigToLockfile,
 } from "../config/loader.js";
 import { getCliLogger } from "../util/logger.js";
 
@@ -29,6 +30,7 @@ export function registerConfigCommand(program: Command): void {
       }
       setNestedValue(raw, key, parsed);
       saveRawConfig(raw);
+      syncConfigToLockfile();
       log.info(`Set ${key} = ${JSON.stringify(parsed)}`);
     });
 

--- a/assistant/src/config/loader.ts
+++ b/assistant/src/config/loader.ts
@@ -19,6 +19,8 @@ import {
   getWorkspaceConfigPath,
   migrateToDataLayout,
   migrateToWorkspaceLayout,
+  readLockfile,
+  writeLockfile,
 } from "../util/platform.js";
 import { AssistantConfigSchema } from "./schema.js";
 import type { AssistantConfig } from "./types.js";
@@ -420,6 +422,30 @@ export function saveRawConfig(config: Record<string, unknown>): void {
   }
 
   cached = null; // invalidate cache
+}
+
+/**
+ * Sync client-relevant config values (e.g. platform.baseUrl) to the lockfile
+ * so external tools (e.g. vel) can discover them without importing the full
+ * config schema.  Mirrors the behaviour of `syncConfigToLockfile` in the
+ * lightweight CLI (`cli/src/lib/assistant-config.ts`).
+ */
+export function syncConfigToLockfile(): void {
+  const configPath = getWorkspaceConfigPath();
+  if (!existsSync(configPath)) return;
+
+  try {
+    const raw = JSON.parse(readFileSync(configPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    const platform = raw.platform as Record<string, unknown> | undefined;
+    const data = readLockfile() ?? {};
+    data.platformBaseUrl = (platform?.baseUrl as string) || undefined;
+    writeLockfile(data);
+  } catch {
+    // Config file unreadable — skip sync
+  }
 }
 
 export function getNestedValue(


### PR DESCRIPTION
## Summary
- Add `syncConfigToLockfile()` to the assistant CLI `config set` command
- The old lightweight CLI config command synced `platform.baseUrl` to the lockfile after every `set`, but this was lost when the command was moved to the assistant CLI in #13243
- Without this sync, external tools (e.g. vel) that read `platformBaseUrl` from the lockfile would see stale values until another sync path (e.g. hatch) ran
- Implements the function in `assistant/src/config/loader.ts` using the existing `readLockfile()`/`writeLockfile()` utilities from `platform.ts`

Addresses feedback on #13243

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
