### PR TITLE
fix: use loose null check in secure-keys to pass lint

### DIFF
--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -91,7 +91,7 @@ export async function getSecureKeyAsync(
   if (broker.isAvailable()) {
     const result = await broker.get(account);
     // null = broker error, fall back to encrypted store
-    if (result === null) return encryptedStore.getKey(account);
+    if (result == null) return encryptedStore.getKey(account);
     // Broker responded — trust its answer
     return result.found ? result.value : undefined;
   }


### PR DESCRIPTION
## Summary
- Replace `=== null` with `== null` in `secure-keys.ts` to satisfy the `no-restricted-syntax` ESLint rule that bans strict null comparisons
- Semantically equivalent — the broker `get()` return type is `{ found, value } | null`, so `== null` catches the same case

## Test plan
- [x] CI lint check passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
