### PR TITLE
feat: add third-party package resolution with allowlist for app builds

### DIFF
--- a/assistant/src/__tests__/app-compiler.test.ts
+++ b/assistant/src/__tests__/app-compiler.test.ts
@@ -1,9 +1,17 @@
+import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
 import { compileApp } from "../bundler/app-compiler.js";
+import {
+  ALLOWED_PACKAGES,
+  getCacheDir,
+  isBareImport,
+  packageName,
+  resolvePackage,
+} from "../bundler/package-resolver.js";
 
 // ---------------------------------------------------------------------------
 // Shared temp directory
@@ -176,5 +184,96 @@ console.log("styled");`,
     const html = await readFile(join(appDir, "dist", "index.html"), "utf-8");
     const matches = html.match(/src="main\.js"/g);
     expect(matches).toHaveLength(1);
+  });
+
+  test("disallowed package import produces a clear error", async () => {
+    const appDir = await scaffold("disallowed-pkg", {
+      "main.tsx": `import leftpad from "left-pad";\nconsole.log(leftpad("hi", 5));`,
+      "index.html": MINIMAL_HTML,
+    });
+
+    const result = await compileApp(appDir);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0].text).toContain("not in the allowed list");
+    expect(result.errors[0].text).toContain("left-pad");
+  });
+
+  test("allowed package (zod) compiles successfully", async () => {
+    const appDir = await scaffold("allowed-pkg-zod", {
+      "main.tsx": `import { z } from "zod";\nconst schema = z.string();\nconsole.log(schema.parse("hello"));`,
+      "index.html": MINIMAL_HTML,
+    });
+
+    const result = await compileApp(appDir);
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toHaveLength(0);
+
+    const js = await readFile(join(appDir, "dist", "main.js"), "utf-8");
+    expect(js.length).toBeGreaterThan(100);
+  }, 30_000);
+
+  test("allowed package uses shared cache on second build", async () => {
+    // First build installs the package
+    const appDir1 = await scaffold("cache-test-1", {
+      "main.tsx": `import { z } from "zod";\nconsole.log(z.string());`,
+      "index.html": MINIMAL_HTML,
+    });
+    const r1 = await compileApp(appDir1);
+    expect(r1.ok).toBe(true);
+
+    // The cache dir should now have zod
+    const cacheDir = getCacheDir();
+    expect(existsSync(join(cacheDir, "node_modules", "zod"))).toBe(true);
+
+    // Second build should reuse the cache (no install needed)
+    const appDir2 = await scaffold("cache-test-2", {
+      "main.tsx": `import { z } from "zod";\nconst s = z.number();\nconsole.log(s.parse(42));`,
+      "index.html": MINIMAL_HTML,
+    });
+    const r2 = await compileApp(appDir2);
+    expect(r2.ok).toBe(true);
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// Package resolver unit tests
+// ---------------------------------------------------------------------------
+
+describe("package-resolver", () => {
+  test("isBareImport identifies bare specifiers", () => {
+    expect(isBareImport("date-fns")).toBe(true);
+    expect(isBareImport("zod")).toBe(true);
+    expect(isBareImport("@scope/pkg")).toBe(true);
+    expect(isBareImport("./local")).toBe(false);
+    expect(isBareImport("../parent")).toBe(false);
+    expect(isBareImport("/absolute")).toBe(false);
+    expect(isBareImport("preact")).toBe(false);
+    expect(isBareImport("preact/hooks")).toBe(false);
+    expect(isBareImport("react")).toBe(false);
+    expect(isBareImport("react-dom")).toBe(false);
+  });
+
+  test("packageName extracts top-level name", () => {
+    expect(packageName("date-fns")).toBe("date-fns");
+    expect(packageName("date-fns/format")).toBe("date-fns");
+    expect(packageName("@scope/pkg")).toBe("@scope/pkg");
+    expect(packageName("@scope/pkg/sub")).toBe("@scope/pkg");
+  });
+
+  test("resolvePackage returns null for disallowed packages", async () => {
+    const result = await resolvePackage("left-pad");
+    expect(result).toBeNull();
+  });
+
+  test("ALLOWED_PACKAGES contains expected entries", () => {
+    expect(ALLOWED_PACKAGES).toContain("date-fns");
+    expect(ALLOWED_PACKAGES).toContain("chart.js");
+    expect(ALLOWED_PACKAGES).toContain("lodash-es");
+    expect(ALLOWED_PACKAGES).toContain("zod");
+    expect(ALLOWED_PACKAGES).toContain("clsx");
+    expect(ALLOWED_PACKAGES).toContain("lucide");
   });
 });

--- a/assistant/src/bundler/app-compiler.ts
+++ b/assistant/src/bundler/app-compiler.ts
@@ -9,9 +9,16 @@ import { existsSync } from "node:fs";
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
-import { build, type Message } from "esbuild";
+import { build, type Message, type Plugin } from "esbuild";
 
 import { getLogger } from "../util/logger.js";
+import {
+  ALLOWED_PACKAGES,
+  getCacheDir,
+  isBareImport,
+  packageName,
+  resolvePackage,
+} from "./package-resolver.js";
 
 const log = getLogger("app-compiler");
 
@@ -64,6 +71,42 @@ export async function compileApp(appDir: string): Promise<CompileResult> {
     "../../node_modules/preact",
   );
 
+  // Plugin that resolves bare third-party imports against the allowlist
+  const resolvePlugin: Plugin = {
+    name: "vellum-package-resolver",
+    setup(pluginBuild) {
+      pluginBuild.onResolve({ filter: /.*/ }, async (args) => {
+        // Only intercept bare specifiers (not relative, not preact/react aliases)
+        if (
+          args.kind !== "import-statement" &&
+          args.kind !== "dynamic-import"
+        ) {
+          return undefined;
+        }
+        if (!isBareImport(args.path)) return undefined;
+
+        const pkg = packageName(args.path);
+        const nodeModulesDir = await resolvePackage(pkg);
+
+        if (nodeModulesDir) {
+          // Let esbuild resolve normally — nodePaths will pick it up
+          return undefined;
+        }
+
+        // Not allowed — produce a clear error
+        return {
+          errors: [
+            {
+              text: `Package '${pkg}' is not in the allowed list. Allowed: ${ALLOWED_PACKAGES.join(", ")}`,
+            },
+          ],
+        };
+      });
+    },
+  };
+
+  const cacheNodeModules = join(getCacheDir(), "node_modules");
+
   let result;
   try {
     result = await build({
@@ -87,8 +130,9 @@ export async function compileApp(appDir: string): Promise<CompileResult> {
         react: "preact/compat",
         "react-dom": "preact/compat",
       },
-      // Point esbuild at the assistant's preact so it can resolve jsx-runtime
-      nodePaths: [resolve(preactDir, "..")],
+      plugins: [resolvePlugin],
+      // Point esbuild at assistant's preact and at the shared package cache
+      nodePaths: [resolve(preactDir, ".."), cacheNodeModules],
       logLevel: "silent",
     });
   } catch (err: unknown) {

--- a/assistant/src/bundler/package-resolver.ts
+++ b/assistant/src/bundler/package-resolver.ts
@@ -1,0 +1,155 @@
+/**
+ * Third-party package resolver with an allowlist for app builds.
+ *
+ * Maintains a shared cache at ~/.vellum/package-cache/ so packages are
+ * installed once and reused across all app compilations.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("package-resolver");
+
+/** Packages the model is likely to use and that we trust in sandboxed apps. */
+export const ALLOWED_PACKAGES: readonly string[] = [
+  "date-fns",
+  "chart.js",
+  "lodash-es",
+  "zod",
+  "clsx",
+  "lucide",
+] as const;
+
+const INSTALL_TIMEOUT_MS = 10_000;
+const MAX_PACKAGE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+
+/** Where all cached packages live on disk. */
+export function getCacheDir(): string {
+  return join(homedir(), ".vellum", "package-cache");
+}
+
+/**
+ * Return true when `name` is a bare specifier that our plugin should handle
+ * (i.e. not a relative/absolute path, not preact/react which are aliased).
+ */
+export function isBareImport(name: string): boolean {
+  if (name.startsWith(".") || name.startsWith("/")) return false;
+  if (name.startsWith("preact") || name === "react" || name === "react-dom") {
+    return false;
+  }
+  return true;
+}
+
+/** Get the top-level package name from a specifier (handles scoped pkgs). */
+export function packageName(specifier: string): string {
+  if (specifier.startsWith("@")) {
+    const parts = specifier.split("/");
+    return parts.slice(0, 2).join("/");
+  }
+  return specifier.split("/")[0];
+}
+
+/**
+ * Resolve a third-party package from the shared cache.
+ *
+ * Returns the path to the package inside node_modules, or null if the
+ * package is not allowed or installation failed.
+ */
+export async function resolvePackage(name: string): Promise<string | null> {
+  const pkg = packageName(name);
+
+  if (!ALLOWED_PACKAGES.includes(pkg)) {
+    return null;
+  }
+
+  const cacheDir = getCacheDir();
+  const nodeModulesDir = join(cacheDir, "node_modules");
+  const pkgDir = join(nodeModulesDir, pkg);
+
+  // Already cached — skip install
+  if (existsSync(pkgDir)) {
+    return nodeModulesDir;
+  }
+
+  // Ensure cache directory exists with a package.json so bun install works
+  await mkdir(cacheDir, { recursive: true });
+  const pkgJsonPath = join(cacheDir, "package.json");
+  if (!existsSync(pkgJsonPath)) {
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(
+      pkgJsonPath,
+      JSON.stringify({ name: "vellum-pkg-cache", private: true }),
+    );
+  }
+
+  log.info({ pkg }, "Installing package into shared cache");
+
+  try {
+    const proc = Bun.spawn(["bun", "install", "--no-save", pkg], {
+      cwd: cacheDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        PATH: `${homedir()}/.bun/bin:${process.env.PATH}`,
+      },
+    });
+
+    // Race against timeout
+    const exited = proc.exited;
+    const timeout = new Promise<"timeout">((resolve) =>
+      setTimeout(() => resolve("timeout"), INSTALL_TIMEOUT_MS),
+    );
+
+    const raceResult = await Promise.race([exited, timeout]);
+
+    if (raceResult === "timeout") {
+      proc.kill();
+      log.warn({ pkg }, "Package install timed out");
+      return null;
+    }
+
+    if (raceResult !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      log.warn({ pkg, stderr }, "Package install failed");
+      return null;
+    }
+
+    // Enforce max size
+    if (existsSync(pkgDir)) {
+      const size = await dirSize(pkgDir);
+      if (size > MAX_PACKAGE_SIZE_BYTES) {
+        log.warn({ pkg, size }, "Package exceeds size limit, removing");
+        const { rm } = await import("node:fs/promises");
+        await rm(pkgDir, { recursive: true, force: true });
+        return null;
+      }
+    }
+
+    return existsSync(pkgDir) ? nodeModulesDir : null;
+  } catch (err) {
+    log.warn({ pkg, err }, "Package resolution failed");
+    return null;
+  }
+}
+
+/** Recursively sum file sizes under a directory. */
+async function dirSize(dir: string): Promise<number> {
+  const { readdir } = await import("node:fs/promises");
+  const entries = await readdir(dir, { withFileTypes: true });
+  let total = 0;
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      total += await dirSize(full);
+    } else {
+      const s = await stat(full);
+      total += s.size;
+    }
+  }
+  return total;
+}


### PR DESCRIPTION
## Summary
- Add `package-resolver.ts` with allowlisted third-party packages (date-fns, chart.js, lodash-es, zod, clsx, lucide)
- Add esbuild plugin for bare import resolution against the allowlist
- Shared package cache at `~/.vellum/package-cache/` with 10s install timeout and 5MB size limit
- Clear error messages for disallowed packages
- Tests cover allowed, disallowed, cached package scenarios, and resolver unit tests

## Test plan
- [x] Existing app-compiler tests still pass (7 original tests)
- [x] Disallowed package import produces clear error with package name and allowed list
- [x] Allowed package (zod) compiles successfully end-to-end
- [x] Second build reuses shared cache (no reinstall)
- [x] Unit tests for `isBareImport`, `packageName`, `ALLOWED_PACKAGES`, `resolvePackage` null for disallowed

Part of plan: multifile-tsx-esbuild-apps.md (PR 13 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
