### PR TITLE
fix: conditional styles import in migration + escape app name in scaffold

### DIFF
--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -386,7 +386,7 @@ describe("executeAppCreate", () => {
     expect(files["src/index.html"]).toContain('<div id="app"></div>');
     expect(files["src/main.tsx"]).toBeDefined();
     expect(files["src/main.tsx"]).toContain("import { render } from 'preact'");
-    expect(files["src/main.tsx"]).toContain("Hello, New App!");
+    expect(files["src/main.tsx"]).toContain('{"Hello, New App!"}');
   });
 
   test("flag on with explicit html: uses provided html as src/index.html", async () => {

--- a/assistant/src/__tests__/app-migration.test.ts
+++ b/assistant/src/__tests__/app-migration.test.ts
@@ -47,7 +47,8 @@ describe("migrateAppToMultifile", () => {
     // src/main.tsx created
     const mainTsx = readFileSync(join(appDir, "src", "main.tsx"), "utf-8");
     expect(mainTsx).toContain("Entry point");
-    expect(mainTsx).toContain("import './styles.css'");
+    // No inline styles in source HTML → no styles.css import
+    expect(mainTsx).not.toContain("import './styles.css'");
   });
 
   test("sets formatVersion to 2 after migration", () => {

--- a/assistant/src/memory/app-migration.ts
+++ b/assistant/src/memory/app-migration.ts
@@ -93,7 +93,8 @@ export function migrateAppToMultifile(appId: string): MigrationResult {
   writeFileSync(join(srcDir, "index.html"), processedHtml, "utf-8");
 
   // Write src/main.tsx placeholder
-  const mainTsx = `// Entry point — migrated from legacy single-file app\nimport './styles.css';\n\nconsole.log('App loaded');\n`;
+  const styleImport = css ? "import './styles.css';\n" : "";
+  const mainTsx = `// Entry point — migrated from legacy single-file app\n${styleImport}\nconsole.log('App loaded');\n`;
   writeFileSync(join(srcDir, "main.tsx"), mainTsx, "utf-8");
 
   // Write src/styles.css if styles were extracted

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -189,6 +189,13 @@ export async function executeAppCreate(
 
   // Scaffold multifile app with src/ files and compile to dist/
   if (multifileEnabled) {
+    const htmlSafeName = name
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+    const jsxSafeName = name.replace(/[<>{}&"']/g, "");
+
     const indexHtml =
       typeof input.html === "string"
         ? input.html
@@ -197,7 +204,7 @@ export async function executeAppCreate(
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${name}</title>
+  <title>${htmlSafeName}</title>
 </head>
 <body>
   <div id="app"></div>
@@ -207,7 +214,7 @@ export async function executeAppCreate(
     const mainTsx = `import { render } from 'preact';
 
 function App() {
-  return <div>Hello, ${name}!</div>;
+  return <div>{"Hello, ${jsxSafeName}!"}</div>;
 }
 
 render(<App />, document.getElementById('app')!);


### PR DESCRIPTION
## Summary
- Only import `styles.css` in migrated `main.tsx` when inline styles were actually extracted, preventing build failures from dangling imports
- Escape app name for HTML `<title>` tag and JSX template to prevent invalid markup when names contain `<`, `>`, `{`, `}`, `&`, or quote characters
- Update tests to match corrected behavior

Addresses review feedback on #13541 and #13544.

## Test plan
- [x] `bun test src/__tests__/app-migration.test.ts` — 6/6 pass
- [x] `bun test src/__tests__/app-executors.test.ts` — 21/21 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
