### PR TITLE
style: increase left padding on settings nav items

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -1107,6 +1107,7 @@ private struct SettingsNavRow: View {
     let tab: SettingsTab
     let isSelected: Bool
     let action: () -> Void
+
     @State private var isHovered = false
 
     var body: some View {
@@ -1119,7 +1120,7 @@ private struct SettingsNavRow: View {
                     .foregroundColor(VColor.textPrimary)
                 Spacer()
             }
-            .padding(.leading, VSpacing.xs)
+            .padding(.leading, VSpacing.sm)
             .padding(.trailing, VSpacing.sm)
             .padding(.vertical, SidebarLayoutMetrics.rowVerticalPadding)
             .frame(minHeight: SidebarLayoutMetrics.rowMinHeight)


### PR DESCRIPTION
## Summary
- Increase left padding on settings nav row text for better alignment within the panel

## Test plan
- [ ] Open Settings panel — verify nav items have slightly more left padding
- [ ] Verify hover and active states still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
