### PR TITLE
refactor: decouple twitter CLI from assistant security and config internals

### DIFF
--- a/assistant/src/__tests__/twitter-cli-routing.test.ts
+++ b/assistant/src/__tests__/twitter-cli-routing.test.ts
@@ -2,8 +2,6 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // --- Mocks (must be declared before importing the module under test) ---
 
-let mockStrategy: string | undefined = undefined;
-let mockOauthAvailable = false;
 let mockOauthPostResult: {
   tweetId: string;
   text: string;
@@ -17,33 +15,13 @@ let mockBrowserPostResult: {
 } | null = null;
 let mockBrowserPostError: Error | null = null;
 
-// Mock the config loader to return a controllable strategy
-mock.module("../config/loader.js", () => ({
-  loadRawConfig: () => {
-    if (mockStrategy !== undefined) {
-      return { twitterOperationStrategy: mockStrategy };
-    }
-    return {};
-  },
-  loadConfig: () => ({}),
-  saveConfig: () => {},
-  saveRawConfig: () => {},
-  getConfig: () => ({
-    ui: {},
-  }),
-  invalidateConfigCache: () => {},
-  getNestedValue: () => undefined,
-  setNestedValue: () => {},
-  API_KEY_PROVIDERS: [],
-}));
-
 // Mock the OAuth client
 mock.module("../twitter/oauth-client.js", () => ({
-  oauthIsAvailable: () => mockOauthAvailable,
+  oauthIsAvailable: (token?: string) => token != null && token.length > 0,
   oauthSupportsOperation: (op: string) => op === "post" || op === "reply",
   oauthPostTweet: async (
     _text: string,
-    _opts?: { inReplyToTweetId?: string },
+    _opts: { inReplyToTweetId?: string; oauthToken: string },
   ) => {
     if (mockOauthPostError) throw mockOauthPostError;
     if (mockOauthPostResult) return mockOauthPostResult;
@@ -100,8 +78,6 @@ mock.module("../util/logger.js", () => ({
 import { routedPostTweet } from "../twitter/router.js";
 
 beforeEach(() => {
-  mockStrategy = undefined;
-  mockOauthAvailable = false;
   mockOauthPostResult = null;
   mockOauthPostError = null;
   mockBrowserPostResult = null;
@@ -111,14 +87,16 @@ beforeEach(() => {
 describe("Twitter strategy router", () => {
   describe("auto strategy", () => {
     test("uses OAuth when available and supported", async () => {
-      mockOauthAvailable = true;
       mockOauthPostResult = {
         tweetId: "111",
         text: "hello",
         url: "https://x.com/u/status/111",
       };
 
-      const { result, pathUsed } = await routedPostTweet("hello");
+      const { result, pathUsed } = await routedPostTweet("hello", {
+        strategy: "auto",
+        oauthToken: "test-token",
+      });
 
       expect(pathUsed).toBe("oauth");
       expect(result.tweetId).toBe("111");
@@ -127,21 +105,21 @@ describe("Twitter strategy router", () => {
     });
 
     test("falls back to browser when OAuth is unavailable", async () => {
-      mockOauthAvailable = false;
       mockBrowserPostResult = {
         tweetId: "222",
         text: "hello",
         url: "https://x.com/u/status/222",
       };
 
-      const { result, pathUsed } = await routedPostTweet("hello");
+      const { result, pathUsed } = await routedPostTweet("hello", {
+        strategy: "auto",
+      });
 
       expect(pathUsed).toBe("browser");
       expect(result.tweetId).toBe("222");
     });
 
     test("falls back to browser when OAuth fails", async () => {
-      mockOauthAvailable = true;
       mockOauthPostError = new Error("OAuth token expired");
       mockBrowserPostResult = {
         tweetId: "333",
@@ -149,31 +127,38 @@ describe("Twitter strategy router", () => {
         url: "https://x.com/u/status/333",
       };
 
-      const { result, pathUsed } = await routedPostTweet("hello");
+      const { result, pathUsed } = await routedPostTweet("hello", {
+        strategy: "auto",
+        oauthToken: "test-token",
+      });
 
       expect(pathUsed).toBe("browser");
       expect(result.tweetId).toBe("333");
     });
 
     test("constructs URL from tweetId when OAuth result has no url", async () => {
-      mockOauthAvailable = true;
       mockOauthPostResult = { tweetId: "444", text: "no url" };
 
-      const { result, pathUsed } = await routedPostTweet("no url");
+      const { result, pathUsed } = await routedPostTweet("no url", {
+        strategy: "auto",
+        oauthToken: "test-token",
+      });
 
       expect(pathUsed).toBe("oauth");
       expect(result.url).toBe("https://x.com/i/status/444");
     });
 
     test("throws combined error when both OAuth and browser fail with SessionExpiredError", async () => {
-      mockOauthAvailable = true;
       mockOauthPostError = new Error("OAuth failed");
       mockBrowserPostError = new MockSessionExpiredError(
         "Browser session expired",
       );
 
       try {
-        await routedPostTweet("will fail");
+        await routedPostTweet("will fail", {
+          strategy: "auto",
+          oauthToken: "test-token",
+        });
         expect(true).toBe(false); // should not reach
       } catch (err) {
         const e = err as Error & { pathUsed: string; oauthError?: string };
@@ -187,11 +172,8 @@ describe("Twitter strategy router", () => {
 
   describe("explicit oauth strategy", () => {
     test("fails with helpful error when OAuth is not configured", async () => {
-      mockStrategy = "oauth";
-      mockOauthAvailable = false;
-
       try {
-        await routedPostTweet("hello");
+        await routedPostTweet("hello", { strategy: "oauth" });
         expect(true).toBe(false); // should not reach
       } catch (err) {
         const e = err as Error & {
@@ -199,18 +181,21 @@ describe("Twitter strategy router", () => {
           suggestAlternative: string;
         };
         expect(e.message).toContain("OAuth is not configured");
-        expect(e.message).toContain("vellum x strategy set browser");
+        expect(e.message).toContain(
+          "assistant config set twitterOperationStrategy browser",
+        );
         expect(e.pathUsed).toBe("oauth");
         expect(e.suggestAlternative).toBe("browser");
       }
     });
 
     test("uses OAuth when available", async () => {
-      mockStrategy = "oauth";
-      mockOauthAvailable = true;
       mockOauthPostResult = { tweetId: "555", text: "oauth post" };
 
-      const { result, pathUsed } = await routedPostTweet("oauth post");
+      const { result, pathUsed } = await routedPostTweet("oauth post", {
+        strategy: "oauth",
+        oauthToken: "test-token",
+      });
 
       expect(pathUsed).toBe("oauth");
       expect(result.tweetId).toBe("555");
@@ -219,26 +204,26 @@ describe("Twitter strategy router", () => {
 
   describe("explicit browser strategy", () => {
     test("uses browser directly, ignoring OAuth availability", async () => {
-      mockStrategy = "browser";
-      mockOauthAvailable = true; // available but should be ignored
       mockBrowserPostResult = {
         tweetId: "666",
         text: "browser post",
         url: "https://x.com/u/status/666",
       };
 
-      const { result, pathUsed } = await routedPostTweet("browser post");
+      const { result, pathUsed } = await routedPostTweet("browser post", {
+        strategy: "browser",
+        oauthToken: "test-token", // available but should be ignored
+      });
 
       expect(pathUsed).toBe("browser");
       expect(result.tweetId).toBe("666");
     });
 
     test("preserves SessionExpiredError type with router metadata", async () => {
-      mockStrategy = "browser";
       mockBrowserPostError = new MockSessionExpiredError("Session expired");
 
       try {
-        await routedPostTweet("will fail");
+        await routedPostTweet("will fail", { strategy: "browser" });
         expect(true).toBe(false); // should not reach
       } catch (err) {
         const e = err as Error & {
@@ -253,11 +238,10 @@ describe("Twitter strategy router", () => {
     });
 
     test("re-throws non-session errors without wrapping", async () => {
-      mockStrategy = "browser";
       mockBrowserPostError = new Error("Network failure");
 
       try {
-        await routedPostTweet("will fail");
+        await routedPostTweet("will fail", { strategy: "browser" });
         expect(true).toBe(false); // should not reach
       } catch (err) {
         expect((err as Error).message).toBe("Network failure");
@@ -267,7 +251,6 @@ describe("Twitter strategy router", () => {
 
   describe("reply routing", () => {
     test("auto strategy routes reply through OAuth when available", async () => {
-      mockOauthAvailable = true;
       mockOauthPostResult = {
         tweetId: "777",
         text: "reply text",
@@ -276,6 +259,8 @@ describe("Twitter strategy router", () => {
 
       const { result, pathUsed } = await routedPostTweet("reply text", {
         inReplyToTweetId: "100",
+        strategy: "auto",
+        oauthToken: "test-token",
       });
 
       expect(pathUsed).toBe("oauth");
@@ -283,7 +268,6 @@ describe("Twitter strategy router", () => {
     });
 
     test("browser strategy routes reply through browser", async () => {
-      mockStrategy = "browser";
       mockBrowserPostResult = {
         tweetId: "888",
         text: "reply text",
@@ -292,6 +276,7 @@ describe("Twitter strategy router", () => {
 
       const { result, pathUsed } = await routedPostTweet("reply text", {
         inReplyToTweetId: "200",
+        strategy: "browser",
       });
 
       expect(pathUsed).toBe("browser");

--- a/assistant/src/__tests__/twitter-oauth-client.test.ts
+++ b/assistant/src/__tests__/twitter-oauth-client.test.ts
@@ -2,39 +2,6 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // --- Mocks (must be declared before importing the module under test) ---
 
-let secureKeyStore: Record<string, string> = {};
-
-mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (account: string) => secureKeyStore[account] ?? undefined,
-  setSecureKey: (account: string, value: string) => {
-    secureKeyStore[account] = value;
-    return true;
-  },
-  deleteSecureKey: () => "deleted",
-  listSecureKeys: () => Object.keys(secureKeyStore),
-  getBackendType: () => "encrypted",
-  isDowngradedFromKeychain: () => false,
-  _resetBackend: () => {},
-  _setBackend: () => {},
-}));
-
-// withValidToken: call the callback directly with a fake token.
-mock.module("../security/token-manager.js", () => ({
-  withValidToken: async (
-    _service: string,
-    cb: (token: string) => Promise<unknown>,
-  ) => cb("fake-oauth-token"),
-  TokenExpiredError: class TokenExpiredError extends Error {
-    constructor(
-      public readonly service: string,
-      message?: string,
-    ) {
-      super(message ?? `Token expired for "${service}".`);
-      this.name = "TokenExpiredError";
-    }
-  },
-}));
-
 mock.module("../util/logger.js", () => ({
   getLogger: () => ({
     info: () => {},
@@ -65,7 +32,6 @@ const originalFetch = globalThis.fetch;
 let _fetchMock: ReturnType<typeof mock> | null = null;
 
 beforeEach(() => {
-  secureKeyStore = {};
   _fetchMock = null;
 });
 
@@ -101,7 +67,9 @@ describe("Twitter OAuth client", () => {
         json: { data: { id: "12345", text: "Hello world" } },
       });
 
-      const result = await oauthPostTweet("Hello world");
+      const result = await oauthPostTweet("Hello world", {
+        oauthToken: "fake-oauth-token",
+      });
 
       expect(result.tweetId).toBe("12345");
       expect(result.text).toBe("Hello world");
@@ -132,6 +100,7 @@ describe("Twitter OAuth client", () => {
 
       const result = await oauthPostTweet("My reply", {
         inReplyToTweetId: "11111",
+        oauthToken: "fake-oauth-token",
       });
 
       expect(result.tweetId).toBe("67890");
@@ -150,12 +119,12 @@ describe("Twitter OAuth client", () => {
         text: "Rate limit exceeded",
       });
 
-      await expect(oauthPostTweet("will fail")).rejects.toThrow(
-        /Twitter API error \(429\)/,
-      );
+      await expect(
+        oauthPostTweet("will fail", { oauthToken: "fake-oauth-token" }),
+      ).rejects.toThrow(/Twitter API error \(429\)/);
     });
 
-    test("attaches status to thrown error for token manager retry", async () => {
+    test("throws with status in error message on 401", async () => {
       mockFetch({
         ok: false,
         status: 401,
@@ -163,23 +132,25 @@ describe("Twitter OAuth client", () => {
       });
 
       try {
-        await oauthPostTweet("will fail");
+        await oauthPostTweet("will fail", { oauthToken: "fake-oauth-token" });
         expect(true).toBe(false); // should not reach
       } catch (err) {
-        expect((err as Error & { status: number }).status).toBe(401);
+        expect((err as Error).message).toContain("401");
       }
     });
   });
 
   describe("oauthIsAvailable", () => {
-    test("returns true when access token exists", () => {
-      secureKeyStore["credential:integration:twitter:access_token"] =
-        "some-token";
-      expect(oauthIsAvailable()).toBe(true);
+    test("returns true when token is provided", () => {
+      expect(oauthIsAvailable("some-token")).toBe(true);
     });
 
-    test("returns false when no access token", () => {
-      expect(oauthIsAvailable()).toBe(false);
+    test("returns false when token is undefined", () => {
+      expect(oauthIsAvailable(undefined)).toBe(false);
+    });
+
+    test("returns false when token is empty string", () => {
+      expect(oauthIsAvailable("")).toBe(false);
     });
   });
 

--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -24,6 +24,7 @@ import {
   searchTweets,
   SessionExpiredError,
 } from "../twitter/client.js";
+import type { TwitterStrategy } from "../twitter/router.js";
 import { routedPostTweet } from "../twitter/router.js";
 import {
   clearSession,
@@ -435,31 +436,59 @@ Examples:
   tw.command("post")
     .description("Post a tweet")
     .argument("<text>", "Tweet text")
+    .requiredOption(
+      "--strategy <strategy>",
+      "Operation strategy: oauth, browser, or auto",
+    )
+    .option(
+      "--oauth-token <token>",
+      "OAuth access token (required when strategy is oauth or auto)",
+    )
     .addHelpText(
       "after",
       `
 Arguments:
   text   The tweet text to post (max 280 characters)
 
-Posts a new tweet using the routed dual-path system. The path used (oauth or
-browser) depends on the current strategy setting. The response includes the
-tweet ID, URL, and which path was used.
+Posts a new tweet using the routed dual-path system. The --strategy flag
+controls which path is used. The response includes the tweet ID, URL, and
+which path was used.
 
 Examples:
-  $ assistant x post "Hello world"
-  $ assistant x post "Check out this thread on AI agents" --json`,
+  $ assistant x post "Hello world" --strategy browser
+  $ assistant x post "Hello world" --strategy oauth --oauth-token "$TOKEN"
+  $ assistant x post "Hello world" --strategy auto --oauth-token "$TOKEN"`,
     )
-    .action(async (text: string, _opts: unknown, cmd: Command) => {
-      await run(cmd, async () => {
-        const { result, pathUsed } = await routedPostTweet(text);
-        return {
-          tweetId: result.tweetId,
-          text: result.text,
-          url: result.url,
-          pathUsed,
-        };
-      });
-    });
+    .action(
+      async (
+        text: string,
+        opts: { strategy: string; oauthToken?: string },
+        cmd: Command,
+      ) => {
+        await run(cmd, async () => {
+          const strategy = opts.strategy as TwitterStrategy;
+          if (
+            strategy !== "oauth" &&
+            strategy !== "browser" &&
+            strategy !== "auto"
+          ) {
+            throw new Error(
+              `Invalid strategy "${opts.strategy}". Must be oauth, browser, or auto.`,
+            );
+          }
+          const { result, pathUsed } = await routedPostTweet(text, {
+            strategy,
+            oauthToken: opts.oauthToken,
+          });
+          return {
+            tweetId: result.tweetId,
+            text: result.text,
+            url: result.url,
+            pathUsed,
+          };
+        });
+      },
+    );
 
   // =========================================================================
   // reply — reply to a tweet
@@ -468,6 +497,14 @@ Examples:
     .description("Reply to a tweet")
     .argument("<tweetUrl>", "Tweet URL or tweet ID")
     .argument("<text>", "Reply text")
+    .requiredOption(
+      "--strategy <strategy>",
+      "Operation strategy: oauth, browser, or auto",
+    )
+    .option(
+      "--oauth-token <token>",
+      "OAuth access token (required when strategy is oauth or auto)",
+    )
     .addHelpText(
       "after",
       `
@@ -477,15 +514,30 @@ Arguments:
 
 Posts a reply to the specified tweet. Accepts either a full tweet URL or a bare
 numeric tweet ID. The tweet ID is extracted from the last numeric segment of the
-URL. Uses the routed dual-path system based on the current strategy.
+URL. The --strategy flag controls which path is used.
 
 Examples:
-  $ assistant x reply https://x.com/elonmusk/status/1234567890 "Great point!"
-  $ assistant x reply 1234567890 "Interesting thread"`,
+  $ assistant x reply https://x.com/elonmusk/status/1234567890 "Great point!" --strategy browser
+  $ assistant x reply 1234567890 "Interesting thread" --strategy oauth --oauth-token "$TOKEN"`,
     )
     .action(
-      async (tweetUrl: string, text: string, _opts: unknown, cmd: Command) => {
+      async (
+        tweetUrl: string,
+        text: string,
+        opts: { strategy: string; oauthToken?: string },
+        cmd: Command,
+      ) => {
         await run(cmd, async () => {
+          const strategy = opts.strategy as TwitterStrategy;
+          if (
+            strategy !== "oauth" &&
+            strategy !== "browser" &&
+            strategy !== "auto"
+          ) {
+            throw new Error(
+              `Invalid strategy "${opts.strategy}". Must be oauth, browser, or auto.`,
+            );
+          }
           // Extract tweet ID: either a bare numeric ID or the last numeric segment of a URL
           const idMatch = tweetUrl.match(/(\d+)\s*$/);
           if (!idMatch) {
@@ -494,6 +546,8 @@ Examples:
           const inReplyToTweetId = idMatch[1];
           const { result, pathUsed } = await routedPostTweet(text, {
             inReplyToTweetId,
+            strategy,
+            oauthToken: opts.oauthToken,
           });
           return {
             tweetId: result.tweetId,

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: true
 metadata: { "vellum": { "emoji": "𝕏" } }
 ---
 
-You are an X (formerly Twitter) assistant. Use the `execute_bash` tool to run `assistant x` CLI commands.
+You are an X (formerly Twitter) assistant. Use the `execute_bash` tool to run `assistant x`, `assistant config`, and `assistant oauth` CLI commands.
 
 ## Connection Options
 
@@ -18,7 +18,7 @@ OAuth uses the official X API v2. It is the most reliable connection method and 
 - Supports: **post** and **reply**
 - Read-only operations (timeline, search, home, bookmarks, notifications, likes, followers, following, media) always use the browser path directly, regardless of the strategy setting.
 - Setup: Collect the OAuth Client ID (and optional Client Secret) from the user in chat using `credential_store` with `action: "prompt"` (canonical field names: `client_id`, `client_secret`), then initiate the `twitter_auth_start` flow. See the **First-Use Decision Flow** for the full sequence.
-- Set the strategy: `assistant x strategy set oauth`
+- Set the strategy: `assistant config set twitterOperationStrategy oauth`
 
 ### Browser session (no developer credentials needed)
 
@@ -26,13 +26,13 @@ The browser path is quick to start and useful when the user does not have X deve
 
 - Supports: **all operations** (post, reply, timeline, search, home, bookmarks, notifications, likes, followers, following, media)
 - Setup: Run `assistant x refresh` to open Chrome and capture session cookies automatically.
-- Set the strategy: `assistant x strategy set browser`
+- Set the strategy: `assistant config set twitterOperationStrategy browser`
 
 ### Auto mode (default)
 
 When the strategy is `auto` (the default), the router tries OAuth first for supported operations if credentials are available, then falls back to the browser path. This gives the best of both worlds without requiring manual switching.
 
-- Set auto mode: `assistant x strategy set auto`
+- Set auto mode: `assistant config set twitterOperationStrategy auto`
 
 ## First-Use Decision Flow
 
@@ -41,10 +41,17 @@ When the user triggers a Twitter operation and no strategy has been configured y
 1. **Check current status:**
 
    ```bash
-   vellum x status --json
+   # Check strategy
+   assistant config get twitterOperationStrategy
+
+   # Check if OAuth token is available
+   assistant oauth token twitter --json
+
+   # Check browser session
+   assistant x status --json
    ```
 
-   Look at `oauthConnected`, `browserSessionActive`, `preferredStrategy`, and `strategyConfigured` in the response. If `strategyConfigured` is `false`, the user has not yet chosen a strategy and should be guided through setup.
+   If the strategy is not set, the user has not yet chosen a strategy and should be guided through setup.
 
 2. **Present both options with trade-offs:**
    - **OAuth**: Most reliable and official. Requires X developer app credentials (OAuth Client ID and optional Client Secret). Supports posting and replying. Set up right here in the chat.
@@ -74,7 +81,7 @@ When the user chooses OAuth, collect their X developer credentials conversationa
 
 5. **Set the preferred strategy:**
    ```bash
-   vellum x strategy set <oauth|browser|auto>
+   assistant config set twitterOperationStrategy <oauth|browser|auto>
    ```
 
 ## Failure Recovery Flow
@@ -92,51 +99,68 @@ When a Twitter operation fails, follow these steps:
 
 3. **Suggest trying the other path as an alternative:**
    - If the browser session expired: suggest setting up OAuth for post/reply operations, or refresh the browser session with `assistant x refresh`.
-   - If OAuth failed or is not configured: suggest using the browser path with `assistant x strategy set browser` and `assistant x refresh`.
-   - If the operation is unsupported via OAuth: explain that this write operation is not yet supported via OAuth, and suggest using the browser path with `assistant x strategy set browser`.
+   - If OAuth failed or is not configured: suggest using the browser path with `assistant config set twitterOperationStrategy browser` and `assistant x refresh`.
+   - If the operation is unsupported via OAuth: explain that this write operation is not yet supported via OAuth, and suggest using the browser path with `assistant config set twitterOperationStrategy browser`.
 
 4. **Offer concrete steps to switch:**
 
    ```bash
    # Switch to the other strategy
-   vellum x strategy set <oauth|browser|auto>
+   assistant config set twitterOperationStrategy <oauth|browser|auto>
 
    # If switching to browser, refresh the session
-   vellum x refresh
+   assistant x refresh
    ```
 
 ## Strategy Management Commands
 
 ```bash
 # Check current strategy
-vellum x strategy
+assistant config get twitterOperationStrategy
 
 # Set strategy to OAuth, browser, or auto
-vellum x strategy set <oauth|browser|auto>
+assistant config set twitterOperationStrategy oauth
+assistant config set twitterOperationStrategy browser
+assistant config set twitterOperationStrategy auto
 
 # Check full status (session, OAuth, and strategy info)
-vellum x status --json
+assistant x status --json
 ```
 
 ## Posting
 
+Before posting, fetch the current strategy and OAuth token:
+
 ```bash
-vellum x post "The post text here"
+# 1. Get the configured strategy
+STRATEGY=$(assistant config get twitterOperationStrategy)
+# If not set, default to "auto"
+
+# 2. If strategy is "oauth" or "auto", get a valid OAuth token
+TOKEN=$(assistant oauth token twitter)
 ```
 
-Returns JSON with `ok`, `tweetId`, `text`, `url`, and `pathUsed` fields. The `pathUsed` field indicates whether the post was sent via `oauth` or `browser`. Share the URL with the user so they can verify the post.
+Then post with the fetched values:
 
-The `post` command routes through the strategy router: it uses OAuth if configured and available, otherwise falls back to the browser path.
+```bash
+# With OAuth token (strategy is oauth or auto):
+assistant x post "The post text here" --strategy "$STRATEGY" --oauth-token "$TOKEN"
+
+# With browser-only strategy:
+assistant x post "The post text here" --strategy browser
+```
+
+Returns JSON with `ok`, `tweetId`, `text`, `url`, and `pathUsed` fields. Share the URL with the user so they can verify the post.
 
 ## Replying
 
+Same setup as posting — fetch strategy and token first, then:
+
 ```bash
-vellum x reply <tweetUrl> "The reply text here"
+assistant x reply <tweetUrl> "The reply text here" --strategy "$STRATEGY" --oauth-token "$TOKEN"
 ```
 
 The first argument is a tweet URL (e.g. `https://x.com/user/status/123456`) or a bare tweet ID.
-
-Like `post`, the `reply` command routes through the strategy router and returns a `pathUsed` field.
 
 ## Reading
 
@@ -145,7 +169,7 @@ Read-only operations always use the browser path directly, regardless of the str
 ### User timeline
 
 ```bash
-vellum x timeline <screenName> [--count N]
+assistant x timeline <screenName> [--count N]
 ```
 
 Returns `user` and `tweets` array.
@@ -153,7 +177,7 @@ Returns `user` and `tweets` array.
 ### Single tweet + replies
 
 ```bash
-vellum x tweet <tweetIdOrUrl>
+assistant x tweet <tweetIdOrUrl>
 ```
 
 Returns the focal tweet and its reply thread.
@@ -161,25 +185,25 @@ Returns the focal tweet and its reply thread.
 ### Search
 
 ```bash
-vellum x search "query" [--count N] [--product Top|Latest|People|Media]
+assistant x search "query" [--count N] [--product Top|Latest|People|Media]
 ```
 
 ### Home timeline
 
 ```bash
-vellum x home [--count N]
+assistant x home [--count N]
 ```
 
 ### Bookmarks
 
 ```bash
-vellum x bookmarks [--count N]
+assistant x bookmarks [--count N]
 ```
 
 ### Notifications
 
 ```bash
-vellum x notifications [--count N]
+assistant x notifications [--count N]
 ```
 
 Returns `notifications` array with `id`, `message`, `timestamp`, `url`.
@@ -187,14 +211,14 @@ Returns `notifications` array with `id`, `message`, `timestamp`, `url`.
 ### Likes
 
 ```bash
-vellum x likes <screenName> [--count N]
+assistant x likes <screenName> [--count N]
 ```
 
 ### Followers / Following
 
 ```bash
-vellum x followers <screenName> [--count N]
-vellum x following <screenName> [--count N]
+assistant x followers <screenName> [--count N]
+assistant x following <screenName> [--count N]
 ```
 
 Returns `user` and `followers`/`following` array (userId, screenName, name).
@@ -202,7 +226,7 @@ Returns `user` and `followers`/`following` array (userId, screenName, name).
 ### Media
 
 ```bash
-vellum x media <screenName> [--count N]
+assistant x media <screenName> [--count N]
 ```
 
 Returns tweets that contain media from the user's profile.

--- a/assistant/src/twitter/oauth-client.ts
+++ b/assistant/src/twitter/oauth-client.ts
@@ -1,17 +1,13 @@
 /**
  * OAuth-backed Twitter API client.
  *
- * Uses stored OAuth2 Bearer tokens (via the token manager) to execute
+ * Accepts an OAuth2 Bearer token as a parameter and uses it to execute
  * Twitter API v2 operations directly, without requiring a browser session.
  * Currently supports post and reply; all other operations fall back to the
  * browser-based CDP client.
  */
 
-import { getSecureKey } from "../security/secure-keys.js";
-import { withValidToken } from "../security/token-manager.js";
-
 const TWITTER_API_BASE = "https://api.x.com/2";
-const SERVICE = "integration:twitter";
 
 /** Operations that the OAuth client can handle natively. */
 const SUPPORTED_OPERATIONS = new Set(["post", "reply"]);
@@ -45,55 +41,47 @@ export class UnsupportedOAuthOperationError extends Error {
 /**
  * Post a tweet (or reply) using OAuth2 Bearer token authentication.
  *
- * The token manager handles refresh transparently — if the stored token
- * is expired it will be refreshed before (or after a 401) calling the API.
+ * The caller is responsible for providing a valid token (e.g. via
+ * `assistant oauth token twitter`).
  */
 export async function oauthPostTweet(
   text: string,
-  opts?: { inReplyToTweetId?: string },
+  opts: { inReplyToTweetId?: string; oauthToken: string },
 ): Promise<OAuthPostResult> {
-  return withValidToken(SERVICE, async (token) => {
-    const body: Record<string, unknown> = { text };
-    if (opts?.inReplyToTweetId) {
-      body.reply = { in_reply_to_tweet_id: opts.inReplyToTweetId };
-    }
+  const body: Record<string, unknown> = { text };
+  if (opts.inReplyToTweetId) {
+    body.reply = { in_reply_to_tweet_id: opts.inReplyToTweetId };
+  }
 
-    const res = await fetch(`${TWITTER_API_BASE}/tweets`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!res.ok) {
-      const errorBody = await res.text().catch(() => "");
-      const err = new Error(
-        `Twitter API error (${res.status}): ${errorBody.slice(0, 500)}`,
-      );
-      // Attach status so the token manager's 401-retry logic can detect it.
-      (err as Error & { status: number }).status = res.status;
-      throw err;
-    }
-
-    const json = (await res.json()) as { data: { id: string; text: string } };
-    return {
-      tweetId: json.data.id,
-      text: json.data.text,
-    };
+  const res = await fetch(`${TWITTER_API_BASE}/tweets`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${opts.oauthToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
   });
+
+  if (!res.ok) {
+    const errorBody = await res.text().catch(() => "");
+    throw new Error(
+      `Twitter API error (${res.status}): ${errorBody.slice(0, 500)}`,
+    );
+  }
+
+  const json = (await res.json()) as { data: { id: string; text: string } };
+  return {
+    tweetId: json.data.id,
+    text: json.data.text,
+  };
 }
 
 /**
- * Check whether OAuth credentials are available for the Twitter integration.
- * Returns true if an access token has been stored (the token manager will
- * handle refresh if it's expired).
+ * Check whether an OAuth token is available.
+ * When the caller provides a token string, OAuth is available.
  */
-export function oauthIsAvailable(): boolean {
-  return (
-    getSecureKey("credential:integration:twitter:access_token") !== undefined
-  );
+export function oauthIsAvailable(oauthToken: string | undefined): boolean {
+  return oauthToken != null && oauthToken.length > 0;
 }
 
 /**

--- a/assistant/src/twitter/router.ts
+++ b/assistant/src/twitter/router.ts
@@ -1,9 +1,8 @@
 /**
  * Strategy router for Twitter operations.
- * Selects OAuth or browser path based on persisted preference and capability.
+ * Selects OAuth or browser path based on the caller-provided strategy.
  */
 
-import { loadRawConfig } from "../config/loader.js";
 import type { PostTweetResult } from "./client.js";
 import {
   postTweet as browserPostTweet,
@@ -29,30 +28,23 @@ export interface RoutedError {
   alternativeSetupHint?: string;
 }
 
-function getPreferredStrategy(): TwitterStrategy {
-  try {
-    const raw = loadRawConfig();
-    const strategy = raw.twitterOperationStrategy as string | undefined;
-    if (strategy === "oauth" || strategy === "browser") return strategy;
-  } catch {
-    /* fall through */
-  }
-  return "auto";
-}
-
 export async function routedPostTweet(
   text: string,
-  opts?: { inReplyToTweetId?: string },
+  opts: {
+    inReplyToTweetId?: string;
+    strategy: TwitterStrategy;
+    oauthToken?: string;
+  },
 ): Promise<RoutedResult<PostTweetResult>> {
-  const strategy = getPreferredStrategy();
-  const operation = opts?.inReplyToTweetId ? "reply" : "post";
+  const strategy = opts.strategy;
+  const operation = opts.inReplyToTweetId ? "reply" : "post";
 
   if (strategy === "oauth") {
     // User explicitly wants OAuth
-    if (!oauthIsAvailable()) {
+    if (!oauthIsAvailable(opts.oauthToken)) {
       throw Object.assign(
         new Error(
-          "OAuth is not configured. Provide your X developer credentials here in the chat to set up OAuth, or switch to browser strategy: `vellum x strategy set browser`.",
+          "OAuth is not configured. Provide your X developer credentials here in the chat to set up OAuth, or switch to browser strategy: `assistant config set twitterOperationStrategy browser`.",
         ),
         {
           pathUsed: "oauth" as const,
@@ -60,7 +52,10 @@ export async function routedPostTweet(
         },
       );
     }
-    const result = await oauthPostTweet(text, opts);
+    const result = await oauthPostTweet(text, {
+      inReplyToTweetId: opts.inReplyToTweetId,
+      oauthToken: opts.oauthToken!,
+    });
     return {
       result: {
         tweetId: result.tweetId,
@@ -74,7 +69,9 @@ export async function routedPostTweet(
   if (strategy === "browser") {
     // User explicitly wants browser
     try {
-      const result = await browserPostTweet(text, opts);
+      const result = await browserPostTweet(text, {
+        inReplyToTweetId: opts.inReplyToTweetId,
+      });
       return { result, pathUsed: "browser" };
     } catch (err) {
       if (err instanceof SessionExpiredError) {
@@ -89,9 +86,12 @@ export async function routedPostTweet(
 
   // auto strategy: try OAuth first if available and supported, fallback to browser
   let oauthError: Error | undefined;
-  if (oauthIsAvailable() && oauthSupportsOperation(operation)) {
+  if (oauthIsAvailable(opts.oauthToken) && oauthSupportsOperation(operation)) {
     try {
-      const result = await oauthPostTweet(text, opts);
+      const result = await oauthPostTweet(text, {
+        inReplyToTweetId: opts.inReplyToTweetId,
+        oauthToken: opts.oauthToken!,
+      });
       return {
         result: {
           tweetId: result.tweetId,
@@ -108,7 +108,9 @@ export async function routedPostTweet(
 
   // Fallback to browser
   try {
-    const result = await browserPostTweet(text, opts);
+    const result = await browserPostTweet(text, {
+      inReplyToTweetId: opts.inReplyToTweetId,
+    });
     return { result, pathUsed: "browser" };
   } catch (err) {
     if (err instanceof SessionExpiredError) {


### PR DESCRIPTION
## Summary
- Remove security and config imports from `oauth-client.ts` and `router.ts`, making `oauthToken` and `strategy` required parameters passed by the caller
- Add `--strategy` (required) and `--oauth-token` (optional) flags to the `post` and `reply` CLI commands
- Update Twitter SKILL.md to instruct the assistant to fetch strategy via `assistant config get` and token via `assistant oauth token` before calling post/reply
- Update all tests to match new parameter-based signatures

## Original prompt
Decouple the Twitter CLI from the assistant runtime by having the skill use `assistant config get` and `assistant oauth token` to fetch values, then pass them as inputs to the twitter CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
