### PR TITLE
docs: add scripts best practices spec reference to skills/AGENTS.md

### DIFF
--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -2,6 +2,7 @@
 
 - **Skills must be self-contained and portable**
   - Use `scripts/` for supporting logic with inline dependencies
+  - When including code assets, utilities, or tools, load the [scripts best practices specification](https://agentskills.io/skill-creation/using-scripts.md) first
   - Do not install CLIs into Vellum or the host system; provide instructions for users to install external packages if needed
   - Do not create new assistant tools and reference them from SKILL.md — this couples skills to Vellum internals and breaks compatibility with other agent systems
 


### PR DESCRIPTION
Adds guidance for coding agents to load the scripts best practices specification when including code assets, utilities, or tools in skills.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
