### PR TITLE
fix: update credentials-cli test mock for async secure-key APIs

### DIFF
--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -39,17 +39,43 @@ mock.module("../security/secure-keys.js", () => ({
     secureKeyStore.set(account, value);
     return true;
   },
-  deleteSecureKey: (account: string) => {
+  setSecureKeyAsync: async (
+    account: string,
+    value: string,
+  ): Promise<boolean> => {
+    _setSecureKeyCalls += 1;
+    secureKeyStore.set(account, value);
+    return true;
+  },
+  deleteSecureKey: (account: string): "deleted" | "not-found" | "error" => {
     _deleteSecureKeyCalls += 1;
     if (secureKeyStore.has(account)) {
       secureKeyStore.delete(account);
-      return "deleted" as const;
+      return "deleted";
     }
-    return "not-found" as const;
+    return "not-found";
+  },
+  deleteSecureKeyAsync: async (
+    account: string,
+  ): Promise<"deleted" | "not-found" | "error"> => {
+    _deleteSecureKeyCalls += 1;
+    if (secureKeyStore.has(account)) {
+      secureKeyStore.delete(account);
+      return "deleted";
+    }
+    return "not-found";
   },
   listSecureKeys: (): string[] => {
     return [...secureKeyStore.keys()];
   },
+  getSecureKeyAsync: async (account: string): Promise<string | undefined> => {
+    _getSecureKeyCalls += 1;
+    return secureKeyStore.get(account);
+  },
+  getBackendType: (): "broker" | "encrypted" | null => null,
+  isDowngradedFromKeychain: (): boolean => false,
+  _resetBackend: (): void => {},
+  _setBackend: (): void => {},
 }));
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Updated the `secure-keys.js` mock in `credentials-cli.test.ts` to export `setSecureKeyAsync` and `deleteSecureKeyAsync` (plus all other module exports) so the test no longer fails with `SyntaxError: Export named 'setSecureKeyAsync' not found` after the sync→async migration in PR #13523.

## Original prompt
[P2] credentials-cli unit test is now broken due to stale secure-keys mock exports.
assistant/src/cli/credentials.ts now imports async APIs: credentials.ts (line 3)
The test mock still only exports sync APIs: credentials-cli.test.ts (line 32)
Repro: cd assistant && bun test src/__tests__/credentials-cli.test.ts fails with:
SyntaxError: Export named 'setSecureKeyAsync' not found .../security/secure-keys.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
