### PR TITLE
fix: regenerate IPC Swift code after app builder changes

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1719,8 +1719,12 @@ public struct IPCGalleryApp: Codable, Sendable {
     public let featured: Bool?
     public let schemaJson: String
     public let htmlDefinition: String
+    /// 2 = multi-file TSX format with sourceFiles
+    public let formatVersion: Int?
+    /// Maps relative path to file content, e.g. { "src/main.tsx": "...", "src/index.html": "..." }
+    public let sourceFiles: [String: String]?
 
-    public init(id: String, name: String, description: String, icon: String, category: String, version: String, featured: Bool? = nil, schemaJson: String, htmlDefinition: String) {
+    public init(id: String, name: String, description: String, icon: String, category: String, version: String, featured: Bool? = nil, schemaJson: String, htmlDefinition: String, formatVersion: Int? = nil, sourceFiles: [String: String]? = nil) {
         self.id = id
         self.name = name
         self.description = description
@@ -1730,6 +1734,8 @@ public struct IPCGalleryApp: Codable, Sendable {
         self.featured = featured
         self.schemaJson = schemaJson
         self.htmlDefinition = htmlDefinition
+        self.formatVersion = formatVersion
+        self.sourceFiles = sourceFiles
     }
 }
 


### PR DESCRIPTION
## Summary
- Regenerate IPC Swift generated code to match updated TypeScript contract
- Adds `formatVersion` and `sourceFiles` fields to `IPCGalleryApp` struct
- Fixes CI failure: "Generated Swift file is out of date"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
