### PR TITLE
M5: Update references and fix tests after CLI removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,9 +317,9 @@ Twitter integration supports two operation paths: **OAuth** (X API v2) and **Bro
 
 - **OAuth path**: Uses stored OAuth2 tokens via `withValidToken('integration:twitter', ...)` to call the X API v2 directly. Supports `post` and `reply`. Most reliable when developer credentials are configured — no browser session needed for these operations.
 
-- **Browser path** (CDP): Uses Chrome DevTools Protocol to execute operations through an authenticated x.com browser tab. Supports all operations including read-only ones (timeline, search, home, notifications, bookmarks, likes, followers, following, media). Quick to start — no developer credentials needed. Session cookies are captured via Ride Shotgun (`vellum x refresh`).
+- **Browser path** (CDP): Uses Chrome DevTools Protocol to execute operations through an authenticated x.com browser tab. Supports all operations including read-only ones (timeline, search, home, notifications, bookmarks, likes, followers, following, media). Quick to start — no developer credentials needed. Session cookies are captured via Ride Shotgun and imported with `bun run scripts/twitter-cli.ts login --recording <path>`.
 
-- **Strategy selection**: `vellum x strategy set <oauth|browser|auto>` controls which path is used. Default is `auto`, which prefers OAuth when credentials are available and the operation is supported, then falls back to browser. The strategy is persisted in config as `twitterOperationStrategy`.
+- **Strategy selection**: `bun run scripts/twitter-cli.ts strategy set <oauth|browser|auto>` controls which path is used. Default is `auto`, which prefers OAuth when credentials are available and the operation is supported, then falls back to browser. The strategy is persisted in config as `twitterOperationStrategy`.
 
 **OAuth2 PKCE setup** (`local_byo` mode): The user provides their own Twitter OAuth2 Client ID (and optional Client Secret). The assistant runs a standard OAuth2 PKCE flow against `twitter.com/i/oauth2/authorize` and `api.x.com/2/oauth2/token`. The flow verifies the user's identity (`GET /2/users/me`) and stores tokens in the vault for use by both identity verification and the OAuth operation path. Connect via the Settings UI or `twitter_auth_start` IPC message.
 

--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -194,7 +194,7 @@ The strategy router (`router.ts`) determines whether to use the OAuth or browser
 
 ```mermaid
 flowchart TD
-    CLI["vellum x post / reply"] --> Router["Strategy Router (router.ts)"]
+    CLI["twitter-cli.ts post / reply"] --> Router["Strategy Router (router.ts)"]
     Router --> StratCheck{Preferred strategy?}
 
     StratCheck -->|oauth| OAuthOnly["OAuth Client (oauth-client.ts)"]
@@ -215,19 +215,19 @@ flowchart TD
 - **`oauth`**: Uses OAuth exclusively. Fails with an actionable error if credentials are not configured.
 - **`browser`**: Uses CDP exclusively. Fails with an actionable error if the browser session has expired.
 
-The strategy is persisted in the Vellum config file as `twitterOperationStrategy` and can be changed via `vellum x strategy set <oauth|browser|auto>`.
+The strategy is persisted in the Vellum config file as `twitterOperationStrategy` and can be changed via `bun run scripts/twitter-cli.ts strategy set <oauth|browser|auto>`.
 
 #### Twitter OAuth2 Specifics
 
-| Aspect | Detail |
-|--------|--------|
-| Auth URL | `https://twitter.com/i/oauth2/authorize` (from provider profile) |
-| Token URL | `https://api.x.com/2/oauth2/token` (from provider profile) |
-| Flow | PKCE (S256), optional client secret, via connect orchestrator |
-| Default scopes | `tweet.read`, `tweet.write`, `users.read`, `offline.access` (from provider profile) |
-| Identity verification | Provider profile `identityVerifier` → `GET https://api.x.com/2/users/me` with Bearer token |
-| Credential names | Canonical: `client_id`, `client_secret`; reads fall back to legacy `oauth_client_id`, `oauth_client_secret` |
-| IPC messages | `oauth_connect_start` / `oauth_connect_result` (generic), plus legacy `twitter_auth_start` / `twitter_auth_status` |
+| Aspect                | Detail                                                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Auth URL              | `https://twitter.com/i/oauth2/authorize` (from provider profile)                                                   |
+| Token URL             | `https://api.x.com/2/oauth2/token` (from provider profile)                                                         |
+| Flow                  | PKCE (S256), optional client secret, via connect orchestrator                                                      |
+| Default scopes        | `tweet.read`, `tweet.write`, `users.read`, `offline.access` (from provider profile)                                |
+| Identity verification | Provider profile `identityVerifier` → `GET https://api.x.com/2/users/me` with Bearer token                         |
+| Credential names      | Canonical: `client_id`, `client_secret`; reads fall back to legacy `oauth_client_id`, `oauth_client_secret`        |
+| IPC messages          | `oauth_connect_start` / `oauth_connect_result` (generic), plus legacy `twitter_auth_start` / `twitter_auth_status` |
 
 #### Twitter Credential Metadata Structure
 
@@ -250,77 +250,77 @@ When the OAuth2 flow completes, the handler stores credential metadata at `integ
 
 **OAuth path** (`oauth-client.ts`): The `oauthPostTweet` function calls X API v2 (`POST https://api.x.com/2/tweets`) with a Bearer token obtained via `withValidToken('integration:twitter', ...)`. The token manager handles automatic refresh if the stored token is expired. Supports `post` and `reply` (by including `reply.in_reply_to_tweet_id` in the request body). All other operations (timeline, search, etc.) throw `UnsupportedOAuthOperationError` and are not available via this path.
 
-**Browser path** (`client.ts`): Connects to Chrome via CDP (`localhost:9222`), finds an authenticated x.com tab, and executes GraphQL mutations/queries through the browser's session cookies. Supports all operations including read-only ones (timeline, search, home, notifications, bookmarks, likes, followers, following, media). Session management is handled by Ride Shotgun recordings (`vellum x refresh`).
+**Browser path** (`client.ts`): Connects to Chrome via CDP (`localhost:9222`), finds an authenticated x.com tab, and executes GraphQL mutations/queries through the browser's session cookies. Supports all operations including read-only ones (timeline, search, home, notifications, bookmarks, likes, followers, following, media). Session management is handled by importing Ride Shotgun recordings via `bun run scripts/twitter-cli.ts login --recording <path>`.
 
 #### Available Twitter Tools
 
-| Tool / Command | Mechanism | Description |
-|----------------|-----------|-------------|
-| `vellum x post` | Strategy router (OAuth or CDP) | Post a tweet. Uses the configured strategy (`auto` by default). |
-| `vellum x reply` | Strategy router (OAuth or CDP) | Reply to a tweet. Uses the configured strategy (`auto` by default). |
-| `vellum x timeline` | CDP | Fetch a user's recent tweets. Browser path only. |
-| `vellum x search` | CDP | Search tweets. Browser path only. |
-| `vellum x home` | CDP | Fetch home timeline. Browser path only. |
-| `vellum x notifications` | CDP | Fetch notifications. Browser path only. |
-| `vellum x bookmarks` | CDP | Fetch bookmarks. Browser path only. |
-| `vellum x likes` | CDP | Fetch a user's liked tweets. Browser path only. |
-| `vellum x followers` | CDP | Fetch a user's followers. Browser path only. |
-| `vellum x following` | CDP | Fetch who a user follows. Browser path only. |
-| `vellum x media` | CDP | Fetch a user's media tweets. Browser path only. |
-| `vellum x strategy` | Config | Get or set the operation strategy (`oauth`, `browser`, `auto`). |
-| `vellum x status` | IPC + local | Check browser session, OAuth connection, and strategy status. |
+| Tool / Command                 | Mechanism                      | Description                                                         |
+| ------------------------------ | ------------------------------ | ------------------------------------------------------------------- |
+| `twitter-cli.ts post`          | Strategy router (OAuth or CDP) | Post a tweet. Uses the configured strategy (`auto` by default).     |
+| `twitter-cli.ts reply`         | Strategy router (OAuth or CDP) | Reply to a tweet. Uses the configured strategy (`auto` by default). |
+| `twitter-cli.ts timeline`      | CDP                            | Fetch a user's recent tweets. Browser path only.                    |
+| `twitter-cli.ts search`        | CDP                            | Search tweets. Browser path only.                                   |
+| `twitter-cli.ts home`          | CDP                            | Fetch home timeline. Browser path only.                             |
+| `twitter-cli.ts notifications` | CDP                            | Fetch notifications. Browser path only.                             |
+| `twitter-cli.ts bookmarks`     | CDP                            | Fetch bookmarks. Browser path only.                                 |
+| `twitter-cli.ts likes`         | CDP                            | Fetch a user's liked tweets. Browser path only.                     |
+| `twitter-cli.ts followers`     | CDP                            | Fetch a user's followers. Browser path only.                        |
+| `twitter-cli.ts following`     | CDP                            | Fetch who a user follows. Browser path only.                        |
+| `twitter-cli.ts media`         | CDP                            | Fetch a user's media tweets. Browser path only.                     |
+| `twitter-cli.ts strategy`      | Config                         | Get or set the operation strategy (`oauth`, `browser`, `auto`).     |
+| `twitter-cli.ts status`        | IPC + local                    | Check browser session, OAuth connection, and strategy status.       |
 
 Note: OAuth2 scopes (`tweet.read`, `tweet.write`, `users.read`, `offline.access`) are requested during the auth flow. The `post` and `reply` operations use these tokens when the OAuth path is selected. Read operations require the browser path.
 
 ### Key Design Decisions
 
-| Decision | Rationale |
-|----------|-----------|
-| PKCE by default, optional client_secret | Desktop apps prefer PKCE; some providers (Slack) require a secret, which is stored in credential metadata for autonomous refresh |
-| Shared connect orchestrator | All OAuth providers route through `orchestrateOAuthConnect()`, which resolves profiles, enforces scope policy, runs the flow, stores tokens, and verifies identity. Adding a provider is a declarative profile entry, not new orchestration code |
-| Canonical credential naming | Writes use `client_id`/`client_secret`; reads fall back to legacy `oauth_client_id`/`oauth_client_secret` for backward compatibility |
-| Gateway callback transport | OAuth callbacks are now routed through the gateway at `${ingress.publicBaseUrl}/webhooks/oauth/callback` instead of a loopback redirect URI. This enables OAuth flows to work in remote and tunneled deployments. |
-| Unified `MessagingProvider` interface | All platforms implement the same contract; generic tools work immediately for new providers |
-| Twitter outside unified messaging | Twitter is a broadcast/read platform, not a conversation platform — it doesn't fit the `MessagingProvider` contract |
-| Dual-path Twitter strategy | OAuth is more reliable for posting (no browser session dependency) but only supports post/reply. Browser path supports all operations. `auto` strategy gives the best of both: OAuth when possible, browser as fallback. User can override via `vellum x strategy set`. |
-| Provider auto-selection | If only one provider is connected, tools skip the `platform` parameter — seamless single-platform UX |
-| Token expiry in credential metadata | Reuses existing `CredentialMetadata` store; `expiresAt` field enables proactive refresh with 5min buffer |
-| Confidence scores on medium-risk tools | LLM self-reports confidence (0-1); enables future trust calibration without blocking execution |
-| Platform-specific extension tools | Operations unique to one platform (e.g. Gmail labels, Slack reactions) are separate tools, not forced into the generic interface |
-| Twitter identity verification before token storage | OAuth2 tokens are only persisted after a successful `GET /2/users/me` call, preventing storage of invalid or mismatched credentials |
+| Decision                                           | Rationale                                                                                                                                                                                                                                                                     |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PKCE by default, optional client_secret            | Desktop apps prefer PKCE; some providers (Slack) require a secret, which is stored in credential metadata for autonomous refresh                                                                                                                                              |
+| Shared connect orchestrator                        | All OAuth providers route through `orchestrateOAuthConnect()`, which resolves profiles, enforces scope policy, runs the flow, stores tokens, and verifies identity. Adding a provider is a declarative profile entry, not new orchestration code                              |
+| Canonical credential naming                        | Writes use `client_id`/`client_secret`; reads fall back to legacy `oauth_client_id`/`oauth_client_secret` for backward compatibility                                                                                                                                          |
+| Gateway callback transport                         | OAuth callbacks are now routed through the gateway at `${ingress.publicBaseUrl}/webhooks/oauth/callback` instead of a loopback redirect URI. This enables OAuth flows to work in remote and tunneled deployments.                                                             |
+| Unified `MessagingProvider` interface              | All platforms implement the same contract; generic tools work immediately for new providers                                                                                                                                                                                   |
+| Twitter outside unified messaging                  | Twitter is a broadcast/read platform, not a conversation platform — it doesn't fit the `MessagingProvider` contract                                                                                                                                                           |
+| Dual-path Twitter strategy                         | OAuth is more reliable for posting (no browser session dependency) but only supports post/reply. Browser path supports all operations. `auto` strategy gives the best of both: OAuth when possible, browser as fallback. User can override via `twitter-cli.ts strategy set`. |
+| Provider auto-selection                            | If only one provider is connected, tools skip the `platform` parameter — seamless single-platform UX                                                                                                                                                                          |
+| Token expiry in credential metadata                | Reuses existing `CredentialMetadata` store; `expiresAt` field enables proactive refresh with 5min buffer                                                                                                                                                                      |
+| Confidence scores on medium-risk tools             | LLM self-reports confidence (0-1); enables future trust calibration without blocking execution                                                                                                                                                                                |
+| Platform-specific extension tools                  | Operations unique to one platform (e.g. Gmail labels, Slack reactions) are separate tools, not forced into the generic interface                                                                                                                                              |
+| Twitter identity verification before token storage | OAuth2 tokens are only persisted after a successful `GET /2/users/me` call, preventing storage of invalid or mismatched credentials                                                                                                                                           |
 
 ### Source Files
 
-| File | Role |
-|------|------|
-| `assistant/src/security/oauth2.ts` | OAuth2 flow: PKCE or client_secret, Bun.serve callback, token exchange |
-| `assistant/src/security/token-manager.ts` | `withValidToken()` — auto-refresh, 401 retry, expiry buffer |
-| `assistant/src/messaging/provider.ts` | `MessagingProvider` interface |
-| `assistant/src/messaging/provider-types.ts` | Platform-agnostic types (Conversation, Message, SearchResult) |
-| `assistant/src/messaging/registry.ts` | Provider registry: register, lookup, list connected |
-| `assistant/src/messaging/activity-analyzer.ts` | Activity classification for conversations |
-| `assistant/src/messaging/style-analyzer.ts` | Writing style extraction from message corpus |
-| `assistant/src/messaging/draft-store.ts` | Local draft storage (platform/id JSON files) |
-| `assistant/src/messaging/providers/slack/` | Slack adapter, client, types |
-| `assistant/src/messaging/providers/gmail/` | Gmail adapter, client, types |
-| `assistant/src/config/bundled-skills/messaging/` | Unified messaging skill (SKILL.md, TOOLS.json, tools/) |
-| `assistant/src/watcher/providers/slack.ts` | Slack watcher for DMs, mentions, thread replies |
-| `assistant/src/watcher/providers/gmail.ts` | Gmail watcher using History API |
-| `assistant/src/watcher/providers/github.ts` | GitHub watcher for PRs, issues, review requests, and mentions |
-| `assistant/src/watcher/providers/linear.ts` | Linear watcher for assigned issues, status changes, and @mentions |
-| `assistant/src/oauth/provider-profiles.ts` | Provider profile registry: auth URLs, token URLs, scopes, policies, identity verifiers |
-| `assistant/src/oauth/connect-orchestrator.ts` | Shared OAuth connect orchestrator: profile resolution, scope policy, flow execution, token storage |
-| `assistant/src/oauth/scope-policy.ts` | Deterministic scope resolution and policy enforcement |
-| `assistant/src/oauth/connect-types.ts` | Shared types: `OAuthProviderProfile`, `OAuthScopePolicy`, `OAuthConnectResult` |
-| `assistant/src/oauth/token-persistence.ts` | Token storage helper: persists tokens, metadata, and runs post-connect hooks |
-| `assistant/src/daemon/handlers/oauth-connect.ts` | Generic OAuth connect IPC handler (`oauth_connect_start` / `oauth_connect_result`) |
-| `assistant/src/daemon/handlers/twitter-auth.ts` | Legacy Twitter OAuth2 flow handlers (`twitter_auth_start`, `twitter_auth_status`) |
-| `assistant/src/twitter/client.ts` | Twitter CDP client: GraphQL mutations/queries via Chrome DevTools Protocol |
-| `assistant/src/twitter/oauth-client.ts` | OAuth-backed Twitter client: X API v2 post/reply via stored tokens using `withValidToken()` |
-| `assistant/src/twitter/router.ts` | Strategy router: selects OAuth or browser path based on `twitterOperationStrategy` config |
-| `assistant/src/twitter/session.ts` | Twitter browser session persistence (cookie import/export) |
-| `assistant/src/cli/twitter.ts` | `vellum x` CLI command group (post, reply, strategy, refresh, status, login, logout, and read operations) |
-| `assistant/src/config/bundled-skills/twitter/SKILL.md` | X (Twitter) bundled skill instructions |
+| File                                             | Role                                                                                               |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `assistant/src/security/oauth2.ts`               | OAuth2 flow: PKCE or client_secret, Bun.serve callback, token exchange                             |
+| `assistant/src/security/token-manager.ts`        | `withValidToken()` — auto-refresh, 401 retry, expiry buffer                                        |
+| `assistant/src/messaging/provider.ts`            | `MessagingProvider` interface                                                                      |
+| `assistant/src/messaging/provider-types.ts`      | Platform-agnostic types (Conversation, Message, SearchResult)                                      |
+| `assistant/src/messaging/registry.ts`            | Provider registry: register, lookup, list connected                                                |
+| `assistant/src/messaging/activity-analyzer.ts`   | Activity classification for conversations                                                          |
+| `assistant/src/messaging/style-analyzer.ts`      | Writing style extraction from message corpus                                                       |
+| `assistant/src/messaging/draft-store.ts`         | Local draft storage (platform/id JSON files)                                                       |
+| `assistant/src/messaging/providers/slack/`       | Slack adapter, client, types                                                                       |
+| `assistant/src/messaging/providers/gmail/`       | Gmail adapter, client, types                                                                       |
+| `assistant/src/config/bundled-skills/messaging/` | Unified messaging skill (SKILL.md, TOOLS.json, tools/)                                             |
+| `assistant/src/watcher/providers/slack.ts`       | Slack watcher for DMs, mentions, thread replies                                                    |
+| `assistant/src/watcher/providers/gmail.ts`       | Gmail watcher using History API                                                                    |
+| `assistant/src/watcher/providers/github.ts`      | GitHub watcher for PRs, issues, review requests, and mentions                                      |
+| `assistant/src/watcher/providers/linear.ts`      | Linear watcher for assigned issues, status changes, and @mentions                                  |
+| `assistant/src/oauth/provider-profiles.ts`       | Provider profile registry: auth URLs, token URLs, scopes, policies, identity verifiers             |
+| `assistant/src/oauth/connect-orchestrator.ts`    | Shared OAuth connect orchestrator: profile resolution, scope policy, flow execution, token storage |
+| `assistant/src/oauth/scope-policy.ts`            | Deterministic scope resolution and policy enforcement                                              |
+| `assistant/src/oauth/connect-types.ts`           | Shared types: `OAuthProviderProfile`, `OAuthScopePolicy`, `OAuthConnectResult`                     |
+| `assistant/src/oauth/token-persistence.ts`       | Token storage helper: persists tokens, metadata, and runs post-connect hooks                       |
+| `assistant/src/daemon/handlers/oauth-connect.ts` | Generic OAuth connect IPC handler (`oauth_connect_start` / `oauth_connect_result`)                 |
+| `assistant/src/daemon/handlers/twitter-auth.ts`  | Legacy Twitter OAuth2 flow handlers (`twitter_auth_start`, `twitter_auth_status`)                  |
+| `assistant/src/twitter/client.ts`                | Twitter CDP client: GraphQL mutations/queries via Chrome DevTools Protocol                         |
+| `assistant/src/twitter/oauth-client.ts`          | OAuth-backed Twitter client: X API v2 post/reply via stored tokens using `withValidToken()`        |
+| `assistant/src/twitter/router.ts`                | Strategy router: selects OAuth or browser path based on `twitterOperationStrategy` config          |
+| `assistant/src/twitter/session.ts`               | Twitter browser session persistence (cookie import/export)                                         |
+| `skills/twitter/scripts/twitter-cli.ts`          | Twitter CLI script (post, reply, strategy, status, login, logout, and read operations)             |
+| `skills/twitter/SKILL.md`                        | X (Twitter) skill instructions                                                                     |
 
 ---
 
@@ -332,15 +332,15 @@ The OAuth extensibility layer makes adding a new OAuth provider a declarative op
 
 `assistant/src/oauth/provider-profiles.ts` contains the `PROVIDER_PROFILES` map — a canonical registry of well-known OAuth providers. Each profile (`OAuthProviderProfile`) declares:
 
-| Field | Purpose |
-|-------|---------|
-| `authUrl` / `tokenUrl` | OAuth2 authorization and token endpoints |
-| `defaultScopes` | Scopes requested on every connect attempt |
-| `scopePolicy` | Controls whether additional scopes are allowed (see Scope Policy below) |
-| `callbackTransport` | `'loopback'` (local redirect) or `'gateway'` (public ingress) |
-| `identityVerifier` | Async function that fetches human-readable account info (e.g. `@username`, email) after token exchange |
-| `setup` | Optional metadata for the generic OAuth setup skill (display name, dashboard URL, app type) |
-| `injectionTemplates` | Auto-applied credential injection rules for the script proxy |
+| Field                  | Purpose                                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| `authUrl` / `tokenUrl` | OAuth2 authorization and token endpoints                                                               |
+| `defaultScopes`        | Scopes requested on every connect attempt                                                              |
+| `scopePolicy`          | Controls whether additional scopes are allowed (see Scope Policy below)                                |
+| `callbackTransport`    | `'loopback'` (local redirect) or `'gateway'` (public ingress)                                          |
+| `identityVerifier`     | Async function that fetches human-readable account info (e.g. `@username`, email) after token exchange |
+| `setup`                | Optional metadata for the generic OAuth setup skill (display name, dashboard URL, app type)            |
+| `injectionTemplates`   | Auto-applied credential injection rules for the script proxy                                           |
 
 Registered providers: `integration:gmail`, `integration:slack`, `integration:notion`, `integration:twitter`. Short aliases (e.g. `gmail`, `twitter`) are resolved via `SERVICE_ALIASES`.
 
@@ -394,17 +394,16 @@ This replaces provider-specific IPC handlers — any provider in the registry ca
 
 ### Key Source Files
 
-| File | Role |
-|------|------|
-| `assistant/src/oauth/provider-profiles.ts` | Provider profile registry and alias resolution |
-| `assistant/src/oauth/scope-policy.ts` | Scope resolution and policy enforcement (pure, no I/O) |
-| `assistant/src/oauth/connect-orchestrator.ts` | Shared connect orchestrator (profile → scopes → flow → tokens) |
-| `assistant/src/oauth/connect-types.ts` | Shared types (`OAuthProviderProfile`, `OAuthScopePolicy`, `OAuthConnectResult`) |
-| `assistant/src/oauth/token-persistence.ts` | Token storage: keychain writes, metadata upsert, post-connect hooks |
-| `assistant/src/daemon/handlers/oauth-connect.ts` | Generic `oauth_connect_start` / `oauth_connect_result` IPC handler |
+| File                                             | Role                                                                            |
+| ------------------------------------------------ | ------------------------------------------------------------------------------- |
+| `assistant/src/oauth/provider-profiles.ts`       | Provider profile registry and alias resolution                                  |
+| `assistant/src/oauth/scope-policy.ts`            | Scope resolution and policy enforcement (pure, no I/O)                          |
+| `assistant/src/oauth/connect-orchestrator.ts`    | Shared connect orchestrator (profile → scopes → flow → tokens)                  |
+| `assistant/src/oauth/connect-types.ts`           | Shared types (`OAuthProviderProfile`, `OAuthScopePolicy`, `OAuthConnectResult`) |
+| `assistant/src/oauth/token-persistence.ts`       | Token storage: keychain writes, metadata upsert, post-connect hooks             |
+| `assistant/src/daemon/handlers/oauth-connect.ts` | Generic `oauth_connect_start` / `oauth_connect_result` IPC handler              |
 
 ---
-
 
 ---
 
@@ -536,14 +535,14 @@ sequenceDiagram
 
 **Policy decisions** are deterministic and structured:
 
-| Decision | Meaning |
-|---|---|
-| `matched` | Exactly one credential template matches the host — inject it |
-| `ambiguous` | Multiple credential templates match — caller must disambiguate |
-| `missing` | Credentials exist but none match this host — no rewrite |
-| `unauthenticated` | No credentials configured for the session |
+| Decision                 | Meaning                                                                    |
+| ------------------------ | -------------------------------------------------------------------------- |
+| `matched`                | Exactly one credential template matches the host — inject it               |
+| `ambiguous`              | Multiple credential templates match — caller must disambiguate             |
+| `missing`                | Credentials exist but none match this host — no rewrite                    |
+| `unauthenticated`        | No credentials configured for the session                                  |
 | `ask_missing_credential` | A known template pattern matches but no credential is bound to the session |
-| `ask_unauthenticated` | Completely unknown host — prompt for unauthenticated access |
+| `ask_unauthenticated`    | Completely unknown host — prompt for unauthenticated access                |
 
 **Trust rule persistence**: The `createProxyApprovalCallback` in `session-tool-setup.ts` is wired into the session startup path and routes policy "ask" decisions through the existing `PermissionPrompter` UI. Trust rules use the `network_request` tool name (not `proxy:*`) with URL-based scope patterns (e.g., `https://api.example.com/*`), aligning with the `buildCommandCandidates()` allowlist generation in `checker.ts`.
 
@@ -566,10 +565,10 @@ Each proxy session is bound to a conversation and tracks authorized credential I
 
 The proxy generates and manages a local Certificate Authority for MITM interception:
 
-| Component | Location | Purpose |
-|---|---|---|
-| CA cert | `{dataDir}/proxy-ca/ca.pem` | Self-signed root cert (valid 10 years, permissions 0644) |
-| CA key | `{dataDir}/proxy-ca/ca-key.pem` | CA private key (permissions 0600) |
+| Component  | Location                                   | Purpose                                                  |
+| ---------- | ------------------------------------------ | -------------------------------------------------------- |
+| CA cert    | `{dataDir}/proxy-ca/ca.pem`                | Self-signed root cert (valid 10 years, permissions 0644) |
+| CA key     | `{dataDir}/proxy-ca/ca-key.pem`            | CA private key (permissions 0600)                        |
 | Leaf certs | `{dataDir}/proxy-ca/issued/{hostname}.pem` | Per-hostname certs (cached, verified against current CA) |
 
 `ensureLocalCA()` is idempotent — it only generates the CA if the files do not already exist. Leaf certificates are cached and revalidated via `X509Certificate.checkIssued()` to detect stale certs from a previous CA.
@@ -602,20 +601,20 @@ The proxy subsystem intercepts outbound HTTPS requests and injects stored creden
 
 ### Key Source Files
 
-| File | Role |
-|---|---|
-| `assistant/src/tools/network/script-proxy/server.ts` | Proxy server factory — HTTP forwarding, CONNECT handling, MITM dispatch |
-| `assistant/src/tools/network/script-proxy/policy.ts` | Policy engine — evaluates requests against credential templates |
-| `assistant/src/tools/network/script-proxy/mitm-handler.ts` | MITM TLS interception — loopback TLS server, request rewrite, upstream forwarding |
-| `assistant/src/tools/network/script-proxy/connect-tunnel.ts` | Plain CONNECT tunnel — raw TCP bidirectional pipe |
-| `assistant/src/tools/network/script-proxy/http-forwarder.ts` | HTTP proxy forwarder — absolute-URL form forwarding with policy callback |
-| `assistant/src/tools/network/script-proxy/session-manager.ts` | Session lifecycle — create, start, stop, idle timeout, env var generation |
-| `assistant/src/tools/network/script-proxy/certs.ts` | Local CA management — ensureLocalCA, issueLeafCert, getCAPath |
-| `assistant/src/tools/network/script-proxy/logging.ts` | Log sanitization (header/URL redaction) and safe decision trace builders for policy and credential resolution |
-| `assistant/src/tools/network/script-proxy/types.ts` | Type definitions — session, policy decisions, approval callback |
-| `assistant/src/tools/executor.ts` | `persistentDecisionsAllowed` gate — disables trust rule saving for proxied bash |
-| `assistant/src/daemon/session-tool-setup.ts` | `createProxyApprovalCallback` — wired into session startup, uses `network_request` tool name with URL-based trust rules |
-| `assistant/src/permissions/checker.ts` | `network_request` trust rule matching and risk classification (Medium) |
+| File                                                          | Role                                                                                                                    |
+| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `assistant/src/tools/network/script-proxy/server.ts`          | Proxy server factory — HTTP forwarding, CONNECT handling, MITM dispatch                                                 |
+| `assistant/src/tools/network/script-proxy/policy.ts`          | Policy engine — evaluates requests against credential templates                                                         |
+| `assistant/src/tools/network/script-proxy/mitm-handler.ts`    | MITM TLS interception — loopback TLS server, request rewrite, upstream forwarding                                       |
+| `assistant/src/tools/network/script-proxy/connect-tunnel.ts`  | Plain CONNECT tunnel — raw TCP bidirectional pipe                                                                       |
+| `assistant/src/tools/network/script-proxy/http-forwarder.ts`  | HTTP proxy forwarder — absolute-URL form forwarding with policy callback                                                |
+| `assistant/src/tools/network/script-proxy/session-manager.ts` | Session lifecycle — create, start, stop, idle timeout, env var generation                                               |
+| `assistant/src/tools/network/script-proxy/certs.ts`           | Local CA management — ensureLocalCA, issueLeafCert, getCAPath                                                           |
+| `assistant/src/tools/network/script-proxy/logging.ts`         | Log sanitization (header/URL redaction) and safe decision trace builders for policy and credential resolution           |
+| `assistant/src/tools/network/script-proxy/types.ts`           | Type definitions — session, policy decisions, approval callback                                                         |
+| `assistant/src/tools/executor.ts`                             | `persistentDecisionsAllowed` gate — disables trust rule saving for proxied bash                                         |
+| `assistant/src/daemon/session-tool-setup.ts`                  | `createProxyApprovalCallback` — wired into session startup, uses `network_request` tool name with URL-based trust rules |
+| `assistant/src/permissions/checker.ts`                        | `network_request` trust rule matching and risk classification (Medium)                                                  |
 
 ### Runtime Wiring Summary
 
@@ -690,13 +689,13 @@ graph TB
 
 ### Search Capabilities
 
-| Parameter | Type | Description |
-|---|---|---|
-| `mime_type` | string | MIME type filter with wildcard support (`image/*`, `application/pdf`) |
-| `filename` | string | Case-insensitive substring match on original filename |
-| `recency` | enum | Time-based filter: `last_hour`, `last_24_hours`, `last_7_days`, `last_30_days`, `last_90_days` |
-| `conversation_id` | string | Scope results to attachments in a specific conversation |
-| `limit` | number | Maximum results (default 20, max 100) |
+| Parameter         | Type   | Description                                                                                    |
+| ----------------- | ------ | ---------------------------------------------------------------------------------------------- |
+| `mime_type`       | string | MIME type filter with wildcard support (`image/*`, `application/pdf`)                          |
+| `filename`        | string | Case-insensitive substring match on original filename                                          |
+| `recency`         | enum   | Time-based filter: `last_hour`, `last_24_hours`, `last_7_days`, `last_30_days`, `last_90_days` |
+| `conversation_id` | string | Scope results to attachments in a specific conversation                                        |
+| `limit`           | number | Maximum results (default 20, max 100)                                                          |
 
 ### Materialize Safeguards
 
@@ -707,13 +706,12 @@ graph TB
 
 ### Key Source Files
 
-| File | Role |
-|---|---|
-| `assistant/src/tools/assets/search.ts` | `asset_search` tool — cross-thread attachment metadata search with visibility filtering |
-| `assistant/src/tools/assets/materialize.ts` | `asset_materialize` tool — decode and write attachment to sandbox path |
-| `assistant/src/daemon/media-visibility-policy.ts` | Pure policy module — `isAttachmentVisible()`, `filterVisibleAttachments()` |
-| `assistant/src/memory/schema.ts` | `attachments` and `message_attachments` table schemas |
-| `assistant/src/memory/conversation-store.ts` | `getConversationThreadType()` — thread type lookup for visibility context |
+| File                                              | Role                                                                                    |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `assistant/src/tools/assets/search.ts`            | `asset_search` tool — cross-thread attachment metadata search with visibility filtering |
+| `assistant/src/tools/assets/materialize.ts`       | `asset_materialize` tool — decode and write attachment to sandbox path                  |
+| `assistant/src/daemon/media-visibility-policy.ts` | Pure policy module — `isAttachmentVisible()`, `filterVisibleAttachments()`              |
+| `assistant/src/memory/schema.ts`                  | `attachments` and `message_attachments` table schemas                                   |
+| `assistant/src/memory/conversation-store.ts`      | `getConversationThreadType()` — thread type lookup for visibility context               |
 
 ---
-

--- a/assistant/scripts/capture-x-graphql.ts
+++ b/assistant/scripts/capture-x-graphql.ts
@@ -3,7 +3,7 @@
  * Capture X.com GraphQL API calls via Chrome CDP.
  *
  * Usage:
- *   1. Make sure Chrome is running with CDP (vellum x refresh will do this)
+ *   1. Make sure Chrome is running with remote debugging enabled (--remote-debugging-port=9222)
  *   2. Run: bun run scripts/capture-x-graphql.ts [--auto] [--all]
  *   3. In --auto mode, Chrome is navigated automatically. Otherwise browse X manually.
  *   4. Press Ctrl+C to stop (or wait for --auto to finish).
@@ -13,24 +13,39 @@
  *   --all   Capture ALL GraphQL queries (skip relevance filter)
  */
 
-import { existsSync,mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync } from "node:fs";
 
-const CDP_BASE = 'http://localhost:9222';
-const CAPTURE_DIR = '/tmp/x-graphql-capture';
+const CDP_BASE = "http://localhost:9222";
+const CAPTURE_DIR = "/tmp/x-graphql-capture";
 
 // ─── Relevance filter ────────────────────────────────────────────────────────
 
 const RELEVANT_QUERIES = new Set([
   // Reads
-  'UserByScreenName', 'UserTweets', 'TweetDetail', 'TweetResultByRestId',
-  'SearchTimeline', 'Bookmarks', 'Likes', 'Favoriters',
-  'Followers', 'Following', 'HomeTimeline', 'HomeLatestTimeline',
-  'NotificationsTimeline', 'ListTimeline',
-  'UserMedia',
+  "UserByScreenName",
+  "UserTweets",
+  "TweetDetail",
+  "TweetResultByRestId",
+  "SearchTimeline",
+  "Bookmarks",
+  "Likes",
+  "Favoriters",
+  "Followers",
+  "Following",
+  "HomeTimeline",
+  "HomeLatestTimeline",
+  "NotificationsTimeline",
+  "ListTimeline",
+  "UserMedia",
   // Writes
-  'CreateTweet', 'DeleteTweet', 'FavoriteTweet',
-  'UnfavoriteTweet', 'CreateRetweet', 'DeleteRetweet', 'CreateBookmark',
-  'DeleteBookmark',
+  "CreateTweet",
+  "DeleteTweet",
+  "FavoriteTweet",
+  "UnfavoriteTweet",
+  "CreateRetweet",
+  "DeleteRetweet",
+  "CreateBookmark",
+  "DeleteBookmark",
 ]);
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -50,28 +65,50 @@ interface CapturedQuery {
 class CDPClient {
   private ws: WebSocket | null = null;
   private nextId = 1;
-  private callbacks = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
-  private eventHandlers = new Map<string, Array<(params: Record<string, unknown>) => void>>();
+  private callbacks = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+  >();
+  private eventHandlers = new Map<
+    string,
+    Array<(params: Record<string, unknown>) => void>
+  >();
 
   async connect(wsUrl: string): Promise<void> {
     return new Promise((resolve, reject) => {
       const ws = new WebSocket(wsUrl);
-      ws.onopen = () => { this.ws = ws; resolve(); };
+      ws.onopen = () => {
+        this.ws = ws;
+        resolve();
+      };
       ws.onerror = (e) => reject(new Error(`CDP error: ${e}`));
-      ws.onclose = () => { this.ws = null; };
+      ws.onclose = () => {
+        this.ws = null;
+      };
       ws.onmessage = (event) => {
         const msg = JSON.parse(String(event.data));
         if (msg.id != null) {
           const cb = this.callbacks.get(msg.id);
-          if (cb) { this.callbacks.delete(msg.id); if (msg.error) { cb.reject(new Error(msg.error.message)); } else { cb.resolve(msg.result); } }
+          if (cb) {
+            this.callbacks.delete(msg.id);
+            if (msg.error) {
+              cb.reject(new Error(msg.error.message));
+            } else {
+              cb.resolve(msg.result);
+            }
+          }
         } else if (msg.method) {
-          for (const h of this.eventHandlers.get(msg.method) ?? []) h(msg.params ?? {});
+          for (const h of this.eventHandlers.get(msg.method) ?? [])
+            h(msg.params ?? {});
         }
       };
     });
   }
 
-  async send(method: string, params?: Record<string, unknown>): Promise<unknown> {
+  async send(
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<unknown> {
     const id = this.nextId++;
     return new Promise((resolve, reject) => {
       this.callbacks.set(id, { resolve, reject });
@@ -85,14 +122,16 @@ class CDPClient {
     this.eventHandlers.set(event, list);
   }
 
-  close() { this.ws?.close(); }
+  close() {
+    this.ws?.close();
+  }
 }
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
 const args = process.argv.slice(2);
-const autoMode = args.includes('--auto');
-const captureAll = args.includes('--all');
+const autoMode = args.includes("--auto");
+const captureAll = args.includes("--all");
 
 const captured: CapturedQuery[] = [];
 const seenQueries = new Set<string>();
@@ -113,7 +152,7 @@ interface GuideStep {
 async function getScreenName(): Promise<string | null> {
   if (!navigationClient) return null;
   try {
-    const result = await navigationClient.send('Runtime.evaluate', {
+    const result = (await navigationClient.send("Runtime.evaluate", {
       expression: `
         (function() {
           const link = document.querySelector('a[data-testid="AppTabBar_Profile_Link"]');
@@ -123,7 +162,7 @@ async function getScreenName(): Promise<string | null> {
       `,
       awaitPromise: false,
       returnByValue: true,
-    }) as { result?: { value?: string | null } };
+    })) as { result?: { value?: string | null } };
     return result?.result?.value ?? null;
   } catch {
     return null;
@@ -132,55 +171,55 @@ async function getScreenName(): Promise<string | null> {
 
 const GUIDE_STEPS: GuideStep[] = [
   {
-    label: 'Home timeline',
-    url: 'https://x.com/home',
-    expectedQueries: ['HomeTimeline', 'HomeLatestTimeline'],
+    label: "Home timeline",
+    url: "https://x.com/home",
+    expectedQueries: ["HomeTimeline", "HomeLatestTimeline"],
   },
   {
-    label: 'Profile',
+    label: "Profile",
     // URL set dynamically in runAutoMode after resolving screen name
     clickSelector: 'a[data-testid="AppTabBar_Profile_Link"]',
-    expectedQueries: ['UserByScreenName', 'UserTweets'],
+    expectedQueries: ["UserByScreenName", "UserTweets"],
   },
   {
-    label: 'Tweet detail',
+    label: "Tweet detail",
     clickSelector: 'article[data-testid="tweet"] a[href*="/status/"]',
-    expectedQueries: ['TweetDetail'],
+    expectedQueries: ["TweetDetail"],
   },
   {
-    label: 'Search',
-    url: 'https://x.com/search?q=hello&src=typed_query',
-    expectedQueries: ['SearchTimeline'],
+    label: "Search",
+    url: "https://x.com/search?q=hello&src=typed_query",
+    expectedQueries: ["SearchTimeline"],
   },
   {
-    label: 'Bookmarks',
-    url: 'https://x.com/i/bookmarks',
-    expectedQueries: ['Bookmarks'],
+    label: "Bookmarks",
+    url: "https://x.com/i/bookmarks",
+    expectedQueries: ["Bookmarks"],
   },
   {
-    label: 'Notifications',
-    url: 'https://x.com/notifications',
-    expectedQueries: ['NotificationsTimeline'],
+    label: "Notifications",
+    url: "https://x.com/notifications",
+    expectedQueries: ["NotificationsTimeline"],
   },
   {
-    label: 'Likes',
+    label: "Likes",
     // URL set dynamically
-    expectedQueries: ['Likes'],
+    expectedQueries: ["Likes"],
   },
   {
-    label: 'Followers',
+    label: "Followers",
     // URL set dynamically
-    expectedQueries: ['Followers'],
+    expectedQueries: ["Followers"],
   },
   {
-    label: 'Following',
+    label: "Following",
     // URL set dynamically
-    expectedQueries: ['Following'],
+    expectedQueries: ["Following"],
   },
   {
-    label: 'Media',
+    label: "Media",
     // URL set dynamically
-    expectedQueries: ['UserMedia'],
+    expectedQueries: ["UserMedia"],
   },
 ];
 
@@ -188,14 +227,20 @@ const GUIDE_STEPS: GuideStep[] = [
 
 const res = await fetch(`${CDP_BASE}/json/list`);
 if (!res.ok) {
-  console.error('Chrome CDP not available. Run `vellum x refresh` first.');
+  console.error(
+    "Chrome CDP not available. Start Chrome with --remote-debugging-port=9222.",
+  );
   process.exit(1);
 }
-const targets = (await res.json()) as Array<{ type: string; url: string; webSocketDebuggerUrl: string }>;
-const pages = targets.filter(t => t.type === 'page');
+const targets = (await res.json()) as Array<{
+  type: string;
+  url: string;
+  webSocketDebuggerUrl: string;
+}>;
+const pages = targets.filter((t) => t.type === "page");
 
 if (pages.length === 0) {
-  console.error('No pages found in Chrome.');
+  console.error("No pages found in Chrome.");
   process.exit(1);
 }
 
@@ -216,9 +261,12 @@ function notifyQuerySeen(queryName: string) {
   }
 }
 
-function waitForAnyQuery(queryNames: string[], timeoutMs = 15000): Promise<boolean> {
-  if (queryNames.some(q => seenQueries.has(q))) return Promise.resolve(true);
-  return new Promise(resolve => {
+function waitForAnyQuery(
+  queryNames: string[],
+  timeoutMs = 15000,
+): Promise<boolean> {
+  if (queryNames.some((q) => seenQueries.has(q))) return Promise.resolve(true);
+  return new Promise((resolve) => {
     const timer = setTimeout(() => {
       for (const q of queryNames) queryWaiters.delete(q);
       resolve(false);
@@ -241,22 +289,22 @@ let navigationClient: CDPClient | null = null;
 for (const page of pages) {
   const client = new CDPClient();
   await client.connect(page.webSocketDebuggerUrl);
-  await client.send('Network.enable');
+  await client.send("Network.enable");
 
   // Track which client is on an x.com tab for navigation
-  if (page.url.includes('x.com') || page.url.includes('twitter.com')) {
+  if (page.url.includes("x.com") || page.url.includes("twitter.com")) {
     navigationClient = client;
   }
 
-  client.on('Network.requestWillBeSent', (params) => {
+  client.on("Network.requestWillBeSent", (params) => {
     const req = params.request as Record<string, unknown> | undefined;
     const url = (req?.url ?? params.url) as string | undefined;
-    if (!url?.includes('/i/api/graphql/')) return;
+    if (!url?.includes("/i/api/graphql/")) return;
 
     const match = url.match(/\/graphql\/([^/]+)\/([^?]+)/);
-    const queryId = match?.[1] ?? 'unknown';
-    const queryName = match?.[2] ?? 'unknown';
-    const method = (req?.method as string) ?? 'GET';
+    const queryId = match?.[1] ?? "unknown";
+    const queryName = match?.[2] ?? "unknown";
+    const method = (req?.method as string) ?? "GET";
 
     // Apply relevance filter
     if (!captureAll && !RELEVANT_QUERIES.has(queryName)) return;
@@ -264,30 +312,42 @@ for (const page of pages) {
     let variables: unknown = undefined;
     let features: unknown = undefined;
 
-    if (method === 'POST' && req?.postData) {
+    if (method === "POST" && req?.postData) {
       try {
         const body = JSON.parse(req.postData as string);
         variables = body.variables;
         features = body.features;
-      } catch { /* ignore */ }
-    } else if (method === 'GET') {
+      } catch {
+        /* ignore */
+      }
+    } else if (method === "GET") {
       try {
         const u = new URL(url);
-        const v = u.searchParams.get('variables');
+        const v = u.searchParams.get("variables");
         if (v) variables = JSON.parse(v);
-        const f = u.searchParams.get('features');
+        const f = u.searchParams.get("features");
         if (f) features = JSON.parse(f);
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
     }
 
     console.log(`\n>>> ${method} ${queryName} (${queryId})`);
-    if (variables) console.log(`    variables: ${JSON.stringify(variables).slice(0, 200)}`);
+    if (variables)
+      console.log(`    variables: ${JSON.stringify(variables).slice(0, 200)}`);
 
     pendingRequests.set(params.requestId as string, { url, queryName });
-    captured.push({ queryName, queryId, method, variables, features, timestamp: Date.now() });
+    captured.push({
+      queryName,
+      queryId,
+      method,
+      variables,
+      features,
+      timestamp: Date.now(),
+    });
   });
 
-  client.on('Network.responseReceived', (params) => {
+  client.on("Network.responseReceived", (params) => {
     const requestId = params.requestId as string;
     const pending = pendingRequests.get(requestId);
     if (!pending) return;
@@ -297,31 +357,47 @@ for (const page of pages) {
     console.log(`    <<< ${status}`);
 
     // Get full response body
-    client.send('Network.getResponseBody', { requestId }).then((result) => {
-      const body = (result as Record<string, unknown>).body as string;
-      try {
-        const json = JSON.parse(body);
-        // Attach full response to the captured entry
-        const entry = [...captured].reverse().find(e => e.queryName === pending.queryName && !e.response);
-        if (entry) {
-          entry.response = json;
+    client
+      .send("Network.getResponseBody", { requestId })
+      .then((result) => {
+        const body = (result as Record<string, unknown>).body as string;
+        try {
+          const json = JSON.parse(body);
+          // Attach full response to the captured entry
+          const entry = [...captured]
+            .reverse()
+            .find((e) => e.queryName === pending.queryName && !e.response);
+          if (entry) {
+            entry.response = json;
 
-          // Write individual file
-          const filename = `${pending.queryName}-${entry.timestamp}.json`;
-          Bun.write(`${CAPTURE_DIR}/${filename}`, JSON.stringify({
-            queryName: entry.queryName,
-            queryId: entry.queryId,
-            method: entry.method,
-            variables: entry.variables,
-            features: entry.features,
-            response: json,
-          }, null, 2));
+            // Write individual file
+            const filename = `${pending.queryName}-${entry.timestamp}.json`;
+            Bun.write(
+              `${CAPTURE_DIR}/${filename}`,
+              JSON.stringify(
+                {
+                  queryName: entry.queryName,
+                  queryId: entry.queryId,
+                  method: entry.method,
+                  variables: entry.variables,
+                  features: entry.features,
+                  response: json,
+                },
+                null,
+                2,
+              ),
+            );
+          }
+
+          // Notify waiters
+          notifyQuerySeen(pending.queryName);
+        } catch {
+          /* ignore */
         }
-
-        // Notify waiters
-        notifyQuerySeen(pending.queryName);
-      } catch { /* ignore */ }
-    }).catch(() => { /* body not available */ });
+      })
+      .catch(() => {
+        /* body not available */
+      });
 
     pendingRequests.delete(requestId);
   });
@@ -337,15 +413,15 @@ if (!navigationClient && pages.length > 0) {
 
 async function navigateTo(url: string): Promise<void> {
   if (!navigationClient) return;
-  await navigationClient.send('Page.navigate', { url });
+  await navigationClient.send("Page.navigate", { url });
   // Wait for page to load
-  await new Promise(r => setTimeout(r, 3000));
+  await new Promise((r) => setTimeout(r, 3000));
 }
 
 async function clickElement(selector: string): Promise<boolean> {
   if (!navigationClient) return false;
   try {
-    const result = await navigationClient.send('Runtime.evaluate', {
+    const result = (await navigationClient.send("Runtime.evaluate", {
       expression: `
         (function() {
           const el = document.querySelector(${JSON.stringify(selector)});
@@ -357,7 +433,7 @@ async function clickElement(selector: string): Promise<boolean> {
       `,
       awaitPromise: false,
       returnByValue: true,
-    }) as { result?: { value?: boolean } };
+    })) as { result?: { value?: boolean } };
     return result?.result?.value === true;
   } catch {
     return false;
@@ -367,44 +443,52 @@ async function clickElement(selector: string): Promise<boolean> {
 async function scrollDown(): Promise<void> {
   if (!navigationClient) return;
   try {
-    await navigationClient.send('Runtime.evaluate', {
-      expression: 'window.scrollBy(0, 800)',
+    await navigationClient.send("Runtime.evaluate", {
+      expression: "window.scrollBy(0, 800)",
       awaitPromise: false,
     });
-  } catch { /* ignore */ }
+  } catch {
+    /* ignore */
+  }
 }
 
 // ─── Auto mode ───────────────────────────────────────────────────────────────
 
 async function runAutoMode() {
-  console.log('\n🚗 Auto mode: navigating Chrome through X.com...\n');
+  console.log("\n🚗 Auto mode: navigating Chrome through X.com...\n");
 
   // Enable Page domain for navigation
   if (navigationClient) {
-    await navigationClient.send('Page.enable').catch(() => {});
+    await navigationClient.send("Page.enable").catch(() => {});
   }
 
   // Navigate to home first to discover the screen name
-  await navigateTo('https://x.com/home');
+  await navigateTo("https://x.com/home");
   const screenName = await getScreenName();
   if (screenName) {
     console.log(`  Detected user: @${screenName}\n`);
     // Fill in profile-based URLs
     for (const step of GUIDE_STEPS) {
-      if (step.label === 'Likes') step.url = `https://x.com/${screenName}/likes`;
-      if (step.label === 'Followers') step.url = `https://x.com/${screenName}/followers`;
-      if (step.label === 'Following') step.url = `https://x.com/${screenName}/following`;
-      if (step.label === 'Media') step.url = `https://x.com/${screenName}/media`;
+      if (step.label === "Likes")
+        step.url = `https://x.com/${screenName}/likes`;
+      if (step.label === "Followers")
+        step.url = `https://x.com/${screenName}/followers`;
+      if (step.label === "Following")
+        step.url = `https://x.com/${screenName}/following`;
+      if (step.label === "Media")
+        step.url = `https://x.com/${screenName}/media`;
     }
   } else {
-    console.log('  Could not detect screen name — some steps will use click navigation\n');
+    console.log(
+      "  Could not detect screen name — some steps will use click navigation\n",
+    );
   }
 
   const completedSteps: string[] = [];
   const failedSteps: string[] = [];
 
   for (const step of GUIDE_STEPS) {
-    const alreadySeen = step.expectedQueries.some(q => seenQueries.has(q));
+    const alreadySeen = step.expectedQueries.some((q) => seenQueries.has(q));
     if (alreadySeen) {
       console.log(`  ✓ ${step.label} (already captured)`);
       completedSteps.push(step.label);
@@ -420,15 +504,15 @@ async function runAutoMode() {
 
     // Click if selector provided
     if (step.clickSelector) {
-      await new Promise(r => setTimeout(r, 1500)); // wait for page to settle
+      await new Promise((r) => setTimeout(r, 1500)); // wait for page to settle
       const clicked = await clickElement(step.clickSelector);
       if (!clicked) {
         // Try scrolling and clicking again
         await scrollDown();
-        await new Promise(r => setTimeout(r, 1000));
+        await new Promise((r) => setTimeout(r, 1000));
         await clickElement(step.clickSelector);
       }
-      await new Promise(r => setTimeout(r, 2000)); // wait for navigation
+      await new Promise((r) => setTimeout(r, 2000)); // wait for navigation
     }
 
     // Scroll to trigger lazy-loaded content
@@ -438,18 +522,22 @@ async function runAutoMode() {
     const seen = await waitForAnyQuery(step.expectedQueries, 10000);
 
     if (seen) {
-      const captured = step.expectedQueries.filter(q => seenQueries.has(q));
-      console.log(`\r  ✅ ${step.label} → ${captured.join(', ')}`);
+      const captured = step.expectedQueries.filter((q) => seenQueries.has(q));
+      console.log(`\r  ✅ ${step.label} → ${captured.join(", ")}`);
       completedSteps.push(step.label);
     } else {
-      console.log(`\r  ⚠️  ${step.label} → no queries captured (page may need manual interaction)`);
+      console.log(
+        `\r  ⚠️  ${step.label} → no queries captured (page may need manual interaction)`,
+      );
       failedSteps.push(step.label);
     }
   }
 
-  console.log(`\n🏁 Auto navigation complete: ${completedSteps.length}/${GUIDE_STEPS.length} steps succeeded`);
+  console.log(
+    `\n🏁 Auto navigation complete: ${completedSteps.length}/${GUIDE_STEPS.length} steps succeeded`,
+  );
   if (failedSteps.length > 0) {
-    console.log(`   Missed: ${failedSteps.join(', ')}`);
+    console.log(`   Missed: ${failedSteps.join(", ")}`);
   }
 
   // Finish
@@ -460,32 +548,35 @@ async function runAutoMode() {
 // ─── Summary ─────────────────────────────────────────────────────────────────
 
 function printSummary() {
-  console.log(`\n\n${'='.repeat(60)}`);
+  console.log(`\n\n${"=".repeat(60)}`);
   console.log(`  Captured ${captured.length} GraphQL requests`);
-  console.log(`${'='.repeat(60)}\n`);
+  console.log(`${"=".repeat(60)}\n`);
 
   // Dedupe by queryName
   const seen = new Set<string>();
-  const unique = captured.filter(q => {
+  const unique = captured.filter((q) => {
     if (seen.has(q.queryName)) return false;
     seen.add(q.queryName);
     return true;
   });
 
   // Print table
-  const nameWidth = Math.max(25, ...unique.map(q => q.queryName.length));
+  const nameWidth = Math.max(25, ...unique.map((q) => q.queryName.length));
   const idWidth = 22;
   const methodWidth = 6;
 
   console.log(
-    `  ${'Query'.padEnd(nameWidth)}  ${'QueryID'.padEnd(idWidth)}  ${'Method'.padEnd(methodWidth)}  Variables`,
+    `  ${"Query".padEnd(nameWidth)}  ${"QueryID".padEnd(idWidth)}  ${"Method".padEnd(methodWidth)}  Variables`,
   );
-  console.log(`  ${'─'.repeat(nameWidth)}  ${'─'.repeat(idWidth)}  ${'─'.repeat(methodWidth)}  ${'─'.repeat(30)}`);
+  console.log(
+    `  ${"─".repeat(nameWidth)}  ${"─".repeat(idWidth)}  ${"─".repeat(methodWidth)}  ${"─".repeat(30)}`,
+  );
 
   for (const q of unique) {
-    const varKeys = q.variables && typeof q.variables === 'object'
-      ? Object.keys(q.variables as Record<string, unknown>).join(', ')
-      : '—';
+    const varKeys =
+      q.variables && typeof q.variables === "object"
+        ? Object.keys(q.variables as Record<string, unknown>).join(", ")
+        : "—";
     console.log(
       `  ${q.queryName.padEnd(nameWidth)}  ${q.queryId.padEnd(idWidth)}  ${q.method.padEnd(methodWidth)}  ${varKeys}`,
     );
@@ -493,14 +584,14 @@ function printSummary() {
 
   // Gap analysis
   if (!captureAll) {
-    const notSeen = [...RELEVANT_QUERIES].filter(q => !seenQueries.has(q));
+    const notSeen = [...RELEVANT_QUERIES].filter((q) => !seenQueries.has(q));
     if (notSeen.length > 0) {
       console.log(`\n  ⚠️  Not captured (${notSeen.length}):`);
       for (const q of notSeen) {
         console.log(`     • ${q}`);
       }
     } else {
-      console.log('\n  ✅ All relevant queries captured!');
+      console.log("\n  ✅ All relevant queries captured!");
     }
   }
 
@@ -509,15 +600,18 @@ function printSummary() {
   const summary = {
     capturedAt: new Date().toISOString(),
     totalRequests: captured.length,
-    uniqueQueries: unique.map(q => ({
+    uniqueQueries: unique.map((q) => ({
       queryName: q.queryName,
       queryId: q.queryId,
       method: q.method,
-      variableKeys: q.variables && typeof q.variables === 'object'
-        ? Object.keys(q.variables as Record<string, unknown>)
-        : [],
+      variableKeys:
+        q.variables && typeof q.variables === "object"
+          ? Object.keys(q.variables as Record<string, unknown>)
+          : [],
     })),
-    notCaptured: captureAll ? [] : [...RELEVANT_QUERIES].filter(q => !seenQueries.has(q)),
+    notCaptured: captureAll
+      ? []
+      : [...RELEVANT_QUERIES].filter((q) => !seenQueries.has(q)),
   };
   Bun.write(summaryPath, JSON.stringify(summary, null, 2));
   console.log(`\n  Summary saved to ${summaryPath}`);
@@ -527,19 +621,23 @@ function printSummary() {
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 if (autoMode) {
-  console.log('\nRecording X.com GraphQL requests (auto mode)...');
-  console.log(`Filter: ${captureAll ? 'ALL queries' : `${RELEVANT_QUERIES.size} relevant queries`}`);
+  console.log("\nRecording X.com GraphQL requests (auto mode)...");
+  console.log(
+    `Filter: ${captureAll ? "ALL queries" : `${RELEVANT_QUERIES.size} relevant queries`}`,
+  );
   // Give network listeners a moment to settle, then start auto-navigation
   setTimeout(() => runAutoMode(), 1000);
 } else {
-  console.log('\nRecording X.com GraphQL requests...');
-  console.log(`Filter: ${captureAll ? 'ALL queries' : `${RELEVANT_QUERIES.size} relevant queries`}`);
-  console.log('Browse X in Chrome — visit a profile, scroll tweets, search.');
-  console.log('Press Ctrl+C to stop and dump results.\n');
+  console.log("\nRecording X.com GraphQL requests...");
+  console.log(
+    `Filter: ${captureAll ? "ALL queries" : `${RELEVANT_QUERIES.size} relevant queries`}`,
+  );
+  console.log("Browse X in Chrome — visit a profile, scroll tweets, search.");
+  console.log("Press Ctrl+C to stop and dump results.\n");
 }
 
 // Ctrl+C handler
-process.on('SIGINT', () => {
+process.on("SIGINT", () => {
   printSummary();
   process.exit(0);
 });

--- a/assistant/src/__tests__/twitter-cli-routing.test.ts
+++ b/assistant/src/__tests__/twitter-cli-routing.test.ts
@@ -199,7 +199,7 @@ describe("Twitter strategy router", () => {
           suggestAlternative: string;
         };
         expect(e.message).toContain("OAuth is not configured");
-        expect(e.message).toContain("vellum x strategy set browser");
+        expect(e.message).toContain("switch to browser strategy");
         expect(e.pathUsed).toBe("oauth");
         expect(e.suggestAlternative).toBe("browser");
       }

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -896,7 +896,7 @@ function buildDynamicSkillWorkflowSection(
     lines.push(
       "",
       "### X (Twitter) Skill",
-      'When the user asks to post, reply, or interact with X/Twitter, load the "twitter" skill using `skill_load`. Do NOT use computer-use or the browser skill for X — the X skill provides CLI commands (`vellum x post`, `vellum x reply`) that are faster and more reliable.',
+      'When the user asks to post, reply, or interact with X/Twitter, load the "twitter" skill using `skill_load`. Do NOT use computer-use or the browser skill for X — the twitter skill provides optimized CLI commands that are faster and more reliable.',
     );
   }
 

--- a/assistant/src/twitter/router.ts
+++ b/assistant/src/twitter/router.ts
@@ -52,7 +52,7 @@ export async function routedPostTweet(
     if (!oauthIsAvailable()) {
       throw Object.assign(
         new Error(
-          "OAuth is not configured. Provide your X developer credentials here in the chat to set up OAuth, or switch to browser strategy: `vellum x strategy set browser`.",
+          "OAuth is not configured. Provide your X developer credentials here in the chat to set up OAuth, or switch to browser strategy.",
         ),
         {
           pathUsed: "oauth" as const,

--- a/skills/twitter/SKILL.md
+++ b/skills/twitter/SKILL.md
@@ -33,7 +33,7 @@ OAuth uses the official X API v2. It is the most reliable connection method and 
 The browser path is quick to start and useful when the user does not have X developer app credentials. It captures auth cookies from Chrome and uses them to interact with X.
 
 - Supports: **all operations** (post, reply, timeline, search, home, bookmarks, notifications, likes, followers, following, media)
-- Setup: Run `vellum x refresh` from the terminal to open Chrome and capture session cookies automatically.
+- Setup: Import a session from a Ride Shotgun recording: `bun run scripts/twitter-cli.ts login --recording <path>`
 - Set the strategy: `bun run scripts/twitter-cli.ts strategy set browser`
 
 ### Auto mode (default)
@@ -56,13 +56,13 @@ When the user triggers a Twitter operation and no strategy has been configured y
 
 2. **Present both options with trade-offs:**
    - **OAuth**: Most reliable and official. Requires X developer app credentials (OAuth Client ID and optional Client Secret). Supports posting and replying. Set up right here in the chat.
-   - **Browser session**: Quick to start, no developer credentials needed. Supports all operations including reading timelines and searching. Set up with `vellum x refresh` from the terminal.
+   - **Browser session**: Quick to start, no developer credentials needed. Supports all operations including reading timelines and searching. Requires importing a Ride Shotgun recording.
 
 3. **Ask the user which they prefer.** Do not choose for them.
 
 4. **Execute setup for the chosen path:**
    - If OAuth: Collect the credentials in-chat using the secure credential prompt, then connect. Follow the **OAuth Setup Sequence** below.
-   - If browser: Direct the user to run `vellum x refresh` from their terminal to capture session cookies from Chrome.
+   - If browser: Direct the user to import a session from a Ride Shotgun recording using `bun run scripts/twitter-cli.ts login --recording <path>`.
 
 ### OAuth Setup Sequence
 
@@ -99,8 +99,8 @@ When a Twitter operation fails, follow these steps:
 2. **Explain the likely cause clearly** to the user.
 
 3. **Suggest trying the other path as an alternative:**
-   - If the browser session expired: suggest setting up OAuth for post/reply operations, or direct the user to refresh the browser session with `vellum x refresh` from the terminal.
-   - If OAuth failed or is not configured: suggest using the browser path with `bun run scripts/twitter-cli.ts strategy set browser` and refreshing via `vellum x refresh`.
+   - If the browser session expired: suggest setting up OAuth for post/reply operations, or ask the user to import a fresh session recording.
+   - If OAuth failed or is not configured: suggest using the browser path with `bun run scripts/twitter-cli.ts strategy set browser` and importing a session via `login --recording`.
    - If the operation is unsupported via OAuth: explain that this write operation is not yet supported via OAuth, and suggest using the browser path with `bun run scripts/twitter-cli.ts strategy set browser`.
 
 4. **Offer concrete steps to switch:**
@@ -109,8 +109,8 @@ When a Twitter operation fails, follow these steps:
    # Switch to the other strategy
    bun run scripts/twitter-cli.ts strategy set <oauth|browser|auto>
 
-   # If switching to browser, direct the user to refresh the session from the terminal
-   # vellum x refresh
+   # If switching to browser, import a session recording
+   bun run scripts/twitter-cli.ts login --recording <path>
    ```
 
 ## Strategy Management Commands
@@ -256,6 +256,6 @@ When the user wants to see how their posts are performing:
 - All commands return JSON with an `ok` field
 - When drafting replies, match the tone of the conversation — casual threads get casual replies
 - Always show the user what you're about to post and get approval before sending
-- If a browser session is expired, direct the user to refresh it with `vellum x refresh` from their terminal before retrying, or suggest switching to OAuth for post/reply operations
+- If a browser session is expired, ask the user to import a fresh session recording via `login --recording`, or suggest switching to OAuth for post/reply operations
 - If an operation fails, check `bun run scripts/twitter-cli.ts status --json` to diagnose the issue before retrying
 - The `post` and `reply` commands include a `pathUsed` field in their response so you can tell the user which connection method was used

--- a/skills/twitter/SKILL.md
+++ b/skills/twitter/SKILL.md
@@ -100,7 +100,7 @@ When a Twitter operation fails, follow these steps:
 
 3. **Suggest trying the other path as an alternative:**
    - If the browser session expired: suggest setting up OAuth for post/reply operations, or ask the user to import a fresh session recording.
-   - If OAuth failed or is not configured: suggest using the browser path with `bun run scripts/twitter-cli.ts strategy set browser` and importing a session via `login --recording`.
+   - If OAuth failed or is not configured: suggest using the browser path with `bun run scripts/twitter-cli.ts strategy set browser` and importing a session via `bun run scripts/twitter-cli.ts login --recording <path>`.
    - If the operation is unsupported via OAuth: explain that this write operation is not yet supported via OAuth, and suggest using the browser path with `bun run scripts/twitter-cli.ts strategy set browser`.
 
 4. **Offer concrete steps to switch:**
@@ -256,6 +256,6 @@ When the user wants to see how their posts are performing:
 - All commands return JSON with an `ok` field
 - When drafting replies, match the tone of the conversation — casual threads get casual replies
 - Always show the user what you're about to post and get approval before sending
-- If a browser session is expired, ask the user to import a fresh session recording via `login --recording`, or suggest switching to OAuth for post/reply operations
+- If a browser session is expired, ask the user to import a fresh session recording via `bun run scripts/twitter-cli.ts login --recording <path>`, or suggest switching to OAuth for post/reply operations
 - If an operation fails, check `bun run scripts/twitter-cli.ts status --json` to diagnose the issue before retrying
 - The `post` and `reply` commands include a `pathUsed` field in their response so you can tell the user which connection method was used

--- a/skills/twitter/scripts/service.ts
+++ b/skills/twitter/scripts/service.ts
@@ -240,8 +240,8 @@ import type { ClientMessage } from "../../../assistant/src/daemon/ipc-contract.j
 // ---------------------------------------------------------------------------
 
 const SESSION_EXPIRED_MSG =
-  "Your Twitter session has expired. Please sign in to Twitter in Chrome — " +
-  "run `vellum x refresh` to capture your session automatically.";
+  "Your Twitter session has expired. Please import a fresh session recording " +
+  "via `login --recording <path>` or switch to OAuth for post/reply operations.";
 
 function success(data: Record<string, unknown>): ToolExecutionResult {
   return {
@@ -751,11 +751,11 @@ async function handleLogout(): Promise<ToolExecutionResult> {
 }
 
 async function handleRefresh(): Promise<ToolExecutionResult> {
-  // Refresh requires Chrome CDP and Ride Shotgun, which must run through
-  // the daemon. Return guidance to use the CLI command.
+  // Refresh requires Chrome CDP and Ride Shotgun. Return guidance for alternatives.
   return failure(
-    "The refresh command requires the full CLI. " +
-      "Run `vellum x refresh` from your terminal to capture fresh cookies.",
+    "Browser session refresh requires Chrome CDP integration. " +
+      "Use `login --recording <path>` to import a Ride Shotgun recording, " +
+      "or switch to OAuth for post/reply operations.",
   );
 }
 

--- a/skills/twitter/scripts/service.ts
+++ b/skills/twitter/scripts/service.ts
@@ -241,7 +241,7 @@ import type { ClientMessage } from "../../../assistant/src/daemon/ipc-contract.j
 
 const SESSION_EXPIRED_MSG =
   "Your Twitter session has expired. Please import a fresh session recording " +
-  "via `login --recording <path>` or switch to OAuth for post/reply operations.";
+  "via `bun run scripts/twitter-cli.ts login --recording <path>` or switch to OAuth for post/reply operations.";
 
 function success(data: Record<string, unknown>): ToolExecutionResult {
   return {


### PR DESCRIPTION
## Summary
- Update system-prompt.ts to remove specific `vellum x` command references
- Update router.ts error message to be more generic
- Update skills/twitter/SKILL.md to use `login --recording` pattern for browser sessions
- Update skills/twitter/scripts/service.ts error messages
- Fix twitter-cli-routing.test.ts to match new error message format

The browser session refresh now requires importing Ride Shotgun recordings via `login --recording <path>` instead of the removed `vellum x refresh`.

Part of #13458

## Test plan
- [x] twitter-cli-routing tests pass
- [x] twitter-cli-error-shaping tests pass
- [x] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
