### PR TITLE
feat: compile multifile apps before packaging into .vellum zip

### DIFF
--- a/assistant/src/__tests__/app-bundler.test.ts
+++ b/assistant/src/__tests__/app-bundler.test.ts
@@ -1,4 +1,10 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import JSZip from "jszip";
 
 // Mock the logger before importing the module under test
 mock.module("../util/logger.js", () => ({
@@ -8,10 +14,33 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+// Temp directory for fake app data used in packageApp tests
+const testAppsDir = join(tmpdir(), `app-bundler-test-${Date.now()}`);
+
+// Mock app-store so packageApp can find our test apps
+const mockApps = new Map<string, Record<string, unknown>>();
+mock.module("../memory/app-store.js", () => ({
+  getApp: (id: string) => mockApps.get(id) ?? null,
+  getAppsDir: () => testAppsDir,
+  isMultifileApp: (app: Record<string, unknown>) => app.formatVersion === 2,
+}));
+
+// Mock content-id to avoid pulling in crypto internals
+mock.module("../util/content-id.js", () => ({
+  computeContentId: () => "abcd1234abcd1234",
+}));
+
+// Mock bundle-signer (not exercised in these tests)
+mock.module("./bundle-signer.js", () => ({
+  signBundle: async () => ({}),
+}));
+
 import {
   extractRemoteUrls,
   materializeAssets,
+  packageApp,
 } from "../bundler/app-bundler.js";
+import type { AppManifest } from "../bundler/manifest.js";
 
 // ---------------------------------------------------------------------------
 // extractRemoteUrls
@@ -321,5 +350,185 @@ describe("materializeAssets", () => {
 
     expect(result.rewrittenHtml).toContain("assets/8550eecd4975.jpg");
     expect(result.rewrittenHtml).not.toContain(cssUrl);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// packageApp — multifile apps
+// ---------------------------------------------------------------------------
+
+describe("packageApp", () => {
+  afterEach(() => {
+    mockApps.clear();
+    try {
+      rmSync(testAppsDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  /**
+   * Helper: set up a fake multifile app on disk with src/ and dist/ dirs
+   * so that compileApp (which we mock below) can pretend to succeed.
+   */
+  function setupMultifileApp(appId: string, opts?: { withCss?: boolean }) {
+    const appDir = join(testAppsDir, appId);
+    const srcDir = join(appDir, "src");
+    mkdirSync(srcDir, { recursive: true });
+
+    // Write minimal src/ so the app directory looks valid
+    if (opts?.withCss) {
+      writeFileSync(join(srcDir, "styles.css"), "body { margin: 0; }");
+      writeFileSync(
+        join(srcDir, "main.tsx"),
+        'import "./styles.css";\nexport default () => "hi";',
+      );
+    } else {
+      writeFileSync(join(srcDir, "main.tsx"), 'export default () => "hi";');
+    }
+    writeFileSync(
+      join(srcDir, "index.html"),
+      "<!DOCTYPE html><html><head></head><body></body></html>",
+    );
+
+    // Write the app JSON (getApp reads from {appsDir}/{id}.json)
+    const appDef = {
+      id: appId,
+      name: "Test Multifile App",
+      description: "A test app",
+      schemaJson: "{}",
+      htmlDefinition: "<unused>",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      formatVersion: 2,
+    };
+    writeFileSync(join(testAppsDir, `${appId}.json`), JSON.stringify(appDef));
+    mockApps.set(appId, appDef);
+
+    return appDef;
+  }
+
+  function setupLegacyApp(appId: string) {
+    const appDir = join(testAppsDir, appId);
+    mkdirSync(appDir, { recursive: true });
+
+    const appDef = {
+      id: appId,
+      name: "Test Legacy App",
+      schemaJson: "{}",
+      htmlDefinition: "<html><body>Hello legacy</body></html>",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    writeFileSync(join(testAppsDir, `${appId}.json`), JSON.stringify(appDef));
+    mockApps.set(appId, appDef);
+    return appDef;
+  }
+
+  test("packages a multifile app with compiled dist/ files in the zip", async () => {
+    const appId = "multi-test-1";
+    setupMultifileApp(appId, { withCss: true });
+
+    const result = await packageApp(appId);
+    const zipData = await readFile(result.bundlePath);
+    const zip = await JSZip.loadAsync(zipData);
+
+    // Verify compiled files are present
+    expect(zip.file("index.html")).not.toBeNull();
+    expect(zip.file("main.js")).not.toBeNull();
+    expect(zip.file("main.css")).not.toBeNull();
+    expect(zip.file("manifest.json")).not.toBeNull();
+
+    // Verify content matches what we wrote to dist/
+    const indexContent = await zip.file("index.html")!.async("string");
+    expect(indexContent).toContain('src="main.js"');
+
+    // main.js should contain compiled output (esbuild minifies the source)
+    const jsContent = await zip.file("main.js")!.async("string");
+    expect(jsContent.length).toBeGreaterThan(0);
+
+    // CSS was imported, so main.css should be present
+    const cssContent = await zip.file("main.css")!.async("string");
+    expect(cssContent).toContain("margin");
+  });
+
+  test("sets format_version to 2 in manifest for multifile apps", async () => {
+    const appId = "multi-test-2";
+    setupMultifileApp(appId);
+
+    const result = await packageApp(appId);
+    const zipData = await readFile(result.bundlePath);
+    const zip = await JSZip.loadAsync(zipData);
+
+    const manifestJson = await zip.file("manifest.json")!.async("string");
+    const manifest: AppManifest = JSON.parse(manifestJson);
+
+    expect(manifest.format_version).toBe(2);
+    expect(manifest.entry).toBe("index.html");
+    expect(manifest.name).toBe("Test Multifile App");
+  });
+
+  test("compile failure produces a clear error", async () => {
+    const appId = "multi-fail-1";
+    const appDir = join(testAppsDir, appId);
+    const srcDir = join(appDir, "src");
+    mkdirSync(srcDir, { recursive: true });
+
+    // Write intentionally broken source so esbuild fails
+    writeFileSync(join(srcDir, "main.tsx"), "const x: number = {{{BROKEN");
+    writeFileSync(
+      join(srcDir, "index.html"),
+      "<!DOCTYPE html><html><head></head><body></body></html>",
+    );
+
+    const appDef = {
+      id: appId,
+      name: "Broken App",
+      schemaJson: "{}",
+      htmlDefinition: "<unused>",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      formatVersion: 2,
+    };
+    writeFileSync(join(testAppsDir, `${appId}.json`), JSON.stringify(appDef));
+    mockApps.set(appId, appDef);
+
+    await expect(packageApp(appId)).rejects.toThrow(
+      /Compilation failed for app "Broken App"/,
+    );
+  });
+
+  test("legacy app packaging remains unchanged (format_version 1)", async () => {
+    const appId = "legacy-test-1";
+    setupLegacyApp(appId);
+
+    const result = await packageApp(appId);
+    const zipData = await readFile(result.bundlePath);
+    const zip = await JSZip.loadAsync(zipData);
+
+    const manifestJson = await zip.file("manifest.json")!.async("string");
+    const manifest: AppManifest = JSON.parse(manifestJson);
+
+    expect(manifest.format_version).toBe(1);
+
+    // Legacy app should have index.html with the original content
+    const indexContent = await zip.file("index.html")!.async("string");
+    expect(indexContent).toContain("Hello legacy");
+
+    // Should NOT have main.js (not a compiled app)
+    expect(zip.file("main.js")).toBeNull();
+  });
+
+  test("multifile app without CSS omits main.css from zip", async () => {
+    const appId = "multi-no-css";
+    setupMultifileApp(appId, { withCss: false });
+
+    const result = await packageApp(appId);
+    const zipData = await readFile(result.bundlePath);
+    const zip = await JSZip.loadAsync(zipData);
+
+    expect(zip.file("index.html")).not.toBeNull();
+    expect(zip.file("main.js")).not.toBeNull();
+    expect(zip.file("main.css")).toBeNull();
   });
 });

--- a/assistant/src/bundler/app-bundler.ts
+++ b/assistant/src/bundler/app-bundler.ts
@@ -14,9 +14,10 @@ import { extname, join } from "node:path";
 import archiver from "archiver";
 import JSZip from "jszip";
 
-import { getApp, getAppsDir } from "../memory/app-store.js";
+import { getApp, getAppsDir, isMultifileApp } from "../memory/app-store.js";
 import { computeContentId } from "../util/content-id.js";
 import { getLogger } from "../util/logger.js";
+import { compileApp } from "./app-compiler.js";
 import type { SigningCallback } from "./bundle-signer.js";
 import { signBundle } from "./bundle-signer.js";
 import type { AppManifest } from "./manifest.js";
@@ -194,13 +195,15 @@ export async function packageApp(
     throw new Error(`App not found: ${appId}`);
   }
 
+  const multifile = isMultifileApp(app);
+
   // Build manifest
   const createdBy = `vellum-assistant/${PACKAGE_VERSION}`;
   const version = app.version ?? "1.0.0";
   const contentId = computeContentId(app.name);
 
   const manifest: AppManifest = {
-    format_version: 1,
+    format_version: multifile ? 2 : 1,
     name: app.name,
     ...(app.description ? { description: app.description } : {}),
     ...(app.icon ? { icon: app.icon } : {}),
@@ -213,28 +216,63 @@ export async function packageApp(
     content_id: contentId,
   };
 
-  // Fetch remote assets and rewrite HTML to reference local copies
-  const { rewrittenHtml, assets: fetchedAssets } = await materializeAssets(
-    app.htmlDefinition,
-  );
-
-  // Also materialize assets in additional pages
+  // For multifile apps, compile first then bundle the dist/ output.
+  // For legacy apps, materialize remote assets and bundle the HTML directly.
+  let rewrittenHtml = "";
+  let allAssets: FetchedAsset[] = [];
   const rewrittenPages: Record<string, string> = {};
-  const pageAssets: FetchedAsset[] = [];
-  if (app.pages) {
-    for (const [filename, content] of Object.entries(app.pages)) {
-      const result = await materializeAssets(content);
-      rewrittenPages[filename] = result.rewrittenHtml;
-      pageAssets.push(...result.assets);
-    }
-  }
+  const compiledFiles: { name: string; data: Buffer }[] = [];
 
-  // Deduplicate assets by archive path
-  const allAssetsMap = new Map<string, FetchedAsset>();
-  for (const asset of [...fetchedAssets, ...pageAssets]) {
-    allAssetsMap.set(asset.archivePath, asset);
+  if (multifile) {
+    const appDir = join(getAppsDir(), appId);
+    const compileResult = await compileApp(appDir);
+    if (!compileResult.ok) {
+      const messages = compileResult.errors
+        .map((e) => {
+          const loc = e.location
+            ? ` (${e.location.file}:${e.location.line}:${e.location.column})`
+            : "";
+          return `${e.text}${loc}`;
+        })
+        .join("\n");
+      throw new Error(`Compilation failed for app "${app.name}":\n${messages}`);
+    }
+
+    const distDir = join(appDir, "dist");
+    const indexHtml = await readFile(join(distDir, "index.html"), "utf-8");
+    const mainJs = await readFile(join(distDir, "main.js"));
+
+    compiledFiles.push({ name: "index.html", data: Buffer.from(indexHtml) });
+    compiledFiles.push({ name: "main.js", data: mainJs });
+
+    // main.css is optional — only produced when the app imports CSS
+    const cssPath = join(distDir, "main.css");
+    if (existsSync(cssPath)) {
+      compiledFiles.push({ name: "main.css", data: await readFile(cssPath) });
+    }
+  } else {
+    // Legacy path: fetch remote assets and rewrite HTML
+    const materialized = await materializeAssets(app.htmlDefinition);
+    rewrittenHtml = materialized.rewrittenHtml;
+    const fetchedAssets = materialized.assets;
+
+    // Also materialize assets in additional pages
+    const pageAssets: FetchedAsset[] = [];
+    if (app.pages) {
+      for (const [filename, content] of Object.entries(app.pages)) {
+        const result = await materializeAssets(content);
+        rewrittenPages[filename] = result.rewrittenHtml;
+        pageAssets.push(...result.assets);
+      }
+    }
+
+    // Deduplicate assets by archive path
+    const allAssetsMap = new Map<string, FetchedAsset>();
+    for (const asset of [...fetchedAssets, ...pageAssets]) {
+      allAssetsMap.set(asset.archivePath, asset);
+    }
+    allAssets = [...allAssetsMap.values()];
   }
-  const allAssets = [...allAssetsMap.values()];
 
   // Create the zip archive
   const safeName = app.name.replace(/[/\\:*?"<>|]/g, "_").trim() || "App";
@@ -264,20 +302,27 @@ export async function packageApp(
     // Add manifest.json at root level
     archive.append(serializeManifest(manifest), { name: "manifest.json" });
 
-    // Add index.html at root level
-    archive.append(rewrittenHtml, { name: "index.html" });
-
-    // Add additional pages alongside index.html (with rewritten asset URLs)
-    if (app.pages) {
-      for (const filename of Object.keys(app.pages)) {
-        const content = rewrittenPages[filename] ?? app.pages[filename];
-        archive.append(content, { name: filename });
+    if (multifile) {
+      // Add compiled dist/ files
+      for (const file of compiledFiles) {
+        archive.append(file.data, { name: file.name });
       }
-    }
+    } else {
+      // Add index.html at root level
+      archive.append(rewrittenHtml, { name: "index.html" });
 
-    // Add fetched remote assets
-    for (const asset of allAssets) {
-      archive.append(asset.data, { name: asset.archivePath });
+      // Add additional pages alongside index.html (with rewritten asset URLs)
+      if (app.pages) {
+        for (const filename of Object.keys(app.pages)) {
+          const content = rewrittenPages[filename] ?? app.pages[filename];
+          archive.append(content, { name: filename });
+        }
+      }
+
+      // Add fetched remote assets
+      for (const asset of allAssets) {
+        archive.append(asset.data, { name: asset.archivePath });
+      }
     }
 
     // Include app icon if one was generated


### PR DESCRIPTION
## Summary
- Compile multifile apps via `compileApp()` before packaging into .vellum zip
- Include `dist/index.html`, `dist/main.js`, `dist/main.css` in zip archive
- Set `format_version: 2` in manifest for multifile apps
- Throw actionable errors on compile failure
- Legacy app packaging unchanged

## Test plan
- [x] Multifile app packages with compiled dist/ files in zip
- [x] format_version is 2 in manifest for multifile apps
- [x] Compile failure produces clear error message
- [x] Legacy apps still package with format_version 1
- [x] Multifile app without CSS omits main.css

Part of plan: multifile-tsx-esbuild-apps.md (PR 9 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
