### PR TITLE
feat: replace NSSharingServicePicker with custom share panel showing app icon

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import SwiftUI
 import VellumAssistantShared
@@ -12,6 +13,8 @@ final class SharingState {
     var showSharePicker = false
     var isBundling = false
     var shareFileURL: URL?
+    var shareAppName: String = ""
+    var shareAppIcon: NSImage?
     var isPublishing = false
     var publishedUrl: String?
     var publishError: String?

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
@@ -125,6 +125,8 @@ extension MainWindowView {
                 let url = Self.cleanBundleURL(bundlePath: response.bundlePath, appName: response.manifest.name)
                 Self.applyFileIcon(to: url, iconBase64: response.iconImageBase64, emojiIcon: response.manifest.icon, appName: response.manifest.name)
                 sharing.shareFileURL = url
+                sharing.shareAppName = response.manifest.name
+                sharing.shareAppIcon = Self.buildAppIcon(iconBase64: response.iconImageBase64, emojiIcon: response.manifest.icon, appName: response.manifest.name)
                 sharing.isBundling = false
                 sharing.showSharePicker = true
             }
@@ -156,6 +158,23 @@ extension MainWindowView {
         } catch {
             return originalURL
         }
+    }
+
+    /// Builds an NSImage for the app icon from base64 PNG, emoji, or app initial fallback.
+    /// Returns the image without applying it to a file — useful for the custom share panel header.
+    static func buildAppIcon(iconBase64: String?, emojiIcon: String?, appName: String) -> NSImage? {
+        if let base64 = iconBase64,
+           let data = Data(base64Encoded: base64),
+           let image = NSImage(data: data) {
+            return image
+        }
+
+        let glyph = (emojiIcon.flatMap { $0.isEmpty ? nil : $0 })
+            ?? String(appName.trimmingCharacters(in: .whitespacesAndNewlines).prefix(1)).uppercased()
+        if !glyph.isEmpty {
+            return renderEmojiIcon(emoji: glyph, size: 512)
+        }
+        return nil
     }
 
     /// Sets a custom icon on the file so the share sheet shows it instead of a blank document.

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -881,12 +881,14 @@ struct DynamicWorkspaceWrapper: View {
 
                     if let appId = data.appId {
                         ZStack {
-                            ShareSheetButton(
+                            AppSharePanel(
                                 items: sharing.shareFileURL != nil ? [sharing.shareFileURL!] : [],
                                 isPresented: Binding(
                                     get: { sharing.showSharePicker },
                                     set: { sharing.showSharePicker = $0 }
-                                )
+                                ),
+                                appName: sharing.shareAppName,
+                                appIcon: sharing.shareAppIcon
                             )
                             .frame(width: 0, height: 0)
                             .opacity(0)

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -12,6 +12,8 @@ struct AppsGridView: View {
     @State private var editingApp: AppListManager.AppItem?
     @State private var sharingAppId: String?
     @State private var shareFileURL: URL?
+    @State private var shareAppName: String = ""
+    @State private var shareAppIcon: NSImage?
     @State private var showShareSheet = false
     @State private var isBundling = false
 
@@ -165,7 +167,7 @@ struct AppsGridView: View {
                 )
                 .overlay(alignment: .topTrailing) {
                     ZStack {
-                        ShareSheetButton(
+                        AppSharePanel(
                             items: shareFileURL != nil && sharingAppId == app.id ? [shareFileURL!] : [],
                             isPresented: Binding(
                                 get: { showShareSheet && sharingAppId == app.id },
@@ -173,7 +175,9 @@ struct AppsGridView: View {
                                     showShareSheet = newValue
                                     if !newValue { sharingAppId = nil }
                                 }
-                            )
+                            ),
+                            appName: shareAppName,
+                            appIcon: shareAppIcon
                         )
                         .frame(width: 0, height: 0)
                         .opacity(0)
@@ -289,6 +293,8 @@ struct AppsGridView: View {
             let url = MainWindowView.cleanBundleURL(bundlePath: response.bundlePath, appName: response.manifest.name)
             MainWindowView.applyFileIcon(to: url, iconBase64: response.iconImageBase64, emojiIcon: response.manifest.icon, appName: response.manifest.name)
             shareFileURL = url
+            shareAppName = response.manifest.name
+            shareAppIcon = MainWindowView.buildAppIcon(iconBase64: response.iconImageBase64, emojiIcon: response.manifest.icon, appName: response.manifest.name)
             isBundling = false
             showShareSheet = true
         }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -38,6 +38,8 @@ struct GeneratedPanel: View {
     @State private var sharingAppId: String?
     @State private var isBundling = false
     @State private var shareFileURL: URL?
+    @State private var shareAppName: String = ""
+    @State private var shareAppIcon: NSImage?
     @State private var showShareSheet = false
     @State private var pendingDeleteId: String?
 
@@ -422,7 +424,7 @@ struct GeneratedPanel: View {
     private func shareButton(for item: DisplayAppItem) -> some View {
         if let localId = item.localAppId {
             ZStack {
-                ShareSheetButton(
+                AppSharePanel(
                     items: shareFileURL != nil && sharingAppId == item.id ? [shareFileURL!] : [],
                     isPresented: Binding(
                         get: { showShareSheet && sharingAppId == item.id },
@@ -430,7 +432,9 @@ struct GeneratedPanel: View {
                             showShareSheet = newValue
                             if !newValue { sharingAppId = nil }
                         }
-                    )
+                    ),
+                    appName: shareAppName,
+                    appIcon: shareAppIcon
                 )
                 .frame(width: 0, height: 0)
                 .opacity(0)
@@ -441,7 +445,7 @@ struct GeneratedPanel: View {
             }
         } else if item.isShared, let uuid = item.sharedUUID {
             ZStack {
-                ShareSheetButton(
+                AppSharePanel(
                     items: shareFileURL != nil && sharingAppId == item.id ? [shareFileURL!] : [],
                     isPresented: Binding(
                         get: { showShareSheet && sharingAppId == item.id },
@@ -449,7 +453,9 @@ struct GeneratedPanel: View {
                             showShareSheet = newValue
                             if !newValue { sharingAppId = nil }
                         }
-                    )
+                    ),
+                    appName: shareAppName,
+                    appIcon: shareAppIcon
                 )
                 .frame(width: 0, height: 0)
                 .opacity(0)
@@ -732,6 +738,8 @@ struct GeneratedPanel: View {
                 let url = MainWindowView.cleanBundleURL(bundlePath: response.bundlePath, appName: response.manifest.name)
                 MainWindowView.applyFileIcon(to: url, iconBase64: response.iconImageBase64, emojiIcon: response.manifest.icon, appName: response.manifest.name)
                 self.shareFileURL = url
+                self.shareAppName = response.manifest.name
+                self.shareAppIcon = MainWindowView.buildAppIcon(iconBase64: response.iconImageBase64, emojiIcon: response.manifest.icon, appName: response.manifest.name)
                 self.isBundling = false
                 self.showShareSheet = true
             }
@@ -750,8 +758,11 @@ struct GeneratedPanel: View {
         // Share the existing unpacked directory as a folder
         let appDir = BundleSandbox.sharedAppsDirectory.appendingPathComponent(uuid)
         guard FileManager.default.fileExists(atPath: appDir.path) else { return }
+        let item = displayItems.first { $0.id == itemId }
         sharingAppId = itemId
         shareFileURL = appDir
+        shareAppName = item?.name ?? "App"
+        shareAppIcon = nil
         showShareSheet = true
     }
 

--- a/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
@@ -1,0 +1,183 @@
+import AppKit
+import SwiftUI
+import VellumAssistantShared
+
+/// Custom share panel that replaces NSSharingServicePicker, showing the app icon
+/// prominently in the header instead of a blank document icon.
+struct AppSharePanelView: View {
+    let fileURL: URL
+    let appName: String
+    let appIcon: NSImage?
+    let onDismiss: () -> Void
+
+    @State private var services: [NSSharingService] = []
+    @State private var hoveredServiceIndex: Int?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header: app icon, name, file size
+            header
+                .padding(VSpacing.lg)
+
+            Divider()
+                .background(VColor.surfaceBorder)
+
+            // Services list
+            ScrollView {
+                VStack(spacing: 0) {
+                    // Slack row
+                    serviceRow(
+                        icon: NSWorkspace.shared.icon(forFile: "/Applications/Slack.app"),
+                        title: "Slack",
+                        index: -2
+                    ) {
+                        handleSlackShare()
+                    }
+
+                    // System sharing services
+                    ForEach(Array(services.enumerated()), id: \.offset) { index, service in
+                        serviceRow(
+                            icon: service.image,
+                            title: service.title,
+                            index: index
+                        ) {
+                            service.perform(withItems: [fileURL])
+                            onDismiss()
+                        }
+                    }
+
+                    Divider()
+                        .background(VColor.surfaceBorder)
+                        .padding(.vertical, VSpacing.xs)
+
+                    // Copy row
+                    serviceRow(
+                        icon: NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: "Copy"),
+                        title: "Copy",
+                        index: -1
+                    ) {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.writeObjects([fileURL as NSURL])
+                        onDismiss()
+                    }
+                }
+                .padding(.vertical, VSpacing.xs)
+            }
+            .frame(maxHeight: 300)
+        }
+        .frame(width: 240)
+        .background(VColor.surface)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .onAppear {
+            services = Self.availableSharingServices(for: fileURL)
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: VSpacing.md) {
+            // App icon at 64x64
+            Group {
+                if let icon = appIcon {
+                    Image(nsImage: icon)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                } else {
+                    // Fallback: first letter of app name
+                    ZStack {
+                        RoundedRectangle(cornerRadius: VRadius.md)
+                            .fill(VColor.backgroundSubtle)
+                        Text(String(appName.prefix(1)).uppercased())
+                            .font(.system(size: 28, weight: .bold))
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                }
+            }
+            .frame(width: 64, height: 64)
+            .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+
+            VStack(alignment: .leading, spacing: VSpacing.xs) {
+                Text(appName)
+                    .font(VFont.headline)
+                    .foregroundColor(VColor.textPrimary)
+                    .lineLimit(2)
+
+                Text(formattedFileSize)
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
+        }
+    }
+
+    // MARK: - Service Row
+
+    private func serviceRow(
+        icon: NSImage?,
+        title: String,
+        index: Int,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: VSpacing.md) {
+                if let icon {
+                    Image(nsImage: icon)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 20, height: 20)
+                } else {
+                    Color.clear.frame(width: 20, height: 20)
+                }
+
+                Text(title)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+
+                Spacer()
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
+            .background(hoveredServiceIndex == index ? VColor.backgroundSubtle : Color.clear)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            hoveredServiceIndex = hovering ? index : nil
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Queries available sharing services. The API was deprecated in macOS 13 in favor of
+    /// NSSharingServicePicker.standardShareMenuItem, but the replacement doesn't expose
+    /// individual services for custom UI. No functional replacement exists.
+    @available(macOS, deprecated: 13.0)
+    private static func availableSharingServices(for url: URL) -> [NSSharingService] {
+        NSSharingService.sharingServices(forItems: [url])
+    }
+
+    private var formattedFileSize: String {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
+              let size = attrs[.size] as? UInt64 else {
+            return ""
+        }
+        return ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
+    }
+
+    private func handleSlackShare() {
+        let downloadsURL = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first!
+        let destinationURL = downloadsURL.appendingPathComponent(fileURL.lastPathComponent)
+
+        if fileURL.standardizedFileURL != destinationURL.standardizedFileURL {
+            try? FileManager.default.removeItem(at: destinationURL)
+            try? FileManager.default.copyItem(at: fileURL, to: destinationURL)
+        }
+
+        if let slackURL = URL(string: "slack://") {
+            NSWorkspace.shared.open(slackURL)
+        }
+
+        NSWorkspace.shared.activateFileViewerSelecting([destinationURL])
+        onDismiss()
+    }
+}

--- a/clients/macos/vellum-assistant/Features/Sharing/ShareSheetHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/ShareSheetHelper.swift
@@ -1,31 +1,25 @@
 import AppKit
 import SwiftUI
 
-/// An NSView wrapper that presents an NSSharingServicePicker anchored to itself.
-/// Usage: set `isPresented` to `true` to trigger the share sheet with `items`.
-struct ShareSheetButton: NSViewRepresentable {
+/// An NSView wrapper that presents a custom share panel (AppSharePanelView) in an
+/// NSPopover anchored to itself. Replaces NSSharingServicePicker so the share panel
+/// shows the app's custom icon instead of a blank document.
+struct AppSharePanel: NSViewRepresentable {
     let items: [Any]
     @Binding var isPresented: Bool
+    let appName: String
+    let appIcon: NSImage?
 
-    func makeNSView(context: Context) -> NSButton {
-        let button = NSButton(frame: .zero)
-        button.bezelStyle = .inline
-        button.isBordered = false
-        button.title = ""
-        button.image = NSImage(systemSymbolName: "square.and.arrow.up", accessibilityDescription: "Share")
-        button.target = context.coordinator
-        button.action = #selector(Coordinator.showPicker(_:))
-        // Make the button invisible — SwiftUI overlay handles appearance
-        button.alphaValue = 0.01
-        return button
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
+        return view
     }
 
-    func updateNSView(_ nsView: NSButton, context: Context) {
+    func updateNSView(_ nsView: NSView, context: Context) {
         context.coordinator.items = items
-        if isPresented && !context.coordinator.isPickerVisible {
-            // Delay presentation until the next run-loop iteration so the
-            // NSButton is fully attached to its window. Showing a picker on
-            // a view without a window crashes NSSharingServicePicker.
+        context.coordinator.appName = appName
+        context.coordinator.appIcon = appIcon
+        if isPresented && !context.coordinator.isPopoverShown {
             DispatchQueue.main.async {
                 guard nsView.window != nil else {
                     self.isPresented = false
@@ -34,76 +28,74 @@ struct ShareSheetButton: NSViewRepresentable {
                 context.coordinator.onDismiss = {
                     self.isPresented = false
                 }
-                context.coordinator.showPicker(nsView)
+                context.coordinator.showPopover(relativeTo: nsView)
             }
+        } else if !isPresented && context.coordinator.isPopoverShown {
+            context.coordinator.dismissPopover()
         }
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(items: items)
+        Coordinator(items: items, appName: appName, appIcon: appIcon)
     }
 
-    class Coordinator: NSObject, NSSharingServicePickerDelegate {
+    class Coordinator: NSObject, NSPopoverDelegate {
         var items: [Any]
-        var isPickerVisible = false
+        var appName: String
+        var appIcon: NSImage?
+        var isPopoverShown = false
         var onDismiss: (() -> Void)?
+        private var popover: NSPopover?
 
-        init(items: [Any]) {
+        init(items: [Any], appName: String, appIcon: NSImage?) {
             self.items = items
+            self.appName = appName
+            self.appIcon = appIcon
         }
 
-        @objc func showPicker(_ sender: NSView) {
-            let picker = NSSharingServicePicker(items: items)
-            picker.delegate = self
-            isPickerVisible = true
-            picker.show(relativeTo: sender.bounds, of: sender, preferredEdge: .minY)
-        }
-
-        func sharingServicePicker(
-            _ sharingServicePicker: NSSharingServicePicker,
-            sharingServicesForItems items: [Any],
-            proposedSharingServices proposedServices: [NSSharingService]
-        ) -> [NSSharingService] {
-            let slackService = NSSharingService(
-                title: "Slack",
-                image: NSWorkspace.shared.icon(forFile: "/Applications/Slack.app"),
-                alternateImage: nil
-            ) { [weak self] in
-                guard let self else { return }
-                self.handleSlackShare(items: items)
+        func showPopover(relativeTo view: NSView) {
+            guard let fileURL = items.compactMap({ $0 as? URL }).first(where: { $0.isFileURL }) else {
+                onDismiss?()
+                onDismiss = nil
+                return
             }
-            return [slackService] + proposedServices
+
+            let panelView = AppSharePanelView(
+                fileURL: fileURL,
+                appName: appName,
+                appIcon: appIcon,
+                onDismiss: { [weak self] in
+                    self?.dismissPopover()
+                }
+            )
+
+            let hostingController = NSHostingController(rootView: panelView)
+            hostingController.view.frame = NSRect(x: 0, y: 0, width: 240, height: 400)
+
+            let popover = NSPopover()
+            popover.contentViewController = hostingController
+            popover.behavior = .transient
+            popover.delegate = self
+            popover.contentSize = NSSize(width: 240, height: 400)
+
+            self.popover = popover
+            isPopoverShown = true
+            popover.show(relativeTo: view.bounds, of: view, preferredEdge: .minY)
         }
 
-        func sharingServicePicker(_ sharingServicePicker: NSSharingServicePicker, didChoose service: NSSharingService?) {
-            // Called when the user picks a service or dismisses the picker (service == nil).
-            isPickerVisible = false
+        func dismissPopover() {
+            popover?.performClose(nil)
+            popover = nil
+            isPopoverShown = false
             onDismiss?()
             onDismiss = nil
         }
 
-        private func handleSlackShare(items: [Any]) {
-            // Find the first file URL in the shared items
-            guard let fileURL = items.compactMap({ $0 as? URL }).first(where: { $0.isFileURL }) else {
-                return
-            }
-
-            let downloadsURL = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first!
-            let destinationURL = downloadsURL.appendingPathComponent(fileURL.lastPathComponent)
-
-            // Copy to Downloads if not already there
-            if fileURL.standardizedFileURL != destinationURL.standardizedFileURL {
-                try? FileManager.default.removeItem(at: destinationURL)
-                try? FileManager.default.copyItem(at: fileURL, to: destinationURL)
-            }
-
-            // Open Slack
-            if let slackURL = URL(string: "slack://") {
-                NSWorkspace.shared.open(slackURL)
-            }
-
-            // Reveal the file in Finder so the user can drag it into Slack
-            NSWorkspace.shared.activateFileViewerSelecting([destinationURL])
+        func popoverDidClose(_ notification: Notification) {
+            popover = nil
+            isPopoverShown = false
+            onDismiss?()
+            onDismiss = nil
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace NSSharingServicePicker (which ignores per-file custom icons) with a custom SwiftUI share panel
- Header shows the app's generated icon, name, and file size prominently
- Lists all available sharing services plus custom Slack handler and Copy option
- Extract icon-building logic into reusable `buildAppIcon` helper

Part of plan: bundle-share-polish.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
