### PR TITLE
fix: make invites list the default subcommand for backward compatibility

### DIFF
--- a/assistant/src/cli/contacts.ts
+++ b/assistant/src/cli/contacts.ts
@@ -109,7 +109,7 @@ export function registerContactsCommand(program: Command): void {
     .description("Manage contact invites");
 
   invites
-    .command("list")
+    .command("list", { isDefault: true })
     .description("List invites")
     .option("--source-channel <sourceChannel>", "Filter by source channel")
     .option("--status <status>", "Filter by invite status")


### PR DESCRIPTION
## Summary
- Adds `{ isDefault: true }` to the `invites list` subcommand registration
- This ensures `vellum contacts invites --source-channel X` still works as before, even without explicitly specifying `list`
- Commander.js `isDefault` option routes parent command invocations to the default subcommand when no subcommand is specified

Addresses feedback on #13306

🤖 Generated with [Claude Code](https://claude.com/claude-code)