### PR TITLE
fix: replace daemon with assistant in CLI help text and fix completions coverage claim

### DIFF
--- a/assistant/src/cli/channels.ts
+++ b/assistant/src/cli/channels.ts
@@ -15,7 +15,7 @@ Queries channel readiness and configuration status through the gateway API.
 Channels are the communication interfaces (telegram, voice, sms, email, etc.)
 that the assistant uses to send and receive messages.
 
-The daemon must be running — channel status is read from the live gateway.
+The assistant must be running — channel status is read from the live gateway.
 
 Examples:
   $ vellum channels readiness

--- a/assistant/src/cli/completions.ts
+++ b/assistant/src/cli/completions.ts
@@ -17,7 +17,7 @@ export function registerCompletionsCommand(program: Command): void {
 Arguments:
   shell   Shell to generate completions for: bash, zsh, or fish
 
-Generates a completion script that enables tab-completion for all vellum
+Generates a completion script that enables tab-completion for common vellum
 commands, subcommands, and flags. The script is written to stdout so you
 can redirect it to a file or eval it directly.
 

--- a/assistant/src/cli/map.ts
+++ b/assistant/src/cli/map.ts
@@ -306,7 +306,7 @@ How it works:
   3. Deduplicates captured requests into unique API endpoints
   4. Saves the API map to disk and prints a summary table
 
-The daemon must be running (the learn session is coordinated through it).
+The assistant must be running (the learn session is coordinated through it).
 
 Examples:
   $ vellum map example.com


### PR DESCRIPTION
Fixes user-facing terminology violations in channels.ts and map.ts help text (daemon → assistant per AGENTS.md). Corrects completions.ts help text to not overstate shell completion coverage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
