### PR TITLE
fix(ci): switch perf regression baseline from wall clock to CPU time

### DIFF
--- a/clients/macos/vellum-assistantTests/AXTreeDiffPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/AXTreeDiffPerformanceTests.swift
@@ -5,7 +5,7 @@ import XCTest
 //
 // These tests establish XCTest performance baselines for AXTreeDiff.diff()
 // computation across representative scenarios. On the first run XCTest records
-// a baseline; subsequent runs fail if wall-clock time regresses by more than
+// a baseline; subsequent runs fail if CPU time regresses by more than
 // the default XCTest allowance (~10 %).
 //
 // Run manually with:
@@ -87,7 +87,7 @@ final class AXTreeDiffPerformanceTests: XCTestCase {
         let previous = Self.makeElements(count: 50, prefix: "s")
         let current = Self.mutateElements(previous, count: 5)
 
-        measure(metrics: [XCTClockMetric()]) {
+        measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
             for _ in 0..<200 {
                 _ = AXTreeDiff.diff(previousFlat: previous, currentFlat: current)
             }
@@ -100,7 +100,7 @@ final class AXTreeDiffPerformanceTests: XCTestCase {
         let previous = Self.makeElements(count: 200, prefix: "m")
         let current = Self.mutateElements(previous, count: 50)
 
-        measure(metrics: [XCTClockMetric()]) {
+        measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
             for _ in 0..<50 {
                 _ = AXTreeDiff.diff(previousFlat: previous, currentFlat: current)
             }
@@ -112,7 +112,7 @@ final class AXTreeDiffPerformanceTests: XCTestCase {
     func testLargeTreeIdentical() {
         let elements = Self.makeElements(count: 500, prefix: "l")
 
-        measure(metrics: [XCTClockMetric()]) {
+        measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
             for _ in 0..<50 {
                 _ = AXTreeDiff.diff(previousFlat: elements, currentFlat: elements)
             }
@@ -126,7 +126,7 @@ final class AXTreeDiffPerformanceTests: XCTestCase {
         let previous = Self.makeElements(count: 200, idOffset: 0, prefix: "old")
         let current = Self.makeElements(count: 200, idOffset: 1000, prefix: "new")
 
-        measure(metrics: [XCTClockMetric()]) {
+        measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
             for _ in 0..<50 {
                 _ = AXTreeDiff.diff(previousFlat: previous, currentFlat: current)
             }

--- a/clients/macos/vellum-assistantTests/MarkdownPerformanceTests.swift
+++ b/clients/macos/vellum-assistantTests/MarkdownPerformanceTests.swift
@@ -6,7 +6,7 @@ import XCTest
 //
 // These tests establish XCTest performance baselines for the markdown parsing
 // and segment-grouping pipeline. On the first run XCTest records a baseline;
-// subsequent runs fail if wall-clock time regresses by more than 10 % (the
+// subsequent runs fail if CPU time regresses by more than 10 % (the
 // default XCTest allowance).
 //
 // Run manually with:
@@ -161,7 +161,7 @@ final class MarkdownPerformanceTests: XCTestCase {
     /// that the baseline captures only the grouping pass.
     func testGroupedSegmentsPerformance() {
         let segments = parseMarkdownSegments(Self.sampleMarkdown)
-        measure(metrics: [XCTClockMetric()]) {
+        measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
             for _ in 0..<200 {
                 _ = groupSegments(segments)
             }
@@ -195,7 +195,7 @@ final class MarkdownPerformanceTests: XCTestCase {
     /// super-linear complexity regressions that may not be visible at 500 words.
     func testMarkdownParsePerformanceLargeInput() {
         let largeSample = (0..<10).map { _ in Self.sampleMarkdown }.joined(separator: "\n\n")
-        measure(metrics: [XCTClockMetric()]) {
+        measure(metrics: [XCTClockMetric(), XCTCPUMetric()]) {
             _ = parseMarkdownSegments(largeSample)
         }
     }

--- a/scripts/compare-perf-baselines.sh
+++ b/scripts/compare-perf-baselines.sh
@@ -67,29 +67,41 @@ for name, avg in sorted(results.items()):
     print(f"  {name}: {avg:.4f}s")
 print()
 
-# First run: no baseline file yet.
-# On main push runs, record current results as baseline and pass.
-# On PR runs (update_baseline=false), skip comparison rather than silently
-# establishing a baseline from the PR — that would let regressions slip through.
+# Metric version tag stored in baselines.json.  When the metric type changes
+# (e.g., from wall-clock to CPU time), stored values are invalid and must be
+# re-established — otherwise the comparison exits with false regressions before
+# updating the baseline, creating a stuck state.
+METRIC_VERSION = "cpu-time-v1"
+
+# First run or metric migration: no baseline file, or baseline from a different metric.
+needs_fresh_baseline = False
 if not os.path.exists(baseline_file):
+    needs_fresh_baseline = True
+else:
+    with open(baseline_file) as f:
+        stored = json.load(f)
+    if stored.get("_metric") != METRIC_VERSION:
+        print(f"Baseline metric mismatch (expected '{METRIC_VERSION}', got '{stored.get('_metric', 'none')}'). Re-establishing baseline.")
+        needs_fresh_baseline = True
+
+if needs_fresh_baseline:
     if update_baseline:
         os.makedirs(baseline_dir, exist_ok=True)
         with open(baseline_file, "w") as f:
-            json.dump(results, f, indent=2)
-        print(f"No baseline found. Recorded current results as baseline ({baseline_file}).")
+            json.dump({"_metric": METRIC_VERSION, **results}, f, indent=2)
+        print(f"No valid baseline found. Recorded current results as baseline ({baseline_file}).")
         with open(summary_file, "w") as sf:
             sf.write("## Performance Baselines\n\nBaseline recorded for the first time. Future runs will compare against these values.\n")
     else:
-        print("WARNING: No baseline found and this is a PR run (UPDATE_BASELINE=false).")
+        print("WARNING: No valid baseline found and this is a PR run (UPDATE_BASELINE=false).")
         print("Run the workflow on main to establish a baseline before regressions can be detected.")
         print("Skipping regression check for this PR run.")
         with open(summary_file, "w") as sf:
             sf.write("## Performance Baselines\n\nNo baseline available yet. Run the workflow on `main` to establish baselines.\n")
     sys.exit(0)
 
-# Load and compare against stored baseline.
-with open(baseline_file) as f:
-    baselines = json.load(f)
+# Load and compare against stored baseline (metric version already verified).
+baselines = {k: v for k, v in stored.items() if k != "_metric"}
 
 regressions = []
 print("=== Regression Check (threshold: {}%) ===".format(int(threshold)))
@@ -138,7 +150,7 @@ if regressions:
 # Update baseline only on main-branch pushes to prevent PR runs from
 # ratcheting the baseline downward and masking future regressions.
 if update_baseline:
-    updated = {**baselines, **results}
+    updated = {"_metric": METRIC_VERSION, **baselines, **results}
     with open(baseline_file, "w") as f:
         json.dump(updated, f, indent=2)
     print("PASS: No regressions detected. Baseline updated.")

--- a/scripts/compare-perf-baselines.sh
+++ b/scripts/compare-perf-baselines.sh
@@ -29,20 +29,18 @@ baseline_dir     = sys.argv[4]
 update_baseline  = sys.argv[5].lower() == "true"
 
 # Parse XCTest timing lines. Format (macOS XCTest via swift test):
-#   Test Case '-[Suite.ClassName testMethodName]' measured [Clock Monotonic Time, s] average: N.NNN, ...
+#   Test Case '-[Suite.ClassName testMethodName]' measured [CPU Time, s] average: N.NNN, ...
 #
-# The metric type varies across Xcode versions — older: "[Time, seconds]",
-# newer (Xcode 15+): "[Clock Monotonic Time, s]".  After the closing ']' of the
-# test name the output includes a single-quote "'" before the space and "measured".
-# We track "Clock Monotonic Time" (wall clock) and fall back to any "Time, seconds"
-# line.  Multiple metric lines appear per test; the first matching one wins so
-# subsequent CPU-cycles/instructions lines don't overwrite the wall-time result.
+# We track "CPU Time" rather than wall clock ("Clock Monotonic Time") because
+# CPU time is far more stable on shared CI runners, eliminating false regression
+# alerts caused by noisy wall-clock measurements.  Multiple metric lines appear
+# per test; we match only the CPU Time line.
 pattern = re.compile(
     r"(?:"
     r"-\[(?:[^\]]*\s+)?(\w+)\]['\"]?"          # ObjC: -[Suite.Class testMethod]
     r"|Test Case '(?:[^/']+/)?(\w+)'"           # SwiftPM: Test Case 'Module.Class/testMethod'
     r")"
-    r"\s+measured \[(?:Clock Monotonic Time, s|Time, seconds)\] average:\s+([0-9.]+)"
+    r"\s+measured \[CPU Time, s\] average:\s+([0-9.]+)"
 )
 
 results = {}
@@ -51,7 +49,7 @@ with open(results_log) as f:
         m = pattern.search(line)
         if m:
             test_name = m.group(1) or m.group(2)
-            if test_name not in results:  # first match wins (wall-time before CPU-cycles lines)
+            if test_name not in results:  # first match wins (CPU Time appears once per test)
                 results[test_name] = float(m.group(3))
 
 summary_file = os.path.join(baseline_dir, "summary.md")


### PR DESCRIPTION
## Summary
Switch the CI performance regression baseline from wall clock time (Clock Monotonic Time) to CPU time. Wall clock measurements are extremely noisy on shared GitHub Actions runners, causing 7 of 11 tests to show false regressions (up to +100%). CPU Time is far more stable and accurately reflects actual computational work.

## Changes
- Added `XCTCPUMetric()` to all performance test `measure()` calls that only had `XCTClockMetric()` (4 in AXTreeDiffPerformanceTests, 2 in MarkdownPerformanceTests)
- Updated `scripts/compare-perf-baselines.sh` regex to parse `[CPU Time, s]` instead of `[Clock Monotonic Time, s]`

## Milestone PRs (merged into feature branch)
- #13565: M1: Switch perf metrics to CPU Time in tests and comparison script

## Project issue
Closes #13563

## Test plan
- [ ] Verify the first main run after merge establishes new CPU Time baselines
- [ ] Verify subsequent runs compare against CPU Time baselines without false regressions

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
