### PR TITLE
fix: add config/loader mock to twilio test files so getTwilioCredentials resolves accountSid

### DIFF
--- a/assistant/src/__tests__/sms-messaging-provider.test.ts
+++ b/assistant/src/__tests__/sms-messaging-provider.test.ts
@@ -21,11 +21,13 @@ let secureKeys: Record<string, string | undefined> = {
 };
 
 let configState: {
+  twilio?: { accountSid?: string };
   sms?: {
     phoneNumber?: string;
     assistantPhoneNumbers?: Record<string, string>;
   };
 } = {
+  twilio: { accountSid: "AC1234567890" },
   sms: {},
 };
 
@@ -71,7 +73,7 @@ describe("smsMessagingProvider", () => {
       "credential:twilio:account_sid": "AC1234567890",
       "credential:twilio:auth_token": "auth-token",
     };
-    configState = { sms: {} };
+    configState = { twilio: { accountSid: "AC1234567890" }, sms: {} };
     delete process.env.TWILIO_PHONE_NUMBER;
     delete process.env.GATEWAY_INTERNAL_BASE_URL;
     delete process.env.GATEWAY_PORT;

--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -33,6 +33,10 @@ mock.module("../util/logger.js", () => ({
 let mockAuthToken: string | undefined = "test-auth-token-secret";
 let mockAccountSid: string | undefined = "AC_test_account";
 
+mock.module("../config/loader.js", () => ({
+  loadConfig: () => ({ twilio: { accountSid: mockAccountSid } }),
+}));
+
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (account: string) => {
     if (account === "credential:twilio:auth_token") return mockAuthToken;


### PR DESCRIPTION
## Summary
- `getTwilioCredentials()` reads account SID from `loadConfig().twilio?.accountSid`, but `twilio-provider.test.ts` did not mock `config/loader.js` — causing every test that calls `getTwilioCredentials` or `initiateCall` to throw a ConfigError.
- `sms-messaging-provider.test.ts` mocked `config/loader.js` but without `twilio.accountSid`, so `hasTwilioCredentials()` returned false and `isConnected` tests failed.
- Added the missing config mock to both test files.

## Original prompt
fix CI for https://github.com/vellum-ai/vellum-assistant/actions/runs/22771436857

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
