### PR TITLE
fix: add messaging.twilio.com to Twilio injection templates

### DIFF
--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -253,6 +253,18 @@ export async function handleSetTwilioCredentials(
           separator: ":",
         },
       },
+      {
+        hostPattern: "messaging.twilio.com",
+        injectionType: "header" as const,
+        headerName: "Authorization",
+        valuePrefix: "Basic ",
+        valueTransform: "base64" as const,
+        composeWith: {
+          service: "twilio",
+          field: "auth_token",
+          separator: ":",
+        },
+      },
     ],
   });
   upsertCredentialMetadata("twilio", "auth_token", {});


### PR DESCRIPTION
Adds messaging.twilio.com alongside api.twilio.com in the Twilio credential injection templates so proxied calls to the Twilio Messaging API receive the same Basic auth injection.