### PR TITLE
fix: add missing help text to twilio sms namespace and sms-compliance alias

### DIFF
--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -372,6 +372,20 @@ Examples:
 
   const twilioSms = twilio.command("sms").description("Twilio SMS status");
 
+  twilioSms.addHelpText(
+    "after",
+    `
+Covers SMS regulatory compliance for the configured Twilio account. All
+subcommands require the daemon to be running since they query the gateway API.
+
+Subcommands:
+  compliance   Check SMS regulatory compliance status
+
+Examples:
+  $ vellum integrations twilio sms compliance
+  $ vellum integrations twilio sms compliance --json`,
+  );
+
   twilioSms
     .command("compliance")
     .description("Get Twilio SMS compliance status")
@@ -397,6 +411,16 @@ Examples:
   twilio
     .command("sms-compliance")
     .description('Alias for "vellum integrations twilio sms compliance"')
+    .addHelpText(
+      "after",
+      `
+Shortcut alias for "vellum integrations twilio sms compliance". Prefer
+the canonical path for scripts and documentation.
+
+Examples:
+  $ vellum integrations twilio sms-compliance
+  $ vellum integrations twilio sms compliance   # canonical form`,
+    )
     .action(async (_opts: unknown, cmd: Command) => {
       await runRead(cmd, async () =>
         gatewayGet("/v1/integrations/twilio/sms/compliance"),


### PR DESCRIPTION
## Summary
Adds .addHelpText("after", ...) to the twilio sms namespace and the sms-compliance shortcut alias in integrations.ts, which were missed during the initial help text rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
