### PR TITLE
fix: replace remaining daemon references in shell completion descriptions

### DIFF
--- a/assistant/src/cli/completions.ts
+++ b/assistant/src/cli/completions.ts
@@ -131,7 +131,7 @@ function generateZshCompletion(
 _vellum() {
     local -a commands
     commands=(
-        'dev:Run daemon in dev mode with auto-restart'
+        'dev:Run assistant in dev mode with auto-restart'
         'sessions:Manage sessions'
         'config:Manage configuration'
         'keys:Manage API keys in secure storage'
@@ -173,7 +173,7 @@ function generateFishCompletion(
   script += `complete -c vellum -f\n`;
 
   const descriptions: Record<string, string> = {
-    dev: "Run daemon in dev mode with auto-restart",
+    dev: "Run assistant in dev mode with auto-restart",
     sessions: "Manage sessions",
     config: "Manage configuration",
     keys: "Manage API keys in secure storage",


### PR DESCRIPTION
Fixes two remaining 'daemon' references in zsh and fish completion descriptions in completions.ts that were missed by PR #13408. Changes 'Run daemon in dev mode' to 'Run assistant in dev mode' per AGENTS.md terminology rules.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
