### PR TITLE
fix: read Twilio accountSid from config instead of secure key store

### DIFF
--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -6,6 +6,7 @@
  * config handler. Uses fetch() directly — no twilio npm package.
  */
 
+import { loadConfig } from "../config/loader.js";
 import { getSecureKey } from "../security/secure-keys.js";
 import { ConfigError, ProviderError } from "../util/errors.js";
 
@@ -14,13 +15,27 @@ export interface TwilioCredentials {
   authToken: string;
 }
 
-/** Resolve Twilio credentials from the secure key store. Throws if not configured. */
+/**
+ * Resolve the Twilio Account SID from config.
+ * Returns undefined if not found.
+ */
+function resolveAccountSid(): string | undefined {
+  try {
+    const config = loadConfig();
+    if (config.twilio?.accountSid) return config.twilio.accountSid;
+  } catch {
+    // Config may not be available during early startup
+  }
+  return undefined;
+}
+
+/** Resolve Twilio credentials from config and secure key store. Throws if not configured. */
 export function getTwilioCredentials(): TwilioCredentials {
-  const accountSid = getSecureKey("credential:twilio:account_sid");
+  const accountSid = resolveAccountSid();
   const authToken = getSecureKey("credential:twilio:auth_token");
   if (!accountSid || !authToken) {
     throw new ConfigError(
-      "Twilio credentials not configured. Set credential:twilio:account_sid and credential:twilio:auth_token via the credential_store tool.",
+      "Twilio credentials not configured. Set twilio.accountSid via config and credential:twilio:auth_token via the credential_store tool.",
     );
   }
   return { accountSid, authToken };
@@ -29,8 +44,7 @@ export function getTwilioCredentials(): TwilioCredentials {
 /** Check whether Twilio credentials are present (non-throwing). */
 export function hasTwilioCredentials(): boolean {
   return (
-    !!getSecureKey("credential:twilio:account_sid") &&
-    !!getSecureKey("credential:twilio:auth_token")
+    !!resolveAccountSid() && !!getSecureKey("credential:twilio:auth_token")
   );
 }
 

--- a/assistant/src/daemon/handlers/config-ingress.ts
+++ b/assistant/src/daemon/handlers/config-ingress.ts
@@ -1,6 +1,7 @@
 import * as net from "node:net";
 
 import {
+  getTwilioCredentials,
   hasTwilioCredentials,
   updatePhoneNumberWebhooks,
 } from "../../calls/twilio-rest.js";
@@ -22,7 +23,6 @@ import {
   type IngressConfig,
 } from "../../inbound/public-ingress-urls.js";
 import { mintDaemonDeliveryToken } from "../../runtime/auth/token-service.js";
-import { getSecureKey } from "../../security/secure-keys.js";
 import type { IngressConfigRequest } from "../ipc-protocol.js";
 import {
   CONFIG_RELOAD_DEBOUNCE_MS,
@@ -280,8 +280,8 @@ export async function handleIngressConfig(
         }
 
         if (assignedNumbers.size > 0) {
-          const acctSid = getSecureKey("credential:twilio:account_sid")!;
-          const acctToken = getSecureKey("credential:twilio:auth_token")!;
+          const { accountSid: acctSid, authToken: acctToken } =
+            getTwilioCredentials();
           // Fire-and-forget: webhook sync failure must not block the ingress save.
           // Reconcile every assigned number so assistant-scoped mappings do not
           // retain stale Twilio webhook URLs after ingress URL changes.

--- a/assistant/src/messaging/providers/sms/adapter.ts
+++ b/assistant/src/messaging/providers/sms/adapter.ts
@@ -15,6 +15,10 @@
  */
 
 import {
+  getTwilioCredentials,
+  hasTwilioCredentials,
+} from "../../../calls/twilio-rest.js";
+import {
   getGatewayInternalBaseUrl,
   getTwilioPhoneNumberEnv,
 } from "../../../config/env.js";
@@ -46,14 +50,6 @@ function getGatewayUrl(): string {
 /** Mint a short-lived JWT for authenticating with the gateway. */
 function getBearerToken(): string {
   return mintDaemonDeliveryToken();
-}
-
-/** Check whether Twilio credentials are stored. */
-function hasTwilioCredentials(): boolean {
-  return (
-    !!getSecureKey("credential:twilio:account_sid") &&
-    !!getSecureKey("credential:twilio:auth_token")
-  );
 }
 
 /** Resolve the configured SMS phone number. */
@@ -118,7 +114,7 @@ export const smsMessagingProvider: MessagingProvider = {
           | Record<string, string>
           | undefined;
         if (mappings && Object.keys(mappings).length > 0) {
-          const accountSid = getSecureKey("credential:twilio:account_sid")!;
+          const accountSid = getTwilioCredentials().accountSid;
           return {
             connected: true,
             user: "assistant-scoped",
@@ -143,7 +139,7 @@ export const smsMessagingProvider: MessagingProvider = {
       };
     }
 
-    const accountSid = getSecureKey("credential:twilio:account_sid")!;
+    const accountSid = getTwilioCredentials().accountSid;
 
     return {
       connected: true,

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -1,6 +1,7 @@
 import {
   getPhoneNumberSid,
   getTollFreeVerificationStatus,
+  getTwilioCredentials,
   hasTwilioCredentials,
 } from "../calls/twilio-rest.js";
 import { getChannelInvitePolicy } from "../channels/config.js";
@@ -99,9 +100,13 @@ const smsProbe: ChannelProbe = {
   async runRemoteChecks(): Promise<ReadinessCheckResult[]> {
     if (!hasTwilioCredentials()) return [];
 
-    const accountSid = getSecureKey("credential:twilio:account_sid");
-    const authToken = getSecureKey("credential:twilio:auth_token");
-    if (!accountSid || !authToken) return [];
+    let accountSid: string;
+    let authToken: string;
+    try {
+      ({ accountSid, authToken } = getTwilioCredentials());
+    } catch {
+      return [];
+    }
 
     const phoneNumber = resolveSmsPhoneNumber();
     if (!phoneNumber) return [];

--- a/assistant/src/runtime/middleware/twilio-validation.ts
+++ b/assistant/src/runtime/middleware/twilio-validation.ts
@@ -71,10 +71,10 @@ export async function validateTwilioWebhook(
 
   const authToken = TwilioConversationRelayProvider.getAuthToken();
 
-  // Fail-closed: reject if no auth token is configured
   if (!authToken) {
     log.error(
-      "Twilio auth token not configured — rejecting webhook request (fail-closed)",
+      "Twilio auth token not found in secure key store — cannot verify webhook HMAC signature. " +
+        "Rejecting request. Set credential:twilio:auth_token via the credential_store tool.",
     );
     return httpError("FORBIDDEN", "Forbidden", 403);
   }

--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -22,6 +22,7 @@ import {
   getPhoneNumberSid,
   getTollFreeVerificationBySid,
   getTollFreeVerificationStatus,
+  getTwilioCredentials,
   hasTwilioCredentials,
   listIncomingPhoneNumbers,
   provisionPhoneNumber,
@@ -149,7 +150,7 @@ function pruneAssistantPhoneNumbers(
 export function handleGetTwilioConfig(): Response {
   const hasCredentials = hasTwilioCredentials();
   const accountSid = hasCredentials
-    ? getSecureKey("credential:twilio:account_sid")
+    ? getTwilioCredentials().accountSid
     : undefined;
   const raw = loadRawConfig();
   const sms = (raw?.sms ?? {}) as Record<string, unknown>;
@@ -239,6 +240,11 @@ export async function handleSetTwilioCredentials(
     });
   }
 
+  const raw = loadRawConfig();
+  const twilio = (raw?.twilio ?? {}) as Record<string, unknown>;
+  twilio.accountSid = body.accountSid;
+  saveRawConfig({ ...raw, twilio });
+
   upsertCredentialMetadata("twilio", "account_sid", {
     injectionTemplates: [
       {
@@ -289,6 +295,11 @@ export async function handleClearTwilioCredentials(): Promise<Response> {
     );
   }
 
+  const raw = loadRawConfig();
+  const twilio = (raw?.twilio ?? {}) as Record<string, unknown>;
+  delete twilio.accountSid;
+  saveRawConfig({ ...raw, twilio });
+
   deleteCredentialMetadata("twilio", "account_sid");
   deleteCredentialMetadata("twilio", "auth_token");
 
@@ -307,8 +318,7 @@ export async function handleListTwilioNumbers(): Promise<Response> {
     });
   }
 
-  const accountSid = getSecureKey("credential:twilio:account_sid")!;
-  const authToken = getSecureKey("credential:twilio:auth_token")!;
+  const { accountSid, authToken } = getTwilioCredentials();
   const numbers = await listIncomingPhoneNumbers(accountSid, authToken);
 
   return Response.json({ success: true, hasCredentials: true, numbers });
@@ -334,8 +344,7 @@ export async function handleProvisionTwilioNumber(
     country?: string;
     areaCode?: string;
   };
-  const accountSid = getSecureKey("credential:twilio:account_sid")!;
-  const authToken = getSecureKey("credential:twilio:auth_token")!;
+  const { accountSid, authToken } = getTwilioCredentials();
   const country = body.country ?? "US";
 
   const available = await searchAvailableNumbers(
@@ -435,8 +444,8 @@ export async function handleAssignTwilioNumber(
   // Best-effort webhook configuration when credentials are available
   let webhookWarning: string | undefined;
   if (hasTwilioCredentials()) {
-    const acctSid = getSecureKey("credential:twilio:account_sid")!;
-    const acctToken = getSecureKey("credential:twilio:auth_token")!;
+    const { accountSid: acctSid, authToken: acctToken } =
+      getTwilioCredentials();
     const webhookResult = await syncTwilioWebhooks(
       body.phoneNumber,
       acctSid,
@@ -484,8 +493,7 @@ export async function handleReleaseTwilioNumber(
     });
   }
 
-  const accountSid = getSecureKey("credential:twilio:account_sid")!;
-  const authToken = getSecureKey("credential:twilio:auth_token")!;
+  const { accountSid, authToken } = getTwilioCredentials();
 
   await releasePhoneNumber(accountSid, authToken, phoneNumber);
 
@@ -532,8 +540,7 @@ export async function handleGetSmsCompliance(): Promise<Response> {
     });
   }
 
-  const accountSid = getSecureKey("credential:twilio:account_sid")!;
-  const authToken = getSecureKey("credential:twilio:auth_token")!;
+  const { accountSid, authToken } = getTwilioCredentials();
 
   const tollFreePrefixes = [
     "+1800",
@@ -702,8 +709,7 @@ export async function handleSubmitTollfreeVerification(
     );
   }
 
-  const accountSid = getSecureKey("credential:twilio:account_sid")!;
-  const authToken = getSecureKey("credential:twilio:auth_token")!;
+  const { accountSid, authToken } = getTwilioCredentials();
 
   const submitParams: TollFreeVerificationSubmitParams = {
     tollfreePhoneNumberSid: vp.tollfreePhoneNumberSid as string,
@@ -754,8 +760,7 @@ export async function handleUpdateTollfreeVerification(
     });
   }
 
-  const accountSid = getSecureKey("credential:twilio:account_sid")!;
-  const authToken = getSecureKey("credential:twilio:auth_token")!;
+  const { accountSid, authToken } = getTwilioCredentials();
 
   const currentVerification = await getTollFreeVerificationBySid(
     accountSid,
@@ -838,8 +843,7 @@ export async function handleDeleteTollfreeVerification(
     });
   }
 
-  const accountSid = getSecureKey("credential:twilio:account_sid")!;
-  const authToken = getSecureKey("credential:twilio:auth_token")!;
+  const { accountSid, authToken } = getTwilioCredentials();
 
   await deleteTollFreeVerification(accountSid, authToken, verificationSid);
 
@@ -896,8 +900,7 @@ export async function handleSmsSendTest(req: Request): Promise<Response> {
     });
   }
 
-  const accountSid = getSecureKey("credential:twilio:account_sid")!;
-  const authToken = getSecureKey("credential:twilio:auth_token")!;
+  const { accountSid, authToken } = getTwilioCredentials();
   const text = body.text || "Test SMS from your Vellum assistant";
 
   // Send via gateway's /deliver/sms endpoint
@@ -1012,8 +1015,7 @@ export async function handleSmsDoctor(): Promise<Response> {
         getSecureKey("credential:twilio:phone_number") ||
         "";
       if (phoneNumber) {
-        const accountSid = getSecureKey("credential:twilio:account_sid")!;
-        const authToken = getSecureKey("credential:twilio:auth_token")!;
+        const { accountSid, authToken } = getTwilioCredentials();
         const isTollFree =
           phoneNumber.startsWith("+1") &&
           ["800", "888", "877", "866", "855", "844", "833"].some((p) =>

--- a/assistant/src/schedule/integration-status.ts
+++ b/assistant/src/schedule/integration-status.ts
@@ -1,3 +1,4 @@
+import { hasTwilioCredentials } from "../calls/twilio-rest.js";
 import { getSecureKey } from "../security/secure-keys.js";
 
 interface IntegrationProbe {
@@ -29,9 +30,7 @@ const INTEGRATION_PROBES: IntegrationProbe[] = [
   {
     name: "SMS",
     category: "messaging",
-    isConnected: () =>
-      !!getSecureKey("credential:twilio:account_sid") &&
-      !!getSecureKey("credential:twilio:auth_token"),
+    isConnected: () => hasTwilioCredentials(),
   },
   {
     name: "Telegram",


### PR DESCRIPTION
## Summary
- **Root cause**: PR #13545 updated `twilio-config.ts` to read `accountSid` from config, but `twilio-rest.ts` and ~15 other callsites still read from the secure key store via `getSecureKey("credential:twilio:account_sid")`. When the twilio-setup skill stores accountSid in config, these callsites can't find it.
- **Fix**: `getTwilioCredentials()` and `hasTwilioCredentials()` in `twilio-rest.ts` now resolve accountSid from `loadConfig().twilio.accountSid`. All direct `getSecureKey("credential:twilio:account_sid")` reads across `twilio-routes.ts`, `sms/adapter.ts`, `integration-status.ts`, `channel-readiness-service.ts`, and `config-ingress.ts` now go through the centralized helpers.
- The HTTP credential set/clear handlers also write/clear `twilio.accountSid` in config for consistency. Webhook HMAC validation now logs an explicit error when auth_token is missing.

## Original prompt
fix all call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
