### PR TITLE
fix: add timeout to Telegram getMe resolution in invite service

### DIFF
--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -63,7 +63,16 @@ export async function ensureTelegramBotUsernameResolved(): Promise<void> {
   if (!token) return;
 
   try {
-    const res = await fetch(`https://api.telegram.org/bot${token}/getMe`);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5_000);
+    let res: Response;
+    try {
+      res = await fetch(`https://api.telegram.org/bot${token}/getMe`, {
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
     if (!res.ok) {
       getLogger("telegram-invite").warn(
         "Failed to resolve Telegram bot username: HTTP %d",


### PR DESCRIPTION
Adds a 5-second AbortController timeout to the fetch call in ensureTelegramBotUsernameResolved() to prevent POST /v1/contacts/invites from blocking indefinitely when api.telegram.org is slow or unreachable. Addresses feedback from PR #13414.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
