### PR TITLE
feat: add NavigationHistory model for back/forward navigation (LUM-20)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/NavigationHistory.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/NavigationHistory.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Manages back/forward navigation stacks for the main window,
+/// allowing users to retrace their steps through view selections.
+@MainActor
+final class NavigationHistory: ObservableObject {
+
+    enum HistoryEntry: Equatable {
+        case selection(ViewSelection)
+        case chatDefault(threadSnapshot: UUID?)
+    }
+
+    @Published private(set) var backStack: [HistoryEntry] = []
+    @Published private(set) var forwardStack: [HistoryEntry] = []
+
+    let maxDepth: Int = 50
+
+    private var suppressionDepth: Int = 0
+
+    var isSuppressed: Bool { suppressionDepth > 0 }
+    var canGoBack: Bool { !backStack.isEmpty }
+    var canGoForward: Bool { !forwardStack.isEmpty }
+
+    // MARK: - Entry Conversion
+
+    func entry(for selection: ViewSelection?, persistentThreadId: UUID?) -> HistoryEntry {
+        if let selection { return .selection(selection) }
+        return .chatDefault(threadSnapshot: persistentThreadId)
+    }
+
+    // MARK: - Recording
+
+    func recordTransition(from: ViewSelection?, to: ViewSelection?, persistentThreadId: UUID?) {
+        guard !isSuppressed else { return }
+
+        let fromEntry = entry(for: from, persistentThreadId: persistentThreadId)
+        let toEntry = entry(for: to, persistentThreadId: persistentThreadId)
+
+        guard fromEntry != toEntry else { return }
+
+        backStack.append(fromEntry)
+        forwardStack.removeAll()
+
+        if backStack.count > maxDepth {
+            backStack.removeFirst()
+        }
+    }
+
+    // MARK: - Navigation
+
+    func popBack(currentSelection: ViewSelection?, persistentThreadId: UUID?) -> HistoryEntry? {
+        guard !backStack.isEmpty else { return nil }
+
+        let destination = backStack.removeLast()
+        let currentEntry = entry(for: currentSelection, persistentThreadId: persistentThreadId)
+        forwardStack.append(currentEntry)
+
+        return destination
+    }
+
+    func popForward(currentSelection: ViewSelection?, persistentThreadId: UUID?) -> HistoryEntry? {
+        guard !forwardStack.isEmpty else { return nil }
+
+        let destination = forwardStack.removeLast()
+        let currentEntry = entry(for: currentSelection, persistentThreadId: persistentThreadId)
+        backStack.append(currentEntry)
+
+        return destination
+    }
+
+    // MARK: - Suppression
+
+    /// Temporarily suppress recording of transitions within the given closure.
+    /// Useful when programmatic navigation (e.g., popBack/popForward) should
+    /// not create new history entries.
+    func withRecordingSuppressed(_ body: () -> Void) {
+        suppressionDepth += 1
+        defer { suppressionDepth -= 1 }
+        body()
+    }
+}

--- a/clients/macos/vellum-assistantTests/NavigationHistoryTests.swift
+++ b/clients/macos/vellum-assistantTests/NavigationHistoryTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class NavigationHistoryTests: XCTestCase {
+
+    // MARK: - No-op transitions
+
+    func testRecordTransitionSkipsNoOp() {
+        let history = NavigationHistory()
+        let id = UUID()
+
+        history.recordTransition(from: .thread(id), to: .thread(id), persistentThreadId: nil)
+
+        XCTAssertTrue(history.backStack.isEmpty)
+    }
+
+    // MARK: - Chat default snapshot
+
+    func testRecordTransitionCapturesChatDefaultSnapshot() {
+        let history = NavigationHistory()
+        let someId = UUID()
+
+        // from nil selection (chat default) to settings panel
+        history.recordTransition(from: nil, to: .panel(.settings), persistentThreadId: someId)
+
+        XCTAssertEqual(history.backStack, [.chatDefault(threadSnapshot: someId)])
+    }
+
+    // MARK: - Round-trip
+
+    func testPopBackAndPopForwardRoundTrip() {
+        let history = NavigationHistory()
+        let idA = UUID()
+        let idB = UUID()
+        let idC = UUID()
+
+        // Record A -> B -> C
+        history.recordTransition(from: .thread(idA), to: .thread(idB), persistentThreadId: nil)
+        history.recordTransition(from: .thread(idB), to: .thread(idC), persistentThreadId: nil)
+
+        // backStack should be [A, B], forwardStack empty
+        XCTAssertEqual(history.backStack.count, 2)
+        XCTAssertTrue(history.forwardStack.isEmpty)
+
+        // Pop back from C -> should return B
+        let first = history.popBack(currentSelection: .thread(idC), persistentThreadId: nil)
+        XCTAssertEqual(first, .selection(.thread(idB)))
+        XCTAssertEqual(history.forwardStack, [.selection(.thread(idC))])
+
+        // Pop back from B -> should return A
+        let second = history.popBack(currentSelection: .thread(idB), persistentThreadId: nil)
+        XCTAssertEqual(second, .selection(.thread(idA)))
+        XCTAssertEqual(history.forwardStack, [.selection(.thread(idC)), .selection(.thread(idB))])
+
+        // Pop forward from A -> should return B
+        let third = history.popForward(currentSelection: .thread(idA), persistentThreadId: nil)
+        XCTAssertEqual(third, .selection(.thread(idB)))
+
+        // Pop forward from B -> should return C
+        let fourth = history.popForward(currentSelection: .thread(idB), persistentThreadId: nil)
+        XCTAssertEqual(fourth, .selection(.thread(idC)))
+
+        // Forward stack should be empty, back stack should have [A, B]
+        XCTAssertTrue(history.forwardStack.isEmpty)
+        XCTAssertEqual(history.backStack.count, 2)
+    }
+
+    // MARK: - Forward cleared on fresh navigation
+
+    func testForwardClearedOnFreshNavigation() {
+        let history = NavigationHistory()
+        let idA = UUID()
+        let idB = UUID()
+        let idC = UUID()
+
+        // Record A -> B, then pop back
+        history.recordTransition(from: .thread(idA), to: .thread(idB), persistentThreadId: nil)
+        _ = history.popBack(currentSelection: .thread(idB), persistentThreadId: nil)
+
+        // Forward stack should have B
+        XCTAssertFalse(history.forwardStack.isEmpty)
+
+        // Fresh navigation from A -> C should clear forward stack
+        history.recordTransition(from: .thread(idA), to: .thread(idC), persistentThreadId: nil)
+
+        XCTAssertTrue(history.forwardStack.isEmpty)
+    }
+
+    // MARK: - Suppression
+
+    func testSuppressionPreventsRecording() {
+        let history = NavigationHistory()
+        let idA = UUID()
+        let idB = UUID()
+
+        history.withRecordingSuppressed {
+            history.recordTransition(from: .thread(idA), to: .thread(idB), persistentThreadId: nil)
+        }
+
+        XCTAssertTrue(history.backStack.isEmpty)
+    }
+
+    // MARK: - Max depth
+
+    func testMaxDepthEnforced() {
+        let history = NavigationHistory()
+
+        // Record 55 transitions: each from thread(i) to thread(i+1)
+        for i in 0..<55 {
+            let fromId = UUID()
+            let toId = UUID()
+            // Use unique IDs so no transition is a no-op
+            history.recordTransition(
+                from: .thread(fromId),
+                to: .thread(toId),
+                persistentThreadId: nil
+            )
+        }
+
+        XCTAssertEqual(history.backStack.count, 50)
+    }
+
+    // MARK: - Empty stacks
+
+    func testEmptyStacksReturnNil() {
+        let history = NavigationHistory()
+
+        XCTAssertNil(history.popBack(currentSelection: nil, persistentThreadId: nil))
+        XCTAssertNil(history.popForward(currentSelection: nil, persistentThreadId: nil))
+    }
+
+    // MARK: - Computed properties
+
+    func testCanGoBackAndCanGoForwardReflectState() {
+        let history = NavigationHistory()
+
+        XCTAssertFalse(history.canGoBack)
+        XCTAssertFalse(history.canGoForward)
+
+        let idA = UUID()
+        let idB = UUID()
+        history.recordTransition(from: .thread(idA), to: .thread(idB), persistentThreadId: nil)
+
+        XCTAssertTrue(history.canGoBack)
+        XCTAssertFalse(history.canGoForward)
+
+        _ = history.popBack(currentSelection: .thread(idB), persistentThreadId: nil)
+
+        XCTAssertFalse(history.canGoBack)
+        XCTAssertTrue(history.canGoForward)
+    }
+
+    // MARK: - Chat default nil snapshot
+
+    func testBackToChatDefaultNilSnapshotResolvesToNil() {
+        let history = NavigationHistory()
+
+        // Record from nil selection with nil persistentThreadId to settings
+        history.recordTransition(from: nil, to: .panel(.settings), persistentThreadId: nil)
+
+        let destination = history.popBack(currentSelection: .panel(.settings), persistentThreadId: nil)
+
+        XCTAssertEqual(destination, .chatDefault(threadSnapshot: nil))
+    }
+}


### PR DESCRIPTION
Add NavigationHistory model with back/forward stacks, suppression, max depth, and 9 focused unit tests. Part of #13585.

## Summary
- `NavigationHistory` is a `@MainActor ObservableObject` with `backStack`/`forwardStack` of `HistoryEntry` enums
- Supports `recordTransition`, `popBack`, `popForward`, and scoped suppression via `withRecordingSuppressed`
- Enforces max depth of 50, dropping oldest entries
- `HistoryEntry` captures either a `ViewSelection` or a chat-default state with optional thread snapshot

## Files Changed
- **New:** `clients/macos/vellum-assistant/Features/MainWindow/NavigationHistory.swift` — model implementation
- **New:** `clients/macos/vellum-assistantTests/NavigationHistoryTests.swift` — 9 unit tests covering no-op, snapshot, round-trip, forward-clear, suppression, max depth, empty stacks, computed properties, and nil snapshot

## Test Plan
- [ ] All 9 NavigationHistory unit tests pass
- [ ] Swift build succeeds with new files included in targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
