### PR TITLE
fix: complete CLI binary rename from vellum to assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,15 @@ See [.githooks/README.md](./.githooks/README.md) for more details about availabl
 <details>
 <summary><b>Assistant Runtime</b></summary>
 
-The assistant runtime lives in `/assistant`. The recommended way to start it is via the `vellum` CLI:
+The assistant runtime lives in `/assistant`. The recommended way to start it is via the `assistant` CLI:
 
 ```bash
-vellum wake    # starts assistant + gateway from current checkout
-vellum ps      # check process status
-vellum sleep   # stop assistant + gateway
+assistant wake    # starts assistant + gateway from current checkout
+assistant ps      # check process status
+assistant sleep   # stop assistant + gateway
 ```
 
-> **Note:** `vellum wake` requires a hatched assistant. Run `vellum hatch` first, or launch the macOS app which handles hatching automatically. Alternatively, the macOS app supports **managed sign-in** during onboarding — authenticating via the platform and connecting to a platform-hosted assistant without running a local assistant.
+> **Note:** `assistant wake` requires a hatched assistant. Run `assistant hatch` first, or launch the macOS app which handles hatching automatically. Alternatively, the macOS app supports **managed sign-in** during onboarding — authenticating via the platform and connecting to a platform-hosted assistant without running a local assistant.
 
 <details>
 <summary>Development: raw bun commands</summary>
@@ -152,7 +152,7 @@ Host tools (`host_bash`, `host_file_read`, `host_file_write`, `host_file_edit`) 
 | `Cannot bind-mount the sandbox root into a Docker container` | Docker Desktop file sharing does not include the sandbox data directory | Open Docker Desktop > Settings > Resources > File Sharing and add the `~/.vellum/workspace` path (or your custom `dataDir` path) |
 | `bwrap is not available or cannot create namespaces` (native backend, Linux) | bubblewrap is not installed or user namespaces are disabled | Install bubblewrap: `apt install bubblewrap` (Debian/Ubuntu) or `dnf install bubblewrap` (Fedora) |
 
-Run `vellum doctor` for a full diagnostic check including sandbox backend status.
+Run `assistant doctor` for a full diagnostic check including sandbox backend status.
 
 </details>
 
@@ -317,9 +317,9 @@ Twitter integration supports two operation paths: **OAuth** (X API v2) and **Bro
 
 - **OAuth path**: Uses stored OAuth2 tokens via `withValidToken('integration:twitter', ...)` to call the X API v2 directly. Supports `post` and `reply`. Most reliable when developer credentials are configured — no browser session needed for these operations.
 
-- **Browser path** (CDP): Uses Chrome DevTools Protocol to execute operations through an authenticated x.com browser tab. Supports all operations including read-only ones (timeline, search, home, notifications, bookmarks, likes, followers, following, media). Quick to start — no developer credentials needed. Session cookies are captured via Ride Shotgun (`vellum x refresh`).
+- **Browser path** (CDP): Uses Chrome DevTools Protocol to execute operations through an authenticated x.com browser tab. Supports all operations including read-only ones (timeline, search, home, notifications, bookmarks, likes, followers, following, media). Quick to start — no developer credentials needed. Session cookies are captured via Ride Shotgun (`assistant x refresh`).
 
-- **Strategy selection**: `vellum x strategy set <oauth|browser|auto>` controls which path is used. Default is `auto`, which prefers OAuth when credentials are available and the operation is supported, then falls back to browser. The strategy is persisted in config as `twitterOperationStrategy`.
+- **Strategy selection**: `assistant x strategy set <oauth|browser|auto>` controls which path is used. Default is `auto`, which prefers OAuth when credentials are available and the operation is supported, then falls back to browser. The strategy is persisted in config as `twitterOperationStrategy`.
 
 **OAuth2 PKCE setup** (`local_byo` mode): The user provides their own Twitter OAuth2 Client ID (and optional Client Secret). The assistant runs a standard OAuth2 PKCE flow against `twitter.com/i/oauth2/authorize` and `api.x.com/2/oauth2/token`. The flow verifies the user's identity (`GET /2/users/me`) and stores tokens in the vault for use by both identity verification and the OAuth operation path. Connect via the Settings UI or `twitter_auth_start` IPC message.
 
@@ -636,9 +636,9 @@ Over SSH-forwarded sockets, the probe fails automatically (the filesystems don't
 | CLI: "could not connect to assistant socket" | Is the SSH socket tunnel active? Check `VELLUM_DAEMON_SOCKET` path |
 | CLI: assistant starts locally despite socket override | Check that `VELLUM_DAEMON_AUTOSTART` is not set to `1` |
 | macOS: not connecting | Verify socket path in `VELLUM_DAEMON_SOCKET` exists and is writable |
-| Any: "connection refused" | Is the remote assistant running? (`vellum ps` on remote) |
+| Any: "connection refused" | Is the remote assistant running? (`assistant ps` on remote) |
 
-Run `vellum doctor` for a full diagnostic check including socket path and autostart policy.
+Run `assistant doctor` for a full diagnostic check including socket path and autostart policy.
 
 </details>
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -59,15 +59,15 @@ When a release includes relevant updates, the assistant materializes release not
 
 ### Lifecycle management (recommended)
 
-Use the `vellum` CLI to manage assistant and gateway processes:
+Use the `assistant` CLI to manage assistant and gateway processes:
 
 ```bash
-vellum wake    # start assistant + gateway from current checkout
-vellum ps      # list assistants and per-assistant process status
-vellum sleep   # stop assistant + gateway (directory-agnostic)
+assistant wake    # start assistant + gateway from current checkout
+assistant ps      # list assistants and per-assistant process status
+assistant sleep   # stop assistant + gateway (directory-agnostic)
 ```
 
-> **Note:** `vellum wake` requires a hatched assistant. Run `vellum hatch` first, or launch the macOS app which handles hatching automatically.
+> **Note:** `assistant wake` requires a hatched assistant. Run `assistant hatch` first, or launch the macOS app which handles hatching automatically.
 
 ### Development: raw bun commands
 
@@ -81,18 +81,18 @@ bun run src/index.ts dev            # dev mode (auto-restart on file changes)
 
 ### CLI commands
 
-| Command                                    | Description                                      |
-| ------------------------------------------ | ------------------------------------------------ |
-| `vellum wake`                              | Start assistant + gateway from current checkout  |
-| `vellum sleep`                             | Stop assistant + gateway processes               |
-| `vellum ps`                                | List assistants and per-assistant process status |
-| `vellum`                                   | Launch interactive CLI session                   |
-| `vellum dev`                               | Run assistant with auto-restart on file changes  |
-| `vellum sessions list\|new\|export\|clear` | Manage conversation sessions                     |
-| `vellum config set\|get\|list`             | Manage configuration                             |
-| `vellum keys set\|list\|delete`            | Manage API keys in secure storage                |
-| `vellum trust list\|remove\|clear`         | Manage trust rules                               |
-| `vellum doctor`                            | Run diagnostic checks                            |
+| Command                                       | Description                                      |
+| --------------------------------------------- | ------------------------------------------------ |
+| `assistant wake`                              | Start assistant + gateway from current checkout  |
+| `assistant sleep`                             | Stop assistant + gateway processes               |
+| `assistant ps`                                | List assistants and per-assistant process status |
+| `assistant`                                   | Launch interactive CLI session                   |
+| `assistant dev`                               | Run assistant with auto-restart on file changes  |
+| `assistant sessions list\|new\|export\|clear` | Manage conversation sessions                     |
+| `assistant config set\|get\|list`             | Manage configuration                             |
+| `assistant keys set\|list\|delete`            | Manage API keys in secure storage                |
+| `assistant trust list\|remove\|clear`         | Manage trust rules                               |
+| `assistant doctor`                            | Run diagnostic checks                            |
 
 ## Project Structure
 
@@ -485,7 +485,7 @@ docker run --rm -p 3001:3001 \
   vellum-assistant:local
 ```
 
-The image exposes port `3001` and bundles the `vellum` CLI binary.
+The image exposes port `3001` and bundles the `assistant` CLI binary.
 
 ## Ride Shotgun
 

--- a/assistant/src/__tests__/lifecycle-docs-guard.test.ts
+++ b/assistant/src/__tests__/lifecycle-docs-guard.test.ts
@@ -5,8 +5,8 @@ import { describe, expect, it } from "bun:test";
 
 /**
  * Guard test: prevent stale lifecycle instructions from being reintroduced
- * into documentation. The canonical lifecycle commands are `vellum wake`,
- * `vellum ps`, and `vellum sleep`. Repo-local slash commands live in
+ * into documentation. The canonical lifecycle commands are `assistant wake`,
+ * `assistant ps`, and `assistant sleep`. Repo-local slash commands live in
  * `.claude/skills/`, not `.claude/commands/`.
  *
  * See AGENTS.md for the conventions these tests enforce.
@@ -58,7 +58,7 @@ describe("lifecycle docs guard", () => {
     }
   });
 
-  it("key docs reference vellum lifecycle commands", () => {
+  it("key docs reference assistant lifecycle commands", () => {
     const checks: Array<{
       file: string;
       pattern: string;
@@ -66,21 +66,21 @@ describe("lifecycle docs guard", () => {
     }> = [
       {
         file: "README.md",
-        pattern: "vellum wake\\|vellum ps\\|vellum sleep",
+        pattern: "assistant wake\\|assistant ps\\|assistant sleep",
         description:
-          "README.md should mention vellum wake, vellum ps, or vellum sleep",
+          "README.md should mention assistant wake, assistant ps, or assistant sleep",
       },
       {
         file: "assistant/README.md",
-        pattern: "vellum wake\\|vellum ps",
+        pattern: "assistant wake\\|assistant ps",
         description:
-          "assistant/README.md should mention vellum wake or vellum ps",
+          "assistant/README.md should mention assistant wake or assistant ps",
       },
       {
         file: "AGENTS.md",
-        pattern: "vellum ps\\|vellum sleep\\|vellum wake",
+        pattern: "assistant ps\\|assistant sleep\\|assistant wake",
         description:
-          "AGENTS.md should mention vellum ps, vellum sleep, or vellum wake in the /update command description",
+          "AGENTS.md should mention assistant ps, assistant sleep, or assistant wake in the /update command description",
       },
     ];
 
@@ -99,11 +99,11 @@ describe("lifecycle docs guard", () => {
 
     if (failures.length > 0) {
       const message = [
-        "Key docs are missing vellum lifecycle command references:",
+        "Key docs are missing assistant lifecycle command references:",
         "",
         ...failures.map((f) => `  - ${f}`),
         "",
-        "These docs should reference vellum CLI lifecycle commands (wake/ps/sleep).",
+        "These docs should reference assistant CLI lifecycle commands (wake/ps/sleep).",
       ].join("\n");
 
       expect(failures, message).toEqual([]);
@@ -195,7 +195,7 @@ describe("lifecycle docs guard", () => {
     if (violations.length > 0) {
       const message = [
         "Found docs using stale daemon startup patterns as primary instructions.",
-        "Use `vellum wake` / `vellum sleep` instead. Raw bun commands are acceptable",
+        "Use `assistant wake` / `assistant sleep` instead. Raw bun commands are acceptable",
         "only in collapsed <details> sections or dev-only contexts.",
         "",
         "Violations:",

--- a/cli/src/adapters/install.sh
+++ b/cli/src/adapters/install.sh
@@ -145,7 +145,7 @@ ensure_bun() {
     success "bun installed ($(bun --version))"
 }
 
-# Ensure ~/.bun/bin is in the user's shell profile so bun and vellum are
+# Ensure ~/.bun/bin is in the user's shell profile so bun and assistant are
 # available in new terminal sessions. The bun installer sometimes skips
 # this (e.g. when stdin is piped via curl | bash).
 configure_shell_profile() {
@@ -179,27 +179,27 @@ configure_shell_profile() {
     done
 }
 
-# Create a symlink so `vellum` is available without ~/.bun/bin in PATH.
+# Create a symlink so `assistant` is available without ~/.bun/bin in PATH.
 # Tries /usr/local/bin first (works on most systems), falls back to
 # ~/.local/bin (user-writable, no sudo needed).
 # This is best-effort — failure must not abort the install script.
-symlink_vellum() {
-    local vellum_bin="$HOME/.bun/bin/vellum"
-    if [ ! -f "$vellum_bin" ]; then
+symlink_assistant() {
+    local assistant_bin="$HOME/.bun/bin/assistant"
+    if [ ! -f "$assistant_bin" ]; then
         return 0
     fi
 
-    # Skip if vellum is already resolvable outside of ~/.bun/bin
+    # Skip if assistant is already resolvable outside of ~/.bun/bin
     local resolved
-    resolved=$(command -v vellum 2>/dev/null || true)
-    if [ -n "$resolved" ] && [ "$resolved" != "$vellum_bin" ]; then
+    resolved=$(command -v assistant 2>/dev/null || true)
+    if [ -n "$resolved" ] && [ "$resolved" != "$assistant_bin" ]; then
         return 0
     fi
 
     # Try /usr/local/bin (may need sudo on some systems)
     if [ -d "/usr/local/bin" ] && [ -w "/usr/local/bin" ]; then
-        if ln -sf "$vellum_bin" /usr/local/bin/vellum 2>/dev/null; then
-            success "Symlinked /usr/local/bin/vellum → $vellum_bin"
+        if ln -sf "$assistant_bin" /usr/local/bin/assistant 2>/dev/null; then
+            success "Symlinked /usr/local/bin/assistant → $assistant_bin"
             return 0
         fi
     fi
@@ -207,8 +207,8 @@ symlink_vellum() {
     # Fallback: ~/.local/bin
     local local_bin="$HOME/.local/bin"
     mkdir -p "$local_bin" 2>/dev/null || true
-    if ln -sf "$vellum_bin" "$local_bin/vellum" 2>/dev/null; then
-        success "Symlinked $local_bin/vellum → $vellum_bin"
+    if ln -sf "$assistant_bin" "$local_bin/assistant" 2>/dev/null; then
+        success "Symlinked $local_bin/assistant → $assistant_bin"
         # Ensure ~/.local/bin is in PATH in shell profile
         for profile in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile"; do
             if [ -f "$profile" ] && ! grep -q "$local_bin" "$profile" 2>/dev/null; then
@@ -237,21 +237,21 @@ esac
 ENVEOF
 }
 
-install_vellum() {
-    if command -v vellum >/dev/null 2>&1; then
-        info "Updating vellum to latest..."
+install_assistant() {
+    if command -v assistant >/dev/null 2>&1; then
+        info "Updating assistant CLI to latest..."
         bun install -g vellum@latest
     else
-        info "Installing vellum globally..."
+        info "Installing assistant CLI globally..."
         bun install -g vellum@latest
     fi
 
-    if ! command -v vellum >/dev/null 2>&1; then
-        error "vellum installation failed. Please install manually: bun install -g vellum"
+    if ! command -v assistant >/dev/null 2>&1; then
+        error "assistant CLI installation failed. Please install manually: bun install -g vellum"
         exit 1
     fi
 
-    success "vellum installed ($(vellum --version 2>/dev/null || echo 'unknown'))"
+    success "assistant CLI installed ($(assistant --version 2>/dev/null || echo 'unknown'))"
 }
 
 main() {
@@ -262,26 +262,26 @@ main() {
     ensure_git
     ensure_bun
     configure_shell_profile
-    install_vellum
-    symlink_vellum
+    install_assistant
+    symlink_assistant
 
     # Write a sourceable env file so the quickstart one-liner can pick up
     # PATH changes in the caller's shell:
     #   curl ... | bash && . ~/.config/vellum/env
     write_env_file
 
-    # Source the shell profile so vellum hatch runs with the correct PATH
+    # Source the shell profile so assistant hatch runs with the correct PATH
     # in this session (the profile changes only take effect in new shells
     # otherwise).
     export BUN_INSTALL="$HOME/.bun"
     export PATH="$BUN_INSTALL/bin:$PATH"
 
-    info "Running vellum hatch..."
+    info "Running assistant hatch..."
     printf "\n"
     if [ -n "${VELLUM_SSH_USER:-}" ] && [ "$(id -u)" = "0" ]; then
-        su - "$VELLUM_SSH_USER" -c "set -a; [ -f \"\$HOME/.vellum/.env\" ] && . \"\$HOME/.vellum/.env\"; set +a; export PATH=\"$HOME/.bun/bin:\$PATH\"; vellum hatch"
+        su - "$VELLUM_SSH_USER" -c "set -a; [ -f \"\$HOME/.vellum/.env\" ] && . \"\$HOME/.vellum/.env\"; set +a; export PATH=\"$HOME/.bun/bin:\$PATH\"; assistant hatch"
     else
-        vellum hatch
+        assistant hatch
     fi
 }
 

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -84,10 +84,10 @@ function parseArgs(): ParsedArgs {
 }
 
 function printUsage(): void {
-  console.log(`${ANSI.bold}vellum client${ANSI.reset} - Connect to a hatched assistant
+  console.log(`${ANSI.bold}assistant client${ANSI.reset} - Connect to a hatched assistant
 
 ${ANSI.bold}USAGE:${ANSI.reset}
-    vellum client [name] [options]
+    assistant client [name] [options]
 
 ${ANSI.bold}ARGUMENTS:${ANSI.reset}
     [name]                     Instance name (default: latest)
@@ -98,14 +98,14 @@ ${ANSI.bold}OPTIONS:${ANSI.reset}
     -h, --help                 Show this help message
 
 ${ANSI.bold}DEFAULTS:${ANSI.reset}
-    Reads from ~/.vellum.lock.json (created by vellum hatch).
+    Reads from ~/.vellum.lock.json (created by assistant hatch).
     Override with flags above or env vars RUNTIME_URL / ASSISTANT_ID.
 
 ${ANSI.bold}EXAMPLES:${ANSI.reset}
-    vellum client
-    vellum client vellum-assistant-foo
-    vellum client --url http://34.56.78.90:${GATEWAY_PORT}
-    vellum client vellum-assistant-foo --url http://localhost:${GATEWAY_PORT}
+    assistant client
+    assistant client vellum-assistant-foo
+    assistant client --url http://34.56.78.90:${GATEWAY_PORT}
+    assistant client vellum-assistant-foo --url http://localhost:${GATEWAY_PORT}
 `);
 }
 

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -185,7 +185,7 @@ function parseArgs(): HatchArgs {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === "--help" || arg === "-h") {
-      console.log("Usage: vellum hatch [species] [options]");
+      console.log("Usage: assistant hatch [species] [options]");
       console.log("");
       console.log("Create a new assistant instance.");
       console.log("");
@@ -536,7 +536,7 @@ function installCLISymlink(): void {
   if (!cliBinary || !existsSync(cliBinary)) return;
 
   // Preferred location — works on most Macs where /usr/local/bin exists
-  const preferredPath = "/usr/local/bin/vellum";
+  const preferredPath = "/usr/local/bin/assistant";
   if (trySymlink(cliBinary, preferredPath)) {
     console.log(`   Symlinked ${preferredPath} → ${cliBinary}`);
     return;
@@ -545,7 +545,7 @@ function installCLISymlink(): void {
   // Fallback — use ~/.local/bin which is user-writable and doesn't need root.
   // On some Macs /usr/local doesn't exist and creating it requires admin privileges.
   const localBinDir = join(homedir(), ".local", "bin");
-  const fallbackPath = join(localBinDir, "vellum");
+  const fallbackPath = join(localBinDir, "assistant");
   if (trySymlink(cliBinary, fallbackPath)) {
     console.log(`   Symlinked ${fallbackPath} → ${cliBinary}`);
     ensureLocalBinInShellProfile(localBinDir);
@@ -553,7 +553,7 @@ function installCLISymlink(): void {
   }
 
   console.log(
-    `   ⚠ Could not create symlink for vellum CLI (tried ${preferredPath} and ${fallbackPath})`,
+    `   ⚠ Could not create symlink for assistant CLI (tried ${preferredPath} and ${fallbackPath})`,
   );
 }
 
@@ -595,7 +595,7 @@ async function displayPairingQRCode(
     const daemonReady = await waitForDaemonReady(runtimeUrl, bearerToken);
     if (!daemonReady) {
       console.warn(
-        "⚠ Assistant health check did not pass within 15s. Run `vellum pair` to try again.\n",
+        "⚠ Assistant health check did not pass within 15s. Run `assistant pair` to try again.\n",
       );
       return;
     }
@@ -616,7 +616,7 @@ async function displayPairingQRCode(
     if (!registerRes.ok) {
       const body = await registerRes.text().catch(() => "");
       console.warn(
-        `⚠ Could not register pairing request: ${registerRes.status} ${registerRes.statusText}${body ? ` — ${body}` : ""}. Run \`vellum pair\` to try again.\n`,
+        `⚠ Could not register pairing request: ${registerRes.status} ${registerRes.statusText}${body ? ` — ${body}` : ""}. Run \`assistant pair\` to try again.\n`,
       );
       return;
     }
@@ -660,12 +660,12 @@ async function displayPairingQRCode(
     console.log("Scan this QR code with the Vellum iOS app to pair:\n");
     console.log(qrString);
     console.log("This pairing request expires in 5 minutes.");
-    console.log("Run `vellum pair` to generate a new one.\n");
+    console.log("Run `assistant pair` to generate a new one.\n");
   } catch (err) {
     // Non-fatal — pairing is optional
     const reason = err instanceof Error ? err.message : String(err);
     console.warn(
-      `⚠ Could not generate pairing QR code: ${reason}. Run \`vellum pair\` to try again.\n`,
+      `⚠ Could not generate pairing QR code: ${reason}. Run \`assistant pair\` to try again.\n`,
     );
   }
 }

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -9,7 +9,7 @@ export async function login(): Promise<void> {
   const args = process.argv.slice(3);
 
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum login --token <session-token>");
+    console.log("Usage: assistant login --token <session-token>");
     console.log("");
     console.log("Log in to the Vellum platform.");
     console.log("");
@@ -32,7 +32,7 @@ export async function login(): Promise<void> {
   }
 
   if (!token) {
-    console.error("Usage: vellum login --token <session-token>");
+    console.error("Usage: assistant login --token <session-token>");
     console.error("");
     console.error("To get your session token:");
     console.error("  1. Log in to the Vellum platform in your browser");
@@ -58,7 +58,7 @@ export async function login(): Promise<void> {
 export async function logout(): Promise<void> {
   const args = process.argv.slice(3);
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum logout");
+    console.log("Usage: assistant logout");
     console.log("");
     console.log(
       "Log out of the Vellum platform and remove the stored session token.",
@@ -73,7 +73,7 @@ export async function logout(): Promise<void> {
 export async function whoami(): Promise<void> {
   const args = process.argv.slice(3);
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum whoami");
+    console.log("Usage: assistant whoami");
     console.log("");
     console.log("Show the currently logged-in Vellum platform user.");
     process.exit(0);
@@ -81,7 +81,9 @@ export async function whoami(): Promise<void> {
 
   const token = readPlatformToken();
   if (!token) {
-    console.error("Not logged in. Run `vellum login --token <token>` first.");
+    console.error(
+      "Not logged in. Run `assistant login --token <token>` first.",
+    );
     process.exit(1);
   }
 

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -78,7 +78,7 @@ export async function pair(): Promise<void> {
   const args = process.argv.slice(3);
 
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum pair <path-to-qrcode.png>");
+    console.log("Usage: assistant pair <path-to-qrcode.png>");
     console.log("");
     console.log(
       "Pair with a remote assistant by scanning the QR code PNG generated during setup.",
@@ -89,7 +89,7 @@ export async function pair(): Promise<void> {
   const qrCodePath = args[0] || process.env.VELLUM_CUSTOM_QR_CODE_PATH;
 
   if (!qrCodePath) {
-    console.error("Usage: vellum pair <path-to-qrcode.png>");
+    console.error("Usage: assistant pair <path-to-qrcode.png>");
     console.error("");
     console.error(
       "Pair with a remote assistant by scanning the QR code PNG generated during setup.",

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -433,7 +433,7 @@ async function listAllAssistants(): Promise<void> {
 export async function ps(): Promise<void> {
   const args = process.argv.slice(3);
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum ps [<name>]");
+    console.log("Usage: assistant ps [<name>]");
     console.log("");
     console.log(
       "List all assistants, or show processes for a specific assistant.",

--- a/cli/src/commands/recover.ts
+++ b/cli/src/commands/recover.ts
@@ -11,7 +11,7 @@ import { exec } from "../lib/step-runner";
 export async function recover(): Promise<void> {
   const args = process.argv.slice(3);
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum recover <name>");
+    console.log("Usage: assistant recover <name>");
     console.log("");
     console.log(
       "Restore a previously retired local assistant from its archive.",
@@ -24,7 +24,7 @@ export async function recover(): Promise<void> {
 
   const name = process.argv[3];
   if (!name) {
-    console.error("Usage: vellum recover <name>");
+    console.error("Usage: assistant recover <name>");
     process.exit(1);
   }
 

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -120,7 +120,7 @@ async function retireCustom(entry: AssistantEntry): Promise<void> {
   console.log(`\u{1F5D1}\ufe0f  Retiring custom instance on ${sshHost}...\n`);
 
   const remoteCmd = [
-    "bunx vellum sleep 2>/dev/null || true",
+    "assistant sleep 2>/dev/null || true",
     "pkill -f gateway 2>/dev/null || true",
     "rm -rf ~/.vellum",
   ].join(" && ");
@@ -203,7 +203,7 @@ export async function retire(): Promise<void> {
 async function retireInner(): Promise<void> {
   const args = process.argv.slice(3);
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum retire <name> [--source <source>]");
+    console.log("Usage: assistant retire <name> [--source <source>]");
     console.log("");
     console.log("Delete an assistant instance and archive its data.");
     console.log("");
@@ -219,14 +219,14 @@ async function retireInner(): Promise<void> {
 
   if (!name) {
     console.error("Error: Instance name is required.");
-    console.error("Usage: vellum retire <name> [--source <source>]");
+    console.error("Usage: assistant retire <name> [--source <source>]");
     process.exit(1);
   }
 
   const entry = findAssistantByName(name);
   if (!entry) {
     console.error(`No assistant found with name '${name}'.`);
-    console.error("Run 'vellum hatch' first, or check the instance name.");
+    console.error("Run 'assistant hatch' first, or check the instance name.");
     process.exit(1);
   }
 

--- a/cli/src/commands/skills.ts
+++ b/cli/src/commands/skills.ts
@@ -49,10 +49,7 @@ function getRepoSkillsDir(): string | undefined {
  */
 function readLocalCatalog(repoSkillsDir: string): CatalogSkill[] {
   try {
-    const raw = readFileSync(
-      join(repoSkillsDir, "catalog.json"),
-      "utf-8",
-    );
+    const raw = readFileSync(join(repoSkillsDir, "catalog.json"), "utf-8");
     const manifest = JSON.parse(raw) as CatalogManifest;
     if (!Array.isArray(manifest.skills)) return [];
     return manifest.skills;
@@ -349,7 +346,7 @@ function hasFlag(args: string[], flag: string): boolean {
 // ---------------------------------------------------------------------------
 
 function printUsage(): void {
-  console.log("Usage: vellum skills <subcommand> [options]");
+  console.log("Usage: assistant skills <subcommand> [options]");
   console.log("");
   console.log("Subcommands:");
   console.log(
@@ -431,7 +428,7 @@ export async function skills(): Promise<void> {
     case "install": {
       const skillId = args.find((a) => !a.startsWith("--") && a !== "install");
       if (!skillId) {
-        console.error("Usage: vellum skills install <skill-id>");
+        console.error("Usage: assistant skills install <skill-id>");
         process.exit(1);
       }
 
@@ -481,7 +478,7 @@ export async function skills(): Promise<void> {
         (a) => !a.startsWith("--") && a !== "uninstall",
       );
       if (!skillId) {
-        console.error("Usage: vellum skills uninstall <skill-id>");
+        console.error("Usage: assistant skills uninstall <skill-id>");
         process.exit(1);
       }
 

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -6,7 +6,7 @@ import { stopProcessByPidFile } from "../lib/process";
 export async function sleep(): Promise<void> {
   const args = process.argv.slice(3);
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum sleep");
+    console.log("Usage: assistant sleep");
     console.log("");
     console.log("Stop the assistant and gateway processes.");
     process.exit(0);
@@ -40,5 +40,4 @@ export async function sleep(): Promise<void> {
   } else {
     console.log("Gateway stopped.");
   }
-
 }

--- a/cli/src/commands/ssh.ts
+++ b/cli/src/commands/ssh.ts
@@ -42,7 +42,7 @@ function extractHostFromUrl(url: string): string {
 export async function ssh(): Promise<void> {
   const args = process.argv.slice(3);
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum ssh [<name>]");
+    console.log("Usage: assistant ssh [<name>]");
     console.log("");
     console.log("SSH into a remote assistant instance.");
     console.log("");
@@ -60,7 +60,9 @@ export async function ssh(): Promise<void> {
     if (name) {
       console.error(`No assistant instance found with name '${name}'.`);
     } else {
-      console.error("No assistant instance found. Run `vellum hatch` first.");
+      console.error(
+        "No assistant instance found. Run `assistant hatch` first.",
+      );
     }
     process.exit(1);
   }
@@ -70,7 +72,7 @@ export async function ssh(): Promise<void> {
   if (cloud === "local") {
     console.error(
       "Cannot SSH into a local assistant. Local assistants run directly on this machine.\n" +
-        `Use 'vellum ps ${entry.assistantId}' to check its processes instead.`,
+        `Use 'assistant ps ${entry.assistantId}' to check its processes instead.`,
     );
     process.exit(1);
   }

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -22,7 +22,7 @@ function parseArgs(): TunnelArgs {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === "--help" || arg === "-h") {
-      console.log("Usage: vellum tunnel [<name>] [options]");
+      console.log("Usage: assistant tunnel [<name>] [options]");
       console.log("");
       console.log("Create a tunnel for a locally hosted assistant.");
       console.log("");
@@ -73,7 +73,9 @@ export async function tunnel(): Promise<void> {
         `No assistant instance found with name '${assistantName}'.`,
       );
     } else {
-      console.error("No assistant instance found. Run `vellum hatch` first.");
+      console.error(
+        "No assistant instance found. Run `assistant hatch` first.",
+      );
     }
     process.exit(1);
   }

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -9,7 +9,7 @@ import { startLocalDaemon, startGateway } from "../lib/local";
 export async function wake(): Promise<void> {
   const args = process.argv.slice(3);
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum wake [options]");
+    console.log("Usage: assistant wake [options]");
     console.log("");
     console.log("Start the assistant and gateway processes.");
     console.log("");
@@ -26,7 +26,7 @@ export async function wake(): Promise<void> {
   const hasLocal = assistants.some((a) => a.cloud === "local");
   if (!hasLocal) {
     console.error(
-      "Error: No local assistant found in lock file. Run 'vellum hatch local' first.",
+      "Error: No local assistant found in lock file. Run 'assistant hatch local' first.",
     );
     process.exit(1);
   }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -74,7 +74,7 @@ async function main() {
   }
 
   if (!commandName || commandName === "--help" || commandName === "-h") {
-    console.log("Usage: vellum <command> [options]");
+    console.log("Usage: assistant <command> [options]");
     console.log("");
     console.log("Commands:");
     console.log("  autonomy View and configure autonomy tiers");


### PR DESCRIPTION
Addresses review feedback on #13494. Updates the lifecycle-docs-guard test, install script, hatch command, and all CLI usage/help text to use 'assistant' instead of 'vellum' for the binary name.

## Changes

- **Guard test** (`lifecycle-docs-guard.test.ts`): Updated patterns from `vellum ps|sleep|wake` to `assistant ps|sleep|wake` so the test matches the renamed AGENTS.md references
- **Install script** (`install.sh`): Renamed `symlink_vellum` to `symlink_assistant`, updated binary paths from `~/.bun/bin/vellum` to `~/.bun/bin/assistant`, and symlink targets from `/usr/local/bin/vellum` to `/usr/local/bin/assistant`
- **Hatch command** (`hatch.ts`): Updated symlink paths from `/usr/local/bin/vellum` and `~/.local/bin/vellum` to use `assistant`
- **CLI help text**: Updated all `Usage: vellum ...` strings across all command files to `Usage: assistant ...`
- **Error messages**: Updated all user-facing error messages referencing `vellum hatch`, `vellum pair`, `vellum login`, etc. to use `assistant`
- **README.md files**: Updated CLI command references in README.md and assistant/README.md to use `assistant`

Internal identifiers (species names, directory paths like `~/.vellum`, env vars like `VELLUM_*`, npm package name `vellum@latest`) are intentionally left unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
