### PR TITLE
fix: replace daemon with assistant in twilio sms help text

### DIFF
--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -376,7 +376,7 @@ Examples:
     "after",
     `
 Covers SMS regulatory compliance for the configured Twilio account. All
-subcommands require the daemon to be running since they query the gateway API.
+subcommands require the assistant to be running since they query the gateway API.
 
 Subcommands:
   compliance   Check SMS regulatory compliance status


### PR DESCRIPTION
Fixes the AGENTS.md terminology violation in the twilio sms namespace help text added by PR #13405. Changes 'daemon' to 'assistant' in user-facing CLI help output.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
