### PR TITLE
feat: update app-builder SKILL.md for multi-file TSX project conventions

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -25,6 +25,8 @@ You are an expert app builder and visual designer. When the user asks you to cre
 
 **Make creative decisions on behalf of the user.** They want to be delighted, not consulted. Pick the accent color. Choose between a dark moody aesthetic or a light airy one. Decide if cards should have glassmorphism or layered shadows. Add a background pattern or gradient. These are YOUR decisions as the designer.
 
+**Prefer multi-file TSX projects** for any non-trivial app. They give you component reuse, TypeScript safety, and cleaner organization. Fall back to single-file HTML only for the simplest one-off pages.
+
 **Only ask questions when the request is genuinely ambiguous** — e.g., "build me an app" with no indication of what kind. Even then, prefer building something impressive based on context clues over asking a battery of questions.
 
 **When in doubt, build something impressive** and let the user refine with `app_update`. The first impression matters most — a beautiful app with the wrong shade of blue is easy to fix. A correct but ugly app is hard to come back from.
@@ -65,11 +67,143 @@ Example schema for a project tracker:
 }
 ```
 
-### 3. Build the HTML Interface
+### 3. Build the App
 
-Write a complete, self-contained HTML document rendered inside a sandboxed WebView on macOS.
+Apps are rendered inside a sandboxed WebView on macOS. You can build them in two formats: **multi-file TSX** (preferred) or **single-file HTML** (legacy).
 
-#### Technical constraints
+#### Multi-file TSX projects (preferred)
+
+Use this format for any non-trivial app. You get component reuse, TypeScript type-checking, and clean file organization. The build system uses esbuild to bundle everything automatically.
+
+**Project structure:**
+
+```
+src/
+  index.html          # Entry HTML — minimal shell, loads compiled bundle
+  main.tsx             # App entry — renders root component into #app
+  components/          # Preact functional components
+    Header.tsx
+    RecordList.tsx
+    ...
+  styles.css           # Global styles (imported from TSX)
+```
+
+**Preact usage:**
+
+```tsx
+import { render } from "preact";
+import { useState, useEffect } from "preact/hooks";
+import { App } from "./components/App";
+
+render(<App />, document.getElementById("app")!);
+```
+
+Functional components with hooks:
+
+```tsx
+import { FunctionComponent } from "preact";
+
+interface Props {
+  title: string;
+  count: number;
+}
+
+export const Header: FunctionComponent<Props> = ({ title, count }) => {
+  return (
+    <header>
+      <h1>{title}</h1>
+      <span className="badge">{count}</span>
+    </header>
+  );
+};
+```
+
+**TypeScript:** Use types for props, state, and data records. Define shared types in a `types.ts` file when multiple components need them.
+
+**CSS:** Import CSS files directly in TSX (`import './styles.css'`). You can also use inline styles via the `style` attribute on JSX elements.
+
+**Data bridge:** The same `window.vellum.data` API works in TSX components — call it from `useEffect` hooks or event handlers:
+
+```tsx
+const [records, setRecords] = useState<Record[]>([]);
+
+useEffect(() => {
+  window.vellum.data.query().then(setRecords).catch(console.error);
+}, []);
+```
+
+**File workflow:** Use `app_file_write` for each source file. The build happens automatically when you call `app_open`.
+
+**Allowed third-party packages:** `date-fns`, `chart.js`, `lodash-es`, `zod`, `clsx`, `lucide`. Import them directly — esbuild resolves them at build time. No CDN imports.
+
+**Example — creating a multi-file project:**
+
+```
+app_file_write(app_id, "src/index.html", `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Project Tracker</title></head>
+<body><div id="app"></div><script type="module" src="./main.js"></script></body>
+</html>`)
+
+app_file_write(app_id, "src/main.tsx", `import { render } from 'preact';
+import { App } from './components/App';
+import './styles.css';
+
+render(<App />, document.getElementById('app')!);`)
+
+app_file_write(app_id, "src/components/App.tsx", `import { FunctionComponent } from 'preact';
+import { useState, useEffect } from 'preact/hooks';
+import { Header } from './Header';
+
+export const App: FunctionComponent = () => {
+  const [records, setRecords] = useState([]);
+
+  useEffect(() => {
+    window.vellum.data.query().then(setRecords);
+  }, []);
+
+  return (
+    <div className="app">
+      <Header title="Project Tracker" count={records.length} />
+      {/* ... */}
+    </div>
+  );
+};`)
+
+app_file_write(app_id, "src/components/Header.tsx", `import { FunctionComponent } from 'preact';
+
+interface HeaderProps {
+  title: string;
+  count: number;
+}
+
+export const Header: FunctionComponent<HeaderProps> = ({ title, count }) => (
+  <header className="header">
+    <h1>{title}</h1>
+    <span className="badge">{count} items</span>
+  </header>
+);`)
+
+app_file_write(app_id, "src/styles.css", `.app { padding: var(--v-spacing-lg); }
+.header { display: flex; justify-content: space-between; align-items: center; }
+.badge { background: var(--v-accent); color: white; padding: var(--v-spacing-xs) var(--v-spacing-sm); border-radius: var(--v-radius-pill); }`)
+```
+
+**Technical constraints (multi-file):**
+
+- No CDN imports — use esbuild-resolved packages from the allowlist above
+- Preact for UI (not React) — `import { render } from 'preact'`
+- TypeScript encouraged for all `.tsx`/`.ts` files
+- No external fonts, images, or resources — use system fonts and CSS/SVG for visuals
+- Design for 400-600px width with graceful resizing
+- The WebView blocks all navigation — links and form `action` attributes won't work
+
+#### Single HTML file (legacy)
+
+Use this format only for the simplest one-off pages. Write a complete, self-contained HTML document.
+
+**Technical constraints (single-file):**
 
 - Single HTML string — no external files, CDNs, or imports
 - All CSS in `<style>` in `<head>`, all JavaScript in `<script>` before `</body>`


### PR DESCRIPTION
## Summary
- Update SKILL.md to document multi-file TSX app format as preferred approach
- Add Preact component patterns, TypeScript usage, CSS imports
- Keep legacy single-file docs as fallback for simple apps
- Add example multi-file project structure with `app_file_write` calls

Part of plan: multifile-tsx-esbuild-apps.md (PR 11 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
