### PR TITLE
fix: add cli/credential.ts to secure-keys ALLOWED_IMPORTERS

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -220,6 +220,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "calls/twilio-rest.ts", // Twilio REST API credential lookup
       "runtime/channel-invite-transports/sms.ts", // SMS invite transport phone number lookup
       "cli/keys.ts", // CLI credential management commands
+      "cli/credential.ts", // CLI credential management commands
       "runtime/http-server.ts", // HTTP server credential lookup
       "daemon/handlers/twitter-auth.ts", // Twitter OAuth token storage
       "twitter/oauth-client.ts", // Twitter OAuth API client (reads access token for API calls)


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for cli-credentials-namespace.md.

**Gap:** cli/credential.ts missing from secure-keys ALLOWED_IMPORTERS
**What was expected:** cli/credential.ts should be allowed to import secure-keys since it legitimately manages credentials
**What was found:** The security invariant test would fail because cli/credential.ts was not added to the allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
