### PR TITLE
feat: add composeWith and valueTransform fields to CredentialInjectionTemplate

### DIFF
--- a/assistant/src/tools/credentials/policy-types.ts
+++ b/assistant/src/tools/credentials/policy-types.ts
@@ -30,6 +30,19 @@ export interface CredentialPolicy {
 /** How a credential value is injected into an outbound proxied request. */
 export type CredentialInjectionType = "header" | "query";
 
+/** Reference to another credential whose value is composed with the primary value. */
+export interface CredentialComposeRef {
+  /** Service of the credential to compose with. */
+  service: string;
+  /** Field of the credential to compose with. */
+  field: string;
+  /** Separator between the primary and composed values (e.g. ":"). */
+  separator: string;
+}
+
+/** Transform applied to a credential value after composition. */
+export type CredentialValueTransform = "base64";
+
 /**
  * Describes where and how to inject a credential into proxied requests
  * matching a specific host pattern.
@@ -45,6 +58,17 @@ export interface CredentialInjectionTemplate {
   valuePrefix?: string;
   /** Query parameter name when injectionType is 'query'. */
   queryParamName?: string;
+  /**
+   * Compose this credential's value with another credential's value before injection.
+   * The result is `{primaryValue}{separator}{composedValue}`, optionally transformed
+   * by `valueTransform`.
+   */
+  composeWith?: CredentialComposeRef;
+  /**
+   * Transform applied to the (possibly composed) value before prepending `valuePrefix`.
+   * Applied after composition.
+   */
+  valueTransform?: CredentialValueTransform;
 }
 
 /** Input fields for specifying policy when storing a credential. */


### PR DESCRIPTION
## Summary
- Add CredentialComposeRef interface for referencing a second credential to compose with
- Add CredentialValueTransform type for post-composition transforms (base64)
- Extend CredentialInjectionTemplate with optional composeWith and valueTransform fields

Part of plan: proxy-compose-injection.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
