### PR TITLE
feat: add Cmd+[ and Cmd+] menu items for back/forward navigation

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -83,6 +83,7 @@ extension AppDelegate {
     func setupViewMenu() {
         guard let mainMenu = NSApp.mainMenu else { return }
         let managedZoomMenuTag = 9_401
+        let managedNavigationMenuTag = 9_402
 
         let viewMenu: NSMenu
         let existingIndex = mainMenu.indexOfItem(withTitle: "View")
@@ -106,7 +107,7 @@ extension AppDelegate {
         // Preserve non-managed items already provided by AppKit/SwiftUI,
         // while making this setup idempotent across reconfiguration cycles.
         let preservedItems = viewMenu.items.filter { item in
-            item.tag != managedZoomMenuTag
+            item.tag != managedZoomMenuTag && item.tag != managedNavigationMenuTag
         }
         viewMenu.removeAllItems()
 
@@ -141,6 +142,30 @@ extension AppDelegate {
         zoomResetItem.tag = managedZoomMenuTag
         viewMenu.addItem(zoomResetItem)
 
+        let navSeparator = NSMenuItem.separator()
+        navSeparator.tag = managedNavigationMenuTag
+        viewMenu.addItem(navSeparator)
+
+        let backItem = NSMenuItem(
+            title: "Back",
+            action: #selector(handleNavigateBack),
+            keyEquivalent: "["
+        )
+        backItem.keyEquivalentModifierMask = .command
+        backItem.target = self
+        backItem.tag = managedNavigationMenuTag
+        viewMenu.addItem(backItem)
+
+        let forwardItem = NSMenuItem(
+            title: "Forward",
+            action: #selector(handleNavigateForward),
+            keyEquivalent: "]"
+        )
+        forwardItem.keyEquivalentModifierMask = .command
+        forwardItem.target = self
+        forwardItem.tag = managedNavigationMenuTag
+        viewMenu.addItem(forwardItem)
+
         if !preservedItems.isEmpty {
             let preservedSeparator = NSMenuItem.separator()
             preservedSeparator.tag = managedZoomMenuTag
@@ -168,10 +193,24 @@ extension AppDelegate {
     @objc public func handleWindowZoomOut() { routeZoomIntent(.windowZoomOut) }
     @objc public func handleWindowZoomReset() { routeZoomIntent(.windowZoomReset) }
 
+    @objc public func handleNavigateBack() {
+        mainWindow?.windowState.navigateBack()
+    }
+
+    @objc public func handleNavigateForward() {
+        mainWindow?.windowState.navigateForward()
+    }
+
     // MARK: - Menu Item Validation
 
     @objc func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         guard let action = menuItem.action else { return true }
+        if action == #selector(handleNavigateBack) {
+            return mainWindow?.windowState.navigationHistory.canGoBack ?? false
+        }
+        if action == #selector(handleNavigateForward) {
+            return mainWindow?.windowState.navigationHistory.canGoForward ?? false
+        }
         if action == #selector(markAllThreadsSeen) {
             return (mainWindow?.threadManager.unseenVisibleConversationCount ?? 0) > 0
         }


### PR DESCRIPTION
Add Back (Cmd+[) and Forward (Cmd+]) menu items to the View menu, with handlers that call navigateBack/navigateForward on MainWindowState. Menu items are dynamically enabled/disabled based on navigation history stack state. Part of #13585.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
