### PR TITLE
fix: use process.exitCode instead of process.exit in broker inline script

### DIFF
--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -160,6 +160,7 @@ const BROKER_INLINE_SCRIPT = `
 const net = require("net");
 const socket = net.createConnection({ path: process.env.BROKER_SOCKET });
 let buf = "";
+const timer = setTimeout(() => { socket.destroy(); }, 4000);
 socket.on("connect", () => {
   const req = JSON.stringify({
     v: 1,
@@ -180,12 +181,11 @@ socket.on("data", (chunk) => {
         process.stdout.write(resp.result.value);
       }
     } catch {}
+    clearTimeout(timer);
     socket.destroy();
-    process.exit(0);
   }
 });
-socket.on("error", () => process.exit(0));
-setTimeout(() => process.exit(0), 4000);
+socket.on("error", () => { clearTimeout(timer); });
 `;
 
 function getBrokerTokenPath(): string {


### PR DESCRIPTION
Replaces process.exit(0) with natural event loop drain in the gateway broker inline script to ensure stdout is fully flushed before the child process exits. This prevents potential truncation of large credential values that could cause the gateway to treat existing broker credentials as missing.

Changes:
- Data handler: clear timeout + destroy socket instead of process.exit(0), letting stdout flush naturally
- Error handler: clear timeout instead of process.exit(0), letting the socket error cleanup finish
- Timeout handler: destroy socket instead of process.exit(0), letting event loop drain
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
