### PR TITLE
fix: exit broker child process immediately after receiving response

### DIFF
--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -181,6 +181,7 @@ socket.on("data", (chunk) => {
       }
     } catch {}
     socket.destroy();
+    process.exit(0);
   }
 });
 socket.on("error", () => process.exit(0));


### PR DESCRIPTION
## Summary
Add `process.exit(0)` after `socket.destroy()` in the inline broker script's data handler so the spawned child process exits immediately once the broker response is received, rather than waiting for the 4-second safety-net timeout.

Without this fix, every successful broker credential read blocks the gateway thread for ~4 seconds because `spawnSync` waits for the child to exit, and the child only exits when the `setTimeout(() => process.exit(0), 4000)` fires. This compounds across multiple credential reads during startup (Telegram 2x, Twilio 2x, Slack 2x, WhatsApp 4x, config 1x).

The 4-second `setTimeout` remains as a safety net for cases where no response arrives at all (broker hangs, malformed response, etc.).

Addresses feedback on #13290

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
