### PR TITLE
fix: read twilio.accountSid from config.json at gateway startup

### DIFF
--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -304,7 +304,7 @@ export async function loadConfig(): Promise<GatewayConfig> {
   const twilioCreds = await readTwilioCredentials();
   const twilioAuthToken =
     process.env.TWILIO_AUTH_TOKEN || twilioCreds?.authToken || undefined;
-  const twilioAccountSid =
+  let twilioAccountSid =
     process.env.TWILIO_ACCOUNT_SID || twilioCreds?.accountSid || undefined;
 
   // Phone number: env var > config file sms.phoneNumber > credential store
@@ -321,6 +321,13 @@ export async function loadConfig(): Promise<GatewayConfig> {
       typeof data.sms.phoneNumber === "string"
     ) {
       twilioPhoneNumber = data.sms.phoneNumber;
+    }
+    if (
+      !twilioAccountSid &&
+      data?.twilio?.accountSid &&
+      typeof data.twilio.accountSid === "string"
+    ) {
+      twilioAccountSid = data.twilio.accountSid;
     }
     const rawMapping = data?.sms?.assistantPhoneNumbers;
     if (


### PR DESCRIPTION
## Summary
- Add config.json fallback for twilioAccountSid in gateway loadConfig(), mirroring the existing pattern used for twilioPhoneNumber
- Priority chain: env var > encrypted credential store > config.json

Part of plan: fix-twilio-gateway-sid-gap.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
