### PR TITLE
fix: restore contacts CLI parity with HTTP route responses

### DIFF
--- a/assistant/src/cli/contacts.ts
+++ b/assistant/src/cli/contacts.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 
 import {
+  getAssistantContactMetadata,
   getContact,
   listContacts,
   mergeContacts,
@@ -43,9 +44,11 @@ export function registerContactsCommand(program: Command): void {
           const role = opts.role as ContactRole | undefined;
           const limit = opts.limit ? Number(opts.limit) : undefined;
 
+          const effectiveLimit = limit ?? 50;
+
           const results = opts.query
-            ? searchContacts({ query: opts.query, role, limit })
-            : listContacts(limit ?? 50, role);
+            ? searchContacts({ query: opts.query, role, limit: effectiveLimit })
+            : listContacts(effectiveLimit, role);
 
           writeOutput(cmd, { ok: true, contacts: results });
         } catch (err) {
@@ -68,7 +71,15 @@ export function registerContactsCommand(program: Command): void {
           process.exitCode = 1;
           return;
         }
-        writeOutput(cmd, { ok: true, contact });
+        const assistantMeta =
+          contact.contactType === "assistant"
+            ? getAssistantContactMetadata(contact.id)
+            : undefined;
+        writeOutput(cmd, {
+          ok: true,
+          contact,
+          assistantMetadata: assistantMeta ?? undefined,
+        });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         writeOutput(cmd, { ok: false, error: message });


### PR DESCRIPTION
## Summary
- Default `contacts list --query` limit to 50 (was silently falling back to searchContacts internal default of 20)
- Include `assistantMetadata` in `contacts get` output for assistant contacts (matching handleGetContact behavior)

Addresses feedback on #13304

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
