### PR TITLE
refactor: simplify getTwilioConfig to read phone number from twilio config only

### DIFF
--- a/assistant/src/__tests__/call-domain.test.ts
+++ b/assistant/src/__tests__/call-domain.test.ts
@@ -207,16 +207,12 @@ describe("resolveCallerIdentity — strict implicit-default policy", () => {
     }
   });
 
-  test("assistant_number resolves from assistant-scoped Twilio number when assistantId is provided", async () => {
-    const result = await resolveCallerIdentity(
-      makeConfig(),
-      undefined,
-      "ast-alpha",
-    );
+  test("assistant_number resolves from twilio config phone number", async () => {
+    const result = await resolveCallerIdentity(makeConfig());
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.mode).toBe("assistant_number");
-      expect(result.fromNumber).toBe("+15550003333");
+      expect(result.fromNumber).toBe("+15550001111");
       expect(result.source).toBe("implicit_default");
     }
   });

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -123,7 +123,6 @@ export type CallerIdentityResult =
 export async function resolveCallerIdentity(
   config: AssistantConfig,
   requestedMode?: "assistant_number" | "user_number",
-  assistantId?: string,
 ): Promise<CallerIdentityResult> {
   const identityConfig = config.calls.callerIdentity;
   let mode: "assistant_number" | "user_number";
@@ -161,7 +160,7 @@ export async function resolveCallerIdentity(
   }
 
   if (mode === "assistant_number") {
-    const twilioConfig = getTwilioConfig(assistantId);
+    const twilioConfig = getTwilioConfig();
     log.info(
       { mode, source, fromNumber: twilioConfig.phoneNumber },
       "Resolved caller identity",
@@ -395,7 +394,6 @@ export async function startCall(
     const identityResult = await resolveCallerIdentity(
       ingressConfig,
       callerIdentityMode,
-      assistantId,
     );
     if (!identityResult.ok) {
       return { ok: false, error: identityResult.error, status: 400 };
@@ -883,12 +881,8 @@ export type StartGuardianVerificationCallResult =
 export async function startGuardianVerificationCall(
   input: StartGuardianVerificationCallInput,
 ): Promise<StartGuardianVerificationCallResult> {
-  const {
-    phoneNumber,
-    guardianVerificationSessionId,
-    assistantId = DAEMON_INTERNAL_ASSISTANT_ID,
-    originConversationId,
-  } = input;
+  const { phoneNumber, guardianVerificationSessionId, originConversationId } =
+    input;
 
   if (!phoneNumber || !E164_REGEX.test(phoneNumber)) {
     return {
@@ -905,11 +899,7 @@ export async function startGuardianVerificationCall(
     const provider = new TwilioConversationRelayProvider();
 
     // Resolve the assistant's Twilio number as the caller ID
-    const identityResult = await resolveCallerIdentity(
-      config,
-      undefined,
-      assistantId,
-    );
+    const identityResult = await resolveCallerIdentity(config);
     if (!identityResult.ok) {
       return { ok: false, error: identityResult.error, status: 400 };
     }

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -1,4 +1,3 @@
-import { getTwilioPhoneNumberEnv } from "../config/env.js";
 import { loadConfig } from "../config/loader.js";
 import {
   getPublicBaseUrl,
@@ -18,29 +17,11 @@ export interface TwilioConfig {
   wssBaseUrl: string;
 }
 
-function resolveTwilioPhoneNumber(
-  config: ReturnType<typeof loadConfig>,
-  assistantId?: string,
-): string {
-  if (assistantId) {
-    const scoped = (
-      config.sms?.assistantPhoneNumbers as Record<string, string> | undefined
-    )?.[assistantId];
-    if (scoped) return scoped;
-  }
-  return (
-    getTwilioPhoneNumberEnv() ||
-    config.twilio?.phoneNumber ||
-    config.sms?.phoneNumber ||
-    ""
-  );
-}
-
-export function getTwilioConfig(assistantId?: string): TwilioConfig {
+export function getTwilioConfig(): TwilioConfig {
   const config = loadConfig();
   const accountSid = config.twilio?.accountSid || "";
   const authToken = getSecureKey("credential:twilio:auth_token");
-  const phoneNumber = resolveTwilioPhoneNumber(config, assistantId);
+  const phoneNumber = config.twilio?.phoneNumber || "";
   const webhookBaseUrl = getPublicBaseUrl(config);
 
   let wssBaseUrl: string;


### PR DESCRIPTION
## Summary
- Removed `resolveTwilioPhoneNumber` helper and all its fallback chain (env var, `sms.phoneNumber`, scoped assistant phone numbers)
- Phone number now reads solely from `config.twilio.phoneNumber`
- Removed `assistantId` parameter from `getTwilioConfig()` and `resolveCallerIdentity()`, updated all call sites and tests

## Original prompt
let's simplify getTwilioPhoneNumberEnv. It should only look at config.twilio?.phoneNumber. We can remove support for everything else (and not worry about backwards compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)