### PR TITLE
docs: codify --help quality standards in CLI AGENTS.md files

### DIFF
--- a/assistant/src/cli/AGENTS.md
+++ b/assistant/src/cli/AGENTS.md
@@ -31,3 +31,33 @@ CLI commands must call the service/store layer directly — the same functions t
 Both the gateway routes and the CLI are thin wrappers around the same shared business logic. For example, `runtime/routes/invite-routes.ts` delegates to `runtime/invite-service.ts`, and `runtime/routes/contact-routes.ts` delegates to `contacts/contact-store.ts`. CLI commands should import and call those same service modules directly.
 
 This avoids a dependency on the gateway process being running and removes an unnecessary network hop.
+
+## Help Text Standards
+
+Every command at every level (namespace, subcommand, nested subcommand) must have
+high-quality `--help` output optimized for AI/LLM consumption. Help text is a
+primary interface — both humans and AI agents read it to understand what a command
+does and how to use it.
+
+### Requirements
+
+1. **Top-level namespace**: Use `.description()` with a concise one-liner, then
+   `.addHelpText("after", ...)` with:
+   - A brief explanation of the domain and key concepts (e.g. naming conventions,
+     storage model)
+   - 3-4 representative examples covering the most common workflows
+
+2. **Each subcommand**: Use `.description()` with a one-liner, then
+   `.addHelpText("after", ...)` with:
+   - An `Arguments:` block explaining each positional argument with its format
+     and constraints
+   - Behavioral notes (what happens on update vs create, what gets deleted, etc.)
+   - 2-3 concrete `Examples:` showing exact invocations with realistic values
+
+3. **Write for machines**: Help text is frequently parsed by AI agents to decide
+   which command to run and how. Be precise about formats (`service:field`),
+   constraints (required vs optional), and side effects. Avoid vague language
+   like "configure settings" — say exactly what is configured and where it's stored.
+
+4. **Use Commander's `.addHelpText("after", ...)`** for extended help. Don't
+   cram everything into `.description()`.

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -27,3 +27,21 @@ Commands that act on a specific assistant should accept an assistant name or ID 
 - Each command manually parses `process.argv.slice(3)` (no framework — keep it lightweight).
 - Register new commands in the `commands` object in `src/index.ts` and add a help line.
 - User-facing output uses `console.log`/`console.error` directly (no shared logger).
+
+## Help Text Standards
+
+Every command must have high-quality `--help` output optimized for AI/LLM
+consumption. Help text is a primary interface — both humans and AI agents read
+it to understand what a command does and how to use it.
+
+### Requirements
+
+1. **Each command**: Include a concise one-liner description in the help output,
+   followed by an explanation of arguments/options with their formats and
+   constraints.
+
+2. **Include examples**: Show 2-3 concrete invocations with realistic values.
+
+3. **Write for machines**: Be precise about formats, constraints, and side effects.
+   AI agents parse help text to decide which command to run and how. Avoid vague
+   language — say exactly what the command does and where state is stored.


### PR DESCRIPTION
## Summary
- Add Help Text Standards section to assistant/src/cli/AGENTS.md with requirements for namespaces and subcommands
- Add Help Text Standards section to cli/AGENTS.md with equivalent requirements for lifecycle CLI
- Both sections emphasize AI/LLM-optimized help text and reference Commander's .addHelpText() API

Part of plan: cli-credentials-namespace.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
