### PR TITLE
fix: avoid ESM init cycles in CI

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -40,6 +40,7 @@ import { isWorkspaceScopedInvocation } from "./workspace-policy.js";
 // risk logic is input-deterministic.
 const RISK_CACHE_MAX = 256;
 const riskCache = new Map<string, RiskLevel>();
+let riskCacheInvalidationHookRegistered = false;
 
 function riskCacheKey(
   toolName: string,
@@ -63,9 +64,13 @@ export function clearRiskCache(): void {
   riskCache.clear();
 }
 
-// Invalidate risk cache whenever trust rules change so that risk decisions
-// referencing config-dependent checks (e.g. skill source paths) stay fresh.
-onRulesChanged(clearRiskCache);
+function ensureRiskCacheInvalidationHook(): void {
+  if (riskCacheInvalidationHookRegistered) return;
+  // Register lazily to avoid an ESM initialization cycle between checker and
+  // trust-store when a higher-level module imports both during startup.
+  riskCacheInvalidationHookRegistered = true;
+  onRulesChanged(clearRiskCache);
+}
 
 // Low-risk shell programs that are read-only / informational
 const LOW_RISK_PROGRAMS = new Set([
@@ -462,6 +467,7 @@ export async function classifyRisk(
   signal?: AbortSignal,
 ): Promise<RiskLevel> {
   signal?.throwIfAborted();
+  ensureRiskCacheInvalidationHook();
 
   // Check cache first (skip when preParsed is provided since caller already
   // parsed and we'd just be duplicating the key computation cost).

--- a/assistant/src/runtime/routes/inbound-stages/bootstrap-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/bootstrap-intercept.ts
@@ -13,7 +13,6 @@
  */
 import type { ChannelId } from "../../../channels/types.js";
 import { getGatewayInternalBaseUrl } from "../../../config/env.js";
-import { RESEND_COOLDOWN_MS } from "../../../daemon/handlers/config-channels.js";
 import { getLogger } from "../../../util/logger.js";
 import { mintDaemonDeliveryToken } from "../../auth/token-service.js";
 import {
@@ -23,6 +22,7 @@ import {
   updateSessionDelivery,
   updateSessionStatus,
 } from "../../channel-guardian-service.js";
+import { RESEND_COOLDOWN_MS } from "../../guardian-outbound-actions.js";
 import {
   composeVerificationTelegram,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,


### PR DESCRIPTION
## Summary
- lazily register the permission risk-cache invalidation hook so checker and trust-store do not trip an ESM startup cycle
- import the bootstrap resend cooldown directly from guardian runtime code so inbound bootstrap handling does not cross the daemon config barrel

## Original prompt
$do fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22749258119/job/65980089785

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
