### PR TITLE
fix: allow custom source event names in notifications list filter

### DIFF
--- a/assistant/src/cli/__tests__/notifications.test.ts
+++ b/assistant/src/cli/__tests__/notifications.test.ts
@@ -426,18 +426,45 @@ describe("notifications list", () => {
     }
   });
 
-  test("list rejects invalid source event name filter", async () => {
+  test("list accepts custom (non-registered) source event names", async () => {
+    createEvent({
+      id: `evt-custom-${Date.now()}`,
+      sourceEventName: "custom.my_event",
+      sourceChannel: "assistant_tool",
+      sourceSessionId: "session-custom",
+      attentionHints: {
+        requiresAction: true,
+        urgency: "medium",
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+      payload: { requestedMessage: "Custom event" },
+    });
+
     const { parsed, exitCode } = await runCommand([
       "list",
       "--source-event-name",
-      "bogus",
+      "custom.my_event",
     ]);
 
-    expect(exitCode).toBe(1);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain("bogus");
-    // Should list valid event names from the registry
-    expect(parsed.error).toContain("user.send_notification");
-    expect(parsed.error).toContain("reminder.fired");
+    expect(exitCode).toBe(0);
+    expect(parsed.ok).toBe(true);
+    const events = parsed.events as Array<Record<string, unknown>>;
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    for (const event of events) {
+      expect(event.sourceEventName).toBe("custom.my_event");
+    }
+  });
+
+  test("list returns empty for non-matching custom event name", async () => {
+    const { parsed, exitCode } = await runCommand([
+      "list",
+      "--source-event-name",
+      "nonexistent.event",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.events).toEqual([]);
   });
 });

--- a/assistant/src/cli/notifications.ts
+++ b/assistant/src/cli/notifications.ts
@@ -332,17 +332,15 @@ Examples:
         cmd: Command,
       ) => {
         try {
-          // Validate --source-event-name
+          // Validate --source-event-name (accept any non-empty string; custom
+          // event names are valid since skills can emit arbitrary names)
           if (
             opts.sourceEventName != null &&
-            !isNotificationSourceEventName(opts.sourceEventName)
+            opts.sourceEventName.trim().length === 0
           ) {
-            const validEvents = NOTIFICATION_SOURCE_EVENT_NAMES.map(
-              (e) => e.id,
-            ).join(", ");
             writeOutput(cmd, {
               ok: false,
-              error: `Invalid source event name "${opts.sourceEventName}". Valid values: ${validEvents}`,
+              error: "Source event name must be a non-empty string",
             });
             process.exitCode = 1;
             return;


### PR DESCRIPTION
Removes the strict whitelist validation on --source-event-name in notifications list, allowing filtering by custom event names that are legitimately stored in the notification database.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
