### PR TITLE
fix: flush coalesced publish after clearing composer inputText

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -62,6 +62,16 @@ public final class ChatViewModel: ObservableObject {
         }
     }
 
+    /// Flush any pending coalesced publish immediately.
+    /// Used after clearing `inputText` in `sendMessage()` so the TextField
+    /// binding updates without the 100ms delay — preventing the field editor
+    /// from writing stale text back through the binding.
+    private func flushCoalescedPublish() {
+        subManagerPublishTask?.cancel()
+        subManagerPublishTask = nil
+        objectWillChange.send()
+    }
+
     // MARK: - Debug publish-rate counters
 
     #if DEBUG
@@ -1004,11 +1014,13 @@ public final class ChatViewModel: ObservableObject {
                 secretBlockedActiveSurfaceId = nil
                 secretBlockedCurrentPage = nil
                 currentTurnUserText = rawText
+                flushCoalescedPublish()
                 return
             }
             pendingSkillInvocation = nil
             inputText = ""
             pendingAttachments = []
+            flushCoalescedPublish()
             return
         }
 
@@ -1054,6 +1066,7 @@ public final class ChatViewModel: ObservableObject {
         secretBlockedAttachments = nil
         secretBlockedActiveSurfaceId = nil
         secretBlockedCurrentPage = nil
+        flushCoalescedPublish()
 
         let ipcAttachments: [IPCAttachment]? = attachments.isEmpty ? nil : attachments.map {
             IPCAttachment(filename: $0.filename, mimeType: $0.mimeType, data: $0.data, extractedText: nil)


### PR DESCRIPTION
## Summary
- When `sendMessage()` clears `inputText`, the `objectWillChange` notification was delayed by 100ms coalescing, creating a window where the NSTextView field editor could write stale text back through the binding
- Added `flushCoalescedPublish()` method that cancels pending coalesced tasks and sends `objectWillChange` immediately
- Called it after `inputText = ""` in all three `sendMessage()` exit paths (bootstrapping with queued message, bootstrapping duplicate guard, and normal send)

## Original prompt
implement that fix for the issue you were just looking into

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
