### PR TITLE
feat: add --help text to completions, map, and channels CLI commands

### DIFF
--- a/assistant/src/cli/channels.ts
+++ b/assistant/src/cli/channels.ts
@@ -8,10 +8,40 @@ export function registerChannelsCommand(program: Command): void {
     .description("Query channel status")
     .option("--json", "Machine-readable compact JSON output");
 
+  channels.addHelpText(
+    "after",
+    `
+Queries channel readiness and configuration status through the gateway API.
+Channels are the communication interfaces (telegram, voice, sms, email, etc.)
+that the assistant uses to send and receive messages.
+
+The daemon must be running — channel status is read from the live gateway.
+
+Examples:
+  $ vellum channels readiness
+  $ vellum channels readiness --channel telegram
+  $ vellum channels readiness --json`,
+  );
+
   channels
     .command("readiness")
     .description("Check channel readiness for accepting messages")
     .option("--channel <channel>", "Filter by channel type")
+    .addHelpText(
+      "after",
+      `
+Reports whether each configured channel is ready to accept messages. A channel
+is "ready" when its credentials are valid, its integration is connected, and
+it can deliver messages to the user.
+
+The --channel flag filters results to a single channel type. Without it, all
+configured channels are returned. Common channel types include: telegram,
+voice, sms, email, slack, vellum.
+
+Examples:
+  $ vellum channels readiness
+  $ vellum channels readiness --channel telegram`,
+    )
     .action(async (opts: { channel?: string }, cmd: Command) => {
       const query = toQueryString({ channel: opts.channel });
       await runRead(cmd, async () =>

--- a/assistant/src/cli/completions.ts
+++ b/assistant/src/cli/completions.ts
@@ -11,6 +11,30 @@ export function registerCompletionsCommand(program: Command): void {
     .description(
       "Generate shell completion script (e.g. vellum completions bash >> ~/.bashrc)",
     )
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  shell   Shell to generate completions for: bash, zsh, or fish
+
+Generates a completion script that enables tab-completion for all vellum
+commands, subcommands, and flags. The script is written to stdout so you
+can redirect it to a file or eval it directly.
+
+Installation per shell:
+  bash   Append to ~/.bashrc or eval in your shell profile:
+           eval "$(vellum completions bash)"
+  zsh    Append to ~/.zshrc or eval in your shell profile:
+           eval "$(vellum completions zsh)"
+  fish   Pipe to source or save to the fish completions directory:
+           vellum completions fish | source
+           vellum completions fish > ~/.config/fish/completions/vellum.fish
+
+Examples:
+  $ vellum completions bash >> ~/.bashrc
+  $ eval "$(vellum completions zsh)"
+  $ vellum completions fish | source`,
+    )
     .action((shell: string) => {
       const subcommands: Record<string, string[]> = {
         sessions: ["list", "new", "export", "clear"],

--- a/assistant/src/cli/map.ts
+++ b/assistant/src/cli/map.ts
@@ -284,6 +284,35 @@ export function registerMapCommand(program: Command): void {
       "Manual mode: browse the site yourself while network traffic is recorded",
     )
     .option("--json", "Machine-readable JSON output")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  domain   The domain to map (e.g. example.com, open.spotify.com). Subdomains
+           are navigated directly but network traffic is recorded for the
+           entire base domain (e.g. open.spotify.com navigates that subdomain
+           but records all *.spotify.com traffic).
+
+Two modes of operation:
+  auto (default)   The assistant auto-navigates the site using Ride Shotgun,
+                   clicking links and exploring pages autonomously. Default
+                   duration: 120 seconds.
+  --manual         You browse the site yourself while network traffic is
+                   recorded in the background. Default duration: 60 seconds.
+
+How it works:
+  1. Launches Chrome with Chrome DevTools Protocol (CDP) enabled
+  2. Starts a Ride Shotgun learn session to capture network traffic
+  3. Deduplicates captured requests into unique API endpoints
+  4. Saves the API map to disk and prints a summary table
+
+The daemon must be running (the learn session is coordinated through it).
+
+Examples:
+  $ vellum map example.com
+  $ vellum map open.spotify.com --duration 180
+  $ vellum map garmin.com --manual`,
+    )
     .action(
       async (
         domain: string,


### PR DESCRIPTION
## Summary
- Add AGENTS.md-compliant help text to completions, map, and channels CLI commands
- Each command now has .addHelpText('after', ...) with domain explanation, behavioral notes, and examples
- Follows the credential.ts gold standard pattern

Part of plan: cli-help-text.md (PR 2 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
