### PR TITLE
fix: correct email CLI help text for daily cap and provider example

### DIFF
--- a/assistant/src/cli/email.ts
+++ b/assistant/src/cli/email.ts
@@ -147,8 +147,7 @@ Persists the provider selection to config. All subsequent email commands
 (setup, inbox, draft, guardrails) will route through the selected provider.
 
 Examples:
-  $ vellum email provider set agentmail
-  $ vellum email provider set resend`,
+  $ vellum email provider set agentmail`,
     )
     .action((name: string, _opts: unknown, cmd: Command) => {
       if (!SUPPORTED_PROVIDERS.includes(name as SupportedProvider)) {
@@ -837,7 +836,7 @@ value unchanged.
   --paused true/false   Enable or disable the outbound pause. When paused,
                         all "approve-send" calls are blocked with exit code 2.
   --daily-cap <n>       Set the maximum number of emails that can be sent per
-                        calendar day. Set to 0 to remove the cap.
+                        calendar day. Set to 0 to disable sending entirely.
 
 Examples:
   $ vellum email guardrails set --paused true


### PR DESCRIPTION
Fixes dangerously incorrect help text claiming daily-cap 0 removes the cap (it actually blocks all sends). Fixes provider example from non-existent 'resend' to valid 'agentmail'.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
