### PR TITLE
feat: add `assistant oauth token` CLI command

### DIFF
--- a/assistant/src/__tests__/oauth-cli.test.ts
+++ b/assistant/src/__tests__/oauth-cli.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+let mockWithValidToken: <T>(
+  service: string,
+  cb: (token: string) => Promise<T>,
+) => Promise<T>;
+
+// ---------------------------------------------------------------------------
+// Mock token-manager
+// ---------------------------------------------------------------------------
+
+mock.module("../security/token-manager.js", () => ({
+  withValidToken: <T>(
+    service: string,
+    cb: (token: string) => Promise<T>,
+  ): Promise<T> => mockWithValidToken(service, cb),
+  // Stubs for any transitive imports that reference other exports:
+  TokenExpiredError: class TokenExpiredError extends Error {
+    constructor(
+      public readonly service: string,
+      message?: string,
+    ) {
+      super(message ?? `Token expired for "${service}".`);
+      this.name = "TokenExpiredError";
+    }
+  },
+}));
+
+// Stub out transitive dependencies that token-manager would normally pull in
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKey: () => undefined,
+  setSecureKey: () => true,
+  getSecureKeyAsync: async () => undefined,
+  setSecureKeyAsync: async () => true,
+  deleteSecureKey: () => "not-found",
+}));
+
+mock.module("../tools/credentials/metadata-store.js", () => ({
+  getCredentialMetadata: () => undefined,
+  upsertCredentialMetadata: () => ({}),
+  listCredentialMetadata: () => [],
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  getCliLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import the module under test (after mocks are registered)
+// ---------------------------------------------------------------------------
+
+const { registerOAuthCommand } = await import("../cli/oauth.js");
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+async function runCli(
+  args: string[],
+): Promise<{ exitCode: number; stdout: string }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  process.exitCode = 0;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeErr: () => {},
+      writeOut: (str: string) => stdoutChunks.push(str),
+    });
+    registerOAuthCommand(program);
+    await program.parseAsync(["node", "assistant", "oauth", ...args]);
+  } catch {
+    if (process.exitCode === 0) process.exitCode = 1;
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = 0;
+
+  return {
+    exitCode,
+    stdout: stdoutChunks.join(""),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("assistant oauth token", () => {
+  beforeEach(() => {
+    mockWithValidToken = async (_service, cb) => cb("mock-access-token-xyz");
+  });
+
+  test("prints bare token in human mode", async () => {
+    const { exitCode, stdout } = await runCli(["token", "twitter"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("mock-access-token-xyz\n");
+  });
+
+  test("prints JSON in --json mode", async () => {
+    const { exitCode, stdout } = await runCli(["token", "twitter", "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toEqual({ ok: true, token: "mock-access-token-xyz" });
+  });
+
+  test("qualifies service name with integration: prefix", async () => {
+    let capturedService: string | undefined;
+    mockWithValidToken = async (service, cb) => {
+      capturedService = service;
+      return cb("tok");
+    };
+
+    await runCli(["token", "twitter"]);
+    expect(capturedService).toBe("integration:twitter");
+  });
+
+  test("works with other service names", async () => {
+    let capturedService: string | undefined;
+    mockWithValidToken = async (service, cb) => {
+      capturedService = service;
+      return cb("gmail-token");
+    };
+
+    const { exitCode, stdout } = await runCli(["token", "gmail"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("gmail-token\n");
+    expect(capturedService).toBe("integration:gmail");
+  });
+
+  test("exits 1 when no token exists", async () => {
+    mockWithValidToken = async () => {
+      throw new Error(
+        'No access token found for "integration:twitter". Authorization required.',
+      );
+    };
+
+    const { exitCode, stdout } = await runCli(["token", "twitter", "--json"]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("No access token found");
+  });
+
+  test("exits 1 when refresh fails", async () => {
+    mockWithValidToken = async () => {
+      throw new Error(
+        'Token refresh failed for "integration:twitter": invalid_grant.',
+      );
+    };
+
+    const { exitCode, stdout } = await runCli(["token", "twitter", "--json"]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("Token refresh failed");
+  });
+
+  test("returns refreshed token transparently", async () => {
+    // Simulate withValidToken refreshing and returning a new token
+    mockWithValidToken = async (_service, cb) => cb("refreshed-new-token");
+
+    const { exitCode, stdout } = await runCli(["token", "twitter"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("refreshed-new-token\n");
+  });
+
+  test("missing service argument exits non-zero", async () => {
+    const { exitCode } = await runCli(["token"]);
+    expect(exitCode).not.toBe(0);
+  });
+});

--- a/assistant/src/cli/oauth.ts
+++ b/assistant/src/cli/oauth.ts
@@ -1,0 +1,77 @@
+import type { Command } from "commander";
+
+import { withValidToken } from "../security/token-manager.js";
+import { shouldOutputJson, writeOutput } from "./integrations.js";
+
+export function registerOAuthCommand(program: Command): void {
+  const oauth = program
+    .command("oauth")
+    .description("Manage OAuth tokens for connected integrations")
+    .option("--json", "Machine-readable compact JSON output");
+
+  oauth.addHelpText(
+    "after",
+    `
+OAuth tokens are managed automatically — the "token" command returns a
+guaranteed-valid access token, refreshing transparently if the stored token
+is expired or near-expiry. Callers never need to handle refresh themselves.
+
+The <service> argument is the short integration name (e.g. "twitter", "gmail",
+"slack"). Internally this maps to credential:integration:<service>:access_token.
+
+Examples:
+  $ assistant oauth token twitter
+  $ assistant oauth token twitter --json
+  $ TOKEN=$(assistant oauth token gmail)
+  $ curl -H "Authorization: Bearer $(assistant oauth token twitter)" https://api.x.com/2/tweets`,
+  );
+
+  // ---------------------------------------------------------------------------
+  // token — return a guaranteed-valid access token
+  // ---------------------------------------------------------------------------
+
+  oauth
+    .command("token <service>")
+    .description(
+      "Print a valid OAuth access token for a service, refreshing if expired",
+    )
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  service   Integration name without the "integration:" prefix
+            (e.g. "twitter", "gmail", "slack")
+
+Returns a valid OAuth access token for the given service. If the stored token
+is expired or near-expiry, it is refreshed automatically before being returned.
+The refresh uses the stored refresh token and OAuth2 configuration from
+credential metadata — no additional input is required.
+
+In human mode, prints the bare token to stdout (suitable for shell substitution).
+In JSON mode (--json), prints {"ok": true, "token": "..."}.
+
+Exits with code 1 if no access token exists for the service, no refresh token
+is available, or the token refresh fails (e.g. revoked credentials).
+
+Examples:
+  $ assistant oauth token twitter
+  $ assistant oauth token gmail --json
+  $ export TOKEN=$(assistant oauth token twitter)`,
+    )
+    .action(async (service: string, _opts: unknown, cmd: Command) => {
+      try {
+        const qualifiedService = `integration:${service}`;
+        const token = await withValidToken(qualifiedService, async (t) => t);
+
+        if (shouldOutputJson(cmd)) {
+          writeOutput(cmd, { ok: true, token });
+        } else {
+          process.stdout.write(token + "\n");
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeOutput(cmd, { ok: false, error: message });
+        process.exitCode = 1;
+      }
+    });
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -22,6 +22,7 @@ import { registerMapCommand } from "./map.js";
 import { registerMcpCommand } from "./mcp.js";
 import { registerMemoryCommand } from "./memory.js";
 import { registerNotificationsCommand } from "./notifications.js";
+import { registerOAuthCommand } from "./oauth.js";
 import { registerSequenceCommand } from "./sequence.js";
 import { registerSessionsCommand } from "./sessions.js";
 import { registerTrustCommand } from "./trust.js";
@@ -55,6 +56,7 @@ export function buildCliProgram(): Command {
   registerAutonomyCommand(program);
   registerCompletionsCommand(program);
   registerNotificationsCommand(program);
+  registerOAuthCommand(program);
 
   registerTwitterCommand(program);
   registerMapCommand(program);


### PR DESCRIPTION
## Summary
- Add new `assistant oauth token <service>` CLI command that returns a guaranteed-valid OAuth access token, refreshing transparently if expired
- Internally delegates to `withValidToken(service, async (t) => t)` so callers never handle refresh themselves
- Supports `--json` mode for machine-readable output and bare token output for shell substitution
- Enables future decoupling of the Twitter module from direct security infrastructure imports

## Original prompt
Implement `assistant oauth token` CLI command (combined from plan oauth-cli.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
