### PR TITLE
fix: migrate remaining credential mutators to async secure-key APIs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -79,7 +79,10 @@ declare -a SAFE_LINE_PATTERNS=(
     # IMPORTANT: must come BEFORE the dotted-ref pattern below, so it strips
     # the full `key: obj.prop,` expression before the dotted-ref strips only
     # the RHS (which would leave `key: obj` still looking suspicious).
-    "[Cc]lient[_-]?[Ss]ecret[[:space:]]*[:=][[:space:]]*[a-zA-Z_][a-zA-Z0-9_.?]*[[:space:]]*((\?\?|\|\|)[[:space:]]*(undefined))?[[:space:]]*([;,)]|$)"
+    "[Cc]lient[_-]?[Ss]ecret[[:space:]]*[:=][[:space:]]*[a-zA-Z_][a-zA-Z0-9_.?]*[[:space:]]*((\?\?|\|\|)[[:space:]]*(undefined|null))?[[:space:]]*([;,)]|$)"
+    # TS/JS: variable declaration containing clientSecret where value continues on next line.
+    # E.g. `const clientSecret =` or `const requiresClientSecret =` at end of line.
+    "(const|let|var)[[:space:]]+[a-zA-Z0-9_]*[Cc]lient[Ss]ecret[[:space:]]*=[[:space:]]*$"
     # TS/JS: clientSecret assigned from a dotted/optional property with `as` type assertion.
     # E.g. `const clientSecret = meta?.oauth2ClientSecret as string | undefined;`
     "[Cc]lient[_-]?[Ss]ecret[[:space:]]*[:=][[:space:]]*[a-zA-Z_][a-zA-Z0-9_.?]*[[:space:]]+as[[:space:]]+(string|String|number|unknown|any)[[:space:]]*([|][[:space:]]*(undefined|null))?[[:space:]]*[;,]"
@@ -251,6 +254,12 @@ if [ "${1:-}" = "--self-test" ]; then
     # Variable-to-variable assignment (false positive to whitelist)
     SAFE_VAR_ASSIGN_SECRET='body.client_secret = clientSecret;'
     SAFE_VAR_NULLISH_SECRET='oauth2ClientSecret: clientSecret ?? undefined,'
+    # Variable-to-variable assignment with null fallback (false positive to whitelist)
+    SAFE_VAR_NULLISH_NULL_SECRET='    oauth2ClientSecret: clientSecret ?? null,'
+    # Multiline variable declaration — value continues on next line (false positive to whitelist)
+    SAFE_MULTILINE_DECL_SECRET='        const clientSecret ='
+    # Multiline requires* variable declaration (false positive to whitelist)
+    SAFE_MULTILINE_REQUIRES_SECRET='        const requiresClientSecret ='
     # Dotted property access as value (false positive to whitelist)
     SAFE_DOTTED_PROP_SECRET='    clientSecret: options.clientSecret,'
     # Swift var declaration with empty string default (false positive to whitelist)
@@ -490,6 +499,18 @@ if [ "${1:-}" = "--self-test" ]; then
     fi
     if matches_secret_pattern "$SAFE_VAR_NULLISH_SECRET" && ! matches_safe_line_pattern "$SAFE_VAR_NULLISH_SECRET"; then
         echo -e "${RED}Self-test failed:${NC} clientSecret nullish coalescing undefined assignment false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_VAR_NULLISH_NULL_SECRET" && ! matches_safe_line_pattern "$SAFE_VAR_NULLISH_NULL_SECRET"; then
+        echo -e "${RED}Self-test failed:${NC} clientSecret nullish coalescing null assignment false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_MULTILINE_DECL_SECRET" && ! matches_safe_line_pattern "$SAFE_MULTILINE_DECL_SECRET"; then
+        echo -e "${RED}Self-test failed:${NC} multiline clientSecret declaration false positive"
+        exit 1
+    fi
+    if matches_secret_pattern "$SAFE_MULTILINE_REQUIRES_SECRET" && ! matches_safe_line_pattern "$SAFE_MULTILINE_REQUIRES_SECRET"; then
+        echo -e "${RED}Self-test failed:${NC} multiline requiresClientSecret declaration false positive"
         exit 1
     fi
     if matches_secret_pattern "$SAFE_DOTTED_PROP_SECRET" && ! matches_safe_line_pattern "$SAFE_DOTTED_PROP_SECRET"; then

--- a/assistant/src/__tests__/credential-security-e2e.test.ts
+++ b/assistant/src/__tests__/credential-security-e2e.test.ts
@@ -30,23 +30,30 @@ mock.module("../util/logger.js", () => ({
 
 // Track keychain writes
 const storedKeys = new Map<string, string>();
-mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (key: string) => storedKeys.get(key) ?? null,
-  setSecureKey: (key: string, value: string) => {
+mock.module("../security/secure-keys.js", () => {
+  const syncSet = (key: string, value: string) => {
     storedKeys.set(key, value);
     return true;
-  },
-  deleteSecureKey: (key: string) => {
+  };
+  const syncDelete = (key: string) => {
     if (storedKeys.has(key)) {
       storedKeys.delete(key);
-      return "deleted";
+      return "deleted" as const;
     }
-    return "not-found";
-  },
-  listSecureKeys: () => [...storedKeys.keys()],
-  getBackendType: () => "encrypted",
-  isDowngradedFromKeychain: () => false,
-}));
+    return "not-found" as const;
+  };
+  return {
+    getSecureKey: (key: string) => storedKeys.get(key) ?? null,
+    setSecureKey: syncSet,
+    setSecureKeyAsync: async (key: string, value: string) =>
+      syncSet(key, value),
+    deleteSecureKey: syncDelete,
+    deleteSecureKeyAsync: async (key: string) => syncDelete(key),
+    listSecureKeys: () => [...storedKeys.keys()],
+    getBackendType: () => "encrypted",
+    isDowngradedFromKeychain: () => false,
+  };
+});
 
 // In-memory metadata store that mirrors storedKeys for list/get operations
 const metadataStore = new Map<

--- a/assistant/src/__tests__/secret-onetime-send.test.ts
+++ b/assistant/src/__tests__/secret-onetime-send.test.ts
@@ -29,23 +29,30 @@ mock.module("../util/logger.js", () => ({
 
 // Track keychain writes
 const storedKeys = new Map<string, string>();
-mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (key: string) => storedKeys.get(key) ?? null,
-  setSecureKey: (key: string, value: string) => {
+mock.module("../security/secure-keys.js", () => {
+  const syncSet = (key: string, value: string) => {
     storedKeys.set(key, value);
     return true;
-  },
-  deleteSecureKey: (key: string) => {
+  };
+  const syncDelete = (key: string) => {
     if (storedKeys.has(key)) {
       storedKeys.delete(key);
-      return "deleted";
+      return "deleted" as const;
     }
-    return "not-found";
-  },
-  listSecureKeys: () => [],
-  getBackendType: () => "encrypted",
-  isDowngradedFromKeychain: () => false,
-}));
+    return "not-found" as const;
+  };
+  return {
+    getSecureKey: (key: string) => storedKeys.get(key) ?? null,
+    setSecureKey: syncSet,
+    setSecureKeyAsync: async (key: string, value: string) =>
+      syncSet(key, value),
+    deleteSecureKey: syncDelete,
+    deleteSecureKeyAsync: async (key: string) => syncDelete(key),
+    listSecureKeys: () => [],
+    getBackendType: () => "encrypted",
+    isDowngradedFromKeychain: () => false,
+  };
+});
 
 mock.module("./metadata-store.js", () => ({
   upsertCredentialMetadata: () => {},

--- a/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
+++ b/assistant/src/__tests__/session-messaging-secret-redirect.test.ts
@@ -26,7 +26,10 @@ const metadataByKey = new Map<
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: () => undefined,
   setSecureKey: setSecureKeyMock,
+  setSecureKeyAsync: async (key?: string, value?: string) =>
+    setSecureKeyMock(key, value),
   deleteSecureKey: () => "deleted",
+  deleteSecureKeyAsync: async () => "deleted" as const,
   listSecureKeys: () => [],
   getBackendType: () => null,
   isDowngradedFromKeychain: () => false,

--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -52,25 +52,32 @@ mock.module("../util/logger.js", () => ({
 // Mock secure key storage
 let secureKeyStore: Record<string, string> = {};
 
-mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (account: string) => secureKeyStore[account] ?? undefined,
-  setSecureKey: (account: string, value: string) => {
+mock.module("../security/secure-keys.js", () => {
+  const syncSet = (account: string, value: string) => {
     secureKeyStore[account] = value;
     return true;
-  },
-  deleteSecureKey: (account: string) => {
+  };
+  const syncDelete = (account: string) => {
     if (account in secureKeyStore) {
       delete secureKeyStore[account];
-      return "deleted";
+      return "deleted" as const;
     }
-    return "not-found";
-  },
-  listSecureKeys: () => Object.keys(secureKeyStore),
-  getBackendType: () => "encrypted",
-  isDowngradedFromKeychain: () => false,
-  _resetBackend: () => {},
-  _setBackend: () => {},
-}));
+    return "not-found" as const;
+  };
+  return {
+    getSecureKey: (account: string) => secureKeyStore[account] ?? undefined,
+    setSecureKey: syncSet,
+    deleteSecureKey: syncDelete,
+    setSecureKeyAsync: async (account: string, value: string) =>
+      syncSet(account, value),
+    deleteSecureKeyAsync: async (account: string) => syncDelete(account),
+    listSecureKeys: () => Object.keys(secureKeyStore),
+    getBackendType: () => "encrypted",
+    isDowngradedFromKeychain: () => false,
+    _resetBackend: () => {},
+    _setBackend: () => {},
+  };
+});
 
 // Mock credential metadata store
 let credentialMetadataStore: Array<{
@@ -245,7 +252,7 @@ describe("Slack channel config handler", () => {
     expect(result.error).toContain("invalid_auth");
   });
 
-  test("DELETE clears credentials", () => {
+  test("DELETE clears credentials", async () => {
     secureKeyStore["credential:slack_channel:bot_token"] = "xoxb-test";
     secureKeyStore["credential:slack_channel:app_token"] = "xapp-test";
     credentialMetadataStore.push({
@@ -257,7 +264,7 @@ describe("Slack channel config handler", () => {
       field: "app_token",
     });
 
-    const result = clearSlackChannelConfig();
+    const result = await clearSlackChannelConfig();
     expect(result.success).toBe(true);
     expect(result.hasBotToken).toBe(false);
     expect(result.hasAppToken).toBe(false);

--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -1,7 +1,7 @@
 import {
-  deleteSecureKey,
+  deleteSecureKeyAsync,
   getSecureKey,
-  setSecureKey,
+  setSecureKeyAsync,
 } from "../../security/secure-keys.js";
 import {
   deleteCredentialMetadata,
@@ -122,7 +122,10 @@ export async function setSlackChannelConfig(
       };
     }
 
-    const stored = setSecureKey("credential:slack_channel:bot_token", botToken);
+    const stored = await setSecureKeyAsync(
+      "credential:slack_channel:bot_token",
+      botToken,
+    );
     if (!stored) {
       const storedBotToken = !!getSecureKey(
         "credential:slack_channel:bot_token",
@@ -166,7 +169,10 @@ export async function setSlackChannelConfig(
       };
     }
 
-    const stored = setSecureKey("credential:slack_channel:app_token", appToken);
+    const stored = await setSecureKeyAsync(
+      "credential:slack_channel:app_token",
+      appToken,
+    );
     if (!stored) {
       const storedBotToken = !!getSecureKey(
         "credential:slack_channel:bot_token",
@@ -207,10 +213,10 @@ export async function setSlackChannelConfig(
   };
 }
 
-export function clearSlackChannelConfig(): SlackChannelConfigResult {
-  deleteSecureKey("credential:slack_channel:bot_token");
+export async function clearSlackChannelConfig(): Promise<SlackChannelConfigResult> {
+  await deleteSecureKeyAsync("credential:slack_channel:bot_token");
   deleteCredentialMetadata("slack_channel", "bot_token");
-  deleteSecureKey("credential:slack_channel:app_token");
+  await deleteSecureKeyAsync("credential:slack_channel:app_token");
   deleteCredentialMetadata("slack_channel", "app_token");
 
   return {

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -403,7 +403,7 @@ export function redirectToSecurePrompt(
     .then(async (result): Promise<void> => {
       if (!result.value) return;
 
-      const { setSecureKey } = await import("../security/secure-keys.js");
+      const { setSecureKeyAsync } = await import("../security/secure-keys.js");
       const { upsertCredentialMetadata } =
         await import("../tools/credentials/metadata-store.js");
 
@@ -435,7 +435,7 @@ export function redirectToSecurePrompt(
         );
       } else {
         const key = `credential:${target.service}:${target.field}`;
-        const stored = setSecureKey(key, result.value);
+        const stored = await setSecureKeyAsync(key, result.value);
         if (stored) {
           try {
             upsertCredentialMetadata(target.service, target.field, {});

--- a/assistant/src/oauth/token-persistence.ts
+++ b/assistant/src/oauth/token-persistence.ts
@@ -10,7 +10,10 @@ import type {
   OAuth2FlowResult,
   TokenEndpointAuthMethod,
 } from "../security/oauth2.js";
-import { deleteSecureKey, setSecureKey } from "../security/secure-keys.js";
+import {
+  deleteSecureKeyAsync,
+  setSecureKeyAsync,
+} from "../security/secure-keys.js";
 import {
   deleteCredentialMetadata,
   upsertCredentialMetadata,
@@ -67,7 +70,7 @@ export async function storeOAuth2Tokens(
     wellKnownInjectionTemplates,
   } = params;
 
-  const tokenStored = setSecureKey(
+  const tokenStored = await setSecureKeyAsync(
     `credential:${service}:access_token`,
     tokens.accessToken,
   );
@@ -95,7 +98,7 @@ export async function storeOAuth2Tokens(
   }
 
   // Persist client credentials in keychain for defense in depth
-  const clientIdStored = setSecureKey(
+  const clientIdStored = await setSecureKeyAsync(
     `credential:${service}:client_id`,
     clientId,
   );
@@ -103,7 +106,7 @@ export async function storeOAuth2Tokens(
     throw new Error("Failed to store client_id in secure storage");
   }
   if (clientSecret) {
-    const clientSecretStored = setSecureKey(
+    const clientSecretStored = await setSecureKeyAsync(
       `credential:${service}:client_secret`,
       clientSecret,
     );
@@ -129,7 +132,7 @@ export async function storeOAuth2Tokens(
   });
 
   if (tokens.refreshToken) {
-    const refreshStored = setSecureKey(
+    const refreshStored = await setSecureKeyAsync(
       `credential:${service}:refresh_token`,
       tokens.refreshToken,
     );
@@ -140,7 +143,7 @@ export async function storeOAuth2Tokens(
     // Re-auth grants that omit refresh_token must clear any stale stored
     // token — otherwise withValidToken() will attempt refresh with invalid
     // credentials.
-    deleteSecureKey(`credential:${service}:refresh_token`);
+    await deleteSecureKeyAsync(`credential:${service}:refresh_token`);
     deleteCredentialMetadata(service, "refresh_token");
   }
 

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -139,8 +139,8 @@ export async function handleSetSlackChannelConfig(
 /**
  * DELETE /v1/integrations/slack/channel/config
  */
-export function handleClearSlackChannelConfig(): Response {
-  const result = clearSlackChannelConfig();
+export async function handleClearSlackChannelConfig(): Promise<Response> {
+  const result = await clearSlackChannelConfig();
   return Response.json(result);
 }
 

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -9,10 +9,10 @@ import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import type { TokenEndpointAuthMethod } from "../../security/oauth2.js";
 import {
-  deleteSecureKey,
+  deleteSecureKeyAsync,
   getSecureKey,
   listSecureKeys,
-  setSecureKey,
+  setSecureKeyAsync,
 } from "../../security/secure-keys.js";
 import { getLogger } from "../../util/logger.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
@@ -381,7 +381,7 @@ class CredentialStoreTool implements Tool {
         }
 
         const key = `credential:${service}:${field}`;
-        const ok = setSecureKey(key, value);
+        const ok = await setSecureKeyAsync(key, value);
         if (!ok) {
           return {
             content: "Error: failed to store credential",
@@ -494,7 +494,7 @@ class CredentialStoreTool implements Tool {
         }
 
         const key = `credential:${service}:${field}`;
-        const result = deleteSecureKey(key);
+        const result = await deleteSecureKeyAsync(key);
         if (result === "error") {
           return {
             content: `Error: failed to delete credential ${service}/${field} from secure storage`,
@@ -564,7 +564,9 @@ class CredentialStoreTool implements Tool {
         const promptPolicy = toPolicyFromInput(promptPolicyInput);
 
         // Parse and validate injection templates (same logic as store action)
-        const promptRawTemplates = input.injection_templates as unknown[] | undefined;
+        const promptRawTemplates = input.injection_templates as
+          | unknown[]
+          | undefined;
         let promptInjectionTemplates: CredentialInjectionTemplate[] | undefined;
         if (promptRawTemplates !== undefined) {
           if (!Array.isArray(promptRawTemplates)) {
@@ -732,7 +734,7 @@ class CredentialStoreTool implements Tool {
 
         // Default: persist to keychain
         const key = `credential:${service}:${field}`;
-        const ok = setSecureKey(key, result.value);
+        const ok = await setSecureKeyAsync(key, result.value);
         if (!ok) {
           return {
             content: "Error: failed to store credential",
@@ -752,7 +754,7 @@ class CredentialStoreTool implements Tool {
             "metadata write failed after storing credential",
           );
         }
-      const promptMeta = getCredentialMetadata(service, field);
+        const promptMeta = getCredentialMetadata(service, field);
         const promptCredIdSuffix = promptMeta
           ? ` (credential_id: ${promptMeta.credentialId})`
           : "";


### PR DESCRIPTION
## Summary
- Migrate Slack channel config writes/deletes from sync `setSecureKey`/`deleteSecureKey` to async `setSecureKeyAsync`/`deleteSecureKeyAsync`, closing the stale-value gap where gateway broker-first reads could diverge from encrypted-store-only writes
- Migrate remaining active-flow credential mutators in `token-persistence.ts` (OAuth2 token storage), `vault.ts` (credential store/delete/prompt actions), and `session-messaging.ts` (ingress secret redirect) to async APIs
- Update pre-commit hook with safe-line patterns for `?? null` fallback and multiline variable declarations; update 4 test files with async mock variants

## Original prompt
[P1] Slack channel credential paths are still sync/encrypted-only, so broker-first reads can still diverge.
[P2] A few other credential mutators still bypass async broker writes, so migration is not complete. Remaining sync writes/deletes in active flows include: token-persistence.ts, vault.ts, session-messaging.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)