### PR TITLE
refactor: rename upsertMember to upsertContactChannel

### DIFF
--- a/assistant/src/__tests__/inbound-invite-redemption.test.ts
+++ b/assistant/src/__tests__/inbound-invite-redemption.test.ts
@@ -87,7 +87,7 @@ mock.module("../runtime/approval-message-composer.js", () => ({
 }));
 
 import { findContactChannel } from "../contacts/contact-store.js";
-import { upsertMember } from "../contacts/contacts-write.js";
+import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { createInvite, revokeInvite } from "../memory/invite-store.js";
 import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
@@ -328,7 +328,7 @@ describe("inbound invite redemption intercept", () => {
 
   test("existing active member sending normal message is unaffected", async () => {
     // Pre-create an active member
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "user-active-member",
       externalChatId: "chat-active",
@@ -377,7 +377,7 @@ describe("inbound invite redemption intercept", () => {
     });
 
     // Pre-create an active member that will click the invite link
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "user-already-active",
       externalChatId: "chat-invite-test",
@@ -403,7 +403,7 @@ describe("inbound invite redemption intercept", () => {
       maxUses: 5,
     });
 
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "user-invite-123",
       externalChatId: "chat-invite-test",

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -24,7 +24,7 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { upsertMember } from "../contacts/contacts-write.js";
+import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
 import {
   createInvite,
@@ -179,7 +179,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create an active member
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "existing-user",
       status: "active",
@@ -209,7 +209,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create a blocked member — simulates a guardian-initiated block
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "blocked-user",
       status: "blocked",
@@ -231,7 +231,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create a revoked member
-    const member = upsertMember({
+    const member = upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "revoked-user",
       status: "revoked",
@@ -282,7 +282,7 @@ describe("invite-redemption-service", () => {
 
   test("returns invalid_token for an active member with a bogus token (no membership probing)", () => {
     // Pre-create an active member
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "probed-user",
       status: "active",
@@ -307,7 +307,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create an active member
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "expired-token-user",
       status: "active",
@@ -331,7 +331,7 @@ describe("invite-redemption-service", () => {
     });
 
     // Pre-create an active member on telegram
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "cross-channel-user",
       status: "active",

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -192,7 +192,7 @@ import {
 import { setVoiceBridgeDeps } from "../calls/voice-session-bridge.js";
 import {
   createGuardianBinding,
-  upsertMember,
+  upsertContactChannel,
 } from "../contacts/contacts-write.js";
 import {
   listCanonicalGuardianRequests,
@@ -291,7 +291,7 @@ function resetTables() {
 }
 
 function addTrustedVoiceContact(phoneNumber: string): void {
-  upsertMember({
+  upsertContactChannel({
     sourceChannel: "voice",
     externalUserId: phoneNumber,
     externalChatId: phoneNumber,
@@ -2452,7 +2452,7 @@ describe("relay-server", () => {
     });
 
     // Create a blocked member
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "voice",
       externalUserId: "+15558881111",
       externalChatId: "+15558881111",

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -91,7 +91,7 @@ import { getResolver } from "../approvals/guardian-request-resolvers.js";
 import { findContactChannel } from "../contacts/contact-store.js";
 import {
   createGuardianBinding,
-  upsertMember,
+  upsertContactChannel,
 } from "../contacts/contacts-write.js";
 import { createApprovalRequest } from "../memory/channel-guardian-store.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
@@ -174,7 +174,7 @@ describe("trusted contact lifecycle notification signals", () => {
       guardianPrincipalId: "guardian-user-789",
       verifiedVia: "test",
     });
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "guardian-user-789",
       externalChatId: "guardian-chat-789",
@@ -253,7 +253,7 @@ describe("trusted contact lifecycle notification signals", () => {
       guardianPrincipalId: "guardian-user-789",
       verifiedVia: "test",
     });
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "guardian-user-789",
       externalChatId: "guardian-chat-789",
@@ -328,7 +328,7 @@ describe("trusted contact lifecycle notification signals", () => {
       guardianPrincipalId: "guardian-user-789",
       verifiedVia: "test",
     });
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "guardian-user-789",
       externalChatId: "guardian-chat-789",
@@ -448,7 +448,7 @@ describe("trusted contact activated notification signal", () => {
       verifiedVia: "test",
     });
 
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "requester-user-456",
       externalChatId: "chat-123",
@@ -509,7 +509,7 @@ describe("trusted contact activated notification signal", () => {
   test("voice access_request resolver has registered handler for access_request kind", () => {
     // The access_request resolver is registered during module load. When the
     // source channel is 'voice', it should directly activate the member via
-    // upsertMember (no verification session). This test validates the resolver
+    // upsertContactChannel (no verification session). This test validates the resolver
     // is registered and accessible.
     const resolver = getResolver("access_request");
     expect(resolver).toBeDefined();
@@ -549,7 +549,7 @@ describe("trusted contact activated notification signal", () => {
     );
     expect(activatedSignals.length).toBe(1);
 
-    // Verify the member was already persisted (the signal fires after upsertMember)
+    // Verify the member was already persisted (the signal fires after upsertContactChannel)
     const result = findContactChannel({
       channelType: "telegram",
       externalUserId: "requester-user-456",

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -98,7 +98,7 @@ mock.module("../runtime/approval-message-composer.js", () => ({
 import { findContactChannel } from "../contacts/contact-store.js";
 import {
   createGuardianBinding,
-  upsertMember,
+  upsertContactChannel,
 } from "../contacts/contacts-write.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import {
@@ -279,7 +279,7 @@ for (const config of CHANNEL_CONFIGS) {
         expect(challengeResult.verificationType).toBe("trusted_contact");
       }
 
-      upsertMember({
+      upsertContactChannel({
         sourceChannel: config.channel,
         externalUserId: config.senderExternalUserId,
         externalChatId: config.externalChatId,
@@ -302,7 +302,7 @@ for (const config of CHANNEL_CONFIGS) {
 
     test("no cross-channel leakage between member records", () => {
       // Create a member for this channel
-      upsertMember({
+      upsertContactChannel({
         sourceChannel: config.channel,
         externalUserId: config.senderExternalUserId,
         externalChatId: config.externalChatId,

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -47,7 +47,7 @@ import {
 import {
   createGuardianBinding,
   revokeMember,
-  upsertMember,
+  upsertContactChannel,
 } from "../contacts/contacts-write.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { resolveActorTrust } from "../runtime/actor-trust-resolver.js";
@@ -115,7 +115,7 @@ describe("trusted contact verification → member activation", () => {
     }
 
     // Simulate the member upsert that inbound-message-handler performs on success
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "requester-user-123",
       externalChatId: "requester-chat-123",
@@ -141,7 +141,7 @@ describe("trusted contact verification → member activation", () => {
   });
 
   test("resolveActorTrust surfaces member displayName when sender displayName is missing", () => {
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "requester-user-jeff",
       externalChatId: "requester-chat-jeff",
@@ -169,7 +169,7 @@ describe("trusted contact verification → member activation", () => {
   });
 
   test("resolveActorTrust prioritizes member displayName over sender displayName", () => {
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "requester-user-jeff-priority",
       externalChatId: "requester-chat-jeff-priority",
@@ -201,7 +201,7 @@ describe("trusted contact verification → member activation", () => {
   test("resolveActorTrust falls back to sender metadata when member record matches chat but not sender (group chat)", () => {
     // Simulate a group chat: member record exists for a different user who
     // shares the same externalChatId (e.g., Telegram group).
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "other-user-in-group",
       externalChatId: "shared-group-chat",
@@ -251,7 +251,7 @@ describe("trusted contact verification → member activation", () => {
     );
 
     // Simulate member upsert on verification success
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "requester-user-456",
       externalChatId: "requester-chat-456",
@@ -289,7 +289,7 @@ describe("trusted contact verification → member activation", () => {
       "chat-cross-test",
     );
 
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "user-cross-test",
       externalChatId: "chat-cross-test",
@@ -315,7 +315,7 @@ describe("trusted contact verification → member activation", () => {
 
   test("re-verification of previously revoked member reactivates them", () => {
     // Create and activate a member
-    const member = upsertMember({
+    const member = upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "user-revoked",
       externalChatId: "chat-revoked",
@@ -359,8 +359,8 @@ describe("trusted contact verification → member activation", () => {
       expect(result.verificationType).toBe("trusted_contact");
     }
 
-    // upsertMember reactivates the existing record
-    upsertMember({
+    // upsertContactChannel reactivates the existing record
+    upsertContactChannel({
       sourceChannel: "telegram",
       externalUserId: "user-revoked",
       externalChatId: "chat-revoked",

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -24,7 +24,7 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { upsertMember } from "../contacts/contacts-write.js";
+import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
 import { createInvite, revokeInvite } from "../memory/invite-store.js";
 import { redeemVoiceInviteCode } from "../runtime/invite-redemption-service.js";
@@ -281,7 +281,7 @@ describe("redeemVoiceInviteCode", () => {
     const { code } = createVoiceInvite({ callerPhone: phone });
 
     // Pre-create an active member for this phone on voice channel
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "voice",
       externalUserId: phone,
       status: "active",
@@ -306,7 +306,7 @@ describe("redeemVoiceInviteCode", () => {
     const phone = "+15551234567";
     const { code } = createVoiceInvite({ callerPhone: phone });
 
-    upsertMember({
+    upsertContactChannel({
       sourceChannel: "voice",
       externalUserId: phone,
       status: "blocked",

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -13,7 +13,7 @@
 
 import { answerCall } from "../calls/call-domain.js";
 import { getGatewayInternalBaseUrl } from "../config/env.js";
-import { upsertMember } from "../contacts/contacts-write.js";
+import { upsertContactChannel } from "../contacts/contacts-write.js";
 import {
   type CanonicalGuardianRequest,
   getCanonicalGuardianRequest,
@@ -459,7 +459,7 @@ const accessRequestResolver: GuardianRequestResolver = {
     // relay server's in-call wait loop will detect the approved status.
     if (channel === "voice") {
       try {
-        upsertMember({
+        upsertContactChannel({
           sourceChannel: "voice",
           externalUserId: requesterExternalUserId,
           externalChatId: requesterChatId,

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -19,7 +19,7 @@ import {
   createGuardianBinding,
   revokeGuardianBinding,
   touchContactInteraction,
-  upsertMember,
+  upsertContactChannel,
 } from "../contacts/contacts-write.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { getCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
@@ -785,7 +785,7 @@ export class RelayConnection {
 
     if (!params.skipMemberActivation) {
       try {
-        upsertMember({
+        upsertContactChannel({
           sourceChannel: "voice",
           externalUserId: fromNumber,
           externalChatId: fromNumber,

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -134,7 +134,7 @@ export function revokeGuardianBinding(channel: string): boolean {
  * Returns the native Contact + ContactChannel, or null if no usable
  * identity was provided or the lookup failed after upsert.
  */
-export function upsertMember(params: {
+export function upsertContactChannel(params: {
   sourceChannel: string;
   externalUserId?: string;
   externalChatId?: string;

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -9,7 +9,7 @@
 
 import type { ChannelId } from "../channels/types.js";
 import { findContactChannel } from "../contacts/contact-store.js";
-import { upsertMember } from "../contacts/contacts-write.js";
+import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getSqlite } from "../memory/db.js";
 import {
   findActiveVoiceInvites,
@@ -147,9 +147,9 @@ export function redeemInvite(params: {
   }
 
   // Inactive member reactivation: when the user already has a member record
-  // in a non-active state (revoked/pending), reactivate it via upsertMember
+  // in a non-active state (revoked/pending), reactivate it via upsertContactChannel
   // and consume an invite use atomically. The fresh-member path below also
-  // uses upsertMember to keep contacts in sync.
+  // uses upsertContactChannel to keep contacts in sync.
   if (existingChannel) {
     // Sentinel error used to trigger a transaction rollback when the invite
     // was concurrently revoked/expired between pre-validation and write time.
@@ -173,11 +173,11 @@ export function redeemInvite(params: {
         ? existingContact.displayName
         : displayName;
 
-    let reactivated: ReturnType<typeof upsertMember> | undefined;
+    let reactivated: ReturnType<typeof upsertContactChannel> | undefined;
     try {
       getSqlite()
         .transaction(() => {
-          reactivated = upsertMember({
+          reactivated = upsertContactChannel({
             sourceChannel,
             externalUserId,
             externalChatId,
@@ -219,11 +219,11 @@ export function redeemInvite(params: {
   // Fresh member creation: upsert into contacts tables and consume an invite
   // use atomically, mirroring the reactivation path above.
   const STALE_INVITE_FRESH = Symbol("stale_invite_fresh");
-  let freshResult: ReturnType<typeof upsertMember> | undefined;
+  let freshResult: ReturnType<typeof upsertContactChannel> | undefined;
   try {
     getSqlite()
       .transaction(() => {
-        freshResult = upsertMember({
+        freshResult = upsertContactChannel({
           sourceChannel,
           externalUserId,
           externalChatId,
@@ -362,7 +362,7 @@ export function redeemVoiceInviteCode(params: {
   try {
     getSqlite()
       .transaction(() => {
-        const writeResult = upsertMember({
+        const writeResult = upsertContactChannel({
           sourceChannel: "voice",
           externalUserId: callerExternalUserId,
           externalChatId: callerExternalUserId,
@@ -481,7 +481,7 @@ export function redeemInviteByCode(params: {
     return { ok: false, reason: "invalid_token" };
   }
 
-  // Inactive member reactivation: reactivate via upsertMember and consume
+  // Inactive member reactivation: reactivate via upsertContactChannel and consume
   // an invite use atomically.
   if (existingChannel) {
     const STALE_INVITE_REACTIVATE = Symbol("stale_invite_reactivate");
@@ -504,11 +504,11 @@ export function redeemInviteByCode(params: {
         ? existingContact.displayName
         : displayName;
 
-    let reactivated: ReturnType<typeof upsertMember> | undefined;
+    let reactivated: ReturnType<typeof upsertContactChannel> | undefined;
     try {
       getSqlite()
         .transaction(() => {
-          reactivated = upsertMember({
+          reactivated = upsertContactChannel({
             sourceChannel,
             externalUserId,
             externalChatId,
@@ -546,11 +546,11 @@ export function redeemInviteByCode(params: {
   // Fresh member creation: upsert into contacts tables and consume an invite
   // use atomically.
   const STALE_INVITE_FRESH = Symbol("stale_invite_fresh");
-  let freshResult: ReturnType<typeof upsertMember> | undefined;
+  let freshResult: ReturnType<typeof upsertContactChannel> | undefined;
   try {
     getSqlite()
       .transaction(() => {
-        freshResult = upsertMember({
+        freshResult = upsertContactChannel({
           sourceChannel,
           externalUserId,
           externalChatId,

--- a/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
@@ -18,7 +18,7 @@ import { findContactChannel } from "../../../contacts/contact-store.js";
 import {
   createGuardianBinding,
   revokeGuardianBinding,
-  upsertMember,
+  upsertContactChannel,
 } from "../../../contacts/contacts-write.js";
 import * as channelDeliveryStore from "../../../memory/channel-delivery-store.js";
 import { emitNotificationSignal } from "../../../notifications/emit-signal.js";
@@ -143,7 +143,7 @@ export async function handleVerificationIntercept(
         ? existingContact.displayName
         : actorDisplayName;
 
-    upsertMember({
+    upsertContactChannel({
       sourceChannel,
       externalUserId: canonicalSenderId ?? rawSenderId,
       externalChatId: conversationExternalId,
@@ -169,7 +169,7 @@ export async function handleVerificationIntercept(
           (canonicalSenderId ?? rawSenderId)
       ) {
         // Edge case: another user already bound. Log and skip binding creation.
-        // The upsertMember above already succeeded, so the sender is a known contact,
+        // The upsertContactChannel above already succeeded, so the sender is a known contact,
         // but they won't get guardian role.
         log.warn(
           {


### PR DESCRIPTION
## Summary
- Rename `upsertMember` to `upsertContactChannel` in contacts-write.ts for clarity
- Update all 12 importing files (call sites and test files) to use the new name
- No behavioral change — purely mechanical rename

Part of plan: invite-accept-ui-auto-update.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)