### PR TITLE
fix: remove --slot-id from amazon SKILL.md after CLI option removal

### DIFF
--- a/assistant/src/config/bundled-skills/amazon/SKILL.md
+++ b/assistant/src/config/bundled-skills/amazon/SKILL.md
@@ -2,7 +2,7 @@
 name: "Amazon"
 description: "Shop on Amazon and Amazon Fresh using the built-in CLI integration"
 user-invocable: true
-metadata: {"vellum": {"emoji": "\uD83D\uDCE6"}}
+metadata: { "vellum": { "emoji": "\uD83D\uDCE6" } }
 ---
 
 You can shop on Amazon (and Amazon Fresh for groceries) for the user using the `vellum amazon` CLI.
@@ -92,7 +92,7 @@ vellum amazon fresh select-slot --slot-id <id> --json
 
 vellum amazon payment-methods --json
 vellum amazon checkout --json
-vellum amazon order place [--payment-method-id <id>] [--slot-id <id>] --json
+vellum amazon order place [--payment-method-id <id>] --json
 ```
 
 ## Example Interactions


### PR DESCRIPTION
Removes the documented --slot-id option from the amazon order place command in SKILL.md, since the option was removed from the CLI in PR #13415. Addresses feedback from Devin on PR #13415.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
