### PR TITLE
feat: register Twilio API injection templates when storing credentials

### DIFF
--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -235,7 +235,22 @@ export async function handleSetTwilioCredentials(
     });
   }
 
-  upsertCredentialMetadata("twilio", "account_sid", {});
+  upsertCredentialMetadata("twilio", "account_sid", {
+    injectionTemplates: [
+      {
+        hostPattern: "api.twilio.com",
+        injectionType: "header" as const,
+        headerName: "Authorization",
+        valuePrefix: "Basic ",
+        valueTransform: "base64" as const,
+        composeWith: {
+          service: "twilio",
+          field: "auth_token",
+          separator: ":",
+        },
+      },
+    ],
+  });
   upsertCredentialMetadata("twilio", "auth_token", {});
 
   return Response.json({ success: true, hasCredentials: true });


### PR DESCRIPTION
## Summary
- Register injection template for api.twilio.com on twilio/account_sid credential
- Template composes account_sid with auth_token, base64-encodes, and injects as Basic auth
- Enables proxied bash calls to Twilio REST API with automatic auth injection

Part of plan: proxy-compose-injection.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
