### PR TITLE
fix: prevent silent fallback in secure-keys async write/delete when broker fails

### DIFF
--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -233,13 +233,16 @@ describe("secure-keys", () => {
       expect(getSecureKey("api-key")).toBe("new-value");
     });
 
-    test("setSecureKeyAsync falls back to encrypted store on broker error", async () => {
+    test("setSecureKeyAsync returns false on broker set error (no silent fallback)", async () => {
       mockBrokerAvailable = true;
       mockBrokerSetError = true;
       const result = await setSecureKeyAsync("api-key", "new-value");
-      expect(result).toBe(true);
+      // Must return false — falling through to encrypted-only write would
+      // leave the broker with stale data that async readers still see.
+      expect(result).toBe(false);
       expect(mockBrokerStore.has("api-key")).toBe(false);
-      expect(getSecureKey("api-key")).toBe("new-value");
+      // Encrypted store should NOT have been written either.
+      expect(getSecureKey("api-key")).toBeUndefined();
     });
 
     test("deleteSecureKeyAsync deletes from broker and encrypted store", async () => {
@@ -252,13 +255,16 @@ describe("secure-keys", () => {
       expect(getSecureKey("api-key")).toBeUndefined();
     });
 
-    test("deleteSecureKeyAsync falls back to encrypted store on broker error", async () => {
+    test("deleteSecureKeyAsync returns false on broker del error (no silent fallback)", async () => {
       mockBrokerAvailable = true;
       mockBrokerDelError = true;
       setSecureKey("api-key", "encrypted-value");
       const result = await deleteSecureKeyAsync("api-key");
-      expect(result).toBe(true);
-      expect(getSecureKey("api-key")).toBeUndefined();
+      // Must return false — falling through to encrypted-only delete would
+      // leave the broker with the key, and async readers would still see it.
+      expect(result).toBe(false);
+      // Encrypted store should NOT have been modified either.
+      expect(getSecureKey("api-key")).toBe("encrypted-value");
     });
   });
 

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -100,8 +100,12 @@ export async function getSecureKeyAsync(
 
 /**
  * Async version of `setSecureKey`. When the broker is available the key
- * is written there first; the encrypted store is always updated as well
- * so that sync callers have a consistent view.
+ * is written there **and** to the encrypted store so that sync callers
+ * have a consistent view. Returns `true` only when both stores succeed.
+ *
+ * If the broker is available but `broker.set()` fails we return `false`
+ * immediately — falling through to an encrypted-store-only write would
+ * leave the broker with stale data that async readers would still see.
  */
 export async function setSecureKeyAsync(
   account: string,
@@ -109,30 +113,33 @@ export async function setSecureKeyAsync(
 ): Promise<boolean> {
   const broker = getBroker();
   if (broker.isAvailable()) {
-    const ok = await broker.set(account, value);
-    if (ok) {
-      // Also persist to encrypted store so sync callers stay consistent.
-      encryptedStore.setKey(account, value);
-      return true;
-    }
+    const brokerOk = await broker.set(account, value);
+    if (!brokerOk) return false;
+    // Broker succeeded — also persist to encrypted store for sync callers.
+    const encOk = encryptedStore.setKey(account, value);
+    return encOk;
   }
   return encryptedStore.setKey(account, value);
 }
 
 /**
  * Async version of `deleteSecureKey`. When the broker is available the
- * key is deleted there first; the encrypted store entry is always removed
- * as well so that sync callers have a consistent view.
+ * key is deleted there **and** from the encrypted store so that sync
+ * callers have a consistent view. Returns `true` only when both stores
+ * succeed.
+ *
+ * If the broker is available but `broker.del()` fails we return `false`
+ * immediately — falling through to an encrypted-store-only delete would
+ * leave the broker with the key, and async readers would still see it.
  */
 export async function deleteSecureKeyAsync(account: string): Promise<boolean> {
   const broker = getBroker();
   if (broker.isAvailable()) {
-    const ok = await broker.del(account);
-    if (ok) {
-      // Also remove from encrypted store so sync callers stay consistent.
-      encryptedStore.deleteKey(account);
-      return true;
-    }
+    const brokerOk = await broker.del(account);
+    if (!brokerOk) return false;
+    // Broker succeeded — also remove from encrypted store for sync callers.
+    const encOk = encryptedStore.deleteKey(account);
+    return encOk;
   }
   return encryptedStore.deleteKey(account);
 }


### PR DESCRIPTION
## Summary
- `setSecureKeyAsync`: when the broker is available but `broker.set()` fails, return `false` immediately instead of silently falling through to an encrypted-store-only write. The old behavior left the broker with stale data that async readers (who check broker first) would still see, making the write appear successful when it was not.
- `deleteSecureKeyAsync`: same fix — when the broker is available but `broker.del()` fails, return `false` instead of silently deleting only from the encrypted store. The old behavior left the broker holding the key, so async readers would still see the credential after a supposedly successful delete.
- When the broker succeeds, the encrypted store result is now checked and propagated instead of being silently discarded, ensuring sync callers see a consistent view.
- Updated tests to match the corrected semantics.

Addresses feedback on #13287

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
