### PR TITLE
M2: macOS local registration and conditional key reprovision

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -134,13 +134,19 @@ struct OnboardingFlowView: View {
         .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
             if isAuthenticated {
                 let currentAssistant = LockfileAssistant.loadLatest()
-                if currentAssistant?.isManaged == true || managedBootstrapEnabled {
+                if let assistant = currentAssistant {
+                    if assistant.isManaged {
+                        Task {
+                            await performManagedBootstrap()
+                        }
+                    } else {
+                        Task {
+                            await performLocalBootstrap(assistant: assistant)
+                        }
+                    }
+                } else if managedBootstrapEnabled {
                     Task {
                         await performManagedBootstrap()
-                    }
-                } else if let assistant = currentAssistant, !assistant.isManaged {
-                    Task {
-                        await performLocalBootstrap(assistant: assistant)
                     }
                 } else {
                     onComplete()
@@ -284,7 +290,7 @@ struct OnboardingFlowView: View {
         let daemonBaseURL = "http://localhost:\(port)"
 
         guard let daemonToken = ActorTokenManager.getToken(), !daemonToken.isEmpty else {
-            localBootstrapError = "No daemon credentials available. Please restart the assistant and try again."
+            localBootstrapError = "No assistant credentials available. Please restart the assistant and try again."
             return
         }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -13,6 +13,8 @@ struct OnboardingFlowView: View {
     @State private var isAdvancingFromWakeUp = false
     @State private var isBootstrappingManaged = false
     @State private var managedBootstrapError: String?
+    @State private var isBootstrappingLocal = false
+    @State private var localBootstrapError: String?
 
     private static let appIcon: NSImage? = {
         guard let path = ResourceBundle.bundle.path(forResource: "vellum-app-icon", ofType: "png") else { return nil }
@@ -64,6 +66,8 @@ struct OnboardingFlowView: View {
                     Group {
                         if isBootstrappingManaged {
                             managedBootstrapView
+                        } else if isBootstrappingLocal {
+                            localBootstrapView
                         } else {
                             switch state.currentStep {
                             case 0:
@@ -100,7 +104,7 @@ struct OnboardingFlowView: View {
                             removal: .opacity.combined(with: .offset(y: -8))
                         )
                     )
-                    .id(isBootstrappingManaged ? -1 : state.currentStep)
+                    .id(isBootstrappingManaged ? -1 : isBootstrappingLocal ? -2 : state.currentStep)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(
@@ -129,9 +133,14 @@ struct OnboardingFlowView: View {
         }
         .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
             if isAuthenticated {
-                if managedBootstrapEnabled {
+                let currentAssistant = LockfileAssistant.loadLatest()
+                if currentAssistant?.isManaged == true || managedBootstrapEnabled {
                     Task {
                         await performManagedBootstrap()
+                    }
+                } else if let assistant = currentAssistant, !assistant.isManaged {
+                    Task {
+                        await performLocalBootstrap(assistant: assistant)
                     }
                 } else {
                     onComplete()
@@ -221,6 +230,83 @@ struct OnboardingFlowView: View {
             onComplete()
         } catch {
             managedBootstrapError = error.localizedDescription
+        }
+    }
+
+    // MARK: - Local Bootstrap
+
+    @ViewBuilder
+    private var localBootstrapView: some View {
+        VStack(spacing: VSpacing.lg) {
+            if localBootstrapError == nil {
+                HStack(spacing: VSpacing.sm) {
+                    ProgressView()
+                        .controlSize(.small)
+                        .progressViewStyle(.circular)
+                    Text("Registering your assistant...")
+                        .font(VFont.monoMedium)
+                        .foregroundColor(VColor.textSecondary)
+                }
+            } else {
+                Text("Registration failed")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundColor(VColor.textPrimary)
+
+                if let error = localBootstrapError {
+                    Text(error)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.error)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 280)
+                }
+
+                OnboardingButton(title: "Try again", style: .primary) {
+                    Task {
+                        if let assistant = LockfileAssistant.loadLatest(), !assistant.isManaged {
+                            await performLocalBootstrap(assistant: assistant)
+                        }
+                    }
+                }
+                .frame(maxWidth: 280)
+            }
+        }
+
+        Spacer()
+    }
+
+    private func performLocalBootstrap(assistant: LockfileAssistant) async {
+        isBootstrappingLocal = true
+        localBootstrapError = nil
+
+        // Resolve the daemon's HTTP base URL and bearer token
+        let portString = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "7821"
+        let port = Int(portString) ?? 7821
+        let daemonBaseURL = "http://localhost:\(port)"
+
+        guard let daemonToken = ActorTokenManager.getToken(), !daemonToken.isEmpty else {
+            localBootstrapError = "No daemon credentials available. Please restart the assistant and try again."
+            return
+        }
+
+        do {
+            let outcome = try await LocalAssistantBootstrapService.shared.bootstrap(
+                runtimeAssistantId: assistant.assistantId,
+                clientPlatform: "macos",
+                daemonBaseURL: daemonBaseURL,
+                daemonToken: daemonToken
+            )
+
+            switch outcome {
+            case .registeredWithExistingKey(let assistantId):
+                UserDefaults.standard.set(assistantId, forKey: "connectedAssistantId")
+            case .registeredAndProvisioned(let assistantId):
+                UserDefaults.standard.set(assistantId, forKey: "connectedAssistantId")
+            }
+
+            isBootstrappingLocal = false
+            onComplete()
+        } catch {
+            localBootstrapError = error.localizedDescription
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -170,7 +170,7 @@ struct OnboardingFlowView: View {
                 }
             } else {
                 Text("Setup failed")
-                    .font(.system(size: 20, weight: .semibold))
+                    .font(VFont.title)
                     .foregroundColor(VColor.textPrimary)
 
                 if let error = managedBootstrapError {
@@ -249,7 +249,7 @@ struct OnboardingFlowView: View {
                 }
             } else {
                 Text("Registration failed")
-                    .font(.system(size: 20, weight: .semibold))
+                    .font(VFont.title)
                     .foregroundColor(VColor.textPrimary)
 
                 if let error = localBootstrapError {

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -1,0 +1,190 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "LocalAssistantBootstrap")
+
+/// Outcome of a local assistant bootstrap attempt.
+public enum LocalBootstrapOutcome: Sendable {
+    case registeredWithExistingKey(assistantId: String)
+    case registeredAndProvisioned(assistantId: String)
+}
+
+/// Errors that can occur during local assistant bootstrapping.
+public enum LocalBootstrapError: LocalizedError, Sendable {
+    case authenticationRequired
+    case registrationFailed(String)
+    case provisioningFailed(String)
+    case daemonInjectionFailed
+    case multipleOrganizations
+
+    public var errorDescription: String? {
+        switch self {
+        case .authenticationRequired:
+            return "Sign in required to register your assistant"
+        case .registrationFailed(let message):
+            return "Registration failed: \(message)"
+        case .provisioningFailed(let message):
+            return "API key provisioning failed: \(message)"
+        case .daemonInjectionFailed:
+            return "Failed to inject API key into the assistant"
+        case .multipleOrganizations:
+            return "Multiple organizations found. Multi-org support is not yet available — please contact support."
+        }
+    }
+}
+
+/// Bootstraps a locally hosted assistant with the platform:
+/// 1. Calls ensure-registration to register (or re-confirm) the local assistant
+/// 2. Checks whether an assistant API key is already stored locally
+/// 3. If missing, calls reprovision-api-key and injects the key into the daemon
+///
+/// Does NOT reuse ManagedAssistantBootstrapService.
+/// Does NOT write cloud = "vellum" into the lockfile.
+@MainActor
+public final class LocalAssistantBootstrapService {
+    public static let shared = LocalAssistantBootstrapService()
+
+    private let authService: AuthService
+
+    /// The keychain/UserDefaults storage provider name for the provisioned credential.
+    private static let credentialProvider = "vellum_assistant_credential"
+
+    public init(authService: AuthService? = nil) {
+        self.authService = authService ?? AuthService.shared
+    }
+
+    /// Bootstrap a local assistant with the platform.
+    /// - Parameters:
+    ///   - runtimeAssistantId: The local assistant's ID from the lockfile
+    ///   - clientPlatform: e.g., "macos"
+    ///   - daemonBaseURL: The local daemon's HTTP base URL (e.g., http://localhost:7821)
+    ///   - daemonToken: The bearer token for authenticating with the local daemon
+    public func bootstrap(
+        runtimeAssistantId: String,
+        clientPlatform: String = "macos",
+        daemonBaseURL: String,
+        daemonToken: String
+    ) async throws -> LocalBootstrapOutcome {
+        let installId = LocalInstallationIdStore.getOrCreate()
+
+        // Resolve the user's organization ID — required for all platform API calls.
+        let organizationId: String
+        if let persistedOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
+            organizationId = persistedOrgId
+            log.info("Using persisted organization: \(organizationId, privacy: .public)")
+        } else {
+            do {
+                let orgs = try await authService.getOrganizations()
+                switch orgs.count {
+                case 0:
+                    throw LocalBootstrapError.registrationFailed("No organizations found for this account")
+                case 1:
+                    organizationId = orgs[0].id
+                default:
+                    throw LocalBootstrapError.multipleOrganizations
+                }
+                UserDefaults.standard.set(organizationId, forKey: "connectedOrganizationId")
+                log.info("Resolved organization: \(organizationId, privacy: .public)")
+            } catch let error as LocalBootstrapError {
+                throw error
+            } catch let error as PlatformAPIError {
+                throw mapPlatformError(error)
+            } catch {
+                throw LocalBootstrapError.registrationFailed(error.localizedDescription)
+            }
+        }
+
+        // Step 1: Ensure registration (idempotent)
+        let registration: EnsureSelfHostedLocalRegistrationResponse
+        do {
+            registration = try await authService.ensureSelfHostedLocalRegistration(
+                organizationId: organizationId,
+                clientInstallationId: installId,
+                runtimeAssistantId: runtimeAssistantId,
+                clientPlatform: clientPlatform
+            )
+        } catch let error as PlatformAPIError {
+            throw mapPlatformError(error)
+        } catch {
+            throw LocalBootstrapError.registrationFailed(error.localizedDescription)
+        }
+
+        let platformAssistantId = registration.assistant.id
+        log.info("Registered local assistant: \(platformAssistantId, privacy: .public)")
+
+        // Step 2: Check if we already have the key stored locally
+        if let existingKey = APIKeyManager.shared.getAPIKey(provider: Self.credentialProvider), !existingKey.isEmpty {
+            // Key exists locally — re-sync to daemon (it may have restarted)
+            try await injectKeyIntoDaemon(key: existingKey, daemonBaseURL: daemonBaseURL, daemonToken: daemonToken)
+            log.info("Re-synced existing API key to daemon")
+            return .registeredWithExistingKey(assistantId: platformAssistantId)
+        }
+
+        // Step 3: No key stored — reprovision
+        let provisionResponse: ReprovisionSelfHostedLocalApiKeyResponse
+        do {
+            provisionResponse = try await authService.reprovisionSelfHostedLocalAssistantApiKey(
+                organizationId: organizationId,
+                clientInstallationId: installId,
+                runtimeAssistantId: runtimeAssistantId,
+                clientPlatform: clientPlatform
+            )
+        } catch let error as PlatformAPIError {
+            throw mapPlatformError(error)
+        } catch {
+            throw LocalBootstrapError.provisioningFailed(error.localizedDescription)
+        }
+
+        let rawKey = provisionResponse.provisioning.assistantApiKey
+        log.info("Provisioned new API key for assistant: \(platformAssistantId, privacy: .public)")
+
+        // Step 4: Store locally for future sign-ins
+        _ = APIKeyManager.shared.setAPIKey(rawKey, provider: Self.credentialProvider)
+
+        // Step 5: Inject into daemon
+        try await injectKeyIntoDaemon(key: rawKey, daemonBaseURL: daemonBaseURL, daemonToken: daemonToken)
+
+        return .registeredAndProvisioned(assistantId: platformAssistantId)
+    }
+
+    /// Inject the assistant API key into the daemon's secret store.
+    private func injectKeyIntoDaemon(key: String, daemonBaseURL: String, daemonToken: String) async throws {
+        guard let url = URL(string: "\(daemonBaseURL)/v1/secrets") else {
+            throw LocalBootstrapError.daemonInjectionFailed
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(daemonToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 10
+
+        let body: [String: String] = [
+            "type": "credential",
+            "name": "vellum:assistant_api_key",
+            "value": key
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw LocalBootstrapError.daemonInjectionFailed
+        }
+    }
+
+    private func mapPlatformError(_ error: PlatformAPIError) -> LocalBootstrapError {
+        switch error {
+        case .authenticationRequired:
+            return .authenticationRequired
+        case .networkError(let message):
+            return .registrationFailed(message)
+        case .serverError(_, let detail):
+            return .registrationFailed(detail ?? error.localizedDescription)
+        case .invalidURL:
+            return .registrationFailed("Invalid URL configuration")
+        case .decodingError(let message):
+            return .registrationFailed("Unexpected response: \(message)")
+        }
+    }
+}

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -57,7 +57,7 @@ public final class LocalAssistantBootstrapService {
     /// - Parameters:
     ///   - runtimeAssistantId: The local assistant's ID from the lockfile
     ///   - clientPlatform: e.g., "macos"
-    ///   - daemonBaseURL: The local daemon's HTTP base URL (e.g., http://localhost:7821)
+    ///   - daemonBaseURL: The local daemon's HTTP base URL
     ///   - daemonToken: The bearer token for authenticating with the local daemon
     public func bootstrap(
         runtimeAssistantId: String,

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -88,7 +88,7 @@ public final class LocalAssistantBootstrapService {
             } catch let error as LocalBootstrapError {
                 throw error
             } catch let error as PlatformAPIError {
-                throw mapPlatformError(error)
+                throw mapPlatformError(error, context: .registration)
             } catch {
                 throw LocalBootstrapError.registrationFailed(error.localizedDescription)
             }
@@ -104,7 +104,7 @@ public final class LocalAssistantBootstrapService {
                 clientPlatform: clientPlatform
             )
         } catch let error as PlatformAPIError {
-            throw mapPlatformError(error)
+            throw mapPlatformError(error, context: .registration)
         } catch {
             throw LocalBootstrapError.registrationFailed(error.localizedDescription)
         }
@@ -130,7 +130,7 @@ public final class LocalAssistantBootstrapService {
                 clientPlatform: clientPlatform
             )
         } catch let error as PlatformAPIError {
-            throw mapPlatformError(error)
+            throw mapPlatformError(error, context: .provisioning)
         } catch {
             throw LocalBootstrapError.provisioningFailed(error.localizedDescription)
         }
@@ -173,18 +173,30 @@ public final class LocalAssistantBootstrapService {
         }
     }
 
-    private func mapPlatformError(_ error: PlatformAPIError) -> LocalBootstrapError {
-        switch error {
-        case .authenticationRequired:
-            return .authenticationRequired
-        case .networkError(let message):
-            return .registrationFailed(message)
-        case .serverError(_, let detail):
-            return .registrationFailed(detail ?? error.localizedDescription)
-        case .invalidURL:
-            return .registrationFailed("Invalid URL configuration")
-        case .decodingError(let message):
-            return .registrationFailed("Unexpected response: \(message)")
+    private enum ErrorContext {
+        case registration
+        case provisioning
+    }
+
+    private func mapPlatformError(_ error: Error, context: ErrorContext) -> LocalBootstrapError {
+        if let platformErr = error as? PlatformAPIError {
+            switch platformErr {
+            case .authenticationRequired:
+                return .authenticationRequired
+            default:
+                switch context {
+                case .registration:
+                    return .registrationFailed(platformErr.localizedDescription)
+                case .provisioning:
+                    return .provisioningFailed(platformErr.localizedDescription)
+                }
+            }
+        }
+        switch context {
+        case .registration:
+            return .registrationFailed(error.localizedDescription)
+        case .provisioning:
+            return .provisioningFailed(error.localizedDescription)
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `LocalAssistantBootstrapService` in shared auth layer that registers local (non-managed) assistants with the platform via `ensure-registration`, conditionally provisions API keys via `reprovision-api-key`, and injects them into the daemon's secret store
- Wire into `OnboardingFlowView` so that on sign-in, if the current lockfile assistant is local (not managed), the local bootstrap flow runs automatically
- Includes progress UI ("Registering your assistant...") and error handling with retry, matching the existing managed bootstrap UX pattern

Part of #13598, closes #13600.

## Test plan

- [ ] Verify that signing in with a local assistant in the lockfile triggers local registration and key provisioning
- [ ] Verify that signing in with a managed assistant still triggers the managed bootstrap flow
- [ ] Verify that if no lockfile assistant exists, `onComplete()` is called directly
- [ ] Verify that re-sign-in with an existing stored key re-syncs to daemon without reprovisioning
- [ ] Verify error states show retry button and error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
