### PR TITLE
fix: mock ensureTelegramBotUsernameResolved in invite-routes-http tests

### DIFF
--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -24,6 +24,18 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+// Prevent ensureTelegramBotUsernameResolved() from reading real credentials
+// and calling the Telegram API, which would populate credential metadata
+// with the real bot username and shadow the env var override in tests.
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKey: () => undefined,
+  setSecureKey: () => {},
+  deleteSecureKey: () => {},
+  getSecureKeyAsync: async () => undefined,
+  setSecureKeyAsync: async () => {},
+  deleteSecureKeyAsync: async () => {},
+}));
+
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
 import {
   handleCreateInvite,


### PR DESCRIPTION
## Summary
Fixes test regression identified during plan review for show-invite-link.md.

**Gap:** Test regression in invite-routes-http.test.ts
**What was expected:** Share URL test should use the env var bot username
**What was found:** ensureTelegramBotUsernameResolved() can shadow env var with real credential metadata

Mocks `../security/secure-keys.js` so `getSecureKey` returns `undefined` in the test environment. This prevents `ensureTelegramBotUsernameResolved()` from reading real credentials, calling the Telegram API, and populating credential metadata that would shadow the `TELEGRAM_BOT_USERNAME` env var override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
