### PR TITLE
feat: add --help text to mcp CLI command and subcommands

### DIFF
--- a/assistant/src/cli/mcp.ts
+++ b/assistant/src/cli/mcp.ts
@@ -57,10 +57,54 @@ export function registerMcpCommand(program: Command): void {
     .command("mcp")
     .description("Manage MCP (Model Context Protocol) servers");
 
+  mcp.addHelpText(
+    "after",
+    `
+MCP servers extend the assistant's capabilities with external tools. Servers
+are configured in the assistant's config.json under the mcp.servers key. Each
+server uses one of three transport types:
+
+  stdio             Local process communicating over stdin/stdout
+  sse               Remote server using Server-Sent Events
+  streamable-http   Remote server using Streamable HTTP transport
+
+Changes to MCP server configuration require a daemon restart to take effect
+(vellum sleep && vellum wake).
+
+Examples:
+  $ vellum mcp list
+  $ vellum mcp add my-server -t stdio -c npx -a my-mcp-server
+  $ vellum mcp auth my-server
+  $ vellum mcp remove my-server`,
+  );
+
   mcp
     .command("list")
     .description("List configured MCP servers and their status")
     .option("--json", "Output as JSON")
+    .addHelpText(
+      "after",
+      `
+Shows each configured MCP server with its current status and configuration:
+
+  Name         The server identifier used in config.json
+  Status       Health check result:
+                 ✓  Connected and responding
+                 ✗  Error or disabled
+                 !  Needs authentication (OAuth required)
+  Transport    stdio, sse, or streamable-http
+  URL/Command  The server URL (sse/streamable-http) or command (stdio)
+  Risk         Default risk level: low, medium, or high
+  Allowed      Tool allowlist filter (if configured)
+  Blocked      Tool blocklist filter (if configured)
+
+When output is a TTY, health checks run in parallel with live status updates.
+In non-TTY mode (piped or --json), checks run sequentially.
+
+Examples:
+  $ vellum mcp list
+  $ vellum mcp list --json`,
+    )
     .action(async (opts: { json?: boolean }) => {
       const raw = loadRawConfig();
       const mcpConfig = raw.mcp as Partial<McpConfig> | undefined;
@@ -217,6 +261,29 @@ export function registerMcpCommand(program: Command): void {
       "high",
     )
     .option("--disabled", "Add as disabled")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  name   Unique identifier for the server (used as the key in config.json)
+
+Transport-specific requirements:
+  stdio             Requires --command (and optional --args for arguments)
+  sse               Requires --url pointing to the SSE endpoint
+  streamable-http   Requires --url pointing to the HTTP endpoint
+
+The --risk flag sets the default risk level for all tools from this server
+(defaults to "high" if not specified). The server starts enabled unless
+--disabled is passed.
+
+If a server with the same name already exists, the command fails. Remove the
+existing server first with "vellum mcp remove <name>".
+
+Examples:
+  $ vellum mcp add my-server -t stdio -c npx -a my-mcp-server
+  $ vellum mcp add remote-api -t streamable-http -u https://api.example.com/mcp -r medium
+  $ vellum mcp add legacy-sse -t sse -u https://old.example.com/events --disabled`,
+    )
     .action(
       (
         name: string,
@@ -301,6 +368,28 @@ export function registerMcpCommand(program: Command): void {
   mcp
     .command("auth <name>")
     .description("Authenticate with an MCP server via OAuth")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  name   Name of a configured MCP server to authenticate with
+
+Only works with sse or streamable-http transports (stdio servers do not use
+OAuth). Opens a browser for OAuth authorization with the remote server and
+starts a local callback server to receive the authorization code.
+
+The command waits up to 2.5 minutes for the user to complete the browser-based
+OAuth flow. If the server already has valid cached tokens, the command succeeds
+immediately without opening a browser. Tokens are cached locally for future use
+by the daemon.
+
+After successful authentication, restart the daemon for changes to take effect
+(vellum sleep && vellum wake).
+
+Examples:
+  $ vellum mcp auth my-server
+  $ vellum mcp auth remote-api`,
+    )
     .action(async (name: string) => {
       const raw = loadRawConfig();
       const mcpConfig = raw.mcp as Partial<McpConfig> | undefined;
@@ -462,6 +551,24 @@ export function registerMcpCommand(program: Command): void {
   mcp
     .command("remove <name>")
     .description("Remove an MCP server configuration")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  name   Name of the MCP server to remove
+
+Removes the server entry from config.json and performs best-effort cleanup of
+any stored OAuth credentials (tokens, client info, discovery metadata) for
+sse/streamable-http servers. If no OAuth credentials exist, the cleanup is
+silently skipped.
+
+After removal, restart the daemon for changes to take effect
+(vellum sleep && vellum wake).
+
+Examples:
+  $ vellum mcp remove my-server
+  $ vellum mcp remove legacy-sse`,
+    )
     .action(async (name: string) => {
       const raw = loadRawConfig();
       const mcpConfig = raw.mcp as Record<string, unknown> | undefined;


### PR DESCRIPTION
## Summary
- Add AGENTS.md-compliant help text to mcp CLI command and all 4 subcommands
- Documents transport types (stdio, sse, streamable-http), config location, and OAuth flow
- Each subcommand has arguments, behavioral notes, and concrete examples

Part of plan: cli-help-text.md (PR 7 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
