### PR TITLE
feat: forward verifiedAt/verifiedVia params through upsertContactChannel

### DIFF
--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -144,6 +144,8 @@ export function upsertContactChannel(params: {
   status?: string;
   inviteId?: string;
   createdBySessionId?: string;
+  verifiedAt?: number;
+  verifiedVia?: string;
 }): ContactWriteResult | null {
   let address: string;
 
@@ -187,6 +189,8 @@ export function upsertContactChannel(params: {
         inviteId: params.inviteId ?? null,
         revokedReason: params.status === "active" ? null : undefined,
         blockedReason: params.status === "active" ? null : undefined,
+        verifiedAt: params.verifiedAt ?? undefined,
+        verifiedVia: params.verifiedVia ?? undefined,
       },
     ],
   });


### PR DESCRIPTION
## Summary
- Add optional `verifiedAt` and `verifiedVia` parameters to `upsertContactChannel()`
- Forward these values through to `upsertContact()` channel data
- Backward compatible — existing callers are unaffected

Part of plan: invite-accept-ui-auto-update.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)