### PR TITLE
fix: address bundle install dialog review feedback

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
@@ -68,8 +68,8 @@ extension AppDelegate {
         let confirmWindow = BundleConfirmationWindow()
         self.bundleConfirmationWindow = confirmWindow
 
-        viewModel.onConfirm = { [weak self] in
-            guard let self else { return }
+        viewModel.onConfirm = { [weak self, weak viewModel] in
+            guard let self, let viewModel else { return }
             viewModel.installState = .installing
             self.unpackAndLoadBundle(
                 filePath: filePath,

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationView.swift
@@ -10,7 +10,11 @@ struct BundleConfirmationView: View {
             switch viewModel.installState {
             case .installed:
                 installedStateView
-            default:
+            case .installing:
+                installingStateView
+            case .error(let message):
+                errorStateView(message: message)
+            case .ready:
                 confirmationContent
             }
         }
@@ -255,6 +259,55 @@ struct BundleConfirmationView: View {
                 }
             }
         }
+    }
+
+    // MARK: - Installing State
+
+    private var installingStateView: some View {
+        VStack(spacing: VSpacing.lg) {
+            Spacer()
+
+            ProgressView()
+                .controlSize(.large)
+
+            Text("Installing…")
+                .font(VFont.title)
+                .foregroundColor(VColor.textPrimary)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .transition(.opacity)
+    }
+
+    // MARK: - Error State
+
+    private func errorStateView(message: String) -> some View {
+        VStack(spacing: VSpacing.lg) {
+            Spacer()
+
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 56))
+                .foregroundColor(VColor.error)
+
+            Text("Installation Failed")
+                .font(VFont.title)
+                .foregroundColor(VColor.textPrimary)
+
+            Text(message)
+                .font(VFont.body)
+                .foregroundColor(VColor.error)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, VSpacing.xxl)
+
+            VButton(label: "Dismiss", style: .ghost, size: .medium) {
+                viewModel.cancel()
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .transition(.opacity)
     }
 
     // MARK: - Installed State

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationViewModel.swift
@@ -99,10 +99,11 @@ final class BundleConfirmationViewModel {
             let cornerRadius = size * 0.22
             let path = NSBezierPath(roundedRect: rect, xRadius: cornerRadius, yRadius: cornerRadius)
 
-            // Gradient background using a stable hash for consistent colors
-            var hasher = Hasher()
-            hasher.combine(glyph)
-            let hash = hasher.finalize() & Int.max
+            // Gradient background using a deterministic hash (djb2) for consistent colors across launches
+            var hash: UInt64 = 5381
+            for byte in glyph.utf8 {
+                hash = hash &* 33 &+ UInt64(byte)
+            }
             let hue = CGFloat(hash % 360) / 360.0
             let topColor = NSColor(hue: hue, saturation: 0.6, brightness: 0.85, alpha: 1.0)
             let bottomColor = NSColor(


### PR DESCRIPTION
## Summary
- Fix retain cycle in onConfirm closure with [weak viewModel]
- Add error state display in BundleConfirmationView
- Disable Install button during .installing state
- Use deterministic hash for stable gradient colors across launches

Addresses review comments on #13515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
