### PR TITLE
refactor: rename CLI from 'vellum' to 'assistant' and add buildCliReferenceSection test

### DIFF
--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -33,7 +33,7 @@ const { version } = require("../../package.json") as { version: string };
 export function buildCliProgram(): Command {
   const program = new Command();
 
-  program.name("vellum").description("Local AI assistant").version(version);
+  program.name("assistant").description("Local AI assistant").version(version);
 
   registerDefaultAction(program);
   registerDevCommand(program);

--- a/assistant/src/config/__tests__/build-cli-reference-section.test.ts
+++ b/assistant/src/config/__tests__/build-cli-reference-section.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for buildCliReferenceSection — verifies the CLI reference section
+ * included in the system prompt has the expected structure and caching behaviour.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  buildCliReferenceSection,
+  _resetCliHelpCache,
+} from "../system-prompt.js";
+
+describe("buildCliReferenceSection", () => {
+  beforeEach(() => {
+    _resetCliHelpCache();
+  });
+
+  test("includes the Assistant CLI heading", () => {
+    const result = buildCliReferenceSection();
+    expect(result).toContain("## Assistant CLI");
+  });
+
+  test("includes CLI help text with command listings", () => {
+    const result = buildCliReferenceSection();
+    // The help text is generated from buildCliProgram().helpInformation()
+    // which lists available commands. Check for at least one known command.
+    expect(result).toContain("Usage:");
+    expect(result).toContain("Commands:");
+  });
+
+  test("mentions bash as the way to invoke the CLI", () => {
+    const result = buildCliReferenceSection();
+    expect(result).toContain("available via `bash`");
+  });
+
+  test("result is cached — calling twice returns the same string", () => {
+    const first = buildCliReferenceSection();
+    const second = buildCliReferenceSection();
+    expect(first).toBe(second);
+  });
+
+  test("cache is reset by _resetCliHelpCache", () => {
+    const first = buildCliReferenceSection();
+    _resetCliHelpCache();
+    const second = buildCliReferenceSection();
+    // Content should be identical even after reset (same CLI program),
+    // but they should be independently computed strings.
+    expect(first).toEqual(second);
+  });
+});

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -23,6 +23,11 @@ const PROMPT_FILES = ["SOUL.md", "IDENTITY.md", "USER.md"] as const;
 
 let cachedCliHelp: string | undefined;
 
+/** @internal Reset the CLI help cache — exposed for testing only. */
+export function _resetCliHelpCache(): void {
+  cachedCliHelp = undefined;
+}
+
 /**
  * Copy template prompt files into the data directory if they don't already exist.
  * Called once during daemon startup so users always have discoverable files to edit.
@@ -782,21 +787,21 @@ function buildConfigSection(): string {
   ].join("\n");
 }
 
-function buildCliReferenceSection(): string {
+export function buildCliReferenceSection(): string {
   if (cachedCliHelp === undefined) {
     cachedCliHelp = buildCliProgram().helpInformation().trim();
   }
 
   return [
-    "## Vellum CLI",
+    "## Assistant CLI",
     "",
-    "The `vellum` CLI is installed on the user's machine and available via `bash`.",
+    "The `assistant` CLI is installed on the user's machine and available via `bash`.",
     "",
     "```",
     cachedCliHelp,
     "```",
     "",
-    "Run `vellum <command> --help` for detailed help on any subcommand.",
+    "Run `assistant <command> --help` for detailed help on any subcommand.",
   ].join("\n");
 }
 


### PR DESCRIPTION
## Summary
- Rename CLI program from `vellum` to `assistant` in src/cli/program.ts
- Update system prompt CLI reference section to use the new name
- Add unit test for buildCliReferenceSection verifying output format and caching

## Test plan
- [ ] Verify `bun run assistant/src/index.ts --help` shows `assistant` as the program name
- [ ] Verify the system prompt includes the CLI reference section with correct naming
- [ ] New test passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
