### PR TITLE
feat: add delete action to contacts IPC contract and handler

### DIFF
--- a/assistant/src/daemon/handlers/contacts.ts
+++ b/assistant/src/daemon/handlers/contacts.ts
@@ -2,6 +2,7 @@ import * as net from "node:net";
 
 import { resolveGuardianName } from "../../config/user-reference.js";
 import {
+  deleteContact,
   getContact,
   listContacts,
   updateChannelStatus,
@@ -131,6 +132,39 @@ export function handleContacts(
           type: "contacts_response",
           success: true,
           contact: parentContact ? toContactPayload(parentContact) : undefined,
+        });
+        return;
+      }
+
+      case "delete": {
+        if (!msg.contactId) {
+          ctx.send(socket, {
+            type: "contacts_response",
+            success: false,
+            error: "contactId is required for delete",
+          });
+          return;
+        }
+        const result = deleteContact(msg.contactId);
+        if (result === "not_found") {
+          ctx.send(socket, {
+            type: "contacts_response",
+            success: false,
+            error: `Contact "${msg.contactId}" not found`,
+          });
+          return;
+        }
+        if (result === "is_guardian") {
+          ctx.send(socket, {
+            type: "contacts_response",
+            success: false,
+            error: "Cannot delete a guardian contact",
+          });
+          return;
+        }
+        ctx.send(socket, {
+          type: "contacts_response",
+          success: true,
         });
         return;
       }

--- a/assistant/src/daemon/ipc-contract/contacts.ts
+++ b/assistant/src/daemon/ipc-contract/contacts.ts
@@ -1,11 +1,11 @@
-// Contact management: list, get, and update channel status.
+// Contact management: list, get, update channel status, and delete.
 
 // === Client → Server ===
 
 export interface ContactsRequest {
   type: "contacts";
-  action: "list" | "get" | "update_channel";
-  /** Contact ID (get only). */
+  action: "list" | "get" | "update_channel" | "delete";
+  /** Contact ID (get and delete). */
   contactId?: string;
   /** Channel ID (update_channel only). */
   channelId?: string;

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -989,7 +989,7 @@ public struct IPCContactsInviteResponseInvite: Codable, Sendable {
 public struct IPCContactsRequest: Codable, Sendable {
     public let type: String
     public let action: String
-    /// Contact ID (get only).
+    /// Contact ID (get and delete).
     public let contactId: String?
     /// Channel ID (update_channel only).
     public let channelId: String?


### PR DESCRIPTION
## Summary
- Add `"delete"` to the contacts IPC action union type
- Add `case "delete"` handler that calls `deleteContact()` and returns appropriate success/error responses
- Regenerate Swift IPC types (`IPCContractGenerated.swift`) and inventory

Part of plan: delete-contact-api-and-ui.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
