### PR TITLE
fix: add missing test mocks and credential guard allowlist entry

### DIFF
--- a/assistant/src/__tests__/computer-use-session-working-dir.test.ts
+++ b/assistant/src/__tests__/computer-use-session-working-dir.test.ts
@@ -51,6 +51,7 @@ mock.module("../util/platform.js", () => ({
   isWindows: () => false,
   normalizeAssistantId: (id: string) => id,
   readLockfile: () => null,
+  writeLockfile: () => {},
 }));
 
 mock.module("../tools/executor.js", () => ({

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -235,6 +235,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "mcp/client.ts", // MCP client cached-token lookup
       "oauth/token-persistence.ts", // OAuth token persistence (set/delete tokens)
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)
+      "daemon/session-messaging.ts", // credential storage during session messaging
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/__tests__/onboarding-starter-tasks.test.ts
+++ b/assistant/src/__tests__/onboarding-starter-tasks.test.ts
@@ -39,6 +39,7 @@ mock.module("../util/platform.js", () => ({
   migrateToWorkspaceLayout: () => {},
   migrateToDataLayout: () => {},
   readLockfile: () => null,
+  writeLockfile: () => {},
 }));
 
 mock.module("../util/logger.js", () => ({

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -31,6 +31,7 @@ mock.module("../util/platform.js", () => ({
   migrateToDataLayout: () => {},
   migrateToWorkspaceLayout: () => {},
   readLockfile: () => null,
+  writeLockfile: () => {},
 }));
 
 mock.module("../util/logger.js", () => ({


### PR DESCRIPTION
## Summary
- Add missing `writeLockfile` mock to platform.js test mocks in 3 test files (computer-use-session-working-dir, onboarding-starter-tasks, skills) that crash with `Export named 'writeLockfile' not found`
- Add `daemon/session-messaging.ts` to the credential security guard's allowlist since it legitimately imports `setSecureKey` for credential storage during session messaging

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22743545305

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
