### PR TITLE
fix: wire isContentStripped into tool progress rehydration path

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -216,6 +216,22 @@ struct AssistantProgressView: View {
                 startDate = Date()
             }
         }
+        .onChange(of: isExpanded) { _, expanded in
+            if expanded, onRehydrate != nil {
+                // Trigger rehydrate when expanding if any complete tool call
+                // has been stripped (all detail fields cleared by stripHeavyContent).
+                let hasStrippedToolCall = toolCalls.contains { tc in
+                    tc.isComplete
+                        && tc.inputFull.isEmpty
+                        && tc.result == nil
+                        && tc.inputRawDict == nil
+                        && tc.cachedImage == nil
+                }
+                if hasStrippedToolCall {
+                    onRehydrate?()
+                }
+            }
+        }
         .onAppear {
             if phase == .processing && processingStartDate == nil {
                 processingStartDate = Date()

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -953,7 +953,7 @@ private struct MessageCellView: View {
                 dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
                 onReportMessage: onReportMessage,
                 onSurfaceRefetch: onSurfaceRefetch,
-                onRehydrate: message.wasTruncated ? { onRehydrateMessage?(message.id) } : nil,
+                onRehydrate: (message.wasTruncated || message.isContentStripped) ? { onRehydrateMessage?(message.id) } : nil,
                 mediaEmbedSettings: mediaEmbedSettings,
                 resolveHttpPort: resolveHttpPort,
                 showAvatar: !previousIsAssistant,

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -594,10 +594,11 @@ public final class ChatViewModel: ObservableObject {
     // MARK: - On-Demand Content Rehydration
 
     /// Fetch full (untruncated) content for a message that was loaded with truncated
-    /// text/tool results. No-ops if the message is not found or wasn't truncated.
+    /// text/tool results or had its heavy content stripped. No-ops if the message is
+    /// not found or doesn't need rehydration.
     public func rehydrateMessage(id: UUID) {
         guard let idx = messages.firstIndex(where: { $0.id == id }),
-              messages[idx].wasTruncated,
+              messages[idx].wasTruncated || messages[idx].isContentStripped,
               let sessionId = sessionId,
               let daemonMessageId = messages[idx].daemonMessageId else { return }
         do {


### PR DESCRIPTION
After stripHeavyContent() clears tool call detail fields, hasDetails returns false and progress rows lose hover/expand. Wire isContentStripped into the same rehydration path that wasTruncated uses, and trigger rehydrate on expand so data loads lazily when needed.

Closes #13570
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13571" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
