### PR TITLE
feat: add icon for frontend-design bundled skill

### DIFF
--- a/assistant/src/config/bundled-skills/frontend-design/icon.svg
+++ b/assistant/src/config/bundled-skills/frontend-design/icon.svg
@@ -1,0 +1,16 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="16" height="16" fill="#f5f5f5"/>
+  <rect x="2" y="2" width="12" height="11" fill="#ffffff" stroke="#333333" stroke-width="1"/>
+  <rect x="2" y="2" width="12" height="2" fill="#ff6b6b"/>
+  <rect x="3" y="3" width="10" height="1" fill="#ffffff"/>
+  <rect x="3" y="5" width="2" height="1" fill="#4ecdc4"/>
+  <rect x="6" y="5" width="2" height="1" fill="#4ecdc4"/>
+  <rect x="9" y="5" width="2" height="1" fill="#4ecdc4"/>
+  <rect x="3" y="7" width="4" height="1" fill="#95e1d3"/>
+  <rect x="3" y="8" width="4" height="1" fill="#95e1d3"/>
+  <rect x="3" y="9" width="3" height="1" fill="#95e1d3"/>
+  <rect x="8" y="7" width="5" height="1" fill="#ffd93d"/>
+  <rect x="8" y="8" width="5" height="1" fill="#ffd93d"/>
+  <rect x="8" y="9" width="3" height="1" fill="#ffd93d"/>
+  <rect x="3" y="11" width="10" height="1" fill="#e8e8e8"/>
+</svg>


### PR DESCRIPTION
## Summary
- Adds an SVG icon for the `frontend-design` bundled skill

## Test plan
- [x] Verify icon renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
