### PR TITLE
feat: drop unsafe-inline script-src for new-format apps

### DIFF
--- a/assistant/src/__tests__/app-routes-csp.test.ts
+++ b/assistant/src/__tests__/app-routes-csp.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// Mock the logger before importing the module under test
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Fake app records keyed by ID
+const legacyApp = {
+  id: "legacy-1",
+  name: "Legacy App",
+  htmlDefinition: "<div>Hello</div>",
+  schemaJson: "{}",
+  createdAt: 0,
+  updatedAt: 0,
+  // No formatVersion → legacy
+};
+
+const multifileApp = {
+  id: "multi-1",
+  name: "Multifile App",
+  htmlDefinition: "",
+  schemaJson: "{}",
+  createdAt: 0,
+  updatedAt: 0,
+  formatVersion: 2,
+};
+
+const apps = new Map<string, typeof legacyApp | typeof multifileApp>([
+  ["legacy-1", legacyApp],
+  ["multi-1", multifileApp],
+]);
+
+mock.module("../memory/app-store.js", () => ({
+  getApp: (id: string) => apps.get(id) ?? null,
+  getAppsDir: () => "/fake/apps",
+  isMultifileApp: (app: Record<string, unknown>) => app.formatVersion === 2,
+}));
+
+// Mock shared-app-links-store (imported by app-routes but unused here)
+mock.module("../memory/shared-app-links-store.js", () => ({
+  createSharedAppLink: () => ({ shareToken: "tok" }),
+  getSharedAppLink: () => null,
+  incrementDownloadCount: () => {},
+  deleteSharedAppLinkByToken: () => false,
+}));
+
+// Stub fs so the multifile path finds a fake dist/index.html
+mock.module("node:fs", () => ({
+  existsSync: (p: string) => p === "/fake/apps/multi-1/dist/index.html",
+  readFileSync: (p: string, _enc?: string) => {
+    if (p === "/fake/apps/multi-1/dist/index.html") {
+      return '<!DOCTYPE html><html><head></head><body><script src="main.js"></script></body></html>';
+    }
+    // Design system CSS — return empty string
+    return "";
+  },
+}));
+
+import { handleServePage } from "../runtime/routes/app-routes.js";
+
+/** Parse CSP header into a directive map. */
+function parseCsp(header: string): Record<string, string> {
+  const directives: Record<string, string> = {};
+  for (const part of header.split(";")) {
+    const trimmed = part.trim();
+    const spaceIdx = trimmed.indexOf(" ");
+    if (spaceIdx === -1) continue;
+    directives[trimmed.slice(0, spaceIdx)] = trimmed.slice(spaceIdx + 1);
+  }
+  return directives;
+}
+
+describe("app-routes CSP headers", () => {
+  describe("legacy apps", () => {
+    test("includes 'unsafe-inline' in script-src", () => {
+      const res = handleServePage("legacy-1");
+      const csp = res.headers.get("Content-Security-Policy")!;
+      const directives = parseCsp(csp);
+      expect(directives["script-src"]).toContain("'unsafe-inline'");
+    });
+
+    test("includes 'unsafe-inline' in style-src", () => {
+      const res = handleServePage("legacy-1");
+      const csp = res.headers.get("Content-Security-Policy")!;
+      const directives = parseCsp(csp);
+      expect(directives["style-src"]).toContain("'unsafe-inline'");
+    });
+
+    test("has img-src with self, data, and https", () => {
+      const res = handleServePage("legacy-1");
+      const csp = res.headers.get("Content-Security-Policy")!;
+      const directives = parseCsp(csp);
+      expect(directives["img-src"]).toContain("'self'");
+      expect(directives["img-src"]).toContain("data:");
+      expect(directives["img-src"]).toContain("https:");
+    });
+  });
+
+  describe("multifile apps", () => {
+    test("does NOT include 'unsafe-inline' in script-src", () => {
+      const res = handleServePage("multi-1");
+      const csp = res.headers.get("Content-Security-Policy")!;
+      const directives = parseCsp(csp);
+      expect(directives["script-src"]).not.toContain("'unsafe-inline'");
+    });
+
+    test("includes 'self' in script-src for external main.js", () => {
+      const res = handleServePage("multi-1");
+      const csp = res.headers.get("Content-Security-Policy")!;
+      const directives = parseCsp(csp);
+      expect(directives["script-src"]).toContain("'self'");
+    });
+
+    test("includes 'unsafe-inline' in style-src", () => {
+      const res = handleServePage("multi-1");
+      const csp = res.headers.get("Content-Security-Policy")!;
+      const directives = parseCsp(csp);
+      expect(directives["style-src"]).toContain("'unsafe-inline'");
+    });
+
+    test("has img-src with self, data, and https", () => {
+      const res = handleServePage("multi-1");
+      const csp = res.headers.get("Content-Security-Policy")!;
+      const directives = parseCsp(csp);
+      expect(directives["img-src"]).toContain("'self'");
+      expect(directives["img-src"]).toContain("data:");
+      expect(directives["img-src"]).toContain("https:");
+    });
+  });
+
+  describe("consistent directives across formats", () => {
+    test("both formats share the same style-src policy", () => {
+      const legacy = handleServePage("legacy-1");
+      const multi = handleServePage("multi-1");
+      const legacyCsp = parseCsp(
+        legacy.headers.get("Content-Security-Policy")!,
+      );
+      const multiCsp = parseCsp(multi.headers.get("Content-Security-Policy")!);
+      expect(legacyCsp["style-src"]).toBe(multiCsp["style-src"]);
+    });
+
+    test("both formats share the same img-src policy", () => {
+      const legacy = handleServePage("legacy-1");
+      const multi = handleServePage("multi-1");
+      const legacyCsp = parseCsp(
+        legacy.headers.get("Content-Security-Policy")!,
+      );
+      const multiCsp = parseCsp(multi.headers.get("Content-Security-Policy")!);
+      expect(legacyCsp["img-src"]).toBe(multiCsp["img-src"]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Multifile TSX apps (formatVersion 2) already have a stricter CSP from PR 8 that omits `'unsafe-inline'` from `script-src`
- Legacy apps retain `'unsafe-inline'` in `script-src` for inline event handlers
- Adds comprehensive test suite verifying CSP headers for both app formats

## Test plan
- [x] Tests verify legacy app CSP includes `'unsafe-inline'` in `script-src`
- [x] Tests verify multifile app CSP does NOT include `'unsafe-inline'` in `script-src`
- [x] Tests verify multifile app CSP includes `'self'` in `script-src` (for external `main.js`)
- [x] Tests verify both formats share consistent `style-src` and `img-src` directives

Part of plan: multifile-tsx-esbuild-apps.md (PR 10 of 13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
