### PR TITLE
fix: resolve Telegram bot username from API when credential metadata missing

### DIFF
--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -10,7 +10,12 @@
  */
 
 import type { ChannelId } from "../../channels/types.js";
-import { getCredentialMetadata } from "../../tools/credentials/metadata-store.js";
+import { getSecureKey } from "../../security/secure-keys.js";
+import {
+  getCredentialMetadata,
+  upsertCredentialMetadata,
+} from "../../tools/credentials/metadata-store.js";
+import { getLogger } from "../../util/logger.js";
 import type {
   ChannelInviteAdapter,
   InviteShareLink,
@@ -35,6 +40,57 @@ function getTelegramBotUsername(): string | undefined {
     return meta.accountInfo.trim();
   }
   return process.env.TELEGRAM_BOT_USERNAME || undefined;
+}
+
+/**
+ * Ensure the Telegram bot username is resolved and cached in credential
+ * metadata. When the bot token was configured via CLI `credential set`,
+ * `credential_store` tool, or ingress secret redirect, the `getMe` API
+ * call that populates `accountInfo` is skipped — this function fills that
+ * gap so that invite share links can be generated.
+ */
+export async function ensureTelegramBotUsernameResolved(): Promise<void> {
+  const meta = getCredentialMetadata("telegram", "bot_token");
+  if (
+    meta?.accountInfo &&
+    typeof meta.accountInfo === "string" &&
+    meta.accountInfo.trim().length > 0
+  ) {
+    return; // Username already cached
+  }
+
+  const token = getSecureKey("credential:telegram:bot_token");
+  if (!token) return;
+
+  try {
+    const res = await fetch(`https://api.telegram.org/bot${token}/getMe`);
+    if (!res.ok) {
+      getLogger("telegram-invite").warn(
+        "Failed to resolve Telegram bot username: HTTP %d",
+        res.status,
+      );
+      return;
+    }
+    const body = (await res.json()) as {
+      ok: boolean;
+      result?: { username?: string };
+    };
+    const username = body.result?.username;
+    if (!username) {
+      getLogger("telegram-invite").warn(
+        "Telegram getMe response did not include a username",
+      );
+      return;
+    }
+    upsertCredentialMetadata("telegram", "bot_token", {
+      accountInfo: username,
+    });
+  } catch (err) {
+    getLogger("telegram-invite").warn(
+      { err },
+      "Failed to resolve Telegram bot username via getMe API",
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -235,6 +235,11 @@ export async function createIngressInvite(params: {
       ? getInviteAdapterRegistry().get(channelId)
       : undefined;
     channelHandle = adapter ? await resolveAdapterHandle(adapter) : undefined;
+    if (params.sourceChannel === "telegram") {
+      const { ensureTelegramBotUsernameResolved } =
+        await import("./channel-invite-transports/telegram.js");
+      await ensureTelegramBotUsernameResolved();
+    }
     const share = buildSharePayload(params.sourceChannel, rawToken);
     guardianInstruction = await generateInviteInstruction({
       contactName: params.contactName,


### PR DESCRIPTION
## Summary
- Add ensureTelegramBotUsernameResolved() that fetches bot username via Telegram getMe API when accountInfo is missing from credential metadata
- Call the resolver in createIngressInvite before building the share payload for Telegram invites
- Username is cached in credential metadata so subsequent invites skip the API call

Part of plan: show-invite-link.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
