### PR TITLE
fix: migrate credential mutators to async secure-key APIs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -80,6 +80,9 @@ declare -a SAFE_LINE_PATTERNS=(
     # the full `key: obj.prop,` expression before the dotted-ref strips only
     # the RHS (which would leave `key: obj` still looking suspicious).
     "[Cc]lient[_-]?[Ss]ecret[[:space:]]*[:=][[:space:]]*[a-zA-Z_][a-zA-Z0-9_.?]*[[:space:]]*((\?\?|\|\|)[[:space:]]*(undefined))?[[:space:]]*([;,)]|$)"
+    # TS/JS: clientSecret assigned from a dotted/optional property with `as` type assertion.
+    # E.g. `const clientSecret = meta?.oauth2ClientSecret as string | undefined;`
+    "[Cc]lient[_-]?[Ss]ecret[[:space:]]*[:=][[:space:]]*[a-zA-Z_][a-zA-Z0-9_.?]*[[:space:]]+as[[:space:]]+(string|String|number|unknown|any)[[:space:]]*([|][[:space:]]*(undefined|null))?[[:space:]]*[;,]"
     # TS/JS: camelCase property names containing clientSecret used as identifiers
     # (typeof checks, null/undefined comparisons, variable/property references).
     # Avoids false positives like `oauth2ClientSecret: typeof record.oauth2ClientSecret`.
@@ -260,6 +263,8 @@ if [ "${1:-}" = "--self-test" ]; then
     SAFE_SWIFT_NAMED_ARG='                clientSecret: trimmedSecret'
     # Swift named argument passing a variable for privateKey (false positive to whitelist)
     SAFE_SWIFT_PRIVATE_KEY_ARG='            sshPrivateKey: state.sshPrivateKey,'
+    # TS type assertion of clientSecret from dotted property (false positive to whitelist)
+    SAFE_TS_TYPE_ASSERTION_SECRET='  const clientSecret = meta?.oauth2ClientSecret as string | undefined;'
     # AWS well-known example key (false positive to whitelist)
     SAFE_AWS_EXAMPLE_KEY='const EXAMPLE_KEY = "AKIAIOSFODNN7EXAMPLE";'
     # Swift storage key constant (safe — UserDefaults key, not a secret)
@@ -513,6 +518,10 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_AWS_EXAMPLE_KEY" && ! matches_safe_line_pattern "$SAFE_AWS_EXAMPLE_KEY"; then
         echo -e "${RED}Self-test failed:${NC} AWS well-known example key false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_TS_TYPE_ASSERTION_SECRET" && ! matches_safe_line_pattern "$SAFE_TS_TYPE_ASSERTION_SECRET"; then
+        echo -e "${RED}Self-test failed:${NC} TS type-assertion clientSecret false positive"
         exit 1
     fi
     if matches_safe_line_pattern "$SAFE_SWIFT_STORAGE_KEY"; then

--- a/assistant/src/__tests__/handlers-telegram-config.test.ts
+++ b/assistant/src/__tests__/handlers-telegram-config.test.ts
@@ -66,20 +66,27 @@ let secureKeyStore: Record<string, string> = {};
 let setSecureKeyOverride: ((account: string, value: string) => boolean) | null =
   null;
 
+function syncSet(account: string, value: string): boolean {
+  if (setSecureKeyOverride) return setSecureKeyOverride(account, value);
+  secureKeyStore[account] = value;
+  return true;
+}
+
+function syncDelete(account: string): "deleted" | "not-found" {
+  if (account in secureKeyStore) {
+    delete secureKeyStore[account];
+    return "deleted";
+  }
+  return "not-found";
+}
+
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (account: string) => secureKeyStore[account] ?? undefined,
-  setSecureKey: (account: string, value: string) => {
-    if (setSecureKeyOverride) return setSecureKeyOverride(account, value);
-    secureKeyStore[account] = value;
-    return true;
-  },
-  deleteSecureKey: (account: string) => {
-    if (account in secureKeyStore) {
-      delete secureKeyStore[account];
-      return "deleted";
-    }
-    return "not-found";
-  },
+  setSecureKey: syncSet,
+  deleteSecureKey: syncDelete,
+  setSecureKeyAsync: async (account: string, value: string) =>
+    syncSet(account, value),
+  deleteSecureKeyAsync: async (account: string) => syncDelete(account),
   listSecureKeys: () => Object.keys(secureKeyStore),
   getBackendType: () => "encrypted",
   isDowngradedFromKeychain: () => false,

--- a/assistant/src/__tests__/handlers-twitter-config.test.ts
+++ b/assistant/src/__tests__/handlers-twitter-config.test.ts
@@ -61,20 +61,27 @@ let secureKeyStore: Record<string, string> = {};
 let setSecureKeyOverride: ((account: string, value: string) => boolean) | null =
   null;
 
+function syncSet(account: string, value: string): boolean {
+  if (setSecureKeyOverride) return setSecureKeyOverride(account, value);
+  secureKeyStore[account] = value;
+  return true;
+}
+
+function syncDelete(account: string): "deleted" | "not-found" {
+  if (account in secureKeyStore) {
+    delete secureKeyStore[account];
+    return "deleted";
+  }
+  return "not-found";
+}
+
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (account: string) => secureKeyStore[account] ?? undefined,
-  setSecureKey: (account: string, value: string) => {
-    if (setSecureKeyOverride) return setSecureKeyOverride(account, value);
-    secureKeyStore[account] = value;
-    return true;
-  },
-  deleteSecureKey: (account: string) => {
-    if (account in secureKeyStore) {
-      delete secureKeyStore[account];
-      return "deleted";
-    }
-    return "not-found";
-  },
+  setSecureKey: syncSet,
+  deleteSecureKey: syncDelete,
+  setSecureKeyAsync: async (account: string, value: string) =>
+    syncSet(account, value),
+  deleteSecureKeyAsync: async (account: string) => syncDelete(account),
   listSecureKeys: () => Object.keys(secureKeyStore),
   getBackendType: () => "encrypted",
   isDowngradedFromKeychain: () => false,
@@ -134,10 +141,25 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 
 import { handleMessage, type HandlerContext } from "../daemon/handlers.js";
 import type {
+  ClientMessage,
   ServerMessage,
   TwitterIntegrationConfigRequest,
 } from "../daemon/ipc-contract.js";
 import { DebouncerMap } from "../util/debounce.js";
+
+/**
+ * Wrapper around handleMessage that flushes the microtask queue so async
+ * handlers complete before assertions run. handleMessage() returns void
+ * and swallows the promise, so we need a macrotask tick to settle.
+ */
+async function handleMessageAsync(
+  msg: ClientMessage,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  handleMessage(msg, socket, ctx);
+  await new Promise<void>((r) => setTimeout(r, 0));
+}
 
 function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
   const sent: ServerMessage[] = [];
@@ -259,7 +281,7 @@ describe("Twitter integration config handler", () => {
     expect(saveRawConfigCalls[0]!.twitterIntegrationMode).toBe("managed");
   });
 
-  test("set_local_client stores credentials in secure storage", () => {
+  test("set_local_client stores credentials in secure storage", async () => {
     const msg: TwitterIntegrationConfigRequest = {
       type: "twitter_integration_config",
       action: "set_local_client",
@@ -268,7 +290,7 @@ describe("Twitter integration config handler", () => {
     };
 
     const { ctx, sent } = createTestContext();
-    handleMessage(msg, {} as net.Socket, ctx);
+    await handleMessageAsync(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
     const res = sent[0] as {
@@ -288,14 +310,14 @@ describe("Twitter integration config handler", () => {
     ).toBe("my-client-secret");
   });
 
-  test("set_local_client without clientId returns error", () => {
+  test("set_local_client without clientId returns error", async () => {
     const msg: TwitterIntegrationConfigRequest = {
       type: "twitter_integration_config",
       action: "set_local_client",
     };
 
     const { ctx, sent } = createTestContext();
-    handleMessage(msg, {} as net.Socket, ctx);
+    await handleMessageAsync(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
     const res = sent[0] as { type: string; success: boolean; error: string };
@@ -303,7 +325,7 @@ describe("Twitter integration config handler", () => {
     expect(res.error).toContain("clientId is required");
   });
 
-  test("clear_local_client removes credentials", () => {
+  test("clear_local_client removes credentials", async () => {
     secureKeyStore["credential:integration:twitter:oauth_client_id"] =
       "my-client-id";
     secureKeyStore["credential:integration:twitter:oauth_client_secret"] =
@@ -315,7 +337,7 @@ describe("Twitter integration config handler", () => {
     };
 
     const { ctx, sent } = createTestContext();
-    handleMessage(msg, {} as net.Socket, ctx);
+    await handleMessageAsync(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
     const res = sent[0] as {
@@ -336,7 +358,7 @@ describe("Twitter integration config handler", () => {
     ).toBeUndefined();
   });
 
-  test("clear_local_client also disconnects if connected", () => {
+  test("clear_local_client also disconnects if connected", async () => {
     secureKeyStore["credential:integration:twitter:oauth_client_id"] =
       "my-client-id";
     secureKeyStore["credential:integration:twitter:access_token"] =
@@ -355,7 +377,7 @@ describe("Twitter integration config handler", () => {
     };
 
     const { ctx, sent } = createTestContext();
-    handleMessage(msg, {} as net.Socket, ctx);
+    await handleMessageAsync(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
     const res = sent[0] as {
@@ -378,7 +400,7 @@ describe("Twitter integration config handler", () => {
     });
   });
 
-  test("disconnect removes tokens and metadata", () => {
+  test("disconnect removes tokens and metadata", async () => {
     secureKeyStore["credential:integration:twitter:oauth_client_id"] =
       "my-client-id";
     secureKeyStore["credential:integration:twitter:access_token"] =
@@ -397,7 +419,7 @@ describe("Twitter integration config handler", () => {
     };
 
     const { ctx, sent } = createTestContext();
-    handleMessage(msg, {} as net.Socket, ctx);
+    await handleMessageAsync(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
     const res = sent[0] as {
@@ -426,7 +448,7 @@ describe("Twitter integration config handler", () => {
     });
   });
 
-  test("set_local_client returns error when setSecureKey fails for client ID", () => {
+  test("set_local_client returns error when setSecureKey fails for client ID", async () => {
     // Override setSecureKey to return false (storage unavailable, not throwing)
     setSecureKeyOverride = () => false;
 
@@ -438,7 +460,7 @@ describe("Twitter integration config handler", () => {
     };
 
     const { ctx, sent } = createTestContext();
-    handleMessage(msg, {} as net.Socket, ctx);
+    await handleMessageAsync(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
     const res = sent[0] as {
@@ -453,7 +475,7 @@ describe("Twitter integration config handler", () => {
     expect(res.error).toContain("Failed to store client ID");
   });
 
-  test("set_local_client returns error when setSecureKey fails for client secret", () => {
+  test("set_local_client returns error when setSecureKey fails for client secret", async () => {
     // Override setSecureKey to fail only for the secret
     setSecureKeyOverride = (account: string, value: string) => {
       if (account.includes("client_secret")) return false;
@@ -469,7 +491,7 @@ describe("Twitter integration config handler", () => {
     };
 
     const { ctx, sent } = createTestContext();
-    handleMessage(msg, {} as net.Socket, ctx);
+    await handleMessageAsync(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
     const res = sent[0] as {
@@ -484,7 +506,7 @@ describe("Twitter integration config handler", () => {
     expect(res.error).toContain("Failed to store client secret");
   });
 
-  test("set_local_client without secret clears stale secret", () => {
+  test("set_local_client without secret clears stale secret", async () => {
     // Pre-populate an old client secret
     secureKeyStore["credential:integration:twitter:oauth_client_id"] = "old-id";
     secureKeyStore["credential:integration:twitter:oauth_client_secret"] =
@@ -497,7 +519,7 @@ describe("Twitter integration config handler", () => {
     };
 
     const { ctx, sent } = createTestContext();
-    handleMessage(msg, {} as net.Socket, ctx);
+    await handleMessageAsync(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
     const res = sent[0] as {
@@ -576,7 +598,7 @@ describe("Twitter integration config handler", () => {
     expect((sent4[0] as { mode: string }).mode).toBe("local_byo");
   });
 
-  test("set_local_client with only clientId (no secret)", () => {
+  test("set_local_client with only clientId (no secret)", async () => {
     const msg: TwitterIntegrationConfigRequest = {
       type: "twitter_integration_config",
       action: "set_local_client",
@@ -584,7 +606,7 @@ describe("Twitter integration config handler", () => {
     };
 
     const { ctx, sent } = createTestContext();
-    handleMessage(msg, {} as net.Socket, ctx);
+    await handleMessageAsync(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
     const res = sent[0] as {
@@ -604,7 +626,7 @@ describe("Twitter integration config handler", () => {
     ).toBeUndefined();
   });
 
-  test("set_local_client overwrites existing credentials", () => {
+  test("set_local_client overwrites existing credentials", async () => {
     // Set initial credentials
     secureKeyStore["credential:integration:twitter:oauth_client_id"] = "old-id";
     secureKeyStore["credential:integration:twitter:oauth_client_secret"] =
@@ -618,7 +640,7 @@ describe("Twitter integration config handler", () => {
     };
 
     const { ctx, sent } = createTestContext();
-    handleMessage(msg, {} as net.Socket, ctx);
+    await handleMessageAsync(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
     const res = sent[0] as {
@@ -638,7 +660,7 @@ describe("Twitter integration config handler", () => {
     ).toBe("new-secret");
   });
 
-  test("clear_local_client when no credentials exist (idempotent)", () => {
+  test("clear_local_client when no credentials exist (idempotent)", async () => {
     // No credentials set at all
     const msg: TwitterIntegrationConfigRequest = {
       type: "twitter_integration_config",
@@ -646,7 +668,7 @@ describe("Twitter integration config handler", () => {
     };
 
     const { ctx, sent } = createTestContext();
-    handleMessage(msg, {} as net.Socket, ctx);
+    await handleMessageAsync(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
     const res = sent[0] as {
@@ -661,7 +683,7 @@ describe("Twitter integration config handler", () => {
     expect(res.connected).toBe(false);
   });
 
-  test("disconnect when not connected (idempotent) preserves client credentials", () => {
+  test("disconnect when not connected (idempotent) preserves client credentials", async () => {
     // Only client credentials, no access token
     secureKeyStore["credential:integration:twitter:oauth_client_id"] =
       "my-client-id";
@@ -674,7 +696,7 @@ describe("Twitter integration config handler", () => {
     };
 
     const { ctx, sent } = createTestContext();
-    handleMessage(msg, {} as net.Socket, ctx);
+    await handleMessageAsync(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
     const res = sent[0] as {
@@ -696,7 +718,7 @@ describe("Twitter integration config handler", () => {
     ).toBe("my-client-secret");
   });
 
-  test("disconnect preserves client credentials when access token exists", () => {
+  test("disconnect preserves client credentials when access token exists", async () => {
     // Set up both client credentials and tokens
     secureKeyStore["credential:integration:twitter:oauth_client_id"] =
       "my-client-id";
@@ -718,7 +740,7 @@ describe("Twitter integration config handler", () => {
     };
 
     const { ctx, sent } = createTestContext();
-    handleMessage(msg, {} as net.Socket, ctx);
+    await handleMessageAsync(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
     const res = sent[0] as {
@@ -752,7 +774,7 @@ describe("Twitter integration config handler", () => {
     });
   });
 
-  test("clear_local_client cascades to remove tokens and metadata", () => {
+  test("clear_local_client cascades to remove tokens and metadata", async () => {
     // Set up client credentials, tokens, and metadata
     secureKeyStore["credential:integration:twitter:oauth_client_id"] =
       "my-client-id";
@@ -774,7 +796,7 @@ describe("Twitter integration config handler", () => {
     };
 
     const { ctx, sent } = createTestContext();
-    handleMessage(msg, {} as net.Socket, ctx);
+    await handleMessageAsync(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
     const res = sent[0] as {
@@ -860,7 +882,7 @@ describe("Twitter integration config handler", () => {
     expect(res.connected).toBe(false);
   });
 
-  test("error in secure storage throws and returns error response", () => {
+  test("error in secure storage throws and returns error response", async () => {
     // Override setSecureKey to throw an error, simulating a storage failure
     setSecureKeyOverride = () => {
       throw new Error("Keychain access denied");
@@ -874,7 +896,7 @@ describe("Twitter integration config handler", () => {
     };
 
     const { ctx, sent } = createTestContext();
-    handleMessage(msg, {} as net.Socket, ctx);
+    await handleMessageAsync(msg, {} as net.Socket, ctx);
 
     expect(sent).toHaveLength(1);
     const res = sent[0] as { type: string; success: boolean; error?: string };

--- a/assistant/src/__tests__/secure-keys.test.ts
+++ b/assistant/src/__tests__/secure-keys.test.ts
@@ -303,6 +303,84 @@ describe("secure-keys", () => {
   });
 
   // -----------------------------------------------------------------------
+  // Stale-value prevention — broker-first reads after credential updates
+  // -----------------------------------------------------------------------
+  describe("stale-value prevention", () => {
+    test("setSecureKeyAsync updates broker so broker-first read returns new value", async () => {
+      mockBrokerAvailable = true;
+      // Simulate broker holding an old value
+      mockBrokerStore.set("api-key", "old-broker-value");
+      setSecureKey("api-key", "old-encrypted-value");
+
+      // Update via async path (writes both broker + encrypted)
+      const ok = await setSecureKeyAsync("api-key", "new-value");
+      expect(ok).toBe(true);
+
+      // Broker-first read should return the new value, not stale old value
+      const value = await getSecureKeyAsync("api-key");
+      expect(value).toBe("new-value");
+      // Both stores should agree
+      expect(mockBrokerStore.get("api-key")).toBe("new-value");
+      expect(getSecureKey("api-key")).toBe("new-value");
+    });
+
+    test("deleteSecureKeyAsync removes from broker so broker-first read falls through", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerStore.set("api-key", "old-broker-value");
+      setSecureKey("api-key", "old-encrypted-value");
+
+      // Delete via async path (deletes from both broker + encrypted)
+      const result = await deleteSecureKeyAsync("api-key");
+      expect(result).toBe("deleted");
+
+      // Broker-first read should not find the key in either store
+      const value = await getSecureKeyAsync("api-key");
+      expect(value).toBeUndefined();
+    });
+
+    test("sync setSecureKey does NOT update broker — stale read demonstrates the problem", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerStore.set("api-key", "old-broker-value");
+
+      // Sync write only updates encrypted store, NOT broker
+      setSecureKey("api-key", "new-encrypted-value");
+
+      // Broker-first read still returns the stale broker value
+      const value = await getSecureKeyAsync("api-key");
+      expect(value).toBe("old-broker-value");
+      // This is the exact bug that async migration fixes
+    });
+
+    test("setSecureKeyAsync failure leaves both stores unchanged", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerSetError = true;
+      mockBrokerStore.set("api-key", "original-value");
+      setSecureKey("api-key", "original-value");
+
+      const ok = await setSecureKeyAsync("api-key", "new-value");
+      expect(ok).toBe(false);
+
+      // Both stores should retain original value — no partial update
+      expect(mockBrokerStore.get("api-key")).toBe("original-value");
+      expect(getSecureKey("api-key")).toBe("original-value");
+    });
+
+    test("deleteSecureKeyAsync failure leaves both stores unchanged", async () => {
+      mockBrokerAvailable = true;
+      mockBrokerDelError = true;
+      mockBrokerStore.set("api-key", "value");
+      setSecureKey("api-key", "value");
+
+      const result = await deleteSecureKeyAsync("api-key");
+      expect(result).toBe("error");
+
+      // Both stores should retain the key — no partial deletion
+      expect(mockBrokerStore.has("api-key")).toBe(true);
+      expect(getSecureKey("api-key")).toBe("value");
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // _setBackend / _resetBackend (no-ops kept for test compat)
   // -----------------------------------------------------------------------
   describe("_setBackend", () => {

--- a/assistant/src/daemon/handlers/config-integrations.ts
+++ b/assistant/src/daemon/handlers/config-integrations.ts
@@ -2,9 +2,9 @@ import * as net from "node:net";
 
 import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
 import {
-  deleteSecureKey,
+  deleteSecureKeyAsync,
   getSecureKey,
-  setSecureKey,
+  setSecureKeyAsync,
 } from "../../security/secure-keys.js";
 import {
   deleteCredentialMetadata,
@@ -17,11 +17,11 @@ import type {
 } from "../ipc-protocol.js";
 import { defineHandlers, type HandlerContext, log } from "./shared.js";
 
-export function handleVercelApiConfig(
+export async function handleVercelApiConfig(
   msg: VercelApiConfigRequest,
   socket: net.Socket,
   ctx: HandlerContext,
-): void {
+): Promise<void> {
   try {
     if (msg.action === "get") {
       const existing = getSecureKey("credential:vercel:api_token");
@@ -40,7 +40,10 @@ export function handleVercelApiConfig(
         });
         return;
       }
-      const stored = setSecureKey("credential:vercel:api_token", msg.apiToken);
+      const stored = await setSecureKeyAsync(
+        "credential:vercel:api_token",
+        msg.apiToken,
+      );
       if (!stored) {
         ctx.send(socket, {
           type: "vercel_api_config_response",
@@ -59,7 +62,7 @@ export function handleVercelApiConfig(
         success: true,
       });
     } else {
-      deleteSecureKey("credential:vercel:api_token");
+      await deleteSecureKeyAsync("credential:vercel:api_token");
       deleteCredentialMetadata("vercel", "api_token");
       ctx.send(socket, {
         type: "vercel_api_config_response",
@@ -87,11 +90,11 @@ function hasTwitterClientId(): boolean {
   );
 }
 
-export function handleTwitterIntegrationConfig(
+export async function handleTwitterIntegrationConfig(
   msg: TwitterIntegrationConfigRequest,
   socket: net.Socket,
   ctx: HandlerContext,
-): void {
+): Promise<void> {
   try {
     if (msg.action === "get") {
       const raw = loadRawConfig();
@@ -205,8 +208,8 @@ export function handleTwitterIntegrationConfig(
       const previousClientId =
         getSecureKey("credential:integration:twitter:client_id") ??
         getSecureKey("credential:integration:twitter:oauth_client_id");
-      // Write canonical key
-      const storedId = setSecureKey(
+      // Write canonical key (async — writes broker + encrypted store)
+      const storedId = await setSecureKeyAsync(
         "credential:integration:twitter:client_id",
         msg.clientId,
       );
@@ -222,30 +225,34 @@ export function handleTwitterIntegrationConfig(
         return;
       }
       // Also write legacy key for backward compatibility
-      setSecureKey(
+      await setSecureKeyAsync(
         "credential:integration:twitter:oauth_client_id",
         msg.clientId,
       );
       if (msg.clientSecret) {
         // Write canonical key
-        const storedSecret = setSecureKey(
+        const storedSecret = await setSecureKeyAsync(
           "credential:integration:twitter:client_secret",
           msg.clientSecret,
         );
         if (!storedSecret) {
           // Roll back the client ID to its previous value to avoid inconsistent OAuth state
           if (previousClientId) {
-            setSecureKey(
+            await setSecureKeyAsync(
               "credential:integration:twitter:client_id",
               previousClientId,
             );
-            setSecureKey(
+            await setSecureKeyAsync(
               "credential:integration:twitter:oauth_client_id",
               previousClientId,
             );
           } else {
-            deleteSecureKey("credential:integration:twitter:client_id");
-            deleteSecureKey("credential:integration:twitter:oauth_client_id");
+            await deleteSecureKeyAsync(
+              "credential:integration:twitter:client_id",
+            );
+            await deleteSecureKeyAsync(
+              "credential:integration:twitter:oauth_client_id",
+            );
           }
           ctx.send(socket, {
             type: "twitter_integration_config_response",
@@ -258,14 +265,18 @@ export function handleTwitterIntegrationConfig(
           return;
         }
         // Also write legacy key for backward compatibility
-        setSecureKey(
+        await setSecureKeyAsync(
           "credential:integration:twitter:oauth_client_secret",
           msg.clientSecret,
         );
       } else {
         // Clear any stale secret when updating client without a secret (e.g. switching to PKCE)
-        deleteSecureKey("credential:integration:twitter:client_secret");
-        deleteSecureKey("credential:integration:twitter:oauth_client_secret");
+        await deleteSecureKeyAsync(
+          "credential:integration:twitter:client_secret",
+        );
+        await deleteSecureKeyAsync(
+          "credential:integration:twitter:oauth_client_secret",
+        );
       }
       ctx.send(socket, {
         type: "twitter_integration_config_response",
@@ -279,15 +290,25 @@ export function handleTwitterIntegrationConfig(
     } else if (msg.action === "clear_local_client") {
       // If connected, disconnect first
       if (getSecureKey("credential:integration:twitter:access_token")) {
-        deleteSecureKey("credential:integration:twitter:access_token");
-        deleteSecureKey("credential:integration:twitter:refresh_token");
+        await deleteSecureKeyAsync(
+          "credential:integration:twitter:access_token",
+        );
+        await deleteSecureKeyAsync(
+          "credential:integration:twitter:refresh_token",
+        );
         deleteCredentialMetadata("integration:twitter", "access_token");
       }
       // Remove both canonical and legacy client credential keys
-      deleteSecureKey("credential:integration:twitter:client_id");
-      deleteSecureKey("credential:integration:twitter:client_secret");
-      deleteSecureKey("credential:integration:twitter:oauth_client_id");
-      deleteSecureKey("credential:integration:twitter:oauth_client_secret");
+      await deleteSecureKeyAsync("credential:integration:twitter:client_id");
+      await deleteSecureKeyAsync(
+        "credential:integration:twitter:client_secret",
+      );
+      await deleteSecureKeyAsync(
+        "credential:integration:twitter:oauth_client_id",
+      );
+      await deleteSecureKeyAsync(
+        "credential:integration:twitter:oauth_client_secret",
+      );
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: true,
@@ -296,8 +317,10 @@ export function handleTwitterIntegrationConfig(
         connected: false,
       });
     } else if (msg.action === "disconnect") {
-      deleteSecureKey("credential:integration:twitter:access_token");
-      deleteSecureKey("credential:integration:twitter:refresh_token");
+      await deleteSecureKeyAsync("credential:integration:twitter:access_token");
+      await deleteSecureKeyAsync(
+        "credential:integration:twitter:refresh_token",
+      );
       deleteCredentialMetadata("integration:twitter", "access_token");
       // Client credentials (client_id, oauth_client_id, etc.) are intentionally
       // preserved so the user can re-connect without reconfiguring.

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -6,9 +6,9 @@ import {
   shouldUsePlatformCallbacks,
 } from "../../inbound/platform-callback-registration.js";
 import {
-  deleteSecureKey,
+  deleteSecureKeyAsync,
   getSecureKey,
-  setSecureKey,
+  setSecureKeyAsync,
 } from "../../security/secure-keys.js";
 import {
   deleteCredentialMetadata,
@@ -130,8 +130,11 @@ export async function setTelegramConfig(
     };
   }
 
-  // Store bot token securely
-  const stored = setSecureKey("credential:telegram:bot_token", resolvedToken);
+  // Store bot token securely (async — writes broker + encrypted store)
+  const stored = await setSecureKeyAsync(
+    "credential:telegram:bot_token",
+    resolvedToken,
+  );
   if (!stored) {
     return {
       success: false,
@@ -152,7 +155,7 @@ export async function setTelegramConfig(
   if (!hasWebhookSecret) {
     const { randomUUID } = await import("node:crypto");
     const webhookSecret = randomUUID();
-    const secretStored = setSecureKey(
+    const secretStored = await setSecureKeyAsync(
       "credential:telegram:webhook_secret",
       webhookSecret,
     );
@@ -164,7 +167,7 @@ export async function setTelegramConfig(
       // When the token came from secure storage it was already valid
       // configuration; deleting it would destroy working state.
       if (isNewToken) {
-        deleteSecureKey("credential:telegram:bot_token");
+        await deleteSecureKeyAsync("credential:telegram:bot_token");
         deleteCredentialMetadata("telegram", "bot_token");
       }
       return {
@@ -226,9 +229,9 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
     }
   }
 
-  deleteSecureKey("credential:telegram:bot_token");
+  await deleteSecureKeyAsync("credential:telegram:bot_token");
   deleteCredentialMetadata("telegram", "bot_token");
-  deleteSecureKey("credential:telegram:webhook_secret");
+  await deleteSecureKeyAsync("credential:telegram:webhook_secret");
   deleteCredentialMetadata("telegram", "webhook_secret");
 
   // Trigger reconcile to deregister webhook

--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -37,9 +37,9 @@ import { getReadinessService } from "../../daemon/handlers/config-channels.js";
 import { syncTwilioWebhooks } from "../../daemon/handlers/config-ingress.js";
 import type { IngressConfig } from "../../inbound/public-ingress-urls.js";
 import {
-  deleteSecureKey,
+  deleteSecureKeyAsync,
   getSecureKey,
-  setSecureKey,
+  setSecureKeyAsync,
 } from "../../security/secure-keys.js";
 import {
   deleteCredentialMetadata,
@@ -213,8 +213,8 @@ export async function handleSetTwilioCredentials(
     });
   }
 
-  // Store credentials securely
-  const sidStored = setSecureKey(
+  // Store credentials securely (async — writes broker + encrypted store)
+  const sidStored = await setSecureKeyAsync(
     "credential:twilio:account_sid",
     body.accountSid,
   );
@@ -226,12 +226,12 @@ export async function handleSetTwilioCredentials(
     });
   }
 
-  const tokenStored = setSecureKey(
+  const tokenStored = await setSecureKeyAsync(
     "credential:twilio:auth_token",
     body.authToken,
   );
   if (!tokenStored) {
-    deleteSecureKey("credential:twilio:account_sid");
+    await deleteSecureKeyAsync("credential:twilio:account_sid");
     return Response.json({
       success: false,
       hasCredentials: false,
@@ -275,9 +275,9 @@ export async function handleSetTwilioCredentials(
 /**
  * DELETE /v1/integrations/twilio/credentials
  */
-export function handleClearTwilioCredentials(): Response {
-  deleteSecureKey("credential:twilio:account_sid");
-  deleteSecureKey("credential:twilio:auth_token");
+export async function handleClearTwilioCredentials(): Promise<Response> {
+  await deleteSecureKeyAsync("credential:twilio:account_sid");
+  await deleteSecureKeyAsync("credential:twilio:auth_token");
   deleteCredentialMetadata("twilio", "account_sid");
   deleteCredentialMetadata("twilio", "auth_token");
 
@@ -347,7 +347,7 @@ export async function handleProvisionTwilioNumber(
     available[0].phoneNumber,
   );
 
-  const phoneStored = setSecureKey(
+  const phoneStored = await setSecureKeyAsync(
     "credential:twilio:phone_number",
     purchased.phoneNumber,
   );
@@ -403,7 +403,7 @@ export async function handleAssignTwilioNumber(
     );
   }
 
-  const phoneStored = setSecureKey(
+  const phoneStored = await setSecureKeyAsync(
     "credential:twilio:phone_number",
     body.phoneNumber,
   );
@@ -486,7 +486,7 @@ export async function handleReleaseTwilioNumber(
 
   const storedPhone = getSecureKey("credential:twilio:phone_number");
   if (storedPhone === phoneNumber) {
-    deleteSecureKey("credential:twilio:phone_number");
+    await deleteSecureKeyAsync("credential:twilio:phone_number");
   }
 
   return Response.json({
@@ -1178,7 +1178,7 @@ export function twilioRouteDefinitions(): RouteDefinition[] {
     {
       endpoint: "integrations/twilio/credentials",
       method: "DELETE",
-      handler: () => handleClearTwilioCredentials(),
+      handler: async () => handleClearTwilioCredentials(),
     },
     {
       endpoint: "integrations/twilio/numbers",

--- a/assistant/src/security/token-manager.ts
+++ b/assistant/src/security/token-manager.ts
@@ -12,7 +12,7 @@ import {
 } from "../tools/credentials/metadata-store.js";
 import { getLogger } from "../util/logger.js";
 import { refreshOAuth2Token, type TokenEndpointAuthMethod } from "./oauth2.js";
-import { getSecureKey, setSecureKey } from "./secure-keys.js";
+import { getSecureKey, setSecureKeyAsync } from "./secure-keys.js";
 
 const log = getLogger("token-manager");
 
@@ -217,7 +217,12 @@ async function doRefresh(service: string): Promise<string> {
     throw err;
   }
 
-  if (!setSecureKey(`credential:${service}:access_token`, result.accessToken)) {
+  if (
+    !(await setSecureKeyAsync(
+      `credential:${service}:access_token`,
+      result.accessToken,
+    ))
+  ) {
     throw new TokenExpiredError(
       service,
       `Failed to store refreshed access token for "${service}".`,
@@ -226,7 +231,10 @@ async function doRefresh(service: string): Promise<string> {
 
   if (result.refreshToken) {
     if (
-      !setSecureKey(`credential:${service}:refresh_token`, result.refreshToken)
+      !(await setSecureKeyAsync(
+        `credential:${service}:refresh_token`,
+        result.refreshToken,
+      ))
     ) {
       throw new TokenExpiredError(
         service,


### PR DESCRIPTION
## Summary
- Migrate all credential mutators (Twilio, Telegram, Twitter, Vercel, OAuth2 token refresh) from sync `setSecureKey`/`deleteSecureKey` to async `setSecureKeyAsync`/`deleteSecureKeyAsync` to keep the keychain broker and encrypted store in sync
- Broker write/delete failures are now surfaced as explicit failures — no silent fallback to encrypted-store-only writes that would leave the broker with stale data
- Added stale-value prevention tests and updated Twitter config tests to handle now-async handlers

## Original prompt
Please address the remaining keychain-broker gaps on main (reviewed at 6338fbea1). Finish the keychain-primary migration so broker-first readers do not return stale values after credential updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
