### PR TITLE
feat: migrate keychain broker to async-first APIs and native UDS

### DIFF
--- a/assistant/docs/architecture/keychain-broker.md
+++ b/assistant/docs/architecture/keychain-broker.md
@@ -30,7 +30,7 @@ graph LR
     end
 
     RUNTIME["Assistant Runtime (Bun)"] -->|"UDS JSON"| SERVER
-    GATEWAY["Gateway (Bun)"] -->|"UDS JSON<br/>(spawnSync node)"| SERVER
+    GATEWAY["Gateway (Bun)"] -->|"UDS JSON<br/>(async)"| SERVER
 
     RUNTIME -.->|"fallback<br/>(sync + broker unavailable)"| ENC["Encrypted Store<br/>(~/.vellum/protected/keys.enc)"]
     GATEWAY -.->|"fallback<br/>(broker unavailable)"| ENC
@@ -55,11 +55,11 @@ graph LR
 
 ### TypeScript side (runtime + gateway)
 
-| File                                               | Role                                                                                                                                                                                                                                                                                                                                                                                              |
-| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `assistant/src/security/keychain-broker-client.ts` | Async UDS client for the runtime. Persistent socket connection, request/response correlation, auth token caching with auto-refresh on `UNAUTHORIZED`. Falls back gracefully (returns safe defaults, never throws).                                                                                                                                                                                |
+| File                                               | Role                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `assistant/src/security/keychain-broker-client.ts` | Async UDS client for the runtime. Persistent socket connection, request/response correlation, auth token caching with auto-refresh on `UNAUTHORIZED`. Falls back gracefully (returns safe defaults, never throws).                                                                                                                                                                                                                                                      |
 | `assistant/src/security/secure-keys.ts`            | Unified API surface. Sync variants use encrypted store only. Async variants (`getSecureKeyAsync`, `setSecureKeyAsync`, `deleteSecureKeyAsync`) try broker first. **Reads** fall back to the encrypted store when the broker is unavailable or key is not found. **Writes** return `false` on broker failure (no encrypted-store fallback). **Deletes** return `"deleted"`, `"not-found"`, or `"error"` to let callers distinguish idempotent no-ops from real failures. |
-| `gateway/src/credential-reader.ts`                 | Read-only credential reader. Tries broker via `spawnSync` + inline Node script (gateway is sync-only at credential read time), falls back to encrypted store.                                                                                                                                                                                                                                     |
+| `gateway/src/credential-reader.ts`                 | Read-only credential reader. Tries broker via native async UDS connection (`node:net`), falls back to encrypted store. All public credential read functions are async.                                                                                                                                                                                                                                                                                                  |
 
 ## IPC Contract
 
@@ -160,6 +160,24 @@ XPC provides stronger caller identity guarantees via audit tokens and code requi
 - **Debug builds:** The `#if !DEBUG` guard compiles out the entire `KeychainBrokerServer`. The `VELLUM_KEYCHAIN_BROKER_SOCKET` env var is not set, so clients see the broker as unavailable and use the encrypted store. Developers never encounter keychain prompts during the edit-build-run cycle.
 - **Release builds:** The broker starts automatically with the app. The daemon discovers it via the socket env var and token file. No configuration needed.
 - **CLI-only / headless:** No macOS app means no broker socket. All storage uses the encrypted file store. This is the expected path for CI, servers, and non-macOS platforms.
+
+## Callsite Policy
+
+### Runtime request handlers (secret-routes, etc.)
+
+All runtime HTTP handlers that write or delete secrets **must** use the async APIs (`setSecureKeyAsync`, `deleteSecureKeyAsync`). These are the primary entry points for macOS app flows and must go through the broker to reach keychain.
+
+### CLI commands (keys, credentials)
+
+CLI commands may use sync APIs (`setSecureKey`, `deleteSecureKey`, `getSecureKey`) since they run outside the macOS app process and the broker may not be available. The sync path uses the encrypted store directly, which is correct for headless/CLI environments.
+
+### Gateway (credential-reader)
+
+The gateway reads credentials via async `readCredential()` which tries the broker first (native async UDS), falling back to the encrypted store. The gateway never writes credentials — that responsibility belongs to the assistant runtime.
+
+### Startup / initialization code
+
+Sync APIs are acceptable for startup paths (e.g. provider initialization, config loading) where async is impractical or the broker may not yet be available.
 
 ## Migration
 

--- a/assistant/src/cli/keys.ts
+++ b/assistant/src/cli/keys.ts
@@ -18,8 +18,8 @@ export function registerKeysCommand(program: Command): void {
   keys.addHelpText(
     "after",
     `
-Keys are stored in OS-native secure storage (macOS Keychain on macOS) and are
-never written to disk in plaintext. Each key is identified by provider name.
+Keys are stored in secure local storage and are never written to disk in
+plaintext. Each key is identified by provider name.
 
 Known providers: ${API_KEY_PROVIDERS.join(", ")}
 
@@ -92,7 +92,7 @@ Examples:
 Arguments:
   provider   Provider name whose key should be removed from secure storage
 
-Removes the API key for the given provider from OS-native secure storage. If
+Removes the API key for the given provider from secure local storage. If
 no key exists for the provider, exits with an error.
 
 Examples:

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -4,7 +4,10 @@ import {
   invalidateConfigCache,
 } from "../../config/loader.js";
 import { initializeProviders } from "../../providers/registry.js";
-import { deleteSecureKey, setSecureKey } from "../../security/secure-keys.js";
+import {
+  deleteSecureKeyAsync,
+  setSecureKeyAsync,
+} from "../../security/secure-keys.js";
 import {
   assertMetadataWritable,
   deleteCredentialMetadata,
@@ -48,7 +51,7 @@ export async function handleAddSecret(req: Request): Promise<Response> {
           400,
         );
       }
-      const stored = setSecureKey(name, value);
+      const stored = await setSecureKeyAsync(name, value);
       if (!stored) {
         return httpError(
           "INTERNAL_ERROR",
@@ -75,7 +78,7 @@ export async function handleAddSecret(req: Request): Promise<Response> {
       const service = name.slice(0, colonIdx);
       const field = name.slice(colonIdx + 1);
       const key = `credential:${service}:${field}`;
-      const stored = setSecureKey(key, value);
+      const stored = await setSecureKeyAsync(key, value);
       if (!stored) {
         return httpError(
           "INTERNAL_ERROR",
@@ -128,7 +131,7 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
           400,
         );
       }
-      const deleteResult = deleteSecureKey(name);
+      const deleteResult = await deleteSecureKeyAsync(name);
       if (deleteResult === "error") {
         return httpError(
           "INTERNAL_ERROR",
@@ -158,7 +161,7 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
       const field = name.slice(colonIdx + 1);
       assertMetadataWritable();
       const key = `credential:${service}:${field}`;
-      const deleteResult = deleteSecureKey(key);
+      const deleteResult = await deleteSecureKeyAsync(key);
       if (deleteResult === "error") {
         return httpError(
           "INTERNAL_ERROR",

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -6,6 +6,7 @@ import {
 import { initializeProviders } from "../../providers/registry.js";
 import {
   deleteSecureKeyAsync,
+  getSecureKeyAsync,
   setSecureKeyAsync,
 } from "../../security/secure-keys.js";
 import {
@@ -131,6 +132,12 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
           400,
         );
       }
+      // Check existence first — the broker always returns "deleted" even
+      // for keys that don't exist, so we need a pre-check for 404 semantics.
+      const existing = await getSecureKeyAsync(name);
+      if (existing === undefined) {
+        return httpError("NOT_FOUND", `API key not found: ${name}`, 404);
+      }
       const deleteResult = await deleteSecureKeyAsync(name);
       if (deleteResult === "error") {
         return httpError(
@@ -138,9 +145,6 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
           `Failed to delete API key from secure storage: ${name}`,
           500,
         );
-      }
-      if (deleteResult === "not-found") {
-        return httpError("NOT_FOUND", `API key not found: ${name}`, 404);
       }
       invalidateConfigCache();
       initializeProviders(getConfig());
@@ -161,6 +165,12 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
       const field = name.slice(colonIdx + 1);
       assertMetadataWritable();
       const key = `credential:${service}:${field}`;
+      // Check existence first — the broker always returns "deleted" even
+      // for keys that don't exist, so we need a pre-check for 404 semantics.
+      const existing = await getSecureKeyAsync(key);
+      if (existing === undefined) {
+        return httpError("NOT_FOUND", `Credential not found: ${name}`, 404);
+      }
       const deleteResult = await deleteSecureKeyAsync(key);
       if (deleteResult === "error") {
         return httpError(
@@ -168,9 +178,6 @@ export async function handleDeleteSecret(req: Request): Promise<Response> {
           `Failed to delete credential from secure storage: ${name}`,
           500,
         );
-      }
-      if (deleteResult === "not-found") {
-        return httpError("NOT_FOUND", `Credential not found: ${name}`, 404);
       }
       deleteCredentialMetadata(service, field);
       log.info({ service, field }, "Credential deleted via HTTP");

--- a/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SecretPromptManager.swift
@@ -201,7 +201,7 @@ struct SecretPromptView: View {
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
                     safetyBullet(
                         icon: "key.fill",
-                        text: "Stored in your Mac's Keychain, not sent to any server"
+                        text: "Stored securely on your Mac, not sent to any server"
                     )
                     safetyBullet(
                         icon: "eye.slash.fill",
@@ -214,7 +214,7 @@ struct SecretPromptView: View {
                     HStack(spacing: VSpacing.xs) {
                         Image(systemName: "checkmark.circle.fill")
                             .foregroundColor(VColor.success)
-                        Text("Saved to Keychain")
+                        Text("Saved securely")
                             .font(VFont.caption)
                             .foregroundColor(VColor.success)
                             .textSelection(.enabled)

--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -10,9 +10,9 @@ const BASE_ENV = {
   ASSISTANT_RUNTIME_BASE_URL: "http://localhost:7821",
 };
 
-function withEnv(
+async function withEnv(
   overrides: Record<string, string | undefined>,
-  fn: () => void,
+  fn: () => Promise<void>,
 ) {
   const saved: Record<string, string | undefined> = {};
   const allKeys = [
@@ -46,7 +46,7 @@ function withEnv(
   Object.assign(process.env, BASE_ENV, overrides);
 
   try {
-    fn();
+    await fn();
   } finally {
     for (const key of allKeys) {
       if (saved[key] === undefined) {
@@ -59,64 +59,64 @@ function withEnv(
 }
 
 describe("config: Telegram-only default mode", () => {
-  test("proxy is disabled when GATEWAY_RUNTIME_PROXY_ENABLED is unset", () => {
-    withEnv({}, () => {
-      const config = loadConfig();
+  test("proxy is disabled when GATEWAY_RUNTIME_PROXY_ENABLED is unset", async () => {
+    await withEnv({}, async () => {
+      const config = await loadConfig();
       expect(config.runtimeProxyEnabled).toBe(false);
     });
   });
 
-  test("proxy is disabled when GATEWAY_RUNTIME_PROXY_ENABLED is explicitly false", () => {
-    withEnv({ GATEWAY_RUNTIME_PROXY_ENABLED: "false" }, () => {
-      const config = loadConfig();
+  test("proxy is disabled when GATEWAY_RUNTIME_PROXY_ENABLED is explicitly false", async () => {
+    await withEnv({ GATEWAY_RUNTIME_PROXY_ENABLED: "false" }, async () => {
+      const config = await loadConfig();
       expect(config.runtimeProxyEnabled).toBe(false);
     });
   });
 });
 
 describe("config: runtime proxy flags", () => {
-  test("proxy disabled by default", () => {
-    withEnv({}, () => {
-      const config = loadConfig();
+  test("proxy disabled by default", async () => {
+    await withEnv({}, async () => {
+      const config = await loadConfig();
       expect(config.runtimeProxyEnabled).toBe(false);
       expect(config.runtimeProxyRequireAuth).toBe(true);
     });
   });
 
-  test("proxy enabled with auth disabled", () => {
-    withEnv(
+  test("proxy enabled with auth disabled", async () => {
+    await withEnv(
       {
         GATEWAY_RUNTIME_PROXY_ENABLED: "true",
         GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "false",
       },
-      () => {
-        const config = loadConfig();
+      async () => {
+        const config = await loadConfig();
         expect(config.runtimeProxyEnabled).toBe(true);
         expect(config.runtimeProxyRequireAuth).toBe(false);
       },
     );
   });
 
-  test("proxy disabled ignores auth setting", () => {
-    withEnv(
+  test("proxy disabled ignores auth setting", async () => {
+    await withEnv(
       {
         GATEWAY_RUNTIME_PROXY_ENABLED: "false",
         GATEWAY_RUNTIME_PROXY_REQUIRE_AUTH: "true",
       },
-      () => {
-        const config = loadConfig();
+      async () => {
+        const config = await loadConfig();
         expect(config.runtimeProxyEnabled).toBe(false);
       },
     );
   });
 
-  test("proxy enabled defaults auth to required", () => {
-    withEnv(
+  test("proxy enabled defaults auth to required", async () => {
+    await withEnv(
       {
         GATEWAY_RUNTIME_PROXY_ENABLED: "true",
       },
-      () => {
-        const config = loadConfig();
+      async () => {
+        const config = await loadConfig();
         expect(config.runtimeProxyRequireAuth).toBe(true);
       },
     );
@@ -124,7 +124,7 @@ describe("config: runtime proxy flags", () => {
 });
 
 describe("config: twilio assistant phone number mapping", () => {
-  test("loads assistantPhoneNumbers from workspace config on startup", () => {
+  test("loads assistantPhoneNumbers from workspace config on startup", async () => {
     const testBaseDir = mkdtempSync(join(tmpdir(), "gateway-config-test-"));
     try {
       const workspaceDir = join(testBaseDir, ".vellum", "workspace");
@@ -142,8 +142,8 @@ describe("config: twilio assistant phone number mapping", () => {
         }),
       );
 
-      withEnv({ BASE_DATA_DIR: testBaseDir }, () => {
-        const config = loadConfig();
+      await withEnv({ BASE_DATA_DIR: testBaseDir }, async () => {
+        const config = await loadConfig();
         expect(config.assistantPhoneNumbers).toEqual({
           "asst-alpha": "+15550002222",
           "asst-beta": "+15550003333",

--- a/gateway/src/__tests__/credential-reader.test.ts
+++ b/gateway/src/__tests__/credential-reader.test.ts
@@ -1,9 +1,27 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, writeFileSync, rmSync, unlinkSync } from "node:fs";
 import { createServer, type Server } from "node:net";
 import { join } from "node:path";
 import { hostname, tmpdir, userInfo } from "node:os";
 import { createCipheriv, pbkdf2Sync, randomBytes } from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// Logger mock — captures all log calls so the secret-leak test can inspect them
+// ---------------------------------------------------------------------------
+
+const logCalls: { method: string; args: unknown[] }[] = [];
+
+mock.module("../logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: (_target, prop) => {
+        if (typeof prop !== "string") return undefined;
+        return (...args: unknown[]) => {
+          logCalls.push({ method: prop, args });
+        };
+      },
+    }),
+}));
 
 import {
   readCredential,
@@ -193,6 +211,7 @@ beforeEach(() => {
   process.env.BASE_DATA_DIR = testDir;
   savedBrokerSocket = process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
   delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
+  logCalls.length = 0;
 });
 
 afterEach(() => {
@@ -351,5 +370,72 @@ describe("readCredential broker integration", () => {
     } finally {
       broker.close();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: secret values must not leak into log output
+// ---------------------------------------------------------------------------
+
+describe("secret leak prevention", () => {
+  function allLogStrings(): string {
+    return JSON.stringify(logCalls);
+  }
+
+  test("broker read does not leak secret values into logs", async () => {
+    const secretValue = "super-secret-broker-credential-value";
+    const broker = createMockBroker({
+      "credential:leak-test:key": secretValue,
+    });
+    try {
+      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = broker.socketPath;
+      writeBrokerToken(TEST_TOKEN);
+
+      const result = await readCredential("credential:leak-test:key");
+      expect(result).toBe(secretValue);
+
+      const serialized = allLogStrings();
+      expect(serialized).not.toContain(secretValue);
+      // The auth token used for broker handshake should also stay out of logs
+      expect(serialized).not.toContain(TEST_TOKEN);
+    } finally {
+      broker.close();
+    }
+  });
+
+  test("encrypted store read does not leak secret values into logs", async () => {
+    const secretValue = "super-secret-encrypted-credential-value";
+    delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
+
+    writeEncryptedStore({
+      "credential:leak-test:key": secretValue,
+    });
+
+    const result = await readCredential("credential:leak-test:key");
+    expect(result).toBe(secretValue);
+
+    const serialized = allLogStrings();
+    expect(serialized).not.toContain(secretValue);
+  });
+
+  test("failed encrypted store read does not leak secret values into logs", async () => {
+    const secretValue = "super-secret-telegram-token";
+    delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
+
+    writeMetadata([
+      { service: "telegram", field: "bot_token" },
+      { service: "telegram", field: "webhook_secret" },
+    ]);
+    writeEncryptedStore({
+      "credential:telegram:bot_token": secretValue,
+      "credential:telegram:webhook_secret": "webhook-secret-value",
+    });
+
+    const result = await readTelegramCredentials();
+    expect(result).not.toBeNull();
+
+    const serialized = allLogStrings();
+    expect(serialized).not.toContain(secretValue);
+    expect(serialized).not.toContain("webhook-secret-value");
   });
 });

--- a/gateway/src/__tests__/credential-reader.test.ts
+++ b/gateway/src/__tests__/credential-reader.test.ts
@@ -1,42 +1,9 @@
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync, unlinkSync } from "node:fs";
+import { createServer, type Server } from "node:net";
 import { join } from "node:path";
 import { hostname, tmpdir, userInfo } from "node:os";
 import { createCipheriv, pbkdf2Sync, randomBytes } from "node:crypto";
-
-// ---------------------------------------------------------------------------
-// Mock logger — capture log calls to verify no secrets leak
-// ---------------------------------------------------------------------------
-
-const logCalls: { level: string; args: unknown[] }[] = [];
-
-mock.module("../logger.js", () => ({
-  getLogger: () =>
-    new Proxy({} as Record<string, unknown>, {
-      get:
-        (_target, prop) =>
-        (...args: unknown[]) => {
-          logCalls.push({ level: String(prop), args });
-        },
-    }),
-}));
-
-// Mock node:child_process to avoid spawnSync deadlock: spawnSync blocks the
-// event loop, preventing an in-process mock broker from accepting connections.
-let mockSpawnSyncImpl:
-  | ((
-      cmd: string,
-      args: string[],
-      opts: Record<string, unknown>,
-    ) => { stdout: Buffer; status: number })
-  | null = null;
-
-mock.module("node:child_process", () => ({
-  spawnSync: (cmd: string, args: string[], opts: Record<string, unknown>) => {
-    if (mockSpawnSyncImpl) return mockSpawnSyncImpl(cmd, args, opts);
-    return { stdout: Buffer.from(""), status: 1 };
-  },
-}));
 
 import {
   readCredential,
@@ -134,16 +101,86 @@ function writeEncryptedStore(entries: Record<string, string>): void {
 }
 
 // ---------------------------------------------------------------------------
-// Broker test helpers
+// Broker test helpers — mock UDS server
 // ---------------------------------------------------------------------------
 
-const BROKER_SOCKET_PLACEHOLDER = "/tmp/mock-broker.sock";
 const TEST_TOKEN = "test-auth-token-abc123";
 
 function writeBrokerToken(token: string): void {
   const tokenDir = join(testDir, ".vellum", "protected");
   mkdirSync(tokenDir, { recursive: true });
   writeFileSync(join(tokenDir, "keychain-broker.token"), token);
+}
+
+/**
+ * Create a mock keychain broker UDS server that responds to key.get requests.
+ * Returns the socket path and a handle to close the server.
+ */
+function createMockBroker(credentials: Record<string, string>): {
+  socketPath: string;
+  server: Server;
+  close: () => void;
+} {
+  const socketPath = join(
+    tmpdir(),
+    `mock-broker-${randomBytes(4).toString("hex")}.sock`,
+  );
+
+  const server = createServer((conn) => {
+    let buf = "";
+    conn.on("data", (chunk) => {
+      buf += chunk.toString();
+      const idx = buf.indexOf("\n");
+      if (idx !== -1) {
+        const line = buf.slice(0, idx);
+        buf = buf.slice(idx + 1);
+        try {
+          const req = JSON.parse(line);
+          if (req.token !== TEST_TOKEN) {
+            conn.write(
+              JSON.stringify({
+                id: req.id,
+                ok: false,
+                error: { code: "UNAUTHORIZED", message: "bad token" },
+              }) + "\n",
+            );
+            return;
+          }
+          if (req.method === "key.get") {
+            const account = req.params?.account;
+            const value = credentials[account];
+            conn.write(
+              JSON.stringify({
+                id: req.id,
+                ok: true,
+                result:
+                  value !== undefined
+                    ? { found: true, value }
+                    : { found: false },
+              }) + "\n",
+            );
+          }
+        } catch {
+          // ignore malformed requests
+        }
+      }
+    });
+  });
+
+  server.listen(socketPath);
+
+  return {
+    socketPath,
+    server,
+    close: () => {
+      server.close();
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        // best-effort
+      }
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -156,8 +193,6 @@ beforeEach(() => {
   process.env.BASE_DATA_DIR = testDir;
   savedBrokerSocket = process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
   delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
-  logCalls.length = 0;
-  mockSpawnSyncImpl = null;
 });
 
 afterEach(() => {
@@ -179,28 +214,28 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("readTelegramCredentials", () => {
-  test("returns null when metadata file does not exist", () => {
-    const result = readTelegramCredentials();
+  test("returns null when metadata file does not exist", async () => {
+    const result = await readTelegramCredentials();
     expect(result).toBeNull();
   });
 
-  test("returns null when metadata has no Telegram entries", () => {
+  test("returns null when metadata has no Telegram entries", async () => {
     writeMetadata([{ service: "github", field: "token" }]);
-    const result = readTelegramCredentials();
+    const result = await readTelegramCredentials();
     expect(result).toBeNull();
   });
 
-  test("returns null when metadata exists but secrets are missing from encrypted store", () => {
+  test("returns null when metadata exists but secrets are missing from encrypted store", async () => {
     writeMetadata([
       { service: "telegram", field: "bot_token" },
       { service: "telegram", field: "webhook_secret" },
     ]);
 
-    const result = readTelegramCredentials();
+    const result = await readTelegramCredentials();
     expect(result).toBeNull();
   });
 
-  test("returns credentials from encrypted store", () => {
+  test("returns credentials from encrypted store", async () => {
     writeMetadata([
       { service: "telegram", field: "bot_token" },
       { service: "telegram", field: "webhook_secret" },
@@ -211,36 +246,11 @@ describe("readTelegramCredentials", () => {
       "credential:telegram:webhook_secret": "enc-webhook-secret",
     });
 
-    const result = readTelegramCredentials();
+    const result = await readTelegramCredentials();
     expect(result).toEqual({
       botToken: "enc-bot-token",
       webhookSecret: "enc-webhook-secret",
     });
-  });
-});
-
-describe("log output: no plaintext secrets", () => {
-  test("log messages never contain secret values", () => {
-    writeMetadata([
-      { service: "telegram", field: "bot_token" },
-      { service: "telegram", field: "webhook_secret" },
-    ]);
-
-    writeEncryptedStore({
-      "credential:telegram:bot_token": "SUPER_SECRET_TOKEN_123",
-      "credential:telegram:webhook_secret": "SUPER_SECRET_WEBHOOK_456",
-    });
-
-    const result = readTelegramCredentials();
-
-    // Verify credentials were actually returned
-    expect(result).not.toBeNull();
-    expect(result!.botToken).toBe("SUPER_SECRET_TOKEN_123");
-
-    // Verify no secret values appear in any log output
-    const allLogText = JSON.stringify(logCalls);
-    expect(allLogText).not.toContain("SUPER_SECRET_TOKEN_123");
-    expect(allLogText).not.toContain("SUPER_SECRET_WEBHOOK_456");
   });
 });
 
@@ -249,13 +259,13 @@ describe("log output: no plaintext secrets", () => {
 // ---------------------------------------------------------------------------
 
 describe("readCredential broker integration", () => {
-  test("returns undefined when broker env var is unset", () => {
+  test("returns undefined when broker env var is unset", async () => {
     delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
-    const result = readCredential("credential:test:key");
+    const result = await readCredential("credential:test:key");
     expect(result).toBeUndefined();
   });
 
-  test("falls back to encrypted store when broker is unavailable", () => {
+  test("falls back to encrypted store when broker is unavailable", async () => {
     // No broker socket configured — should fall through to encrypted store
     delete process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
 
@@ -263,11 +273,11 @@ describe("readCredential broker integration", () => {
       "credential:test:key": "encrypted-value",
     });
 
-    const result = readCredential("credential:test:key");
+    const result = await readCredential("credential:test:key");
     expect(result).toBe("encrypted-value");
   });
 
-  test("falls back to encrypted store when broker socket path is set but no server", () => {
+  test("falls back to encrypted store when broker socket path is set but no server", async () => {
     process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = "/tmp/nonexistent-broker.sock";
     writeBrokerToken(TEST_TOKEN);
 
@@ -275,95 +285,71 @@ describe("readCredential broker integration", () => {
       "credential:test:key": "encrypted-value",
     });
 
-    const result = readCredential("credential:test:key");
+    const result = await readCredential("credential:test:key");
     expect(result).toBe("encrypted-value");
   });
 
-  test("falls back to encrypted store when broker token file is missing", () => {
-    process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = BROKER_SOCKET_PLACEHOLDER;
+  test("falls back to encrypted store when broker token file is missing", async () => {
+    process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = "/tmp/nonexistent-broker.sock";
     // Don't write a token file
 
     writeEncryptedStore({
       "credential:test:key": "encrypted-value",
     });
 
-    const result = readCredential("credential:test:key");
+    const result = await readCredential("credential:test:key");
     expect(result).toBe("encrypted-value");
   });
 
-  test("reads credential from broker when available", () => {
-    process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = BROKER_SOCKET_PLACEHOLDER;
-    writeBrokerToken(TEST_TOKEN);
+  test("reads credential from broker when available", async () => {
+    const broker = createMockBroker({
+      "credential:test:key": "broker-secret-value",
+    });
+    try {
+      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = broker.socketPath;
+      writeBrokerToken(TEST_TOKEN);
 
-    mockSpawnSyncImpl = (cmd, args, opts) => {
-      expect(cmd).toBe("node");
-      // Verify the inline script uses the correct protocol format
-      const script = (args as string[])[1];
-      expect(script).toContain("v: 1");
-      expect(script).toContain('"key.get"');
-      expect(script).toContain("params:");
-      expect(script).toContain("resp.result");
-      const env = opts.env as Record<string, string>;
-      expect(env.BROKER_SOCKET).toBe(BROKER_SOCKET_PLACEHOLDER);
-      expect(env.BROKER_TOKEN).toBe(TEST_TOKEN);
-      expect(env.BROKER_ACCOUNT).toBe("credential:test:key");
-      expect(env.BROKER_REQ_ID).toBeDefined();
-      return { stdout: Buffer.from("broker-secret-value"), status: 0 };
-    };
-
-    const result = readCredential("credential:test:key");
-    expect(result).toBe("broker-secret-value");
+      const result = await readCredential("credential:test:key");
+      expect(result).toBe("broker-secret-value");
+    } finally {
+      broker.close();
+    }
   });
 
-  test("broker result takes priority over encrypted store", () => {
-    process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = BROKER_SOCKET_PLACEHOLDER;
-    writeBrokerToken(TEST_TOKEN);
-
-    writeEncryptedStore({
-      "credential:test:key": "encrypted-value",
+  test("broker result takes priority over encrypted store", async () => {
+    const broker = createMockBroker({
+      "credential:test:key": "broker-value",
     });
+    try {
+      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = broker.socketPath;
+      writeBrokerToken(TEST_TOKEN);
 
-    mockSpawnSyncImpl = (cmd, args, opts) => {
-      expect(cmd).toBe("node");
-      const script = (args as string[])[1];
-      expect(script).toContain("v: 1");
-      expect(script).toContain('"key.get"');
-      const env = opts.env as Record<string, string>;
-      expect(env.BROKER_SOCKET).toBe(BROKER_SOCKET_PLACEHOLDER);
-      expect(env.BROKER_TOKEN).toBe(TEST_TOKEN);
-      expect(env.BROKER_ACCOUNT).toBe("credential:test:key");
-      expect(env.BROKER_REQ_ID).toBeDefined();
-      return { stdout: Buffer.from("broker-value"), status: 0 };
-    };
+      writeEncryptedStore({
+        "credential:test:key": "encrypted-value",
+      });
 
-    const result = readCredential("credential:test:key");
-    expect(result).toBe("broker-value");
+      const result = await readCredential("credential:test:key");
+      expect(result).toBe("broker-value");
+    } finally {
+      broker.close();
+    }
   });
 
-  test("falls back to encrypted store when broker returns not found", () => {
-    process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = BROKER_SOCKET_PLACEHOLDER;
-    writeBrokerToken(TEST_TOKEN);
+  test("falls back to encrypted store when broker returns not found", async () => {
+    // Broker has no entry for "credential:test:key"
+    const broker = createMockBroker({});
+    try {
+      process.env.VELLUM_KEYCHAIN_BROKER_SOCKET = broker.socketPath;
+      writeBrokerToken(TEST_TOKEN);
 
-    writeEncryptedStore({
-      "credential:test:key": "encrypted-value",
-    });
+      writeEncryptedStore({
+        "credential:test:key": "encrypted-value",
+      });
 
-    // Mock returns empty stdout, simulating broker responding with
-    // { ok: true, result: { found: false } } — the inline script
-    // only writes to stdout when result.found is true.
-    mockSpawnSyncImpl = (cmd, args, opts) => {
-      expect(cmd).toBe("node");
-      const script = (args as string[])[1];
-      expect(script).toContain("resp.result.found");
-      const env = opts.env as Record<string, string>;
-      expect(env.BROKER_SOCKET).toBe(BROKER_SOCKET_PLACEHOLDER);
-      expect(env.BROKER_TOKEN).toBe(TEST_TOKEN);
-      expect(env.BROKER_ACCOUNT).toBe("credential:test:key");
-      expect(env.BROKER_REQ_ID).toBeDefined();
-      return { stdout: Buffer.from(""), status: 0 };
-    };
-
-    const result = readCredential("credential:test:key");
-    expect(result).toBe("encrypted-value");
+      const result = await readCredential("credential:test:key");
+      expect(result).toBe("encrypted-value");
+    } finally {
+      broker.close();
+    }
   });
 });

--- a/gateway/src/__tests__/probes.test.ts
+++ b/gateway/src/__tests__/probes.test.ts
@@ -20,7 +20,7 @@ const { loadConfig } = await import("../config.js");
 const { createTelegramWebhookHandler } =
   await import("../http/routes/telegram-webhook.js");
 
-const config = loadConfig();
+const config = await loadConfig();
 
 const { handler: handleTelegramWebhook } = createTelegramWebhookHandler(config);
 

--- a/gateway/src/__tests__/telegram-only-default.test.ts
+++ b/gateway/src/__tests__/telegram-only-default.test.ts
@@ -35,7 +35,7 @@ const { createRuntimeProxyHandler } =
 const { createRuntimeHealthProxyHandler } =
   await import("../http/routes/runtime-health-proxy.js");
 
-const config = loadConfig();
+const config = await loadConfig();
 
 const { handler: handleTelegramWebhook } = createTelegramWebhookHandler(config);
 const runtimeHealthProxy = createRuntimeHealthProxyHandler(config);

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -124,7 +124,7 @@ function parseRoutingJson(raw: string): RoutingEntry[] {
   return entries;
 }
 
-export function loadConfig(): GatewayConfig {
+export async function loadConfig(): Promise<GatewayConfig> {
   const telegramBotToken = process.env.TELEGRAM_BOT_TOKEN || undefined;
   const telegramWebhookSecret =
     process.env.TELEGRAM_WEBHOOK_SECRET || undefined;
@@ -301,7 +301,7 @@ export function loadConfig(): GatewayConfig {
   }
 
   // Twilio credentials: env var > credential store (encrypted file)
-  const twilioCreds = readTwilioCredentials();
+  const twilioCreds = await readTwilioCredentials();
   const twilioAuthToken =
     process.env.TWILIO_AUTH_TOKEN || twilioCreds?.authToken || undefined;
   const twilioAccountSid =
@@ -343,11 +343,11 @@ export function loadConfig(): GatewayConfig {
   }
   if (!twilioPhoneNumber) {
     twilioPhoneNumber =
-      readCredential("credential:twilio:phone_number") || undefined;
+      (await readCredential("credential:twilio:phone_number")) || undefined;
   }
 
   // WhatsApp credentials: env var > credential store (encrypted file)
-  const whatsappCreds = readWhatsAppCredentials();
+  const whatsappCreds = await readWhatsAppCredentials();
   const whatsappPhoneNumberId =
     process.env.WHATSAPP_PHONE_NUMBER_ID ||
     whatsappCreds?.phoneNumberId ||
@@ -405,7 +405,7 @@ export function loadConfig(): GatewayConfig {
   }
 
   // Slack channel credentials: env var > credential store (encrypted file)
-  const slackChannelCreds = readSlackChannelCredentials();
+  const slackChannelCreds = await readSlackChannelCredentials();
   const slackChannelBotToken =
     process.env.SLACK_CHANNEL_BOT_TOKEN ||
     slackChannelCreds?.botToken ||

--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -5,9 +5,9 @@
  * encrypted-at-rest file (~/.vellum/protected/keys.enc).
  */
 
-import { spawnSync } from "node:child_process";
 import { createDecipheriv, pbkdf2Sync, randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
+import { createConnection } from "node:net";
 import { hostname, userInfo } from "node:os";
 import { join } from "node:path";
 import { getLogger } from "./logger.js";
@@ -143,50 +143,10 @@ function readEncryptedCredential(account: string): string | undefined {
 }
 
 // ---------------------------------------------------------------------------
-// Keychain broker reader (UDS)
+// Keychain broker reader (UDS) — native async implementation
 // ---------------------------------------------------------------------------
 
-/**
- * Inline Node script executed via spawnSync to perform a synchronous UDS
- * round-trip to the keychain broker. Communicates via newline-delimited JSON.
- *
- * Environment variables consumed:
- *   BROKER_SOCKET  — path to the Unix domain socket
- *   BROKER_TOKEN   — auth token
- *   BROKER_ACCOUNT — credential account key
- *   BROKER_REQ_ID  — unique request ID
- */
-const BROKER_INLINE_SCRIPT = `
-const net = require("net");
-const socket = net.createConnection({ path: process.env.BROKER_SOCKET });
-let buf = "";
-const timer = setTimeout(() => { socket.destroy(); }, 4000);
-socket.on("connect", () => {
-  const req = JSON.stringify({
-    v: 1,
-    id: process.env.BROKER_REQ_ID,
-    method: "key.get",
-    token: process.env.BROKER_TOKEN,
-    params: { account: process.env.BROKER_ACCOUNT },
-  }) + "\\n";
-  socket.write(req);
-});
-socket.on("data", (chunk) => {
-  buf += chunk.toString();
-  const idx = buf.indexOf("\\n");
-  if (idx !== -1) {
-    try {
-      const resp = JSON.parse(buf.slice(0, idx));
-      if (resp.ok && resp.result && resp.result.found && typeof resp.result.value === "string") {
-        process.stdout.write(resp.result.value);
-      }
-    } catch {}
-    clearTimeout(timer);
-    socket.destroy();
-  }
-});
-socket.on("error", () => { clearTimeout(timer); });
-`;
+const BROKER_TIMEOUT_MS = 5_000;
 
 function getBrokerTokenPath(): string {
   return join(getRootDir(), "protected", "keychain-broker.token");
@@ -194,12 +154,19 @@ function getBrokerTokenPath(): string {
 
 /**
  * Try to read a credential from the keychain broker over its Unix domain socket.
+ * Uses a native UDS connection (no external process spawn).
  * Returns `undefined` if the broker is unavailable, the socket env var is unset,
  * the token file is missing, or the broker doesn't have the requested key.
  */
-function readBrokerCredential(account: string): string | undefined {
+async function readBrokerCredential(
+  account: string,
+): Promise<string | undefined> {
   const socketPath = process.env.VELLUM_KEYCHAIN_BROKER_SOCKET;
   if (!socketPath) return undefined;
+
+  // Check socket file exists before attempting connection — createConnection
+  // can throw synchronously in some runtimes (e.g. Bun) for ENOENT.
+  if (!existsSync(socketPath)) return undefined;
 
   const tokenPath = getBrokerTokenPath();
   let token: string;
@@ -211,21 +178,69 @@ function readBrokerCredential(account: string): string | undefined {
     return undefined;
   }
 
+  const reqId = randomUUID();
+  const request = JSON.stringify({
+    v: 1,
+    id: reqId,
+    method: "key.get",
+    token,
+    params: { account },
+  });
+
   try {
-    const result = spawnSync("node", ["-e", BROKER_INLINE_SCRIPT], {
-      env: {
-        ...process.env,
-        BROKER_SOCKET: socketPath,
-        BROKER_TOKEN: token,
-        BROKER_ACCOUNT: account,
-        BROKER_REQ_ID: randomUUID(),
-      },
-      timeout: 5_000,
-      stdio: ["ignore", "pipe", "ignore"],
+    return await new Promise<string | undefined>((resolve) => {
+      let buf = "";
+      let settled = false;
+
+      const timer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          socket.destroy();
+          log.debug({ account }, "Broker read timed out");
+          resolve(undefined);
+        }
+      }, BROKER_TIMEOUT_MS);
+
+      const socket = createConnection({ path: socketPath });
+
+      socket.on("connect", () => {
+        socket.write(request + "\n");
+      });
+
+      socket.on("data", (chunk) => {
+        buf += chunk.toString();
+        const idx = buf.indexOf("\n");
+        if (idx !== -1) {
+          clearTimeout(timer);
+          if (settled) return;
+          settled = true;
+          try {
+            const resp = JSON.parse(buf.slice(0, idx));
+            if (
+              resp.ok &&
+              resp.result?.found &&
+              typeof resp.result.value === "string"
+            ) {
+              resolve(resp.result.value);
+            } else {
+              resolve(undefined);
+            }
+          } catch {
+            resolve(undefined);
+          }
+          socket.destroy();
+        }
+      });
+
+      socket.on("error", (err) => {
+        clearTimeout(timer);
+        if (!settled) {
+          settled = true;
+          log.debug({ err, account }, "Failed to read from keychain broker");
+          resolve(undefined);
+        }
+      });
     });
-    const value = result.stdout?.toString();
-    if (!value) return undefined;
-    return value;
   } catch (err) {
     log.debug({ err, account }, "Failed to read from keychain broker");
     return undefined;
@@ -241,8 +256,10 @@ function readBrokerCredential(account: string): string | undefined {
  * Tries the keychain broker first (when available), then falls back
  * to the encrypted-at-rest store.
  */
-export function readCredential(account: string): string | undefined {
-  const brokerValue = readBrokerCredential(account);
+export async function readCredential(
+  account: string,
+): Promise<string | undefined> {
+  const brokerValue = await readBrokerCredential(account);
   if (brokerValue !== undefined) return brokerValue;
   return readEncryptedCredential(account);
 }
@@ -266,7 +283,7 @@ export type TwilioCredentials = {
  * - Telegram bot_token or webhook_secret entries are missing from metadata
  * - The actual secret values can't be read from the encrypted store
  */
-export function readTelegramCredentials(): TelegramCredentials | null {
+export async function readTelegramCredentials(): Promise<TelegramCredentials | null> {
   try {
     const metadataPath = getMetadataPath();
     if (!existsSync(metadataPath)) return null;
@@ -286,12 +303,14 @@ export function readTelegramCredentials(): TelegramCredentials | null {
 
     if (!hasBotToken || !hasWebhookSecret) return null;
 
-    const botToken = readCredential("credential:telegram:bot_token");
-    const webhookSecret = readCredential("credential:telegram:webhook_secret");
+    const botToken = await readCredential("credential:telegram:bot_token");
+    const webhookSecret = await readCredential(
+      "credential:telegram:webhook_secret",
+    );
 
     if (!botToken || !webhookSecret) {
       log.warn(
-        "Telegram credential metadata exists but secrets could not be read from encrypted store",
+        "Telegram credential metadata exists but secrets could not be read",
       );
       return null;
     }
@@ -312,7 +331,7 @@ export function readTelegramCredentials(): TelegramCredentials | null {
  * - Twilio account_sid or auth_token entries are missing from metadata
  * - The actual secret values can't be read from the encrypted store
  */
-export function readTwilioCredentials(): TwilioCredentials | null {
+export async function readTwilioCredentials(): Promise<TwilioCredentials | null> {
   try {
     const metadataPath = getMetadataPath();
     if (!existsSync(metadataPath)) return null;
@@ -332,12 +351,12 @@ export function readTwilioCredentials(): TwilioCredentials | null {
 
     if (!hasAccountSid || !hasAuthToken) return null;
 
-    const accountSid = readCredential("credential:twilio:account_sid");
-    const authToken = readCredential("credential:twilio:auth_token");
+    const accountSid = await readCredential("credential:twilio:account_sid");
+    const authToken = await readCredential("credential:twilio:auth_token");
 
     if (!accountSid || !authToken) {
       log.warn(
-        "Twilio credential metadata exists but secrets could not be read from encrypted store",
+        "Twilio credential metadata exists but secrets could not be read",
       );
       return null;
     }
@@ -365,7 +384,7 @@ export type SlackChannelCredentials = {
  * - Slack channel bot_token or app_token entries are missing from metadata
  * - The actual secret values can't be read from the encrypted store
  */
-export function readSlackChannelCredentials(): SlackChannelCredentials | null {
+export async function readSlackChannelCredentials(): Promise<SlackChannelCredentials | null> {
   try {
     const metadataPath = getMetadataPath();
     if (!existsSync(metadataPath)) return null;
@@ -385,12 +404,12 @@ export function readSlackChannelCredentials(): SlackChannelCredentials | null {
 
     if (!hasBotToken || !hasAppToken) return null;
 
-    const botToken = readCredential("credential:slack_channel:bot_token");
-    const appToken = readCredential("credential:slack_channel:app_token");
+    const botToken = await readCredential("credential:slack_channel:bot_token");
+    const appToken = await readCredential("credential:slack_channel:app_token");
 
     if (!botToken || !appToken) {
       log.warn(
-        "Slack channel credential metadata exists but secrets could not be read from encrypted store",
+        "Slack channel credential metadata exists but secrets could not be read",
       );
       return null;
     }
@@ -422,7 +441,7 @@ export type WhatsAppCredentials = {
  * - Required WhatsApp entries are missing from metadata
  * - The actual secret values can't be read from the encrypted store
  */
-export function readWhatsAppCredentials(): WhatsAppCredentials | null {
+export async function readWhatsAppCredentials(): Promise<WhatsAppCredentials | null> {
   try {
     const metadataPath = getMetadataPath();
     if (!existsSync(metadataPath)) return null;
@@ -456,16 +475,20 @@ export function readWhatsAppCredentials(): WhatsAppCredentials | null {
     )
       return null;
 
-    const phoneNumberId = readCredential("credential:whatsapp:phone_number_id");
-    const accessToken = readCredential("credential:whatsapp:access_token");
-    const appSecret = readCredential("credential:whatsapp:app_secret");
-    const webhookVerifyToken = readCredential(
+    const phoneNumberId = await readCredential(
+      "credential:whatsapp:phone_number_id",
+    );
+    const accessToken = await readCredential(
+      "credential:whatsapp:access_token",
+    );
+    const appSecret = await readCredential("credential:whatsapp:app_secret");
+    const webhookVerifyToken = await readCredential(
       "credential:whatsapp:webhook_verify_token",
     );
 
     if (!phoneNumberId || !accessToken || !appSecret || !webhookVerifyToken) {
       log.warn(
-        "WhatsApp credential metadata exists but secrets could not be read from encrypted store",
+        "WhatsApp credential metadata exists but secrets could not be read",
       );
       return null;
     }

--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -195,16 +195,29 @@ async function readBrokerCredential(
       const timer = setTimeout(() => {
         if (!settled) {
           settled = true;
-          socket.destroy();
+          try {
+            socket?.destroy();
+          } catch {
+            /* already destroyed or never created */
+          }
           log.debug({ account }, "Broker read timed out");
           resolve(undefined);
         }
       }, BROKER_TIMEOUT_MS);
 
-      const socket = createConnection({ path: socketPath });
+      let socket: ReturnType<typeof createConnection> | undefined;
+      try {
+        socket = createConnection({ path: socketPath });
+      } catch (err) {
+        clearTimeout(timer);
+        settled = true;
+        log.debug({ err, account }, "Failed to connect to keychain broker");
+        resolve(undefined);
+        return;
+      }
 
       socket.on("connect", () => {
-        socket.write(request + "\n");
+        socket!.write(request + "\n");
       });
 
       socket.on("data", (chunk) => {
@@ -228,7 +241,7 @@ async function readBrokerCredential(
           } catch {
             resolve(undefined);
           }
-          socket.destroy();
+          socket!.destroy();
         }
       });
 

--- a/gateway/src/credential-watcher.ts
+++ b/gateway/src/credential-watcher.ts
@@ -53,6 +53,7 @@ export class CredentialWatcher {
   private lastWhatsAppWebhookVerifyToken: string | undefined;
   private lastSlackChannelBotToken: string | undefined;
   private lastSlackChannelAppToken: string | undefined;
+  private polling = false;
   private callback: CredentialChangeCallback;
   private metadataPath: string;
 
@@ -141,95 +142,101 @@ export class CredentialWatcher {
   }
 
   private async pollOnce(): Promise<void> {
-    const telegramCredentials = await readTelegramCredentials();
-    const twilioCredentials = await readTwilioCredentials();
-    const whatsappCredentials = await readWhatsAppCredentials();
-    const slackChannelCredentials = await readSlackChannelCredentials();
+    if (this.polling) return;
+    this.polling = true;
+    try {
+      const telegramCredentials = await readTelegramCredentials();
+      const twilioCredentials = await readTwilioCredentials();
+      const whatsappCredentials = await readWhatsAppCredentials();
+      const slackChannelCredentials = await readSlackChannelCredentials();
 
-    const newBotToken = telegramCredentials?.botToken;
-    const newWebhookSecret = telegramCredentials?.webhookSecret;
-    const newTwilioAccountSid = twilioCredentials?.accountSid;
-    const newTwilioAuthToken = twilioCredentials?.authToken;
-    const newWhatsAppPhoneNumberId = whatsappCredentials?.phoneNumberId;
-    const newWhatsAppAccessToken = whatsappCredentials?.accessToken;
-    const newWhatsAppAppSecret = whatsappCredentials?.appSecret;
-    const newWhatsAppWebhookVerifyToken =
-      whatsappCredentials?.webhookVerifyToken;
-    const newSlackChannelBotToken = slackChannelCredentials?.botToken;
-    const newSlackChannelAppToken = slackChannelCredentials?.appToken;
+      const newBotToken = telegramCredentials?.botToken;
+      const newWebhookSecret = telegramCredentials?.webhookSecret;
+      const newTwilioAccountSid = twilioCredentials?.accountSid;
+      const newTwilioAuthToken = twilioCredentials?.authToken;
+      const newWhatsAppPhoneNumberId = whatsappCredentials?.phoneNumberId;
+      const newWhatsAppAccessToken = whatsappCredentials?.accessToken;
+      const newWhatsAppAppSecret = whatsappCredentials?.appSecret;
+      const newWhatsAppWebhookVerifyToken =
+        whatsappCredentials?.webhookVerifyToken;
+      const newSlackChannelBotToken = slackChannelCredentials?.botToken;
+      const newSlackChannelAppToken = slackChannelCredentials?.appToken;
 
-    const telegramChanged =
-      newBotToken !== this.lastBotToken ||
-      newWebhookSecret !== this.lastWebhookSecret;
+      const telegramChanged =
+        newBotToken !== this.lastBotToken ||
+        newWebhookSecret !== this.lastWebhookSecret;
 
-    const twilioChanged =
-      newTwilioAccountSid !== this.lastTwilioAccountSid ||
-      newTwilioAuthToken !== this.lastTwilioAuthToken;
+      const twilioChanged =
+        newTwilioAccountSid !== this.lastTwilioAccountSid ||
+        newTwilioAuthToken !== this.lastTwilioAuthToken;
 
-    const whatsappChanged =
-      newWhatsAppPhoneNumberId !== this.lastWhatsAppPhoneNumberId ||
-      newWhatsAppAccessToken !== this.lastWhatsAppAccessToken ||
-      newWhatsAppAppSecret !== this.lastWhatsAppAppSecret ||
-      newWhatsAppWebhookVerifyToken !== this.lastWhatsAppWebhookVerifyToken;
+      const whatsappChanged =
+        newWhatsAppPhoneNumberId !== this.lastWhatsAppPhoneNumberId ||
+        newWhatsAppAccessToken !== this.lastWhatsAppAccessToken ||
+        newWhatsAppAppSecret !== this.lastWhatsAppAppSecret ||
+        newWhatsAppWebhookVerifyToken !== this.lastWhatsAppWebhookVerifyToken;
 
-    const slackChannelChanged =
-      newSlackChannelBotToken !== this.lastSlackChannelBotToken ||
-      newSlackChannelAppToken !== this.lastSlackChannelAppToken;
+      const slackChannelChanged =
+        newSlackChannelBotToken !== this.lastSlackChannelBotToken ||
+        newSlackChannelAppToken !== this.lastSlackChannelAppToken;
 
-    if (
-      !telegramChanged &&
-      !twilioChanged &&
-      !whatsappChanged &&
-      !slackChannelChanged
-    ) {
-      return;
+      if (
+        !telegramChanged &&
+        !twilioChanged &&
+        !whatsappChanged &&
+        !slackChannelChanged
+      ) {
+        return;
+      }
+
+      this.lastBotToken = newBotToken;
+      this.lastWebhookSecret = newWebhookSecret;
+      this.lastTwilioAccountSid = newTwilioAccountSid;
+      this.lastTwilioAuthToken = newTwilioAuthToken;
+      this.lastWhatsAppPhoneNumberId = newWhatsAppPhoneNumberId;
+      this.lastWhatsAppAccessToken = newWhatsAppAccessToken;
+      this.lastWhatsAppAppSecret = newWhatsAppAppSecret;
+      this.lastWhatsAppWebhookVerifyToken = newWhatsAppWebhookVerifyToken;
+      this.lastSlackChannelBotToken = newSlackChannelBotToken;
+      this.lastSlackChannelAppToken = newSlackChannelAppToken;
+
+      if (telegramChanged) {
+        log.info(
+          { hasCredentials: !!telegramCredentials },
+          "Telegram credentials changed",
+        );
+      }
+      if (twilioChanged) {
+        log.info(
+          { hasCredentials: !!twilioCredentials },
+          "Twilio credentials changed",
+        );
+      }
+      if (whatsappChanged) {
+        log.info(
+          { hasCredentials: !!whatsappCredentials },
+          "WhatsApp credentials changed",
+        );
+      }
+      if (slackChannelChanged) {
+        log.info(
+          { hasCredentials: !!slackChannelCredentials },
+          "Slack channel credentials changed",
+        );
+      }
+
+      this.callback({
+        telegramCredentials,
+        telegramChanged,
+        twilioCredentials,
+        twilioChanged,
+        whatsappCredentials,
+        whatsappChanged,
+        slackChannelCredentials,
+        slackChannelChanged,
+      });
+    } finally {
+      this.polling = false;
     }
-
-    this.lastBotToken = newBotToken;
-    this.lastWebhookSecret = newWebhookSecret;
-    this.lastTwilioAccountSid = newTwilioAccountSid;
-    this.lastTwilioAuthToken = newTwilioAuthToken;
-    this.lastWhatsAppPhoneNumberId = newWhatsAppPhoneNumberId;
-    this.lastWhatsAppAccessToken = newWhatsAppAccessToken;
-    this.lastWhatsAppAppSecret = newWhatsAppAppSecret;
-    this.lastWhatsAppWebhookVerifyToken = newWhatsAppWebhookVerifyToken;
-    this.lastSlackChannelBotToken = newSlackChannelBotToken;
-    this.lastSlackChannelAppToken = newSlackChannelAppToken;
-
-    if (telegramChanged) {
-      log.info(
-        { hasCredentials: !!telegramCredentials },
-        "Telegram credentials changed",
-      );
-    }
-    if (twilioChanged) {
-      log.info(
-        { hasCredentials: !!twilioCredentials },
-        "Twilio credentials changed",
-      );
-    }
-    if (whatsappChanged) {
-      log.info(
-        { hasCredentials: !!whatsappCredentials },
-        "WhatsApp credentials changed",
-      );
-    }
-    if (slackChannelChanged) {
-      log.info(
-        { hasCredentials: !!slackChannelCredentials },
-        "Slack channel credentials changed",
-      );
-    }
-
-    this.callback({
-      telegramCredentials,
-      telegramChanged,
-      twilioCredentials,
-      twilioChanged,
-      whatsappCredentials,
-      whatsappChanged,
-      slackChannelCredentials,
-      slackChannelChanged,
-    });
   }
 }

--- a/gateway/src/credential-watcher.ts
+++ b/gateway/src/credential-watcher.ts
@@ -62,7 +62,7 @@ export class CredentialWatcher {
   }
 
   start(): void {
-    this.pollOnce();
+    void this.pollOnce();
 
     this.watchingDirectory = !existsSync(this.metadataPath);
     const watchTarget = this.watchingDirectory
@@ -113,7 +113,7 @@ export class CredentialWatcher {
     }
     this.debounceTimer = setTimeout(() => {
       this.debounceTimer = null;
-      this.pollOnce();
+      void this.pollOnce();
 
       if (this.watchingDirectory && existsSync(this.metadataPath)) {
         this.upgradeWatcher();
@@ -140,11 +140,11 @@ export class CredentialWatcher {
     }
   }
 
-  private pollOnce(): void {
-    const telegramCredentials = readTelegramCredentials();
-    const twilioCredentials = readTwilioCredentials();
-    const whatsappCredentials = readWhatsAppCredentials();
-    const slackChannelCredentials = readSlackChannelCredentials();
+  private async pollOnce(): Promise<void> {
+    const telegramCredentials = await readTelegramCredentials();
+    const twilioCredentials = await readTwilioCredentials();
+    const whatsappCredentials = await readWhatsAppCredentials();
+    const slackChannelCredentials = await readSlackChannelCredentials();
 
     const newBotToken = telegramCredentials?.botToken;
     const newWebhookSecret = telegramCredentials?.webhookSecret;

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -98,8 +98,8 @@ function getClientIp(
   return addr?.address ?? "unknown";
 }
 
-function main() {
-  const config = loadConfig();
+async function main() {
+  const config = await loadConfig();
   initLogger(config.logFile);
 
   log.info("Starting Vellum Gateway...");


### PR DESCRIPTION
## Summary
- Migrate `secret-routes.ts` from sync to async secure-key APIs (`setSecureKeyAsync`/`deleteSecureKeyAsync`) so macOS app save/delete flows go through the keychain broker
- Replace gateway `spawnSync("node", "-e", ...)` broker reader with native async UDS client (`node:net`), making all credential read functions async
- Update user-facing copy in SecretPromptManager.swift and CLI help text to say "secure local storage" instead of over-promising Keychain usage
- Add callsite policy section to architecture docs; update gateway credential-reader tests to use mock UDS server instead of spawnSync mock

## Original prompt
You are implementing follow-up work for the macOS keychain broker migration in `main`.

## Context
We already decided **not** to run a separate broker daemon process.  
Broker is app-embedded and should remain that way.

## Problems To Solve
1. Keychain is not actually primary for most runtime paths.
2. UX text over-promises Keychain usage.
3. Gateway broker access depends on `spawnSync("node", ...)`.

## Goals
1. Keep broker in-process (no separate daemon/process).
2. Make keychain the primary storage path for macOS app flows.
3. Preserve encrypted store fallback for debug/headless/CLI-only environments.
4. Avoid stale divergence between broker and encrypted store.
5. Align user-facing copy with real behavior at every stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
