### PR TITLE
fix: add negative guard to invite instruction generator when no share link available

### DIFF
--- a/assistant/src/runtime/invite-instruction-generator.ts
+++ b/assistant/src/runtime/invite-instruction-generator.ts
@@ -122,6 +122,10 @@ export async function generateInviteInstruction(params: {
     }
     if (params.hasShareUrl) {
       parts.push("A share link is available (displayed separately in the UI).");
+    } else {
+      parts.push(
+        "No share link is available for this channel. Do NOT mention sharing a link or URL.",
+      );
     }
     parts.push(
       "",


### PR DESCRIPTION
## Summary
- Add explicit negative instruction to LLM prompt when no share link is available, preventing hallucinated link mentions
- Verified deterministic fallback already correctly handles the no-link case

Part of plan: show-invite-link.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
