### PR TITLE
fix: move socket declaration before timeout to prevent TDZ crash in credential reader

### DIFF
--- a/gateway/src/credential-reader.ts
+++ b/gateway/src/credential-reader.ts
@@ -192,6 +192,10 @@ async function readBrokerCredential(
       let buf = "";
       let settled = false;
 
+      // Declare socket before the timer so the timeout closure never
+      // hits a TDZ if createConnection throws synchronously.
+      let socket: ReturnType<typeof createConnection> | undefined;
+
       const timer = setTimeout(() => {
         if (!settled) {
           settled = true;
@@ -205,7 +209,6 @@ async function readBrokerCredential(
         }
       }, BROKER_TIMEOUT_MS);
 
-      let socket: ReturnType<typeof createConnection> | undefined;
       try {
         socket = createConnection({ path: socketPath });
       } catch (err) {


### PR DESCRIPTION
Addresses review feedback on PR #13421:\n\n- Fix TDZ crash in readBrokerCredential: the `let socket` declaration was after the `setTimeout` callback that referenced it. If `createConnection` threw synchronously and the timer somehow fired, the closure would hit a Temporal Dead Zone error. Moved the declaration before the timer.\n\nThe other review findings (serialize async polls, queue follow-up poll, preserve 404 semantics) were already addressed in PR #13442 and the current code on main.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
