### PR TITLE
fix: block requests when composed credential is missing and add composeWith tests

### DIFF
--- a/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
+++ b/assistant/src/__tests__/script-proxy-injection-runtime.test.ts
@@ -505,10 +505,8 @@ describe("composeWith injection", () => {
     }
   });
 
-  test("composeWith with missing composed credential fails gracefully", async () => {
-    let receivedHeaders: http.IncomingHttpHeaders = {};
-    const echo = http.createServer((req, res) => {
-      receivedHeaders = req.headers;
+  test("composeWith with missing composed credential blocks request", async () => {
+    const echo = http.createServer((_req, res) => {
       res.writeHead(200);
       res.end("ok");
     });
@@ -551,9 +549,8 @@ describe("composeWith injection", () => {
         `http://127.0.0.1:${echoPort}/test`,
       );
 
-      // Graceful degradation: request passes through without injection, not a 403
-      expect(status).toBe(200);
-      expect(receivedHeaders["authorization"]).toBeUndefined();
+      // Missing composeWith credential blocks the request (fail-closed)
+      expect(status).toBe(403);
     } finally {
       echo.close();
     }
@@ -596,6 +593,65 @@ describe("composeWith injection", () => {
       const expectedValue =
         "Token " + Buffer.from("plaintext").toString("base64");
       expect(receivedHeaders["authorization"]).toBe(expectedValue);
+    } finally {
+      echo.close();
+    }
+  });
+
+  test("composeWith blocks when composed credential resolves but secret value is missing", async () => {
+    const echo = http.createServer((_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    await new Promise<void>((resolve) => echo.listen(0, "127.0.0.1", resolve));
+    const echoPort = (echo.address() as { port: number }).port;
+
+    try {
+      const tpl: CredentialInjectionTemplate = {
+        hostPattern: "127.0.0.1",
+        injectionType: "header",
+        headerName: "Authorization",
+        valuePrefix: "Basic ",
+        valueTransform: "base64",
+        composeWith: { service: "twilio", field: "auth_token", separator: ":" },
+      };
+
+      const primaryResolved = makeResolved(
+        "cred-primary",
+        [tpl],
+        "twilio",
+        "account_sid",
+      );
+      resolveByIdResults.set("cred-primary", primaryResolved);
+      credentialMetadataList.push(primaryResolved.metadata);
+      secureKeyValues.set("credential:twilio:account_sid", "ACtest123");
+
+      // Composed credential metadata resolves, but no secret value stored
+      const composedResolved = makeResolved(
+        "cred-composed",
+        [],
+        "twilio",
+        "auth_token",
+      );
+      resolveByServiceFieldResults.set("twilio:auth_token", composedResolved);
+      // Do NOT set secureKeyValues for "credential:twilio:auth_token"
+
+      const session = createSession(
+        CONV_ID,
+        ["cred-primary"],
+        undefined,
+        DATA_DIR,
+      );
+      const started = await startSession(session.id);
+      expect(started.status).toBe("active");
+
+      const status = await proxyRequest(
+        started.port!,
+        `http://127.0.0.1:${echoPort}/test`,
+      );
+
+      // Missing secret value for composed credential blocks the request
+      expect(status).toBe(403);
     } finally {
       echo.close();
     }

--- a/assistant/src/tools/network/script-proxy/session-manager.ts
+++ b/assistant/src/tools/network/script-proxy/session-manager.ts
@@ -326,7 +326,13 @@ export async function startSession(
             if (!value) return req.headers;
 
             const headerValue = buildInjectedValue(tpl, value);
-            if (!headerValue) return req.headers;
+            if (!headerValue) {
+              log.warn(
+                { host: req.hostname, credentialId: credId },
+                "MITM rewrite: blocking request — composeWith credential missing",
+              );
+              return null;
+            }
             req.headers[tpl.headerName.toLowerCase()] = headerValue;
             return req.headers;
           }
@@ -409,7 +415,13 @@ export async function startSession(
 
         if (template.injectionType === "header" && template.headerName) {
           const headerValue = buildInjectedValue(template, value);
-          if (!headerValue) return {};
+          if (!headerValue) {
+            log.warn(
+              { hostname, credentialId },
+              "Policy: blocking matched request — composeWith credential missing",
+            );
+            return null;
+          }
           return { [template.headerName.toLowerCase()]: headerValue };
         }
         // Query param injection is handled via URL rewriting in the MITM path


### PR DESCRIPTION
When buildInjectedValue returns null (missing composeWith credential), block/warn instead of silently forwarding unauthenticated traffic. Also adds test coverage for composeWith, valueTransform, and combined paths.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
