### PR TITLE
fix: use registry type guard for sourceChannel fallback in access request resolver

### DIFF
--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -19,7 +19,10 @@ import {
   getCanonicalGuardianRequest,
 } from "../memory/canonical-guardian-store.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
-import type { NotificationSourceChannel } from "../notifications/signal.js";
+import {
+  isNotificationSourceChannel,
+  type NotificationSourceChannel,
+} from "../notifications/signal.js";
 import { addRule } from "../permissions/trust-store.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { mintDaemonDeliveryToken } from "../runtime/auth/token-service.js";
@@ -346,8 +349,11 @@ const accessRequestResolver: GuardianRequestResolver = {
 
   async resolve(ctx: ResolverContext): Promise<ResolverResult> {
     const { request, decision, channelDeliveryContext } = ctx;
-    const channel = (request.sourceChannel ??
-      "unknown") as NotificationSourceChannel;
+    const channel: NotificationSourceChannel = isNotificationSourceChannel(
+      request.sourceChannel,
+    )
+      ? request.sourceChannel
+      : "vellum";
     const requesterExternalUserId = request.requesterExternalUserId ?? "";
     const requesterChatId =
       request.requesterChatId ?? request.requesterExternalUserId ?? "";


### PR DESCRIPTION
## Summary
- Replaces unsafe `"unknown" as NotificationSourceChannel` cast with proper `isNotificationSourceChannel()` type guard validation
- Falls back to `"vellum"` (a valid registry member) when stored sourceChannel is null or unrecognized
- Identified during self-review of cli-notifications-command.md plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
