### PR TITLE
feat: implement composeWith and valueTransform in proxy credential injection

### DIFF
--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -32,6 +32,7 @@ import { listCredentialMetadata } from "../../credentials/metadata-store.js";
 import type { CredentialInjectionTemplate } from "../../credentials/policy-types.js";
 import {
   resolveById,
+  resolveByServiceField,
   type ResolvedCredential,
 } from "../../credentials/resolve.js";
 
@@ -91,6 +92,35 @@ const sessions = new Map<ProxySessionId, ManagedSession>();
  * duplicate sessions (check-then-act race).
  */
 const acquireLocks = new Map<string, Promise<ProxySession>>();
+
+/**
+ * Build the final header value for a matched credential injection template.
+ * Handles optional composition with a second credential and value transforms.
+ * Returns null if any referenced credential cannot be resolved.
+ */
+function buildInjectedValue(
+  tpl: CredentialInjectionTemplate,
+  primaryValue: string,
+): string | null {
+  let value = primaryValue;
+
+  if (tpl.composeWith) {
+    const composed = resolveByServiceField(
+      tpl.composeWith.service,
+      tpl.composeWith.field,
+    );
+    if (!composed) return null;
+    const composedValue = getSecureKey(composed.storageKey);
+    if (!composedValue) return null;
+    value = `${value}${tpl.composeWith.separator}${composedValue}`;
+  }
+
+  if (tpl.valueTransform === "base64") {
+    value = Buffer.from(value).toString("base64");
+  }
+
+  return (tpl.valuePrefix ?? "") + value;
+}
 
 /**
  * Resolve injection templates for a credential.
@@ -295,8 +325,9 @@ export async function startSession(
             const value = getSecureKey(resolved.storageKey);
             if (!value) return req.headers;
 
-            req.headers[tpl.headerName.toLowerCase()] =
-              (tpl.valuePrefix ?? "") + value;
+            const headerValue = buildInjectedValue(tpl, value);
+            if (!headerValue) return req.headers;
+            req.headers[tpl.headerName.toLowerCase()] = headerValue;
             return req.headers;
           }
 
@@ -377,7 +408,8 @@ export async function startSession(
         if (!value) return {};
 
         if (template.injectionType === "header" && template.headerName) {
-          const headerValue = (template.valuePrefix ?? "") + value;
+          const headerValue = buildInjectedValue(template, value);
+          if (!headerValue) return {};
           return { [template.headerName.toLowerCase()]: headerValue };
         }
         // Query param injection is handled via URL rewriting in the MITM path


### PR DESCRIPTION
## Summary
- Extract shared buildInjectedValue helper for credential injection
- Support composeWith to combine two credential values with a separator
- Support valueTransform to apply base64 encoding before prefix

Part of plan: proxy-compose-injection.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
