### PR TITLE
refactor: consolidate duplicate config.json reads in gateway startup

### DIFF
--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -315,6 +315,7 @@ export async function loadConfig(): Promise<GatewayConfig> {
   let twilioPhoneNumber: string | undefined =
     process.env.TWILIO_PHONE_NUMBER || undefined;
   let assistantPhoneNumbers: Record<string, string> | undefined;
+  let assistantEmail: string | undefined;
   try {
     const cfgPath = join(getRootDir(), "workspace", "config.json");
     const raw = readFileSync(cfgPath, "utf-8");
@@ -348,6 +349,9 @@ export async function loadConfig(): Promise<GatewayConfig> {
         }
       }
       assistantPhoneNumbers = normalized;
+    }
+    if (data?.email?.address && typeof data.email.address === "string") {
+      assistantEmail = data.email.address;
     }
   } catch {
     // config file may not exist yet
@@ -500,19 +504,6 @@ export async function loadConfig(): Promise<GatewayConfig> {
   const trustProxy = trustProxyRaw === "true";
 
   const ingressPublicBaseUrl = process.env.INGRESS_PUBLIC_BASE_URL || undefined;
-
-  // Assistant email from workspace config file
-  let assistantEmail: string | undefined;
-  try {
-    const cfgPath = join(getRootDir(), "workspace", "config.json");
-    const raw = readFileSync(cfgPath, "utf-8");
-    const data = JSON.parse(raw);
-    if (data?.email?.address && typeof data.email.address === "string") {
-      assistantEmail = data.email.address;
-    }
-  } catch {
-    // config file may not exist yet
-  }
 
   const logFileDir = process.env.GATEWAY_LOG_DIR || undefined;
 


### PR DESCRIPTION
## Summary
- Merge the two separate config.json try/catch blocks in loadConfig() into one
- email.address is now extracted from the same parsed data as sms.phoneNumber, twilio.accountSid, and sms.assistantPhoneNumbers
- No behavior change — just eliminates a redundant file read

Part of plan: generalize-config-file-watcher.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
