### PR TITLE
fix: address review feedback on credentials reveal

### DIFF
--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -751,6 +751,14 @@ describe("vellum credentials CLI", () => {
       expect(parsed.error).toContain("Invalid credential name");
     });
 
+    test("reveal in human mode emits bare secret with trailing newline", async () => {
+      seedCredential("twilio", "auth_token", "secret_xyz_789");
+
+      const result = await runCli(["reveal", "twilio:auth_token"]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe("secret_xyz_789\n");
+    });
+
     test("errors when metadata exists but no secret stored", async () => {
       seedMetadataOnly("test", "nosecret");
 

--- a/assistant/src/cli/credentials.ts
+++ b/assistant/src/cli/credentials.ts
@@ -553,7 +553,7 @@ Examples:
         if (shouldOutputJson(cmd)) {
           writeOutput(cmd, { ok: true, value: secret });
         } else {
-          process.stdout.write(secret);
+          process.stdout.write(secret + "\n");
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Addresses reviewer feedback on PR #13436 (credentials reveal bare secret emission).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
