### PR TITLE
feat: add --help text to keys, trust, and config CLI commands

### DIFF
--- a/assistant/src/cli/config.ts
+++ b/assistant/src/cli/config.ts
@@ -14,10 +14,43 @@ const log = getCliLogger("cli");
 export function registerConfigCommand(program: Command): void {
   const config = program.command("config").description("Manage configuration");
 
+  config.addHelpText(
+    "after",
+    `
+Configuration is stored in config.json in the assistant workspace directory.
+Keys support dotted paths for nested values (e.g. calls.enabled, apiKeys.anthropic).
+Values are auto-parsed as JSON (booleans, numbers, objects) with fallback to
+plain string if parsing fails.
+
+Examples:
+  $ vellum config list
+  $ vellum config get provider
+  $ vellum config set provider anthropic
+  $ vellum config set calls.enabled true`,
+  );
+
   config
     .command("set <key> <value>")
     .description(
       "Set a config value (supports dotted paths like apiKeys.anthropic)",
+    )
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  key     Dotted path to the config key (e.g. provider, calls.enabled,
+          apiKeys.anthropic). Intermediate objects are created automatically.
+  value   The value to store. Parsed as JSON first (so "true" becomes boolean
+          true, "42" becomes number 42). Falls back to plain string if JSON
+          parsing fails.
+
+After writing the value to config.json, the lockfile is automatically synced
+to reflect the updated configuration.
+
+Examples:
+  $ vellum config set provider anthropic
+  $ vellum config set calls.enabled true
+  $ vellum config set apiKeys.anthropic sk-ant-abc123`,
     )
     .action((key: string, value: string) => {
       const raw = loadRawConfig();
@@ -37,6 +70,20 @@ export function registerConfigCommand(program: Command): void {
   config
     .command("get <key>")
     .description("Get a config value (supports dotted paths)")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  key   Dotted path to the config key (e.g. provider, calls.enabled)
+
+Prints the value at the given key path. If the key is not set, prints
+"(not set)". Object values are pretty-printed as indented JSON.
+
+Examples:
+  $ vellum config get provider
+  $ vellum config get calls.enabled
+  $ vellum config get apiKeys`,
+    )
     .action((key: string) => {
       const raw = loadRawConfig();
       const value = getNestedValue(raw, key);
@@ -54,6 +101,15 @@ export function registerConfigCommand(program: Command): void {
   config
     .command("list")
     .description("List all config values")
+    .addHelpText(
+      "after",
+      `
+Dumps the full raw configuration from config.json as pretty-printed JSON.
+If no configuration has been set, prints "No configuration set".
+
+Examples:
+  $ vellum config list`,
+    )
     .action(() => {
       const raw = loadRawConfig();
       if (Object.keys(raw).length === 0) {
@@ -66,6 +122,18 @@ export function registerConfigCommand(program: Command): void {
   config
     .command("validate-allowlist")
     .description("Validate regex patterns in secret-allowlist.json")
+    .addHelpText(
+      "after",
+      `
+Reads secret-allowlist.json from the workspace and checks each regex pattern
+for syntax errors. Reports the index and error message for any invalid
+patterns. Exits with code 1 if any patterns are invalid, or prints a success
+message if all patterns are valid. If no secret-allowlist.json file exists,
+reports that and exits normally.
+
+Examples:
+  $ vellum config validate-allowlist`,
+    )
     .action(() => {
       const { validateAllowlistFile } =
         // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/assistant/src/cli/keys.ts
+++ b/assistant/src/cli/keys.ts
@@ -15,9 +15,33 @@ export function registerKeysCommand(program: Command): void {
     .command("keys")
     .description("Manage API keys in secure storage");
 
+  keys.addHelpText(
+    "after",
+    `
+Keys are stored in OS-native secure storage (macOS Keychain on macOS) and are
+never written to disk in plaintext. Each key is identified by provider name.
+
+Known providers: ${API_KEY_PROVIDERS.join(", ")}
+
+Examples:
+  $ vellum keys list
+  $ vellum keys set anthropic sk-ant-...
+  $ vellum keys delete openai`,
+  );
+
   keys
     .command("list")
     .description("List all stored API key names")
+    .addHelpText(
+      "after",
+      `
+Checks each known provider (${API_KEY_PROVIDERS.join(", ")}) and prints the
+names of providers that have a stored key. Providers without a stored key are
+omitted from the output.
+
+Examples:
+  $ vellum keys list`,
+    )
     .action(() => {
       const stored: string[] = [];
       for (const provider of API_KEY_PROVIDERS) {
@@ -36,6 +60,20 @@ export function registerKeysCommand(program: Command): void {
   keys
     .command("set <provider> <key>")
     .description("Store an API key (e.g. vellum keys set anthropic sk-ant-...)")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  provider   Provider name (e.g. anthropic, openai, gemini)
+  key        The API key value to store
+
+If a key already exists for the given provider, it is silently overwritten.
+
+Examples:
+  $ vellum keys set anthropic sk-ant-abc123
+  $ vellum keys set openai sk-proj-xyz789
+  $ vellum keys set fireworks fw-abc123`,
+    )
     .action((provider: string, key: string) => {
       if (setSecureKey(provider, key)) {
         log.info(`Stored API key for "${provider}"`);
@@ -48,6 +86,19 @@ export function registerKeysCommand(program: Command): void {
   keys
     .command("delete <provider>")
     .description("Delete a stored API key")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  provider   Provider name whose key should be removed from secure storage
+
+Removes the API key for the given provider from OS-native secure storage. If
+no key exists for the provider, exits with an error.
+
+Examples:
+  $ vellum keys delete openai
+  $ vellum keys delete anthropic`,
+    )
     .action((provider: string) => {
       const result = deleteSecureKey(provider);
       if (result === "deleted") {

--- a/assistant/src/cli/trust.ts
+++ b/assistant/src/cli/trust.ts
@@ -14,9 +14,43 @@ const SHORT_HASH_LENGTH = 8;
 export function registerTrustCommand(program: Command): void {
   const trust = program.command("trust").description("Manage trust rules");
 
+  trust.addHelpText(
+    "after",
+    `
+Trust rules are pattern-based decisions (allow/deny) for tool invocations.
+Each rule specifies a tool name, a command pattern matched with glob syntax,
+a scope, a decision (allow or deny), and a priority. Rules are stored in
+~/.vellum/protected/trust.json and evaluated in priority order when the
+assistant invokes a tool.
+
+Examples:
+  $ vellum trust list
+  $ vellum trust remove abc123
+  $ vellum trust clear`,
+  );
+
   trust
     .command("list")
     .description("List all trust rules")
+    .addHelpText(
+      "after",
+      `
+Displays a table of all trust rules with the following columns:
+
+  ID        First 8 characters of the full rule UUID
+  Tool      Tool name the rule applies to (e.g. bash, host_bash)
+  Pattern   Glob pattern matched against the tool's command argument
+  Scope     Context scope for the rule (e.g. workspace path)
+  Dcn       Decision: allow or deny
+  Pri       Priority (higher values take precedence)
+  Created   Date the rule was created (YYYY-MM-DD)
+
+IDs are shown truncated to 8 characters. Use the full ID or any unique
+prefix with "trust remove".
+
+Examples:
+  $ vellum trust list`,
+    )
     .action(() => {
       const rules = getAllRules();
       if (rules.length === 0) {
@@ -57,6 +91,21 @@ export function registerTrustCommand(program: Command): void {
   trust
     .command("remove <id>")
     .description("Remove a trust rule by ID (or prefix)")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  id   Full UUID or any unique prefix of the rule to remove
+
+Matches the given id against all stored rule IDs using prefix matching. If
+exactly one rule matches, it is removed. If no rule matches, exits with an
+error. Use "trust list" to see rule IDs (shown truncated to 8 chars).
+
+Examples:
+  $ vellum trust remove abc12345
+  $ vellum trust remove abc1
+  $ vellum trust remove a1b2c3d4-e5f6-7890-abcd-ef1234567890`,
+    )
     .action((id: string) => {
       const rules = getAllRules();
       const match = rules.find((r) => r.id.startsWith(id));
@@ -80,6 +129,16 @@ export function registerTrustCommand(program: Command): void {
   trust
     .command("clear")
     .description("Remove all trust rules")
+    .addHelpText(
+      "after",
+      `
+Removes every trust rule from ~/.vellum/protected/trust.json. Prompts for
+confirmation before proceeding (y/N). This action is irreversible — all
+rules must be re-created manually after clearing.
+
+Examples:
+  $ vellum trust clear`,
+    )
     .action(async () => {
       const rules = getAllRules();
       if (rules.length === 0) {


### PR DESCRIPTION
## Summary
- Add AGENTS.md-compliant help text to keys, trust, and config CLI commands
- Each command now has .addHelpText('after', ...) with domain explanation, behavioral notes, and examples

Part of plan: cli-help-text.md (PR 3 of 13)

Generated with Claude Code