### PR TITLE
fix: restore encrypted-store fallback in getSecureKeyAsync on broker not-found

### DIFF
--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -209,12 +209,19 @@ describe("secure-keys", () => {
       expect(await getSecureKeyAsync("api-key")).toBe("broker-value");
     });
 
-    test("getSecureKeyAsync returns undefined when broker reports not-found (no fallback)", async () => {
+    test("getSecureKeyAsync falls back to encrypted store when broker reports not-found", async () => {
       mockBrokerAvailable = true;
       // Broker has nothing for this key — returns { found: false }.
-      // The new behaviour trusts the broker answer and does NOT fall back.
+      // Keys may exist only in the encrypted store (written while broker
+      // was unavailable or via sync setSecureKey), so we must fall back.
       setSecureKey("api-key", "encrypted-value");
-      expect(await getSecureKeyAsync("api-key")).toBeUndefined();
+      expect(await getSecureKeyAsync("api-key")).toBe("encrypted-value");
+    });
+
+    test("getSecureKeyAsync returns undefined when neither broker nor encrypted store has key", async () => {
+      mockBrokerAvailable = true;
+      // Neither store has the key — should return undefined
+      expect(await getSecureKeyAsync("missing-key")).toBeUndefined();
     });
 
     test("getSecureKeyAsync falls back to encrypted store on broker error", async () => {

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -81,8 +81,9 @@ export function isDowngradedFromKeychain(): boolean {
 /**
  * Async version of `getSecureKey`. When the broker is available it is
  * queried first. A `null` return from the broker means error (fall back
- * to encrypted store). A `{ found: false }` means the key definitively
- * does not exist in the keychain — no fall-through needed.
+ * to encrypted store). A `{ found: false }` also falls back to the
+ * encrypted store — keys may exist only in `keys.enc` (e.g. written
+ * while the broker was unavailable or via sync `setSecureKey`).
  */
 export async function getSecureKeyAsync(
   account: string,
@@ -92,8 +93,10 @@ export async function getSecureKeyAsync(
     const result = await broker.get(account);
     // null = broker error, fall back to encrypted store
     if (result == null) return encryptedStore.getKey(account);
-    // Broker responded — trust its answer
-    return result.found ? result.value : undefined;
+    // Broker found the key — use it
+    if (result.found) return result.value;
+    // Broker says not found — check encrypted store as fallback
+    return encryptedStore.getKey(account);
   }
   return encryptedStore.getKey(account);
 }


### PR DESCRIPTION
When the broker responds with found:false, getSecureKeyAsync now falls back to the encrypted store before returning undefined. This restores the upgrade path for keys that exist only in keys.enc and aligns with the architecture doc and gateway behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
