### PR TITLE
feat: include accountSid in Twilio config response for URL path construction

### DIFF
--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -148,6 +148,9 @@ function pruneAssistantPhoneNumbers(
  */
 export function handleGetTwilioConfig(): Response {
   const hasCredentials = hasTwilioCredentials();
+  const accountSid = hasCredentials
+    ? getSecureKey("credential:twilio:account_sid")
+    : undefined;
   const raw = loadRawConfig();
   const sms = (raw?.sms ?? {}) as Record<string, unknown>;
   const phoneNumber = (sms.phoneNumber as string) ?? "";
@@ -155,6 +158,7 @@ export function handleGetTwilioConfig(): Response {
   return Response.json({
     success: true,
     hasCredentials,
+    accountSid: accountSid || undefined,
     phoneNumber: phoneNumber || undefined,
   });
 }


### PR DESCRIPTION
## Summary
- Expose accountSid in GET /v1/integrations/twilio/config response
- Enables skills to construct Twilio API URL paths without accessing secure storage directly
- Account SID is a public identifier per Twilio docs, not a secret

Part of plan: proxy-compose-injection.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
