### PR TITLE
feat: wire NavigationHistory into MainWindowState with back/forward methods (LUM-20)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -17,8 +17,11 @@ public final class MainWindowState: ObservableObject {
     @AppStorage("isAppChatOpen") private var isAppChatOpen = false
 
     /// The single source of truth for what the main content area displays.
+    let navigationHistory = NavigationHistory()
+
     @Published var selection: ViewSelection? {
         didSet {
+            navigationHistory.recordTransition(from: oldValue, to: selection, persistentThreadId: persistentThreadId)
             // When navigating to a thread, update the persistent thread tracker.
             // For overlays (app, appEditing, panel) and nil, leave persistentThreadId unchanged.
             if case .thread(let id) = selection {
@@ -157,6 +160,50 @@ public final class MainWindowState: ObservableObject {
         selection = newSelection
     }
 
+    func navigateBack() {
+        guard let destination = navigationHistory.popBack(
+            currentSelection: selection,
+            persistentThreadId: persistentThreadId
+        ) else { return }
+        navigationHistory.withRecordingSuppressed {
+            switch destination {
+            case .selection(let viewSelection):
+                self.selection = viewSelection
+            case .chatDefault(let threadSnapshot):
+                if let threadId = threadSnapshot {
+                    self.selection = .thread(threadId)
+                } else {
+                    self.selection = nil
+                }
+            }
+        }
+    }
+
+    func navigateForward() {
+        guard let destination = navigationHistory.popForward(
+            currentSelection: selection,
+            persistentThreadId: persistentThreadId
+        ) else { return }
+        navigationHistory.withRecordingSuppressed {
+            switch destination {
+            case .selection(let viewSelection):
+                self.selection = viewSelection
+            case .chatDefault(let threadSnapshot):
+                if let threadId = threadSnapshot {
+                    self.selection = .thread(threadId)
+                } else {
+                    self.selection = nil
+                }
+            }
+        }
+    }
+
+    func applySelectionCorrection(_ newSelection: ViewSelection?) {
+        navigationHistory.withRecordingSuppressed {
+            self.selection = newSelection
+        }
+    }
+
     /// Whether an app is currently shown (either standalone or editing)
     var activeAppId: String? {
         switch selection {
@@ -253,8 +300,9 @@ public final class MainWindowState: ObservableObject {
     func restoreLastActivePanel() {
         guard let savedPanelString = lastActivePanelString,
               let panel = SidePanelType(rawValue: savedPanelString) else { return }
-
-        selection = .panel(panel)
+        navigationHistory.withRecordingSuppressed {
+            selection = .panel(panel)
+        }
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -170,6 +170,7 @@ public final class MainWindowState: ObservableObject {
             case .selection(let viewSelection):
                 self.selection = viewSelection
             case .chatDefault(let threadSnapshot):
+                self.persistentThreadId = threadSnapshot
                 if let threadId = threadSnapshot {
                     self.selection = .thread(threadId)
                 } else {
@@ -189,6 +190,7 @@ public final class MainWindowState: ObservableObject {
             case .selection(let viewSelection):
                 self.selection = viewSelection
             case .chatDefault(let threadSnapshot):
+                self.persistentThreadId = threadSnapshot
                 if let threadId = threadSnapshot {
                     self.selection = .thread(threadId)
                 } else {

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -272,9 +272,9 @@ struct MainWindowView: View {
                     } else {
                         // Thread was archived/deleted — fall back to the first visible thread
                         if let fallback = threadManager.visibleThreads.first {
-                            windowState.selection = .thread(fallback.id)
+                            windowState.applySelectionCorrection(.thread(fallback.id))
                         } else {
-                            windowState.selection = nil
+                            windowState.applySelectionCorrection(nil)
                         }
                     }
                 }

--- a/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
+++ b/clients/macos/vellum-assistantTests/MainWindowStateNavigationHistoryTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import VellumAssistantLib
+
+@MainActor
+final class MainWindowStateNavigationHistoryTests: XCTestCase {
+
+    func testBackForwardAcrossThreadPanelApp() {
+        let state = MainWindowState(hasAPIKey: false)
+        let id1 = UUID()
+        state.selection = .thread(id1)
+        state.selection = .panel(.settings)
+        state.selection = .app("myapp")
+
+        // Back twice
+        state.navigateBack()
+        XCTAssertEqual(state.selection, .panel(.settings))
+        state.navigateBack()
+        XCTAssertEqual(state.selection, .thread(id1))
+
+        // Forward twice
+        state.navigateForward()
+        XCTAssertEqual(state.selection, .panel(.settings))
+        state.navigateForward()
+        XCTAssertEqual(state.selection, .app("myapp"))
+    }
+
+    func testRepeatedShowAppsPanelNoDuplicates() {
+        let state = MainWindowState(hasAPIKey: false)
+        state.showAppsPanel()
+        state.showAppsPanel()
+
+        // Second call is from == to, so only 1 entry in back stack
+        XCTAssertEqual(state.navigationHistory.backStack.count, 1)
+    }
+
+    func testBackOnEmptyStackIsNoOp() {
+        let state = MainWindowState(hasAPIKey: false)
+        state.navigateBack()
+        XCTAssertNil(state.selection)
+    }
+
+    func testBackToChatDefaultRestoresThread() {
+        let state = MainWindowState(hasAPIKey: false)
+        let someId = UUID()
+        state.persistentThreadId = someId
+        // selection is nil (chat default), persistentThreadId is someId
+        state.selection = .panel(.settings)
+        // back should restore chat default with snapshot
+        state.navigateBack()
+        XCTAssertEqual(state.selection, .thread(someId))
+    }
+
+    func testNavigateBackDoesNotReRecord() {
+        let state = MainWindowState(hasAPIKey: false)
+        let idA = UUID()
+        let idB = UUID()
+        state.selection = .thread(idA)
+        state.selection = .thread(idB)
+        state.navigateBack()
+        // Back stack should now have 1 entry: nil->A creates [chatDefault(nil)], A->B creates [chatDefault(nil), A]
+        // navigateBack pops A, so back is [chatDefault(nil)]
+        XCTAssertEqual(state.navigationHistory.backStack.count, 1)
+    }
+
+    func testRestoreLastActivePanelDoesNotSeedHistory() {
+        let freshState = MainWindowState(hasAPIKey: false)
+        // restoreLastActivePanel reads from @AppStorage which we can't easily mock
+        // So just verify the method doesn't crash and check suppression behavior
+        freshState.restoreLastActivePanel()
+        XCTAssertTrue(freshState.navigationHistory.backStack.isEmpty)
+    }
+
+    func testBackToChatDefaultNilResolvesToNilSelection() {
+        let state = MainWindowState(hasAPIKey: false)
+        // selection is nil, persistentThreadId is nil
+        state.selection = .panel(.settings)
+        state.navigateBack()
+        XCTAssertNil(state.selection)
+    }
+}


### PR DESCRIPTION
Wire NavigationHistory into MainWindowState, add navigateBack/navigateForward/applySelectionCorrection methods, suppress recording in restoreLastActivePanel, update corrective fallbacks in MainWindowView, and add 7 integration tests. Part of #13585.

## Summary
- Add `navigationHistory` property to `MainWindowState`
- Record transitions in `selection`'s `didSet` (before `persistentThreadId` update)
- Add `navigateBack()`, `navigateForward()`, and `applySelectionCorrection()` methods with recording suppression
- Wrap `restoreLastActivePanel()` in suppression so app launch doesn't seed history
- Update corrective fallbacks in `MainWindowView` to use `applySelectionCorrection` instead of direct assignment

## Test Plan
- 7 new tests in `MainWindowStateNavigationHistoryTests.swift` covering back/forward across selections, no-op on empty stack, chat default restoration, suppression during navigate, and restore panel suppression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
