### PR TITLE
fix: resolve CI lint failures

### DIFF
--- a/assistant/src/cli/credential.ts
+++ b/assistant/src/cli/credential.ts
@@ -6,8 +6,8 @@ import {
   setSecureKey,
 } from "../security/secure-keys.js";
 import {
-  type CredentialMetadata,
   assertMetadataWritable,
+  type CredentialMetadata,
   deleteCredentialMetadata,
   getCredentialMetadata,
   getCredentialMetadataById,

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -25,7 +25,6 @@ import {
   upsertContact,
   validateSpeciesMetadata,
 } from "../../contacts/contact-store.js";
-import type { ContactChannel } from "../../contacts/types.js";
 import type {
   AssistantSpecies,
   ChannelPolicy,


### PR DESCRIPTION
## Summary
- Fix import sort order in `credential.ts` (simple-import-sort/imports)
- Remove unused `ContactChannel` import in `contact-routes.ts` (@typescript-eslint/no-unused-vars)

## Original prompt
fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22746935475

🤖 Generated with [Claude Code](https://claude.com/claude-code)