### PR TITLE
fix: add explicit defaults for notification attention flag options

### DIFF
--- a/assistant/src/cli/notifications.ts
+++ b/assistant/src/cli/notifications.ts
@@ -261,11 +261,11 @@ Examples:
             sourceChannel: opts.sourceChannel,
             sourceSessionId,
             attentionHints: {
-              requiresAction: opts.requiresAction,
+              requiresAction: opts.requiresAction ?? true,
               urgency,
               deadlineAt,
-              isAsyncBackground: opts.isAsyncBackground,
-              visibleInSourceNow: opts.visibleInSourceNow,
+              isAsyncBackground: opts.isAsyncBackground ?? false,
+              visibleInSourceNow: opts.visibleInSourceNow ?? false,
             },
             contextPayload: {
               requestedMessage: message,


### PR DESCRIPTION
Adds explicit default values for the --requires-action, --is-async-background, and --visible-in-source-now boolean options in the notifications send CLI command. Previously these were undefined when omitted, contradicting help text defaults and causing routing behavior changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
