### PR TITLE
fix: remove orphaned KEYCHAIN node from architecture diagram

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -249,7 +249,6 @@ graph TB
     end
 
     subgraph "macOS Local Storage"
-        KEYCHAIN["Keychain<br/>(via broker SecItem*)"]
         ENC_STORE["Encrypted Store<br/>(~/.vellum/protected/keys.enc)"]
         USERDEFAULTS["UserDefaults<br/>preferences / state"]
         APP_SUPPORT["~/Library/App Support/<br/>vellum-assistant/"]


### PR DESCRIPTION
Removes the disconnected KEYCHAIN node from the Mermaid diagram in ARCHITECTURE.md. The node had no edges after the keychain-broker migration redirected token storage edges to ENC_STORE.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
