### PR TITLE
refactor: rename twitter config keys to dot-separated convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Twitter integration supports two operation paths: **OAuth** (X API v2) and **Bro
 
 - **Browser path** (CDP): Uses Chrome DevTools Protocol to execute operations through an authenticated x.com browser tab. Supports all operations including read-only ones (timeline, search, home, notifications, bookmarks, likes, followers, following, media). Quick to start — no developer credentials needed. Session cookies are captured via Ride Shotgun (`vellum x refresh`).
 
-- **Strategy selection**: `vellum x strategy set <oauth|browser|auto>` controls which path is used. Default is `auto`, which prefers OAuth when credentials are available and the operation is supported, then falls back to browser. The strategy is persisted in config as `twitterOperationStrategy`.
+- **Strategy selection**: `vellum x strategy set <oauth|browser|auto>` controls which path is used. Default is `auto`, which prefers OAuth when credentials are available and the operation is supported, then falls back to browser. The strategy is persisted in config as `twitter.operationStrategy`.
 
 **OAuth2 PKCE setup** (`local_byo` mode): The user provides their own Twitter OAuth2 Client ID (and optional Client Secret). The assistant runs a standard OAuth2 PKCE flow against `twitter.com/i/oauth2/authorize` and `api.x.com/2/oauth2/token`. The flow verifies the user's identity (`GET /2/users/me`) and stores tokens in the vault for use by both identity verification and the OAuth operation path. Connect via the Settings UI or `twitter_auth_start` IPC message.
 

--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -190,7 +190,7 @@ sequenceDiagram
 
 #### Dual-Path Operation Architecture
 
-The strategy router (`router.ts`) determines whether to use the OAuth or browser path for each operation. The preferred strategy is read from the `twitterOperationStrategy` config field (default: `auto`).
+The strategy router (`router.ts`) determines whether to use the OAuth or browser path for each operation. The preferred strategy is read from the `twitter.operationStrategy` config field (default: `auto`).
 
 ```mermaid
 flowchart TD
@@ -215,19 +215,19 @@ flowchart TD
 - **`oauth`**: Uses OAuth exclusively. Fails with an actionable error if credentials are not configured.
 - **`browser`**: Uses CDP exclusively. Fails with an actionable error if the browser session has expired.
 
-The strategy is persisted in the Vellum config file as `twitterOperationStrategy` and can be changed via `vellum x strategy set <oauth|browser|auto>`.
+The strategy is persisted in the Vellum config file as `twitter.operationStrategy` and can be changed via `vellum x strategy set <oauth|browser|auto>`.
 
 #### Twitter OAuth2 Specifics
 
-| Aspect | Detail |
-|--------|--------|
-| Auth URL | `https://twitter.com/i/oauth2/authorize` (from provider profile) |
-| Token URL | `https://api.x.com/2/oauth2/token` (from provider profile) |
-| Flow | PKCE (S256), optional client secret, via connect orchestrator |
-| Default scopes | `tweet.read`, `tweet.write`, `users.read`, `offline.access` (from provider profile) |
-| Identity verification | Provider profile `identityVerifier` → `GET https://api.x.com/2/users/me` with Bearer token |
-| Credential names | Canonical: `client_id`, `client_secret`; reads fall back to legacy `oauth_client_id`, `oauth_client_secret` |
-| IPC messages | `oauth_connect_start` / `oauth_connect_result` (generic), plus legacy `twitter_auth_start` / `twitter_auth_status` |
+| Aspect                | Detail                                                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Auth URL              | `https://twitter.com/i/oauth2/authorize` (from provider profile)                                                   |
+| Token URL             | `https://api.x.com/2/oauth2/token` (from provider profile)                                                         |
+| Flow                  | PKCE (S256), optional client secret, via connect orchestrator                                                      |
+| Default scopes        | `tweet.read`, `tweet.write`, `users.read`, `offline.access` (from provider profile)                                |
+| Identity verification | Provider profile `identityVerifier` → `GET https://api.x.com/2/users/me` with Bearer token                         |
+| Credential names      | Canonical: `client_id`, `client_secret`; reads fall back to legacy `oauth_client_id`, `oauth_client_secret`        |
+| IPC messages          | `oauth_connect_start` / `oauth_connect_result` (generic), plus legacy `twitter_auth_start` / `twitter_auth_status` |
 
 #### Twitter Credential Metadata Structure
 
@@ -254,73 +254,73 @@ When the OAuth2 flow completes, the handler stores credential metadata at `integ
 
 #### Available Twitter Tools
 
-| Tool / Command | Mechanism | Description |
-|----------------|-----------|-------------|
-| `vellum x post` | Strategy router (OAuth or CDP) | Post a tweet. Uses the configured strategy (`auto` by default). |
-| `vellum x reply` | Strategy router (OAuth or CDP) | Reply to a tweet. Uses the configured strategy (`auto` by default). |
-| `vellum x timeline` | CDP | Fetch a user's recent tweets. Browser path only. |
-| `vellum x search` | CDP | Search tweets. Browser path only. |
-| `vellum x home` | CDP | Fetch home timeline. Browser path only. |
-| `vellum x notifications` | CDP | Fetch notifications. Browser path only. |
-| `vellum x bookmarks` | CDP | Fetch bookmarks. Browser path only. |
-| `vellum x likes` | CDP | Fetch a user's liked tweets. Browser path only. |
-| `vellum x followers` | CDP | Fetch a user's followers. Browser path only. |
-| `vellum x following` | CDP | Fetch who a user follows. Browser path only. |
-| `vellum x media` | CDP | Fetch a user's media tweets. Browser path only. |
-| `vellum x strategy` | Config | Get or set the operation strategy (`oauth`, `browser`, `auto`). |
-| `vellum x status` | IPC + local | Check browser session, OAuth connection, and strategy status. |
+| Tool / Command           | Mechanism                      | Description                                                         |
+| ------------------------ | ------------------------------ | ------------------------------------------------------------------- |
+| `vellum x post`          | Strategy router (OAuth or CDP) | Post a tweet. Uses the configured strategy (`auto` by default).     |
+| `vellum x reply`         | Strategy router (OAuth or CDP) | Reply to a tweet. Uses the configured strategy (`auto` by default). |
+| `vellum x timeline`      | CDP                            | Fetch a user's recent tweets. Browser path only.                    |
+| `vellum x search`        | CDP                            | Search tweets. Browser path only.                                   |
+| `vellum x home`          | CDP                            | Fetch home timeline. Browser path only.                             |
+| `vellum x notifications` | CDP                            | Fetch notifications. Browser path only.                             |
+| `vellum x bookmarks`     | CDP                            | Fetch bookmarks. Browser path only.                                 |
+| `vellum x likes`         | CDP                            | Fetch a user's liked tweets. Browser path only.                     |
+| `vellum x followers`     | CDP                            | Fetch a user's followers. Browser path only.                        |
+| `vellum x following`     | CDP                            | Fetch who a user follows. Browser path only.                        |
+| `vellum x media`         | CDP                            | Fetch a user's media tweets. Browser path only.                     |
+| `vellum x strategy`      | Config                         | Get or set the operation strategy (`oauth`, `browser`, `auto`).     |
+| `vellum x status`        | IPC + local                    | Check browser session, OAuth connection, and strategy status.       |
 
 Note: OAuth2 scopes (`tweet.read`, `tweet.write`, `users.read`, `offline.access`) are requested during the auth flow. The `post` and `reply` operations use these tokens when the OAuth path is selected. Read operations require the browser path.
 
 ### Key Design Decisions
 
-| Decision | Rationale |
-|----------|-----------|
-| PKCE by default, optional client_secret | Desktop apps prefer PKCE; some providers (Slack) require a secret, which is stored in credential metadata for autonomous refresh |
-| Shared connect orchestrator | All OAuth providers route through `orchestrateOAuthConnect()`, which resolves profiles, enforces scope policy, runs the flow, stores tokens, and verifies identity. Adding a provider is a declarative profile entry, not new orchestration code |
-| Canonical credential naming | Writes use `client_id`/`client_secret`; reads fall back to legacy `oauth_client_id`/`oauth_client_secret` for backward compatibility |
-| Gateway callback transport | OAuth callbacks are now routed through the gateway at `${ingress.publicBaseUrl}/webhooks/oauth/callback` instead of a loopback redirect URI. This enables OAuth flows to work in remote and tunneled deployments. |
-| Unified `MessagingProvider` interface | All platforms implement the same contract; generic tools work immediately for new providers |
-| Twitter outside unified messaging | Twitter is a broadcast/read platform, not a conversation platform — it doesn't fit the `MessagingProvider` contract |
-| Dual-path Twitter strategy | OAuth is more reliable for posting (no browser session dependency) but only supports post/reply. Browser path supports all operations. `auto` strategy gives the best of both: OAuth when possible, browser as fallback. User can override via `vellum x strategy set`. |
-| Provider auto-selection | If only one provider is connected, tools skip the `platform` parameter — seamless single-platform UX |
-| Token expiry in credential metadata | Reuses existing `CredentialMetadata` store; `expiresAt` field enables proactive refresh with 5min buffer |
-| Confidence scores on medium-risk tools | LLM self-reports confidence (0-1); enables future trust calibration without blocking execution |
-| Platform-specific extension tools | Operations unique to one platform (e.g. Gmail labels, Slack reactions) are separate tools, not forced into the generic interface |
-| Twitter identity verification before token storage | OAuth2 tokens are only persisted after a successful `GET /2/users/me` call, preventing storage of invalid or mismatched credentials |
+| Decision                                           | Rationale                                                                                                                                                                                                                                                               |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PKCE by default, optional client_secret            | Desktop apps prefer PKCE; some providers (Slack) require a secret, which is stored in credential metadata for autonomous refresh                                                                                                                                        |
+| Shared connect orchestrator                        | All OAuth providers route through `orchestrateOAuthConnect()`, which resolves profiles, enforces scope policy, runs the flow, stores tokens, and verifies identity. Adding a provider is a declarative profile entry, not new orchestration code                        |
+| Canonical credential naming                        | Writes use `client_id`/`client_secret`; reads fall back to legacy `oauth_client_id`/`oauth_client_secret` for backward compatibility                                                                                                                                    |
+| Gateway callback transport                         | OAuth callbacks are now routed through the gateway at `${ingress.publicBaseUrl}/webhooks/oauth/callback` instead of a loopback redirect URI. This enables OAuth flows to work in remote and tunneled deployments.                                                       |
+| Unified `MessagingProvider` interface              | All platforms implement the same contract; generic tools work immediately for new providers                                                                                                                                                                             |
+| Twitter outside unified messaging                  | Twitter is a broadcast/read platform, not a conversation platform — it doesn't fit the `MessagingProvider` contract                                                                                                                                                     |
+| Dual-path Twitter strategy                         | OAuth is more reliable for posting (no browser session dependency) but only supports post/reply. Browser path supports all operations. `auto` strategy gives the best of both: OAuth when possible, browser as fallback. User can override via `vellum x strategy set`. |
+| Provider auto-selection                            | If only one provider is connected, tools skip the `platform` parameter — seamless single-platform UX                                                                                                                                                                    |
+| Token expiry in credential metadata                | Reuses existing `CredentialMetadata` store; `expiresAt` field enables proactive refresh with 5min buffer                                                                                                                                                                |
+| Confidence scores on medium-risk tools             | LLM self-reports confidence (0-1); enables future trust calibration without blocking execution                                                                                                                                                                          |
+| Platform-specific extension tools                  | Operations unique to one platform (e.g. Gmail labels, Slack reactions) are separate tools, not forced into the generic interface                                                                                                                                        |
+| Twitter identity verification before token storage | OAuth2 tokens are only persisted after a successful `GET /2/users/me` call, preventing storage of invalid or mismatched credentials                                                                                                                                     |
 
 ### Source Files
 
-| File | Role |
-|------|------|
-| `assistant/src/security/oauth2.ts` | OAuth2 flow: PKCE or client_secret, Bun.serve callback, token exchange |
-| `assistant/src/security/token-manager.ts` | `withValidToken()` — auto-refresh, 401 retry, expiry buffer |
-| `assistant/src/messaging/provider.ts` | `MessagingProvider` interface |
-| `assistant/src/messaging/provider-types.ts` | Platform-agnostic types (Conversation, Message, SearchResult) |
-| `assistant/src/messaging/registry.ts` | Provider registry: register, lookup, list connected |
-| `assistant/src/messaging/activity-analyzer.ts` | Activity classification for conversations |
-| `assistant/src/messaging/style-analyzer.ts` | Writing style extraction from message corpus |
-| `assistant/src/messaging/draft-store.ts` | Local draft storage (platform/id JSON files) |
-| `assistant/src/messaging/providers/slack/` | Slack adapter, client, types |
-| `assistant/src/messaging/providers/gmail/` | Gmail adapter, client, types |
-| `assistant/src/config/bundled-skills/messaging/` | Unified messaging skill (SKILL.md, TOOLS.json, tools/) |
-| `assistant/src/watcher/providers/slack.ts` | Slack watcher for DMs, mentions, thread replies |
-| `assistant/src/watcher/providers/gmail.ts` | Gmail watcher using History API |
-| `assistant/src/watcher/providers/github.ts` | GitHub watcher for PRs, issues, review requests, and mentions |
-| `assistant/src/watcher/providers/linear.ts` | Linear watcher for assigned issues, status changes, and @mentions |
-| `assistant/src/oauth/provider-profiles.ts` | Provider profile registry: auth URLs, token URLs, scopes, policies, identity verifiers |
-| `assistant/src/oauth/connect-orchestrator.ts` | Shared OAuth connect orchestrator: profile resolution, scope policy, flow execution, token storage |
-| `assistant/src/oauth/scope-policy.ts` | Deterministic scope resolution and policy enforcement |
-| `assistant/src/oauth/connect-types.ts` | Shared types: `OAuthProviderProfile`, `OAuthScopePolicy`, `OAuthConnectResult` |
-| `assistant/src/oauth/token-persistence.ts` | Token storage helper: persists tokens, metadata, and runs post-connect hooks |
-| `assistant/src/daemon/handlers/oauth-connect.ts` | Generic OAuth connect IPC handler (`oauth_connect_start` / `oauth_connect_result`) |
-| `assistant/src/daemon/handlers/twitter-auth.ts` | Legacy Twitter OAuth2 flow handlers (`twitter_auth_start`, `twitter_auth_status`) |
-| `assistant/src/twitter/client.ts` | Twitter CDP client: GraphQL mutations/queries via Chrome DevTools Protocol |
-| `assistant/src/twitter/oauth-client.ts` | OAuth-backed Twitter client: X API v2 post/reply via stored tokens using `withValidToken()` |
-| `assistant/src/twitter/router.ts` | Strategy router: selects OAuth or browser path based on `twitterOperationStrategy` config |
-| `assistant/src/twitter/session.ts` | Twitter browser session persistence (cookie import/export) |
-| `assistant/src/cli/twitter.ts` | `vellum x` CLI command group (post, reply, strategy, refresh, status, login, logout, and read operations) |
-| `assistant/src/config/bundled-skills/twitter/SKILL.md` | X (Twitter) bundled skill instructions |
+| File                                                   | Role                                                                                                      |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| `assistant/src/security/oauth2.ts`                     | OAuth2 flow: PKCE or client_secret, Bun.serve callback, token exchange                                    |
+| `assistant/src/security/token-manager.ts`              | `withValidToken()` — auto-refresh, 401 retry, expiry buffer                                               |
+| `assistant/src/messaging/provider.ts`                  | `MessagingProvider` interface                                                                             |
+| `assistant/src/messaging/provider-types.ts`            | Platform-agnostic types (Conversation, Message, SearchResult)                                             |
+| `assistant/src/messaging/registry.ts`                  | Provider registry: register, lookup, list connected                                                       |
+| `assistant/src/messaging/activity-analyzer.ts`         | Activity classification for conversations                                                                 |
+| `assistant/src/messaging/style-analyzer.ts`            | Writing style extraction from message corpus                                                              |
+| `assistant/src/messaging/draft-store.ts`               | Local draft storage (platform/id JSON files)                                                              |
+| `assistant/src/messaging/providers/slack/`             | Slack adapter, client, types                                                                              |
+| `assistant/src/messaging/providers/gmail/`             | Gmail adapter, client, types                                                                              |
+| `assistant/src/config/bundled-skills/messaging/`       | Unified messaging skill (SKILL.md, TOOLS.json, tools/)                                                    |
+| `assistant/src/watcher/providers/slack.ts`             | Slack watcher for DMs, mentions, thread replies                                                           |
+| `assistant/src/watcher/providers/gmail.ts`             | Gmail watcher using History API                                                                           |
+| `assistant/src/watcher/providers/github.ts`            | GitHub watcher for PRs, issues, review requests, and mentions                                             |
+| `assistant/src/watcher/providers/linear.ts`            | Linear watcher for assigned issues, status changes, and @mentions                                         |
+| `assistant/src/oauth/provider-profiles.ts`             | Provider profile registry: auth URLs, token URLs, scopes, policies, identity verifiers                    |
+| `assistant/src/oauth/connect-orchestrator.ts`          | Shared OAuth connect orchestrator: profile resolution, scope policy, flow execution, token storage        |
+| `assistant/src/oauth/scope-policy.ts`                  | Deterministic scope resolution and policy enforcement                                                     |
+| `assistant/src/oauth/connect-types.ts`                 | Shared types: `OAuthProviderProfile`, `OAuthScopePolicy`, `OAuthConnectResult`                            |
+| `assistant/src/oauth/token-persistence.ts`             | Token storage helper: persists tokens, metadata, and runs post-connect hooks                              |
+| `assistant/src/daemon/handlers/oauth-connect.ts`       | Generic OAuth connect IPC handler (`oauth_connect_start` / `oauth_connect_result`)                        |
+| `assistant/src/daemon/handlers/twitter-auth.ts`        | Legacy Twitter OAuth2 flow handlers (`twitter_auth_start`, `twitter_auth_status`)                         |
+| `assistant/src/twitter/client.ts`                      | Twitter CDP client: GraphQL mutations/queries via Chrome DevTools Protocol                                |
+| `assistant/src/twitter/oauth-client.ts`                | OAuth-backed Twitter client: X API v2 post/reply via stored tokens using `withValidToken()`               |
+| `assistant/src/twitter/router.ts`                      | Strategy router: selects OAuth or browser path based on `twitter.operationStrategy` config                |
+| `assistant/src/twitter/session.ts`                     | Twitter browser session persistence (cookie import/export)                                                |
+| `assistant/src/cli/twitter.ts`                         | `vellum x` CLI command group (post, reply, strategy, refresh, status, login, logout, and read operations) |
+| `assistant/src/config/bundled-skills/twitter/SKILL.md` | X (Twitter) bundled skill instructions                                                                    |
 
 ---
 
@@ -332,15 +332,15 @@ The OAuth extensibility layer makes adding a new OAuth provider a declarative op
 
 `assistant/src/oauth/provider-profiles.ts` contains the `PROVIDER_PROFILES` map — a canonical registry of well-known OAuth providers. Each profile (`OAuthProviderProfile`) declares:
 
-| Field | Purpose |
-|-------|---------|
-| `authUrl` / `tokenUrl` | OAuth2 authorization and token endpoints |
-| `defaultScopes` | Scopes requested on every connect attempt |
-| `scopePolicy` | Controls whether additional scopes are allowed (see Scope Policy below) |
-| `callbackTransport` | `'loopback'` (local redirect) or `'gateway'` (public ingress) |
-| `identityVerifier` | Async function that fetches human-readable account info (e.g. `@username`, email) after token exchange |
-| `setup` | Optional metadata for the generic OAuth setup skill (display name, dashboard URL, app type) |
-| `injectionTemplates` | Auto-applied credential injection rules for the script proxy |
+| Field                  | Purpose                                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| `authUrl` / `tokenUrl` | OAuth2 authorization and token endpoints                                                               |
+| `defaultScopes`        | Scopes requested on every connect attempt                                                              |
+| `scopePolicy`          | Controls whether additional scopes are allowed (see Scope Policy below)                                |
+| `callbackTransport`    | `'loopback'` (local redirect) or `'gateway'` (public ingress)                                          |
+| `identityVerifier`     | Async function that fetches human-readable account info (e.g. `@username`, email) after token exchange |
+| `setup`                | Optional metadata for the generic OAuth setup skill (display name, dashboard URL, app type)            |
+| `injectionTemplates`   | Auto-applied credential injection rules for the script proxy                                           |
 
 Registered providers: `integration:gmail`, `integration:slack`, `integration:notion`, `integration:twitter`. Short aliases (e.g. `gmail`, `twitter`) are resolved via `SERVICE_ALIASES`.
 
@@ -394,17 +394,16 @@ This replaces provider-specific IPC handlers — any provider in the registry ca
 
 ### Key Source Files
 
-| File | Role |
-|------|------|
-| `assistant/src/oauth/provider-profiles.ts` | Provider profile registry and alias resolution |
-| `assistant/src/oauth/scope-policy.ts` | Scope resolution and policy enforcement (pure, no I/O) |
-| `assistant/src/oauth/connect-orchestrator.ts` | Shared connect orchestrator (profile → scopes → flow → tokens) |
-| `assistant/src/oauth/connect-types.ts` | Shared types (`OAuthProviderProfile`, `OAuthScopePolicy`, `OAuthConnectResult`) |
-| `assistant/src/oauth/token-persistence.ts` | Token storage: keychain writes, metadata upsert, post-connect hooks |
-| `assistant/src/daemon/handlers/oauth-connect.ts` | Generic `oauth_connect_start` / `oauth_connect_result` IPC handler |
+| File                                             | Role                                                                            |
+| ------------------------------------------------ | ------------------------------------------------------------------------------- |
+| `assistant/src/oauth/provider-profiles.ts`       | Provider profile registry and alias resolution                                  |
+| `assistant/src/oauth/scope-policy.ts`            | Scope resolution and policy enforcement (pure, no I/O)                          |
+| `assistant/src/oauth/connect-orchestrator.ts`    | Shared connect orchestrator (profile → scopes → flow → tokens)                  |
+| `assistant/src/oauth/connect-types.ts`           | Shared types (`OAuthProviderProfile`, `OAuthScopePolicy`, `OAuthConnectResult`) |
+| `assistant/src/oauth/token-persistence.ts`       | Token storage: keychain writes, metadata upsert, post-connect hooks             |
+| `assistant/src/daemon/handlers/oauth-connect.ts` | Generic `oauth_connect_start` / `oauth_connect_result` IPC handler              |
 
 ---
-
 
 ---
 
@@ -536,14 +535,14 @@ sequenceDiagram
 
 **Policy decisions** are deterministic and structured:
 
-| Decision | Meaning |
-|---|---|
-| `matched` | Exactly one credential template matches the host — inject it |
-| `ambiguous` | Multiple credential templates match — caller must disambiguate |
-| `missing` | Credentials exist but none match this host — no rewrite |
-| `unauthenticated` | No credentials configured for the session |
+| Decision                 | Meaning                                                                    |
+| ------------------------ | -------------------------------------------------------------------------- |
+| `matched`                | Exactly one credential template matches the host — inject it               |
+| `ambiguous`              | Multiple credential templates match — caller must disambiguate             |
+| `missing`                | Credentials exist but none match this host — no rewrite                    |
+| `unauthenticated`        | No credentials configured for the session                                  |
 | `ask_missing_credential` | A known template pattern matches but no credential is bound to the session |
-| `ask_unauthenticated` | Completely unknown host — prompt for unauthenticated access |
+| `ask_unauthenticated`    | Completely unknown host — prompt for unauthenticated access                |
 
 **Trust rule persistence**: The `createProxyApprovalCallback` in `session-tool-setup.ts` is wired into the session startup path and routes policy "ask" decisions through the existing `PermissionPrompter` UI. Trust rules use the `network_request` tool name (not `proxy:*`) with URL-based scope patterns (e.g., `https://api.example.com/*`), aligning with the `buildCommandCandidates()` allowlist generation in `checker.ts`.
 
@@ -566,10 +565,10 @@ Each proxy session is bound to a conversation and tracks authorized credential I
 
 The proxy generates and manages a local Certificate Authority for MITM interception:
 
-| Component | Location | Purpose |
-|---|---|---|
-| CA cert | `{dataDir}/proxy-ca/ca.pem` | Self-signed root cert (valid 10 years, permissions 0644) |
-| CA key | `{dataDir}/proxy-ca/ca-key.pem` | CA private key (permissions 0600) |
+| Component  | Location                                   | Purpose                                                  |
+| ---------- | ------------------------------------------ | -------------------------------------------------------- |
+| CA cert    | `{dataDir}/proxy-ca/ca.pem`                | Self-signed root cert (valid 10 years, permissions 0644) |
+| CA key     | `{dataDir}/proxy-ca/ca-key.pem`            | CA private key (permissions 0600)                        |
 | Leaf certs | `{dataDir}/proxy-ca/issued/{hostname}.pem` | Per-hostname certs (cached, verified against current CA) |
 
 `ensureLocalCA()` is idempotent — it only generates the CA if the files do not already exist. Leaf certificates are cached and revalidated via `X509Certificate.checkIssued()` to detect stale certs from a previous CA.
@@ -602,20 +601,20 @@ The proxy subsystem intercepts outbound HTTPS requests and injects stored creden
 
 ### Key Source Files
 
-| File | Role |
-|---|---|
-| `assistant/src/tools/network/script-proxy/server.ts` | Proxy server factory — HTTP forwarding, CONNECT handling, MITM dispatch |
-| `assistant/src/tools/network/script-proxy/policy.ts` | Policy engine — evaluates requests against credential templates |
-| `assistant/src/tools/network/script-proxy/mitm-handler.ts` | MITM TLS interception — loopback TLS server, request rewrite, upstream forwarding |
-| `assistant/src/tools/network/script-proxy/connect-tunnel.ts` | Plain CONNECT tunnel — raw TCP bidirectional pipe |
-| `assistant/src/tools/network/script-proxy/http-forwarder.ts` | HTTP proxy forwarder — absolute-URL form forwarding with policy callback |
-| `assistant/src/tools/network/script-proxy/session-manager.ts` | Session lifecycle — create, start, stop, idle timeout, env var generation |
-| `assistant/src/tools/network/script-proxy/certs.ts` | Local CA management — ensureLocalCA, issueLeafCert, getCAPath |
-| `assistant/src/tools/network/script-proxy/logging.ts` | Log sanitization (header/URL redaction) and safe decision trace builders for policy and credential resolution |
-| `assistant/src/tools/network/script-proxy/types.ts` | Type definitions — session, policy decisions, approval callback |
-| `assistant/src/tools/executor.ts` | `persistentDecisionsAllowed` gate — disables trust rule saving for proxied bash |
-| `assistant/src/daemon/session-tool-setup.ts` | `createProxyApprovalCallback` — wired into session startup, uses `network_request` tool name with URL-based trust rules |
-| `assistant/src/permissions/checker.ts` | `network_request` trust rule matching and risk classification (Medium) |
+| File                                                          | Role                                                                                                                    |
+| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `assistant/src/tools/network/script-proxy/server.ts`          | Proxy server factory — HTTP forwarding, CONNECT handling, MITM dispatch                                                 |
+| `assistant/src/tools/network/script-proxy/policy.ts`          | Policy engine — evaluates requests against credential templates                                                         |
+| `assistant/src/tools/network/script-proxy/mitm-handler.ts`    | MITM TLS interception — loopback TLS server, request rewrite, upstream forwarding                                       |
+| `assistant/src/tools/network/script-proxy/connect-tunnel.ts`  | Plain CONNECT tunnel — raw TCP bidirectional pipe                                                                       |
+| `assistant/src/tools/network/script-proxy/http-forwarder.ts`  | HTTP proxy forwarder — absolute-URL form forwarding with policy callback                                                |
+| `assistant/src/tools/network/script-proxy/session-manager.ts` | Session lifecycle — create, start, stop, idle timeout, env var generation                                               |
+| `assistant/src/tools/network/script-proxy/certs.ts`           | Local CA management — ensureLocalCA, issueLeafCert, getCAPath                                                           |
+| `assistant/src/tools/network/script-proxy/logging.ts`         | Log sanitization (header/URL redaction) and safe decision trace builders for policy and credential resolution           |
+| `assistant/src/tools/network/script-proxy/types.ts`           | Type definitions — session, policy decisions, approval callback                                                         |
+| `assistant/src/tools/executor.ts`                             | `persistentDecisionsAllowed` gate — disables trust rule saving for proxied bash                                         |
+| `assistant/src/daemon/session-tool-setup.ts`                  | `createProxyApprovalCallback` — wired into session startup, uses `network_request` tool name with URL-based trust rules |
+| `assistant/src/permissions/checker.ts`                        | `network_request` trust rule matching and risk classification (Medium)                                                  |
 
 ### Runtime Wiring Summary
 
@@ -690,13 +689,13 @@ graph TB
 
 ### Search Capabilities
 
-| Parameter | Type | Description |
-|---|---|---|
-| `mime_type` | string | MIME type filter with wildcard support (`image/*`, `application/pdf`) |
-| `filename` | string | Case-insensitive substring match on original filename |
-| `recency` | enum | Time-based filter: `last_hour`, `last_24_hours`, `last_7_days`, `last_30_days`, `last_90_days` |
-| `conversation_id` | string | Scope results to attachments in a specific conversation |
-| `limit` | number | Maximum results (default 20, max 100) |
+| Parameter         | Type   | Description                                                                                    |
+| ----------------- | ------ | ---------------------------------------------------------------------------------------------- |
+| `mime_type`       | string | MIME type filter with wildcard support (`image/*`, `application/pdf`)                          |
+| `filename`        | string | Case-insensitive substring match on original filename                                          |
+| `recency`         | enum   | Time-based filter: `last_hour`, `last_24_hours`, `last_7_days`, `last_30_days`, `last_90_days` |
+| `conversation_id` | string | Scope results to attachments in a specific conversation                                        |
+| `limit`           | number | Maximum results (default 20, max 100)                                                          |
 
 ### Materialize Safeguards
 
@@ -707,13 +706,12 @@ graph TB
 
 ### Key Source Files
 
-| File | Role |
-|---|---|
-| `assistant/src/tools/assets/search.ts` | `asset_search` tool — cross-thread attachment metadata search with visibility filtering |
-| `assistant/src/tools/assets/materialize.ts` | `asset_materialize` tool — decode and write attachment to sandbox path |
-| `assistant/src/daemon/media-visibility-policy.ts` | Pure policy module — `isAttachmentVisible()`, `filterVisibleAttachments()` |
-| `assistant/src/memory/schema.ts` | `attachments` and `message_attachments` table schemas |
-| `assistant/src/memory/conversation-store.ts` | `getConversationThreadType()` — thread type lookup for visibility context |
+| File                                              | Role                                                                                    |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `assistant/src/tools/assets/search.ts`            | `asset_search` tool — cross-thread attachment metadata search with visibility filtering |
+| `assistant/src/tools/assets/materialize.ts`       | `asset_materialize` tool — decode and write attachment to sandbox path                  |
+| `assistant/src/daemon/media-visibility-policy.ts` | Pure policy module — `isAttachmentVisible()`, `filterVisibleAttachments()`              |
+| `assistant/src/memory/schema.ts`                  | `attachments` and `message_attachments` table schemas                                   |
+| `assistant/src/memory/conversation-store.ts`      | `getConversationThreadType()` — thread type lookup for visibility context               |
 
 ---
-

--- a/assistant/src/__tests__/handlers-twitter-config.test.ts
+++ b/assistant/src/__tests__/handlers-twitter-config.test.ts
@@ -10,18 +10,49 @@ const testDir = mkdtempSync(join(tmpdir(), "handlers-twitter-cfg-test-"));
 let rawConfigStore: Record<string, unknown> = {};
 const saveRawConfigCalls: Record<string, unknown>[] = [];
 
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  const keys = path.split(".");
+  let current: unknown = obj;
+  for (const key of keys) {
+    if (current == null || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+function setNestedValue(
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): void {
+  const keys = path.split(".");
+  let current = obj;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i]!;
+    if (current[key] == null || typeof current[key] !== "object") {
+      current[key] = {};
+    }
+    current = current[key] as Record<string, unknown>;
+  }
+  current[keys[keys.length - 1]!] = value;
+}
+
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
   }),
   loadConfig: () => ({}),
-  loadRawConfig: () => ({ ...rawConfigStore }),
+  loadRawConfig: () => structuredClone(rawConfigStore),
   saveRawConfig: (cfg: Record<string, unknown>) => {
     saveRawConfigCalls.push(cfg);
-    rawConfigStore = { ...cfg };
+    rawConfigStore = structuredClone(cfg);
   },
   saveConfig: () => {},
   invalidateConfigCache: () => {},
+  getNestedValue,
+  setNestedValue,
 }));
 
 mock.module("../util/platform.js", () => ({
@@ -225,7 +256,7 @@ describe("Twitter integration config handler", () => {
   });
 
   test("get action returns correct status when configured and connected", () => {
-    rawConfigStore = { twitterIntegrationMode: "local_byo" };
+    rawConfigStore = { twitter: { integrationMode: "local_byo" } };
     secureKeyStore["credential:integration:twitter:oauth_client_id"] =
       "test-client-id";
     secureKeyStore["credential:integration:twitter:access_token"] =
@@ -278,7 +309,9 @@ describe("Twitter integration config handler", () => {
     expect(res.mode).toBe("managed");
 
     expect(saveRawConfigCalls).toHaveLength(1);
-    expect(saveRawConfigCalls[0]!.twitterIntegrationMode).toBe("managed");
+    expect(
+      getNestedValue(saveRawConfigCalls[0]!, "twitter.integrationMode"),
+    ).toBe("managed");
   });
 
   test("set_local_client stores credentials in secure storage", async () => {
@@ -1006,7 +1039,9 @@ describe("Twitter integration config handler", () => {
     // Verify persistence via saveRawConfig
     expect(saveRawConfigCalls.length).toBeGreaterThan(0);
     const lastSaved = saveRawConfigCalls[saveRawConfigCalls.length - 1]!;
-    expect(lastSaved.twitterOperationStrategy).toBe("oauth");
+    expect(getNestedValue(lastSaved, "twitter.operationStrategy")).toBe(
+      "oauth",
+    );
   });
 
   test("set_strategy with invalid value returns error", () => {
@@ -1044,7 +1079,7 @@ describe("Twitter integration config handler", () => {
 
   test("get action includes strategy field with strategyConfigured=true when set", () => {
     // Set a specific strategy first
-    rawConfigStore = { twitterOperationStrategy: "browser" };
+    rawConfigStore = { twitter: { operationStrategy: "browser" } };
 
     const msg: TwitterIntegrationConfigRequest = {
       type: "twitter_integration_config",

--- a/assistant/src/__tests__/twitter-auth-handler.test.ts
+++ b/assistant/src/__tests__/twitter-auth-handler.test.ts
@@ -10,17 +10,30 @@ const testDir = mkdtempSync(join(tmpdir(), "handlers-twitter-auth-test-"));
 let rawConfigStore: Record<string, unknown> = {};
 let mockIngressPublicBaseUrl: string | undefined = "https://test.example.com";
 
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  const keys = path.split(".");
+  let current: unknown = obj;
+  for (const key of keys) {
+    if (current == null || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
   }),
   loadConfig: () => ({ ingress: { publicBaseUrl: mockIngressPublicBaseUrl } }),
-  loadRawConfig: () => ({ ...rawConfigStore }),
+  loadRawConfig: () => structuredClone(rawConfigStore),
   saveRawConfig: (cfg: Record<string, unknown>) => {
-    rawConfigStore = { ...cfg };
+    rawConfigStore = structuredClone(cfg);
   },
   saveConfig: () => {},
   invalidateConfigCache: () => {},
+  getNestedValue,
 }));
 
 mock.module("../inbound/public-ingress-urls.js", () => ({
@@ -207,7 +220,7 @@ describe("Twitter auth handler", () => {
 
   describe("twitter_auth_start", () => {
     test("fails if mode is not local_byo", async () => {
-      rawConfigStore = { twitterIntegrationMode: "managed" };
+      rawConfigStore = { twitter: { integrationMode: "managed" } };
 
       const msg: TwitterAuthStartRequest = { type: "twitter_auth_start" };
       const { ctx, sent } = createTestContext();
@@ -228,7 +241,7 @@ describe("Twitter auth handler", () => {
     });
 
     test("fails if no client credentials configured", async () => {
-      rawConfigStore = { twitterIntegrationMode: "local_byo" };
+      rawConfigStore = { twitter: { integrationMode: "local_byo" } };
       // No client ID in secure storage
 
       const msg: TwitterAuthStartRequest = { type: "twitter_auth_start" };
@@ -249,7 +262,7 @@ describe("Twitter auth handler", () => {
     });
 
     test("succeeds with valid config (mock orchestrator)", async () => {
-      rawConfigStore = { twitterIntegrationMode: "local_byo" };
+      rawConfigStore = { twitter: { integrationMode: "local_byo" } };
       secureKeyStore["credential:integration:twitter:oauth_client_id"] =
         "test-client-id";
       secureKeyStore["credential:integration:twitter:oauth_client_secret"] =
@@ -283,7 +296,7 @@ describe("Twitter auth handler", () => {
     });
 
     test("delegates to orchestrateOAuthConnect with correct options", async () => {
-      rawConfigStore = { twitterIntegrationMode: "local_byo" };
+      rawConfigStore = { twitter: { integrationMode: "local_byo" } };
       secureKeyStore["credential:integration:twitter:oauth_client_id"] =
         "test-client-id";
       secureKeyStore["credential:integration:twitter:oauth_client_secret"] =
@@ -312,7 +325,7 @@ describe("Twitter auth handler", () => {
     });
 
     test("fails fast with actionable error when no ingress URL is configured", async () => {
-      rawConfigStore = { twitterIntegrationMode: "local_byo" };
+      rawConfigStore = { twitter: { integrationMode: "local_byo" } };
       secureKeyStore["credential:integration:twitter:oauth_client_id"] =
         "test-client-id";
       mockIngressPublicBaseUrl = undefined;
@@ -349,7 +362,7 @@ describe("Twitter auth handler", () => {
     });
 
     test("maps orchestrator error result to twitter_auth_result", async () => {
-      rawConfigStore = { twitterIntegrationMode: "local_byo" };
+      rawConfigStore = { twitter: { integrationMode: "local_byo" } };
       secureKeyStore["credential:integration:twitter:oauth_client_id"] =
         "test-client-id";
 
@@ -379,7 +392,7 @@ describe("Twitter auth handler", () => {
 
     describe("auth hardening", () => {
       test("OAuth cancel path returns sanitized failure", async () => {
-        rawConfigStore = { twitterIntegrationMode: "local_byo" };
+        rawConfigStore = { twitter: { integrationMode: "local_byo" } };
         secureKeyStore["credential:integration:twitter:oauth_client_id"] =
           "test-client-id";
 
@@ -404,7 +417,7 @@ describe("Twitter auth handler", () => {
       });
 
       test("OAuth timeout path returns sanitized failure", async () => {
-        rawConfigStore = { twitterIntegrationMode: "local_byo" };
+        rawConfigStore = { twitter: { integrationMode: "local_byo" } };
         secureKeyStore["credential:integration:twitter:oauth_client_id"] =
           "test-client-id";
 
@@ -431,7 +444,7 @@ describe("Twitter auth handler", () => {
       });
 
       test("error payload never includes secrets or raw provider bodies", async () => {
-        rawConfigStore = { twitterIntegrationMode: "local_byo" };
+        rawConfigStore = { twitter: { integrationMode: "local_byo" } };
         secureKeyStore["credential:integration:twitter:oauth_client_id"] =
           "test-client-id";
 
@@ -466,7 +479,7 @@ describe("Twitter auth handler", () => {
       });
 
       test("succeeds even when identity verification returns no accountInfo", async () => {
-        rawConfigStore = { twitterIntegrationMode: "local_byo" };
+        rawConfigStore = { twitter: { integrationMode: "local_byo" } };
         secureKeyStore["credential:integration:twitter:oauth_client_id"] =
           "test-client-id";
 
@@ -499,7 +512,7 @@ describe("Twitter auth handler", () => {
 
   describe("twitter_auth_status", () => {
     test("returns disconnected when no token exists", () => {
-      rawConfigStore = { twitterIntegrationMode: "local_byo" };
+      rawConfigStore = { twitter: { integrationMode: "local_byo" } };
 
       const msg: TwitterAuthStatusRequest = { type: "twitter_auth_status" };
       const { ctx, sent } = createTestContext();
@@ -519,7 +532,7 @@ describe("Twitter auth handler", () => {
     });
 
     test("returns connected with account info when token exists", () => {
-      rawConfigStore = { twitterIntegrationMode: "local_byo" };
+      rawConfigStore = { twitter: { integrationMode: "local_byo" } };
       secureKeyStore["credential:integration:twitter:access_token"] =
         "test-access-token";
       credentialMetadataStore.push({

--- a/assistant/src/__tests__/twitter-cli-routing.test.ts
+++ b/assistant/src/__tests__/twitter-cli-routing.test.ts
@@ -182,7 +182,7 @@ describe("Twitter strategy router", () => {
         };
         expect(e.message).toContain("OAuth is not configured");
         expect(e.message).toContain(
-          "assistant config set twitterOperationStrategy browser",
+          "assistant config set twitter.operationStrategy browser",
         );
         expect(e.pathUsed).toBe("oauth");
         expect(e.suggestAlternative).toBe("browser");

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -18,7 +18,7 @@ OAuth uses the official X API v2. It is the most reliable connection method and 
 - Supports: **post** and **reply**
 - Read-only operations (timeline, search, home, bookmarks, notifications, likes, followers, following, media) always use the browser path directly, regardless of the strategy setting.
 - Setup: Collect the OAuth Client ID (and optional Client Secret) from the user in chat using `credential_store` with `action: "prompt"` (canonical field names: `client_id`, `client_secret`), then initiate the `twitter_auth_start` flow. See the **First-Use Decision Flow** for the full sequence.
-- Set the strategy: `assistant config set twitterOperationStrategy oauth`
+- Set the strategy: `assistant config set twitter.operationStrategy oauth`
 
 ### Browser session (no developer credentials needed)
 
@@ -26,13 +26,13 @@ The browser path is quick to start and useful when the user does not have X deve
 
 - Supports: **all operations** (post, reply, timeline, search, home, bookmarks, notifications, likes, followers, following, media)
 - Setup: Run `assistant x refresh` to open Chrome and capture session cookies automatically.
-- Set the strategy: `assistant config set twitterOperationStrategy browser`
+- Set the strategy: `assistant config set twitter.operationStrategy browser`
 
 ### Auto mode (default)
 
 When the strategy is `auto` (the default), the router tries OAuth first for supported operations if credentials are available, then falls back to the browser path. This gives the best of both worlds without requiring manual switching.
 
-- Set auto mode: `assistant config set twitterOperationStrategy auto`
+- Set auto mode: `assistant config set twitter.operationStrategy auto`
 
 ## First-Use Decision Flow
 
@@ -42,7 +42,7 @@ When the user triggers a Twitter operation and no strategy has been configured y
 
    ```bash
    # Check strategy
-   assistant config get twitterOperationStrategy
+   assistant config get twitter.operationStrategy
 
    # Check if OAuth token is available
    assistant oauth token twitter --json
@@ -81,7 +81,7 @@ When the user chooses OAuth, collect their X developer credentials conversationa
 
 5. **Set the preferred strategy:**
    ```bash
-   assistant config set twitterOperationStrategy <oauth|browser|auto>
+   assistant config set twitter.operationStrategy <oauth|browser|auto>
    ```
 
 ## Failure Recovery Flow
@@ -99,14 +99,14 @@ When a Twitter operation fails, follow these steps:
 
 3. **Suggest trying the other path as an alternative:**
    - If the browser session expired: suggest setting up OAuth for post/reply operations, or refresh the browser session with `assistant x refresh`.
-   - If OAuth failed or is not configured: suggest using the browser path with `assistant config set twitterOperationStrategy browser` and `assistant x refresh`.
-   - If the operation is unsupported via OAuth: explain that this write operation is not yet supported via OAuth, and suggest using the browser path with `assistant config set twitterOperationStrategy browser`.
+   - If OAuth failed or is not configured: suggest using the browser path with `assistant config set twitter.operationStrategy browser` and `assistant x refresh`.
+   - If the operation is unsupported via OAuth: explain that this write operation is not yet supported via OAuth, and suggest using the browser path with `assistant config set twitter.operationStrategy browser`.
 
 4. **Offer concrete steps to switch:**
 
    ```bash
    # Switch to the other strategy
-   assistant config set twitterOperationStrategy <oauth|browser|auto>
+   assistant config set twitter.operationStrategy <oauth|browser|auto>
 
    # If switching to browser, refresh the session
    assistant x refresh
@@ -116,12 +116,12 @@ When a Twitter operation fails, follow these steps:
 
 ```bash
 # Check current strategy
-assistant config get twitterOperationStrategy
+assistant config get twitter.operationStrategy
 
 # Set strategy to OAuth, browser, or auto
-assistant config set twitterOperationStrategy oauth
-assistant config set twitterOperationStrategy browser
-assistant config set twitterOperationStrategy auto
+assistant config set twitter.operationStrategy oauth
+assistant config set twitter.operationStrategy browser
+assistant config set twitter.operationStrategy auto
 
 # Check full status (session, OAuth, and strategy info)
 assistant x status --json
@@ -133,7 +133,7 @@ Before posting, fetch the current strategy and OAuth token:
 
 ```bash
 # 1. Get the configured strategy
-STRATEGY=$(assistant config get twitterOperationStrategy)
+STRATEGY=$(assistant config get twitter.operationStrategy)
 # If not set, default to "auto"
 
 # 2. If strategy is "oauth" or "auto", get a valid OAuth token

--- a/assistant/src/daemon/handlers/config-integrations.ts
+++ b/assistant/src/daemon/handlers/config-integrations.ts
@@ -1,6 +1,11 @@
 import * as net from "node:net";
 
-import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
+import {
+  getNestedValue,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../config/loader.js";
 import {
   deleteSecureKeyAsync,
   getSecureKey,
@@ -108,18 +113,18 @@ export async function handleTwitterIntegrationConfig(
     if (msg.action === "get") {
       const raw = loadRawConfig();
       const mode =
-        (raw.twitterIntegrationMode as "local_byo" | "managed" | undefined) ??
-        "local_byo";
+        (getNestedValue(raw, "twitter.integrationMode") as
+          | "local_byo"
+          | "managed"
+          | undefined) ?? "local_byo";
       const strategy =
-        (raw.twitterOperationStrategy as
+        (getNestedValue(raw, "twitter.operationStrategy") as
           | "oauth"
           | "browser"
           | "auto"
           | undefined) ?? "auto";
-      const strategyConfigured = Object.prototype.hasOwnProperty.call(
-        raw,
-        "twitterOperationStrategy",
-      );
+      const strategyConfigured =
+        getNestedValue(raw, "twitter.operationStrategy") !== undefined;
       const localClientConfigured = hasTwitterClientId();
       const connected = !!getSecureKey(
         "credential:integration:twitter:access_token",
@@ -139,15 +144,13 @@ export async function handleTwitterIntegrationConfig(
     } else if (msg.action === "get_strategy") {
       const raw = loadRawConfig();
       const strategy =
-        (raw.twitterOperationStrategy as
+        (getNestedValue(raw, "twitter.operationStrategy") as
           | "oauth"
           | "browser"
           | "auto"
           | undefined) ?? "auto";
-      const strategyConfigured = Object.prototype.hasOwnProperty.call(
-        raw,
-        "twitterOperationStrategy",
-      );
+      const strategyConfigured =
+        getNestedValue(raw, "twitter.operationStrategy") !== undefined;
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: true,
@@ -174,7 +177,7 @@ export async function handleTwitterIntegrationConfig(
         return;
       }
       const raw = loadRawConfig();
-      raw.twitterOperationStrategy = value;
+      setNestedValue(raw, "twitter.operationStrategy", value);
       saveRawConfig(raw);
       ctx.send(socket, {
         type: "twitter_integration_config_response",
@@ -189,7 +192,7 @@ export async function handleTwitterIntegrationConfig(
       });
     } else if (msg.action === "set_mode") {
       const raw = loadRawConfig();
-      raw.twitterIntegrationMode = msg.mode ?? "local_byo";
+      setNestedValue(raw, "twitter.integrationMode", msg.mode ?? "local_byo");
       saveRawConfig(raw);
       ctx.send(socket, {
         type: "twitter_integration_config_response",

--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -1,6 +1,10 @@
 import * as net from "node:net";
 
-import { loadConfig, loadRawConfig } from "../../config/loader.js";
+import {
+  getNestedValue,
+  loadConfig,
+  loadRawConfig,
+} from "../../config/loader.js";
 import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
 import { orchestrateOAuthConnect } from "../../oauth/connect-orchestrator.js";
 import { getSecureKey } from "../../security/secure-keys.js";
@@ -51,7 +55,8 @@ export async function handleTwitterAuthStart(
   try {
     const raw = loadRawConfig();
     const mode =
-      (raw.twitterIntegrationMode as string | undefined) ?? "local_byo";
+      (getNestedValue(raw, "twitter.integrationMode") as string | undefined) ??
+      "local_byo";
     if (mode !== "local_byo") {
       ctx.send(socket, {
         type: "twitter_auth_result",
@@ -186,8 +191,10 @@ export function handleTwitterAuthStatus(
     );
     const raw = loadRawConfig();
     const mode =
-      (raw.twitterIntegrationMode as "local_byo" | "managed" | undefined) ??
-      "local_byo";
+      (getNestedValue(raw, "twitter.integrationMode") as
+        | "local_byo"
+        | "managed"
+        | undefined) ?? "local_byo";
     const meta = getCredentialMetadata("integration:twitter", "access_token");
 
     ctx.send(socket, {

--- a/assistant/src/twitter/router.ts
+++ b/assistant/src/twitter/router.ts
@@ -44,7 +44,7 @@ export async function routedPostTweet(
     if (!oauthIsAvailable(opts.oauthToken)) {
       throw Object.assign(
         new Error(
-          "OAuth is not configured. Provide your X developer credentials here in the chat to set up OAuth, or switch to browser strategy: `assistant config set twitterOperationStrategy browser`.",
+          "OAuth is not configured. Provide your X developer credentials here in the chat to set up OAuth, or switch to browser strategy: `assistant config set twitter.operationStrategy browser`.",
         ),
         {
           pathUsed: "oauth" as const,


### PR DESCRIPTION
## Summary
- Rename `twitterOperationStrategy` -> `twitter.operationStrategy` and `twitterIntegrationMode` -> `twitter.integrationMode` to follow the project's dot-separated config key convention
- Update daemon handlers to use `getNestedValue`/`setNestedValue` instead of direct property access on the raw config object
- Update all tests, SKILL.md, README, and architecture docs

## Original prompt
Align `twitterOperationStrategy` config key to the project's dot-separated naming convention (`twitter.operationStrategy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
