### PR TITLE
fix: queue follow-up poll when credential watcher skips an in-flight poll

### DIFF
--- a/gateway/src/credential-watcher.ts
+++ b/gateway/src/credential-watcher.ts
@@ -54,6 +54,7 @@ export class CredentialWatcher {
   private lastSlackChannelBotToken: string | undefined;
   private lastSlackChannelAppToken: string | undefined;
   private polling = false;
+  private pendingPoll = false;
   private callback: CredentialChangeCallback;
   private metadataPath: string;
 
@@ -142,7 +143,12 @@ export class CredentialWatcher {
   }
 
   private async pollOnce(): Promise<void> {
-    if (this.polling) return;
+    if (this.polling) {
+      // A poll is already in flight — flag that another round is needed
+      // so credential updates arriving mid-poll aren't silently dropped.
+      this.pendingPoll = true;
+      return;
+    }
     this.polling = true;
     try {
       const telegramCredentials = await readTelegramCredentials();
@@ -237,6 +243,10 @@ export class CredentialWatcher {
       });
     } finally {
       this.polling = false;
+      if (this.pendingPoll) {
+        this.pendingPoll = false;
+        void this.pollOnce();
+      }
     }
   }
 }


### PR DESCRIPTION
Addresses remaining feedback from review of PR #13421 (keychain broker migration):

The `pollOnce()` serialization guard added in #13421 correctly prevents overlapping async polls, but silently drops filesystem-triggered refreshes that arrive while a poll is in flight. When broker reads are slow (up to 5s timeout), this can cause credential updates to be missed indefinitely until the next metadata write.

Fix: add a `pendingPoll` flag so that when `pollOnce()` is called during an active poll, one follow-up poll is queued to run after the current poll completes.

The other two review items (socket TDZ in credential-reader.ts and 404 behavior in secret-routes.ts) were already addressed in the merged PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
