### PR TITLE
refactor: type TEMPLATES keys in copy-composer against event name registry

### DIFF
--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -13,7 +13,10 @@ import {
   buildGuardianRequestCodeInstruction,
   resolveGuardianQuestionInstructionMode,
 } from "./guardian-question-mode.js";
-import type { NotificationSignal } from "./signal.js";
+import type {
+  NotificationSignal,
+  NotificationSourceEventName,
+} from "./signal.js";
 import type { NotificationChannel, RenderedChannelCopy } from "./types.js";
 
 type CopyTemplate = (payload: Record<string, unknown>) => RenderedChannelCopy;
@@ -229,7 +232,7 @@ export function buildAccessRequestContractText(
 }
 
 // Templates keyed by dot-separated sourceEventName strings matching producers.
-const TEMPLATES: Record<string, CopyTemplate> = {
+const TEMPLATES: Partial<Record<NotificationSourceEventName, CopyTemplate>> = {
   "reminder.fired": (payload) => ({
     title: "Reminder",
     body: str(payload.message, str(payload.label, "A reminder has fired")),
@@ -367,7 +370,8 @@ export function composeFallbackCopy(
   signal: NotificationSignal,
   channels: NotificationChannel[],
 ): Partial<Record<NotificationChannel, RenderedChannelCopy>> {
-  const template = TEMPLATES[signal.sourceEventName];
+  const template =
+    TEMPLATES[signal.sourceEventName as NotificationSourceEventName];
 
   const baseCopy: RenderedChannelCopy = template
     ? template(signal.contextPayload)


### PR DESCRIPTION
## Summary
- Change TEMPLATES type from Record<string, CopyTemplate> to Partial<Record<NotificationSourceEventName, CopyTemplate>>
- Compiler now enforces that every TEMPLATES key is a valid registered event name
- Safe cast at lookup site with existing fallback for unknown event names

Part of plan: cli-notifications-command.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
