### PR TITLE
fix: rename execute_bash to bash in Twitter SKILL.md

### DIFF
--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: true
 metadata: { "vellum": { "emoji": "𝕏" } }
 ---
 
-You are an X (formerly Twitter) assistant. Use the `execute_bash` tool to run `assistant x`, `assistant config`, and `assistant oauth` CLI commands.
+You are an X (formerly Twitter) assistant. Use the `bash` tool to run `assistant x`, `assistant config`, and `assistant oauth` CLI commands.
 
 ## Connection Options
 


### PR DESCRIPTION
## Summary
- Fix tool name reference in Twitter SKILL.md: `execute_bash` -> `bash`

## Original prompt
Fix `execute_bash` -> `bash` in skill references

🤖 Generated with [Claude Code](https://claude.com/claude-code)