### PR TITLE
fix: correct OAuth capability and daemon terminology in x CLI help text

### DIFF
--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -124,7 +124,7 @@ export function registerTwitterCommand(program: Command): void {
 Twitter (X) uses a dual-path architecture for interacting with the platform:
 
   1. OAuth (official API) — uses an authenticated Twitter OAuth application for
-     posting and reading. Requires a connected OAuth credential.
+     posting and replying. Requires a connected OAuth credential.
   2. Browser session (Ride Shotgun) — uses cookies captured from a real Chrome
      session to call Twitter's internal GraphQL API. Supports all read operations
      and posting as a fallback.
@@ -221,7 +221,7 @@ The --duration flag sets how long (in seconds) the recording runs before
 stopping. Default is 180 seconds (3 minutes). After the recording completes,
 cookies are imported automatically and Chrome is minimized.
 
-Requires the assistant daemon to be running (Ride Shotgun runs via the daemon).
+Requires the assistant to be running (Ride Shotgun runs via the assistant).
 
 Examples:
   $ vellum x refresh
@@ -284,7 +284,7 @@ Shows the current state of both authentication paths:
   OAuth — whether an OAuth credential is connected, the linked account, the
     current strategy setting, and whether a strategy has been explicitly configured.
 
-If the daemon is not running, OAuth fields will be reported as undefined.
+If the assistant is not running, OAuth fields will be reported as undefined.
 
 Examples:
   $ vellum x status
@@ -395,7 +395,7 @@ Arguments:
   value   Strategy to use: "oauth", "browser", or "auto"
 
 Sets the preferred strategy for Twitter operations that support dual-path
-routing. The setting is persisted by the daemon and applies to all subsequent
+routing. The setting is persisted by the assistant and applies to all subsequent
 operations until changed.
 
 Examples:


### PR DESCRIPTION
## Summary
- Fix OAuth capability description: changed "posting and reading" to "posting and replying" to match the actual SUPPORTED_OPERATIONS (post, reply) in oauth-client.ts
- Replace 3 user-facing occurrences of "daemon" with "assistant" in --help text (refresh, status, strategy set subcommands)

Addresses review feedback from #13399.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
