### PR TITLE
fix: resolve Telegram bot username before channelHandle in invite service

### DIFF
--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -234,12 +234,12 @@ export async function createIngressInvite(params: {
     const adapter = channelId
       ? getInviteAdapterRegistry().get(channelId)
       : undefined;
-    channelHandle = adapter ? await resolveAdapterHandle(adapter) : undefined;
     if (params.sourceChannel === "telegram") {
       const { ensureTelegramBotUsernameResolved } =
         await import("./channel-invite-transports/telegram.js");
       await ensureTelegramBotUsernameResolved();
     }
+    channelHandle = adapter ? await resolveAdapterHandle(adapter) : undefined;
     const share = buildSharePayload(params.sourceChannel, rawToken);
     guardianInstruction = await generateInviteInstruction({
       contactName: params.contactName,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for show-invite-link.md.

**Gap:** ensureTelegramBotUsernameResolved() called after channelHandle resolution
**What was expected:** Bot username should be resolved before channelHandle so both channelHandle and share URL benefit from the cached username
**What was found:** The resolution was placed after channelHandle, causing channelHandle to be undefined on first invite

🤖 Generated with [Claude Code](https://claude.com/claude-code)