### PR TITLE
fix: clean file paths in app_file_list + normalize ./ prefix in resolveAppFilePath

### DIFF
--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -138,6 +138,20 @@ describe("resolveAppFilePath", () => {
     const app = makeLegacyApp({ formatVersion: 1 });
     expect(resolveAppFilePath(app, "index.html")).toBe("index.html");
   });
+
+  test("strips ./ prefix and prepends src/ for multifile app", () => {
+    const app = makeMultifileApp();
+    expect(resolveAppFilePath(app, "./main.tsx")).toBe("src/main.tsx");
+  });
+
+  test("strips ./ prefix for known top-level dir in multifile app", () => {
+    const app = makeMultifileApp();
+    expect(resolveAppFilePath(app, "./src/main.tsx")).toBe("src/main.tsx");
+    expect(resolveAppFilePath(app, "./dist/bundle.js")).toBe("dist/bundle.js");
+    expect(resolveAppFilePath(app, "./records/data.json")).toBe(
+      "records/data.json",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -285,7 +299,7 @@ describe("executeAppFileEdit", () => {
 // ---------------------------------------------------------------------------
 
 describe("executeAppFileList", () => {
-  test("annotates dist/ files as build output for multifile app", () => {
+  test("returns clean file paths and separate buildOutput for multifile app", () => {
     const app = makeMultifileApp();
     const store = mockStore(app, {
       "src/main.tsx": "",
@@ -294,11 +308,21 @@ describe("executeAppFileList", () => {
     });
 
     const result = executeAppFileList({ app_id: app.id }, store);
-    const parsed = JSON.parse(result.content) as string[];
+    const parsed = JSON.parse(result.content) as {
+      files: string[];
+      buildOutput: string[];
+    };
 
-    expect(parsed).toContain("src/main.tsx");
-    expect(parsed).toContain("src/components/Header.tsx");
-    expect(parsed).toContain("dist/index.html [build output]");
+    // File paths must be clean — no annotations appended
+    expect(parsed.files).toContain("src/main.tsx");
+    expect(parsed.files).toContain("src/components/Header.tsx");
+    expect(parsed.files).toContain("dist/index.html");
+    expect(
+      parsed.files.every((f: string) => !f.includes("[build output]")),
+    ).toBe(true);
+
+    // Build output files listed separately
+    expect(parsed.buildOutput).toEqual(["dist/index.html"]);
   });
 
   test("does not annotate files for legacy app", () => {

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -93,15 +93,15 @@ export type ProxyResolver = (
  */
 export function resolveAppFilePath(app: AppDefinition, path: string): string {
   if (!isMultifileApp(app)) return path;
-  const normalized = path.replace(/\\/g, "/");
+  const normalized = path.replace(/\\/g, "/").replace(/^\.\//, "");
   if (
     normalized.startsWith("src/") ||
     normalized.startsWith("dist/") ||
     normalized.startsWith("records/")
   ) {
-    return path;
+    return normalized;
   }
-  return `src/${path}`;
+  return `src/${normalized}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -375,15 +375,18 @@ export function executeAppFileList(
   const app = store.getApp(input.app_id);
 
   if (app && isMultifileApp(app)) {
-    // Annotate dist/ files as build output for clarity
-    const annotated = files.map((f) => {
-      const normalized = f.replace(/\\/g, "/");
-      if (normalized.startsWith("dist/")) {
-        return `${f} [build output]`;
-      }
-      return f;
-    });
-    return { content: JSON.stringify(annotated), isError: false };
+    // Separate build output paths from source paths without mutating the
+    // file path strings — consumers need clean paths for subsequent tool calls.
+    const buildOutputPaths = files.filter((f) =>
+      f.replace(/\\/g, "/").startsWith("dist/"),
+    );
+    return {
+      content: JSON.stringify({
+        files,
+        buildOutput: buildOutputPaths,
+      }),
+      isError: false,
+    };
   }
 
   return { content: JSON.stringify(files), isError: false };


### PR DESCRIPTION
## Summary
- Return clean file paths in `app_file_list` — no longer appends `[build output]` to path strings. Build output files are now listed in a separate `buildOutput` property in the response JSON.
- Strip leading `./` in `resolveAppFilePath` to prevent double-prefixing (e.g. `src/./src/main.tsx`).

Addresses review feedback on #13543.

## Test plan
- [x] Updated existing `executeAppFileList` test to verify clean paths and separate `buildOutput` property
- [x] Added `resolveAppFilePath` tests for `./`-prefixed paths (`./main.tsx`, `./src/main.tsx`, `./dist/bundle.js`, `./records/data.json`)
- [x] All 23 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
