### PR TITLE
feat: serve compiled dist/ output for multifile apps in app_open

### DIFF
--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -9,7 +9,9 @@
 
 import { join } from "node:path";
 
+import { compileApp } from "../bundler/app-compiler.js";
 import { generateAppIcon } from "../media/app-icon-generator.js";
+import { getApp, getAppsDir, isMultifileApp } from "../memory/app-store.js";
 import { updatePublishedAppDeployment } from "../services/published-app-updater.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { getLogger } from "../util/logger.js";
@@ -44,6 +46,34 @@ function handleAppChange(
   broadcastToAllClients: ((msg: ServerMessage) => void) | undefined,
   opts?: { fileChange?: boolean; status?: string },
 ): void {
+  const app = getApp(appId);
+
+  // Multifile apps need a recompile before refreshing surfaces so the
+  // WebView picks up the latest compiled output.
+  if (app && isMultifileApp(app)) {
+    const appDir = join(getAppsDir(), appId);
+    void compileApp(appDir)
+      .then((result) => {
+        if (!result.ok) {
+          log.warn(
+            { appId, errors: result.errors },
+            "Recompile failed on app change, serving stale dist/",
+          );
+        }
+        refreshSurfacesForApp(ctx, appId, opts);
+        broadcastToAllClients?.({ type: "app_files_changed", appId });
+        void updatePublishedAppDeployment(appId);
+      })
+      .catch((err) => {
+        log.warn({ appId, err }, "Recompile threw on app change");
+        // Still refresh surfaces with stale output
+        refreshSurfacesForApp(ctx, appId, opts);
+        broadcastToAllClients?.({ type: "app_files_changed", appId });
+        void updatePublishedAppDeployment(appId);
+      });
+    return;
+  }
+
   refreshSurfacesForApp(ctx, appId, opts);
   broadcastToAllClients?.({ type: "app_files_changed", appId });
   void updatePublishedAppDeployment(appId);

--- a/assistant/src/runtime/routes/app-routes.ts
+++ b/assistant/src/runtime/routes/app-routes.ts
@@ -2,13 +2,13 @@
  * Route handlers for shareable app pages and cloud sharing.
  */
 import { randomBytes } from "node:crypto";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { extname, join } from "node:path";
 
 import JSZip from "jszip";
 
 import type { AppManifest } from "../../bundler/manifest.js";
-import { getApp } from "../../memory/app-store.js";
+import { getApp, getAppsDir, isMultifileApp } from "../../memory/app-store.js";
 import * as sharedAppLinksStore from "../../memory/shared-app-links-store.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
@@ -44,6 +44,11 @@ export function handleServePage(appId: string): Response {
   const app = getApp(appId);
   if (!app) {
     return httpError("NOT_FOUND", "App not found", 404);
+  }
+
+  // Multifile apps serve the compiled dist/index.html directly.
+  if (isMultifileApp(app)) {
+    return serveMultifileApp(appId, app.name);
   }
 
   const css = loadDesignSystemCss();
@@ -95,6 +100,109 @@ ${noncedHtml}
     headers: {
       "Content-Type": "text/html; charset=utf-8",
       "Content-Security-Policy": csp,
+    },
+  });
+}
+
+/**
+ * Serve compiled output for multifile TSX apps.
+ * Falls back to a "not compiled yet" message if dist/index.html is missing.
+ */
+function serveMultifileApp(appId: string, appName: string): Response {
+  const distDir = join(getAppsDir(), appId, "dist");
+  const indexPath = join(distDir, "index.html");
+
+  if (!existsSync(indexPath)) {
+    const escapedName = appName.replace(
+      /[<>&"]/g,
+      (c) => HTML_ESCAPE_MAP[c] ?? c,
+    );
+    return new Response(
+      `<!DOCTYPE html><html><head><title>${escapedName}</title></head>` +
+        `<body><p>App has not been compiled yet. Edit a source file to trigger a build.</p></body></html>`,
+      {
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      },
+    );
+  }
+
+  // Rewrite relative asset paths to use the dist route so the WebView
+  // can load main.js and main.css via the HTTP server.
+  let html = readFileSync(indexPath, "utf-8");
+  html = html.replace(
+    /(?:src|href)="(main\.(js|css))"/g,
+    (_match, filename) => {
+      const attr = (filename as string).endsWith(".css") ? "href" : "src";
+      return `${attr}="/v1/apps/${appId}/dist/${filename}"`;
+    },
+  );
+
+  // Compiled apps use external scripts so 'unsafe-inline' is not needed for
+  // script-src; however we keep it for style-src since the app HTML may use
+  // inline styles.
+  const csp = [
+    "default-src 'self'",
+    "style-src 'self' 'unsafe-inline'",
+    "script-src 'self'",
+    "img-src 'self' data: https:",
+    "font-src 'self' data: https:",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'self'",
+  ].join("; ");
+
+  return new Response(html, {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Content-Security-Policy": csp,
+    },
+  });
+}
+
+/** Content-Type map for static dist/ assets. */
+const DIST_CONTENT_TYPES: Record<string, string> = {
+  ".js": "application/javascript",
+  ".css": "text/css",
+  ".html": "text/html",
+  ".json": "application/json",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".woff2": "font/woff2",
+  ".woff": "font/woff",
+};
+
+/**
+ * Serve a static file from an app's dist/ directory.
+ * Validates the filename to prevent path traversal.
+ */
+export function handleServeDistFile(appId: string, filename: string): Response {
+  // Reject any traversal attempts
+  if (
+    !filename ||
+    filename.includes("..") ||
+    filename.includes("/") ||
+    filename.includes("\\") ||
+    filename !== filename.trim()
+  ) {
+    return httpError("BAD_REQUEST", "Invalid filename", 400);
+  }
+
+  const filePath = join(getAppsDir(), appId, "dist", filename);
+  if (!existsSync(filePath)) {
+    return httpError("NOT_FOUND", "File not found", 404);
+  }
+
+  const ext = extname(filename).toLowerCase();
+  const contentType = DIST_CONTENT_TYPES[ext] ?? "application/octet-stream";
+  const content = readFileSync(filePath);
+
+  return new Response(content, {
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control": "no-cache",
     },
   });
 }
@@ -207,6 +315,13 @@ export function handleDeleteSharedApp(shareToken: string): Response {
 
 export function appRouteDefinitions(): RouteDefinition[] {
   return [
+    {
+      endpoint: "apps/:appId/dist/:filename",
+      method: "GET",
+      policyKey: "apps/dist",
+      handler: ({ params }) =>
+        handleServeDistFile(params.appId, params.filename),
+    },
     {
       endpoint: "apps/share",
       method: "POST",


### PR DESCRIPTION
## Summary
- Serve `dist/index.html` for multifile apps instead of inline HTML
- Add static file routes for `dist/main.js` and `dist/main.css`
- Trigger recompile on file edits via tool-side-effects
- Legacy apps completely unaffected

Part of plan: multifile-tsx-esbuild-apps.md (PR 8 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
