### PR TITLE
fix: catch rejected promises from async IPC message handlers

### DIFF
--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -198,11 +198,25 @@ export function handleMessage(
   if (msg.type === "auth") return;
 
   const handler = handlers[msg.type] as
-    | ((msg: ClientMessage, socket: net.Socket, ctx: HandlerContext) => void)
+    | ((
+        msg: ClientMessage,
+        socket: net.Socket,
+        ctx: HandlerContext,
+      ) => void | Promise<void>)
     | undefined;
   if (!handler) {
     log.warn({ type: msg.type }, "Unknown message type, ignoring");
     return;
   }
-  handler(msg, socket, ctx);
+  // Handlers may be async — catch rejected promises so they don't become
+  // unhandled rejections at the process level.
+  const result = handler(msg, socket, ctx);
+  if (result && typeof result.catch === "function") {
+    result.catch((err: unknown) => {
+      log.error(
+        { err, type: msg.type },
+        "Unhandled error in async message handler",
+      );
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- The IPC dispatcher in `handleMessage` was discarding return values from async handlers, causing potential unhandled promise rejections
- Updated the handler type cast to reflect the actual `void | Promise<void>` return type
- Added a `.catch()` guard on the returned promise to log errors instead of letting them become unhandled rejections

Addresses review feedback from #13426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
