### PR TITLE
fix: clear autocomplete ghost text on user input

### DIFF
--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -23,7 +23,12 @@ public final class ChatMessageManager: ObservableObject {
 
     // MARK: - Input / send state
 
-    @Published public var inputText: String = ""
+    @Published public var inputText: String = "" {
+        didSet {
+            guard inputText != oldValue else { return }
+            suggestion = nil
+        }
+    }
     @Published public var isThinking: Bool = false
     @Published public var isSending: Bool = false
     @Published public var assistantActivityPhase: String = "idle"

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -23,14 +23,7 @@ public final class ChatMessageManager: ObservableObject {
 
     // MARK: - Input / send state
 
-    @Published public var inputText: String = "" {
-        didSet {
-            guard inputText != oldValue else { return }
-            if let suggestion, !suggestion.hasPrefix(inputText) {
-                self.suggestion = nil
-            }
-        }
-    }
+    @Published public var inputText: String = ""
     @Published public var isThinking: Bool = false
     @Published public var isSending: Bool = false
     @Published public var assistantActivityPhase: String = "idle"

--- a/clients/shared/Features/Chat/ChatMessageManager.swift
+++ b/clients/shared/Features/Chat/ChatMessageManager.swift
@@ -26,7 +26,9 @@ public final class ChatMessageManager: ObservableObject {
     @Published public var inputText: String = "" {
         didSet {
             guard inputText != oldValue else { return }
-            suggestion = nil
+            if let suggestion, !suggestion.hasPrefix(inputText) {
+                self.suggestion = nil
+            }
         }
     }
     @Published public var isThinking: Bool = false

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -116,9 +116,11 @@ public final class ChatViewModel: ObservableObject {
         get { messageManager.inputText }
         set {
             let oldValue = messageManager.inputText
+            let oldSuggestion = messageManager.suggestion
             messageManager.inputText = newValue
             guard newValue != oldValue else { return }
-            if let suggestion, !suggestion.hasPrefix(newValue) {
+            if let oldSuggestion, !oldSuggestion.hasPrefix(newValue) {
+                messageManager.suggestion = nil
                 pendingSuggestionRequestId = nil
             }
         }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -118,7 +118,9 @@ public final class ChatViewModel: ObservableObject {
             let oldValue = messageManager.inputText
             messageManager.inputText = newValue
             guard newValue != oldValue else { return }
-            pendingSuggestionRequestId = nil
+            if let suggestion, !suggestion.hasPrefix(newValue) {
+                pendingSuggestionRequestId = nil
+            }
         }
     }
     public var isThinking: Bool {

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -114,7 +114,12 @@ public final class ChatViewModel: ObservableObject {
     }
     public var inputText: String {
         get { messageManager.inputText }
-        set { messageManager.inputText = newValue }
+        set {
+            let oldValue = messageManager.inputText
+            messageManager.inputText = newValue
+            guard newValue != oldValue else { return }
+            pendingSuggestionRequestId = nil
+        }
     }
     public var isThinking: Bool {
         get { messageManager.isThinking }


### PR DESCRIPTION
## Summary
- Clears `suggestion` in `ChatMessageManager.inputText` `didSet` when text changes, so ghost text overlay disappears immediately on typing
- Clears `pendingSuggestionRequestId` in `ChatViewModel.inputText` setter to prevent late daemon `suggestion_response` from resurrecting stale ghost text

Fixes [LUM-33](https://linear.app/vellum/issue/LUM-33/autocompleteplaceholder-overlay-persists-while-typing-in-chat-input)

## Test plan
- [ ] Start a chat session, get a suggestion (ghost text appears)
- [ ] Type text that diverges from the suggestion → ghost text should disappear immediately
- [ ] Type text that initially matches the suggestion prefix → ghost suffix should show, then disappear once typing diverges
- [ ] Accept a suggestion via Tab → input should populate correctly
- [ ] Send a message → suggestion should clear as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
