### PR TITLE
feat: scaffold src/index.html + src/main.tsx for new-format app creation

### DIFF
--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { AppDefinition } from "../memory/app-store.js";
 import type { AppStore } from "../tools/apps/executors.js";
 import {
+  executeAppCreate,
   executeAppFileEdit,
   executeAppFileList,
   executeAppFileRead,
@@ -315,5 +316,102 @@ describe("executeAppFileList", () => {
     expect(parsed.every((f: string) => !f.includes("[build output]"))).toBe(
       true,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeAppCreate
+// ---------------------------------------------------------------------------
+
+describe("executeAppCreate", () => {
+  test("flag off: creates legacy app with root index.html", async () => {
+    const files: Record<string, string> = {};
+    let createdParams: Record<string, unknown> | undefined;
+    const app = makeLegacyApp();
+    const store: AppStore = {
+      ...mockStore(app, files),
+      createApp: (params) => {
+        createdParams = params as unknown as Record<string, unknown>;
+        return app;
+      },
+    };
+
+    const result = await executeAppCreate(
+      {
+        name: "Test App",
+        html: "<html><body>Hello</body></html>",
+      },
+      store,
+    );
+
+    expect(result.isError).toBe(false);
+    // Legacy path: no formatVersion set, htmlDefinition is the provided html
+    expect(createdParams?.formatVersion).toBeUndefined();
+    expect(createdParams?.htmlDefinition).toBe(
+      "<html><body>Hello</body></html>",
+    );
+    // No src/ files should be written
+    expect(files["src/index.html"]).toBeUndefined();
+    expect(files["src/main.tsx"]).toBeUndefined();
+  });
+
+  test("flag on: creates multifile app with src/ scaffold", async () => {
+    const files: Record<string, string> = {};
+    let createdParams: Record<string, unknown> | undefined;
+    const app = makeMultifileApp({ name: "New App" });
+    const store: AppStore = {
+      ...mockStore(app, files),
+      createApp: (params) => {
+        createdParams = params as unknown as Record<string, unknown>;
+        return app;
+      },
+    };
+
+    const result = await executeAppCreate(
+      {
+        name: "New App",
+        featureFlags: { multifileEnabled: true },
+      },
+      store,
+    );
+
+    expect(result.isError).toBe(false);
+    // formatVersion 2 passed to createApp
+    expect(createdParams?.formatVersion).toBe(2);
+    // htmlDefinition should be empty for multifile apps
+    expect(createdParams?.htmlDefinition).toBe("");
+    // Scaffold files should be written
+    expect(files["src/index.html"]).toBeDefined();
+    expect(files["src/index.html"]).toContain("<title>New App</title>");
+    expect(files["src/index.html"]).toContain('<div id="app"></div>');
+    expect(files["src/main.tsx"]).toBeDefined();
+    expect(files["src/main.tsx"]).toContain("import { render } from 'preact'");
+    expect(files["src/main.tsx"]).toContain("Hello, New App!");
+  });
+
+  test("flag on with explicit html: uses provided html as src/index.html", async () => {
+    const files: Record<string, string> = {};
+    const app = makeMultifileApp({ name: "Custom App" });
+    const store: AppStore = {
+      ...mockStore(app, files),
+      createApp: () => app,
+    };
+
+    const customHtml =
+      '<!DOCTYPE html><html><head></head><body><div id="root"></div></body></html>';
+    const result = await executeAppCreate(
+      {
+        name: "Custom App",
+        html: customHtml,
+        featureFlags: { multifileEnabled: true },
+      },
+      store,
+    );
+
+    expect(result.isError).toBe(false);
+    // Explicit HTML should be used instead of scaffold
+    expect(files["src/index.html"]).toBe(customHtml);
+    // main.tsx scaffold should still be written
+    expect(files["src/main.tsx"]).toBeDefined();
   });
 });

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
@@ -1,3 +1,5 @@
+import { isAssistantFeatureFlagEnabled } from "../../../../config/assistant-feature-flags.js";
+import { getConfig } from "../../../../config/loader.js";
 import * as appStore from "../../../../memory/app-store.js";
 import type { AppCreateInput } from "../../../../tools/apps/executors.js";
 import { executeAppCreate } from "../../../../tools/apps/executors.js";
@@ -10,9 +12,13 @@ export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  return executeAppCreate(
-    input as unknown as AppCreateInput,
-    appStore,
-    context.proxyToolResolver,
+  const multifileEnabled = isAssistantFeatureFlagEnabled(
+    "feature_flags.app-builder-multifile.enabled",
+    getConfig(),
   );
+  const createInput: AppCreateInput = {
+    ...(input as unknown as AppCreateInput),
+    featureFlags: { multifileEnabled },
+  };
+  return executeAppCreate(createInput, appStore, context.proxyToolResolver);
 }

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -8,13 +8,14 @@
  * ToolDefinition or ToolContext types.
  */
 
+import { compileApp } from "../../bundler/app-compiler.js";
 import { setHomeBaseAppLink } from "../../home-base/app-link-store.js";
 import { generateAppIcon } from "../../media/app-icon-generator.js";
 import type {
   AppDefinition,
   EditEngineResult,
 } from "../../memory/app-store.js";
-import { isMultifileApp } from "../../memory/app-store.js";
+import { getAppsDir, isMultifileApp } from "../../memory/app-store.js";
 
 // ---------------------------------------------------------------------------
 // Shared result type
@@ -116,6 +117,8 @@ export interface AppCreateInput {
   auto_open?: boolean;
   set_as_home_base?: boolean;
   preview?: Record<string, unknown>;
+  /** When provided, controls multifile scaffold behavior. */
+  featureFlags?: { multifileEnabled: boolean };
 }
 
 export async function executeAppCreate(
@@ -172,14 +175,52 @@ export async function executeAppCreate(
   const rawIcon = preview?.icon as string | undefined;
   const icon = rawIcon && !rawIcon.startsWith("http") ? rawIcon : undefined;
 
+  const multifileEnabled = input.featureFlags?.multifileEnabled === true;
+
   const app = store.createApp({
     name,
     description,
     icon,
     schemaJson,
-    htmlDefinition,
-    pages,
+    htmlDefinition: multifileEnabled ? "" : htmlDefinition,
+    pages: multifileEnabled ? undefined : pages,
+    formatVersion: multifileEnabled ? 2 : undefined,
   });
+
+  // Scaffold multifile app with src/ files and compile to dist/
+  if (multifileEnabled) {
+    const indexHtml =
+      typeof input.html === "string"
+        ? input.html
+        : `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${name}</title>
+</head>
+<body>
+  <div id="app"></div>
+</body>
+</html>`;
+
+    const mainTsx = `import { render } from 'preact';
+
+function App() {
+  return <div>Hello, ${name}!</div>;
+}
+
+render(<App />, document.getElementById('app')!);
+`;
+
+    store.writeAppFile(app.id, "src/index.html", indexHtml);
+    store.writeAppFile(app.id, "src/main.tsx", mainTsx);
+
+    // Compile src/ → dist/
+    const { join } = await import("node:path");
+    const appDir = join(getAppsDir(), app.id);
+    await compileApp(appDir);
+  }
 
   if (input.set_as_home_base) {
     setHomeBaseAppLink(app.id, "personalized");


### PR DESCRIPTION
## Summary
- When `app-builder-multifile` flag is on, `app_create` scaffolds `src/index.html` + `src/main.tsx` + compiled `dist/`
- When flag is off, existing single-HTML behavior unchanged
- Feature flag resolution passed through from app-create tool executor

## Test plan
- [x] Added test: flag off creates legacy app with root index.html (no src/ files)
- [x] Added test: flag on creates multifile app with src/ scaffold (index.html + main.tsx)
- [x] Added test: flag on with explicit html uses provided html as src/index.html
- [x] All existing tests continue to pass

Part of plan: multifile-tsx-esbuild-apps.md (PR 6 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
