### PR TITLE
fix: replace daemon terminology and correct help text in sessions, autonomy, and memory CLI

### DIFF
--- a/assistant/src/cli/autonomy.ts
+++ b/assistant/src/cli/autonomy.ts
@@ -199,7 +199,8 @@ Resolution order (first match wins):
   3. Channel default    — per-channel tier set via --channel
   4. Global default     — the fallback tier set via --default
 
-Config is stored in ~/.vellum/workspace/autonomy.json.
+Config is stored in <data-dir>/.vellum/workspace/autonomy.json, where
+<data-dir> is the BASE_DATA_DIR environment variable (defaults to $HOME).
 
 Examples:
   $ vellum autonomy get
@@ -246,7 +247,8 @@ Examples:
     .addHelpText(
       "after",
       `
-Four mutually exclusive targeting modes (use exactly one per invocation):
+Four targeting modes — provide one of the following per invocation. If multiple
+are given, the first match is applied in this priority order:
 
   --default <tier>                Set the global default tier. The <tier>
                                   value is the argument itself — do not

--- a/assistant/src/cli/memory.ts
+++ b/assistant/src/cli/memory.ts
@@ -278,7 +278,8 @@ Two modes of operation:
   --pattern <regex>  Dismiss only conflicts where either the existing or
                      candidate statement matches the given regex (case-insensitive)
 
-Exactly one of --all or --pattern must be provided.
+At least one of --all or --pattern must be provided. If both are given,
+--all takes priority and all pending conflicts are dismissed.
 
 The --scope flag targets a specific memory scope. Defaults to "default" if
 omitted. The --dry-run flag previews which conflicts would be dismissed

--- a/assistant/src/cli/sessions.ts
+++ b/assistant/src/cli/sessions.ts
@@ -26,7 +26,7 @@ export function registerSessionsCommand(program: Command): void {
     "after",
     `
 Sessions represent conversation threads with the assistant. Each session has a
-unique ID and a title. The daemon must be running for "list" and "new" (they
+unique ID and a title. The assistant must be running for "list" and "new" (they
 communicate via IPC), while "export" and "clear" operate on the local SQLite
 database directly.
 
@@ -46,8 +46,8 @@ Examples:
 Shows all sessions with their ID, title, and a relative timestamp (e.g.
 "3 hours ago"). Sessions are listed in order of most recently updated.
 
-Requires the daemon to be running — communicates via IPC. If auto-start is
-enabled, the daemon will be started automatically.
+Requires the assistant to be running — communicates via IPC. If auto-start is
+enabled, the assistant will be started automatically.
 
 Examples:
   $ vellum sessions list`,
@@ -76,10 +76,10 @@ Examples:
       `
 Arguments:
   title   Optional session title (string). If omitted, a default title is
-          assigned by the daemon.
+          assigned by the assistant.
 
 Creates a new conversation session and prints its title and ID. Requires the
-daemon to be running — communicates via IPC.
+assistant to be running — communicates via IPC.
 
 Examples:
   $ vellum sessions new
@@ -118,7 +118,7 @@ Two output formats are available:
   json  Structured JSON export with full metadata, message content arrays,
         and timestamps.
 
-Operates on the local SQLite database directly — does not require the daemon.
+Operates on the local SQLite database directly — does not require the assistant.
 
 Examples:
   $ vellum sessions export
@@ -195,11 +195,11 @@ Examples:
       `
 Permanently deletes ALL conversations, messages, and Qdrant vector data.
 Prompts for confirmation (y/N) before proceeding. After clearing the local
-database, notifies the running daemon (if any) to invalidate its in-memory
+database, notifies the running assistant (if any) to invalidate its in-memory
 sessions so it does not serve stale history.
 
 Operates on the local SQLite database and Qdrant directly — does not require
-the daemon, but will notify it if running.
+the assistant, but will notify it if running.
 
 Intended for development use. This action cannot be undone.
 


### PR DESCRIPTION
Addresses review feedback on PRs #13390, #13391, and #13393:\n- Replace daemon with assistant in sessions.ts help text\n- Fix config path description in autonomy.ts (no longer hardcodes ~/.vellum/workspace)\n- Correct mutually-exclusive flag descriptions in autonomy.ts and memory.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
