### PR TITLE
fix: correct --slot-id description in amazon CLI help text

### DIFF
--- a/assistant/src/amazon/checkout.ts
+++ b/assistant/src/amazon/checkout.ts
@@ -291,7 +291,6 @@ export async function getCheckoutSummary(): Promise<CheckoutSummary> {
 export async function placeOrder(
   opts: {
     paymentMethodId?: string;
-    deliverySlotId?: string;
   } = {},
 ): Promise<PlaceOrderResult> {
   const { tabId } = await prepareRequest();

--- a/assistant/src/cli/amazon.ts
+++ b/assistant/src/cli/amazon.ts
@@ -671,7 +671,7 @@ Examples:
       `
 Reserves an Amazon Fresh delivery slot for the current order. The slot ID
 must be obtained from "fresh delivery-slots". A slot must be selected before
-placing an Amazon Fresh order via "order place --slot-id".
+placing an Amazon Fresh order via "order place".
 
 Examples:
   $ vellum amazon fresh select-slot --slot-id slot_abc123
@@ -768,7 +768,6 @@ Examples:
       "--payment-method-id <id>",
       "Payment method ID (uses default if omitted)",
     )
-    .option("--slot-id <id>", "Amazon Fresh delivery slot ID")
     .addHelpText(
       "after",
       `
@@ -780,9 +779,9 @@ Options:
   --payment-method-id <id>   Payment method to charge. Obtain IDs from
                              "payment-methods". If omitted, Amazon uses the
                              account's default payment method.
-  --slot-id <id>             Amazon Fresh delivery slot. Required for Fresh
-                             orders. Obtain IDs from "fresh delivery-slots"
-                             and reserve with "fresh select-slot" first.
+
+For Amazon Fresh orders, select a delivery slot before placing the order:
+  $ vellum amazon fresh select-slot --slot-id slot_abc123
 
 Recommended workflow before placing an order:
   1. vellum amazon cart view          (verify cart contents)
@@ -793,22 +792,16 @@ Recommended workflow before placing an order:
 Examples:
   $ vellum amazon order place
   $ vellum amazon order place --payment-method-id pm_abc123
-  $ vellum amazon order place --slot-id slot_abc123 --json`,
+  $ vellum amazon order place --json`,
     )
-    .action(
-      async (
-        opts: { paymentMethodId?: string; slotId?: string },
-        cmd: Command,
-      ) => {
-        await run(cmd, async () => {
-          const result = await placeOrder({
-            paymentMethodId: opts.paymentMethodId,
-            deliverySlotId: opts.slotId,
-          });
-          return { order: result };
+    .action(async (opts: { paymentMethodId?: string }, cmd: Command) => {
+      await run(cmd, async () => {
+        const result = await placeOrder({
+          paymentMethodId: opts.paymentMethodId,
         });
-      },
-    );
+        return { order: result };
+      });
+    });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes inaccurate help text about --slot-id being required for Fresh orders. The option was forwarded as deliverySlotId but placeOrder() never used it during form submission. Removed the dead --slot-id option from 'order place', cleaned up the unused deliverySlotId parameter from placeOrder(), and updated help text to correctly direct users to run 'fresh select-slot' as a separate step before placing an order.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
