### PR TITLE
fix: add missing app target dependency to iOS test target

### DIFF
--- a/clients/ios/project.yml
+++ b/clients/ios/project.yml
@@ -40,6 +40,7 @@ targets:
     platform: iOS
     sources: [Tests]
     dependencies:
+      - target: vellum-assistant-ios
       - package: VellumAssistant
         product: VellumAssistantShared
     settings:


### PR DESCRIPTION
## Summary
- The iOS test target (`vellum-assistant-iosTests`) uses `@testable import vellum_assistant_ios` to test views defined in the main app target
- The test target was missing a dependency on `vellum-assistant-ios` in `project.yml`, so XcodeGen didn't wire the module dependency
- Added `- target: vellum-assistant-ios` to the test target's dependencies

## Test plan
- [ ] CI iOS build + test should pass (the only failing step)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
