### PR TITLE
fix: show full rule IDs in ambiguous trust remove output

### DIFF
--- a/assistant/src/cli/trust.ts
+++ b/assistant/src/cli/trust.ts
@@ -118,9 +118,7 @@ Examples:
       if (matches.length > 1) {
         log.error(`Ambiguous prefix "${id}" matches ${matches.length} rules:`);
         for (const m of matches) {
-          log.error(
-            `  ${m.id.slice(0, SHORT_HASH_LENGTH)}  ${m.tool}: ${m.pattern}`,
-          );
+          log.error(`  ${m.id}  ${m.tool}: ${m.pattern}`);
         }
         log.error("Provide a longer prefix to uniquely identify the rule.");
         process.exit(1);


### PR DESCRIPTION
Shows full rule IDs instead of truncated ones in the ambiguous prefix error output, so users can provide a longer prefix to disambiguate.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
