### PR TITLE
fix: update secure-keys allowlist after credential CLI module rename

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -220,7 +220,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "calls/twilio-rest.ts", // Twilio REST API credential lookup
       "runtime/channel-invite-transports/sms.ts", // SMS invite transport phone number lookup
       "cli/keys.ts", // CLI credential management commands
-      "cli/credential.ts", // CLI credential management commands
+      "cli/credentials.ts", // CLI credential management commands
       "runtime/http-server.ts", // HTTP server credential lookup
       "daemon/handlers/twitter-auth.ts", // Twitter OAuth token storage
       "twitter/oauth-client.ts", // Twitter OAuth API client (reads access token for API calls)


### PR DESCRIPTION
Updates the security invariant test allowlist in credential-security-invariants.test.ts to reference the renamed cli/credentials.ts path (was cli/credential.ts). The rename happened in PR #13417 but the allowlist wasn't updated, which would cause the security guard test to flag the renamed module as unauthorized.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
