### PR TITLE
fix: require settings.write scope for contacts DELETE route

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -166,6 +166,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "home-base-ui", scopes: ["settings.read"] },
   { endpoint: "contacts", scopes: ["settings.read"] },
   { endpoint: "contacts:POST", scopes: ["settings.write"] },
+  { endpoint: "contacts:DELETE", scopes: ["settings.write"] },
   { endpoint: "contacts/merge", scopes: ["settings.write"] },
   { endpoint: "contacts:GET", scopes: ["settings.read"] },
   { endpoint: "contact-channels", scopes: ["settings.write"] },


### PR DESCRIPTION
Adds a write-scoped policy entry for the contacts DELETE operation so that read-only tokens cannot delete contacts. The DELETE route was previously inheriting the read-scoped contacts policy. Addresses security feedback from Codex on PR #13418.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
