### PR TITLE
feat: mark channels as verified via invite on redemption

### DIFF
--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -24,6 +24,7 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+import { findContactChannel } from "../contacts/contact-store.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
 import {
@@ -74,6 +75,31 @@ describe("invite-redemption-service", () => {
       memberId: expect.any(String),
       inviteId: invite.id,
     });
+  });
+
+  test("marks channel as verified via invite on redemption", () => {
+    const { rawToken } = createInvite({
+      sourceChannel: "telegram",
+      maxUses: 1,
+    });
+
+    const outcome = redeemInvite({
+      rawToken,
+      sourceChannel: "telegram",
+      externalUserId: "user-1",
+    });
+
+    expect(outcome.ok).toBe(true);
+
+    const result = findContactChannel({
+      channelType: "telegram",
+      externalUserId: "user-1",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.channel.verifiedAt).toBeGreaterThan(0);
+    expect(result!.channel.verifiedVia).toBe("invite");
+    expect(result!.channel.status).toBe("active");
   });
 
   test("returns invalid_token for a bogus token", () => {

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -24,6 +24,7 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+import { findContactChannel } from "../contacts/contact-store.js";
 import { upsertContactChannel } from "../contacts/contacts-write.js";
 import { getSqlite, initializeDb, resetDb } from "../memory/db.js";
 import { createInvite, revokeInvite } from "../memory/invite-store.js";
@@ -175,6 +176,29 @@ describe("redeemVoiceInviteCode", () => {
       memberId: expect.any(String),
       inviteId: expect.any(String),
     });
+  });
+
+  test("marks channel as verified via invite on voice redemption", () => {
+    const phone = "+15551234567";
+    const { code } = createVoiceInvite({ callerPhone: phone });
+
+    const result = redeemVoiceInviteCode({
+      callerExternalUserId: phone,
+      sourceChannel: "voice",
+      code,
+    });
+
+    expect(result.ok).toBe(true);
+
+    const channelResult = findContactChannel({
+      channelType: "voice",
+      externalUserId: phone,
+    });
+
+    expect(channelResult).not.toBeNull();
+    expect(channelResult!.channel.verifiedAt).toBeGreaterThan(0);
+    expect(channelResult!.channel.verifiedVia).toBe("invite");
+    expect(channelResult!.channel.status).toBe("active");
   });
 
   test("wrong caller identity fails with generic error", () => {

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -187,6 +187,8 @@ export function redeemInvite(params: {
             status: "active",
             policy: "allow",
             inviteId: invite.id,
+            verifiedAt: Date.now(),
+            verifiedVia: "invite",
           });
 
           const recorded = recordInviteUse({
@@ -232,6 +234,8 @@ export function redeemInvite(params: {
           status: "active",
           policy: "allow",
           inviteId: invite.id,
+          verifiedAt: Date.now(),
+          verifiedVia: "invite",
         });
 
         const recorded = recordInviteUse({
@@ -370,6 +374,8 @@ export function redeemVoiceInviteCode(params: {
           status: "active",
           policy: "allow",
           inviteId: invite.id,
+          verifiedAt: Date.now(),
+          verifiedVia: "invite",
         });
         memberId = writeResult!.channel.id;
 
@@ -517,6 +523,8 @@ export function redeemInviteByCode(params: {
             status: "active",
             policy: "allow",
             inviteId: invite.id,
+            verifiedAt: Date.now(),
+            verifiedVia: "invite",
           });
 
           const recorded = recordInviteUse({
@@ -559,6 +567,8 @@ export function redeemInviteByCode(params: {
           status: "active",
           policy: "allow",
           inviteId: invite.id,
+          verifiedAt: Date.now(),
+          verifiedVia: "invite",
         });
 
         const recorded = recordInviteUse({


### PR DESCRIPTION
## Summary
- Set `verifiedAt: Date.now()` and `verifiedVia: "invite"` in all five `upsertContactChannel()` call sites across `redeemInvite()`, `redeemVoiceInviteCode()`, and `redeemInviteByCode()`
- Add test assertions verifying the channel is marked as verified after token and voice code redemption
- Fixes the macOS contact UI showing channels as "Active" instead of "Verified" after invite acceptance

Part of plan: invite-accept-ui-auto-update.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
