### PR TITLE
fix: validate numeric CLI options in invites create to prevent NaN propagation

### DIFF
--- a/assistant/src/cli/contacts.ts
+++ b/assistant/src/cli/contacts.ts
@@ -175,14 +175,32 @@ export function registerContactsCommand(program: Command): void {
         cmd: Command,
       ) => {
         try {
+          const maxUses = opts.maxUses ? Number(opts.maxUses) : undefined;
+          if (maxUses !== undefined && !Number.isFinite(maxUses)) {
+            writeOutput(cmd, {
+              ok: false,
+              error: `--max-uses must be a number, got: ${opts.maxUses}`,
+            });
+            process.exitCode = 1;
+            return;
+          }
+          const expiresInMs = opts.expiresInMs
+            ? Number(opts.expiresInMs)
+            : undefined;
+          if (expiresInMs !== undefined && !Number.isFinite(expiresInMs)) {
+            writeOutput(cmd, {
+              ok: false,
+              error: `--expires-in-ms must be a number, got: ${opts.expiresInMs}`,
+            });
+            process.exitCode = 1;
+            return;
+          }
           initializeDb();
           const result = await createIngressInvite({
             sourceChannel: opts.sourceChannel,
             note: opts.note,
-            maxUses: opts.maxUses ? Number(opts.maxUses) : undefined,
-            expiresInMs: opts.expiresInMs
-              ? Number(opts.expiresInMs)
-              : undefined,
+            maxUses,
+            expiresInMs,
             contactName: opts.contactName,
             expectedExternalUserId: opts.expectedExternalUserId,
             friendName: opts.friendName,


### PR DESCRIPTION
## Summary
- Adds `Number.isFinite()` validation for `--max-uses` and `--expires-in-ms` CLI options before passing to `createIngressInvite()`
- Returns a structured `{ ok: false, error }` response with a clear message when non-numeric values are provided (e.g. `--max-uses foo`)
- Prevents NaN from propagating into the invite store, which would create broken invite records that can never expire or reach their use limit

Addresses feedback on #13309

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
