### PR TITLE
feat: implement credentials reveal command

### DIFF
--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -17,13 +17,13 @@ function nextUUID(): string {
   return `00000000-0000-0000-0000-${String(idCounter).padStart(12, "0")}`;
 }
 
-// Track mock call counts for reveal isolation tests
-let getSecureKeyCalls = 0;
+// Track mock call counts
+let _getSecureKeyCalls = 0;
 let _setSecureKeyCalls = 0;
 let _deleteSecureKeyCalls = 0;
-let listMetadataCalls = 0;
-let getMetadataCalls = 0;
-let getMetadataByIdCalls = 0;
+let _listMetadataCalls = 0;
+let _getMetadataCalls = 0;
+let _getMetadataByIdCalls = 0;
 
 // ---------------------------------------------------------------------------
 // Mock secure-keys
@@ -31,7 +31,7 @@ let getMetadataByIdCalls = 0;
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (account: string): string | undefined => {
-    getSecureKeyCalls += 1;
+    _getSecureKeyCalls += 1;
     return secureKeyStore.get(account);
   },
   setSecureKey: (account: string, value: string): boolean => {
@@ -113,7 +113,7 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
     service: string,
     field: string,
   ): CredentialMetadata | undefined => {
-    getMetadataCalls += 1;
+    _getMetadataCalls += 1;
     return metadataStore.find(
       (c) => c.service === service && c.field === field,
     );
@@ -121,7 +121,7 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
   getCredentialMetadataById: (
     credentialId: string,
   ): CredentialMetadata | undefined => {
-    getMetadataByIdCalls += 1;
+    _getMetadataByIdCalls += 1;
     return metadataStore.find((c) => c.credentialId === credentialId);
   },
   deleteCredentialMetadata: (service: string, field: string): boolean => {
@@ -133,7 +133,7 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
     return true;
   },
   listCredentialMetadata: (): CredentialMetadata[] => {
-    listMetadataCalls += 1;
+    _listMetadataCalls += 1;
     return [...metadataStore];
   },
 }));
@@ -248,12 +248,12 @@ describe("vellum credentials CLI", () => {
     secureKeyStore = new Map();
     metadataStore = [];
     idCounter = 0;
-    getSecureKeyCalls = 0;
+    _getSecureKeyCalls = 0;
     _setSecureKeyCalls = 0;
     _deleteSecureKeyCalls = 0;
-    listMetadataCalls = 0;
-    getMetadataCalls = 0;
-    getMetadataByIdCalls = 0;
+    _listMetadataCalls = 0;
+    _getMetadataCalls = 0;
+    _getMetadataByIdCalls = 0;
     process.exitCode = 0;
   });
 
@@ -703,31 +703,62 @@ describe("vellum credentials CLI", () => {
   // =========================================================================
 
   describe("reveal", () => {
-    test("returns not-implemented error with exit code 1", async () => {
+    test("returns plaintext value by service:field", async () => {
       seedCredential("twilio", "account_sid", "AC123456789012");
 
       const result = await runCli(["reveal", "twilio:account_sid", "--json"]);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.value).toBe("AC123456789012");
+    });
+
+    test("returns plaintext value by UUID", async () => {
+      const meta = seedCredential("github", "token", "ghp_abcdefghij1234");
+
+      const result = await runCli(["reveal", meta.credentialId, "--json"]);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.value).toBe("ghp_abcdefghij1234");
+    });
+
+    test("errors on nonexistent credential", async () => {
+      const result = await runCli(["reveal", "nonexistent:field", "--json"]);
       expect(result.exitCode).toBe(1);
       const parsed = JSON.parse(result.stdout);
       expect(parsed.ok).toBe(false);
-      expect(parsed.error).toContain("Not implemented");
+      expect(parsed.error).toContain("not found");
     });
 
-    test("does not access secure storage or metadata", async () => {
-      seedCredential("twilio", "account_sid", "AC123456789012");
+    test("errors on nonexistent UUID", async () => {
+      const result = await runCli([
+        "reveal",
+        "00000000-0000-0000-0000-000000000099",
+        "--json",
+      ]);
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("not found");
+    });
 
-      // Reset call counters after seeding
-      getSecureKeyCalls = 0;
-      getMetadataCalls = 0;
-      getMetadataByIdCalls = 0;
-      listMetadataCalls = 0;
+    test("rejects invalid name without colon", async () => {
+      const result = await runCli(["reveal", ":field_only", "--json"]);
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("Invalid credential name");
+    });
 
-      await runCli(["reveal", "twilio:account_sid", "--json"]);
+    test("errors when metadata exists but no secret stored", async () => {
+      seedMetadataOnly("test", "nosecret");
 
-      expect(getSecureKeyCalls).toBe(0);
-      expect(getMetadataCalls).toBe(0);
-      expect(getMetadataByIdCalls).toBe(0);
-      expect(listMetadataCalls).toBe(0);
+      const result = await runCli(["reveal", "test:nosecret", "--json"]);
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toContain("not found");
     });
   });
 
@@ -765,17 +796,11 @@ describe("vellum credentials CLI", () => {
       expect(out).toContain("UUID");
     });
 
-    test("credentials reveal --help mentions not yet implemented and points to inspect", async () => {
+    test("credentials reveal --help mentions piping and examples", async () => {
       const result = await runCli(["reveal", "--help"]);
       const out = result.stdout;
-      expect(out).toContain("inspect");
-      // Check for "not yet implemented" or related wording
-      const lowerOut = out.toLowerCase();
-      expect(
-        lowerOut.includes("not yet implemented") ||
-          lowerOut.includes("reserved for future use") ||
-          lowerOut.includes("currently disabled"),
-      ).toBe(true);
+      expect(out).toContain("stdout");
+      expect(out).toContain("Examples:");
     });
   });
 });

--- a/assistant/src/cli/credentials.ts
+++ b/assistant/src/cli/credentials.ts
@@ -493,35 +493,72 @@ Examples:
     });
 
   // -------------------------------------------------------------------------
-  // reveal (intentionally not implemented)
+  // reveal
   // -------------------------------------------------------------------------
 
   credential
     .command("reveal <name>")
-    .description(
-      "Print the plaintext value of a credential (not yet implemented)",
-    )
+    .description("Print the plaintext value of a credential")
     .addHelpText(
       "after",
       `
 Arguments:
   name   Credential name in service:field format, or a credential UUID
 
-This command is reserved for future use. It will print the raw secret value
-to stdout for piping into other tools. Currently disabled as a safeguard
-against the assistant inadvertently reading credential plaintext.
+Prints the raw secret value to stdout for piping into other tools. In JSON
+mode the value is returned as {"ok": true, "value": "..."}. In human mode
+only the bare secret is printed (no labels or decoration) so it can be
+captured with shell substitution, e.g. $(vellum credentials reveal twilio:auth_token).
 
-Use "inspect" to view a masked preview of the value instead.`,
+Examples:
+  $ vellum credentials reveal twilio:auth_token
+  $ vellum credentials reveal 7a3b1c2d-4e5f-6789-abcd-ef0123456789
+  $ vellum credentials reveal --json twilio:account_sid
+  $ export TWILIO_TOKEN=$(vellum credentials reveal twilio:auth_token)`,
     )
-    .action((_name: string, _opts: unknown, cmd: Command) => {
-      // Intentionally not implemented. We want to avoid the assistant being able to
-      // fetch credential plaintext via CLI. If a legitimate use case emerges that
-      // requires programmatic plaintext access, this is the command we'll use.
-      writeOutput(cmd, {
-        ok: false,
-        error:
-          "Not implemented. Credential plaintext retrieval is intentionally disabled.",
-      });
-      process.exitCode = 1;
+    .action((name: string, _opts: unknown, cmd: Command) => {
+      try {
+        let storageKey: string;
+
+        if (name.includes(":")) {
+          const parsed = parseCredentialName(name);
+          if (!parsed) {
+            writeOutput(cmd, {
+              ok: false,
+              error: `Invalid credential name "${name}". Expected service:field format (e.g. twilio:account_sid)`,
+            });
+            process.exitCode = 1;
+            return;
+          }
+          storageKey = `credential:${parsed.service}:${parsed.field}`;
+        } else {
+          const metadata = getCredentialMetadataById(name);
+          if (metadata) {
+            storageKey = `credential:${metadata.service}:${metadata.field}`;
+          } else {
+            writeOutput(cmd, { ok: false, error: "Credential not found" });
+            process.exitCode = 1;
+            return;
+          }
+        }
+
+        const secret = getSecureKey(storageKey);
+
+        if (secret == null || secret.length === 0) {
+          writeOutput(cmd, { ok: false, error: "Credential not found" });
+          process.exitCode = 1;
+          return;
+        }
+
+        writeOutput(cmd, { ok: true, value: secret });
+
+        if (!shouldOutputJson(cmd)) {
+          log.info(secret);
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeOutput(cmd, { ok: false, error: message });
+        process.exitCode = 1;
+      }
     });
 }


### PR DESCRIPTION
## Summary
- Implement the previously-stubbed `vellum credentials reveal` command to print plaintext credential values
- Supports lookup by `service:field` name or credential UUID, outputs raw value for shell piping
- Replace stub tests with full coverage: success by name/UUID, not-found errors, invalid name, no-secret cases

## Original prompt
implement the biz logic for assistant/src/cli credentials reveal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
