### PR TITLE
fix: handle setSecureKeyAsync/deleteSecureKeyAsync failures in callers

### DIFF
--- a/assistant/docs/architecture/keychain-broker.md
+++ b/assistant/docs/architecture/keychain-broker.md
@@ -55,11 +55,11 @@ graph LR
 
 ### TypeScript side (runtime + gateway)
 
-| File                                               | Role                                                                                                                                                                                                                                     |
-| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `assistant/src/security/keychain-broker-client.ts` | Async UDS client for the runtime. Persistent socket connection, request/response correlation, auth token caching with auto-refresh on `UNAUTHORIZED`. Falls back gracefully (returns safe defaults, never throws).                       |
-| `assistant/src/security/secure-keys.ts`            | Unified API surface. Sync variants use encrypted store only. Async variants (`getSecureKeyAsync`, `setSecureKeyAsync`, `deleteSecureKeyAsync`) try broker first, fall back to encrypted store. Writes go to both stores for consistency. |
-| `gateway/src/credential-reader.ts`                 | Read-only credential reader. Tries broker via `spawnSync` + inline Node script (gateway is sync-only at credential read time), falls back to encrypted store.                                                                            |
+| File                                               | Role                                                                                                                                                                                                                                                                                                                                                                                              |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `assistant/src/security/keychain-broker-client.ts` | Async UDS client for the runtime. Persistent socket connection, request/response correlation, auth token caching with auto-refresh on `UNAUTHORIZED`. Falls back gracefully (returns safe defaults, never throws).                                                                                                                                                                                |
+| `assistant/src/security/secure-keys.ts`            | Unified API surface. Sync variants use encrypted store only. Async variants (`getSecureKeyAsync`, `setSecureKeyAsync`, `deleteSecureKeyAsync`) try broker first. **Reads** fall back to the encrypted store when the broker is unavailable or key is not found. **Writes and deletes** return `false` on broker failure (no encrypted-store fallback) to prevent stale divergence between stores. |
+| `gateway/src/credential-reader.ts`                 | Read-only credential reader. Tries broker via `spawnSync` + inline Node script (gateway is sync-only at credential read time), falls back to encrypted store.                                                                                                                                                                                                                                     |
 
 ## IPC Contract
 
@@ -163,6 +163,6 @@ XPC provides stronger caller identity guarantees via audit tokens and code requi
 
 ## Migration
 
-Existing encrypted store keys remain accessible — the encrypted store is always consulted as a fallback when the broker does not have a key. New writes from async code paths go to both the broker (keychain) and the encrypted store, keeping both in sync. There is no one-time migration step required.
+Existing encrypted store keys remain accessible — the encrypted store is always consulted as a **read** fallback when the broker does not have a key. Successful writes from async code paths go to both the broker (keychain) and the encrypted store, keeping both in sync. If a broker write or delete fails, the operation returns `false` without falling back to the encrypted store alone, preventing stale divergence. Callers must inspect the boolean return value and handle failures (typically by logging a warning). There is no one-time migration step required.
 
 The old `keychain.ts` module (which called `/usr/bin/security` CLI directly) has been deleted. The old keychain-to-encrypted migration code has been removed. All keychain access now flows exclusively through the broker.

--- a/assistant/src/mcp/mcp-oauth-provider.ts
+++ b/assistant/src/mcp/mcp-oauth-provider.ts
@@ -101,7 +101,17 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
-    await setSecureKeyAsync(tokensKey(this.serverId), JSON.stringify(tokens));
+    const ok = await setSecureKeyAsync(
+      tokensKey(this.serverId),
+      JSON.stringify(tokens),
+    );
+    if (!ok) {
+      log.warn(
+        { serverId: this.serverId },
+        "Failed to persist OAuth tokens to secure storage",
+      );
+      return;
+    }
     log.info({ serverId: this.serverId }, "OAuth tokens saved");
   }
 
@@ -124,7 +134,17 @@ export class McpOAuthProvider implements OAuthClientProvider {
   async saveClientInformation(
     info: OAuthClientInformationMixed,
   ): Promise<void> {
-    await setSecureKeyAsync(clientInfoKey(this.serverId), JSON.stringify(info));
+    const ok = await setSecureKeyAsync(
+      clientInfoKey(this.serverId),
+      JSON.stringify(info),
+    );
+    if (!ok) {
+      log.warn(
+        { serverId: this.serverId },
+        "Failed to persist OAuth client information to secure storage",
+      );
+      return;
+    }
     log.info({ serverId: this.serverId }, "OAuth client information saved");
   }
 
@@ -154,7 +174,16 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
-    await setSecureKeyAsync(discoveryKey(this.serverId), JSON.stringify(state));
+    const ok = await setSecureKeyAsync(
+      discoveryKey(this.serverId),
+      JSON.stringify(state),
+    );
+    if (!ok) {
+      log.warn(
+        { serverId: this.serverId },
+        "Failed to persist OAuth discovery state to secure storage",
+      );
+    }
   }
 
   // --- Redirect to Authorization ---
@@ -214,16 +243,34 @@ export class McpOAuthProvider implements OAuthClientProvider {
     );
 
     if (scope === "all" || scope === "tokens") {
-      await deleteSecureKeyAsync(tokensKey(this.serverId));
+      const ok = await deleteSecureKeyAsync(tokensKey(this.serverId));
+      if (!ok) {
+        log.warn(
+          { serverId: this.serverId },
+          "Failed to delete OAuth tokens from secure storage",
+        );
+      }
     }
     if (scope === "all" || scope === "client") {
-      await deleteSecureKeyAsync(clientInfoKey(this.serverId));
+      const ok = await deleteSecureKeyAsync(clientInfoKey(this.serverId));
+      if (!ok) {
+        log.warn(
+          { serverId: this.serverId },
+          "Failed to delete OAuth client information from secure storage",
+        );
+      }
     }
     if (scope === "all" || scope === "verifier") {
       this._codeVerifier = undefined;
     }
     if (scope === "all" || scope === "discovery") {
-      await deleteSecureKeyAsync(discoveryKey(this.serverId));
+      const ok = await deleteSecureKeyAsync(discoveryKey(this.serverId));
+      if (!ok) {
+        log.warn(
+          { serverId: this.serverId },
+          "Failed to delete OAuth discovery state from secure storage",
+        );
+      }
     }
   }
 
@@ -373,11 +420,22 @@ export class McpOAuthProvider implements OAuthClientProvider {
 export async function deleteMcpOAuthCredentials(
   serverId: string,
 ): Promise<void> {
-  await Promise.all([
+  const [tokensOk, clientOk, discoveryOk] = await Promise.all([
     deleteSecureKeyAsync(tokensKey(serverId)),
     deleteSecureKeyAsync(clientInfoKey(serverId)),
     deleteSecureKeyAsync(discoveryKey(serverId)),
   ]);
+  if (!tokensOk || !clientOk || !discoveryOk) {
+    const failed = [
+      !tokensOk && "tokens",
+      !clientOk && "client_info",
+      !discoveryOk && "discovery",
+    ].filter(Boolean);
+    log.warn(
+      { serverId, failedKeys: failed },
+      "Some OAuth credentials could not be deleted from secure storage",
+    );
+  }
   log.info({ serverId }, "OAuth credentials deleted");
 }
 


### PR DESCRIPTION
Updates all callers of setSecureKeyAsync and deleteSecureKeyAsync to check the boolean return value and log warnings on failure. Previously these callers ignored the return, leading to silent credential loss when the broker is unavailable. Also updates the keychain-broker architecture doc to reflect that the encrypted-store fallback applies to reads only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
