### PR TITLE
fix: tool progress rows non-interactive after memory stripping

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -216,6 +216,22 @@ struct AssistantProgressView: View {
                 startDate = Date()
             }
         }
+        .onChange(of: isExpanded) { _, expanded in
+            if expanded, onRehydrate != nil {
+                // Trigger rehydrate when expanding if any complete tool call
+                // has been stripped (all detail fields cleared by stripHeavyContent).
+                let hasStrippedToolCall = toolCalls.contains { tc in
+                    tc.isComplete
+                        && tc.inputFull.isEmpty
+                        && tc.result == nil
+                        && tc.inputRawDict == nil
+                        && tc.cachedImage == nil
+                }
+                if hasStrippedToolCall {
+                    onRehydrate?()
+                }
+            }
+        }
         .onAppear {
             if phase == .processing && processingStartDate == nil {
                 processingStartDate = Date()

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -31,6 +31,7 @@ struct AssistantProgressView: View {
     let decidedConfirmations: [ToolConfirmationData]
     var onRehydrate: (() -> Void)?
 
+    @Environment(\.suppressAutoScroll) private var suppressAutoScroll
     @State private var isExpanded: Bool = false
     @State private var startDate: Date = Date()
     @State private var processingStartDate: Date?
@@ -249,6 +250,7 @@ struct AssistantProgressView: View {
     private var headerRow: some View {
         Button(action: {
             guard hasChevron else { return }
+            suppressAutoScroll?()
             withAnimation(VAnimation.fast) {
                 isExpanded.toggle()
             }
@@ -495,6 +497,7 @@ private struct StepDetailRow: View {
     /// Cached formatted input — computed once on first expand.
     @State private var cachedInputFull: String?
     @Environment(\.displayScale) private var displayScale
+    @Environment(\.suppressAutoScroll) private var suppressAutoScroll
 
     /// Lazily resolved full input text.
     private var resolvedInputFull: String {
@@ -523,6 +526,7 @@ private struct StepDetailRow: View {
             // Row header
             Button {
                 guard hasDetails else { return }
+                suppressAutoScroll?()
                 withAnimation(VAnimation.fast) { isDetailExpanded.toggle() }
             } label: {
                 HStack(spacing: VSpacing.sm) {

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -628,10 +628,7 @@ private struct StepDetailRow: View {
                             if !toolCall.inputFull.isEmpty {
                                 cachedInputFull = toolCall.inputFull
                             } else if let dict = toolCall.inputRawDict {
-                                let rawDict = dict
-                                Task { @MainActor in
-                                    cachedInputFull = ToolCallData.formatAllToolInput(rawDict)
-                                }
+                                cachedInputFull = ToolCallData.formatAllToolInput(dict)
                             }
                         }
                         if isTruncated {
@@ -646,10 +643,7 @@ private struct StepDetailRow: View {
                 if !toolCall.inputFull.isEmpty {
                     cachedInputFull = toolCall.inputFull
                 } else if let dict = toolCall.inputRawDict {
-                    let rawDict = dict
-                    Task { @MainActor in
-                        cachedInputFull = ToolCallData.formatAllToolInput(rawDict)
-                    }
+                    cachedInputFull = ToolCallData.formatAllToolInput(dict)
                 }
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -624,7 +624,10 @@ private struct StepDetailRow: View {
                             if !toolCall.inputFull.isEmpty {
                                 cachedInputFull = toolCall.inputFull
                             } else if let dict = toolCall.inputRawDict {
-                                cachedInputFull = ToolCallData.formatAllToolInput(dict)
+                                let rawDict = dict
+                                Task { @MainActor in
+                                    cachedInputFull = ToolCallData.formatAllToolInput(rawDict)
+                                }
                             }
                         }
                         if isTruncated {
@@ -636,10 +639,13 @@ private struct StepDetailRow: View {
         .animation(VAnimation.fast, value: isDetailExpanded)
         .onChange(of: isDetailExpanded) { _, newValue in
             if newValue, cachedInputFull == nil {
-                if let dict = toolCall.inputRawDict {
-                    cachedInputFull = ToolCallData.formatAllToolInput(dict)
-                } else if !toolCall.inputFull.isEmpty {
+                if !toolCall.inputFull.isEmpty {
                     cachedInputFull = toolCall.inputFull
+                } else if let dict = toolCall.inputRawDict {
+                    let rawDict = dict
+                    Task { @MainActor in
+                        cachedInputFull = ToolCallData.formatAllToolInput(rawDict)
+                    }
                 }
             }
         }
@@ -747,15 +753,10 @@ private struct StepDetailRow: View {
 
                     ZStack(alignment: .topTrailing) {
                         ScrollView {
-                            VStack(alignment: .leading, spacing: 0) {
-                                ForEach(Array(result.components(separatedBy: "\n").enumerated()), id: \.offset) { _, line in
-                                    Text(line)
-                                        .font(VFont.monoSmall)
-                                        .foregroundColor(diffLineColor(line, result: result, isError: toolCall.isError))
-                                        .frame(maxWidth: .infinity, alignment: .leading)
-                                }
-                            }
-                            .textSelection(.enabled)
+                            Text(coloredOutput(result, isError: toolCall.isError))
+                                .font(VFont.monoSmall)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .textSelection(.enabled)
                         }
                         .frame(maxHeight: 200)
                         .padding(VSpacing.sm)
@@ -816,14 +817,33 @@ private struct StepDetailRow: View {
         )
     }
 
-    private func diffLineColor(_ line: String, result: String, isError: Bool) -> Color {
-        if isError { return VColor.error }
+    private func coloredOutput(_ result: String, isError: Bool) -> AttributedString {
+        let lines = result.components(separatedBy: "\n")
         let isDiff = result.contains("@@") && result.contains("---") && result.contains("+++")
-        guard isDiff else { return VColor.textSecondary }
-        if line.hasPrefix("+") { return Emerald._400 }
-        if line.hasPrefix("-") { return Danger._400 }
-        if line.hasPrefix("@@") { return VColor.textMuted }
-        return VColor.textSecondary
+        var attributed = AttributedString()
+        for (index, line) in lines.enumerated() {
+            var part = AttributedString(line)
+            let color: Color
+            if isError {
+                color = VColor.error
+            } else if !isDiff {
+                color = VColor.textSecondary
+            } else if line.hasPrefix("+") {
+                color = Emerald._400
+            } else if line.hasPrefix("-") {
+                color = Danger._400
+            } else if line.hasPrefix("@@") {
+                color = VColor.textMuted
+            } else {
+                color = VColor.textSecondary
+            }
+            part.foregroundColor = color
+            attributed.append(part)
+            if index < lines.count - 1 {
+                attributed.append(AttributedString("\n"))
+            }
+        }
+        return attributed
     }
 
     private func formatDuration(_ seconds: TimeInterval) -> String {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -953,7 +953,7 @@ private struct MessageCellView: View {
                 dismissedDocumentSurfaceIds: dismissedDocumentSurfaceIds,
                 onReportMessage: onReportMessage,
                 onSurfaceRefetch: onSurfaceRefetch,
-                onRehydrate: message.wasTruncated ? { onRehydrateMessage?(message.id) } : nil,
+                onRehydrate: (message.wasTruncated || message.isContentStripped) ? { onRehydrateMessage?(message.id) } : nil,
                 mediaEmbedSettings: mediaEmbedSettings,
                 resolveHttpPort: resolveHttpPort,
                 showAvatar: !previousIsAssistant,

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -6,6 +6,21 @@ import VellumAssistantShared
 
 private let log = Logger(subsystem: "com.vellum.vellum-assistant", category: "MessageListView")
 
+// MARK: - Scroll Suppression Environment
+
+/// Environment key that child views (e.g. AssistantProgressView) call to
+/// temporarily suppress auto-scroll-to-bottom during content expansion.
+private struct SuppressAutoScrollKey: EnvironmentKey {
+    static let defaultValue: (() -> Void)? = nil
+}
+
+extension EnvironmentValues {
+    var suppressAutoScroll: (() -> Void)? {
+        get { self[SuppressAutoScrollKey.self] }
+        set { self[SuppressAutoScrollKey.self] = newValue }
+    }
+}
+
 /// Holds the last-known anchor minY without triggering SwiftUI re-renders.
 /// Only `isVisible` is @Published so re-renders happen only when the
 /// visible/invisible boundary is crossed — not on every scroll tick.
@@ -432,6 +447,13 @@ struct MessageListView: View {
             .scrollContentBackground(.hidden)
             .coordinateSpace(name: "chatScrollView")
             .scrollDisabled(messages.isEmpty && !isSending)
+            .environment(\.suppressAutoScroll, { [self] in
+                isSuppressingBottomScroll = true
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 200_000_000)
+                    isSuppressingBottomScroll = false
+                }
+            })
             .onHover { hovering in
                 handleThreadContentHover(hovering)
             }

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -454,7 +454,12 @@ struct MessageListView: View {
                 expandSuppressionTask = Task { @MainActor in
                     try? await Task.sleep(nanoseconds: 200_000_000)
                     guard !Task.isCancelled else { return }
-                    isSuppressingBottomScroll = false
+                    // Only clear if no other mechanism (resize, pagination) still needs suppression.
+                    let resizeActive = resizeScrollTask != nil && !resizeScrollTask!.isCancelled
+                    let paginationActive = isPaginationInFlight
+                    if !resizeActive && !paginationActive {
+                        isSuppressingBottomScroll = false
+                    }
                 }
             })
             .onHover { hovering in

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -118,6 +118,7 @@ struct MessageListView: View {
     @State private var hoverExitDebounceTask: Task<Void, Never>?
     @State private var threadSwitchSuppressionTask: Task<Void, Never>?
     @State private var suppressScrollbarDuringThreadSwitch: Bool = false
+    @State private var expandSuppressionTask: Task<Void, Never>?
     /// Tracks the last pending confirmation request ID that triggered an
     /// auto-focus handoff. Used to detect nil→non-nil transitions so we
     /// resign first responder exactly once per new confirmation appearance.
@@ -449,8 +450,10 @@ struct MessageListView: View {
             .scrollDisabled(messages.isEmpty && !isSending)
             .environment(\.suppressAutoScroll, { [self] in
                 isSuppressingBottomScroll = true
-                Task { @MainActor in
+                expandSuppressionTask?.cancel()
+                expandSuppressionTask = Task { @MainActor in
                     try? await Task.sleep(nanoseconds: 200_000_000)
+                    guard !Task.isCancelled else { return }
                     isSuppressingBottomScroll = false
                 }
             })
@@ -564,6 +567,8 @@ struct MessageListView: View {
                 anchorTimeoutTask = nil
                 resizeScrollTask?.cancel()
                 resizeScrollTask = nil
+                expandSuppressionTask?.cancel()
+                expandSuppressionTask = nil
             }
             .onChange(of: isSending) {
                 if isSending {
@@ -698,6 +703,8 @@ struct MessageListView: View {
                 scrollDebounceTask = nil
                 resizeScrollTask?.cancel()
                 resizeScrollTask = nil
+                expandSuppressionTask?.cancel()
+                expandSuppressionTask = nil
                 isPaginationInFlight = false
                 isSuppressingBottomScroll = false
                 isNearBottom = true

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -594,10 +594,11 @@ public final class ChatViewModel: ObservableObject {
     // MARK: - On-Demand Content Rehydration
 
     /// Fetch full (untruncated) content for a message that was loaded with truncated
-    /// text/tool results. No-ops if the message is not found or wasn't truncated.
+    /// text/tool results or had its heavy content stripped. No-ops if the message is
+    /// not found or doesn't need rehydration.
     public func rehydrateMessage(id: UUID) {
         guard let idx = messages.firstIndex(where: { $0.id == id }),
-              messages[idx].wasTruncated,
+              messages[idx].wasTruncated || messages[idx].isContentStripped,
               let sessionId = sessionId,
               let daemonMessageId = messages[idx].daemonMessageId else { return }
         do {


### PR DESCRIPTION
## Summary
After `stripHeavyContent()` runs (on thread switch, background trim, or message count threshold), tool call rows in AssistantProgressView lose hover and expand because `hasDetails` returns false — all fields it checks (`inputFull`, `inputRawDict`, `result`, `cachedImage`) are cleared. The `onRehydrate` callback was only wired for `wasTruncated` (daemon-side truncation), not `isContentStripped` (client-side stripping), leaving no path to recover.

This PR wires `isContentStripped` into the existing rehydration path so stripped tool call data is lazily reloaded when the user expands a progress view.

## Changes
- `MessageListView.swift:956` — `onRehydrate` now fires for `isContentStripped` messages (not just `wasTruncated`)
- `ChatViewModel.swift:599` — `rehydrateMessage()` guard accepts `isContentStripped` alongside `wasTruncated`
- `AssistantProgressView.swift:219-232` — Added `.onChange(of: isExpanded)` that triggers `onRehydrate` when expanded and any complete tool call has empty detail fields (stripped state)

## Milestone PRs (merged into feature branch)
- #13571: fix: wire isContentStripped into tool progress rehydration path

## Project issue
Closes #13569

## Test plan
- [ ] Start a conversation with multiple tool calls, switch threads to trigger `stripHeavyContent()`, switch back
- [ ] Expand the progress view on the stripped message — verify data reloads and rows become hoverable/expandable
- [ ] Verify `trimForBackground()` path: background the app, return, expand old tool progress — data should reload
- [ ] Verify no double-rehydration: expand, collapse, expand again — should not re-fetch

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
