### PR TITLE
fix: handle ambiguous trust-rule prefixes in trust remove command

### DIFF
--- a/assistant/src/cli/trust.ts
+++ b/assistant/src/cli/trust.ts
@@ -98,8 +98,10 @@ Arguments:
   id   Full UUID or any unique prefix of the rule to remove
 
 Matches the given id against all stored rule IDs using prefix matching. If
-exactly one rule matches, it is removed. If no rule matches, exits with an
-error. Use "trust list" to see rule IDs (shown truncated to 8 chars).
+exactly one rule matches, it is removed. If multiple rules match (ambiguous
+prefix), lists the matches and exits with an error — no rule is removed. If
+no rule matches, exits with an error. Use "trust list" to see rule IDs
+(shown truncated to 8 chars).
 
 Examples:
   $ vellum trust remove abc12345
@@ -108,11 +110,22 @@ Examples:
     )
     .action((id: string) => {
       const rules = getAllRules();
-      const match = rules.find((r) => r.id.startsWith(id));
-      if (!match) {
+      const matches = rules.filter((r) => r.id.startsWith(id));
+      if (matches.length === 0) {
         log.error(`No rule found matching "${id}"`);
         process.exit(1);
       }
+      if (matches.length > 1) {
+        log.error(`Ambiguous prefix "${id}" matches ${matches.length} rules:`);
+        for (const m of matches) {
+          log.error(
+            `  ${m.id.slice(0, SHORT_HASH_LENGTH)}  ${m.tool}: ${m.pattern}`,
+          );
+        }
+        log.error("Provide a longer prefix to uniquely identify the rule.");
+        process.exit(1);
+      }
+      const match = matches[0]!;
       try {
         removeRule(match.id);
       } catch (err) {


### PR DESCRIPTION
## Summary
- Fix `trust remove` to reject ambiguous prefixes instead of silently deleting the first match
- Use `filter()` instead of `find()` to collect all prefix matches, then error if more than one rule matches
- When ambiguous, list all matching rules so the user can provide a longer prefix
- Update help text to document the ambiguous-prefix error behavior

Addresses review feedback from #13392.

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
