### PR TITLE
feat: add deleteContact() function to contact store

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -624,6 +624,31 @@ export function mergeContacts(
 }
 
 /**
+ * Delete a contact by ID. Guardians cannot be deleted as a safety guard.
+ * Associated contactChannels and assistantContactMetadata rows are
+ * cascade-deleted by the DB schema's onDelete constraints.
+ */
+export function deleteContact(
+  contactId: string,
+): "ok" | "not_found" | "is_guardian" {
+  const db = getDb();
+
+  const contact = db
+    .select()
+    .from(contacts)
+    .where(eq(contacts.id, contactId))
+    .get();
+
+  if (!contact) return "not_found";
+  if (contact.role === "guardian") return "is_guardian";
+
+  db.delete(contacts).where(eq(contacts.id, contactId)).run();
+
+  emitContactChange();
+  return "ok";
+}
+
+/**
  * Find a contact by a specific channel address. Returns null if not found.
  */
 export function findContactByAddress(


### PR DESCRIPTION
## Summary
- Add `deleteContact(contactId)` to contact store that returns `"ok" | "not_found" | "is_guardian"`
- Guardian contacts cannot be deleted (safety guard)
- Cascade deletes all associated contact-channels and assistant metadata via DB schema constraints
- Emits `contactChange` event on successful deletion

Part of plan: delete-contact-api-and-ui.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)