### PR TITLE
fix: add assertMetadataWritable checks before credential set/delete mutations

### DIFF
--- a/assistant/src/cli/credential.ts
+++ b/assistant/src/cli/credential.ts
@@ -7,6 +7,7 @@ import {
 } from "../security/secure-keys.js";
 import {
   type CredentialMetadata,
+  assertMetadataWritable,
   deleteCredentialMetadata,
   getCredentialMetadata,
   getCredentialMetadataById,
@@ -274,6 +275,8 @@ Examples:
           const { service, field } = parsed;
           const storageKey = `credential:${service}:${field}`;
 
+          assertMetadataWritable();
+
           const stored = setSecureKey(storageKey, value);
           if (!stored) {
             writeOutput(cmd, {
@@ -348,6 +351,8 @@ Examples:
 
         const { service, field } = parsed;
         const storageKey = `credential:${service}:${field}`;
+
+        assertMetadataWritable();
 
         const secretDeleted = deleteSecureKey(storageKey);
         const metadataDeleted = deleteCredentialMetadata(service, field);


### PR DESCRIPTION
## Summary
- Adds `assertMetadataWritable()` preflight checks before irreversible secret mutations in the credential CLI `set` and `delete` subcommands
- Prevents orphaned credential state when metadata persistence fails (e.g., unrecognized metadata version during a downgrade)
- Follows the same pattern already used in the HTTP secret route (`secret-routes.ts`)

## Test plan
- [x] Verified the pattern matches the existing usage in `secret-routes.ts`
- [x] Type-checking passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
