### PR TITLE
fix: check delete results in clear/disconnect paths & migrate CLI credentials to async

### DIFF
--- a/assistant/src/cli/credentials.ts
+++ b/assistant/src/cli/credentials.ts
@@ -1,9 +1,9 @@
 import type { Command } from "commander";
 
 import {
-  deleteSecureKey,
+  deleteSecureKeyAsync,
   getSecureKey,
-  setSecureKey,
+  setSecureKeyAsync,
 } from "../security/secure-keys.js";
 import {
   assertMetadataWritable,
@@ -255,7 +255,7 @@ Examples:
   $ assistant credentials set github:token ghp_abc --allowed-tools "bash,host_bash"`,
     )
     .action(
-      (
+      async (
         name: string,
         value: string,
         opts: { label?: string; description?: string; allowedTools?: string },
@@ -277,7 +277,7 @@ Examples:
 
           assertMetadataWritable();
 
-          const stored = setSecureKey(storageKey, value);
+          const stored = await setSecureKeyAsync(storageKey, value);
           if (!stored) {
             writeOutput(cmd, {
               ok: false,
@@ -337,7 +337,7 @@ Examples:
   $ assistant credentials delete twilio:auth_token
   $ assistant credentials delete github:token`,
     )
-    .action((name: string, _opts: unknown, cmd: Command) => {
+    .action(async (name: string, _opts: unknown, cmd: Command) => {
       try {
         const parsed = parseCredentialName(name);
         if (!parsed) {
@@ -354,7 +354,7 @@ Examples:
 
         assertMetadataWritable();
 
-        const secretResult = deleteSecureKey(storageKey);
+        const secretResult = await deleteSecureKeyAsync(storageKey);
         if (secretResult === "error") {
           writeOutput(cmd, {
             ok: false,

--- a/assistant/src/daemon/handlers/config-integrations.ts
+++ b/assistant/src/daemon/handlers/config-integrations.ts
@@ -62,8 +62,17 @@ export async function handleVercelApiConfig(
         success: true,
       });
     } else {
-      await deleteSecureKeyAsync("credential:vercel:api_token");
+      const r = await deleteSecureKeyAsync("credential:vercel:api_token");
       deleteCredentialMetadata("vercel", "api_token");
+      if (r === "error") {
+        ctx.send(socket, {
+          type: "vercel_api_config_response",
+          hasToken: !!getSecureKey("credential:vercel:api_token"),
+          success: false,
+          error: "Failed to delete Vercel API token from secure storage",
+        });
+        return;
+      }
       ctx.send(socket, {
         type: "vercel_api_config_response",
         hasToken: false,
@@ -289,47 +298,79 @@ export async function handleTwitterIntegrationConfig(
       });
     } else if (msg.action === "clear_local_client") {
       // If connected, disconnect first
+      const deleteResults: Array<"deleted" | "not-found" | "error"> = [];
       if (getSecureKey("credential:integration:twitter:access_token")) {
-        await deleteSecureKeyAsync(
-          "credential:integration:twitter:access_token",
+        deleteResults.push(
+          await deleteSecureKeyAsync(
+            "credential:integration:twitter:access_token",
+          ),
         );
-        await deleteSecureKeyAsync(
-          "credential:integration:twitter:refresh_token",
+        deleteResults.push(
+          await deleteSecureKeyAsync(
+            "credential:integration:twitter:refresh_token",
+          ),
         );
         deleteCredentialMetadata("integration:twitter", "access_token");
       }
       // Remove both canonical and legacy client credential keys
-      await deleteSecureKeyAsync("credential:integration:twitter:client_id");
-      await deleteSecureKeyAsync(
-        "credential:integration:twitter:client_secret",
+      deleteResults.push(
+        await deleteSecureKeyAsync("credential:integration:twitter:client_id"),
       );
-      await deleteSecureKeyAsync(
-        "credential:integration:twitter:oauth_client_id",
+      deleteResults.push(
+        await deleteSecureKeyAsync(
+          "credential:integration:twitter:client_secret",
+        ),
       );
-      await deleteSecureKeyAsync(
-        "credential:integration:twitter:oauth_client_secret",
+      deleteResults.push(
+        await deleteSecureKeyAsync(
+          "credential:integration:twitter:oauth_client_id",
+        ),
       );
+      deleteResults.push(
+        await deleteSecureKeyAsync(
+          "credential:integration:twitter:oauth_client_secret",
+        ),
+      );
+      const hasDeleteError = deleteResults.some((r) => r === "error");
       ctx.send(socket, {
         type: "twitter_integration_config_response",
-        success: true,
+        success: !hasDeleteError,
         managedAvailable: false,
-        localClientConfigured: false,
-        connected: false,
+        localClientConfigured: hasDeleteError ? hasTwitterClientId() : false,
+        connected: hasDeleteError
+          ? !!getSecureKey("credential:integration:twitter:access_token")
+          : false,
+        ...(hasDeleteError
+          ? {
+              error:
+                "Failed to delete some Twitter credentials from secure storage",
+            }
+          : {}),
       });
     } else if (msg.action === "disconnect") {
-      await deleteSecureKeyAsync("credential:integration:twitter:access_token");
-      await deleteSecureKeyAsync(
+      const dr1 = await deleteSecureKeyAsync(
+        "credential:integration:twitter:access_token",
+      );
+      const dr2 = await deleteSecureKeyAsync(
         "credential:integration:twitter:refresh_token",
       );
       deleteCredentialMetadata("integration:twitter", "access_token");
       // Client credentials (client_id, oauth_client_id, etc.) are intentionally
       // preserved so the user can re-connect without reconfiguring.
+      const disconnectFailed = dr1 === "error" || dr2 === "error";
       ctx.send(socket, {
         type: "twitter_integration_config_response",
-        success: true,
+        success: !disconnectFailed,
         managedAvailable: false,
         localClientConfigured: hasTwitterClientId(),
-        connected: false,
+        connected: disconnectFailed
+          ? !!getSecureKey("credential:integration:twitter:access_token")
+          : false,
+        ...(disconnectFailed
+          ? {
+              error: "Failed to delete Twitter tokens from secure storage",
+            }
+          : {}),
       });
     } else {
       ctx.send(socket, {

--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -214,10 +214,20 @@ export async function setSlackChannelConfig(
 }
 
 export async function clearSlackChannelConfig(): Promise<SlackChannelConfigResult> {
-  await deleteSecureKeyAsync("credential:slack_channel:bot_token");
+  const r1 = await deleteSecureKeyAsync("credential:slack_channel:bot_token");
   deleteCredentialMetadata("slack_channel", "bot_token");
-  await deleteSecureKeyAsync("credential:slack_channel:app_token");
+  const r2 = await deleteSecureKeyAsync("credential:slack_channel:app_token");
   deleteCredentialMetadata("slack_channel", "app_token");
+
+  if (r1 === "error" || r2 === "error") {
+    return {
+      success: false,
+      hasBotToken: !!getSecureKey("credential:slack_channel:bot_token"),
+      hasAppToken: !!getSecureKey("credential:slack_channel:app_token"),
+      connected: false,
+      error: "Failed to delete Slack channel credentials from secure storage",
+    };
+  }
 
   return {
     success: true,

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -229,15 +229,25 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
     }
   }
 
-  await deleteSecureKeyAsync("credential:telegram:bot_token");
+  const r1 = await deleteSecureKeyAsync("credential:telegram:bot_token");
   deleteCredentialMetadata("telegram", "bot_token");
-  await deleteSecureKeyAsync("credential:telegram:webhook_secret");
+  const r2 = await deleteSecureKeyAsync("credential:telegram:webhook_secret");
   deleteCredentialMetadata("telegram", "webhook_secret");
 
   // Trigger reconcile to deregister webhook
   const effectiveUrl = getIngressPublicBaseUrl();
   if (effectiveUrl) {
     triggerGatewayReconcile(effectiveUrl);
+  }
+
+  if (r1 === "error" || r2 === "error") {
+    return {
+      success: false,
+      hasBotToken: !!getSecureKey("credential:telegram:bot_token"),
+      connected: false,
+      hasWebhookSecret: !!getSecureKey("credential:telegram:webhook_secret"),
+      error: "Failed to delete Telegram credentials from secure storage",
+    };
   }
 
   return {

--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -276,10 +276,20 @@ export async function handleSetTwilioCredentials(
  * DELETE /v1/integrations/twilio/credentials
  */
 export async function handleClearTwilioCredentials(): Promise<Response> {
-  await deleteSecureKeyAsync("credential:twilio:account_sid");
-  await deleteSecureKeyAsync("credential:twilio:auth_token");
+  const r1 = await deleteSecureKeyAsync("credential:twilio:account_sid");
+  const r2 = await deleteSecureKeyAsync("credential:twilio:auth_token");
   deleteCredentialMetadata("twilio", "account_sid");
   deleteCredentialMetadata("twilio", "auth_token");
+
+  if (r1 === "error" || r2 === "error") {
+    return Response.json(
+      {
+        success: false,
+        error: "Failed to delete Twilio credentials from secure storage",
+      },
+      { status: 500 },
+    );
+  }
 
   return Response.json({ success: true, hasCredentials: false });
 }


### PR DESCRIPTION
## Summary
- **P2**: Clear/disconnect handlers in twilio-routes, config-slack-channel, config-telegram, and config-integrations now check `deleteSecureKeyAsync()` return values and report `success: false` when deletes fail, instead of unconditionally reporting success while credentials may still exist in storage.
- **P3**: CLI credential `set` and `delete` actions in `cli/credentials.ts` now use `setSecureKeyAsync`/`deleteSecureKeyAsync` instead of their sync-only counterparts, ensuring the broker is updated alongside the encrypted store to prevent stale-value divergence in mixed workflows.

## Original prompt
[P2] Clear/disconnect paths still report success even when secure-store deletes fail.
deleteSecureKeyAsync() can return "error", but several handlers ignore the result and unconditionally continue/succeed. That can leave credentials in storage while UI/API says they were cleared.
twilio-routes.ts (line 278)
config-slack-channel.ts (line 216)
config-telegram.ts (line 232)
config-integrations.ts (line 293)
[P3] CLI credential mutators are still sync-only (encrypted-store-only), so broker-first reads can still diverge in mixed workflows.
If broker has an older value and credentials are changed via CLI while app/broker is active, broker-first readers may keep seeing stale keychain values.
cli/credentials.ts (line 280)
cli/credentials.ts (line 357)
Sync behavior source: secure-keys.ts (line 37)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
