### PR TITLE
fix: validate appId in handleServeDistFile to prevent path traversal

### DIFF
--- a/assistant/src/__tests__/app-routes-csp.test.ts
+++ b/assistant/src/__tests__/app-routes-csp.test.ts
@@ -60,7 +60,10 @@ mock.module("node:fs", () => ({
   },
 }));
 
-import { handleServePage } from "../runtime/routes/app-routes.js";
+import {
+  handleServeDistFile,
+  handleServePage,
+} from "../runtime/routes/app-routes.js";
 
 /** Parse CSP header into a directive map. */
 function parseCsp(header: string): Record<string, string> {
@@ -129,6 +132,49 @@ describe("app-routes CSP headers", () => {
       expect(directives["img-src"]).toContain("'self'");
       expect(directives["img-src"]).toContain("data:");
       expect(directives["img-src"]).toContain("https:");
+    });
+  });
+
+  describe("handleServeDistFile appId validation", () => {
+    test("rejects appId with encoded path traversal (..)", () => {
+      const res = handleServeDistFile("..", "main.js");
+      expect(res.status).toBe(400);
+    });
+
+    test("rejects appId with forward slash", () => {
+      const res = handleServeDistFile("../../etc", "main.js");
+      expect(res.status).toBe(400);
+    });
+
+    test("rejects appId with backslash", () => {
+      const res = handleServeDistFile("foo\\bar", "main.js");
+      expect(res.status).toBe(400);
+    });
+
+    test("rejects empty appId", () => {
+      const res = handleServeDistFile("", "main.js");
+      expect(res.status).toBe(400);
+    });
+
+    test("rejects appId with leading whitespace", () => {
+      const res = handleServeDistFile(" multi-1", "main.js");
+      expect(res.status).toBe(400);
+    });
+
+    test("rejects appId with trailing whitespace", () => {
+      const res = handleServeDistFile("multi-1 ", "main.js");
+      expect(res.status).toBe(400);
+    });
+
+    test("rejects appId containing .. in the middle", () => {
+      const res = handleServeDistFile("foo..bar", "main.js");
+      expect(res.status).toBe(400);
+    });
+
+    test("allows valid appId and filename (file not found is 404)", () => {
+      const res = handleServeDistFile("multi-1", "main.js");
+      // File doesn't exist in our mock fs, so 404
+      expect(res.status).toBe(404);
     });
   });
 

--- a/assistant/src/runtime/routes/app-routes.ts
+++ b/assistant/src/runtime/routes/app-routes.ts
@@ -179,7 +179,18 @@ const DIST_CONTENT_TYPES: Record<string, string> = {
  * Validates the filename to prevent path traversal.
  */
 export function handleServeDistFile(appId: string, filename: string): Response {
-  // Reject any traversal attempts
+  // Reject any traversal attempts on appId
+  if (
+    !appId ||
+    appId.includes("..") ||
+    appId.includes("/") ||
+    appId.includes("\\") ||
+    appId !== appId.trim()
+  ) {
+    return httpError("BAD_REQUEST", "Invalid appId", 400);
+  }
+
+  // Reject any traversal attempts on filename
   if (
     !filename ||
     filename.includes("..") ||


### PR DESCRIPTION
## Summary
- Add `appId` validation in `handleServeDistFile` to prevent path traversal via URL-encoded `..` (`%2e%2e`)
- Matches the same validation pattern (`..`, `/`, `\`, empty, untrimmed) used by `validateId()` in app-store.ts
- Add 8 test cases covering traversal attempts on `appId`

Addresses review feedback on #13546.

## Test plan
- [x] All 17 tests pass in `app-routes-csp.test.ts` (9 existing + 8 new)
- [x] New tests cover: `..`, `/`, `\`, empty string, leading/trailing whitespace, embedded `..`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
