### PR TITLE
feat: add app_builder_multifile_enabled feature flag

### DIFF
--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -112,6 +112,14 @@
       "label": "Outbound Proxy Sidecar",
       "description": "Route proxy session management through the sidecar process instead of running in-process",
       "defaultEnabled": false
+    },
+    {
+      "id": "app-builder-multifile",
+      "scope": "assistant",
+      "key": "feature_flags.app-builder-multifile.enabled",
+      "label": "App Builder Multi-file",
+      "description": "Enable multi-file TSX app creation with esbuild compilation instead of single-HTML apps",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -112,6 +112,14 @@
       "label": "Outbound Proxy Sidecar",
       "description": "Route proxy session management through the sidecar process instead of running in-process",
       "defaultEnabled": false
+    },
+    {
+      "id": "app-builder-multifile",
+      "scope": "assistant",
+      "key": "feature_flags.app-builder-multifile.enabled",
+      "label": "App Builder Multi-file",
+      "description": "Enable multi-file TSX app creation with esbuild compilation instead of single-HTML apps",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `app-builder-multifile` feature flag to registry (defaultEnabled: false)
- Copy updated registry to assistant bundled config

Part of plan: multifile-tsx-esbuild-apps.md (PR 1 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
