### PR TITLE
fix: restore contacts route and schema parity

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -408,14 +408,14 @@ async function main() {
         contactsControlPlaneProxy.handleRevokeInvite(req, params[0]),
     },
     {
-      path: /^\/v1\/contacts\/(?!invites$|merge$)([^/]+)$/,
+      path: /^\/v1\/contacts\/([^/]+)$/,
       method: "DELETE",
       auth: "edge",
       handler: (req, params) =>
         contactsControlPlaneProxy.handleDeleteContact(req, params[0]),
     },
     {
-      path: /^\/v1\/contacts\/(?!invites$|merge$)([^/]+)$/,
+      path: /^\/v1\/contacts\/([^/]+)$/,
       method: "GET",
       auth: "edge",
       handler: (req, params) =>

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1170,6 +1170,32 @@ export function buildSchema(): Record<string, unknown> {
             "504": { description: "Assistant runtime request timed out" },
           },
         },
+        delete: {
+          summary: "Delete a contact by ID",
+          description:
+            "Authenticated gateway endpoint that deletes a contact by ID via the assistant runtime.",
+          operationId: "contactsDeleteById",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "contactId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "204": { description: "Contact deleted" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "403": { description: "Contact cannot be deleted" },
+            "404": { description: "Contact not found" },
+            "503": { description: "Bearer token not configured" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
       },
       "/v1/contact-channels/{contactChannelId}/verify": {
         post: {


### PR DESCRIPTION
## Summary
- restore the gateway contact-by-id route regex so first-match ordering handles `/v1/contacts/merge` and the schema guard can resolve the path again
- document `DELETE /v1/contacts/{contactId}` in the gateway OpenAPI schema so route methods and schema methods stay in sync
- verify with targeted gateway schema and contact-route tests

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22748400939/job/65977221264

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
