### PR TITLE
fix(ci): switch perf regression baseline from wall clock to CPU time

### DIFF
--- a/clients/macos/vellum-assistantTests/AXTreeDiffPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/AXTreeDiffPerformanceTests.swift
@@ -5,7 +5,7 @@ import XCTest
 //
 // These tests establish XCTest performance baselines for AXTreeDiff.diff()
 // computation across representative scenarios. On the first run XCTest records
-// a baseline; subsequent runs fail if wall-clock time regresses by more than
+// a baseline; subsequent runs fail if CPU time regresses by more than
 // the default XCTest allowance (~10 %).
 //
 // Run manually with:
@@ -87,7 +87,7 @@ final class AXTreeDiffPerformanceTests: XCTestCase {
         let previous = Self.makeElements(count: 50, prefix: "s")
         let current = Self.mutateElements(previous, count: 5)
 
-        measure(metrics: [XCTClockMetric()]) {
+        measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
             for _ in 0..<200 {
                 _ = AXTreeDiff.diff(previousFlat: previous, currentFlat: current)
             }
@@ -100,7 +100,7 @@ final class AXTreeDiffPerformanceTests: XCTestCase {
         let previous = Self.makeElements(count: 200, prefix: "m")
         let current = Self.mutateElements(previous, count: 50)
 
-        measure(metrics: [XCTClockMetric()]) {
+        measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
             for _ in 0..<50 {
                 _ = AXTreeDiff.diff(previousFlat: previous, currentFlat: current)
             }
@@ -112,7 +112,7 @@ final class AXTreeDiffPerformanceTests: XCTestCase {
     func testLargeTreeIdentical() {
         let elements = Self.makeElements(count: 500, prefix: "l")
 
-        measure(metrics: [XCTClockMetric()]) {
+        measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
             for _ in 0..<50 {
                 _ = AXTreeDiff.diff(previousFlat: elements, currentFlat: elements)
             }
@@ -126,7 +126,7 @@ final class AXTreeDiffPerformanceTests: XCTestCase {
         let previous = Self.makeElements(count: 200, idOffset: 0, prefix: "old")
         let current = Self.makeElements(count: 200, idOffset: 1000, prefix: "new")
 
-        measure(metrics: [XCTClockMetric()]) {
+        measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
             for _ in 0..<50 {
                 _ = AXTreeDiff.diff(previousFlat: previous, currentFlat: current)
             }

--- a/clients/macos/vellum-assistantTests/MarkdownPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MarkdownPerformanceTests.swift
@@ -6,7 +6,7 @@ import XCTest
 //
 // These tests establish XCTest performance baselines for the markdown parsing
 // and segment-grouping pipeline. On the first run XCTest records a baseline;
-// subsequent runs fail if wall-clock time regresses by more than 10 % (the
+// subsequent runs fail if CPU time regresses by more than 10 % (the
 // default XCTest allowance).
 //
 // Run manually with:
@@ -161,7 +161,7 @@ final class MarkdownPerformanceTests: XCTestCase {
     /// that the baseline captures only the grouping pass.
     func testGroupedSegmentsPerformance() {
         let segments = parseMarkdownSegments(Self.sampleMarkdown)
-        measure(metrics: [XCTClockMetric()]) {
+        measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
             for _ in 0..<200 {
                 _ = groupSegments(segments)
             }
@@ -195,7 +195,7 @@ final class MarkdownPerformanceTests: XCTestCase {
     /// super-linear complexity regressions that may not be visible at 500 words.
     func testMarkdownParsePerformanceLargeInput() {
         let largeSample = (0..<10).map { _ in Self.sampleMarkdown }.joined(separator: "\n\n")
-        measure(metrics: [XCTClockMetric()]) {
+        measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
             _ = parseMarkdownSegments(largeSample)
         }
     }

--- a/scripts/compare-perf-baselines.sh
+++ b/scripts/compare-perf-baselines.sh
@@ -29,20 +29,18 @@ baseline_dir     = sys.argv[4]
 update_baseline  = sys.argv[5].lower() == "true"
 
 # Parse XCTest timing lines. Format (macOS XCTest via swift test):
-#   Test Case '-[Suite.ClassName testMethodName]' measured [Clock Monotonic Time, s] average: N.NNN, ...
+#   Test Case '-[Suite.ClassName testMethodName]' measured [CPU Time, s] average: N.NNN, ...
 #
-# The metric type varies across Xcode versions — older: "[Time, seconds]",
-# newer (Xcode 15+): "[Clock Monotonic Time, s]".  After the closing ']' of the
-# test name the output includes a single-quote "'" before the space and "measured".
-# We track "Clock Monotonic Time" (wall clock) and fall back to any "Time, seconds"
-# line.  Multiple metric lines appear per test; the first matching one wins so
-# subsequent CPU-cycles/instructions lines don't overwrite the wall-time result.
+# We track "CPU Time" rather than wall clock ("Clock Monotonic Time") because
+# CPU time is far more stable on shared CI runners, eliminating false regression
+# alerts caused by noisy wall-clock measurements.  Multiple metric lines appear
+# per test; we match only the CPU Time line.
 pattern = re.compile(
     r"(?:"
     r"-\[(?:[^\]]*\s+)?(\w+)\]['\"]?"          # ObjC: -[Suite.Class testMethod]
     r"|Test Case '(?:[^/']+/)?(\w+)'"           # SwiftPM: Test Case 'Module.Class/testMethod'
     r")"
-    r"\s+measured \[(?:Clock Monotonic Time, s|Time, seconds)\] average:\s+([0-9.]+)"
+    r"\s+measured \[CPU Time, s\] average:\s+([0-9.]+)"
 )
 
 results = {}
@@ -51,7 +49,7 @@ with open(results_log) as f:
         m = pattern.search(line)
         if m:
             test_name = m.group(1) or m.group(2)
-            if test_name not in results:  # first match wins (wall-time before CPU-cycles lines)
+            if test_name not in results:  # first match wins (CPU Time appears once per test)
                 results[test_name] = float(m.group(3))
 
 summary_file = os.path.join(baseline_dir, "summary.md")


### PR DESCRIPTION
Switch compare-perf-baselines.sh to parse CPU Time instead of Clock Monotonic Time, and add XCTCPUMetric to all performance tests. CPU Time is far more stable on shared CI runners, eliminating false regression alerts. Closes #13564.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
