### PR TITLE
fix: make usage cost formatting consistently locale-aware

### DIFF
--- a/clients/ios/Tests/UsageDashboardViewTests.swift
+++ b/clients/ios/Tests/UsageDashboardViewTests.swift
@@ -166,14 +166,18 @@ final class UsageDashboardViewTests: XCTestCase {
 
     // MARK: - Formatting Helpers (platform-independent)
 
-    func testFormatCostProducesDollarString() {
+    func testFormatCostProducesCurrencyString() {
         let result = UsageFormatting.formatCost(1.2345)
-        XCTAssertEqual(result, "$1.2345")
+        // Verify it contains the expected digits regardless of locale-specific
+        // currency symbol placement and decimal separator.
+        XCTAssertTrue(result.contains("1"), "Formatted cost should contain the integer part")
+        XCTAssertTrue(result.contains("2345"), "Formatted cost should contain 4 fraction digits")
     }
 
     func testFormatCostZero() {
         let result = UsageFormatting.formatCost(0)
-        XCTAssertEqual(result, "$0.0000")
+        XCTAssertTrue(result.contains("0"), "Formatted zero cost should contain '0'")
+        XCTAssertTrue(result.contains("0000"), "Formatted zero cost should show 4 fraction digits")
     }
 
     func testFormatCountUsesDecimalGrouping() {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SubagentDetailPanel.swift
@@ -287,8 +287,8 @@ struct SubagentDetailPanel: View {
     }
 
     private func formatCost(_ cost: Double) -> String {
-        if cost == 0 { return "$0.00" }
-        if cost < 0.01 { return "<$0.01" }
-        return String(format: "$%.2f", cost)
+        if cost == 0 { return UsageFormatting.formatCostShort(0) }
+        if cost < 0.01 { return "<\(UsageFormatting.formatCostShort(0.01))" }
+        return UsageFormatting.formatCostShort(cost)
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -303,7 +303,7 @@ struct UsageDashboardPanel: View {
         if usd < 0.01 {
             return UsageFormatting.formatCost(usd)
         }
-        return String(format: "$%.2f", usd)
+        return UsageFormatting.formatCostShort(usd)
     }
 
     private func formatTokenCount(_ count: Int) -> String {

--- a/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
@@ -243,8 +243,9 @@ struct UsageDashboardPanelViewEmptyTests {
         #expect(joined.contains("Daily Trend"))
         #expect(joined.contains("Breakdown"))
 
-        // Zero cost formatting: formatCost(0) produces "$0.0000"
-        #expect(joined.contains("$0.0000"))
+        // Zero cost formatting: verify the formatted zero cost appears
+        let zeroCost = UsageFormatting.formatCost(0)
+        #expect(joined.contains(zeroCost))
 
         // Empty-state placeholders
         #expect(joined.contains("No daily data"))
@@ -283,8 +284,9 @@ struct UsageDashboardPanelViewPopulatedTests {
         #expect(joined.contains("Daily Trend"))
         #expect(joined.contains("Breakdown"))
 
-        // Formatted cost: formatCost(1.23) produces "$1.23"
-        #expect(joined.contains("$1.23"))
+        // Formatted cost: verify the formatted cost appears
+        let formattedCost = UsageFormatting.formatCostShort(1.23)
+        #expect(joined.contains(formattedCost))
 
         // Daily dates
         #expect(joined.contains("2026-03-04"))

--- a/clients/shared/Features/Usage/UsageDashboardStore.swift
+++ b/clients/shared/Features/Usage/UsageDashboardStore.swift
@@ -63,12 +63,22 @@ public enum UsageGroupByDimension: String, CaseIterable, Sendable {
 /// Formatting helpers for usage dashboard values, shared across platforms.
 public enum UsageFormatting {
     public static func formatCost(_ usd: Double) -> String {
+        formatCostWithPrecision(usd, fractionDigits: 4)
+    }
+
+    /// Format a cost value with 2 decimal places, suitable for display
+    /// amounts >= $0.01 where extra precision is unnecessary.
+    public static func formatCostShort(_ usd: Double) -> String {
+        formatCostWithPrecision(usd, fractionDigits: 2)
+    }
+
+    private static func formatCostWithPrecision(_ usd: Double, fractionDigits: Int) -> String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
         formatter.currencyCode = "USD"
-        formatter.minimumFractionDigits = 4
-        formatter.maximumFractionDigits = 4
-        return formatter.string(from: NSNumber(value: usd)) ?? String(format: "$%.4f", usd)
+        formatter.minimumFractionDigits = fractionDigits
+        formatter.maximumFractionDigits = fractionDigits
+        return formatter.string(from: NSNumber(value: usd)) ?? "\(usd)"
     }
 
     public static func formatCount(_ n: Int) -> String {


### PR DESCRIPTION
Follow-up to #13316. Makes all cost formatting use locale-aware formatters consistently instead of mixing locale-aware and hardcoded US formats.

- Fix fallback in `UsageFormatting.formatCost` to not hardcode `$` and `.`
- Add `formatCostShort` (2 decimal places) for display amounts >= $0.01
- Update `UsageDashboardPanel.swift` and `SubagentDetailPanel.swift` to use `UsageFormatting` instead of hardcoded `String(format:)`
- Update iOS and macOS tests to check for locale-aware formatted output instead of hardcoded `$1.2345` strings
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
