### PR TITLE
feat: add one-way migration helper from legacy HTML to src/ layout

### DIFF
--- a/assistant/src/__tests__/app-migration.test.ts
+++ b/assistant/src/__tests__/app-migration.test.ts
@@ -1,0 +1,147 @@
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { migrateAppToMultifile } from "../memory/app-migration.js";
+import { createApp, getApp, getAppsDir } from "../memory/app-store.js";
+
+// Redirect app storage to a temp directory for test isolation
+const tmpDir = join(import.meta.dir, ".tmp-app-migration-test");
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => tmpDir,
+  isContainerized: () => false,
+}));
+
+describe("migrateAppToMultifile", () => {
+  beforeEach(() => {
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("migrates a simple HTML app to src/ layout", () => {
+    const app = createApp({
+      name: "Test App",
+      schemaJson: "{}",
+      htmlDefinition: "<html><body>Hello</body></html>",
+    });
+
+    const result = migrateAppToMultifile(app.id);
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeUndefined();
+
+    const appDir = join(getAppsDir(), app.id);
+
+    // Root index.html is preserved
+    expect(existsSync(join(appDir, "index.html"))).toBe(true);
+    expect(readFileSync(join(appDir, "index.html"), "utf-8")).toBe(
+      "<html><body>Hello</body></html>",
+    );
+
+    // src/index.html created
+    expect(existsSync(join(appDir, "src", "index.html"))).toBe(true);
+
+    // src/main.tsx created
+    const mainTsx = readFileSync(join(appDir, "src", "main.tsx"), "utf-8");
+    expect(mainTsx).toContain("Entry point");
+    expect(mainTsx).toContain("import './styles.css'");
+  });
+
+  test("sets formatVersion to 2 after migration", () => {
+    const app = createApp({
+      name: "Version Test",
+      schemaJson: "{}",
+      htmlDefinition: "<html><body>Hi</body></html>",
+    });
+
+    expect(app.formatVersion).toBeUndefined();
+
+    migrateAppToMultifile(app.id);
+
+    const updated = getApp(app.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.formatVersion).toBe(2);
+  });
+
+  test("extracts inline styles to CSS file", () => {
+    const htmlWithStyle = `<html>
+<head><style>body { color: red; }</style></head>
+<body>Styled</body>
+</html>`;
+
+    const app = createApp({
+      name: "Styled App",
+      schemaJson: "{}",
+      htmlDefinition: htmlWithStyle,
+    });
+
+    const result = migrateAppToMultifile(app.id);
+    expect(result.ok).toBe(true);
+
+    const appDir = join(getAppsDir(), app.id);
+
+    // styles.css should contain the extracted CSS
+    const css = readFileSync(join(appDir, "src", "styles.css"), "utf-8");
+    expect(css).toContain("body { color: red; }");
+
+    // src/index.html should have a <link> tag instead of <style>
+    const srcHtml = readFileSync(join(appDir, "src", "index.html"), "utf-8");
+    expect(srcHtml).toContain('<link rel="stylesheet" href="styles.css">');
+    expect(srcHtml).not.toContain("<style>");
+  });
+
+  test("extracts multiple inline style blocks", () => {
+    const html = `<html>
+<head><style>.a { margin: 0; }</style></head>
+<body><style>.b { padding: 0; }</style></body>
+</html>`;
+
+    const app = createApp({
+      name: "Multi Style",
+      schemaJson: "{}",
+      htmlDefinition: html,
+    });
+
+    migrateAppToMultifile(app.id);
+
+    const appDir = join(getAppsDir(), app.id);
+    const css = readFileSync(join(appDir, "src", "styles.css"), "utf-8");
+    expect(css).toContain(".a { margin: 0; }");
+    expect(css).toContain(".b { padding: 0; }");
+  });
+
+  test("migration of already-migrated app is a no-op", () => {
+    const app = createApp({
+      name: "Already Migrated",
+      schemaJson: "{}",
+      htmlDefinition: "<html><body>Done</body></html>",
+    });
+
+    const first = migrateAppToMultifile(app.id);
+    expect(first.ok).toBe(true);
+
+    // Grab the updatedAt after first migration
+    const afterFirst = getApp(app.id);
+    const firstUpdatedAt = afterFirst!.updatedAt;
+
+    // Small delay so updatedAt would differ if re-written
+    const second = migrateAppToMultifile(app.id);
+    expect(second.ok).toBe(true);
+
+    // formatVersion should still be 2
+    const afterSecond = getApp(app.id);
+    expect(afterSecond!.formatVersion).toBe(2);
+
+    // updatedAt should NOT have changed (no-op)
+    expect(afterSecond!.updatedAt).toBe(firstUpdatedAt);
+  });
+
+  test("returns error when app not found", () => {
+    const result = migrateAppToMultifile("nonexistent-id-12345");
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("App not found");
+  });
+});

--- a/assistant/src/memory/app-migration.ts
+++ b/assistant/src/memory/app-migration.ts
@@ -1,0 +1,113 @@
+/**
+ * One-way migration helper: converts legacy single-HTML apps to the
+ * multi-file src/ layout (formatVersion 2).
+ *
+ * Non-destructive — the root index.html is preserved as a legacy fallback.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getApp, getAppsDir, isMultifileApp } from "./app-store.js";
+
+export interface MigrationResult {
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * Extract inline `<style>` blocks from HTML, returning the extracted CSS
+ * and the HTML with those blocks replaced by a `<link>` tag.
+ */
+function extractInlineStyles(html: string): {
+  css: string;
+  html: string;
+} {
+  const styleRegex = /<style[^>]*>([\s\S]*?)<\/style>/gi;
+  const cssChunks: string[] = [];
+
+  for (const match of html.matchAll(styleRegex)) {
+    cssChunks.push(match[1].trim());
+  }
+
+  if (cssChunks.length === 0) {
+    return { css: "", html };
+  }
+
+  const css = cssChunks.join("\n\n");
+
+  // Replace the first <style> block with a <link> tag, remove the rest
+  let replaced = false;
+  const updatedHtml = html.replace(styleRegex, () => {
+    if (!replaced) {
+      replaced = true;
+      return `<link rel="stylesheet" href="styles.css">`;
+    }
+    return "";
+  });
+
+  return { css, html: updatedHtml };
+}
+
+/**
+ * Migrate a legacy single-HTML app to the multi-file src/ layout.
+ *
+ * Steps:
+ *   1. Read existing index.html
+ *   2. Create {appId}/src/ directory
+ *   3. Copy HTML content to src/index.html (with inline styles extracted)
+ *   4. Create src/main.tsx placeholder entry point
+ *   5. If inline styles found, write src/styles.css
+ *   6. Update app metadata to formatVersion: 2
+ *   7. Keep root index.html untouched (legacy fallback)
+ */
+export function migrateAppToMultifile(appId: string): MigrationResult {
+  const app = getApp(appId);
+  if (!app) {
+    return { ok: false, error: `App not found: ${appId}` };
+  }
+
+  // Already migrated — treat as no-op
+  if (isMultifileApp(app)) {
+    return { ok: true };
+  }
+
+  const appsDir = getAppsDir();
+  const appDir = join(appsDir, appId);
+  const rootIndex = join(appDir, "index.html");
+
+  if (!existsSync(rootIndex)) {
+    return { ok: false, error: `Root index.html not found for app ${appId}` };
+  }
+
+  const originalHtml = readFileSync(rootIndex, "utf-8");
+
+  // Create src/ directory
+  const srcDir = join(appDir, "src");
+  mkdirSync(srcDir, { recursive: true });
+
+  // Extract inline styles if present
+  const { css, html: processedHtml } = extractInlineStyles(originalHtml);
+
+  // Write src/index.html
+  writeFileSync(join(srcDir, "index.html"), processedHtml, "utf-8");
+
+  // Write src/main.tsx placeholder
+  const mainTsx = `// Entry point — migrated from legacy single-file app\nimport './styles.css';\n\nconsole.log('App loaded');\n`;
+  writeFileSync(join(srcDir, "main.tsx"), mainTsx, "utf-8");
+
+  // Write src/styles.css if styles were extracted
+  if (css) {
+    writeFileSync(join(srcDir, "styles.css"), css, "utf-8");
+  }
+
+  // Update metadata to formatVersion 2
+  const metadataPath = join(appsDir, `${appId}.json`);
+  const rawMeta = readFileSync(metadataPath, "utf-8");
+  const metadata = JSON.parse(rawMeta);
+  metadata.formatVersion = 2;
+  metadata.updatedAt = Date.now();
+  writeFileSync(metadataPath, JSON.stringify(metadata, null, 2));
+
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- Add `migrateAppToMultifile()` for non-destructive migration of legacy apps to src/ layout
- Extracts inline styles to separate CSS file
- Sets formatVersion: 2 on migrated app metadata
- Preserves root index.html as legacy fallback
- Full test coverage including idempotency and error cases

Part of plan: multifile-tsx-esbuild-apps.md (PR 5 of 13)

## Test plan
- [x] Migrates simple HTML app to src/ layout
- [x] Sets formatVersion to 2 after migration
- [x] Extracts inline styles to CSS file
- [x] Handles multiple inline style blocks
- [x] Migration of already-migrated app is idempotent (no-op)
- [x] Returns error for non-existent app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
