### PR TITLE
fix: exclude reserved subpaths from contacts DELETE catch-all route

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -408,14 +408,14 @@ function main() {
         contactsControlPlaneProxy.handleRevokeInvite(req, params[0]),
     },
     {
-      path: /^\/v1\/contacts\/([^/]+)$/,
+      path: /^\/v1\/contacts\/(?!invites$|merge$)([^/]+)$/,
       method: "DELETE",
       auth: "edge",
       handler: (req, params) =>
         contactsControlPlaneProxy.handleDeleteContact(req, params[0]),
     },
     {
-      path: /^\/v1\/contacts\/([^/]+)$/,
+      path: /^\/v1\/contacts\/(?!invites$|merge$)([^/]+)$/,
       method: "GET",
       auth: "edge",
       handler: (req, params) =>


### PR DESCRIPTION
Adds a negative lookahead to the contacts DELETE and GET catch-all route regexes in the gateway to prevent reserved paths like /v1/contacts/invites and /v1/contacts/merge from being matched as contact IDs. Previously, DELETE requests to these paths would be forwarded as delete-contact requests with the literal path segment as the ID. Addresses feedback from Codex on PR #13420.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
