### PR TITLE
feat: generate app icons via Gemini for bundles and share sheet

### DIFF
--- a/assistant/src/bundler/app-bundler.ts
+++ b/assistant/src/bundler/app-bundler.ts
@@ -6,7 +6,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { createWriteStream } from "node:fs";
+import { createWriteStream, existsSync, readFileSync } from "node:fs";
 import { readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { extname, join } from "node:path";
@@ -14,7 +14,7 @@ import { extname, join } from "node:path";
 import archiver from "archiver";
 import JSZip from "jszip";
 
-import { getApp } from "../memory/app-store.js";
+import { getApp, getAppsDir } from "../memory/app-store.js";
 import { computeContentId } from "../util/content-id.js";
 import { getLogger } from "../util/logger.js";
 import type { SigningCallback } from "./bundle-signer.js";
@@ -172,6 +172,8 @@ export async function materializeAssets(
 export interface BundleResult {
   bundlePath: string;
   manifest: AppManifest;
+  /** Base64-encoded PNG of the app icon, if one was generated. */
+  iconImageBase64?: string;
 }
 
 /**
@@ -278,6 +280,12 @@ export async function packageApp(
       archive.append(asset.data, { name: asset.archivePath });
     }
 
+    // Include app icon if one was generated
+    const iconPath = join(getAppsDir(), appId, "icon.png");
+    if (existsSync(iconPath)) {
+      archive.append(readFileSync(iconPath), { name: "icon.png" });
+    }
+
     archive.finalize();
   });
 
@@ -319,5 +327,12 @@ export async function packageApp(
     );
   }
 
-  return { bundlePath, manifest };
+  // Read icon for inclusion in the response
+  let iconImageBase64: string | undefined;
+  const iconFilePath = join(getAppsDir(), appId, "icon.png");
+  if (existsSync(iconFilePath)) {
+    iconImageBase64 = readFileSync(iconFilePath).toString("base64");
+  }
+
+  return { bundlePath, manifest, iconImageBase64 };
 }

--- a/assistant/src/config/bundled-skills/app-builder/TOOLS.json
+++ b/assistant/src/config/bundled-skills/app-builder/TOOLS.json
@@ -326,6 +326,32 @@
       },
       "executor": "tools/app-file-write.ts",
       "execution_target": "host"
+    },
+    {
+      "name": "app_generate_icon",
+      "description": "Generate or regenerate an AI-designed icon for an app. Uses Gemini to create a professional app icon. Call this when the user wants a new or different icon for their app.",
+      "category": "apps",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "app_id": {
+            "type": "string",
+            "description": "The ID of the app to generate an icon for"
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional description to guide icon generation (e.g. 'a blue calendar with a checkmark'). If omitted, the app name and description are used."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Brief non-technical explanation of why this tool is being called"
+          }
+        },
+        "required": ["app_id"]
+      },
+      "executor": "tools/app-generate-icon.ts",
+      "execution_target": "host"
     }
   ]
 }

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-generate-icon.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-generate-icon.ts
@@ -1,0 +1,13 @@
+import * as appStore from "../../../../memory/app-store.js";
+import type { AppGenerateIconInput } from "../../../../tools/apps/executors.js";
+import { executeAppGenerateIcon } from "../../../../tools/apps/executors.js";
+import type { ToolExecutionResult } from "../../../../tools/types.js";
+
+export async function run(
+  input: Record<string, unknown>,
+): Promise<ToolExecutionResult> {
+  return executeAppGenerateIcon(
+    input as unknown as AppGenerateIconInput,
+    appStore,
+  );
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -20,6 +20,7 @@ import * as appFileEdit from "./bundled-skills/app-builder/tools/app-file-edit.j
 import * as appFileList from "./bundled-skills/app-builder/tools/app-file-list.js";
 import * as appFileRead from "./bundled-skills/app-builder/tools/app-file-read.js";
 import * as appFileWrite from "./bundled-skills/app-builder/tools/app-file-write.js";
+import * as appGenerateIcon from "./bundled-skills/app-builder/tools/app-generate-icon.js";
 import * as appList from "./bundled-skills/app-builder/tools/app-list.js";
 import * as appQuery from "./bundled-skills/app-builder/tools/app-query.js";
 import * as appUpdate from "./bundled-skills/app-builder/tools/app-update.js";
@@ -190,6 +191,7 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
   ["app-builder:tools/app-file-read.ts", appFileRead],
   ["app-builder:tools/app-file-edit.ts", appFileEdit],
   ["app-builder:tools/app-file-write.ts", appFileWrite],
+  ["app-builder:tools/app-generate-icon.ts", appGenerateIcon],
 
   // browser
   ["browser:tools/browser-navigate.ts", browserNavigate],

--- a/assistant/src/daemon/handlers/apps.ts
+++ b/assistant/src/daemon/handlers/apps.ts
@@ -559,6 +559,7 @@ export async function handleBundleApp(
     ctx.send(socket, {
       type: "bundle_app_response",
       bundlePath: result.bundlePath,
+      iconImageBase64: result.iconImageBase64,
       manifest: result.manifest,
     });
   } catch (err) {

--- a/assistant/src/daemon/ipc-contract/apps.ts
+++ b/assistant/src/daemon/ipc-contract/apps.ts
@@ -238,6 +238,8 @@ export interface ForkSharedAppResponse {
 export interface BundleAppResponse {
   type: "bundle_app_response";
   bundlePath: string;
+  /** Base64-encoded PNG of the generated app icon, if available. */
+  iconImageBase64?: string;
   manifest: {
     format_version: number;
     name: string;

--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -9,13 +9,17 @@
 
 import { join } from "node:path";
 
+import { generateAppIcon } from "../media/app-icon-generator.js";
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import type { ToolExecutionResult } from "../tools/types.js";
+import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { isDoordashCommand, updateDoordashProgress } from "./doordash-steps.js";
 import type { ServerMessage } from "./ipc-protocol.js";
 import { refreshSurfacesForApp } from "./session-surfaces.js";
 import type { ToolSetupContext } from "./session-tool-setup.js";
+
+const log = getLogger("tool-side-effects");
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -65,16 +69,50 @@ function registerHook(
 
 // Broadcast app_files_changed when a new app is created so clients
 // (e.g. macOS "Things" sidebar) refresh their app list immediately.
+// Also kicks off async icon generation via Gemini.
 registerHook(
   "app_create",
   (_name, _input, result, { ctx, broadcastToAllClients }) => {
     try {
-      const parsed = JSON.parse(result.content) as { id?: string };
+      const parsed = JSON.parse(result.content) as {
+        id?: string;
+        name?: string;
+        description?: string;
+      };
       if (parsed.id) {
         handleAppChange(ctx, parsed.id, broadcastToAllClients);
+
+        // Fire-and-forget: generate an app icon in the background.
+        // When complete, broadcast again so clients pick up the new icon.
+        if (parsed.name) {
+          void generateAppIcon(parsed.id, parsed.name, parsed.description)
+            .then(() => {
+              broadcastToAllClients?.({
+                type: "app_files_changed",
+                appId: parsed.id!,
+              });
+            })
+            .catch((err) => {
+              log.warn(
+                { err, appId: parsed.id },
+                "Background icon generation failed",
+              );
+            });
+        }
       }
     } catch {
       // Result wasn't valid JSON — skip the broadcast.
+    }
+  },
+);
+
+// Broadcast app_files_changed when an icon is (re)generated so clients refresh.
+registerHook(
+  "app_generate_icon",
+  (_name, input, _result, { broadcastToAllClients }) => {
+    const appId = input.app_id as string | undefined;
+    if (appId) {
+      broadcastToAllClients?.({ type: "app_files_changed", appId });
     }
   },
 );

--- a/assistant/src/media/app-icon-generator.ts
+++ b/assistant/src/media/app-icon-generator.ts
@@ -1,0 +1,86 @@
+/**
+ * Generates app icons using the Gemini image generation service.
+ *
+ * Called as an async side-effect after app creation — never blocks
+ * the main app_create flow. Icons are saved to the app's directory
+ * as `icon.png` and included in .vellum bundles.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getConfig } from "../config/loader.js";
+import { getAppsDir } from "../memory/app-store.js";
+import { getLogger } from "../util/logger.js";
+import { generateImage, mapGeminiError } from "./gemini-image-service.js";
+
+const log = getLogger("app-icon-generator");
+
+/**
+ * Generate an app icon and save it to `~/.vellum/apps/{appId}/icon.png`.
+ *
+ * Uses Gemini image generation when an API key is available.
+ * Silently no-ops if no key is configured or generation fails.
+ */
+export async function generateAppIcon(
+  appId: string,
+  appName: string,
+  appDescription?: string,
+): Promise<void> {
+  const config = getConfig();
+  const apiKey = config.apiKeys.gemini ?? process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    log.debug("No Gemini API key — skipping app icon generation");
+    return;
+  }
+
+  const appDir = join(getAppsDir(), appId);
+  const iconPath = join(appDir, "icon.png");
+
+  // Don't regenerate if icon already exists
+  if (existsSync(iconPath)) {
+    return;
+  }
+
+  const descPart = appDescription ? ` Description: ${appDescription}.` : "";
+
+  const prompt =
+    `Design a beautiful, minimal app icon for "${appName}".${descPart}\n\n` +
+    "Style requirements:\n" +
+    "- Square app icon with rounded corners (like macOS/iOS app icons)\n" +
+    "- Clean, flat design with a single bold symbol or glyph in the center\n" +
+    "- Rich gradient background using 2-3 harmonious colors\n" +
+    "- The symbol should be white or very light colored for contrast\n" +
+    "- No text, no letters, no words — only a symbolic glyph\n" +
+    "- Professional quality, recognizable at small sizes (32px)\n" +
+    "- Modern aesthetic similar to Apple's design language";
+
+  try {
+    log.info({ appId, appName }, "Generating app icon via Gemini");
+
+    const result = await generateImage(apiKey, {
+      prompt,
+      mode: "generate",
+      model: config.imageGenModel,
+    });
+
+    if (result.images.length === 0) {
+      log.warn({ appId }, "Gemini returned no image for app icon");
+      return;
+    }
+
+    const image = result.images[0];
+    const pngBuffer = Buffer.from(image.dataBase64, "base64");
+
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(iconPath, pngBuffer);
+
+    log.info({ appId, iconPath }, "App icon saved");
+  } catch (error) {
+    const message = mapGeminiError(error);
+    log.warn(
+      { appId, error: message },
+      "App icon generation failed — skipping",
+    );
+  }
+}

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -9,6 +9,7 @@
  */
 
 import { setHomeBaseAppLink } from "../../home-base/app-link-store.js";
+import { generateAppIcon } from "../../media/app-icon-generator.js";
 import type { AppDefinition } from "../../memory/app-store.js";
 import type { EditEngineResult } from "../../memory/app-store.js";
 
@@ -40,6 +41,7 @@ export interface AppStoreWriter {
   createApp(params: {
     name: string;
     description?: string;
+    icon?: string;
     schemaJson: string;
     htmlDefinition: string;
     pages?: Record<string, string>;
@@ -139,9 +141,13 @@ export async function executeAppCreate(
     }
   }
 
+  // Extract icon from preview if provided (emoji or URL)
+  const icon = preview?.icon as string | undefined;
+
   const app = store.createApp({
     name,
     description,
+    icon,
     schemaJson,
     htmlDefinition,
     pages,
@@ -403,5 +409,57 @@ export function executeAppFileWrite(
     content: JSON.stringify({ written: true, path: input.path }),
     isError: false,
     status: input.status,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// app_generate_icon
+// ---------------------------------------------------------------------------
+
+export interface AppGenerateIconInput {
+  app_id: string;
+  description?: string;
+}
+
+export async function executeAppGenerateIcon(
+  input: AppGenerateIconInput,
+  store: AppStoreReader,
+): Promise<ExecutorResult> {
+  const app = store.getApp(input.app_id);
+  if (!app) {
+    return {
+      content: JSON.stringify({ error: `App '${input.app_id}' not found` }),
+      isError: true,
+    };
+  }
+
+  // Remove existing icon so generateAppIcon doesn't skip
+  const { existsSync, unlinkSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  const { getAppsDir } = await import("../../memory/app-store.js");
+  const iconPath = join(getAppsDir(), input.app_id, "icon.png");
+  if (existsSync(iconPath)) {
+    unlinkSync(iconPath);
+  }
+
+  await generateAppIcon(
+    input.app_id,
+    app.name,
+    input.description ?? app.description,
+  );
+
+  if (existsSync(iconPath)) {
+    return {
+      content: JSON.stringify({ generated: true, appId: input.app_id }),
+      isError: false,
+    };
+  }
+
+  return {
+    content: JSON.stringify({
+      error:
+        "Icon generation failed. Make sure a Gemini API key is configured in Settings.",
+    }),
+    isError: true,
   };
 }

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -141,8 +141,10 @@ export async function executeAppCreate(
     }
   }
 
-  // Extract icon from preview if provided (emoji or URL)
-  const icon = preview?.icon as string | undefined;
+  // Extract icon from preview if provided — only persist emoji-like values,
+  // not URLs which would render as raw strings in UI and bundle manifests.
+  const rawIcon = preview?.icon as string | undefined;
+  const icon = rawIcon && !rawIcon.startsWith("http") ? rawIcon : undefined;
 
   const app = store.createApp({
     name,
@@ -433,13 +435,17 @@ export async function executeAppGenerateIcon(
     };
   }
 
-  // Remove existing icon so generateAppIcon doesn't skip
-  const { existsSync, unlinkSync } = await import("node:fs");
+  // Generate to a temp path first, then swap on success to avoid
+  // destroying an existing icon if generation fails.
+  const { existsSync, renameSync, unlinkSync } = await import("node:fs");
   const { join } = await import("node:path");
   const { getAppsDir } = await import("../../memory/app-store.js");
   const iconPath = join(getAppsDir(), input.app_id, "icon.png");
+  const tempPath = join(getAppsDir(), input.app_id, "icon.tmp.png");
+
+  // Temporarily move existing icon aside so generateAppIcon doesn't skip
   if (existsSync(iconPath)) {
-    unlinkSync(iconPath);
+    renameSync(iconPath, tempPath);
   }
 
   await generateAppIcon(
@@ -449,10 +455,19 @@ export async function executeAppGenerateIcon(
   );
 
   if (existsSync(iconPath)) {
+    // Success — clean up the old icon backup
+    if (existsSync(tempPath)) {
+      unlinkSync(tempPath);
+    }
     return {
       content: JSON.stringify({ generated: true, appId: input.app_id }),
       isError: false,
     };
+  }
+
+  // Generation failed — restore the previous icon if we had one
+  if (existsSync(tempPath)) {
+    renameSync(tempPath, iconPath);
   }
 
   return {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import VellumAssistantShared
 
@@ -121,7 +122,9 @@ extension MainWindowView {
             let previousHandler = daemonClient.onBundleAppResponse
             daemonClient.onBundleAppResponse = { response in
                 daemonClient.onBundleAppResponse = previousHandler
-                sharing.shareFileURL = Self.cleanBundleURL(bundlePath: response.bundlePath, appName: response.manifest.name)
+                let url = Self.cleanBundleURL(bundlePath: response.bundlePath, appName: response.manifest.name)
+                Self.applyFileIcon(to: url, iconBase64: response.iconImageBase64, emojiIcon: response.manifest.icon, appName: response.manifest.name)
+                sharing.shareFileURL = url
                 sharing.isBundling = false
                 sharing.showSharePicker = true
             }
@@ -152,6 +155,62 @@ extension MainWindowView {
             return cleanURL
         } catch {
             return originalURL
+        }
+    }
+
+    /// Sets a custom icon on the file so the share sheet shows it instead of a blank document.
+    /// Prefers the AI-generated icon (base64 PNG), falls back to rendering the emoji or app initial.
+    static func applyFileIcon(to url: URL, iconBase64: String?, emojiIcon: String?, appName: String) {
+        if let base64 = iconBase64,
+           let data = Data(base64Encoded: base64),
+           let image = NSImage(data: data) {
+            NSWorkspace.shared.setIcon(image, forFile: url.path, options: [])
+            return
+        }
+
+        // Fallback: render the emoji or first letter as an icon
+        let glyph = (emojiIcon.flatMap { $0.isEmpty ? nil : $0 })
+            ?? String(appName.trimmingCharacters(in: .whitespacesAndNewlines).prefix(1)).uppercased()
+        if !glyph.isEmpty {
+            let image = renderEmojiIcon(emoji: glyph, size: 512)
+            NSWorkspace.shared.setIcon(image, forFile: url.path, options: [])
+        }
+    }
+
+    /// Renders a glyph (emoji or letter) as a square icon image with a gradient background.
+    /// Uses NSImage(size:flipped:drawingHandler:) to avoid deprecated lockFocus on macOS 14+.
+    private static func renderEmojiIcon(emoji: String, size: CGFloat) -> NSImage {
+        return NSImage(size: NSSize(width: size, height: size), flipped: false) { rect in
+            let cornerRadius = size * 0.22
+            let path = NSBezierPath(roundedRect: rect, xRadius: cornerRadius, yRadius: cornerRadius)
+
+            // Gradient background — use a stable hash for consistent colors per glyph
+            var hasher = Hasher()
+            hasher.combine(emoji)
+            let hash = abs(hasher.finalize())
+            let hue = CGFloat(hash % 360) / 360.0
+            let topColor = NSColor(hue: hue, saturation: 0.6, brightness: 0.85, alpha: 1.0)
+            let bottomColor = NSColor(
+                hue: (hue + 0.08).truncatingRemainder(dividingBy: 1.0),
+                saturation: 0.7, brightness: 0.65, alpha: 1.0
+            )
+            if let gradient = NSGradient(starting: topColor, ending: bottomColor) {
+                gradient.draw(in: path, angle: -90)
+            }
+
+            // Draw the glyph centered
+            let fontSize = size * 0.55
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: fontSize),
+            ]
+            let emojiString = NSAttributedString(string: emoji, attributes: attributes)
+            let emojiSize = emojiString.size()
+            let origin = NSPoint(
+                x: (size - emojiSize.width) / 2,
+                y: (size - emojiSize.height) / 2
+            )
+            emojiString.draw(at: origin)
+            return true
         }
     }
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
@@ -187,7 +187,7 @@ extension MainWindowView {
             // Gradient background — use a stable hash for consistent colors per glyph
             var hasher = Hasher()
             hasher.combine(emoji)
-            let hash = abs(hasher.finalize())
+            let hash = hasher.finalize() & Int.max
             let hue = CGFloat(hash % 360) / 360.0
             let topColor = NSColor(hue: hue, saturation: 0.6, brightness: 0.85, alpha: 1.0)
             let bottomColor = NSColor(

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -286,7 +286,9 @@ struct AppsGridView: View {
         let previousHandler = daemonClient.onBundleAppResponse
         daemonClient.onBundleAppResponse = { response in
             daemonClient.onBundleAppResponse = previousHandler
-            shareFileURL = MainWindowView.cleanBundleURL(bundlePath: response.bundlePath, appName: response.manifest.name)
+            let url = MainWindowView.cleanBundleURL(bundlePath: response.bundlePath, appName: response.manifest.name)
+            MainWindowView.applyFileIcon(to: url, iconBase64: response.iconImageBase64, emojiIcon: response.manifest.icon, appName: response.manifest.name)
+            shareFileURL = url
             isBundling = false
             showShareSheet = true
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -729,7 +729,9 @@ struct GeneratedPanel: View {
             let previousHandler = daemonClient.onBundleAppResponse
             daemonClient.onBundleAppResponse = { response in
                 daemonClient.onBundleAppResponse = previousHandler
-                self.shareFileURL = MainWindowView.cleanBundleURL(bundlePath: response.bundlePath, appName: response.manifest.name)
+                let url = MainWindowView.cleanBundleURL(bundlePath: response.bundlePath, appName: response.manifest.name)
+                MainWindowView.applyFileIcon(to: url, iconBase64: response.iconImageBase64, emojiIcon: response.manifest.icon, appName: response.manifest.name)
+                self.shareFileURL = url
                 self.isBundling = false
                 self.showShareSheet = true
             }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -584,11 +584,14 @@ public struct IPCBundleAppRequest: Codable, Sendable {
 public struct IPCBundleAppResponse: Codable, Sendable {
     public let type: String
     public let bundlePath: String
+    /// Base64-encoded PNG of the generated app icon, if available.
+    public let iconImageBase64: String?
     public let manifest: IPCBundleAppResponseManifest
 
-    public init(type: String, bundlePath: String, manifest: IPCBundleAppResponseManifest) {
+    public init(type: String, bundlePath: String, iconImageBase64: String? = nil, manifest: IPCBundleAppResponseManifest) {
         self.type = type
         self.bundlePath = bundlePath
+        self.iconImageBase64 = iconImageBase64
         self.manifest = manifest
     }
 }


### PR DESCRIPTION
## Summary
- Adds Gemini-powered app icon generation as an async side effect during app creation
- New `app_generate_icon` tool lets users regenerate icons on demand ("change the icon for this app")
- Icons stored as `icon.png` in app directory, included in `.vellum` bundles, and passed via IPC as base64
- Fixes existing bug where `preview.icon` emoji wasn't passed through to the app store on creation
- Swift side applies icon to shared files via `NSWorkspace.setIcon` with emoji/initial fallback

## Known limitation
`NSSharingServicePicker` doesn't display per-file custom icons set via `NSWorkspace.setIcon` in its header preview — the icon is written correctly (verified via resource fork), but the share sheet uses UTI-based icons instead. Needs a different approach (custom `NSItemProvider` or delegate customization) in a follow-up.

## Test plan
- [ ] Create a new app with Gemini key configured — verify `icon.png` appears in `~/.vellum/workspace/data/apps/{id}/`
- [ ] Ask the assistant to "change the icon" for an app — verify `app_generate_icon` tool runs successfully
- [ ] Bundle and share an app — verify icon.png is included in the `.vellum` zip
- [ ] Share an app without a generated icon — verify fallback renders emoji or initial (no blank icon)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
