### PR TITLE
fix: replace daemon with assistant in audit, dev, and doctor CLI help text

### DIFF
--- a/assistant/src/cli/audit.ts
+++ b/assistant/src/cli/audit.ts
@@ -13,7 +13,7 @@ export function registerAuditCommand(program: Command): void {
     .addHelpText(
       "after",
       `
-Reads from the local tool invocation log stored by the daemon. Each row
+Reads from the local tool invocation log stored by the assistant. Each row
 represents one tool call the assistant made, including what was invoked,
 how the approval system classified it, and how long it took.
 

--- a/assistant/src/cli/dev.ts
+++ b/assistant/src/cli/dev.ts
@@ -11,7 +11,7 @@ const log = getCliLogger("cli");
 export function registerDevCommand(program: Command): void {
   program
     .command("dev")
-    .description("Run the daemon in dev mode")
+    .description("Run the assistant in dev mode")
     .option(
       "--watch",
       "Auto-restart on source file changes (disruptive during Claude Code sessions)",
@@ -19,20 +19,20 @@ export function registerDevCommand(program: Command): void {
     .addHelpText(
       "after",
       `
-Starts the daemon in foreground dev mode for local development. If an
-existing daemon is running, it is stopped first (waits up to 5 seconds
-for an unresponsive daemon before force-killing it).
+Starts the assistant in foreground dev mode for local development. If an
+existing assistant is running, it is stopped first (waits up to 5 seconds
+for an unresponsive assistant before force-killing it).
 
 Behavioral notes:
   - Sets VELLUM_DEBUG=1 for DEBUG-level logging
   - Sets VELLUM_LOG_STDERR=1 so logs stream to stderr (visible in terminal)
   - Sets BASE_DATA_DIR to the repository root
-  - The daemon runs in the foreground; press Ctrl+C to stop
+  - The assistant runs in the foreground; press Ctrl+C to stop
 
 The --watch flag passes bun --watch to the child process, which
-auto-restarts the daemon whenever source files change. This is useful
+auto-restarts the assistant whenever source files change. This is useful
 during development but disruptive if a Claude Code session is active,
-since the restart kills the running daemon mid-conversation.
+since the restart kills the running assistant mid-conversation.
 
 Examples:
   $ vellum dev
@@ -41,11 +41,11 @@ Examples:
     .action(async (opts: { watch?: boolean }) => {
       let status = await getDaemonStatus();
       if (status.running) {
-        log.info("Stopping existing daemon...");
+        log.info("Stopping existing assistant...");
         const stopResult = await stopDaemon();
         if (!stopResult.stopped && stopResult.reason === "stop_failed") {
           log.error(
-            "Failed to stop existing daemon — process survived SIGKILL",
+            "Failed to stop existing assistant — process survived SIGKILL",
           );
           process.exit(1);
         }
@@ -54,7 +54,7 @@ Examples:
         // This can happen during the daemon startup window before the socket
         // is bound. Wait briefly for it to come up before replacing.
         log.info(
-          "Daemon process alive but socket unresponsive — waiting for startup...",
+          "Assistant process alive but socket unresponsive — waiting for startup...",
         );
         const maxWait = 5000;
         const interval = 500;
@@ -66,11 +66,11 @@ Examples:
           status = await getDaemonStatus();
           if (status.running) {
             // Socket came up — stop the daemon normally.
-            log.info("Daemon became responsive, stopping it...");
+            log.info("Assistant became responsive, stopping it...");
             const stopResult = await stopDaemon();
             if (!stopResult.stopped && stopResult.reason === "stop_failed") {
               log.error(
-                "Failed to stop existing daemon — process survived SIGKILL",
+                "Failed to stop existing assistant — process survived SIGKILL",
               );
               process.exit(1);
             }
@@ -86,11 +86,11 @@ Examples:
         if (!resolved) {
           // Still alive but unresponsive after waiting — stop it via stopDaemon()
           // which handles SIGTERM → SIGKILL escalation and PID file cleanup.
-          log.info("Daemon still unresponsive after wait — stopping it...");
+          log.info("Assistant still unresponsive after wait — stopping it...");
           const stopResult = await stopDaemon();
           if (!stopResult.stopped && stopResult.reason === "stop_failed") {
             log.error(
-              "Failed to stop existing daemon — process survived SIGKILL",
+              "Failed to stop existing assistant — process survived SIGKILL",
             );
             process.exit(1);
           }
@@ -101,7 +101,7 @@ Examples:
 
       const useWatch = opts.watch === true;
       log.info(
-        `Starting daemon in dev mode${
+        `Starting assistant in dev mode${
           useWatch ? " with file watching" : ""
         } (Ctrl+C to stop)`,
       );

--- a/assistant/src/cli/doctor.ts
+++ b/assistant/src/cli/doctor.ts
@@ -42,13 +42,13 @@ Output symbols:
 Diagnostic checks performed:
   1.  Bun is installed           Verifies bun is available in PATH
   2.  API key configured         Checks for a valid provider API key in config or env
-  3.  Daemon reachable           Connects to the daemon Unix socket
+  3.  Assistant reachable         Connects to the assistant Unix socket
   4.  Database exists/readable   Opens the SQLite database and runs a test query
   5.  Directory structure        Verifies required ~/.vellum/ directories exist
   6.  Disk space                 Ensures at least 100MB free on the data partition
   7.  Log file size              Warns if the log file exceeds 50MB
   8.  Database integrity         Runs SQLite PRAGMA integrity_check
-  9.  Socket permissions         Verifies the daemon socket has 0600 or 0700 mode
+  9.  Socket permissions         Verifies the assistant socket has 0600 or 0700 mode
   10. Trust rule syntax          Validates trust.json structure and rule fields
   11. WASM files                 Checks that tree-sitter WASM binaries are present
   12. Browser runtime            Verifies Playwright and Chromium availability
@@ -118,7 +118,10 @@ Examples:
       try {
         const sock = getSocketPath();
         if (!existsSync(sock)) {
-          fail("Daemon reachable", "socket not found (is the daemon running?)");
+          fail(
+            "Assistant reachable",
+            "socket not found (is the assistant running?)",
+          );
         } else {
           await new Promise<void>((resolve, reject) => {
             const s = net.createConnection(sock);
@@ -136,10 +139,10 @@ Examples:
               reject(err);
             });
           });
-          pass("Daemon reachable");
+          pass("Assistant reachable");
         }
       } catch {
-        fail("Daemon reachable", "could not connect to daemon socket");
+        fail("Assistant reachable", "could not connect to assistant socket");
       }
 
       // 4. DB exists and readable
@@ -272,7 +275,7 @@ Examples:
           fail("Socket permissions", "could not stat socket");
         }
       } else {
-        pass("Socket permissions (socket not present — daemon not running)");
+        pass("Socket permissions (socket not present — assistant not running)");
       }
 
       // 10. Trust rule syntax


### PR DESCRIPTION
Updates user-facing help text in audit.ts, dev.ts, and doctor.ts CLI commands to use 'assistant' instead of 'daemon' per AGENTS.md terminology rules.