### PR TITLE
feat: redesign bundle install dialog as DMG-like experience with prominent icon

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
@@ -70,13 +70,24 @@ extension AppDelegate {
 
         viewModel.onConfirm = { [weak self] in
             guard let self else { return }
-            confirmWindow.close()
-            self.bundleConfirmationWindow = nil
+            viewModel.installState = .installing
             self.unpackAndLoadBundle(
                 filePath: filePath,
                 manifest: response.manifest,
                 signatureResult: response.signatureResult,
-                bundleSizeBytes: response.bundleSizeBytes
+                bundleSizeBytes: response.bundleSizeBytes,
+                onSuccess: {
+                    viewModel.installState = .installed
+                    // Auto-close after brief success feedback
+                    Task { @MainActor in
+                        try? await Task.sleep(for: .milliseconds(500))
+                        confirmWindow.close()
+                        self.bundleConfirmationWindow = nil
+                    }
+                },
+                onError: { errorMessage in
+                    viewModel.installState = .error(errorMessage)
+                }
             )
         }
 
@@ -92,7 +103,9 @@ extension AppDelegate {
         filePath: String,
         manifest: OpenBundleResponseMessage.Manifest,
         signatureResult: OpenBundleResponseMessage.SignatureResult,
-        bundleSizeBytes: Int
+        bundleSizeBytes: Int,
+        onSuccess: (() -> Void)? = nil,
+        onError: ((String) -> Void)? = nil
     ) {
         // Run the unzip on a background thread to avoid blocking the UI.
         Task.detached {
@@ -138,16 +151,21 @@ extension AppDelegate {
                         messageId: nil
                     )
                     self.surfaceManager.showSurface(surfaceMsg)
+                    onSuccess?()
                 }
             } catch {
                 await MainActor.run {
                     log.error("Failed to unpack bundle: \(error.localizedDescription)")
-                    let alert = NSAlert()
-                    alert.messageText = "Failed to open app"
-                    alert.informativeText = error.localizedDescription
-                    alert.alertStyle = .critical
-                    alert.addButton(withTitle: "OK")
-                    alert.runModal()
+                    if let onError {
+                        onError(error.localizedDescription)
+                    } else {
+                        let alert = NSAlert()
+                        alert.messageText = "Failed to open app"
+                        alert.informativeText = error.localizedDescription
+                        alert.alertStyle = .critical
+                        alert.addButton(withTitle: "OK")
+                        alert.runModal()
+                    }
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationView.swift
@@ -7,294 +7,273 @@ struct BundleConfirmationView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header
-            headerSection
-
-            Divider()
-                .background(VColor.surfaceBorder)
-
-            // Content
-            ScrollView {
-                VStack(alignment: .leading, spacing: VSpacing.lg) {
-                    trustTierSection
-                    scanResultSection
-                    bundleSizeSection
-                }
-                .padding(VSpacing.xl)
-                .textSelection(.enabled)
+            switch viewModel.installState {
+            case .installed:
+                installedStateView
+            default:
+                confirmationContent
             }
-
-            Divider()
-                .background(VColor.surfaceBorder)
-
-            // Footer buttons
-            footerSection
         }
-        .frame(minWidth: 420, maxWidth: 420, minHeight: 350)
+        .frame(width: 480, height: 400)
         .background(VColor.background)
     }
 
-    // MARK: - Header
+    // MARK: - Main Confirmation Content
 
-    private var headerSection: some View {
-        VStack(spacing: VSpacing.sm) {
-            Text(viewModel.manifest.icon ?? "\u{1F4E6}")
-                .font(.system(size: 40))
+    private var confirmationContent: some View {
+        VStack(spacing: 0) {
+            // Hero section — icon + name + description
+            heroSection
 
+            // Info section — trust, size, warnings
+            infoSection
+
+            Spacer(minLength: 0)
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            // Action buttons
+            footerSection
+        }
+    }
+
+    // MARK: - Hero Section
+
+    private var heroSection: some View {
+        VStack(spacing: VSpacing.md) {
+            Spacer()
+                .frame(height: VSpacing.xl)
+
+            // App icon — 96pt centered with rounded corners and shadow
+            Group {
+                if let icon = viewModel.appIconImage {
+                    Image(nsImage: icon)
+                        .resizable()
+                        .interpolation(.high)
+                        .aspectRatio(contentMode: .fit)
+                } else {
+                    // Inline emoji fallback while icon loads
+                    Text(viewModel.manifest.icon ?? "\u{1F4E6}")
+                        .font(.system(size: 64))
+                }
+            }
+            .frame(width: 96, height: 96)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.xl))
+            .vShadow(VShadow.md)
+
+            // App name
             Text(viewModel.manifest.name)
                 .font(VFont.title)
                 .foregroundColor(VColor.textPrimary)
                 .multilineTextAlignment(.center)
+                .lineLimit(2)
 
+            // Description
             if let description = viewModel.manifest.description, !description.isEmpty {
                 Text(description)
                     .font(VFont.body)
                     .foregroundColor(VColor.textSecondary)
                     .multilineTextAlignment(.center)
-                    .lineLimit(3)
+                    .lineLimit(2)
+                    .padding(.horizontal, VSpacing.xxl)
             }
-
-            Text("by \(viewModel.manifest.createdBy)")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textMuted)
         }
-        .padding(VSpacing.xl)
         .frame(maxWidth: .infinity)
-        .textSelection(.enabled)
+        .padding(.bottom, VSpacing.lg)
     }
 
-    // MARK: - Trust Tier
+    // MARK: - Info Section
 
-    private var trustTierSection: some View {
-        HStack(spacing: VSpacing.sm) {
-            trustTierIcon
-            trustTierText
+    private var infoSection: some View {
+        VStack(spacing: VSpacing.sm) {
+            // Trust tier badge — centered
+            trustBadge
+
+            // Signer info
+            if let signerName = viewModel.signatureResult.signerDisplayName, !signerName.isEmpty {
+                Text("Signed by \(signerName)")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textSecondary)
+            }
+
+            // Bundle size
+            Text(viewModel.formattedSize)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+
+            // Security warnings — expandable disclosure
+            if !viewModel.scanResult.warnings.isEmpty {
+                warningsDisclosure
+            }
         }
-        .padding(VSpacing.md)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(trustTierBackground)
-        .cornerRadius(VRadius.md)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, VSpacing.xl)
+    }
+
+    // MARK: - Trust Badge
+
+    private var trustBadge: some View {
+        HStack(spacing: VSpacing.xs) {
+            trustBadgeIcon
+            trustBadgeLabel
+        }
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.xs)
+        .background(trustBadgeBackground)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.pill))
     }
 
     @ViewBuilder
-    private var trustTierIcon: some View {
+    private var trustBadgeIcon: some View {
         switch viewModel.trustTier {
         case .verified:
             Image(systemName: "checkmark.seal.fill")
                 .foregroundColor(VColor.success)
+                .font(.system(size: 14))
         case .signed:
             Image(systemName: "checkmark.seal.fill")
                 .foregroundColor(VColor.accent)
+                .font(.system(size: 14))
         case .unsigned:
             Image(systemName: "lock.open")
                 .foregroundColor(VColor.textSecondary)
+                .font(.system(size: 12))
         case .tampered:
             Image(systemName: "xmark.seal.fill")
+                .foregroundColor(VColor.error)
+                .font(.system(size: 14))
+        }
+    }
+
+    @ViewBuilder
+    private var trustBadgeLabel: some View {
+        switch viewModel.trustTier {
+        case .verified:
+            Text("Verified")
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.success)
+        case .signed:
+            Text("Signed")
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.accent)
+        case .unsigned:
+            Text("Not Signed")
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.textSecondary)
+        case .tampered:
+            Text("Tampered")
+                .font(VFont.captionMedium)
                 .foregroundColor(VColor.error)
         }
     }
 
-    @ViewBuilder
-    private var trustTierText: some View {
+    private var trustBadgeBackground: Color {
         switch viewModel.trustTier {
-        case .verified:
-            VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                Text("Verified")
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.success)
-                Text("Created by \(viewModel.signatureResult.signerDisplayName ?? "Unknown") (\(viewModel.signatureResult.signerAccount ?? ""))")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
-            }
-        case .signed:
-            VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                Text("Signed")
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.accent)
-                let keyId = viewModel.signatureResult.signerKeyId ?? "unknown"
-                let shortKey = keyId.count > 8 ? String(keyId.prefix(8)) + "..." : keyId
-                Text("Created by \(viewModel.signatureResult.signerDisplayName ?? shortKey). Content hasn't been modified.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
-            }
-        case .unsigned:
-            VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                Text("Not signed")
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.textSecondary)
-                Text("This app hasn't been signed. Only open apps from sources you trust.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
-            }
-        case .tampered:
-            VStack(alignment: .leading, spacing: VSpacing.xxs) {
-                Text("Tampered")
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.error)
-                Text("This app has been modified since it was signed.")
-                    .font(VFont.caption)
-                    .foregroundColor(VColor.textSecondary)
-            }
+        case .verified: return VColor.success.opacity(0.15)
+        case .signed: return VColor.accent.opacity(0.15)
+        case .unsigned: return VColor.surface
+        case .tampered: return VColor.error.opacity(0.15)
         }
     }
 
-    private var trustTierBackground: Color {
-        switch viewModel.trustTier {
-        case .verified:
-            return VColor.success.opacity(0.1)
-        case .signed:
-            return VColor.accent.opacity(0.1)
-        case .unsigned:
-            return VColor.surface
-        case .tampered:
-            return VColor.error.opacity(0.1)
-        }
-    }
+    // MARK: - Warnings Disclosure
 
-    // MARK: - Scan Result
-
-    @ViewBuilder
-    private var scanResultSection: some View {
-        if !viewModel.scanResult.blocked.isEmpty {
-            // Blocked state (should not normally reach here)
-            HStack(spacing: VSpacing.sm) {
-                Image(systemName: "xmark.circle.fill")
-                    .foregroundColor(VColor.error)
-                Text("Security scan blocked")
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.error)
-            }
-            .padding(VSpacing.md)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(VColor.error.opacity(0.1))
-            .cornerRadius(VRadius.md)
-        } else if !viewModel.scanResult.warnings.isEmpty {
-            // Warnings
-            VStack(alignment: .leading, spacing: VSpacing.sm) {
-                Button(action: { viewModel.warningsExpanded.toggle() }) {
-                    HStack(spacing: VSpacing.sm) {
-                        Image(systemName: "info.circle")
-                            .foregroundColor(VColor.textSecondary)
-                        Text("Scan complete — \(viewModel.scanResult.warnings.count) note\(viewModel.scanResult.warnings.count == 1 ? "" : "s")")
-                            .font(VFont.bodyMedium)
-                            .foregroundColor(VColor.textSecondary)
-                        Spacer()
-                        Image(systemName: viewModel.warningsExpanded ? "chevron.up" : "chevron.down")
-                            .foregroundColor(VColor.textSecondary)
-                            .font(.system(size: 10))
-                    }
+    private var warningsDisclosure: some View {
+        VStack(alignment: .leading, spacing: VSpacing.xs) {
+            Button(action: {
+                withAnimation(VAnimation.standard) {
+                    viewModel.warningsExpanded.toggle()
                 }
-                .buttonStyle(.plain)
-
-                if viewModel.warningsExpanded {
-                    VStack(alignment: .leading, spacing: VSpacing.xs) {
-                        ForEach(viewModel.scanResult.warnings, id: \.self) { warning in
-                            HStack(alignment: .top, spacing: VSpacing.sm) {
-                                Text("\u{2022}")
-                                    .foregroundColor(VColor.textMuted)
-                                Text(warning)
-                                    .font(VFont.caption)
-                                    .foregroundColor(VColor.textSecondary)
-                            }
-                        }
-                    }
-                    .padding(.leading, VSpacing.xl)
+            }) {
+                HStack(spacing: VSpacing.xs) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .foregroundColor(VColor.warning)
+                        .font(.system(size: 10))
+                    Text("\(viewModel.scanResult.warnings.count) warning\(viewModel.scanResult.warnings.count == 1 ? "" : "s")")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textSecondary)
+                    Image(systemName: viewModel.warningsExpanded ? "chevron.up" : "chevron.down")
+                        .foregroundColor(VColor.textMuted)
+                        .font(.system(size: 8))
                 }
             }
-            .padding(VSpacing.md)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(VColor.surface)
-            .cornerRadius(VRadius.md)
-        } else {
-            // Clean scan
-            HStack(spacing: VSpacing.sm) {
-                Image(systemName: "checkmark.shield.fill")
-                    .foregroundColor(VColor.success)
-                Text("Security scan passed")
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.success)
+            .buttonStyle(.plain)
+
+            if viewModel.warningsExpanded {
+                VStack(alignment: .leading, spacing: VSpacing.xxs) {
+                    ForEach(viewModel.scanResult.warnings, id: \.self) { warning in
+                        Text("\u{2022} \(warning)")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                }
+                .padding(.leading, VSpacing.lg)
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
-            .padding(VSpacing.md)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(VColor.success.opacity(0.1))
-            .cornerRadius(VRadius.md)
         }
-    }
-
-    // MARK: - Bundle Size
-
-    private var bundleSizeSection: some View {
-        HStack(spacing: VSpacing.sm) {
-            Image(systemName: "doc.zipper")
-                .foregroundColor(VColor.textSecondary)
-            Text("Bundle size: \(viewModel.formattedSize)")
-                .font(VFont.caption)
-                .foregroundColor(VColor.textSecondary)
-        }
+        .padding(.top, VSpacing.xs)
     }
 
     // MARK: - Footer
 
     private var footerSection: some View {
         HStack(spacing: VSpacing.md) {
-            // Cancel button
-            Button(action: { viewModel.cancel() }) {
-                Text("Cancel")
-                    .font(VFont.bodyMedium)
-                    .foregroundColor(VColor.textSecondary)
-                    .padding(.vertical, VSpacing.buttonV)
-                    .padding(.horizontal, VSpacing.lg)
+            VButton(label: "Cancel", style: .ghost, size: .medium) {
+                viewModel.cancel()
             }
-            .buttonStyle(.plain)
-            .background(VColor.surface)
-            .cornerRadius(VRadius.md)
 
             Spacer()
 
             if viewModel.isTampered {
-                if viewModel.showTamperedWarning {
-                    // Show "Open Anyway" destructive button
-                    VStack(alignment: .trailing, spacing: VSpacing.xs) {
-                        Text("This app may contain malicious content.")
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.error)
-                        Button(action: { viewModel.confirm() }) {
-                            Text("Open Anyway")
-                                .font(VFont.bodyMedium)
-                                .foregroundColor(VColor.error)
-                                .padding(.vertical, VSpacing.buttonV)
-                                .padding(.horizontal, VSpacing.lg)
-                        }
-                        .buttonStyle(.plain)
-                        .background(VColor.error.opacity(0.2))
-                        .cornerRadius(VRadius.md)
-                    }
-                } else {
-                    Button(action: { viewModel.showTamperedWarning = true }) {
-                        Text("Open Anyway...")
-                            .font(VFont.bodyMedium)
-                            .foregroundColor(VColor.textSecondary)
-                            .padding(.vertical, VSpacing.buttonV)
-                            .padding(.horizontal, VSpacing.lg)
-                    }
-                    .buttonStyle(.plain)
-                    .background(VColor.surface)
-                    .cornerRadius(VRadius.md)
-                }
+                tamperedInstallButton
             } else {
-                // Normal "Open in Vellum" button
-                Button(action: { viewModel.confirm() }) {
-                    Text("\(viewModel.manifest.icon ?? "\u{1F4E6}") Open in Vellum")
-                        .font(VFont.bodyMedium)
-                        .foregroundColor(VColor.textPrimary)
-                        .padding(.vertical, VSpacing.buttonV)
-                        .padding(.horizontal, VSpacing.lg)
+                VButton(label: "Install", style: .primary, size: .medium) {
+                    viewModel.confirm()
                 }
-                .buttonStyle(.plain)
-                .background(VColor.accent)
-                .cornerRadius(VRadius.md)
             }
         }
-        .padding(VSpacing.lg)
+        .padding(.horizontal, VSpacing.lg)
+        .padding(.vertical, VSpacing.md)
+    }
+
+    @ViewBuilder
+    private var tamperedInstallButton: some View {
+        if viewModel.showTamperedWarning {
+            VStack(alignment: .trailing, spacing: VSpacing.xxs) {
+                Text("This app may have been modified.")
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.error)
+                VButton(label: "Install Anyway", style: .danger, size: .medium) {
+                    viewModel.confirm()
+                }
+            }
+        } else {
+            VButton(label: "Install", style: .ghost, size: .medium) {
+                withAnimation(VAnimation.standard) {
+                    viewModel.showTamperedWarning = true
+                }
+            }
+        }
+    }
+
+    // MARK: - Installed State
+
+    private var installedStateView: some View {
+        VStack(spacing: VSpacing.lg) {
+            Spacer()
+
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 56))
+                .foregroundColor(VColor.success)
+
+            Text("Installed")
+                .font(VFont.title)
+                .foregroundColor(VColor.textPrimary)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .transition(.opacity)
     }
 }

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationViewModel.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import SwiftUI
 import VellumAssistantShared
@@ -17,6 +18,19 @@ final class BundleConfirmationViewModel {
     var showTamperedWarning = false
     var warningsExpanded = false
 
+    /// The app icon extracted from the .vellum ZIP, or a fallback emoji rendering.
+    var appIconImage: NSImage?
+
+    /// Post-install state: nil = not yet installed, true = success, false = error.
+    var installState: InstallState = .ready
+
+    enum InstallState {
+        case ready
+        case installing
+        case installed
+        case error(String)
+    }
+
     init(
         response: OpenBundleResponseMessage,
         filePath: String,
@@ -30,6 +44,89 @@ final class BundleConfirmationViewModel {
         self.filePath = filePath
         self.onConfirm = onConfirm
         self.onCancel = onCancel
+
+        loadIcon()
+    }
+
+    // MARK: - Icon Loading
+
+    /// Attempts to extract icon.png from the .vellum ZIP. Falls back to emoji rendering.
+    private func loadIcon() {
+        // Try extracting icon.png from the ZIP via unzip -p (stdout extraction)
+        if !filePath.isEmpty {
+            Task.detached { [filePath, manifest] in
+                let image = Self.extractIconFromZip(filePath: filePath)
+                    ?? Self.renderEmojiFallback(emoji: manifest.icon, appName: manifest.name)
+                await MainActor.run { [image] in
+                    self.appIconImage = image
+                }
+            }
+        } else {
+            appIconImage = Self.renderEmojiFallback(emoji: manifest.icon, appName: manifest.name)
+        }
+    }
+
+    /// Extract icon.png from a .vellum ZIP without fully unpacking.
+    private nonisolated static func extractIconFromZip(filePath: String) -> NSImage? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+        process.arguments = ["-p", filePath, "icon.png"]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe() // Suppress stderr
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0, !data.isEmpty else { return nil }
+        return NSImage(data: data)
+    }
+
+    /// Render the manifest emoji (or first letter) on a gradient background as a fallback icon.
+    nonisolated static func renderEmojiFallback(emoji: String?, appName: String) -> NSImage {
+        let glyph = (emoji.flatMap { $0.isEmpty ? nil : $0 })
+            ?? String(appName.trimmingCharacters(in: .whitespacesAndNewlines).prefix(1)).uppercased()
+
+        let size: CGFloat = 512
+        return NSImage(size: NSSize(width: size, height: size), flipped: false) { rect in
+            let cornerRadius = size * 0.22
+            let path = NSBezierPath(roundedRect: rect, xRadius: cornerRadius, yRadius: cornerRadius)
+
+            // Gradient background using a stable hash for consistent colors
+            var hasher = Hasher()
+            hasher.combine(glyph)
+            let hash = hasher.finalize() & Int.max
+            let hue = CGFloat(hash % 360) / 360.0
+            let topColor = NSColor(hue: hue, saturation: 0.6, brightness: 0.85, alpha: 1.0)
+            let bottomColor = NSColor(
+                hue: (hue + 0.08).truncatingRemainder(dividingBy: 1.0),
+                saturation: 0.7, brightness: 0.65, alpha: 1.0
+            )
+            if let gradient = NSGradient(starting: topColor, ending: bottomColor) {
+                gradient.draw(in: path, angle: -90)
+            }
+
+            // Draw the glyph centered
+            let fontSize = size * 0.55
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: fontSize),
+            ]
+            let emojiString = NSAttributedString(string: glyph, attributes: attributes)
+            let emojiSize = emojiString.size()
+            let origin = NSPoint(
+                x: (size - emojiSize.width) / 2,
+                y: (size - emojiSize.height) / 2
+            )
+            emojiString.draw(at: origin)
+            return true
+        }
     }
 
     // MARK: - Trust Tier

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationWindow.swift
@@ -17,7 +17,7 @@ final class BundleConfirmationWindow {
         let hostingController = NSHostingController(rootView: confirmationView)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 420, height: 480),
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 400),
             styleMask: [.titled, .closable, .fullSizeContentView],
             backing: .buffered,
             defer: false

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import os
 import VellumAssistantShared
@@ -105,7 +106,22 @@ enum BundleSandbox {
 
         log.info("Wrote metadata to \(metaPath.path)")
 
+        // Persist icon.png alongside metadata if it exists in the extracted bundle
+        let extractedIcon = targetDir.appendingPathComponent("icon.png")
+        if fm.fileExists(atPath: extractedIcon.path) {
+            let iconDest = sharedAppsDirectory.appendingPathComponent("\(uuid)-icon.png")
+            try? fm.copyItem(at: extractedIcon, to: iconDest)
+            log.info("Persisted icon to \(iconDest.path)")
+        }
+
         return (uuid: uuid, directory: targetDir)
+    }
+
+    /// Loads the persisted icon image for a given bundle UUID, if available.
+    static func iconImage(for uuid: String) -> NSImage? {
+        let iconPath = sharedAppsDirectory.appendingPathComponent("\(uuid)-icon.png")
+        guard FileManager.default.fileExists(atPath: iconPath.path) else { return nil }
+        return NSImage(contentsOf: iconPath)
     }
 
     /// Walk the extracted directory and remove any symlinks or hardlinks whose


### PR DESCRIPTION
## Summary
- Redesign BundleConfirmationView with hero icon section (96pt), spacious layout
- Extract icon.png from .vellum ZIP for rich icon display, emoji fallback
- Clean Install/Cancel buttons, post-install success state with auto-open
- Persist icon.png alongside bundle metadata for reuse

Part of plan: bundle-share-polish.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
