### PR TITLE
fix: add concurrency guards for delete contact in macOS UI

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -163,7 +163,7 @@ struct ContactDetailView: View {
                             }
                         }
                         .buttonStyle(.plain)
-                        .disabled(isDeleting)
+                        .disabled(isDeleting || actionInProgress != nil || verificationInProgress != nil)
                         .help("Delete contact")
                         .opacity(isHoveringHeader ? 1 : 0)
                         .animation(VAnimation.fast, value: isHoveringHeader)
@@ -647,7 +647,7 @@ struct ContactDetailView: View {
     private func channelActions(for channel: ContactChannelPayload) -> some View {
         // Disable ALL action buttons while any channel action is in-flight to
         // serialize updates and prevent response correlation mix-ups.
-        let anyActionInFlight = actionInProgress != nil || verificationInProgress != nil
+        let anyActionInFlight = actionInProgress != nil || verificationInProgress != nil || isDeleting
         let isThisChannel = actionInProgress == channel.id
 
         VStack(alignment: .leading, spacing: VSpacing.sm) {
@@ -1054,6 +1054,7 @@ struct ContactDetailView: View {
 
     private func deleteContact() {
         guard let daemonClient else { return }
+        guard actionInProgress == nil, verificationInProgress == nil else { return }
         isDeleting = true
         errorMessage = nil
 


### PR DESCRIPTION
Fixes three concurrency issues in ContactDetailView.swift:
1. Added guard in deleteContact() to prevent execution when channel operations are in-flight
2. Disabled delete button when any action or verification is in progress
3. Added isDeleting to anyActionInFlight to disable channel buttons during delete

These prevent response mis-correlation when delete and channel operations overlap. Addresses feedback from Devin on PR #13422.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
