### PR TITLE
fix: show 'App Bundle' instead of wrong size for directory shares

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
@@ -157,6 +157,13 @@ struct AppSharePanelView: View {
     }
 
     private var formattedFileSize: String {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: fileURL.path, isDirectory: &isDirectory) else {
+            return ""
+        }
+        if isDirectory.boolValue {
+            return "App Bundle"
+        }
         guard let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
               let size = attrs[.size] as? UInt64 else {
             return ""


### PR DESCRIPTION
## Summary
- Fix formattedFileSize to detect directories and show 'App Bundle' instead of misleading tiny size
- Addresses review comment on #13517

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
