### PR TITLE
feat: add delete contact button to macOS Contact Detail view

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -17,8 +17,11 @@ struct ContactDetailView: View {
     let contact: ContactPayload
     var daemonClient: DaemonClient?
     var store: SettingsStore?
+    var onDelete: (() -> Void)?
 
     @State var currentContact: ContactPayload?
+    @State private var showDeleteConfirmation = false
+    @State private var isDeleting = false
     @State private var actionInProgress: String?
     @State var errorMessage: String?
     @State private var isEditing = false
@@ -68,6 +71,18 @@ struct ContactDetailView: View {
             .padding(VSpacing.xl)
         }
         .background(VColor.background)
+        .confirmationDialog(
+            "Delete \(displayContact.displayName)?",
+            isPresented: $showDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                deleteContact()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will permanently delete this contact and all their channels. This action cannot be undone.")
+        }
         .onAppear {
             currentContact = contact
             if contact.role == "guardian" {
@@ -136,6 +151,24 @@ struct ContactDetailView: View {
                     .opacity(isHoveringHeader ? 1 : 0)
                     .animation(VAnimation.fast, value: isHoveringHeader)
                     .accessibilityLabel("Edit contact")
+
+                    if displayContact.role != "guardian" {
+                        Button(action: { showDeleteConfirmation = true }) {
+                            if isDeleting {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else {
+                                Image(systemName: "trash")
+                                    .foregroundColor(VColor.error)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(isDeleting)
+                        .help("Delete contact")
+                        .opacity(isHoveringHeader ? 1 : 0)
+                        .animation(VAnimation.fast, value: isHoveringHeader)
+                        .accessibilityLabel("Delete contact")
+                    }
                 }
             }
 
@@ -1016,6 +1049,38 @@ struct ContactDetailView: View {
             }
 
             actionInProgress = nil
+        }
+    }
+
+    private func deleteContact() {
+        guard let daemonClient else { return }
+        isDeleting = true
+        errorMessage = nil
+
+        Task {
+            let stream = daemonClient.subscribe()
+
+            do {
+                try daemonClient.sendDeleteContact(contactId: displayContact.id)
+            } catch {
+                errorMessage = "Failed to delete contact: \(error.localizedDescription)"
+                isDeleting = false
+                return
+            }
+
+            for await message in stream {
+                if case .contactsResponse(let response) = message {
+                    if response.success {
+                        onDelete?()
+                    } else {
+                        errorMessage = response.error ?? "Failed to delete contact"
+                    }
+                    isDeleting = false
+                    return
+                }
+            }
+
+            isDeleting = false
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsContainerView.swift
@@ -51,7 +51,11 @@ struct ContactsContainerView: View {
                 ContactDetailView(
                     contact: contact,
                     daemonClient: daemonClient,
-                    store: store
+                    store: store,
+                    onDelete: {
+                        selectedContactId = nil
+                        viewModel.loadContacts()
+                    }
                 )
                 .id(contactId)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1794,6 +1794,11 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(ContactsRequestMessage(action: "update_channel", channelId: channelId, status: status, policy: policy, reason: reason))
     }
 
+    /// Request deletion of a contact by ID.
+    public func sendDeleteContact(contactId: String) throws {
+        try send(ContactsRequestMessage(action: "delete", contactId: contactId))
+    }
+
     /// Update a contact's metadata via the HTTP API (`POST /v1/contacts`).
     /// Routes through `HTTPTransport` when available so that managed-mode
     /// URL paths (`/v1/assistants/{id}/contacts/`) and auth headers


### PR DESCRIPTION
## Summary
- Add `sendDeleteContact()` method to DaemonClient
- Add trash icon button to ContactDetailView header (hidden for guardians)
- Show confirmation dialog before deletion with warning about cascade
- Navigate back to contact list on successful deletion
- Show loading spinner and error messages during deletion

Part of plan: delete-contact-api-and-ui.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
