### PR TITLE
feat: add DELETE /v1/contacts/:id gateway proxy route

### DIFF
--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -110,6 +110,13 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
       return proxyToRuntime(req, `/v1/contacts/${contactId}`, "");
     },
 
+    async handleDeleteContact(
+      req: Request,
+      contactId: string,
+    ): Promise<Response> {
+      return proxyToRuntime(req, `/v1/contacts/${contactId}`, "");
+    },
+
     async handleMergeContacts(req: Request): Promise<Response> {
       return proxyToRuntime(req, "/v1/contacts/merge", "");
     },

--- a/gateway/src/http/routes/contacts-control-plane-route-match.ts
+++ b/gateway/src/http/routes/contacts-control-plane-route-match.ts
@@ -2,6 +2,7 @@ export type ContactsControlPlaneRoute =
   | { kind: "listContacts" }
   | { kind: "upsertContact" }
   | { kind: "getContact"; contactId: string }
+  | { kind: "deleteContact"; contactId: string }
   | { kind: "mergeContacts" }
   | { kind: "updateContactChannel"; contactChannelId: string }
   | { kind: "listInvites" }
@@ -63,8 +64,11 @@ export function matchContactsControlPlaneRoute(
 
   // Contact by ID — must come after /invites and /merge to avoid false matches
   const contactIdMatch = pathname.match(/^\/v1\/contacts\/([^/]+)$/);
-  if (contactIdMatch && method === "GET") {
-    return { kind: "getContact", contactId: contactIdMatch[1] };
+  if (contactIdMatch) {
+    if (method === "GET")
+      return { kind: "getContact", contactId: contactIdMatch[1] };
+    if (method === "DELETE")
+      return { kind: "deleteContact", contactId: contactIdMatch[1] };
   }
 
   return null;

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -378,10 +378,7 @@ function main() {
       method: "POST",
       auth: "edge",
       handler: (req, params) =>
-        contactsControlPlaneProxy.handleVerifyContactChannel(
-          req,
-          params[0],
-        ),
+        contactsControlPlaneProxy.handleVerifyContactChannel(req, params[0]),
     },
 
     // ── Contacts/invites control plane ──
@@ -409,6 +406,13 @@ function main() {
       auth: "edge",
       handler: (req, params) =>
         contactsControlPlaneProxy.handleRevokeInvite(req, params[0]),
+    },
+    {
+      path: /^\/v1\/contacts\/([^/]+)$/,
+      method: "DELETE",
+      auth: "edge",
+      handler: (req, params) =>
+        contactsControlPlaneProxy.handleDeleteContact(req, params[0]),
     },
     {
       path: /^\/v1\/contacts\/([^/]+)$/,


### PR DESCRIPTION
## Summary
- Add `deleteContact` kind to gateway route matcher for `DELETE /v1/contacts/:id`
- Add `handleDeleteContact` proxy method that forwards to runtime
- Register the DELETE route in gateway index with `auth: "edge"`

Part of plan: delete-contact-api-and-ui.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
