### PR TITLE
fix: harden keychain broker against RNG failure and lossy set operations

### DIFF
--- a/clients/macos/vellum-assistant/Security/KeychainBrokerServer.swift
+++ b/clients/macos/vellum-assistant/Security/KeychainBrokerServer.swift
@@ -59,7 +59,11 @@ final class KeychainBrokerServer {
     func start() {
         // Generate auth token.
         var bytes = [UInt8](repeating: 0, count: 32)
-        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        let rngStatus = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard rngStatus == errSecSuccess else {
+            log.error("SecRandomCopyBytes failed with status \(rngStatus) — aborting broker start")
+            return
+        }
         let token = bytes.map { String(format: "%02x", $0) }.joined()
         authToken = token
 

--- a/clients/macos/vellum-assistant/Security/KeychainBrokerService.swift
+++ b/clients/macos/vellum-assistant/Security/KeychainBrokerService.swift
@@ -37,25 +37,43 @@ enum KeychainBrokerService {
 
     // MARK: - Set
 
-    /// Store a UTF-8 string value for a given account. Uses delete-then-add
-    /// to handle both insert and update cases.
+    /// Store a UTF-8 string value for a given account. Uses update-first
+    /// with add-fallback so a transient add failure never erases an existing
+    /// secret (unlike the previous delete-then-add approach).
     @discardableResult
     static func set(account: String, value: String) -> Bool {
-        // Delete any existing item first (ignore not-found errors).
-        delete(account: account)
-
         guard let data = value.data(using: .utf8) else { return false }
 
-        let attributes: [String: Any] = [
+        // Try to update an existing item first.
+        let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: serviceName,
             kSecAttrAccount as String: account,
+        ]
+        let updateAttributes: [String: Any] = [
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
         ]
+        let updateStatus = SecItemUpdate(query as CFDictionary, updateAttributes as CFDictionary)
 
-        let status = SecItemAdd(attributes as CFDictionary, nil)
-        return status == errSecSuccess
+        if updateStatus == errSecSuccess {
+            return true
+        }
+
+        // Item doesn't exist yet — add it.
+        if updateStatus == errSecItemNotFound {
+            let addAttributes: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: serviceName,
+                kSecAttrAccount as String: account,
+                kSecValueData as String: data,
+                kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+            ]
+            let addStatus = SecItemAdd(addAttributes as CFDictionary, nil)
+            return addStatus == errSecSuccess
+        }
+
+        return false
     }
 
     // MARK: - Delete


### PR DESCRIPTION
## Summary
- Check SecRandomCopyBytes return value in KeychainBrokerServer.start() and abort startup if entropy generation fails, preventing a predictable all-zeros auth token
- Replace delete-then-add pattern in KeychainBrokerService.set() with update-first/add-fallback so a transient SecItemAdd failure never erases an existing secret

Addresses feedback on #13276

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
