### PR TITLE
fix: drain pipe before waitUntilExit to prevent Quick Look deadlock

### DIFF
--- a/clients/macos/VellumQLPreview/PreviewProvider.swift
+++ b/clients/macos/VellumQLPreview/PreviewProvider.swift
@@ -71,13 +71,13 @@ class PreviewProvider: QLPreviewProvider, QLPreviewingController {
 
         do {
             try process.run()
-            process.waitUntilExit()
         } catch {
             return nil
         }
 
-        guard process.terminationStatus == 0 else { return nil }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
         return data.isEmpty ? nil : data
     }
 

--- a/clients/macos/VellumQLThumbnail/ThumbnailProvider.swift
+++ b/clients/macos/VellumQLThumbnail/ThumbnailProvider.swift
@@ -70,13 +70,13 @@ class ThumbnailProvider: QLThumbnailProvider {
 
         do {
             try process.run()
-            process.waitUntilExit()
         } catch {
             return nil
         }
 
-        guard process.terminationStatus == 0 else { return nil }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
         return data.isEmpty ? nil : data
     }
 


### PR DESCRIPTION
## Summary
- Fix pipe deadlock in both QLPreview and QLThumbnail extensions
- Read stdout data before calling waitUntilExit() to prevent hanging on large icon.png files
- Addresses review comments on #13521 and pre-existing issue in #13514

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
