### PR TITLE
fix: add missing readLockfile mock to three test files

### DIFF
--- a/assistant/src/__tests__/computer-use-session-working-dir.test.ts
+++ b/assistant/src/__tests__/computer-use-session-working-dir.test.ts
@@ -50,6 +50,7 @@ mock.module("../util/platform.js", () => ({
   isLinux: () => true,
   isWindows: () => false,
   normalizeAssistantId: (id: string) => id,
+  readLockfile: () => null,
 }));
 
 mock.module("../tools/executor.js", () => ({

--- a/assistant/src/__tests__/onboarding-starter-tasks.test.ts
+++ b/assistant/src/__tests__/onboarding-starter-tasks.test.ts
@@ -38,6 +38,7 @@ mock.module("../util/platform.js", () => ({
   migratePath: () => {},
   migrateToWorkspaceLayout: () => {},
   migrateToDataLayout: () => {},
+  readLockfile: () => null,
 }));
 
 mock.module("../util/logger.js", () => ({

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -30,6 +30,7 @@ mock.module("../util/platform.js", () => ({
   getWorkspacePromptPath: (file: string) => join(TEST_DIR, file),
   migrateToDataLayout: () => {},
   migrateToWorkspaceLayout: () => {},
+  readLockfile: () => null,
 }));
 
 mock.module("../util/logger.js", () => ({


### PR DESCRIPTION
## Summary
- Added `readLockfile: () => null` to the `../util/platform.js` mock in `skills.test.ts`, `onboarding-starter-tasks.test.ts`, and `computer-use-session-working-dir.test.ts`
- These tests failed because their platform mock didn't include the `readLockfile` export, causing a `SyntaxError: Export named 'readLockfile' not found` when other modules in the import chain tried to access it

## Original prompt
help me fix this CI failure: https://github.com/vellum-ai/vellum-assistant/actions/runs/22743395608

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
