### PR TITLE
fix: surface compileApp errors in app_create + clear stale dist before rebuild

### DIFF
--- a/assistant/src/bundler/app-compiler.ts
+++ b/assistant/src/bundler/app-compiler.ts
@@ -5,7 +5,7 @@
  * script/style tag injection, and returns structured diagnostics.
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
@@ -62,6 +62,10 @@ export async function compileApp(appDir: string): Promise<CompileResult> {
   const distDir = join(appDir, "dist");
   const entryPoint = join(srcDir, "main.tsx");
 
+  // Clear stale dist/ output so removed assets (e.g. CSS) don't persist
+  if (existsSync(distDir)) {
+    rmSync(distDir, { recursive: true, force: true });
+  }
   await mkdir(distDir, { recursive: true });
 
   // Resolve preact from the assistant's own node_modules so per-app

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -219,7 +219,18 @@ render(<App />, document.getElementById('app')!);
     // Compile src/ → dist/
     const { join } = await import("node:path");
     const appDir = join(getAppsDir(), app.id);
-    await compileApp(appDir);
+    const compileResult = await compileApp(appDir);
+    if (!compileResult.ok) {
+      return {
+        content: JSON.stringify({
+          ...app,
+          compile_errors: compileResult.errors,
+          compile_warnings: compileResult.warnings,
+          compile_duration_ms: compileResult.durationMs,
+        }),
+        isError: false,
+      };
+    }
   }
 
   if (input.set_as_home_base) {


### PR DESCRIPTION
## Summary
- Surface compilation diagnostics in `executeAppCreate` response when build fails, so the LLM can self-correct
- Clear `dist/` directory before esbuild compilation to prevent stale artifacts (e.g. orphaned `main.css` after CSS import removal)

Addresses review feedback on #13544 and #13540.

## Test plan
- [x] `bun test src/__tests__/app-compiler.test.ts` — 14 pass
- [x] `bun test src/__tests__/app-executors.test.ts` — 21 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
