### PR TITLE
fix: add missing assertMetadataWritable mock to credential-cli test

### DIFF
--- a/assistant/src/__tests__/credential-cli.test.ts
+++ b/assistant/src/__tests__/credential-cli.test.ts
@@ -57,6 +57,7 @@ mock.module("../security/secure-keys.js", () => ({
 // ---------------------------------------------------------------------------
 
 mock.module("../tools/credentials/metadata-store.js", () => ({
+  assertMetadataWritable: (): void => {},
   upsertCredentialMetadata: (
     service: string,
     field: string,


### PR DESCRIPTION
## Summary
- Add `assertMetadataWritable` no-op mock to the metadata-store mock in `credential-cli.test.ts`, fixing the `Export named 'assertMetadataWritable' not found` error that has been breaking CI on main

## Original prompt
fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22746630759

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
