### PR TITLE
feat: add const-array registries for notification source channels and event names

### DIFF
--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -19,6 +19,7 @@ import {
   getCanonicalGuardianRequest,
 } from "../memory/canonical-guardian-store.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
+import type { NotificationSourceChannel } from "../notifications/signal.js";
 import { addRule } from "../permissions/trust-store.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { mintDaemonDeliveryToken } from "../runtime/auth/token-service.js";
@@ -345,7 +346,8 @@ const accessRequestResolver: GuardianRequestResolver = {
 
   async resolve(ctx: ResolverContext): Promise<ResolverResult> {
     const { request, decision, channelDeliveryContext } = ctx;
-    const channel = request.sourceChannel ?? "unknown";
+    const channel = (request.sourceChannel ??
+      "unknown") as NotificationSourceChannel;
     const requesterExternalUserId = request.requesterExternalUserId ?? "";
     const requesterChatId =
       request.requesterChatId ?? request.requesterExternalUserId ?? "";

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -34,6 +34,7 @@ import type {
   AttentionHints,
   NotificationContextPayload,
   NotificationSignal,
+  NotificationSourceChannel,
   RoutingIntent,
 } from "./signal.js";
 import type {
@@ -151,8 +152,8 @@ function getConnectedChannels(): NotificationChannel[] {
 export interface EmitSignalParams<TEventName extends string = string> {
   /** Free-form event name, e.g. 'reminder.fired', 'schedule.complete'. */
   sourceEventName: TEventName;
-  /** Source channel that produced the event. */
-  sourceChannel: string;
+  /** Source channel that produced the event — must be a registered channel. */
+  sourceChannel: NotificationSourceChannel;
   /** Session or conversation ID from the source context. */
   sourceSessionId: string;
   /** Attention hints for the decision engine. */

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -6,6 +6,110 @@
 
 import type { GuardianQuestionPayload } from "./guardian-question-mode.js";
 
+// ── Source channel registry ────────────────────────────────────────────
+
+export const NOTIFICATION_SOURCE_CHANNELS = [
+  { id: "assistant_tool", description: "Assistant skill/tool invocation" },
+  { id: "vellum", description: "Vellum native client (macOS/iOS)" },
+  { id: "voice", description: "Voice call pipeline" },
+  { id: "telegram", description: "Telegram channel" },
+  { id: "sms", description: "SMS channel" },
+  { id: "slack", description: "Slack channel" },
+  { id: "scheduler", description: "Scheduled task runner (reminders, cron)" },
+  { id: "watcher", description: "File/event watcher subsystem" },
+] as const;
+
+export type NotificationSourceChannel =
+  (typeof NOTIFICATION_SOURCE_CHANNELS)[number]["id"];
+
+export function isNotificationSourceChannel(
+  value: unknown,
+): value is NotificationSourceChannel {
+  return (
+    typeof value === "string" &&
+    NOTIFICATION_SOURCE_CHANNELS.some((c) => c.id === value)
+  );
+}
+
+// ── Source event name registry ─────────────────────────────────────────
+
+export const NOTIFICATION_SOURCE_EVENT_NAMES = [
+  {
+    id: "user.send_notification",
+    description: "User-initiated notification via assistant tool",
+  },
+  { id: "reminder.fired", description: "Scheduled reminder triggered" },
+  { id: "schedule.complete", description: "Scheduled task finished running" },
+  {
+    id: "guardian.question",
+    description: "Guardian approval question requiring response",
+  },
+  { id: "ingress.access_request", description: "Non-member requesting access" },
+  {
+    id: "ingress.access_request.callback_handoff",
+    description: "Caller requested callback while unreachable",
+  },
+  {
+    id: "ingress.escalation",
+    description: "Incoming message escalated for attention",
+  },
+  {
+    id: "ingress.trusted_contact.guardian_decision",
+    description: "Guardian decided on trusted contact request",
+  },
+  {
+    id: "ingress.trusted_contact.denied",
+    description: "Trusted contact request denied",
+  },
+  {
+    id: "ingress.trusted_contact.verification_sent",
+    description: "Verification sent to trusted contact",
+  },
+  {
+    id: "ingress.trusted_contact.activated",
+    description: "Trusted contact activated",
+  },
+  {
+    id: "watcher.notification",
+    description: "Watcher detected a notable event",
+  },
+  {
+    id: "watcher.escalation",
+    description: "Watcher event requiring immediate attention",
+  },
+  {
+    id: "tool_confirmation.required_action",
+    description: "Tool requires user confirmation before executing",
+  },
+  { id: "activity.complete", description: "Background activity finished" },
+  {
+    id: "quick_chat.response_ready",
+    description: "Quick chat response ready for review",
+  },
+  {
+    id: "voice.response_ready",
+    description: "Voice response ready for playback",
+  },
+  {
+    id: "ride_shotgun.invitation",
+    description: "Invitation to ride shotgun on a session",
+  },
+] as const;
+
+export type NotificationSourceEventName =
+  (typeof NOTIFICATION_SOURCE_EVENT_NAMES)[number]["id"];
+
+export function isNotificationSourceEventName(
+  value: unknown,
+): value is NotificationSourceEventName {
+  return (
+    typeof value === "string" &&
+    NOTIFICATION_SOURCE_EVENT_NAMES.some((e) => e.id === value)
+  );
+}
+
+// ── Attention hints & routing ──────────────────────────────────────────
+
 export interface AttentionHints {
   requiresAction: boolean;
   urgency: "low" | "medium" | "high";
@@ -28,7 +132,7 @@ export type NotificationContextPayload<TEventName extends string = string> =
 export interface NotificationSignal<TEventName extends string = string> {
   signalId: string;
   createdAt: number; // epoch ms
-  sourceChannel: string; // free-form: 'vellum', 'telegram', 'voice', 'scheduler', etc.
+  sourceChannel: NotificationSourceChannel; // see NOTIFICATION_SOURCE_CHANNELS registry
   sourceSessionId: string;
   sourceEventName: TEventName; // free-form: 'reminder_fired', 'schedule_complete', 'guardian_question', etc.
   contextPayload: NotificationContextPayload<TEventName>;

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -26,6 +26,7 @@ import {
   updateCanonicalGuardianDelivery,
 } from "../memory/canonical-guardian-store.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
+import type { NotificationSourceChannel } from "../notifications/signal.js";
 import type { NotificationDeliveryResult } from "../notifications/types.js";
 import { getLogger } from "../util/logger.js";
 import { ensureVellumGuardianBinding } from "./guardian-vellum-migration.js";
@@ -216,7 +217,7 @@ export function notifyGuardianOfAccessRequest(
   let vellumDeliveryId: string | null = null;
   void emitNotificationSignal({
     sourceEventName: "ingress.access_request",
-    sourceChannel,
+    sourceChannel: sourceChannel as NotificationSourceChannel,
     sourceSessionId: `access-req-${sourceChannel}-${actorExternalId}`,
     attentionHints: {
       requiresAction: true,

--- a/assistant/src/runtime/confirmation-request-guardian-bridge.ts
+++ b/assistant/src/runtime/confirmation-request-guardian-bridge.ts
@@ -18,6 +18,7 @@ import {
   createCanonicalGuardianDelivery,
 } from "../memory/canonical-guardian-store.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
+import type { NotificationSourceChannel } from "../notifications/signal.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { getLogger } from "../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
@@ -144,7 +145,7 @@ export function bridgeConfirmationRequestToGuardian(
   // Emit guardian.question notification so the guardian is alerted.
   const signalPromise = emitNotificationSignal({
     sourceEventName: "guardian.question",
-    sourceChannel,
+    sourceChannel: sourceChannel as NotificationSourceChannel,
     sourceSessionId: conversationId,
     attentionHints: {
       requiresAction: true,

--- a/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
@@ -11,6 +11,7 @@ import {
   type GuardianApprovalRequest,
 } from "../../../memory/channel-guardian-store.js";
 import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
+import type { NotificationSourceChannel } from "../../../notifications/signal.js";
 import { getLogger } from "../../../util/logger.js";
 import { runApprovalConversationTurn } from "../../approval-conversation-turn.js";
 import { composeApprovalMessageGenerative } from "../../approval-message-composer.js";
@@ -791,7 +792,7 @@ async function handleAccessRequestApproval(
     // Emit both guardian_decision and denied signals so all lifecycle
     // observers are notified of the denial.
     const deniedPayload = {
-      sourceChannel: approval.channel,
+      sourceChannel: approval.channel as NotificationSourceChannel,
       requesterExternalUserId: approval.requesterExternalUserId,
       requesterChatId: approval.requesterChatId,
       decidedByExternalUserId,
@@ -800,7 +801,7 @@ async function handleAccessRequestApproval(
 
     void emitNotificationSignal({
       sourceEventName: "ingress.trusted_contact.guardian_decision",
-      sourceChannel: approval.channel,
+      sourceChannel: approval.channel as NotificationSourceChannel,
       sourceSessionId: approval.conversationId,
       attentionHints: {
         requiresAction: false,
@@ -814,7 +815,7 @@ async function handleAccessRequestApproval(
 
     void emitNotificationSignal({
       sourceEventName: "ingress.trusted_contact.denied",
-      sourceChannel: approval.channel,
+      sourceChannel: approval.channel as NotificationSourceChannel,
       sourceSessionId: approval.conversationId,
       attentionHints: {
         requiresAction: false,
@@ -882,7 +883,7 @@ async function handleAccessRequestApproval(
   if (!decisionResult.verificationSessionId) {
     void emitNotificationSignal({
       sourceEventName: "ingress.trusted_contact.guardian_decision",
-      sourceChannel: approval.channel,
+      sourceChannel: approval.channel as NotificationSourceChannel,
       sourceSessionId: approval.conversationId,
       attentionHints: {
         requiresAction: false,
@@ -891,7 +892,7 @@ async function handleAccessRequestApproval(
         visibleInSourceNow: false,
       },
       contextPayload: {
-        sourceChannel: approval.channel,
+        sourceChannel: approval.channel as NotificationSourceChannel,
         requesterExternalUserId: approval.requesterExternalUserId,
         requesterChatId: approval.requesterChatId,
         decidedByExternalUserId,
@@ -908,7 +909,7 @@ async function handleAccessRequestApproval(
   if (decisionResult.verificationSessionId && codeDelivered) {
     void emitNotificationSignal({
       sourceEventName: "ingress.trusted_contact.verification_sent",
-      sourceChannel: approval.channel,
+      sourceChannel: approval.channel as NotificationSourceChannel,
       sourceSessionId: approval.conversationId,
       attentionHints: {
         requiresAction: false,
@@ -917,7 +918,7 @@ async function handleAccessRequestApproval(
         visibleInSourceNow: true,
       },
       contextPayload: {
-        sourceChannel: approval.channel,
+        sourceChannel: approval.channel as NotificationSourceChannel,
         requesterExternalUserId: approval.requesterExternalUserId,
         requesterChatId: approval.requesterChatId,
         verificationSessionId: decisionResult.verificationSessionId,

--- a/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/escalation-intercept.ts
@@ -11,6 +11,7 @@ import type { ChannelId, InterfaceId } from "../../../channels/types.js";
 import { createCanonicalGuardianRequest } from "../../../memory/canonical-guardian-store.js";
 import * as channelDeliveryStore from "../../../memory/channel-delivery-store.js";
 import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
+import type { NotificationSourceChannel } from "../../../notifications/signal.js";
 import { getLogger } from "../../../util/logger.js";
 import { getGuardianBinding } from "../../channel-guardian-service.js";
 import { GUARDIAN_APPROVAL_TTL_MS } from "../channel-route-shared.js";
@@ -132,7 +133,7 @@ export function handleEscalationIntercept(
   // channels, supplementing the direct guardian notification below.
   void emitNotificationSignal({
     sourceEventName: "ingress.escalation",
-    sourceChannel,
+    sourceChannel: sourceChannel as NotificationSourceChannel,
     sourceSessionId: conversationId,
     attentionHints: {
       requiresAction: true,

--- a/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
@@ -22,6 +22,7 @@ import {
 } from "../../../contacts/contacts-write.js";
 import * as channelDeliveryStore from "../../../memory/channel-delivery-store.js";
 import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
+import type { NotificationSourceChannel } from "../../../notifications/signal.js";
 import { canonicalizeInboundIdentity } from "../../../util/canonicalize-identity.js";
 import { getLogger } from "../../../util/logger.js";
 import {
@@ -230,7 +231,7 @@ export async function handleVerificationIntercept(
     if (verifyResult.verificationType === "trusted_contact") {
       void emitNotificationSignal({
         sourceEventName: "ingress.trusted_contact.activated",
-        sourceChannel,
+        sourceChannel: sourceChannel as NotificationSourceChannel,
         sourceSessionId: conversationId,
         attentionHints: {
           requiresAction: false,

--- a/assistant/src/runtime/tool-grant-request-helper.ts
+++ b/assistant/src/runtime/tool-grant-request-helper.ts
@@ -18,6 +18,7 @@ import {
   listCanonicalGuardianRequests,
 } from "../memory/canonical-guardian-store.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
+import type { NotificationSourceChannel } from "../notifications/signal.js";
 import { getLogger } from "../util/logger.js";
 import { getGuardianBinding } from "./channel-guardian-service.js";
 import { GUARDIAN_APPROVAL_TTL_MS } from "./routes/channel-route-shared.js";
@@ -144,7 +145,7 @@ export function createOrReuseToolGrantRequest(
   // pipeline is preserved.
   const signalPromise = emitNotificationSignal({
     sourceEventName: "guardian.question",
-    sourceChannel,
+    sourceChannel: sourceChannel as NotificationSourceChannel,
     sourceSessionId: conversationId,
     attentionHints: {
       requiresAction: true,


### PR DESCRIPTION
## Summary
- Add NOTIFICATION_SOURCE_CHANNELS and NOTIFICATION_SOURCE_EVENT_NAMES const arrays with id+description entries to notifications/signal.ts
- Derive NotificationSourceChannel and NotificationSourceEventName types from the arrays with type guard functions
- Narrow sourceChannel on NotificationSignal and EmitSignalParams from string to NotificationSourceChannel

Part of plan: cli-notifications-command.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
