### PR TITLE
feat: unify drawer menus and theme toggle with nav item styling

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -506,8 +506,8 @@ extension MainWindowView {
                             .background(
                                 RoundedRectangle(cornerRadius: VRadius.md)
                                     .fill(windowState.isShowingChat && threadManager.activeThread != nil
-                                        ? Color(hex: 0xD4DFD0)
-                                        : Color(hex: 0xE8E6DA))
+                                        ? VColor.navActive
+                                        : VColor.navHover)
                             )
 
                         if switcher.switchTargets.contains(where: { $0.hasUnseenLatestAssistantMessage }) {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -15,22 +15,22 @@ struct DrawerMenuView: View {
             VColor.surfaceBorder.frame(height: 1)
                 .padding(.vertical, VSpacing.xs)
 
-            DrawerMenuItem(icon: "gearshape", label: String(localized: "Settings"), description: String(localized: "Ask the assistant to help you with any settings you wish to change"), action: onSettings)
+            SidebarPrimaryRow(icon: "gearshape", label: String(localized: "Settings"), action: onSettings)
+
+            Text("Ask the assistant to help you with any settings you wish to change")
+                .font(VFont.caption)
+                .foregroundColor(VColor.textSecondary)
+                .padding(.horizontal, VSpacing.lg)
+                .padding(.bottom, VSpacing.xs)
 
             VColor.surfaceBorder.frame(height: 1)
                 .padding(.vertical, VSpacing.xs)
 
-            DrawerMenuItem(icon: "chart.bar", label: String(localized: "Usage"), action: onUsage)
+            SidebarPrimaryRow(icon: "chart.bar", label: String(localized: "Usage"), action: onUsage)
 
-            VColor.surfaceBorder.frame(height: 1)
-                .padding(.vertical, VSpacing.xs)
+            SidebarPrimaryRow(icon: "ladybug", label: "Debug", action: onDebug)
 
-            DrawerMenuItem(icon: "ladybug", label: "Debug", action: onDebug)
-
-            VColor.surfaceBorder.frame(height: 1)
-                .padding(.vertical, VSpacing.xs)
-
-            DrawerMenuItem(icon: "rectangle.portrait.and.arrow.right", label: String(localized: "Log Out"), action: onLogOut)
+            SidebarPrimaryRow(icon: "rectangle.portrait.and.arrow.right", label: String(localized: "Log Out"), action: onLogOut)
         }
         .padding(.vertical, VSpacing.sm)
         .background(VColor.surfaceSubtle)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerThemeToggle.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerThemeToggle.swift
@@ -20,8 +20,8 @@ struct DrawerThemeToggle: View {
     var body: some View {
         HStack(spacing: VSpacing.xs) {
             Text("Theme")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textSecondary)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
             Spacer()
             HStack(spacing: 2) {
                 ForEach(options, id: \.value) { option in
@@ -31,15 +31,20 @@ struct DrawerThemeToggle: View {
                         AppDelegate.shared?.applyThemePreference()
                     } label: {
                         Image(systemName: option.icon)
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundColor(isSelected ? VColor.textPrimary : VColor.textMuted)
-                            .frame(width: 28, height: 22)
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(
+                                isSelected
+                                    ? adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400)
+                                    : VColor.textMuted
+                            )
+                            .frame(width: 30, height: 24)
                             .background(
                                 isSelected
-                                    ? VColor.hoverOverlay.opacity(0.1)
+                                    ? adaptiveColor(light: Color(hex: 0xD3DECF), dark: Forest._800)
                                     : Color.clear
                             )
-                            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
+                            .clipShape(RoundedRectangle(cornerRadius: VRadius.sm))
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                     .help(option.tooltip)
@@ -47,13 +52,9 @@ struct DrawerThemeToggle: View {
                     .accessibilityValue(isSelected ? "Selected" : "")
                 }
             }
-            .padding(2)
-            .background(VColor.surface)
+            .padding(3)
+            .background(adaptiveColor(light: Color(hex: 0xE8E6DA), dark: Moss._700))
             .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .overlay(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .stroke(VColor.surfaceBorder, lineWidth: 1)
-            )
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarPrimaryRow.swift
@@ -22,7 +22,7 @@ struct SidebarPrimaryRow: View {
                     .foregroundColor(adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400))
                     .frame(width: SidebarLayoutMetrics.iconSlotSize, height: SidebarLayoutMetrics.iconSlotSize)
                 Text(label)
-                    .font(VFont.bodyMedium)
+                    .font(VFont.body)
                     .foregroundColor(VColor.textPrimary)
                     .lineLimit(1)
                     .truncationMode(.tail)

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadTitleActionsControl.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadTitleActionsControl.swift
@@ -53,24 +53,18 @@ struct ThreadActionsDrawer: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if presentation.canCopy {
-                DrawerMenuItem(icon: "doc.on.doc", label: "Copy full thread", action: onCopy)
-
-                VColor.surfaceBorder.frame(height: 1)
-                    .padding(.vertical, VSpacing.xs)
+                SidebarPrimaryRow(icon: "doc.on.doc", label: "Copy full thread", action: onCopy)
             }
 
-            DrawerMenuItem(
+            SidebarPrimaryRow(
                 icon: presentation.isPinned ? "pin.slash" : "pin",
                 label: presentation.isPinned ? "Unpin" : "Pin",
                 action: presentation.isPinned ? onUnpin : onPin
             )
 
-            DrawerMenuItem(icon: "pencil", label: "Rename thread", action: onRename)
+            SidebarPrimaryRow(icon: "pencil", label: "Rename thread", action: onRename)
 
-            VColor.surfaceBorder.frame(height: 1)
-                .padding(.vertical, VSpacing.xs)
-
-            DrawerMenuItem(icon: "archivebox", label: "Archive thread", action: onArchive)
+            SidebarPrimaryRow(icon: "archivebox", label: "Archive thread", action: onArchive)
         }
         .padding(.vertical, VSpacing.sm)
         .background(VColor.surfaceSubtle)


### PR DESCRIPTION
## Summary
- Replace DrawerMenuItem with SidebarPrimaryRow in preferences and thread title action drawers
- Restyle theme toggle with custom pill background (#E8E6DA light / Moss._700 dark) and active state (#D3DECF light / Forest._800 dark)
- Use VColor.navHover/navActive tokens for collapsed thread count badge (fixes dark mode)
- Reduce nav item font weight from medium to regular
- Remove dividers from thread title actions popover

## Test plan
- [x] Preferences drawer items match nav item styling
- [x] Thread title actions popover uses nav item components
- [x] Theme toggle uses custom pill with proper dark mode colors
- [x] Collapsed thread count badge renders correctly in dark mode
- [x] All interactive areas have proper hit targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
