### PR TITLE
feat: add --help text to integrations CLI command and subcommands

### DIFF
--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -201,13 +201,58 @@ export function registerIntegrationsCommand(program: Command): void {
     .description("Read integration and ingress status through the gateway API")
     .option("--json", "Machine-readable compact JSON output");
 
+  integrations.addHelpText(
+    "after",
+    `
+Reads integration configuration and status through the gateway API. The
+daemon must be running for most subcommands (telegram, twilio, guardian)
+since they query the gateway. Exceptions: "ingress config" and "voice config"
+read from the local config file and do not require the gateway.
+
+Integration categories:
+  telegram     Telegram bot configuration and webhook status
+  twilio       Twilio credentials, phone numbers, and SMS compliance
+  guardian     Guardian trust verification system for contacts
+  ingress      Public ingress URL and local gateway target (config-only)
+  voice        Voice/call readiness and ElevenLabs voice ID (config-only)
+
+Examples:
+  $ vellum integrations telegram config
+  $ vellum integrations twilio numbers
+  $ vellum integrations guardian status --channel sms`,
+  );
+
   const telegram = integrations
     .command("telegram")
     .description("Telegram integration status");
 
+  telegram.addHelpText(
+    "after",
+    `
+Checks the Telegram bot configuration status through the gateway API.
+Requires the daemon to be running.
+
+Examples:
+  $ vellum integrations telegram config
+  $ vellum integrations telegram config --json`,
+  );
+
   telegram
     .command("config")
     .description("Get Telegram integration configuration status")
+    .addHelpText(
+      "after",
+      `
+Returns the Telegram bot token status, webhook URL, and bot username from
+the gateway. Requires the daemon to be running.
+
+The response includes whether a bot token is configured, the current webhook
+endpoint, and the bot's Telegram username.
+
+Examples:
+  $ vellum integrations telegram config
+  $ vellum integrations telegram config --json`,
+    )
     .action(async (_opts: unknown, cmd: Command) => {
       await runRead(cmd, async () =>
         gatewayGet("/v1/integrations/telegram/config"),
@@ -218,10 +263,38 @@ export function registerIntegrationsCommand(program: Command): void {
     .command("guardian")
     .description("Guardian verification status");
 
+  guardian.addHelpText(
+    "after",
+    `
+Guardian is the trust verification system for contacts. It tracks whether
+contacts on each channel have completed identity verification. Requires
+the daemon to be running.
+
+Examples:
+  $ vellum integrations guardian status
+  $ vellum integrations guardian status --channel voice`,
+  );
+
   guardian
     .command("status")
     .description("Get guardian status for a channel")
     .option("--channel <channel>", "Channel: telegram|voice|sms", "telegram")
+    .addHelpText(
+      "after",
+      `
+Returns the guardian verification state for the specified channel. Requires
+the daemon to be running.
+
+The --channel flag accepts: telegram, voice, sms. Defaults to telegram if
+not specified. The response includes whether guardian verification is active
+and the current verification state for that channel.
+
+Examples:
+  $ vellum integrations guardian status
+  $ vellum integrations guardian status --channel telegram
+  $ vellum integrations guardian status --channel voice
+  $ vellum integrations guardian status --channel sms --json`,
+    )
     .action(async (opts: { channel?: GuardianChannel }, cmd: Command) => {
       const channel = opts.channel ?? "telegram";
       await runRead(cmd, async () =>
@@ -235,9 +308,40 @@ export function registerIntegrationsCommand(program: Command): void {
     .command("twilio")
     .description("Twilio integration status");
 
+  twilio.addHelpText(
+    "after",
+    `
+Covers Twilio credential status, phone number management, and SMS regulatory
+compliance. All subcommands require the daemon to be running since they
+query the gateway API.
+
+Subcommands:
+  config          Check Twilio credential status and phone number configuration
+  numbers         List all Twilio incoming phone numbers
+  sms compliance  Check SMS regulatory compliance status
+
+Examples:
+  $ vellum integrations twilio config
+  $ vellum integrations twilio numbers
+  $ vellum integrations twilio sms compliance`,
+  );
+
   twilio
     .command("config")
     .description("Get Twilio credential and phone number status")
+    .addHelpText(
+      "after",
+      `
+Checks the Twilio credential status and phone number configuration through
+the gateway. Requires the daemon to be running.
+
+The response includes whether the Twilio account SID and auth token are
+configured, and the currently assigned phone number.
+
+Examples:
+  $ vellum integrations twilio config
+  $ vellum integrations twilio config --json`,
+    )
     .action(async (_opts: unknown, cmd: Command) => {
       await runRead(cmd, async () =>
         gatewayGet("/v1/integrations/twilio/config"),
@@ -247,6 +351,19 @@ export function registerIntegrationsCommand(program: Command): void {
   twilio
     .command("numbers")
     .description("List Twilio incoming phone numbers")
+    .addHelpText(
+      "after",
+      `
+Lists all incoming phone numbers associated with the configured Twilio
+account. Requires the daemon to be running.
+
+Returns an array of phone number objects with their SID, phone number,
+friendly name, and capabilities.
+
+Examples:
+  $ vellum integrations twilio numbers
+  $ vellum integrations twilio numbers --json`,
+    )
     .action(async (_opts: unknown, cmd: Command) => {
       await runRead(cmd, async () =>
         gatewayGet("/v1/integrations/twilio/numbers"),
@@ -258,6 +375,19 @@ export function registerIntegrationsCommand(program: Command): void {
   twilioSms
     .command("compliance")
     .description("Get Twilio SMS compliance status")
+    .addHelpText(
+      "after",
+      `
+Checks the SMS regulatory compliance status for the configured Twilio
+account. Requires the daemon to be running.
+
+Returns the current compliance state, including whether the account is
+approved for SMS messaging and any outstanding compliance requirements.
+
+Examples:
+  $ vellum integrations twilio sms compliance
+  $ vellum integrations twilio sms compliance --json`,
+    )
     .action(async (_opts: unknown, cmd: Command) => {
       await runRead(cmd, async () =>
         gatewayGet("/v1/integrations/twilio/sms/compliance"),
@@ -277,18 +407,66 @@ export function registerIntegrationsCommand(program: Command): void {
     .command("ingress")
     .description("Trusted contact membership and invite status");
 
+  ingress.addHelpText(
+    "after",
+    `
+Shows the public ingress URL and local gateway target URL. Reads from the
+local config file and does not require the gateway to be running.
+
+Examples:
+  $ vellum integrations ingress config`,
+  );
+
   ingress
     .command("config")
     .description("Get public ingress URL and local gateway target")
+    .addHelpText(
+      "after",
+      `
+Shows the public ingress URL and the local gateway target URL. Reads from
+the local config file and does not require the gateway to be running.
+
+The response includes whether ingress is enabled, the configured public base
+URL (if any), and the local gateway target address. Ingress is considered
+enabled if explicitly set to true or if a publicBaseUrl is configured.
+
+Examples:
+  $ vellum integrations ingress config
+  $ vellum integrations ingress config --json`,
+    )
     .action(async (_opts: unknown, cmd: Command) => {
       await runRead(cmd, async () => readIngressConfig());
     });
 
   const voice = integrations.command("voice").description("Voice setup status");
 
+  voice.addHelpText(
+    "after",
+    `
+Shows voice and call readiness configuration. Reads from the local config
+file and does not require the gateway to be running.
+
+Examples:
+  $ vellum integrations voice config`,
+  );
+
   voice
     .command("config")
     .description("Get voice and call readiness config")
+    .addHelpText(
+      "after",
+      `
+Shows voice and call readiness status. Reads from the local config file and
+does not require the gateway to be running.
+
+The response includes whether calls are enabled, the active ElevenLabs voice
+ID (falls back to default if not configured), whether a custom voice ID is
+set, and whether the default voice is in use.
+
+Examples:
+  $ vellum integrations voice config
+  $ vellum integrations voice config --json`,
+    )
     .action(async (_opts: unknown, cmd: Command) => {
       await runRead(cmd, async () => readVoiceConfig());
     });


### PR DESCRIPTION
## Summary
- Add AGENTS.md-compliant help text to integrations CLI command and all nested subcommands
- Covers Telegram, Twilio, Guardian, ingress, and voice integration commands
- Notes which commands need the gateway vs read from config directly

Part of plan: cli-help-text.md (PR 9 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)