### PR TITLE
fix: hide .vellum extension in Finder for shared bundles

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
@@ -154,6 +154,13 @@ extension MainWindowView {
         try? FileManager.default.removeItem(at: cleanURL)
         do {
             try FileManager.default.linkItem(at: originalURL, to: cleanURL)
+            // Hide .vellum extension in Finder so it displays as just the app name
+            var resourceURL = cleanURL
+            try? resourceURL.setResourceValues({
+                var v = URLResourceValues()
+                v.hasHiddenExtension = true
+                return v
+            }())
             return cleanURL
         } catch {
             return originalURL


### PR DESCRIPTION
## Summary
- Sets `hasHiddenExtension` on shared `.vellum` bundle files so Finder displays them as just the app name (e.g. "inkwell" instead of "inkwell.vellum")

## Test plan
- [ ] Share an app from the Things list → verify the file in Downloads shows without the `.vellum` extension
- [ ] Right-click → Get Info on the downloaded file → confirm "Hide extension" is checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
