### PR TITLE
fix: share popover, panel styling, and icon transparency

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
@@ -166,7 +166,7 @@ extension MainWindowView {
         if let base64 = iconBase64,
            let data = Data(base64Encoded: base64),
            let image = NSImage(data: data) {
-            return image
+            return roundedIcon(from: image)
         }
 
         let glyph = (emojiIcon.flatMap { $0.isEmpty ? nil : $0 })
@@ -179,11 +179,12 @@ extension MainWindowView {
 
     /// Sets a custom icon on the file so the share sheet shows it instead of a blank document.
     /// Prefers the AI-generated icon (base64 PNG), falls back to rendering the emoji or app initial.
+    /// All icons are clipped to a rounded rect so Finder shows transparent corners.
     static func applyFileIcon(to url: URL, iconBase64: String?, emojiIcon: String?, appName: String) {
         if let base64 = iconBase64,
            let data = Data(base64Encoded: base64),
            let image = NSImage(data: data) {
-            NSWorkspace.shared.setIcon(image, forFile: url.path, options: [])
+            NSWorkspace.shared.setIcon(roundedIcon(from: image), forFile: url.path, options: [])
             return
         }
 
@@ -193,6 +194,17 @@ extension MainWindowView {
         if !glyph.isEmpty {
             let image = renderEmojiIcon(emoji: glyph, size: 512)
             NSWorkspace.shared.setIcon(image, forFile: url.path, options: [])
+        }
+    }
+
+    /// Clips an image to a rounded rect with transparent corners, matching macOS icon shape.
+    private static func roundedIcon(from source: NSImage, size: CGFloat = 512) -> NSImage {
+        let cornerRadius = size * 0.22
+        return NSImage(size: NSSize(width: size, height: size), flipped: false) { rect in
+            let path = NSBezierPath(roundedRect: rect, xRadius: cornerRadius, yRadius: cornerRadius)
+            path.addClip()
+            source.draw(in: rect, from: .zero, operation: .sourceOver, fraction: 1.0)
+            return true
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -886,18 +886,6 @@ struct DynamicWorkspaceWrapper: View {
 
                     ZStack {
                         if let appId = data.appId {
-                            AppSharePanel(
-                                items: sharing.shareFileURL != nil ? [sharing.shareFileURL!] : [],
-                                isPresented: Binding(
-                                    get: { sharing.showSharePicker },
-                                    set: { sharing.showSharePicker = $0 }
-                                ),
-                                appName: sharing.shareAppName,
-                                appIcon: sharing.shareAppIcon
-                            )
-                            .frame(width: 0, height: 0)
-                            .opacity(0)
-
                             if sharing.isBundling || sharing.isPublishing {
                                 ProgressView()
                                     .controlSize(.small)
@@ -917,6 +905,18 @@ struct DynamicWorkspaceWrapper: View {
                                             onPublishPage(data.html, data.preview?.title, data.appId)
                                         }
                                     )
+                                }
+                                .overlay {
+                                    AppSharePanel(
+                                        items: sharing.shareFileURL != nil ? [sharing.shareFileURL!] : [],
+                                        isPresented: Binding(
+                                            get: { sharing.showSharePicker },
+                                            set: { sharing.showSharePicker = $0 }
+                                        ),
+                                        appName: sharing.shareAppName,
+                                        appIcon: sharing.shareAppIcon
+                                    )
+                                    .allowsHitTesting(false)
                                 }
                             }
                         } else if sharing.isPublishing {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -167,21 +167,6 @@ struct AppsGridView: View {
                 )
                 .overlay(alignment: .topTrailing) {
                     ZStack {
-                        AppSharePanel(
-                            items: shareFileURL != nil && sharingAppId == app.id ? [shareFileURL!] : [],
-                            isPresented: Binding(
-                                get: { showShareSheet && sharingAppId == app.id },
-                                set: { newValue in
-                                    showShareSheet = newValue
-                                    if !newValue { sharingAppId = nil }
-                                }
-                            ),
-                            appName: shareAppName,
-                            appIcon: shareAppIcon
-                        )
-                        .frame(width: 0, height: 0)
-                        .opacity(0)
-
                         VIconButton(label: "App actions", icon: "ellipsis", iconOnly: true, variant: .filled(VColor.buttonPrimary), size: 24) {}
                             .allowsHitTesting(false)
                         Menu {
@@ -231,6 +216,21 @@ struct AppsGridView: View {
                     .opacity(isHovered ? 1 : 0)
                     .allowsHitTesting(isHovered)
                     .animation(VAnimation.fast, value: isHovered)
+                    .overlay {
+                        AppSharePanel(
+                            items: shareFileURL != nil && sharingAppId == app.id ? [shareFileURL!] : [],
+                            isPresented: Binding(
+                                get: { showShareSheet && sharingAppId == app.id },
+                                set: { newValue in
+                                    showShareSheet = newValue
+                                    if !newValue { sharingAppId = nil }
+                                }
+                            ),
+                            appName: shareAppName,
+                            appIcon: shareAppIcon
+                        )
+                        .allowsHitTesting(false)
+                    }
                 }
 
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -167,8 +167,14 @@ struct AppsGridView: View {
                 )
                 .overlay(alignment: .topTrailing) {
                     ZStack {
-                        VIconButton(label: "App actions", icon: "ellipsis", iconOnly: true, variant: .filled(VColor.buttonPrimary), size: 24) {}
-                            .allowsHitTesting(false)
+                        if isBundling && sharingAppId == app.id {
+                            ProgressView()
+                                .controlSize(.small)
+                                .frame(width: 24, height: 24)
+                        } else {
+                            VIconButton(label: "App actions", icon: "ellipsis", iconOnly: true, variant: .filled(VColor.buttonPrimary), size: 24) {}
+                                .allowsHitTesting(false)
+                        }
                         Menu {
                             Button {
                                 if app.isPinned {
@@ -213,8 +219,8 @@ struct AppsGridView: View {
                     .padding(VSpacing.sm)
                     .contentShape(Rectangle())
                     .onTapGesture {} // absorb tap so it doesn't propagate to parent Button
-                    .opacity(isHovered ? 1 : 0)
-                    .allowsHitTesting(isHovered)
+                    .opacity(isHovered || (isBundling && sharingAppId == app.id) ? 1 : 0)
+                    .allowsHitTesting(isHovered || (isBundling && sharingAppId == app.id))
                     .animation(VAnimation.fast, value: isHovered)
                     .overlay {
                         AppSharePanel(

--- a/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
@@ -65,6 +65,12 @@ struct AppSharePanelView: View {
             .frame(maxHeight: 300)
         }
         .frame(width: 240)
+        .onDisappear {
+            if hoveredServiceIndex != nil {
+                NSCursor.pop()
+                hoveredServiceIndex = nil
+            }
+        }
         .background(VColor.surfaceSubtle)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
         .overlay(

--- a/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
@@ -19,8 +19,7 @@ struct AppSharePanelView: View {
             header
                 .padding(VSpacing.lg)
 
-            Divider()
-                .background(VColor.surfaceBorder)
+            VColor.surfaceBorder.frame(height: 1)
 
             // Services list
             ScrollView {
@@ -46,8 +45,8 @@ struct AppSharePanelView: View {
                         }
                     }
 
-                    Divider()
-                        .background(VColor.surfaceBorder)
+                    VColor.surfaceBorder.frame(height: 1)
+                        .padding(.horizontal, VSpacing.xs)
                         .padding(.vertical, VSpacing.xs)
 
                     // Copy row
@@ -66,8 +65,13 @@ struct AppSharePanelView: View {
             .frame(maxHeight: 300)
         }
         .frame(width: 240)
-        .background(VColor.surface)
+        .background(VColor.surfaceSubtle)
         .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.15), radius: 6, y: 2)
         .onAppear {
             services = Self.availableSharingServices(for: fileURL)
         }
@@ -119,14 +123,14 @@ struct AppSharePanelView: View {
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
-            HStack(spacing: VSpacing.md) {
+            HStack(spacing: VSpacing.sm) {
                 if let icon {
                     Image(nsImage: icon)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(width: 20, height: 20)
+                        .frame(width: 18, height: 18)
                 } else {
-                    Color.clear.frame(width: 20, height: 20)
+                    Color.clear.frame(width: 18, height: 18)
                 }
 
                 Text(title)
@@ -137,12 +141,13 @@ struct AppSharePanelView: View {
             }
             .padding(.horizontal, VSpacing.md)
             .padding(.vertical, VSpacing.sm)
-            .background(hoveredServiceIndex == index ? VColor.backgroundSubtle : Color.clear)
+            .background(hoveredServiceIndex == index ? VColor.navHover : Color.clear)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .onHover { hovering in
             hoveredServiceIndex = hovering ? index : nil
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Sharing/ShareSheetHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/ShareSheetHelper.swift
@@ -20,15 +20,8 @@ struct AppSharePanel: NSViewRepresentable {
         context.coordinator.appName = appName
         context.coordinator.appIcon = appIcon
         if isPresented && !context.coordinator.isPopoverShown {
-            DispatchQueue.main.async {
-                guard nsView.window != nil else {
-                    self.isPresented = false
-                    return
-                }
-                context.coordinator.onDismiss = {
-                    self.isPresented = false
-                }
-                context.coordinator.showPopover(relativeTo: nsView)
+            context.coordinator.presentWhenReady(nsView: nsView) {
+                self.isPresented = false
             }
         } else if !isPresented && context.coordinator.isPopoverShown {
             context.coordinator.dismissPopover()
@@ -51,6 +44,26 @@ struct AppSharePanel: NSViewRepresentable {
             self.items = items
             self.appName = appName
             self.appIcon = appIcon
+        }
+
+        /// Waits for the NSView to be added to a window before showing the popover.
+        /// When `isBundling` flips to `false` and `showSharePicker` becomes `true`
+        /// in the same state update, SwiftUI swaps the spinner for the share button
+        /// and creates a fresh AppSharePanel overlay. The new NSView may not yet be
+        /// in a window when `updateNSView` fires, so we poll until it is.
+        func presentWhenReady(nsView: NSView, attempt: Int = 0, onDismiss: @escaping () -> Void) {
+            if nsView.window != nil {
+                self.onDismiss = onDismiss
+                showPopover(relativeTo: nsView)
+                return
+            }
+            if attempt >= 10 {
+                onDismiss()
+                return
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+                self?.presentWhenReady(nsView: nsView, attempt: attempt + 1, onDismiss: onDismiss)
+            }
         }
 
         func showPopover(relativeTo view: NSView) {


### PR DESCRIPTION
## Summary
- **Share popover not appearing**: When bundling completes, SwiftUI swaps the spinner for the share button in the same render pass. The `AppSharePanel` overlay's NSView wasn't in a window yet when `updateNSView` fired, so the popover silently failed. Fixed by polling for window attachment (up to 500ms) before showing. Also moved the `AppSharePanel` from a standalone 0×0 hidden view to an `.overlay` on the share button so it inherits the button's frame.
- **Share panel styling**: Updated `AppSharePanelView` to match app drawer conventions — `surfaceSubtle` background, `navHover` row highlights, `surfaceBorder` stroke, consistent shadow/spacing, pointing hand cursor.
- **Icon transparency**: AI-generated icon PNGs have opaque backgrounds causing white square corners in Finder. Now clips to a rounded rect (22% corner radius) before applying as file icon and in the share panel header.

## Test plan
- [ ] Open an app from Things, click Share icon → Share — popover should appear with sharing services
- [ ] Verify share panel styling matches other app popovers (background, hover, border)
- [ ] Share an app with an AI-generated icon → check Downloads — icon should have rounded corners with transparent background

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
