### PR TITLE
fix: restore rejected status in draft list help and clarify provider-failure semantics

### DIFF
--- a/assistant/src/cli/email.ts
+++ b/assistant/src/cli/email.ts
@@ -502,8 +502,11 @@ Use --status to narrow results to a specific lifecycle stage:
   pending   — created but not yet approved
   approved  — approved and queued for sending
   sent      — successfully delivered
+  rejected  — delivery failed by the provider (e.g. bounce or send error)
 
-Note: rejected drafts are permanently deleted and will not appear here.
+Note: drafts rejected via "draft reject" are permanently deleted and will
+not appear here. The "rejected" status only applies to provider-side
+delivery failures.
 
 Examples:
   $ vellum email draft list


### PR DESCRIPTION
Addresses reviewer feedback on PR #13455. The previous help text claimed rejected drafts are permanently deleted and will not appear in draft list, but `mapSendStatus("failed") -> "rejected"` in agentmail.ts means provider-side delivery failures produce drafts with rejected status that DO appear in listings. This fix: keeps `rejected` in the `--status` option values (it is a valid filter), re-adds the `rejected` status definition to the help text explaining it means provider delivery failure, and clarifies that only drafts rejected via `draft reject` are permanently deleted.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
