### PR TITLE
fix: address review feedback on credential watcher poll queuing

### DIFF
--- a/gateway/src/credential-watcher.ts
+++ b/gateway/src/credential-watcher.ts
@@ -103,6 +103,7 @@ export class CredentialWatcher {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = null;
     }
+    this.pendingPoll = false;
     if (this.watcher) {
       this.watcher.close();
       this.watcher = null;


### PR DESCRIPTION
Addresses reviewer feedback on PR #13442 (credential watcher follow-up poll).

The `stop()` method now clears `pendingPoll` to prevent the `finally` block in `pollOnce()` from firing another poll cycle after the watcher has been stopped. This avoids potential use-after-teardown errors during graceful shutdown.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
