### PR TITLE
fix: read twilio account SID and phone number from config instead of secret store

### DIFF
--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -30,16 +30,16 @@ function resolveTwilioPhoneNumber(
   }
   return (
     getTwilioPhoneNumberEnv() ||
+    config.twilio?.phoneNumber ||
     config.sms?.phoneNumber ||
-    getSecureKey("credential:twilio:phone_number") ||
     ""
   );
 }
 
 export function getTwilioConfig(assistantId?: string): TwilioConfig {
-  const accountSid = getSecureKey("credential:twilio:account_sid");
-  const authToken = getSecureKey("credential:twilio:auth_token");
   const config = loadConfig();
+  const accountSid = config.twilio?.accountSid || "";
+  const authToken = getSecureKey("credential:twilio:auth_token");
   const phoneNumber = resolveTwilioPhoneNumber(config, assistantId);
   const webhookBaseUrl = getPublicBaseUrl(config);
 
@@ -52,7 +52,7 @@ export function getTwilioConfig(assistantId?: string): TwilioConfig {
 
   if (!accountSid || !authToken) {
     throw new ConfigError(
-      "Twilio credentials not configured. Set credential:twilio:account_sid and credential:twilio:auth_token via the credential_store tool.",
+      "Twilio credentials not configured. Set twilio.accountSid via config and twilio:auth_token via the credential_store tool.",
     );
   }
   if (!phoneNumber) {

--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -234,6 +234,15 @@ export const ModelPricingOverrideSchema = z.object({
     ),
 });
 
+export const TwilioConfigSchema = z.object({
+  accountSid: z
+    .string({ error: "twilio.accountSid must be a string" })
+    .default(""),
+  phoneNumber: z
+    .string({ error: "twilio.phoneNumber must be a string" })
+    .default(""),
+});
+
 export const SmsConfigSchema = z.object({
   enabled: z.boolean({ error: "sms.enabled must be a boolean" }).default(false),
   provider: z
@@ -397,6 +406,7 @@ export type ContextOverflowRecoveryConfig = z.infer<
 >;
 export type ContextWindowConfig = z.infer<typeof ContextWindowConfigSchema>;
 export type ModelPricingOverride = z.infer<typeof ModelPricingOverrideSchema>;
+export type TwilioConfig = z.infer<typeof TwilioConfigSchema>;
 export type SmsConfig = z.infer<typeof SmsConfigSchema>;
 export type WhatsAppConfig = z.infer<typeof WhatsAppConfigSchema>;
 export type IngressWebhookConfig = z.infer<typeof IngressWebhookConfigSchema>;

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -48,6 +48,7 @@ export type {
   SmsConfig,
   ThinkingConfig,
   TimeoutConfig,
+  TwilioConfig,
   UiConfig,
   WhatsAppConfig,
 } from "./core-schema.js";
@@ -69,6 +70,7 @@ export {
   SmsConfigSchema,
   ThinkingConfigSchema,
   TimeoutConfigSchema,
+  TwilioConfigSchema,
   UiConfigSchema,
   WhatsAppConfigSchema,
 } from "./core-schema.js";
@@ -162,6 +164,7 @@ import {
   SmsConfigSchema,
   ThinkingConfigSchema,
   TimeoutConfigSchema,
+  TwilioConfigSchema,
   UiConfigSchema,
   WhatsAppConfigSchema,
 } from "./core-schema.js";
@@ -259,6 +262,7 @@ export const AssistantConfigSchema = z
     workspaceGit: WorkspaceGitConfigSchema.default(
       WorkspaceGitConfigSchema.parse({}),
     ),
+    twilio: TwilioConfigSchema.default(TwilioConfigSchema.parse({})),
     calls: CallsConfigSchema.default(CallsConfigSchema.parse({})),
     elevenlabs: ElevenLabsConfigSchema.default(
       ElevenLabsConfigSchema.parse({}),


### PR DESCRIPTION
## Summary
- Added `TwilioConfigSchema` with `accountSid` and `phoneNumber` to the config schema so `assistant config set twilio.accountSid` values are parsed by `loadConfig()`
- Updated `getTwilioConfig()` in `src/calls/twilio-config.ts` to read account SID and phone number from config instead of the encrypted credential store
- Only auth token remains in secure storage, aligning the code with the twilio-setup skill's documented storage model

## Original prompt
lets update src/calls/twilio-config.ts to read the twilio sid from our config rather than from secret store. Same for reading phone number. Check twilio-setup/SKILL.md for the name of the config keys. Right now phone calling is busted because its looking for values in the wrong place

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
