### PR TITLE
fix: guarantee clipboard cleanup after secure credential paste

### DIFF
--- a/playwright/agent/tools/fill-secure-credential.ts
+++ b/playwright/agent/tools/fill-secure-credential.ts
@@ -145,10 +145,14 @@ tell application "System Events"
           -- Clear any existing content
           keystroke "a" using command down
           delay 0.1
-          -- Set clipboard, paste, then immediately clear clipboard
+          -- Set clipboard, paste, then clear clipboard.
+          -- The clear lives outside the try so the clipboard is wiped
+          -- even if the paste keystroke throws an AppleScript error.
           set the clipboard to "${escaped}"
-          keystroke "v" using command down
-          delay 0.1
+          try
+            keystroke "v" using command down
+            delay 0.1
+          end try
           set the clipboard to ""
           delay 0.2
           set foundField to true
@@ -252,5 +256,8 @@ end tell
     };
   } finally {
     try { unlinkSync(scriptPath); } catch {}
+    // Best-effort clipboard clear in case the AppleScript was interrupted
+    // (e.g. execSync timeout or process kill) before it could clear the clipboard itself
+    try { execSync('osascript -e "set the clipboard to \\"\\""', { timeout: 5_000 }); } catch {}
   }
 }


### PR DESCRIPTION
Ensures the clipboard is always cleared after pasting a secure credential, even when AppleScript errors or Node.js timeouts occur. Restructures the AppleScript try block and adds a best-effort clipboard clear in the TypeScript finally block.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
