### PR TITLE
feat: add --help text to audit, doctor, and dev CLI commands

### DIFF
--- a/assistant/src/cli/audit.ts
+++ b/assistant/src/cli/audit.ts
@@ -10,6 +10,25 @@ export function registerAuditCommand(program: Command): void {
     .command("audit")
     .description("Show recent tool invocations")
     .option("-l, --limit <n>", "Number of entries to show", "20")
+    .addHelpText(
+      "after",
+      `
+Reads from the local tool invocation log stored by the daemon. Each row
+represents one tool call the assistant made, including what was invoked,
+how the approval system classified it, and how long it took.
+
+Table columns:
+  Timestamp   When the tool was invoked (UTC, YYYY-MM-DD HH:MM:SS)
+  Tool        Tool name (e.g. bash, read_file, write_file, browser)
+  Input       Truncated summary of the tool input (command, path, etc.)
+  Decision    Approval decision: allow, deny, or ask
+  Risk        Risk classification: none, low, medium, high
+  Duration    Wall-clock execution time (e.g. 120ms, 1.3s)
+
+Examples:
+  $ vellum audit
+  $ vellum audit --limit 50`,
+    )
     .action((opts: { limit: string }) => {
       const limit = parseInt(opts.limit, 10) || 20;
       const rows = getRecentInvocations(limit);

--- a/assistant/src/cli/dev.ts
+++ b/assistant/src/cli/dev.ts
@@ -16,6 +16,28 @@ export function registerDevCommand(program: Command): void {
       "--watch",
       "Auto-restart on source file changes (disruptive during Claude Code sessions)",
     )
+    .addHelpText(
+      "after",
+      `
+Starts the daemon in foreground dev mode for local development. If an
+existing daemon is running, it is stopped first (waits up to 5 seconds
+for an unresponsive daemon before force-killing it).
+
+Behavioral notes:
+  - Sets VELLUM_DEBUG=1 for DEBUG-level logging
+  - Sets VELLUM_LOG_STDERR=1 so logs stream to stderr (visible in terminal)
+  - Sets BASE_DATA_DIR to the repository root
+  - The daemon runs in the foreground; press Ctrl+C to stop
+
+The --watch flag passes bun --watch to the child process, which
+auto-restarts the daemon whenever source files change. This is useful
+during development but disruptive if a Claude Code session is active,
+since the restart kills the running daemon mid-conversation.
+
+Examples:
+  $ vellum dev
+  $ vellum dev --watch`,
+    )
     .action(async (opts: { watch?: boolean }) => {
       let status = await getDaemonStatus();
       if (status.running) {

--- a/assistant/src/cli/doctor.ts
+++ b/assistant/src/cli/doctor.ts
@@ -28,6 +28,35 @@ export function registerDoctorCommand(program: Command): void {
   program
     .command("doctor")
     .description("Run diagnostic checks")
+    .addHelpText(
+      "after",
+      `
+Runs a series of diagnostic checks against the local assistant environment
+and prints pass/fail results. Use this to verify that the assistant is
+correctly installed and configured before starting a session.
+
+Output symbols:
+  ✓   Check passed
+  ✗   Check failed (detail message follows the label)
+
+Diagnostic checks performed:
+  1.  Bun is installed           Verifies bun is available in PATH
+  2.  API key configured         Checks for a valid provider API key in config or env
+  3.  Daemon reachable           Connects to the daemon Unix socket
+  4.  Database exists/readable   Opens the SQLite database and runs a test query
+  5.  Directory structure        Verifies required ~/.vellum/ directories exist
+  6.  Disk space                 Ensures at least 100MB free on the data partition
+  7.  Log file size              Warns if the log file exceeds 50MB
+  8.  Database integrity         Runs SQLite PRAGMA integrity_check
+  9.  Socket permissions         Verifies the daemon socket has 0600 or 0700 mode
+  10. Trust rule syntax          Validates trust.json structure and rule fields
+  11. WASM files                 Checks that tree-sitter WASM binaries are present
+  12. Browser runtime            Verifies Playwright and Chromium availability
+  13. Sandbox diagnostics        Reports sandbox backend status and configuration
+
+Examples:
+  $ vellum doctor`,
+    )
     .action(async () => {
       const pass = (label: string) => log.info(`  \u2713 ${label}`);
       const fail = (label: string, detail?: string) =>


### PR DESCRIPTION
## Summary
- Add AGENTS.md-compliant help text to audit, doctor, and dev CLI commands
- Each command now has .addHelpText('after', ...) with domain explanation, behavioral notes, and examples
- Follows the credential.ts gold standard pattern

Part of plan: cli-help-text.md (PR 1 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)