### PR TITLE
feat: add lint check to pre-push hook for changed files

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,7 +6,8 @@
 # 1. Swift build (clients/) — when .swift files changed (macOS SPM)
 # 2. iOS build (clients/ios/) — when .swift files changed (xcodebuild for simulator)
 # 3. TypeScript type check (assistant/) — when .ts/.tsx files changed
-# 4. Related test discovery and execution — via dependency graph + filename heuristics
+# 4. Lint (assistant/, cli/, gateway/) — eslint on changed .ts/.tsx/.js/.jsx/.mjs files
+# 5. Related test discovery and execution — via dependency graph + filename heuristics
 #
 # Skip Swift build only:  SKIP_SWIFT_BUILD=1 git push
 # Skip iOS build only:    SKIP_IOS_BUILD=1 git push
@@ -210,6 +211,39 @@ if [ -n "$CHANGED_FILES" ]; then
         echo -e "  ${GREEN}✅ Type check OK in assistant/${NC}"
         _debug_log "tsc --noEmit done (passed)"
     fi
+
+    # --- Lint check for assistant/, cli/, gateway/ ---
+    # Runs eslint on changed files to catch import-sort, unused-vars, and other
+    # lint issues that tsc doesn't cover. Scoped to only the changed files for speed.
+    LINT_PACKAGES=("assistant" "cli" "gateway")
+    for lint_pkg in "${LINT_PACKAGES[@]}"; do
+        lint_files=()
+        while IFS= read -r file; do
+            if [[ "$file" == "$lint_pkg/"* ]] && [[ "$file" =~ \.(ts|tsx|js|jsx|mjs)$ ]]; then
+                lint_files+=("${file#${lint_pkg}/}")
+            fi
+        done <<< "$CHANGED_FILES"
+
+        if [ ${#lint_files[@]} -eq 0 ]; then
+            continue
+        fi
+
+        echo ""
+        echo "🔍 Linting ${#lint_files[@]} changed file(s) in ${lint_pkg}/..."
+        _debug_log "$lint_pkg: lint start (${#lint_files[@]} files)"
+        if ! (cd "${REPO_ROOT}/${lint_pkg}" && "$BUN" run lint "${lint_files[@]}") 2>&1; then
+            echo ""
+            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+            echo -e "${RED}Lint errors in ${lint_pkg}/ — push blocked${NC}"
+            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+            echo ""
+            echo "Fix the lint errors or push with --no-verify to skip."
+            _debug_log "$lint_pkg: lint done (FAILED)"
+            exit 1
+        fi
+        echo -e "  ${GREEN}✅ Lint OK in ${lint_pkg}/${NC}"
+        _debug_log "$lint_pkg: lint done (passed)"
+    done
 
     # Temp dir for capturing test output
     RESULTS_DIR="$(mktemp -d)"


### PR DESCRIPTION
## Summary
- Adds an eslint lint check to the pre-push hook, scoped to only the changed `.ts/.tsx/.js/.jsx/.mjs` files across `assistant/`, `cli/`, and `gateway/` packages
- This closes a gap where lint errors could slip through: pre-commit lints staged files but pre-push only ran type checking and tests, and there's no PR-level CI lint — only post-merge CI on main
- Mirrors the pre-commit hook's lint pattern but uses the diff-based changed file list instead of staged files

## Original prompt
lets Add lint to the pre-push hook, especially if we can scope it to only the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)