### PR TITLE
feat: migrate twilio-setup skill from gateway API to CLI commands

### DIFF
--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -6,112 +6,72 @@ includes: ["public-ingress"]
 metadata: { "vellum": { "emoji": "\ud83d\udcf1" } }
 ---
 
-You are helping your user configure Twilio for voice calls and SMS messaging. Twilio is the shared telephony provider for both the **phone-calls** and **SMS messaging** capabilities. When this skill is invoked, walk through each step below using existing CLI tools and secure credential storage.
+You are helping your user configure Twilio for voice calls and SMS messaging. Walk through each step below.
 
-## Quick Start
+## Retrieving Twilio Credentials
+
+Many steps below require the Account SID and Auth Token. Retrieve them with:
 
 ```bash
-# 1. Check current status
-assistant config get twilio.accountSid
-assistant credentials inspect twilio:auth_token --json
-assistant config get twilio.phoneNumber
-# 2. Store credentials (after collecting via credential_store prompt)
-assistant config set twilio.accountSid "ACxxx"
-assistant credentials set twilio:auth_token "xxx"
-# 3. Get Account SID and Auth Token for Twilio API calls
 TWILIO_SID=$(assistant config get twilio.accountSid)
 TWILIO_TOKEN=$(assistant credentials reveal twilio:auth_token)
-# 4. Search and provision via Twilio API
-curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/AvailablePhoneNumbers/US/Local.json?SmsEnabled=true&VoiceEnabled=true"
-curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/IncomingPhoneNumbers.json" -d "PhoneNumber=+1xxx"
-# 5. Assign locally (saves to config)
-assistant config set twilio.phoneNumber "+1xxx"
 ```
-
-For voice call setup after Twilio is configured, use `phone-calls` + `call_start`.
-
-## Overview
-
-This skill manages the full Twilio lifecycle:
-
-- **Credential storage** — Auth Token stored securely via `assistant credentials set twilio:auth_token`; Account SID stored in config via `assistant config set twilio.accountSid`
-- **Direct Twilio API access** — Search and purchase numbers via the Twilio REST API using credentials retrieved from CLI
-- **Phone number assignment** — Assign an existing Twilio number to the assistant via `assistant config set twilio.phoneNumber`
-- **Status checking** — Verify credentials and assigned number via `assistant credentials inspect twilio:auth_token` + `assistant config get`
-
-Number search and purchase use direct calls to the Twilio REST API with credentials retrieved via `assistant credentials reveal` and `assistant config get`. Local bookkeeping (Account SID, phone number, config updates) uses `assistant config` commands. Auth Token is stored in encrypted credential storage via `assistant credentials`.
 
 ## Step 1: Check Current Configuration
 
-First, check whether Twilio is already configured:
-
 ```bash
-# Check if Account SID is configured
 assistant config get twilio.accountSid
-
-# Check if Auth Token is stored
-assistant credentials inspect twilio:auth_token --json
-# -> look at "hasSecret" field (true = auth token exists)
-
-# Check assigned phone number
+assistant credentials inspect twilio:auth_token --json  # check "hasSecret" field
 assistant config get twilio.phoneNumber
 ```
 
-If `twilio.accountSid` returns a value and `hasSecret` is `true` on `twilio:auth_token`, credentials are stored. If `twilio.phoneNumber` also returns a phone number, Twilio is fully configured. Tell the user Twilio is already configured and offer to show the current status or reconfigure.
+- If `twilio.accountSid` has a value, `hasSecret` is `true`, and `twilio.phoneNumber` is set -- Twilio is fully configured. Offer to show status or reconfigure.
+- Otherwise, continue to the missing steps.
 
 ## Step 2: Collect and Store Credentials
 
-If credentials are not yet stored, guide the user through Twilio account setup:
+Tell the user: **"You'll need a Twilio account. Sign up at https://www.twilio.com/try-twilio -- it's free to start and includes trial credit."**
 
-1. Tell the user: **"You'll need a Twilio account. Sign up at https://www.twilio.com/try-twilio -- it's free to start and includes trial credit."**
-2. Once they have an account, they need two pieces of information:
-   - **Account SID** -- found on the Twilio Console dashboard at https://console.twilio.com
-   - **Auth Token** -- found on the same dashboard (click "Show" to reveal it)
+They need two values from the Twilio Console dashboard (https://console.twilio.com):
 
-**IMPORTANT -- Secure credential collection only:** Never use credentials pasted in plaintext chat. Always collect credentials through the secure credential prompt flow:
+- **Account SID**
+- **Auth Token** (click "Show" to reveal)
 
-- Call `credential_store` with `action: "prompt"`, `service: "twilio"`, `field: "account_sid"`, `label: "Twilio Account SID"`, `description: "Enter your Account SID from the Twilio Console dashboard"`, and `placeholder: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"`.
-- Call `credential_store` with `action: "prompt"`, `service: "twilio"`, `field: "auth_token"`, `label: "Twilio Auth Token"`, `description: "Enter your Auth Token from the Twilio Console dashboard"`, and `placeholder: "your_auth_token"`.
+Collect them securely -- never accept credentials pasted in plaintext chat:
 
-After both credentials are collected, store them using CLI commands:
+- Call `credential_store` with `action: "prompt"`, `service: "twilio"`, `field: "account_sid"`, `label: "Twilio Account SID"`, `description: "Enter your Account SID from the Twilio Console dashboard"`, `placeholder: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"`.
+- Call `credential_store` with `action: "prompt"`, `service: "twilio"`, `field: "auth_token"`, `label: "Twilio Auth Token"`, `description: "Enter your Auth Token from the Twilio Console dashboard"`, `placeholder: "your_auth_token"`.
+
+Then store them:
 
 ```bash
 assistant config set twilio.accountSid "<value from credential_store for twilio/account_sid>"
 assistant credentials set twilio:auth_token "<value from credential_store for twilio/auth_token>"
 ```
 
-The Account SID is stored in config (it is not a secret), while the Auth Token is stored in encrypted credential storage.
-
-Both values are required. If credentials are invalid, Twilio API calls (Step 3b) will fail -- tell the user and ask them to re-enter via the secure prompt.
+If credentials are invalid, Twilio API calls in Step 3 will fail -- ask the user to re-enter.
 
 ## Step 3: Get a Phone Number
 
-The assistant needs a phone number to make calls and send SMS. There are two paths:
+The assistant needs a phone number for calls and SMS. Three options:
 
 ### Option A: Provision a New Number
 
-If the user wants to buy a new number through Twilio:
+Retrieve credentials (see "Retrieving Twilio Credentials" above), then:
 
-**3a. Retrieve credentials for Twilio API calls:**
-
-```bash
-TWILIO_SID=$(assistant config get twilio.accountSid)
-TWILIO_TOKEN=$(assistant credentials reveal twilio:auth_token)
-```
-
-**3b. Search for available numbers:**
+**Search for available numbers:**
 
 ```bash
 curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" \
   "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/AvailablePhoneNumbers/US/Local.json?SmsEnabled=true&VoiceEnabled=true&AreaCode=415"
 ```
 
-- `AreaCode` is optional -- ask the user if they have a preferred area code
-- Replace `US` with a different ISO 3166-1 alpha-2 country code if the user wants a non-US number
+- `AreaCode` is optional -- ask the user if they have a preference
+- Replace `US` with another country code if needed
 
-The response contains an `available_phone_numbers` array. Present the first few options to the user with their `phone_number` and `friendly_name`.
+Present the first few results from the `available_phone_numbers` array (show `phone_number` and `friendly_name`).
 
-**3c. Purchase the chosen number:**
+**Purchase the chosen number:**
 
 ```bash
 curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST \
@@ -119,59 +79,43 @@ curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST \
   -d "PhoneNumber=+14155551234"
 ```
 
-The response includes the purchased number's `phone_number` and `sid`.
+Note the `sid` field (starts with `PN`) from the response -- needed for webhook setup in Step 4.
 
-**3d. Assign locally (saves to config):**
+**Trial account note:** Trial accounts come with one free number. Check "Active Numbers" in the Console first.
 
-```bash
-assistant config set twilio.phoneNumber "+14155551234"
-```
+### Option B: Use an Existing Number
 
-This stores the phone number in config. After assigning, configure webhooks on the number so Twilio can reach the assistant -- see Step 4.
-
-**Trial account note:** Twilio trial accounts come with one free phone number. Check "Active Numbers" in the Twilio Console first before provisioning.
-
-### Option B: Assign an Existing Number
-
-If the user already has a Twilio phone number, first retrieve credentials (same as Option A, step 3a), then list existing numbers:
+Retrieve credentials, then list numbers on the account:
 
 ```bash
 curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" \
   "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/IncomingPhoneNumbers.json"
 ```
 
-The response includes an `incoming_phone_numbers` array with each number's `phone_number`, `friendly_name`, and `capabilities`. Present these to the user and let them choose.
-
-Then assign the chosen number:
-
-```bash
-assistant config set twilio.phoneNumber "+14155551234"
-```
-
-The phone number must be in E.164 format. After assigning, configure webhooks -- see Step 4.
+Present the `incoming_phone_numbers` array. Let the user choose.
 
 ### Option C: Manual Entry
 
-If the user wants to enter a number directly (e.g., they know it already), assign it using a CLI command:
+If the user already knows their number, skip the API calls.
+
+### Save the phone number
+
+After choosing a number via any option:
 
 ```bash
 assistant config set twilio.phoneNumber "+14155551234"
 ```
 
-After assigning, configure webhooks -- see Step 4.
-
 ## Step 4: Set Up Public Ingress and Webhooks
 
-Twilio needs a publicly reachable URL for voice webhooks, ConversationRelay WebSocket, and SMS delivery reports. The **public-ingress** skill handles this via ngrok.
-
-Check if ingress is already configured:
+Twilio needs a publicly reachable URL for voice webhooks and SMS delivery. Check if ingress is configured:
 
 ```bash
 assistant config get ingress.publicBaseUrl
 assistant config get ingress.enabled
 ```
 
-If not configured, load and run the public-ingress skill:
+If not configured, load the public-ingress skill:
 
 ```
 skill_load skill=public-ingress
@@ -179,7 +123,9 @@ skill_load skill=public-ingress
 
 ### Configure Twilio Webhooks
 
-Once ingress is configured, set the webhook URLs on the Twilio phone number so Twilio knows where to send incoming calls and messages. Retrieve the required values:
+Set webhook URLs on the phone number so Twilio routes traffic to the assistant.
+
+Retrieve credentials and config values:
 
 ```bash
 TWILIO_SID=$(assistant config get twilio.accountSid)
@@ -188,14 +134,14 @@ PUBLIC_URL=$(assistant config get ingress.publicBaseUrl)
 PHONE_NUMBER=$(assistant config get twilio.phoneNumber)
 ```
 
-Look up the phone number's SID (needed to update it):
+Look up the phone number's SID:
 
 ```bash
 curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" \
   "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/IncomingPhoneNumbers.json?PhoneNumber=$PHONE_NUMBER"
 ```
 
-Note the `sid` field (starts with `PN`) from the matching entry in `incoming_phone_numbers`. Then update the webhooks:
+Note the `sid` field (starts with `PN`) from the matching entry, then update webhooks:
 
 ```bash
 curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST \
@@ -205,53 +151,29 @@ curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST \
   -d "SmsUrl=$PUBLIC_URL/webhooks/twilio/sms"
 ```
 
-The expected webhook URLs are:
+## Step 5: Verify and Enable
 
-- **Voice URL:** `{publicBaseUrl}/webhooks/twilio/voice`
-- **Voice status callback:** `{publicBaseUrl}/webhooks/twilio/status`
-- **SMS URL:** `{publicBaseUrl}/webhooks/twilio/sms`
-- **ConversationRelay WebSocket:** `{publicBaseUrl}/webhooks/twilio/relay` (wss://, configured at call time)
-
-## Step 5: Verify Setup
-
-After configuration, verify by checking credential and config status:
+Re-run the checks from Step 1 to confirm everything is set. Then enable voice calls:
 
 ```bash
-assistant config get twilio.accountSid
-assistant credentials inspect twilio:auth_token --json
-assistant config get twilio.phoneNumber
+assistant config set calls.enabled true
 ```
 
-Confirm:
+SMS is available automatically once Twilio is configured -- no flag needed.
 
-- `twilio.accountSid` returns the Account SID
-- `hasSecret` is `true` on `twilio:auth_token`
-- `twilio.phoneNumber` returns the expected phone number
+Tell the user: **"Twilio is configured. Your assistant's phone number is {phoneNumber}."**
 
-Tell the user: **"Twilio is configured. Your assistant's phone number is {phoneNumber}. This number is used for both voice calls and SMS messaging."**
+## Step 6: Guardian Verification (Optional)
 
-## Step 5.5: Guardian Verification (Voice)
+Link the user's phone number as the trusted voice guardian so the assistant can verify inbound callers.
 
-Now link the user's phone number as the trusted voice guardian. Tell the user: "Now let's verify your guardian identity for voice. This links your phone number so the assistant can verify inbound callers."
+Load the guardian-verify-setup skill with `channel: "voice"`:
 
-Load the **guardian-verify-setup** skill to handle the verification flow:
+```
+skill_load skill=guardian-verify-setup
+```
 
-- Call `skill_load` with `skill: "guardian-verify-setup"` to load the dependency skill.
-
-When invoking the skill, indicate the channel is `voice`. The guardian-verify-setup skill manages the full outbound verification flow, including:
-
-- Collecting the user's phone number as the destination (accepts any common format -- the API normalizes to E.164)
-- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/outbound/start` with `channel: "voice"`
-- Calling the phone number and providing a code for the user to enter via their phone's keypad
-- Proactively polling for completion (voice auto-check) so the user gets instant confirmation
-- Checking guardian status to confirm the binding was created
-- Handling resend, cancel, and error cases
-
-Tell the user: _"I've loaded the guardian verification guide. It will walk you through linking your phone number as the trusted voice guardian."_
-
-After the guardian-verify-setup skill completes (or the user skips), continue to Step 6.
-
-**Note:** Guardian verification is optional but recommended. If the user declines or wants to skip, proceed to Step 6 without blocking.
+The skill handles the full verification flow (outbound call, code entry, confirmation). If the user declines, skip this step.
 
 To re-check guardian status later:
 
@@ -259,63 +181,44 @@ To re-check guardian status later:
 assistant integrations guardian status --channel voice --json
 ```
 
-## Step 6: Enable Features
-
-Now that Twilio is configured, the user can enable the features that depend on it:
-
-**For voice calls:**
-
-```bash
-assistant config set calls.enabled true
-```
-
-**For SMS messaging:**
-SMS is available automatically once Twilio is configured -- no additional feature flag is needed.
-
 ## Clearing Credentials
 
-If the user wants to disconnect Twilio:
+To disconnect Twilio:
 
 ```bash
 assistant credentials delete twilio:auth_token
 assistant config set twilio.accountSid ""
 ```
 
-This deletes the Auth Token from encrypted storage and clears the Account SID from config. Phone number assignments are preserved. Voice calls and SMS will stop working until credentials are reconfigured.
+Phone number assignments are preserved. Voice calls and SMS will stop until credentials are reconfigured.
 
 ## Troubleshooting
 
 ### "Twilio credentials not configured"
 
-Run Steps 2 and 3 to store credentials and assign a phone number.
+Run Steps 2 and 3.
 
 ### "No phone number assigned"
 
-Run Step 3 to provision or assign a phone number.
+Run Step 3.
 
 ### Phone number provisioning fails
 
-- Verify Twilio credentials are correct
-- On trial accounts, you may already have a free number -- check "Active Numbers" in the Console
-- Ensure the Twilio account has sufficient balance for paid accounts
+- Verify credentials are correct
+- Trial accounts may already have a free number -- check "Active Numbers" in the Console
+- Ensure the account has sufficient balance
 
 ### Calls/SMS fail after setup
 
-- Verify public ingress is running (`ingress.publicBaseUrl` must be set)
+- Verify ingress is running: `assistant config get ingress.publicBaseUrl`
 - For calls, ensure `calls.enabled` is `true`
-- On trial accounts, outbound calls and SMS can only reach verified numbers
+- Trial accounts can only reach verified numbers
 
-### "Number not found" when assigning
+### Incoming calls/SMS not reaching the assistant
 
-- The number must be owned by the same Twilio account
-- Use the list numbers endpoint to see available numbers
-- Ensure the number is in E.164 format (`+` followed by country code and number)
+Webhooks on the Twilio phone number may not match the current ingress URL. This happens when ngrok restarts with a new URL or webhooks were never configured.
 
-### Incoming calls/SMS not reaching the assistant (webhook mismatch)
-
-This usually means the webhooks on the Twilio phone number don't match the current public ingress URL. This can happen when the ingress URL changes (e.g., ngrok restarts with a new URL) or webhooks were never configured.
-
-**Diagnose:** Fetch the phone number's current webhook configuration from Twilio and compare it to the expected ingress URL:
+**Diagnose** -- fetch the number's current webhooks and compare to the expected URL:
 
 ```bash
 TWILIO_SID=$(assistant config get twilio.accountSid)
@@ -323,12 +226,11 @@ TWILIO_TOKEN=$(assistant credentials reveal twilio:auth_token)
 PUBLIC_URL=$(assistant config get ingress.publicBaseUrl)
 PHONE_NUMBER=$(assistant config get twilio.phoneNumber)
 
-# Fetch current webhooks
 curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" \
   "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/IncomingPhoneNumbers.json?PhoneNumber=$PHONE_NUMBER"
 ```
 
-In the response, check the `voice_url`, `status_callback`, and `sms_url` fields. They should start with the current `ingress.publicBaseUrl`. If they don't match (e.g., they point to an old ngrok URL), update them:
+Check that `voice_url`, `status_callback`, and `sms_url` start with the current `ingress.publicBaseUrl`. If they don't match, update them:
 
 ```bash
 PHONE_SID=<PN sid from the response above>

--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -42,24 +42,6 @@ This skill manages the full Twilio lifecycle:
 
 Number search and purchase use proxied calls to the Twilio REST API (`bash` with `network_mode: "proxied"`). Local bookkeeping (Account SID, phone number, config updates) uses `assistant config` commands. Auth Token is stored in encrypted credential storage via `assistant credentials`. Status/list retrieval uses `assistant credentials inspect` and `assistant config get`.
 
-### Multi-Assistant Setups
-
-In a multi-assistant environment (multiple assistants sharing the same runtime), some actions are **assistant-scoped** while others are **global** (shared across all assistants):
-
-**Global actions** (shared across all assistants):
-
-- `assistant config set twilio.accountSid` -- Stores Account SID in config. All assistants share the same Twilio account.
-- `assistant credentials set twilio:auth_token` -- Stores Auth Token in encrypted credential storage. Shared across all assistants.
-- `assistant credentials delete twilio:auth_token` -- Removes the Auth Token. This affects all assistants.
-
-**Assistant-scoped actions** (phone number configuration is scoped per assistant via local config):
-
-- `assistant config get twilio.accountSid` / `assistant config get twilio.phoneNumber` -- Returns the Account SID and the phone number assigned to the current assistant.
-- `assistant config set twilio.phoneNumber` -- Assigns a phone number to the current assistant.
-- Proxied Twilio API calls (search/list/purchase numbers) -- Use global credentials to interact with the shared Twilio account.
-
-CLI commands operate on the local assistant's config directly, so no `assistantId` parameter is needed. In multi-assistant setups, ensure you are running commands in the correct assistant's context.
-
 ## Step 1: Check Current Configuration
 
 First, check whether Twilio is already configured:
@@ -106,8 +88,6 @@ Both values are required. If credentials are invalid, proxied Twilio API calls (
 **Note:** Unlike the previous gateway endpoint, this does not validate credentials against the Twilio API before storing. Verify credentials are correct by attempting a proxied Twilio API call (Step 3b) -- if it fails, the credentials are invalid.
 
 **Note:** Injection templates for proxied Twilio API calls are not automatically configured by these CLI commands. If proxied calls fail with auth errors, this is a known gap requiring a future CLI command.
-
-**Note:** Setting credentials is a global operation -- credentials are stored once and shared across all assistants.
 
 ## Step 3: Get a Phone Number
 
@@ -307,8 +287,6 @@ assistant config set twilio.accountSid ""
 
 This deletes the Auth Token from encrypted storage and clears the Account SID from config. Phone number assignments are preserved. Voice calls and SMS will stop working until credentials are reconfigured.
 
-**Note:** Clearing credentials is a global operation -- it removes credentials for all assistants, not just the current one. In multi-assistant setups, warn the user that clearing credentials will affect all assistants sharing this Twilio account.
-
 ## Troubleshooting
 
 ### "Twilio credentials not configured"
@@ -351,5 +329,5 @@ do not yet have CLI equivalents:
 3. **Webhook auto-configuration** -- Voice, status callback, and SMS webhook
    URLs are not automatically set on the Twilio phone number. Configure
    webhooks manually in the Twilio Console or wait for a future CLI command.
-4. **Stale phone number pruning** -- In multi-assistant setups, stale
-   assistant phone number mappings are not automatically cleaned up.
+4. **Stale phone number pruning** -- Stale phone number mappings are not
+   automatically cleaned up.

--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -18,13 +18,12 @@ assistant config get twilio.phoneNumber
 # 2. Store credentials (after collecting via credential_store prompt)
 assistant config set twilio.accountSid "ACxxx"
 assistant credentials set twilio:auth_token "xxx"
-# 3. Get credential ID and Account SID for proxied calls
-assistant credentials inspect twilio:auth_token --json  # -> note credentialId
-assistant config get twilio.accountSid  # -> note Account SID value
-# 4. Search and provision via Twilio API (proxy injects auth automatically)
-#    bash network_mode=proxied credential_ids=["<cred_id>"]
-curl -s "https://api.twilio.com/2010-04-01/Accounts/<SID>/AvailablePhoneNumbers/US/Local.json?SmsEnabled=true&VoiceEnabled=true"
-curl -s -X POST "https://api.twilio.com/2010-04-01/Accounts/<SID>/IncomingPhoneNumbers.json" -d "PhoneNumber=+1xxx"
+# 3. Get Account SID and Auth Token for Twilio API calls
+TWILIO_SID=$(assistant config get twilio.accountSid)
+TWILIO_TOKEN=$(assistant credentials reveal twilio:auth_token)
+# 4. Search and provision via Twilio API
+curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/AvailablePhoneNumbers/US/Local.json?SmsEnabled=true&VoiceEnabled=true"
+curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/IncomingPhoneNumbers.json" -d "PhoneNumber=+1xxx"
 # 5. Assign locally (saves to config)
 assistant config set twilio.phoneNumber "+1xxx"
 ```
@@ -36,11 +35,11 @@ For voice call setup after Twilio is configured, use `phone-calls` + `call_start
 This skill manages the full Twilio lifecycle:
 
 - **Credential storage** — Auth Token stored securely via `assistant credentials set twilio:auth_token`; Account SID stored in config via `assistant config set twilio.accountSid`
-- **Direct Twilio API access** — Search and purchase numbers via proxied calls to the Twilio REST API (the proxy injects authentication automatically)
+- **Direct Twilio API access** — Search and purchase numbers via the Twilio REST API using credentials retrieved from CLI
 - **Phone number assignment** — Assign an existing Twilio number to the assistant via `assistant config set twilio.phoneNumber`
 - **Status checking** — Verify credentials and assigned number via `assistant credentials inspect twilio:auth_token` + `assistant config get`
 
-Number search and purchase use proxied calls to the Twilio REST API (`bash` with `network_mode: "proxied"`). Local bookkeeping (Account SID, phone number, config updates) uses `assistant config` commands. Auth Token is stored in encrypted credential storage via `assistant credentials`. Status/list retrieval uses `assistant credentials inspect` and `assistant config get`.
+Number search and purchase use direct calls to the Twilio REST API with credentials retrieved via `assistant credentials reveal` and `assistant config get`. Local bookkeeping (Account SID, phone number, config updates) uses `assistant config` commands. Auth Token is stored in encrypted credential storage via `assistant credentials`.
 
 ## Step 1: Check Current Configuration
 
@@ -83,11 +82,7 @@ assistant credentials set twilio:auth_token "<value from credential_store for tw
 
 The Account SID is stored in config (it is not a secret), while the Auth Token is stored in encrypted credential storage.
 
-Both values are required. If credentials are invalid, proxied Twilio API calls (Step 3b) will fail -- tell the user and ask them to re-enter via the secure prompt.
-
-**Note:** Unlike the previous gateway endpoint, this does not validate credentials against the Twilio API before storing. Verify credentials are correct by attempting a proxied Twilio API call (Step 3b) -- if it fails, the credentials are invalid.
-
-**Note:** Injection templates for proxied Twilio API calls are not automatically configured by these CLI commands. If proxied calls fail with auth errors, this is a known gap requiring a future CLI command.
+Both values are required. If credentials are invalid, Twilio API calls (Step 3b) will fail -- tell the user and ask them to re-enter via the secure prompt.
 
 ## Step 3: Get a Phone Number
 
@@ -97,45 +92,31 @@ The assistant needs a phone number to make calls and send SMS. There are two pat
 
 If the user wants to buy a new number through Twilio:
 
-**3a. Get the credential ID and Account SID:**
+**3a. Retrieve credentials for Twilio API calls:**
 
 ```bash
-assistant credentials inspect twilio:auth_token --json
+TWILIO_SID=$(assistant config get twilio.accountSid)
+TWILIO_TOKEN=$(assistant credentials reveal twilio:auth_token)
 ```
 
-Note the `credentialId` field from the response (needed for proxied calls).
-
-Then retrieve the Account SID value (needed for Twilio URL paths):
+**3b. Search for available numbers:**
 
 ```bash
-assistant config get twilio.accountSid
-```
-
-**3b. Search for available numbers (proxied Twilio API):**
-
-```
-bash:
-  network_mode: proxied
-  credential_ids: ["<credential_id from 3a>"]
-  command: |
-    curl -s "https://api.twilio.com/2010-04-01/Accounts/<ACCOUNT_SID>/AvailablePhoneNumbers/US/Local.json?SmsEnabled=true&VoiceEnabled=true&AreaCode=415"
+curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" \
+  "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/AvailablePhoneNumbers/US/Local.json?SmsEnabled=true&VoiceEnabled=true&AreaCode=415"
 ```
 
 - `AreaCode` is optional -- ask the user if they have a preferred area code
 - Replace `US` with a different ISO 3166-1 alpha-2 country code if the user wants a non-US number
-- The proxy automatically injects `Authorization: Basic <credentials>` -- do not include an Authorization header
 
 The response contains an `available_phone_numbers` array. Present the first few options to the user with their `phone_number` and `friendly_name`.
 
-**3c. Purchase the chosen number (proxied Twilio API):**
+**3c. Purchase the chosen number:**
 
-```
-bash:
-  network_mode: proxied
-  credential_ids: ["<credential_id from 3a>"]
-  command: |
-    curl -s -X POST "https://api.twilio.com/2010-04-01/Accounts/<ACCOUNT_SID>/IncomingPhoneNumbers.json" \
-      -d "PhoneNumber=+14155551234"
+```bash
+curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST \
+  "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/IncomingPhoneNumbers.json" \
+  -d "PhoneNumber=+14155551234"
 ```
 
 The response includes the purchased number's `phone_number` and `sid`.
@@ -160,14 +141,11 @@ This stores the phone number in config.
 
 ### Option B: Assign an Existing Number
 
-If the user already has a Twilio phone number, first get the credential ID and Account SID (same as Option A, step 3a), then list available numbers:
+If the user already has a Twilio phone number, first retrieve credentials (same as Option A, step 3a), then list existing numbers:
 
-```
-bash:
-  network_mode: proxied
-  credential_ids: ["<credential_id>"]
-  command: |
-    curl -s "https://api.twilio.com/2010-04-01/Accounts/<ACCOUNT_SID>/IncomingPhoneNumbers.json"
+```bash
+curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" \
+  "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/IncomingPhoneNumbers.json"
 ```
 
 The response includes an `incoming_phone_numbers` array with each number's `phone_number`, `friendly_name`, and `capabilities`. Present these to the user and let them choose.
@@ -320,14 +298,8 @@ Run Step 3 to provision or assign a phone number.
 The following operations were previously handled by gateway API endpoints and
 do not yet have CLI equivalents:
 
-1. **Credential validation** -- Credentials are stored without verifying them
-   against the Twilio API. Verify manually by attempting a proxied API call.
-2. **Injection template registration** -- Proxied Twilio API calls require
-   injection templates to auto-inject HTTP Basic auth. These are not set up
-   by `assistant credentials set`. If proxied calls fail, templates may need
-   to be registered via a future CLI command.
-3. **Webhook auto-configuration** -- Voice, status callback, and SMS webhook
+1. **Webhook auto-configuration** -- Voice, status callback, and SMS webhook
    URLs are not automatically set on the Twilio phone number. Configure
    webhooks manually in the Twilio Console or wait for a future CLI command.
-4. **Stale phone number pruning** -- Stale phone number mappings are not
+2. **Stale phone number pruning** -- Stale phone number mappings are not
    automatically cleaned up.

--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -12,21 +12,21 @@ You are helping your user configure Twilio for voice calls and SMS messaging. Tw
 
 ```bash
 # 1. Check current status
-assistant credentials inspect twilio:account_sid --json
-assistant config get sms.phoneNumber
+assistant config get twilio.accountSid
+assistant credentials inspect twilio:auth_token --json
+assistant config get twilio.phoneNumber
 # 2. Store credentials (after collecting via credential_store prompt)
-assistant credentials set twilio:account_sid "ACxxx"
+assistant config set twilio.accountSid "ACxxx"
 assistant credentials set twilio:auth_token "xxx"
 # 3. Get credential ID and Account SID for proxied calls
-assistant credentials inspect twilio:account_sid --json  # -> note credentialId
-assistant credentials reveal twilio:account_sid  # -> note Account SID value
+assistant credentials inspect twilio:auth_token --json  # -> note credentialId
+assistant config get twilio.accountSid  # -> note Account SID value
 # 4. Search and provision via Twilio API (proxy injects auth automatically)
 #    bash network_mode=proxied credential_ids=["<cred_id>"]
 curl -s "https://api.twilio.com/2010-04-01/Accounts/<SID>/AvailablePhoneNumbers/US/Local.json?SmsEnabled=true&VoiceEnabled=true"
 curl -s -X POST "https://api.twilio.com/2010-04-01/Accounts/<SID>/IncomingPhoneNumbers.json" -d "PhoneNumber=+1xxx"
-# 5. Assign locally (saves to credential store + config)
-assistant credentials set twilio:phone_number "+1xxx"
-assistant config set sms.phoneNumber "+1xxx"
+# 5. Assign locally (saves to config)
+assistant config set twilio.phoneNumber "+1xxx"
 ```
 
 For voice call setup after Twilio is configured, use `phone-calls` + `call_start`.
@@ -35,26 +35,27 @@ For voice call setup after Twilio is configured, use `phone-calls` + `call_start
 
 This skill manages the full Twilio lifecycle:
 
-- **Credential storage** — Account SID and Auth Token via `assistant credentials set/delete`
+- **Credential storage** — Auth Token stored securely via `assistant credentials set twilio:auth_token`; Account SID stored in config via `assistant config set twilio.accountSid`
 - **Direct Twilio API access** — Search and purchase numbers via proxied calls to the Twilio REST API (the proxy injects authentication automatically)
-- **Phone number assignment** — Assign an existing Twilio number to the assistant via `assistant credentials set` + `assistant config set`
-- **Status checking** — Verify credentials and assigned number via `assistant credentials inspect` + `assistant config get`
+- **Phone number assignment** — Assign an existing Twilio number to the assistant via `assistant config set twilio.phoneNumber`
+- **Status checking** — Verify credentials and assigned number via `assistant credentials inspect twilio:auth_token` + `assistant config get`
 
-Number search and purchase use proxied calls to the Twilio REST API (`bash` with `network_mode: "proxied"`). Local bookkeeping (credential storage, phone number assignment, config updates) uses CLI credential and config commands. Status/list retrieval uses `assistant credentials inspect` and `assistant config get`.
+Number search and purchase use proxied calls to the Twilio REST API (`bash` with `network_mode: "proxied"`). Local bookkeeping (Account SID, phone number, config updates) uses `assistant config` commands. Auth Token is stored in encrypted credential storage via `assistant credentials`. Status/list retrieval uses `assistant credentials inspect` and `assistant config get`.
 
 ### Multi-Assistant Setups
 
 In a multi-assistant environment (multiple assistants sharing the same runtime), some actions are **assistant-scoped** while others are **global** (shared across all assistants):
 
-**Global actions** (credentials are shared across all assistants):
+**Global actions** (shared across all assistants):
 
-- `assistant credentials set twilio:account_sid` / `assistant credentials set twilio:auth_token` -- Stores Account SID and Auth Token in global secure storage. All assistants share the same Twilio account credentials.
-- `assistant credentials delete twilio:account_sid` / `assistant credentials delete twilio:auth_token` -- Removes the globally stored Account SID and Auth Token. This affects all assistants.
+- `assistant config set twilio.accountSid` -- Stores Account SID in config. All assistants share the same Twilio account.
+- `assistant credentials set twilio:auth_token` -- Stores Auth Token in encrypted credential storage. Shared across all assistants.
+- `assistant credentials delete twilio:auth_token` -- Removes the Auth Token. This affects all assistants.
 
 **Assistant-scoped actions** (phone number configuration is scoped per assistant via local config):
 
-- `assistant credentials inspect twilio:account_sid --json` / `assistant config get sms.phoneNumber` -- Returns credential status and the phone number assigned to the current assistant.
-- `assistant credentials set twilio:phone_number` / `assistant config set sms.phoneNumber` -- Assigns a phone number to the current assistant.
+- `assistant config get twilio.accountSid` / `assistant config get twilio.phoneNumber` -- Returns the Account SID and the phone number assigned to the current assistant.
+- `assistant config set twilio.phoneNumber` -- Assigns a phone number to the current assistant.
 - Proxied Twilio API calls (search/list/purchase numbers) -- Use global credentials to interact with the shared Twilio account.
 
 CLI commands operate on the local assistant's config directly, so no `assistantId` parameter is needed. In multi-assistant setups, ensure you are running commands in the correct assistant's context.
@@ -64,19 +65,18 @@ CLI commands operate on the local assistant's config directly, so no `assistantI
 First, check whether Twilio is already configured:
 
 ```bash
-# Check if Twilio credentials are stored
-assistant credentials inspect twilio:account_sid --json
-# -> look at "hasSecret" field (true = credentials exist)
+# Check if Account SID is configured
+assistant config get twilio.accountSid
 
-# Check if auth token is also stored
+# Check if Auth Token is stored
 assistant credentials inspect twilio:auth_token --json
-# -> look at "hasSecret" field
+# -> look at "hasSecret" field (true = auth token exists)
 
 # Check assigned phone number
-assistant config get sms.phoneNumber
+assistant config get twilio.phoneNumber
 ```
 
-If `hasSecret` is `true` on both `twilio:account_sid` and `twilio:auth_token`, credentials are stored. If `sms.phoneNumber` also returns a phone number, Twilio is fully configured. Tell the user Twilio is already configured and offer to show the current status or reconfigure.
+If `twilio.accountSid` returns a value and `hasSecret` is `true` on `twilio:auth_token`, credentials are stored. If `twilio.phoneNumber` also returns a phone number, Twilio is fully configured. Tell the user Twilio is already configured and offer to show the current status or reconfigure.
 
 ## Step 2: Collect and Store Credentials
 
@@ -95,15 +95,17 @@ If credentials are not yet stored, guide the user through Twilio account setup:
 After both credentials are collected, store them using CLI commands:
 
 ```bash
-assistant credentials set twilio:account_sid "<value from credential_store for twilio/account_sid>"
+assistant config set twilio.accountSid "<value from credential_store for twilio/account_sid>"
 assistant credentials set twilio:auth_token "<value from credential_store for twilio/auth_token>"
 ```
+
+The Account SID is stored in config (it is not a secret), while the Auth Token is stored in encrypted credential storage.
 
 Both values are required. If credentials are invalid, proxied Twilio API calls (Step 3b) will fail -- tell the user and ask them to re-enter via the secure prompt.
 
 **Note:** Unlike the previous gateway endpoint, this does not validate credentials against the Twilio API before storing. Verify credentials are correct by attempting a proxied Twilio API call (Step 3b) -- if it fails, the credentials are invalid.
 
-**Note:** Injection templates for proxied Twilio API calls are not automatically configured by `credentials set`. If proxied calls fail with auth errors, this is a known gap requiring a future CLI command.
+**Note:** Injection templates for proxied Twilio API calls are not automatically configured by these CLI commands. If proxied calls fail with auth errors, this is a known gap requiring a future CLI command.
 
 **Note:** Setting credentials is a global operation -- credentials are stored once and shared across all assistants.
 
@@ -118,7 +120,7 @@ If the user wants to buy a new number through Twilio:
 **3a. Get the credential ID and Account SID:**
 
 ```bash
-assistant credentials inspect twilio:account_sid --json
+assistant credentials inspect twilio:auth_token --json
 ```
 
 Note the `credentialId` field from the response (needed for proxied calls).
@@ -126,7 +128,7 @@ Note the `credentialId` field from the response (needed for proxied calls).
 Then retrieve the Account SID value (needed for Twilio URL paths):
 
 ```bash
-assistant credentials reveal twilio:account_sid
+assistant config get twilio.accountSid
 ```
 
 **3b. Search for available numbers (proxied Twilio API):**
@@ -158,14 +160,13 @@ bash:
 
 The response includes the purchased number's `phone_number` and `sid`.
 
-**3d. Assign locally (saves to credential store + config):**
+**3d. Assign locally (saves to config):**
 
 ```bash
-assistant credentials set twilio:phone_number "+14155551234"
-assistant config set sms.phoneNumber "+14155551234"
+assistant config set twilio.phoneNumber "+14155551234"
 ```
 
-This stores the phone number in both secure credential storage and config.
+This stores the phone number in config.
 
 **Note:** Webhook auto-configuration (voice, status callback, SMS) is not performed by these CLI commands -- this is a known gap requiring a future CLI command (e.g., `assistant integrations twilio sync-webhooks`). Webhooks must be configured manually in the Twilio Console or will be set up when a future CLI command is available.
 
@@ -194,22 +195,20 @@ The response includes an `incoming_phone_numbers` array with each number's `phon
 Then assign the chosen number:
 
 ```bash
-assistant credentials set twilio:phone_number "+14155551234"
-assistant config set sms.phoneNumber "+14155551234"
+assistant config set twilio.phoneNumber "+14155551234"
 ```
 
-The phone number must be in E.164 format. **Note:** Webhook auto-configuration is not performed by these CLI commands -- this is a known gap. See Step 3d for webhook URLs to configure manually.
+The phone number must be in E.164 format. **Note:** Webhook auto-configuration is not performed by this CLI command -- this is a known gap. See Step 3d for webhook URLs to configure manually.
 
 ### Option C: Manual Entry
 
-If the user wants to enter a number directly (e.g., they know it already), assign it using CLI commands:
+If the user wants to enter a number directly (e.g., they know it already), assign it using a CLI command:
 
 ```bash
-assistant credentials set twilio:phone_number "+14155551234"
-assistant config set sms.phoneNumber "+14155551234"
+assistant config set twilio.phoneNumber "+14155551234"
 ```
 
-**Note:** Webhook auto-configuration is not performed by these CLI commands -- this is a known gap. See Step 3d for webhook URLs to configure manually.
+**Note:** Webhook auto-configuration is not performed by this CLI command -- this is a known gap. See Step 3d for webhook URLs to configure manually.
 
 ## Step 4: Set Up Public Ingress
 
@@ -242,15 +241,16 @@ Webhook URLs must be manually configured on the Twilio phone number in the Twili
 After configuration, verify by checking credential and config status:
 
 ```bash
-assistant credentials inspect twilio:account_sid --json
+assistant config get twilio.accountSid
 assistant credentials inspect twilio:auth_token --json
-assistant config get sms.phoneNumber
+assistant config get twilio.phoneNumber
 ```
 
 Confirm:
 
-- `hasSecret` is `true` on both `twilio:account_sid` and `twilio:auth_token`
-- `sms.phoneNumber` returns the expected phone number
+- `twilio.accountSid` returns the Account SID
+- `hasSecret` is `true` on `twilio:auth_token`
+- `twilio.phoneNumber` returns the expected phone number
 
 Tell the user: **"Twilio is configured. Your assistant's phone number is {phoneNumber}. This number is used for both voice calls and SMS messaging."**
 
@@ -301,11 +301,11 @@ SMS is available automatically once Twilio is configured -- no additional featur
 If the user wants to disconnect Twilio:
 
 ```bash
-assistant credentials delete twilio:account_sid
 assistant credentials delete twilio:auth_token
+assistant config set twilio.accountSid ""
 ```
 
-This deletes both the encrypted secret and associated metadata for each credential. Phone number assignments are preserved. Voice calls and SMS will stop working until credentials are reconfigured.
+This deletes the Auth Token from encrypted storage and clears the Account SID from config. Phone number assignments are preserved. Voice calls and SMS will stop working until credentials are reconfigured.
 
 **Note:** Clearing credentials is a global operation -- it removes credentials for all assistants, not just the current one. In multi-assistant setups, warn the user that clearing credentials will affect all assistants sharing this Twilio account.
 
@@ -352,4 +352,4 @@ do not yet have CLI equivalents:
    URLs are not automatically set on the Twilio phone number. Configure
    webhooks manually in the Twilio Console or wait for a future CLI command.
 4. **Stale phone number pruning** -- In multi-assistant setups, stale
-   `sms.assistantPhoneNumbers` mappings are not automatically cleaned up.
+   assistant phone number mappings are not automatically cleaned up.

--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -6,28 +6,27 @@ includes: ["public-ingress"]
 metadata: { "vellum": { "emoji": "\ud83d\udcf1" } }
 ---
 
-You are helping your user configure Twilio for voice calls and SMS messaging. Twilio is the shared telephony provider for both the **phone-calls** and **SMS messaging** capabilities. When this skill is invoked, walk through each step below using the Twilio HTTP control-plane endpoints and existing tools.
+You are helping your user configure Twilio for voice calls and SMS messaging. Twilio is the shared telephony provider for both the **phone-calls** and **SMS messaging** capabilities. When this skill is invoked, walk through each step below using existing CLI tools and secure credential storage.
 
 ## Quick Start
 
 ```bash
 # 1. Check current status
-assistant integrations twilio config --json
+vellum credentials inspect twilio:account_sid --json
+vellum config get sms.phoneNumber
 # 2. Store credentials (after collecting via credential_store prompt)
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/credentials" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" -H "Content-Type: application/json" \
-  -d '{"accountSid":"ACxxx","authToken":"xxx"}'
+vellum credentials set twilio:account_sid "ACxxx"
+vellum credentials set twilio:auth_token "xxx"
 # 3. Get credential ID and Account SID for proxied calls
-credential_store action=list  # → note credential_id for twilio/account_sid
-assistant integrations twilio config --json | jq -r '.accountSid'
+vellum credentials inspect twilio:account_sid --json  # -> note credentialId
+vellum credentials reveal twilio:account_sid  # -> note Account SID value
 # 4. Search and provision via Twilio API (proxy injects auth automatically)
 #    bash network_mode=proxied credential_ids=["<cred_id>"]
 curl -s "https://api.twilio.com/2010-04-01/Accounts/<SID>/AvailablePhoneNumbers/US/Local.json?SmsEnabled=true&VoiceEnabled=true"
 curl -s -X POST "https://api.twilio.com/2010-04-01/Accounts/<SID>/IncomingPhoneNumbers.json" -d "PhoneNumber=+1xxx"
-# 5. Assign locally (saves to config + sets up webhooks)
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/numbers/assign" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" -H "Content-Type: application/json" \
-  -d '{"phoneNumber":"+1xxx"}'
+# 5. Assign locally (saves to credential store + config)
+vellum credentials set twilio:phone_number "+1xxx"
+vellum config set sms.phoneNumber "+1xxx"
 ```
 
 For voice call setup after Twilio is configured, use `phone-calls` + `call_start`.
@@ -36,78 +35,77 @@ For voice call setup after Twilio is configured, use `phone-calls` + `call_start
 
 This skill manages the full Twilio lifecycle:
 
-- **Credential storage** — Account SID and Auth Token
+- **Credential storage** — Account SID and Auth Token via `vellum credentials set/delete`
 - **Direct Twilio API access** — Search and purchase numbers via proxied calls to the Twilio REST API (the proxy injects authentication automatically)
-- **Phone number assignment** — Assign an existing Twilio number to the assistant
-- **Status checking** — Verify credentials and assigned number
+- **Phone number assignment** — Assign an existing Twilio number to the assistant via `vellum credentials set` + `vellum config set`
+- **Status checking** — Verify credentials and assigned number via `vellum credentials inspect` + `vellum config get`
 
-Number search and purchase use proxied calls to the Twilio REST API (`bash` with `network_mode: "proxied"`). Local bookkeeping (assign, webhook sync) uses gateway control-plane endpoints. Status/list retrieval uses `assistant integrations ...` CLI reads.
+Number search and purchase use proxied calls to the Twilio REST API (`bash` with `network_mode: "proxied"`). Local bookkeeping (credential storage, phone number assignment, config updates) uses CLI credential and config commands. Status/list retrieval uses `vellum credentials inspect` and `vellum config get`.
 
 ### Multi-Assistant Setups
 
 In a multi-assistant environment (multiple assistants sharing the same runtime), some actions are **assistant-scoped** while others are **global** (shared across all assistants):
 
-**Global actions** (ignore `assistantId` — credentials are shared across all assistants):
+**Global actions** (credentials are shared across all assistants):
 
-- `POST /v1/integrations/twilio/credentials` — Stores Account SID and Auth Token in global secure storage (`credential:twilio:*` keys). All assistants share the same Twilio account credentials.
-- `DELETE /v1/integrations/twilio/credentials` — Removes the globally stored Account SID and Auth Token. This affects all assistants.
+- `vellum credentials set twilio:account_sid` / `vellum credentials set twilio:auth_token` -- Stores Account SID and Auth Token in global secure storage. All assistants share the same Twilio account credentials.
+- `vellum credentials delete twilio:account_sid` / `vellum credentials delete twilio:auth_token` -- Removes the globally stored Account SID and Auth Token. This affects all assistants.
 
-**Assistant-scoped actions** (use `assistantId` query parameter to scope phone number configuration per assistant):
+**Assistant-scoped actions** (phone number configuration is scoped per assistant via local config):
 
-- `GET /v1/integrations/twilio/config` — Returns the phone number assigned to the specified assistant.
-- `POST /v1/integrations/twilio/numbers/assign` — Assigns a phone number to a specific assistant via the per-assistant mapping.
-- `POST /v1/integrations/twilio/numbers/provision` — Legacy convenience endpoint that provisions a new number and assigns it to the specified assistant. The main flow now uses proxied Twilio API calls (search + purchase) followed by the assign endpoint.
-- `GET /v1/integrations/twilio/numbers` — Lists all phone numbers on the shared Twilio account (uses global credentials).
+- `vellum credentials inspect twilio:account_sid --json` / `vellum config get sms.phoneNumber` -- Returns credential status and the phone number assigned to the current assistant.
+- `vellum credentials set twilio:phone_number` / `vellum config set sms.phoneNumber` -- Assigns a phone number to the current assistant.
+- Proxied Twilio API calls (search/list/purchase numbers) -- Use global credentials to interact with the shared Twilio account.
 
-Include `assistantId` as a query parameter in assistant-scoped requests whenever:
-
-- Multiple assistants share the same Twilio account but use different phone numbers
-- You want to ensure configuration changes only affect a specific assistant
-- The user has explicitly selected or referenced a particular assistant
-
-All HTTP examples below include the optional `assistantId` query parameter in assistant-scoped requests. Omit it in single-assistant setups. For global actions (credentials), the `assistantId` parameter is accepted but ignored.
+CLI commands operate on the local assistant's config directly, so no `assistantId` parameter is needed. In multi-assistant setups, ensure you are running commands in the correct assistant's context.
 
 ## Step 1: Check Current Configuration
 
 First, check whether Twilio is already configured:
 
 ```bash
-assistant integrations twilio config --json
+# Check if Twilio credentials are stored
+vellum credentials inspect twilio:account_sid --json
+# -> look at "hasSecret" field (true = credentials exist)
+
+# Check if auth token is also stored
+vellum credentials inspect twilio:auth_token --json
+# -> look at "hasSecret" field
+
+# Check assigned phone number
+vellum config get sms.phoneNumber
 ```
 
-The response includes:
-
-- `hasCredentials` — whether Account SID and Auth Token are stored
-- `phoneNumber` — the currently assigned phone number (if any)
-
-If both are present, tell the user Twilio is already configured and offer to show the current status or reconfigure.
+If `hasSecret` is `true` on both `twilio:account_sid` and `twilio:auth_token`, credentials are stored. If `sms.phoneNumber` also returns a phone number, Twilio is fully configured. Tell the user Twilio is already configured and offer to show the current status or reconfigure.
 
 ## Step 2: Collect and Store Credentials
 
 If credentials are not yet stored, guide the user through Twilio account setup:
 
-1. Tell the user: **"You'll need a Twilio account. Sign up at https://www.twilio.com/try-twilio — it's free to start and includes trial credit."**
+1. Tell the user: **"You'll need a Twilio account. Sign up at https://www.twilio.com/try-twilio -- it's free to start and includes trial credit."**
 2. Once they have an account, they need two pieces of information:
-   - **Account SID** — found on the Twilio Console dashboard at https://console.twilio.com
-   - **Auth Token** — found on the same dashboard (click "Show" to reveal it)
+   - **Account SID** -- found on the Twilio Console dashboard at https://console.twilio.com
+   - **Auth Token** -- found on the same dashboard (click "Show" to reveal it)
 
-**IMPORTANT — Secure credential collection only:** Never use credentials pasted in plaintext chat. Always collect credentials through the secure credential prompt flow:
+**IMPORTANT -- Secure credential collection only:** Never use credentials pasted in plaintext chat. Always collect credentials through the secure credential prompt flow:
 
 - Call `credential_store` with `action: "prompt"`, `service: "twilio"`, `field: "account_sid"`, `label: "Twilio Account SID"`, `description: "Enter your Account SID from the Twilio Console dashboard"`, and `placeholder: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"`.
 - Call `credential_store` with `action: "prompt"`, `service: "twilio"`, `field: "auth_token"`, `label: "Twilio Auth Token"`, `description: "Enter your Auth Token from the Twilio Console dashboard"`, and `placeholder: "your_auth_token"`.
 
-After both credentials are collected, retrieve them from secure storage and send them to the gateway:
+After both credentials are collected, store them using CLI commands:
 
 ```bash
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/credentials" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"accountSid":"<value from credential_store for twilio/account_sid>","authToken":"<value from credential_store for twilio/auth_token>"}'
+vellum credentials set twilio:account_sid "<value from credential_store for twilio/account_sid>"
+vellum credentials set twilio:auth_token "<value from credential_store for twilio/auth_token>"
 ```
 
-Both `accountSid` and `authToken` are required — the endpoint validates the credentials against the Twilio API before storing them. If credentials are invalid, the response returns an error. Tell the user and ask them to re-enter via the secure prompt.
+Both values are required. If credentials are invalid, proxied Twilio API calls (Step 3b) will fail -- tell the user and ask them to re-enter via the secure prompt.
 
-**Note:** Setting credentials is a global operation — credentials are stored once and shared across all assistants. The `assistantId` parameter is accepted but ignored.
+**Note:** Unlike the previous gateway endpoint, this does not validate credentials against the Twilio API before storing. Verify credentials are correct by attempting a proxied Twilio API call (Step 3b) -- if it fails, the credentials are invalid.
+
+**Note:** Injection templates for proxied Twilio API calls are not automatically configured by `credentials set`. If proxied calls fail with auth errors, this is a known gap requiring a future CLI command.
+
+**Note:** Setting credentials is a global operation -- credentials are stored once and shared across all assistants.
 
 ## Step 3: Get a Phone Number
 
@@ -119,16 +117,16 @@ If the user wants to buy a new number through Twilio:
 
 **3a. Get the credential ID and Account SID:**
 
-```
-credential_store action=list
+```bash
+vellum credentials inspect twilio:account_sid --json
 ```
 
-Find the entry with `service: "twilio"` and `field: "account_sid"`. Note its `credential_id`.
+Note the `credentialId` field from the response (needed for proxied calls).
 
-Then retrieve the Account SID (needed for Twilio URL paths):
+Then retrieve the Account SID value (needed for Twilio URL paths):
 
 ```bash
-assistant integrations twilio config --json | jq -r '.accountSid'
+vellum credentials reveal twilio:account_sid
 ```
 
 **3b. Search for available numbers (proxied Twilio API):**
@@ -141,9 +139,9 @@ bash:
     curl -s "https://api.twilio.com/2010-04-01/Accounts/<ACCOUNT_SID>/AvailablePhoneNumbers/US/Local.json?SmsEnabled=true&VoiceEnabled=true&AreaCode=415"
 ```
 
-- `AreaCode` is optional — ask the user if they have a preferred area code
+- `AreaCode` is optional -- ask the user if they have a preferred area code
 - Replace `US` with a different ISO 3166-1 alpha-2 country code if the user wants a non-US number
-- The proxy automatically injects `Authorization: Basic <credentials>` — do not include an Authorization header
+- The proxy automatically injects `Authorization: Basic <credentials>` -- do not include an Authorization header
 
 The response contains an `available_phone_numbers` array. Present the first few options to the user with their `phone_number` and `friendly_name`.
 
@@ -160,24 +158,22 @@ bash:
 
 The response includes the purchased number's `phone_number` and `sid`.
 
-**3d. Assign locally (saves to config + sets up webhooks):**
+**3d. Assign locally (saves to credential store + config):**
 
 ```bash
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/numbers/assign" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"phoneNumber":"+14155551234"}'
+vellum credentials set twilio:phone_number "+14155551234"
+vellum config set sms.phoneNumber "+14155551234"
 ```
 
-This persists the number to secure storage and config, and configures Twilio webhooks (voice, status callback, SMS) if a public ingress URL is available. The response includes the new `phoneNumber`. No separate assign call is needed.
+This stores the phone number in both secure credential storage and config.
 
-**Webhook auto-configuration:** When `ingress.publicBaseUrl` is configured, the assign endpoint automatically sets the following webhooks on the Twilio phone number:
+**Note:** Webhook auto-configuration (voice, status callback, SMS) is not performed by these CLI commands -- this is a known gap requiring a future CLI command (e.g., `vellum integrations twilio sync-webhooks`). Webhooks must be configured manually in the Twilio Console or will be set up when a future CLI command is available.
+
+**Webhook URLs (manual configuration required until CLI support is added):** When `ingress.publicBaseUrl` is configured, the following webhooks should be set on the Twilio phone number:
 
 - Voice webhook: `{publicBaseUrl}/webhooks/twilio/voice`
 - Voice status callback: `{publicBaseUrl}/webhooks/twilio/status`
 - SMS webhook: `{publicBaseUrl}/webhooks/twilio/sms`
-
-If ingress is not yet configured, webhook setup is skipped gracefully — the number is still assigned and usable once ingress is set up later.
 
 **Trial account note:** Twilio trial accounts come with one free phone number. Check "Active Numbers" in the Twilio Console first before provisioning.
 
@@ -198,30 +194,22 @@ The response includes an `incoming_phone_numbers` array with each number's `phon
 Then assign the chosen number:
 
 ```bash
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/numbers/assign" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"phoneNumber":"+14155551234"}'
+vellum credentials set twilio:phone_number "+14155551234"
+vellum config set sms.phoneNumber "+14155551234"
 ```
 
-The phone number must be in E.164 format. Like provisioning, assigning also auto-configures Twilio webhooks when a public ingress URL is available.
+The phone number must be in E.164 format. **Note:** Webhook auto-configuration is not performed by these CLI commands -- this is a known gap. See Step 3d for webhook URLs to configure manually.
 
 ### Option C: Manual Entry
 
-If the user wants to enter a number directly (e.g., they know it already), store it via credential store:
-
-```
-credential_store action=store service=twilio field=phone_number value=+14155551234
-```
-
-Then assign it through the gateway:
+If the user wants to enter a number directly (e.g., they know it already), assign it using CLI commands:
 
 ```bash
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/numbers/assign" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"phoneNumber":"+14155551234"}'
+vellum credentials set twilio:phone_number "+14155551234"
+vellum config set sms.phoneNumber "+14155551234"
 ```
+
+**Note:** Webhook auto-configuration is not performed by these CLI commands -- this is a known gap. See Step 3d for webhook URLs to configure manually.
 
 ## Step 4: Set Up Public Ingress
 
@@ -240,27 +228,29 @@ If not configured, load and run the public-ingress skill:
 skill_load skill=public-ingress
 ```
 
-**Twilio webhook endpoints (auto-configured on provision/assign):**
+**Twilio webhook endpoints (manual configuration required until CLI support is added):**
 
 - Voice webhook: `{publicBaseUrl}/webhooks/twilio/voice`
 - Voice status callback: `{publicBaseUrl}/webhooks/twilio/status`
 - ConversationRelay WebSocket: `{publicBaseUrl}/webhooks/twilio/relay` (wss://)
 - SMS webhook: `{publicBaseUrl}/webhooks/twilio/sms`
 
-Webhook URLs are automatically configured on the Twilio phone number when provisioning or assigning a number with a valid ingress URL. No manual Twilio Console webhook configuration is needed.
+Webhook URLs must be manually configured on the Twilio phone number in the Twilio Console. A future CLI command (e.g., `vellum integrations twilio sync-webhooks`) will automate this.
 
 ## Step 5: Verify Setup
 
-After configuration, verify by checking the config endpoint again.
+After configuration, verify by checking credential and config status:
 
 ```bash
-assistant integrations twilio config --json
+vellum credentials inspect twilio:account_sid --json
+vellum credentials inspect twilio:auth_token --json
+vellum config get sms.phoneNumber
 ```
 
 Confirm:
 
-- `hasCredentials` is `true`
-- `phoneNumber` is set to the expected number
+- `hasSecret` is `true` on both `twilio:account_sid` and `twilio:auth_token`
+- `sms.phoneNumber` returns the expected phone number
 
 Tell the user: **"Twilio is configured. Your assistant's phone number is {phoneNumber}. This number is used for both voice calls and SMS messaging."**
 
@@ -304,20 +294,20 @@ assistant config set calls.enabled true
 ```
 
 **For SMS messaging:**
-SMS is available automatically once Twilio is configured — no additional feature flag is needed.
+SMS is available automatically once Twilio is configured -- no additional feature flag is needed.
 
 ## Clearing Credentials
 
 If the user wants to disconnect Twilio:
 
 ```bash
-curl -s -X DELETE "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/credentials" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN"
+vellum credentials delete twilio:account_sid
+vellum credentials delete twilio:auth_token
 ```
 
-This removes the stored Account SID and Auth Token. Phone number assignments are preserved. Voice calls and SMS will stop working until credentials are reconfigured.
+This deletes both the encrypted secret and associated metadata for each credential. Phone number assignments are preserved. Voice calls and SMS will stop working until credentials are reconfigured.
 
-**Note:** Clearing credentials is a global operation — it removes credentials for all assistants, not just the current one. The `assistantId` parameter is accepted but ignored. In multi-assistant setups, warn the user that clearing credentials will affect all assistants sharing this Twilio account.
+**Note:** Clearing credentials is a global operation -- it removes credentials for all assistants, not just the current one. In multi-assistant setups, warn the user that clearing credentials will affect all assistants sharing this Twilio account.
 
 ## Troubleshooting
 
@@ -332,7 +322,7 @@ Run Step 3 to provision or assign a phone number.
 ### Phone number provisioning fails
 
 - Verify Twilio credentials are correct
-- On trial accounts, you may already have a free number — check "Active Numbers" in the Console
+- On trial accounts, you may already have a free number -- check "Active Numbers" in the Console
 - Ensure the Twilio account has sufficient balance for paid accounts
 
 ### Calls/SMS fail after setup
@@ -346,3 +336,20 @@ Run Step 3 to provision or assign a phone number.
 - The number must be owned by the same Twilio account
 - Use the list numbers endpoint to see available numbers
 - Ensure the number is in E.164 format (`+` followed by country code and number)
+
+## Known Gaps (Future CLI Commands Needed)
+
+The following operations were previously handled by gateway API endpoints and
+do not yet have CLI equivalents:
+
+1. **Credential validation** -- Credentials are stored without verifying them
+   against the Twilio API. Verify manually by attempting a proxied API call.
+2. **Injection template registration** -- Proxied Twilio API calls require
+   injection templates to auto-inject HTTP Basic auth. These are not set up
+   by `vellum credentials set`. If proxied calls fail, templates may need
+   to be registered via a future CLI command.
+3. **Webhook auto-configuration** -- Voice, status callback, and SMS webhook
+   URLs are not automatically set on the Twilio phone number. Configure
+   webhooks manually in the Twilio Console or wait for a future CLI command.
+4. **Stale phone number pruning** -- In multi-assistant setups, stale
+   `sms.assistantPhoneNumbers` mappings are not automatically cleaned up.

--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: "Twilio Setup"
-description: "Configure Twilio credentials and phone numbers for voice calls and SMS messaging"
+description: "Configure Twilio credentials and phone numbers for voice calls"
 user-invocable: true
 includes: ["public-ingress"]
 metadata: { "vellum": { "emoji": "\ud83d\udcf1" } }
 ---
 
-You are helping your user configure Twilio for voice calls and SMS messaging. Walk through each step below.
+You are helping your user configure Twilio for voice calls. Walk through each step below.
 
 ## Retrieving Twilio Credentials
 
@@ -53,7 +53,7 @@ If credentials are invalid, Twilio API calls in Step 3 will fail -- ask the user
 
 ## Step 3: Get a Phone Number
 
-The assistant needs a phone number for calls and SMS. Three options:
+The assistant needs a phone number for voice calls. Three options:
 
 ### Option A: Provision a New Number
 
@@ -63,7 +63,7 @@ Retrieve credentials (see "Retrieving Twilio Credentials" above), then:
 
 ```bash
 curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" \
-  "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/AvailablePhoneNumbers/US/Local.json?SmsEnabled=true&VoiceEnabled=true&AreaCode=415"
+  "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/AvailablePhoneNumbers/US/Local.json?VoiceEnabled=true&AreaCode=415"
 ```
 
 - `AreaCode` is optional -- ask the user if they have a preference
@@ -108,7 +108,7 @@ assistant config set twilio.phoneNumber "+14155551234"
 
 ## Step 4: Set Up Public Ingress and Webhooks
 
-Twilio needs a publicly reachable URL for voice webhooks and SMS delivery. Check if ingress is configured:
+Twilio needs a publicly reachable URL for voice webhooks. Check if ingress is configured:
 
 ```bash
 assistant config get ingress.publicBaseUrl
@@ -147,8 +147,7 @@ Note the `sid` field (starts with `PN`) from the matching entry, then update web
 curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST \
   "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/IncomingPhoneNumbers/$PHONE_SID.json" \
   -d "VoiceUrl=$PUBLIC_URL/webhooks/twilio/voice" \
-  -d "StatusCallback=$PUBLIC_URL/webhooks/twilio/status" \
-  -d "SmsUrl=$PUBLIC_URL/webhooks/twilio/sms"
+  -d "StatusCallback=$PUBLIC_URL/webhooks/twilio/status"
 ```
 
 ## Step 5: Verify and Enable
@@ -158,8 +157,6 @@ Re-run the checks from Step 1 to confirm everything is set. Then enable voice ca
 ```bash
 assistant config set calls.enabled true
 ```
-
-SMS is available automatically once Twilio is configured -- no flag needed.
 
 Tell the user: **"Twilio is configured. Your assistant's phone number is {phoneNumber}."**
 
@@ -190,7 +187,7 @@ assistant credentials delete twilio:auth_token
 assistant config set twilio.accountSid ""
 ```
 
-Phone number assignments are preserved. Voice calls and SMS will stop until credentials are reconfigured.
+Phone number assignments are preserved. Voice calls will stop until credentials are reconfigured.
 
 ## Troubleshooting
 
@@ -208,13 +205,13 @@ Run Step 3.
 - Trial accounts may already have a free number -- check "Active Numbers" in the Console
 - Ensure the account has sufficient balance
 
-### Calls/SMS fail after setup
+### Calls fail after setup
 
 - Verify ingress is running: `assistant config get ingress.publicBaseUrl`
 - For calls, ensure `calls.enabled` is `true`
 - Trial accounts can only reach verified numbers
 
-### Incoming calls/SMS not reaching the assistant
+### Incoming calls not reaching the assistant
 
 Webhooks on the Twilio phone number may not match the current ingress URL. This happens when ngrok restarts with a new URL or webhooks were never configured.
 
@@ -230,13 +227,12 @@ curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" \
   "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/IncomingPhoneNumbers.json?PhoneNumber=$PHONE_NUMBER"
 ```
 
-Check that `voice_url`, `status_callback`, and `sms_url` start with the current `ingress.publicBaseUrl`. If they don't match, update them:
+Check that `voice_url` and `status_callback` start with the current `ingress.publicBaseUrl`. If they don't match, update them:
 
 ```bash
 PHONE_SID=<PN sid from the response above>
 curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST \
   "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/IncomingPhoneNumbers/$PHONE_SID.json" \
   -d "VoiceUrl=$PUBLIC_URL/webhooks/twilio/voice" \
-  -d "StatusCallback=$PUBLIC_URL/webhooks/twilio/status" \
-  -d "SmsUrl=$PUBLIC_URL/webhooks/twilio/sms"
+  -d "StatusCallback=$PUBLIC_URL/webhooks/twilio/status"
 ```

--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -127,15 +127,7 @@ The response includes the purchased number's `phone_number` and `sid`.
 assistant config set twilio.phoneNumber "+14155551234"
 ```
 
-This stores the phone number in config.
-
-**Note:** Webhook auto-configuration (voice, status callback, SMS) is not performed by these CLI commands -- this is a known gap requiring a future CLI command (e.g., `assistant integrations twilio sync-webhooks`). Webhooks must be configured manually in the Twilio Console or will be set up when a future CLI command is available.
-
-**Webhook URLs (manual configuration required until CLI support is added):** When `ingress.publicBaseUrl` is configured, the following webhooks should be set on the Twilio phone number:
-
-- Voice webhook: `{publicBaseUrl}/webhooks/twilio/voice`
-- Voice status callback: `{publicBaseUrl}/webhooks/twilio/status`
-- SMS webhook: `{publicBaseUrl}/webhooks/twilio/sms`
+This stores the phone number in config. After assigning, configure webhooks on the number so Twilio can reach the assistant -- see Step 4.
 
 **Trial account note:** Twilio trial accounts come with one free phone number. Check "Active Numbers" in the Twilio Console first before provisioning.
 
@@ -156,7 +148,7 @@ Then assign the chosen number:
 assistant config set twilio.phoneNumber "+14155551234"
 ```
 
-The phone number must be in E.164 format. **Note:** Webhook auto-configuration is not performed by this CLI command -- this is a known gap. See Step 3d for webhook URLs to configure manually.
+The phone number must be in E.164 format. After assigning, configure webhooks -- see Step 4.
 
 ### Option C: Manual Entry
 
@@ -166,9 +158,9 @@ If the user wants to enter a number directly (e.g., they know it already), assig
 assistant config set twilio.phoneNumber "+14155551234"
 ```
 
-**Note:** Webhook auto-configuration is not performed by this CLI command -- this is a known gap. See Step 3d for webhook URLs to configure manually.
+After assigning, configure webhooks -- see Step 4.
 
-## Step 4: Set Up Public Ingress
+## Step 4: Set Up Public Ingress and Webhooks
 
 Twilio needs a publicly reachable URL for voice webhooks, ConversationRelay WebSocket, and SMS delivery reports. The **public-ingress** skill handles this via ngrok.
 
@@ -185,14 +177,40 @@ If not configured, load and run the public-ingress skill:
 skill_load skill=public-ingress
 ```
 
-**Twilio webhook endpoints (manual configuration required until CLI support is added):**
+### Configure Twilio Webhooks
 
-- Voice webhook: `{publicBaseUrl}/webhooks/twilio/voice`
-- Voice status callback: `{publicBaseUrl}/webhooks/twilio/status`
-- ConversationRelay WebSocket: `{publicBaseUrl}/webhooks/twilio/relay` (wss://)
-- SMS webhook: `{publicBaseUrl}/webhooks/twilio/sms`
+Once ingress is configured, set the webhook URLs on the Twilio phone number so Twilio knows where to send incoming calls and messages. Retrieve the required values:
 
-Webhook URLs must be manually configured on the Twilio phone number in the Twilio Console. A future CLI command (e.g., `assistant integrations twilio sync-webhooks`) will automate this.
+```bash
+TWILIO_SID=$(assistant config get twilio.accountSid)
+TWILIO_TOKEN=$(assistant credentials reveal twilio:auth_token)
+PUBLIC_URL=$(assistant config get ingress.publicBaseUrl)
+PHONE_NUMBER=$(assistant config get twilio.phoneNumber)
+```
+
+Look up the phone number's SID (needed to update it):
+
+```bash
+curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" \
+  "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/IncomingPhoneNumbers.json?PhoneNumber=$PHONE_NUMBER"
+```
+
+Note the `sid` field (starts with `PN`) from the matching entry in `incoming_phone_numbers`. Then update the webhooks:
+
+```bash
+curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST \
+  "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/IncomingPhoneNumbers/$PHONE_SID.json" \
+  -d "VoiceUrl=$PUBLIC_URL/webhooks/twilio/voice" \
+  -d "StatusCallback=$PUBLIC_URL/webhooks/twilio/status" \
+  -d "SmsUrl=$PUBLIC_URL/webhooks/twilio/sms"
+```
+
+The expected webhook URLs are:
+
+- **Voice URL:** `{publicBaseUrl}/webhooks/twilio/voice`
+- **Voice status callback:** `{publicBaseUrl}/webhooks/twilio/status`
+- **SMS URL:** `{publicBaseUrl}/webhooks/twilio/sms`
+- **ConversationRelay WebSocket:** `{publicBaseUrl}/webhooks/twilio/relay` (wss://, configured at call time)
 
 ## Step 5: Verify Setup
 
@@ -293,13 +311,30 @@ Run Step 3 to provision or assign a phone number.
 - Use the list numbers endpoint to see available numbers
 - Ensure the number is in E.164 format (`+` followed by country code and number)
 
-## Known Gaps (Future CLI Commands Needed)
+### Incoming calls/SMS not reaching the assistant (webhook mismatch)
 
-The following operations were previously handled by gateway API endpoints and
-do not yet have CLI equivalents:
+This usually means the webhooks on the Twilio phone number don't match the current public ingress URL. This can happen when the ingress URL changes (e.g., ngrok restarts with a new URL) or webhooks were never configured.
 
-1. **Webhook auto-configuration** -- Voice, status callback, and SMS webhook
-   URLs are not automatically set on the Twilio phone number. Configure
-   webhooks manually in the Twilio Console or wait for a future CLI command.
-2. **Stale phone number pruning** -- Stale phone number mappings are not
-   automatically cleaned up.
+**Diagnose:** Fetch the phone number's current webhook configuration from Twilio and compare it to the expected ingress URL:
+
+```bash
+TWILIO_SID=$(assistant config get twilio.accountSid)
+TWILIO_TOKEN=$(assistant credentials reveal twilio:auth_token)
+PUBLIC_URL=$(assistant config get ingress.publicBaseUrl)
+PHONE_NUMBER=$(assistant config get twilio.phoneNumber)
+
+# Fetch current webhooks
+curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" \
+  "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/IncomingPhoneNumbers.json?PhoneNumber=$PHONE_NUMBER"
+```
+
+In the response, check the `voice_url`, `status_callback`, and `sms_url` fields. They should start with the current `ingress.publicBaseUrl`. If they don't match (e.g., they point to an old ngrok URL), update them:
+
+```bash
+PHONE_SID=<PN sid from the response above>
+curl -s -u "$TWILIO_SID:$TWILIO_TOKEN" -X POST \
+  "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_SID/IncomingPhoneNumbers/$PHONE_SID.json" \
+  -d "VoiceUrl=$PUBLIC_URL/webhooks/twilio/voice" \
+  -d "StatusCallback=$PUBLIC_URL/webhooks/twilio/status" \
+  -d "SmsUrl=$PUBLIC_URL/webhooks/twilio/sms"
+```

--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -12,21 +12,21 @@ You are helping your user configure Twilio for voice calls and SMS messaging. Tw
 
 ```bash
 # 1. Check current status
-vellum credentials inspect twilio:account_sid --json
-vellum config get sms.phoneNumber
+assistant credentials inspect twilio:account_sid --json
+assistant config get sms.phoneNumber
 # 2. Store credentials (after collecting via credential_store prompt)
-vellum credentials set twilio:account_sid "ACxxx"
-vellum credentials set twilio:auth_token "xxx"
+assistant credentials set twilio:account_sid "ACxxx"
+assistant credentials set twilio:auth_token "xxx"
 # 3. Get credential ID and Account SID for proxied calls
-vellum credentials inspect twilio:account_sid --json  # -> note credentialId
-vellum credentials reveal twilio:account_sid  # -> note Account SID value
+assistant credentials inspect twilio:account_sid --json  # -> note credentialId
+assistant credentials reveal twilio:account_sid  # -> note Account SID value
 # 4. Search and provision via Twilio API (proxy injects auth automatically)
 #    bash network_mode=proxied credential_ids=["<cred_id>"]
 curl -s "https://api.twilio.com/2010-04-01/Accounts/<SID>/AvailablePhoneNumbers/US/Local.json?SmsEnabled=true&VoiceEnabled=true"
 curl -s -X POST "https://api.twilio.com/2010-04-01/Accounts/<SID>/IncomingPhoneNumbers.json" -d "PhoneNumber=+1xxx"
 # 5. Assign locally (saves to credential store + config)
-vellum credentials set twilio:phone_number "+1xxx"
-vellum config set sms.phoneNumber "+1xxx"
+assistant credentials set twilio:phone_number "+1xxx"
+assistant config set sms.phoneNumber "+1xxx"
 ```
 
 For voice call setup after Twilio is configured, use `phone-calls` + `call_start`.
@@ -35,12 +35,12 @@ For voice call setup after Twilio is configured, use `phone-calls` + `call_start
 
 This skill manages the full Twilio lifecycle:
 
-- **Credential storage** — Account SID and Auth Token via `vellum credentials set/delete`
+- **Credential storage** — Account SID and Auth Token via `assistant credentials set/delete`
 - **Direct Twilio API access** — Search and purchase numbers via proxied calls to the Twilio REST API (the proxy injects authentication automatically)
-- **Phone number assignment** — Assign an existing Twilio number to the assistant via `vellum credentials set` + `vellum config set`
-- **Status checking** — Verify credentials and assigned number via `vellum credentials inspect` + `vellum config get`
+- **Phone number assignment** — Assign an existing Twilio number to the assistant via `assistant credentials set` + `assistant config set`
+- **Status checking** — Verify credentials and assigned number via `assistant credentials inspect` + `assistant config get`
 
-Number search and purchase use proxied calls to the Twilio REST API (`bash` with `network_mode: "proxied"`). Local bookkeeping (credential storage, phone number assignment, config updates) uses CLI credential and config commands. Status/list retrieval uses `vellum credentials inspect` and `vellum config get`.
+Number search and purchase use proxied calls to the Twilio REST API (`bash` with `network_mode: "proxied"`). Local bookkeeping (credential storage, phone number assignment, config updates) uses CLI credential and config commands. Status/list retrieval uses `assistant credentials inspect` and `assistant config get`.
 
 ### Multi-Assistant Setups
 
@@ -48,13 +48,13 @@ In a multi-assistant environment (multiple assistants sharing the same runtime),
 
 **Global actions** (credentials are shared across all assistants):
 
-- `vellum credentials set twilio:account_sid` / `vellum credentials set twilio:auth_token` -- Stores Account SID and Auth Token in global secure storage. All assistants share the same Twilio account credentials.
-- `vellum credentials delete twilio:account_sid` / `vellum credentials delete twilio:auth_token` -- Removes the globally stored Account SID and Auth Token. This affects all assistants.
+- `assistant credentials set twilio:account_sid` / `assistant credentials set twilio:auth_token` -- Stores Account SID and Auth Token in global secure storage. All assistants share the same Twilio account credentials.
+- `assistant credentials delete twilio:account_sid` / `assistant credentials delete twilio:auth_token` -- Removes the globally stored Account SID and Auth Token. This affects all assistants.
 
 **Assistant-scoped actions** (phone number configuration is scoped per assistant via local config):
 
-- `vellum credentials inspect twilio:account_sid --json` / `vellum config get sms.phoneNumber` -- Returns credential status and the phone number assigned to the current assistant.
-- `vellum credentials set twilio:phone_number` / `vellum config set sms.phoneNumber` -- Assigns a phone number to the current assistant.
+- `assistant credentials inspect twilio:account_sid --json` / `assistant config get sms.phoneNumber` -- Returns credential status and the phone number assigned to the current assistant.
+- `assistant credentials set twilio:phone_number` / `assistant config set sms.phoneNumber` -- Assigns a phone number to the current assistant.
 - Proxied Twilio API calls (search/list/purchase numbers) -- Use global credentials to interact with the shared Twilio account.
 
 CLI commands operate on the local assistant's config directly, so no `assistantId` parameter is needed. In multi-assistant setups, ensure you are running commands in the correct assistant's context.
@@ -65,15 +65,15 @@ First, check whether Twilio is already configured:
 
 ```bash
 # Check if Twilio credentials are stored
-vellum credentials inspect twilio:account_sid --json
+assistant credentials inspect twilio:account_sid --json
 # -> look at "hasSecret" field (true = credentials exist)
 
 # Check if auth token is also stored
-vellum credentials inspect twilio:auth_token --json
+assistant credentials inspect twilio:auth_token --json
 # -> look at "hasSecret" field
 
 # Check assigned phone number
-vellum config get sms.phoneNumber
+assistant config get sms.phoneNumber
 ```
 
 If `hasSecret` is `true` on both `twilio:account_sid` and `twilio:auth_token`, credentials are stored. If `sms.phoneNumber` also returns a phone number, Twilio is fully configured. Tell the user Twilio is already configured and offer to show the current status or reconfigure.
@@ -95,8 +95,8 @@ If credentials are not yet stored, guide the user through Twilio account setup:
 After both credentials are collected, store them using CLI commands:
 
 ```bash
-vellum credentials set twilio:account_sid "<value from credential_store for twilio/account_sid>"
-vellum credentials set twilio:auth_token "<value from credential_store for twilio/auth_token>"
+assistant credentials set twilio:account_sid "<value from credential_store for twilio/account_sid>"
+assistant credentials set twilio:auth_token "<value from credential_store for twilio/auth_token>"
 ```
 
 Both values are required. If credentials are invalid, proxied Twilio API calls (Step 3b) will fail -- tell the user and ask them to re-enter via the secure prompt.
@@ -118,7 +118,7 @@ If the user wants to buy a new number through Twilio:
 **3a. Get the credential ID and Account SID:**
 
 ```bash
-vellum credentials inspect twilio:account_sid --json
+assistant credentials inspect twilio:account_sid --json
 ```
 
 Note the `credentialId` field from the response (needed for proxied calls).
@@ -126,7 +126,7 @@ Note the `credentialId` field from the response (needed for proxied calls).
 Then retrieve the Account SID value (needed for Twilio URL paths):
 
 ```bash
-vellum credentials reveal twilio:account_sid
+assistant credentials reveal twilio:account_sid
 ```
 
 **3b. Search for available numbers (proxied Twilio API):**
@@ -161,13 +161,13 @@ The response includes the purchased number's `phone_number` and `sid`.
 **3d. Assign locally (saves to credential store + config):**
 
 ```bash
-vellum credentials set twilio:phone_number "+14155551234"
-vellum config set sms.phoneNumber "+14155551234"
+assistant credentials set twilio:phone_number "+14155551234"
+assistant config set sms.phoneNumber "+14155551234"
 ```
 
 This stores the phone number in both secure credential storage and config.
 
-**Note:** Webhook auto-configuration (voice, status callback, SMS) is not performed by these CLI commands -- this is a known gap requiring a future CLI command (e.g., `vellum integrations twilio sync-webhooks`). Webhooks must be configured manually in the Twilio Console or will be set up when a future CLI command is available.
+**Note:** Webhook auto-configuration (voice, status callback, SMS) is not performed by these CLI commands -- this is a known gap requiring a future CLI command (e.g., `assistant integrations twilio sync-webhooks`). Webhooks must be configured manually in the Twilio Console or will be set up when a future CLI command is available.
 
 **Webhook URLs (manual configuration required until CLI support is added):** When `ingress.publicBaseUrl` is configured, the following webhooks should be set on the Twilio phone number:
 
@@ -194,8 +194,8 @@ The response includes an `incoming_phone_numbers` array with each number's `phon
 Then assign the chosen number:
 
 ```bash
-vellum credentials set twilio:phone_number "+14155551234"
-vellum config set sms.phoneNumber "+14155551234"
+assistant credentials set twilio:phone_number "+14155551234"
+assistant config set sms.phoneNumber "+14155551234"
 ```
 
 The phone number must be in E.164 format. **Note:** Webhook auto-configuration is not performed by these CLI commands -- this is a known gap. See Step 3d for webhook URLs to configure manually.
@@ -205,8 +205,8 @@ The phone number must be in E.164 format. **Note:** Webhook auto-configuration i
 If the user wants to enter a number directly (e.g., they know it already), assign it using CLI commands:
 
 ```bash
-vellum credentials set twilio:phone_number "+14155551234"
-vellum config set sms.phoneNumber "+14155551234"
+assistant credentials set twilio:phone_number "+14155551234"
+assistant config set sms.phoneNumber "+14155551234"
 ```
 
 **Note:** Webhook auto-configuration is not performed by these CLI commands -- this is a known gap. See Step 3d for webhook URLs to configure manually.
@@ -235,16 +235,16 @@ skill_load skill=public-ingress
 - ConversationRelay WebSocket: `{publicBaseUrl}/webhooks/twilio/relay` (wss://)
 - SMS webhook: `{publicBaseUrl}/webhooks/twilio/sms`
 
-Webhook URLs must be manually configured on the Twilio phone number in the Twilio Console. A future CLI command (e.g., `vellum integrations twilio sync-webhooks`) will automate this.
+Webhook URLs must be manually configured on the Twilio phone number in the Twilio Console. A future CLI command (e.g., `assistant integrations twilio sync-webhooks`) will automate this.
 
 ## Step 5: Verify Setup
 
 After configuration, verify by checking credential and config status:
 
 ```bash
-vellum credentials inspect twilio:account_sid --json
-vellum credentials inspect twilio:auth_token --json
-vellum config get sms.phoneNumber
+assistant credentials inspect twilio:account_sid --json
+assistant credentials inspect twilio:auth_token --json
+assistant config get sms.phoneNumber
 ```
 
 Confirm:
@@ -301,8 +301,8 @@ SMS is available automatically once Twilio is configured -- no additional featur
 If the user wants to disconnect Twilio:
 
 ```bash
-vellum credentials delete twilio:account_sid
-vellum credentials delete twilio:auth_token
+assistant credentials delete twilio:account_sid
+assistant credentials delete twilio:auth_token
 ```
 
 This deletes both the encrypted secret and associated metadata for each credential. Phone number assignments are preserved. Voice calls and SMS will stop working until credentials are reconfigured.
@@ -346,7 +346,7 @@ do not yet have CLI equivalents:
    against the Twilio API. Verify manually by attempting a proxied API call.
 2. **Injection template registration** -- Proxied Twilio API calls require
    injection templates to auto-inject HTTP Basic auth. These are not set up
-   by `vellum credentials set`. If proxied calls fail, templates may need
+   by `assistant credentials set`. If proxied calls fail, templates may need
    to be registered via a future CLI command.
 3. **Webhook auto-configuration** -- Voice, status callback, and SMS webhook
    URLs are not automatically set on the Twilio phone number. Configure


### PR DESCRIPTION
## Summary
- Replaces all gateway HTTP API calls (`curl` to `$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/...`) in the twilio-setup skill with direct `vellum` CLI commands
- Status checks now use `vellum credentials inspect` + `vellum config get` instead of `vellum integrations twilio config --json` (which routes through the gateway)
- Credential storage/deletion uses `vellum credentials set/delete` instead of gateway POST/DELETE
- Phone number assignment uses `vellum credentials set` + `vellum config set` instead of gateway POST to `/numbers/assign`
- Documents known gaps that require future CLI commands (credential validation, injection templates, webhook auto-config, stale number pruning)

## Test plan
- [ ] Read through the updated SKILL.md and verify all gateway curl calls have been replaced
- [ ] Verify `vellum credentials inspect twilio:account_sid --json` returns expected output format
- [ ] Verify `vellum credentials set twilio:account_sid <value>` stores correctly
- [ ] Verify `vellum config get sms.phoneNumber` returns the phone number
- [ ] Verify no references to `$INTERNAL_GATEWAY_BASE_URL` or `$GATEWAY_AUTH_TOKEN` remain (except in Known Gaps notes)
- [ ] Verify proxied Twilio API calls (search/purchase numbers) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
