### PR TITLE
fix: move deleteCredentialMetadata after error check in credential clear paths

### DIFF
--- a/assistant/src/daemon/handlers/config-integrations.ts
+++ b/assistant/src/daemon/handlers/config-integrations.ts
@@ -63,7 +63,6 @@ export async function handleVercelApiConfig(
       });
     } else {
       const r = await deleteSecureKeyAsync("credential:vercel:api_token");
-      deleteCredentialMetadata("vercel", "api_token");
       if (r === "error") {
         ctx.send(socket, {
           type: "vercel_api_config_response",
@@ -73,6 +72,7 @@ export async function handleVercelApiConfig(
         });
         return;
       }
+      deleteCredentialMetadata("vercel", "api_token");
       ctx.send(socket, {
         type: "vercel_api_config_response",
         hasToken: false,
@@ -310,7 +310,6 @@ export async function handleTwitterIntegrationConfig(
             "credential:integration:twitter:refresh_token",
           ),
         );
-        deleteCredentialMetadata("integration:twitter", "access_token");
       }
       // Remove both canonical and legacy client credential keys
       deleteResults.push(
@@ -332,6 +331,9 @@ export async function handleTwitterIntegrationConfig(
         ),
       );
       const hasDeleteError = deleteResults.some((r) => r === "error");
+      if (!hasDeleteError) {
+        deleteCredentialMetadata("integration:twitter", "access_token");
+      }
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: !hasDeleteError,
@@ -354,10 +356,12 @@ export async function handleTwitterIntegrationConfig(
       const dr2 = await deleteSecureKeyAsync(
         "credential:integration:twitter:refresh_token",
       );
-      deleteCredentialMetadata("integration:twitter", "access_token");
       // Client credentials (client_id, oauth_client_id, etc.) are intentionally
       // preserved so the user can re-connect without reconfiguring.
       const disconnectFailed = dr1 === "error" || dr2 === "error";
+      if (!disconnectFailed) {
+        deleteCredentialMetadata("integration:twitter", "access_token");
+      }
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: !disconnectFailed,

--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -215,19 +215,22 @@ export async function setSlackChannelConfig(
 
 export async function clearSlackChannelConfig(): Promise<SlackChannelConfigResult> {
   const r1 = await deleteSecureKeyAsync("credential:slack_channel:bot_token");
-  deleteCredentialMetadata("slack_channel", "bot_token");
   const r2 = await deleteSecureKeyAsync("credential:slack_channel:app_token");
-  deleteCredentialMetadata("slack_channel", "app_token");
 
   if (r1 === "error" || r2 === "error") {
+    const hasBotToken = !!getSecureKey("credential:slack_channel:bot_token");
+    const hasAppToken = !!getSecureKey("credential:slack_channel:app_token");
     return {
       success: false,
-      hasBotToken: !!getSecureKey("credential:slack_channel:bot_token"),
-      hasAppToken: !!getSecureKey("credential:slack_channel:app_token"),
-      connected: false,
+      hasBotToken,
+      hasAppToken,
+      connected: hasBotToken && hasAppToken,
       error: "Failed to delete Slack channel credentials from secure storage",
     };
   }
+
+  deleteCredentialMetadata("slack_channel", "bot_token");
+  deleteCredentialMetadata("slack_channel", "app_token");
 
   return {
     success: true,

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -230,9 +230,7 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
   }
 
   const r1 = await deleteSecureKeyAsync("credential:telegram:bot_token");
-  deleteCredentialMetadata("telegram", "bot_token");
   const r2 = await deleteSecureKeyAsync("credential:telegram:webhook_secret");
-  deleteCredentialMetadata("telegram", "webhook_secret");
 
   // Trigger reconcile to deregister webhook
   const effectiveUrl = getIngressPublicBaseUrl();
@@ -241,14 +239,21 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
   }
 
   if (r1 === "error" || r2 === "error") {
+    const hasBotToken = !!getSecureKey("credential:telegram:bot_token");
+    const hasWebhookSecret = !!getSecureKey(
+      "credential:telegram:webhook_secret",
+    );
     return {
       success: false,
-      hasBotToken: !!getSecureKey("credential:telegram:bot_token"),
-      connected: false,
-      hasWebhookSecret: !!getSecureKey("credential:telegram:webhook_secret"),
+      hasBotToken,
+      connected: hasBotToken && hasWebhookSecret,
+      hasWebhookSecret,
       error: "Failed to delete Telegram credentials from secure storage",
     };
   }
+
+  deleteCredentialMetadata("telegram", "bot_token");
+  deleteCredentialMetadata("telegram", "webhook_secret");
 
   return {
     success: true,

--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -278,8 +278,6 @@ export async function handleSetTwilioCredentials(
 export async function handleClearTwilioCredentials(): Promise<Response> {
   const r1 = await deleteSecureKeyAsync("credential:twilio:account_sid");
   const r2 = await deleteSecureKeyAsync("credential:twilio:auth_token");
-  deleteCredentialMetadata("twilio", "account_sid");
-  deleteCredentialMetadata("twilio", "auth_token");
 
   if (r1 === "error" || r2 === "error") {
     return Response.json(
@@ -290,6 +288,9 @@ export async function handleClearTwilioCredentials(): Promise<Response> {
       { status: 500 },
     );
   }
+
+  deleteCredentialMetadata("twilio", "account_sid");
+  deleteCredentialMetadata("twilio", "auth_token");
 
   return Response.json({ success: true, hasCredentials: false });
 }


### PR DESCRIPTION
Fixes feedback from PR #13523: moves deleteCredentialMetadata() calls to after the deleteSecureKeyAsync error check in all credential handlers (Vercel, Slack, Telegram, Twilio, Twitter). This prevents orphaned secrets when async deletion fails. Also fixes Slack and Telegram error responses to derive connected state from actual credentials instead of hardcoding false.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
