### PR TITLE
M3: Update SKILL.md with new script-based instructions

### DIFF
--- a/skills/twitter/SKILL.md
+++ b/skills/twitter/SKILL.md
@@ -7,4 +7,255 @@ metadata:
 
 You are an X (formerly Twitter) assistant. Use the CLI script in `scripts/` to interact with X.
 
-<!-- TODO: Full content will be added in M3 -->
+## Usage
+
+Run the twitter command via:
+
+```bash
+bun run scripts/twitter-cli.ts <command> [options]
+```
+
+## Connection Options
+
+There are two supported ways to connect to X. Both are fully functional; choose whichever fits the user's situation.
+
+### OAuth (recommended with X developer credentials)
+
+OAuth uses the official X API v2. It is the most reliable connection method and does not depend on browser sessions.
+
+- Supports: **post** and **reply**
+- Read-only operations (timeline, search, home, bookmarks, notifications, likes, followers, following, media) always use the browser path directly, regardless of the strategy setting.
+- Setup: Collect the OAuth Client ID (and optional Client Secret) from the user in chat using `credential_store` with `action: "prompt"` (canonical field names: `client_id`, `client_secret`), then initiate the `twitter_auth_start` flow. See the **First-Use Decision Flow** for the full sequence.
+- Set the strategy: `bun run scripts/twitter-cli.ts strategy set oauth`
+
+### Browser session (no developer credentials needed)
+
+The browser path is quick to start and useful when the user does not have X developer app credentials. It captures auth cookies from Chrome and uses them to interact with X.
+
+- Supports: **all operations** (post, reply, timeline, search, home, bookmarks, notifications, likes, followers, following, media)
+- Setup: Run `vellum x refresh` from the terminal to open Chrome and capture session cookies automatically.
+- Set the strategy: `bun run scripts/twitter-cli.ts strategy set browser`
+
+### Auto mode (default)
+
+When the strategy is `auto` (the default), the router tries OAuth first for supported operations if credentials are available, then falls back to the browser path. This gives the best of both worlds without requiring manual switching.
+
+- Set auto mode: `bun run scripts/twitter-cli.ts strategy set auto`
+
+## First-Use Decision Flow
+
+When the user triggers a Twitter operation and no strategy has been configured yet, follow these steps:
+
+1. **Check current status:**
+
+   ```bash
+   bun run scripts/twitter-cli.ts status --json
+   ```
+
+   Look at `oauthConnected`, `browserSessionActive`, `preferredStrategy`, and `strategyConfigured` in the response. If `strategyConfigured` is `false`, the user has not yet chosen a strategy and should be guided through setup.
+
+2. **Present both options with trade-offs:**
+   - **OAuth**: Most reliable and official. Requires X developer app credentials (OAuth Client ID and optional Client Secret). Supports posting and replying. Set up right here in the chat.
+   - **Browser session**: Quick to start, no developer credentials needed. Supports all operations including reading timelines and searching. Set up with `vellum x refresh` from the terminal.
+
+3. **Ask the user which they prefer.** Do not choose for them.
+
+4. **Execute setup for the chosen path:**
+   - If OAuth: Collect the credentials in-chat using the secure credential prompt, then connect. Follow the **OAuth Setup Sequence** below.
+   - If browser: Direct the user to run `vellum x refresh` from their terminal to capture session cookies from Chrome.
+
+### OAuth Setup Sequence
+
+When the user chooses OAuth, collect their X developer credentials conversationally using the secure UI. The OAuth flow delegates to the generic connect orchestrator, which resolves the Twitter provider profile, computes scopes via policy, opens the X authorization page in the user's browser, verifies the user's identity, and stores tokens. The orchestrator also manages stale refresh-token cleanup and enforces integration-mode guards.
+
+1. **Collect the Client ID securely:**
+   Call `credential_store` with `action: "prompt"`, `service: "integration:twitter"`, `field: "client_id"`, `label: "X (Twitter) OAuth Client ID"`, `description: "Enter the Client ID from your X Developer App"`, and `placeholder: "your-client-id"`.
+
+2. **Collect the Client Secret (if applicable):**
+   Ask the user if their X app uses a confidential client (has a Client Secret). If yes, call `credential_store` with `action: "prompt"`, `service: "integration:twitter"`, `field: "client_secret"`, `label: "X (Twitter) OAuth Client Secret"`, `description: "Enter the Client Secret from your X Developer App (leave blank if using a public client)"`, and `placeholder: "your-client-secret"`.
+
+3. **Initiate the OAuth flow:**
+   Trigger the Twitter auth start flow. The connect orchestrator resolves the Twitter provider profile, computes scopes via policy, opens the X authorization page in the user's browser, verifies the user's identity, and stores tokens. Wait for the auth result.
+
+4. **Confirm success:**
+   Tell the user: "Great, your X account is connected! You can always update these credentials from the Settings page."
+
+5. **Set the preferred strategy:**
+   ```bash
+   bun run scripts/twitter-cli.ts strategy set <oauth|browser|auto>
+   ```
+
+## Failure Recovery Flow
+
+When a Twitter operation fails, follow these steps:
+
+1. **Detect the failure type from the error output:**
+   - `session_expired` or `SessionExpiredError` — the browser session cookies have expired.
+   - `OAuth is not configured` — the user chose OAuth but credentials are not set up.
+   - `Twitter API error (401)` — OAuth token may be expired or revoked.
+   - `UnsupportedOAuthOperationError` — the requested write operation is not available via OAuth.
+   - `Cannot connect to assistant` — the Vellum assistant is not running.
+
+2. **Explain the likely cause clearly** to the user.
+
+3. **Suggest trying the other path as an alternative:**
+   - If the browser session expired: suggest setting up OAuth for post/reply operations, or direct the user to refresh the browser session with `vellum x refresh` from the terminal.
+   - If OAuth failed or is not configured: suggest using the browser path with `bun run scripts/twitter-cli.ts strategy set browser` and refreshing via `vellum x refresh`.
+   - If the operation is unsupported via OAuth: explain that this write operation is not yet supported via OAuth, and suggest using the browser path with `bun run scripts/twitter-cli.ts strategy set browser`.
+
+4. **Offer concrete steps to switch:**
+
+   ```bash
+   # Switch to the other strategy
+   bun run scripts/twitter-cli.ts strategy set <oauth|browser|auto>
+
+   # If switching to browser, direct the user to refresh the session from the terminal
+   # vellum x refresh
+   ```
+
+## Strategy Management Commands
+
+```bash
+# Check current strategy
+bun run scripts/twitter-cli.ts strategy
+
+# Set strategy to OAuth, browser, or auto
+bun run scripts/twitter-cli.ts strategy set <oauth|browser|auto>
+
+# Check full status (session, OAuth, and strategy info)
+bun run scripts/twitter-cli.ts status --json
+```
+
+## Posting
+
+```bash
+bun run scripts/twitter-cli.ts post "The post text here"
+```
+
+Returns JSON with `ok`, `tweetId`, `text`, `url`, and `pathUsed` fields. The `pathUsed` field indicates whether the post was sent via `oauth` or `browser`. Share the URL with the user so they can verify the post.
+
+The `post` command routes through the strategy router: it uses OAuth if configured and available, otherwise falls back to the browser path.
+
+## Replying
+
+```bash
+bun run scripts/twitter-cli.ts reply <tweetUrl> "The reply text here"
+```
+
+The first argument is a tweet URL (e.g. `https://x.com/user/status/123456`) or a bare tweet ID.
+
+Like `post`, the `reply` command routes through the strategy router and returns a `pathUsed` field.
+
+## Reading
+
+Read-only operations always use the browser path directly, regardless of the strategy setting. They work the same whether the strategy is `oauth`, `browser`, or `auto` — the strategy only affects `post` and `reply` commands.
+
+### User timeline
+
+```bash
+bun run scripts/twitter-cli.ts timeline <screenName> [--count N]
+```
+
+Returns `user` and `tweets` array.
+
+### Single tweet + replies
+
+```bash
+bun run scripts/twitter-cli.ts tweet <tweetIdOrUrl>
+```
+
+Returns the focal tweet and its reply thread.
+
+### Search
+
+```bash
+bun run scripts/twitter-cli.ts search "query" [--product Top|Latest|People|Media]
+```
+
+### Home timeline
+
+```bash
+bun run scripts/twitter-cli.ts home [--count N]
+```
+
+### Bookmarks
+
+```bash
+bun run scripts/twitter-cli.ts bookmarks [--count N]
+```
+
+### Notifications
+
+```bash
+bun run scripts/twitter-cli.ts notifications [--count N]
+```
+
+Returns `notifications` array with `id`, `message`, `timestamp`, `url`.
+
+### Likes
+
+```bash
+bun run scripts/twitter-cli.ts likes <screenName> [--count N]
+```
+
+### Followers / Following
+
+```bash
+bun run scripts/twitter-cli.ts followers <screenName>
+bun run scripts/twitter-cli.ts following <screenName> [--count N]
+```
+
+Returns `user` and `followers`/`following` array (userId, screenName, name).
+
+### Media
+
+```bash
+bun run scripts/twitter-cli.ts media <screenName> [--count N]
+```
+
+Returns tweets that contain media from the user's profile.
+
+## Workflows
+
+### Check Mentions
+
+When the user asks to check mentions, check X, or see what's happening:
+
+1. Fetch notifications: `bun run scripts/twitter-cli.ts notifications --count 20`
+2. Fetch their recent tweets to see replies: `bun run scripts/twitter-cli.ts timeline <theirScreenName> --count 10`
+3. Summarize what needs attention:
+   - Group by type: replies to their tweets, likes, new followers, mentions
+   - For anything that looks like it needs a reply, fetch the full thread with `bun run scripts/twitter-cli.ts tweet <tweetId>` to understand context
+   - Prioritize: direct questions > mentions > engagement notifications
+4. For items that need replies, draft a response and ask the user to approve before sending with `bun run scripts/twitter-cli.ts reply`
+
+Present the summary as a scannable list, not a wall of text. Lead with action items.
+
+### Research a Topic
+
+When the user wants to understand what people are saying about something:
+
+1. Search: `bun run scripts/twitter-cli.ts search "topic"`
+2. For the most interesting tweets, fetch threads: `bun run scripts/twitter-cli.ts tweet <tweetId>`
+3. Summarize: key themes, notable voices, sentiment, and any emerging consensus
+4. If the user wants to engage, draft a post or reply that adds to the conversation
+
+### Engagement Check
+
+When the user wants to see how their posts are performing:
+
+1. Fetch their recent tweets: `bun run scripts/twitter-cli.ts timeline <screenName> --count 20`
+2. For each tweet, note engagement signals from the text/metadata
+3. Fetch notifications to see who's interacting: `bun run scripts/twitter-cli.ts notifications --count 20`
+4. Summarize: which posts got traction, who's engaging, any conversations worth continuing
+
+## Tips
+
+- Keep posts under 280 characters
+- All `screenName` arguments should be without the `@` prefix
+- All commands return JSON with an `ok` field
+- When drafting replies, match the tone of the conversation — casual threads get casual replies
+- Always show the user what you're about to post and get approval before sending
+- If a browser session is expired, direct the user to refresh it with `vellum x refresh` from their terminal before retrying, or suggest switching to OAuth for post/reply operations
+- If an operation fails, check `bun run scripts/twitter-cli.ts status --json` to diagnose the issue before retrying
+- The `post` and `reply` commands include a `pathUsed` field in their response so you can tell the user which connection method was used


### PR DESCRIPTION
## Summary
- Replace all `vellum x` CLI command references with `bun run scripts/twitter-cli.ts` commands
- The skill now documents the new script-based pattern for all Twitter operations
- Updated all command examples and workflows to use the new format
- Browser refresh still uses `vellum x refresh` since that requires the full CLI with CDP/Ride Shotgun

Part of #13458

## Test plan
- [ ] Verify SKILL.md parses correctly
- [ ] Verify command examples are correct
- [ ] Verify workflow documentation is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
