### PR TITLE
fix: restore config clearing behavior in ConfigFileWatcher consumer

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -910,8 +910,9 @@ async function main() {
           }
         | undefined;
       config.twilioPhoneNumber =
-        (typeof sms?.phoneNumber === "string" ? sms.phoneNumber : undefined) ??
-        config.twilioPhoneNumber;
+        typeof sms?.phoneNumber === "string"
+          ? sms.phoneNumber || undefined
+          : undefined;
       if (
         sms?.assistantPhoneNumbers &&
         typeof sms.assistantPhoneNumbers === "object" &&
@@ -921,6 +922,8 @@ async function main() {
           string,
           string
         >;
+      } else {
+        config.assistantPhoneNumbers = undefined;
       }
     }
 


### PR DESCRIPTION
## Summary
Fixes 3 clearing regressions in the ConfigFileWatcher consumer introduced during the generalization refactor:

- **twilioPhoneNumber**: Remove `?? config.twilioPhoneNumber` fallback so removing sms.phoneNumber from config.json correctly clears the value
- **twilioPhoneNumber empty string**: Add `|| undefined` to normalize empty strings to undefined (matching old behavior)
- **assistantPhoneNumbers**: Add else branch to clear the mapping when sms.assistantPhoneNumbers is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
