### PR TITLE
fix: properly handle deleteSecureKey error vs not-found in all callers

### DIFF
--- a/assistant/src/cli/credential.ts
+++ b/assistant/src/cli/credential.ts
@@ -355,6 +355,15 @@ Examples:
         assertMetadataWritable();
 
         const secretResult = deleteSecureKey(storageKey);
+        if (secretResult === "error") {
+          writeOutput(cmd, {
+            ok: false,
+            error: "Failed to delete credential from secure storage",
+          });
+          process.exitCode = 1;
+          return;
+        }
+
         const metadataDeleted = deleteCredentialMetadata(service, field);
 
         if (secretResult !== "deleted" && !metadataDeleted) {

--- a/assistant/src/cli/keys.ts
+++ b/assistant/src/cli/keys.ts
@@ -103,6 +103,9 @@ Examples:
       const result = deleteSecureKey(provider);
       if (result === "deleted") {
         log.info(`Deleted API key for "${provider}"`);
+      } else if (result === "error") {
+        log.error(`Failed to delete API key for "${provider}": storage error`);
+        process.exit(1);
       } else {
         log.error(`No API key found for "${provider}"`);
         process.exit(1);

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -129,7 +129,14 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
         );
       }
       const deleteResult = deleteSecureKey(name);
-      if (deleteResult !== "deleted") {
+      if (deleteResult === "error") {
+        return httpError(
+          "INTERNAL_ERROR",
+          `Failed to delete API key from secure storage: ${name}`,
+          500,
+        );
+      }
+      if (deleteResult === "not-found") {
         return httpError("NOT_FOUND", `API key not found: ${name}`, 404);
       }
       invalidateConfigCache();
@@ -152,7 +159,14 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
       assertMetadataWritable();
       const key = `credential:${service}:${field}`;
       const deleteResult = deleteSecureKey(key);
-      if (deleteResult !== "deleted") {
+      if (deleteResult === "error") {
+        return httpError(
+          "INTERNAL_ERROR",
+          `Failed to delete credential from secure storage: ${name}`,
+          500,
+        );
+      }
+      if (deleteResult === "not-found") {
         return httpError("NOT_FOUND", `Credential not found: ${name}`, 404);
       }
       deleteCredentialMetadata(service, field);

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -495,7 +495,13 @@ class CredentialStoreTool implements Tool {
 
         const key = `credential:${service}:${field}`;
         const result = deleteSecureKey(key);
-        if (result !== "deleted") {
+        if (result === "error") {
+          return {
+            content: `Error: failed to delete credential ${service}/${field} from secure storage`,
+            isError: true,
+          };
+        }
+        if (result === "not-found") {
           return {
             content: `Error: credential ${service}/${field} not found`,
             isError: true,


### PR DESCRIPTION
Fixes callers of deleteSecureKey to distinguish 'error' (I/O failure) from 'not-found' (key absent). HTTP routes now return 500 for errors instead of 404. Vault and CLI callers show appropriate error messages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
