### PR TITLE
fix: align dismiss-conflicts usage error with updated help text

### DIFF
--- a/assistant/src/cli/memory.ts
+++ b/assistant/src/cli/memory.ts
@@ -298,9 +298,7 @@ Examples:
         dryRun?: boolean;
       }) => {
         if (!opts.all && !opts.pattern) {
-          log.info(
-            "Usage: vellum memory dismiss-conflicts --all  OR  --pattern <regex>",
-          );
+          log.info("At least one of --all or --pattern must be provided.");
           log.info("Use --dry-run to preview without making changes.");
           return;
         }


### PR DESCRIPTION
Updates the usage error message in memory.ts dismiss-conflicts to match the help text that says --all and --pattern can both be provided (with --all taking priority), rather than implying they are mutually exclusive.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
