### PR TITLE
fix: emit only bare secret in non-JSON mode for credentials reveal

### DIFF
--- a/assistant/src/cli/credentials.ts
+++ b/assistant/src/cli/credentials.ts
@@ -550,10 +550,10 @@ Examples:
           return;
         }
 
-        writeOutput(cmd, { ok: true, value: secret });
-
-        if (!shouldOutputJson(cmd)) {
-          log.info(secret);
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, { ok: true, value: secret });
+        } else {
+          process.stdout.write(secret);
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Fixes the credentials reveal command to emit only the bare secret to stdout in non-JSON mode, making shell substitution work correctly (e.g. export TOKEN=$(vellum credentials reveal twilio:auth_token)). Previously it wrote both JSON and the bare secret. Addresses feedback from Codex and Devin on PR #13425.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
