### PR TITLE
feat: add Quick Look thumbnail provider for .vellum bundle files

### DIFF
--- a/clients/macos/VellumQLThumbnail/Info.plist
+++ b/clients/macos/VellumQLThumbnail/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.vellum.vellum-assistant.QLThumbnail</string>
+    <key>CFBundleName</key>
+    <string>VellumQLThumbnail</string>
+    <key>CFBundleDisplayName</key>
+    <string>Vellum Quick Look Thumbnail</string>
+    <key>CFBundleExecutable</key>
+    <string>VellumQLThumbnail</string>
+    <key>CFBundlePackageType</key>
+    <string>XPC!</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.quicklook.thumbnail</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>VellumQLThumbnail.ThumbnailProvider</string>
+        <key>NSExtensionAttributes</key>
+        <dict>
+            <key>QLSupportedContentTypes</key>
+            <array>
+                <string>com.vellum.app-bundle</string>
+            </array>
+            <key>QLSupportsSearchableItems</key>
+            <false/>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/clients/macos/VellumQLThumbnail/ThumbnailProvider.swift
+++ b/clients/macos/VellumQLThumbnail/ThumbnailProvider.swift
@@ -1,0 +1,161 @@
+import QuickLookThumbnailing
+import AppKit
+import CoreGraphics
+
+/// Quick Look thumbnail provider for .vellum bundle files.
+///
+/// Extracts icon.png from the ZIP-based .vellum file for the thumbnail.
+/// Falls back to rendering the emoji from manifest.json, or the first
+/// letter of the app name on a gradient background.
+class ThumbnailProvider: QLThumbnailProvider {
+
+    override func provideThumbnail(
+        for request: QLFileThumbnailRequest,
+        _ handler: @escaping (QLThumbnailReply?, Error?) -> Void
+    ) {
+        let fileURL = request.fileURL
+        let maxSize = request.maximumSize
+
+        // Try extracting icon.png from the .vellum ZIP
+        if let iconData = extractFileFromZip(at: fileURL, entryName: "icon.png"),
+           let nsImage = NSImage(data: iconData) {
+            let reply = QLThumbnailReply(contextSize: maxSize) { context -> Bool in
+                let rect = CGRect(origin: .zero, size: maxSize)
+                NSGraphicsContext.saveGraphicsState()
+                let gfxContext = NSGraphicsContext(cgContext: context, flipped: false)
+                NSGraphicsContext.current = gfxContext
+                nsImage.draw(in: rect, from: .zero, operation: .copy, fraction: 1.0)
+                NSGraphicsContext.restoreGraphicsState()
+                return true
+            }
+            handler(reply, nil)
+            return
+        }
+
+        // Try extracting manifest.json for emoji/name fallback
+        var emoji: String?
+        var name: String?
+        if let manifestData = extractFileFromZip(at: fileURL, entryName: "manifest.json"),
+           let json = try? JSONSerialization.jsonObject(with: manifestData) as? [String: Any] {
+            emoji = json["icon"] as? String
+            name = json["name"] as? String
+        }
+
+        let displayEmoji = emoji
+        let displayName = name ?? fileURL.deletingPathExtension().lastPathComponent
+
+        let reply = QLThumbnailReply(contextSize: maxSize) { context -> Bool in
+            Self.drawFallbackThumbnail(
+                context: context,
+                size: maxSize,
+                emoji: displayEmoji,
+                name: displayName
+            )
+            return true
+        }
+        handler(reply, nil)
+    }
+
+    // MARK: - ZIP Extraction
+
+    /// Extracts a single file entry from a ZIP archive using the `unzip` command.
+    private func extractFileFromZip(at url: URL, entryName: String) -> Data? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+        process.arguments = ["-p", url.path, entryName]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+
+        guard process.terminationStatus == 0 else { return nil }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return data.isEmpty ? nil : data
+    }
+
+    // MARK: - Fallback Rendering
+
+    /// Draws a gradient background with centered emoji or first-letter text.
+    private static func drawFallbackThumbnail(
+        context: CGContext,
+        size: CGSize,
+        emoji: String?,
+        name: String
+    ) {
+        let rect = CGRect(origin: .zero, size: size)
+
+        // Generate a hash-based gradient color from the name
+        let hue = Self.stableHue(for: name)
+        let topColor = NSColor(hue: hue, saturation: 0.5, brightness: 0.85, alpha: 1.0)
+        let bottomColor = NSColor(hue: hue, saturation: 0.6, brightness: 0.55, alpha: 1.0)
+
+        // Draw rounded rect background with gradient
+        let cornerRadius = min(size.width, size.height) * 0.18
+        let path = CGPath(roundedRect: rect, cornerWidth: cornerRadius, cornerHeight: cornerRadius, transform: nil)
+        context.addPath(path)
+        context.clip()
+
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        if let gradient = CGGradient(
+            colorsSpace: colorSpace,
+            colors: [topColor.cgColor, bottomColor.cgColor] as CFArray,
+            locations: [0.0, 1.0]
+        ) {
+            context.drawLinearGradient(
+                gradient,
+                start: CGPoint(x: size.width / 2, y: size.height),
+                end: CGPoint(x: size.width / 2, y: 0),
+                options: []
+            )
+        }
+
+        // Draw centered text (emoji or first letter)
+        let displayText: String
+        let fontSize: CGFloat
+
+        if let emoji = emoji, !emoji.isEmpty {
+            displayText = emoji
+            fontSize = size.width * 0.5
+        } else {
+            displayText = String(name.prefix(1)).uppercased()
+            fontSize = size.width * 0.45
+        }
+
+        let font = NSFont.systemFont(ofSize: fontSize, weight: .bold)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.white,
+        ]
+
+        let attrString = NSAttributedString(string: displayText, attributes: attributes)
+        let textSize = attrString.size()
+        let textRect = CGRect(
+            x: (size.width - textSize.width) / 2,
+            y: (size.height - textSize.height) / 2,
+            width: textSize.width,
+            height: textSize.height
+        )
+
+        NSGraphicsContext.saveGraphicsState()
+        let gfxContext = NSGraphicsContext(cgContext: context, flipped: false)
+        NSGraphicsContext.current = gfxContext
+        attrString.draw(in: textRect)
+        NSGraphicsContext.restoreGraphicsState()
+    }
+
+    /// Produces a stable hue value (0-1) from a string using a simple hash.
+    private static func stableHue(for string: String) -> CGFloat {
+        var hash: UInt64 = 5381
+        for char in string.utf8 {
+            hash = ((hash &<< 5) &+ hash) &+ UInt64(char)
+        }
+        return CGFloat(hash % 360) / 360.0
+    }
+}

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -698,6 +698,37 @@ fi
 # Copy document type icon for .vellum UTI
 cp "$SCRIPT_DIR/vellum-assistant/Resources/VellumDocument.icns" "$RESOURCES_DIR/"
 
+# Build and embed Quick Look Thumbnail extension (appex)
+QLTHUMB_SRC="$SCRIPT_DIR/VellumQLThumbnail"
+if [ -d "$QLTHUMB_SRC" ]; then
+    echo "Building VellumQLThumbnail appex..."
+    QLTHUMB_APPEX="$CONTENTS/PlugIns/VellumQLThumbnail.appex"
+    QLTHUMB_APPEX_CONTENTS="$QLTHUMB_APPEX/Contents"
+    QLTHUMB_APPEX_MACOS="$QLTHUMB_APPEX_CONTENTS/MacOS"
+    mkdir -p "$QLTHUMB_APPEX_MACOS"
+
+    # Compile the extension as an appex binary.
+    # App extensions use NSExtensionMain as the entry point (provided by Foundation).
+    # The -Xlinker -e -Xlinker _NSExtensionMain flags tell the linker to use it
+    # instead of a regular main() function.
+    xcrun swiftc \
+        -module-name VellumQLThumbnail \
+        -emit-executable \
+        -target "$(uname -m)-apple-macosx14.0" \
+        -sdk "$(xcrun --show-sdk-path)" \
+        -framework QuickLookThumbnailing \
+        -framework AppKit \
+        -framework CoreGraphics \
+        -Xlinker -e -Xlinker _NSExtensionMain \
+        -o "$QLTHUMB_APPEX_MACOS/VellumQLThumbnail" \
+        "$QLTHUMB_SRC/ThumbnailProvider.swift"
+
+    # Copy Info.plist
+    cp "$QLTHUMB_SRC/Info.plist" "$QLTHUMB_APPEX_CONTENTS/Info.plist"
+
+    echo "VellumQLThumbnail appex built"
+fi
+
 # Remove transient runtime artifacts that may be written into the app bundle
 # during local dev runs (for example qdrant marker files). These are not part
 # of the distributable app and can break outer-bundle codesign verification.
@@ -743,6 +774,17 @@ if [ -d "$FRAMEWORKS_DIR/Sparkle.framework" ]; then
         codesign "${FW_SIGN_FLAGS[@]}" "$FRAMEWORKS_DIR/Sparkle.framework"
     fi
     echo "Sparkle.framework signed (including nested binaries)"
+fi
+
+# Sign Quick Look Thumbnail extension (must be signed before outer app bundle)
+QLTHUMB_APPEX="$CONTENTS/PlugIns/VellumQLThumbnail.appex"
+if [ -d "$QLTHUMB_APPEX" ]; then
+    QLTHUMB_SIGN_FLAGS=(--force --sign "$SIGN_IDENTITY")
+    if [ "$CONFIG" = "release" ] && [ "$SIGN_IDENTITY" != "-" ]; then
+        QLTHUMB_SIGN_FLAGS+=(--timestamp --options runtime)
+    fi
+    codesign "${QLTHUMB_SIGN_FLAGS[@]}" "$QLTHUMB_APPEX"
+    echo "VellumQLThumbnail.appex signed"
 fi
 
 # Sign CLI binary


### PR DESCRIPTION
## Summary
- Add QLThumbnailProvider extension for .vellum files
- Shows generated app icon from bundle, falls back to emoji/initial rendering
- Extension compiled, embedded in PlugIns/, and codesigned via build.sh

Part of plan: bundle-share-polish.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)