### PR TITLE
fix: align CLI binary name with program name 'assistant'

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ When your PR establishes a new mandatory pattern, convention, or architectural c
 
 ## Slash Commands
 
-Most commands are shared from [`claude-skills`](https://github.com/vellum-ai/claude-skills) via symlinks. Repo-local commands (`/update`, `/release`) live in `.claude/skills/<name>/`. See `.claude/README.md` for the full list. The `/update` command uses `vellum ps`, `vellum sleep`, and `vellum wake` to manage assistant and gateway lifecycle.
+Most commands are shared from [`claude-skills`](https://github.com/vellum-ai/claude-skills) via symlinks. Repo-local commands (`/update`, `/release`) live in `.claude/skills/<name>/`. See `.claude/README.md` for the full list. The `/update` command uses `assistant ps`, `assistant sleep`, and `assistant wake` to manage assistant and gateway lifecycle.
 
 ## Linear Ticket Hygiene
 

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.36",
   "type": "module",
   "bin": {
-    "vellum": "./src/index.ts"
+    "assistant": "./src/index.ts"
   },
   "scripts": {
     "dev": "bun run src/index.ts",

--- a/cli/package.json
+++ b/cli/package.json
@@ -11,7 +11,7 @@
     "./src/commands/*": "./src/commands/*.ts"
   },
   "bin": {
-    "vellum": "./src/index.ts"
+    "assistant": "./src/index.ts"
   },
   "scripts": {
     "format": "prettier --write .",


### PR DESCRIPTION
Updates the bin field in assistant/package.json and cli/package.json to register the executable as 'assistant' instead of 'vellum', aligning with the program.name() change from PR #13444. Also updates AGENTS.md CLI command references to match.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
