### PR TITLE
fix: update integration-status test to mock config for Twilio accountSid

### DIFF
--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -1,9 +1,18 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const secureKeyValues = new Map<string, string>();
+let mockTwilioAccountSid: string | undefined;
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (account: string) => secureKeyValues.get(account),
+}));
+
+mock.module("../config/loader.js", () => ({
+  loadConfig: () => ({
+    twilio: mockTwilioAccountSid
+      ? { accountSid: mockTwilioAccountSid }
+      : undefined,
+  }),
 }));
 
 const { getIntegrationSummary, formatIntegrationSummary, hasCapability } =
@@ -12,6 +21,7 @@ const { getIntegrationSummary, formatIntegrationSummary, hasCapability } =
 describe("integration-status", () => {
   beforeEach(() => {
     secureKeyValues.clear();
+    mockTwilioAccountSid = undefined;
   });
 
   describe("getIntegrationSummary", () => {
@@ -30,7 +40,7 @@ describe("integration-status", () => {
       secureKeyValues.set("credential:integration:gmail:access_token", "tok");
       secureKeyValues.set("credential:integration:twitter:access_token", "tok");
       secureKeyValues.set("credential:integration:slack:access_token", "tok");
-      secureKeyValues.set("credential:twilio:account_sid", "sid");
+      mockTwilioAccountSid = "sid";
       secureKeyValues.set("credential:twilio:auth_token", "auth");
       secureKeyValues.set("credential:telegram:bot_token", "tok");
       secureKeyValues.set("credential:telegram:webhook_secret", "secret");
@@ -42,7 +52,7 @@ describe("integration-status", () => {
     });
 
     test("returns mixed status", () => {
-      secureKeyValues.set("credential:twilio:account_sid", "sid");
+      mockTwilioAccountSid = "sid";
       secureKeyValues.set("credential:twilio:auth_token", "auth");
       secureKeyValues.set("credential:telegram:bot_token", "tok");
       secureKeyValues.set("credential:telegram:webhook_secret", "secret");
@@ -67,7 +77,7 @@ describe("integration-status", () => {
     });
 
     test("SMS disconnected when only account_sid is set (missing auth_token)", () => {
-      secureKeyValues.set("credential:twilio:account_sid", "sid");
+      mockTwilioAccountSid = "sid";
 
       const summary = getIntegrationSummary();
       const sms = summary.find((s: { name: string }) => s.name === "SMS");
@@ -87,7 +97,7 @@ describe("integration-status", () => {
 
   describe("formatIntegrationSummary", () => {
     test("shows checkmarks and crosses", () => {
-      secureKeyValues.set("credential:twilio:account_sid", "sid");
+      mockTwilioAccountSid = "sid";
       secureKeyValues.set("credential:twilio:auth_token", "auth");
       secureKeyValues.set("credential:telegram:bot_token", "tok");
       secureKeyValues.set("credential:telegram:webhook_secret", "secret");
@@ -109,7 +119,7 @@ describe("integration-status", () => {
       secureKeyValues.set("credential:integration:gmail:access_token", "tok");
       secureKeyValues.set("credential:integration:twitter:access_token", "tok");
       secureKeyValues.set("credential:integration:slack:access_token", "tok");
-      secureKeyValues.set("credential:twilio:account_sid", "sid");
+      mockTwilioAccountSid = "sid";
       secureKeyValues.set("credential:twilio:auth_token", "auth");
       secureKeyValues.set("credential:telegram:bot_token", "tok");
       secureKeyValues.set("credential:telegram:webhook_secret", "secret");


### PR DESCRIPTION
## Summary
- `integration-status.test.ts` was mocking `credential:twilio:account_sid` in the secure key store, but after PR #13574 the production code reads accountSid from `loadConfig().twilio?.accountSid` via `hasTwilioCredentials()`.
- Added a `config/loader.js` mock and replaced secure key store mocks with `mockTwilioAccountSid` config variable.

## Original prompt
fix all call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
