### PR TITLE
Self-Hosted Local Assistant API Keys (Swift Client)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -297,7 +297,8 @@ struct OnboardingFlowView: View {
         }
 
         do {
-            let outcome = try await LocalAssistantBootstrapService.shared.bootstrap(
+            let bootstrapService = LocalAssistantBootstrapService(credentialStorage: KeychainCredentialStorage())
+            let outcome = try await bootstrapService.bootstrap(
                 runtimeAssistantId: assistant.assistantId,
                 clientPlatform: "macos",
                 daemonBaseURL: daemonBaseURL,

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -305,10 +305,8 @@ struct OnboardingFlowView: View {
             )
 
             switch outcome {
-            case .registeredWithExistingKey(let assistantId):
-                UserDefaults.standard.set(assistantId, forKey: "connectedAssistantId")
-            case .registeredAndProvisioned(let assistantId):
-                UserDefaults.standard.set(assistantId, forKey: "connectedAssistantId")
+            case .registeredWithExistingKey, .registeredAndProvisioned:
+                UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")
             }
 
             isBootstrappingLocal = false

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -270,7 +270,7 @@ struct OnboardingFlowView: View {
 
                 OnboardingButton(title: "Try again", style: .primary) {
                     Task {
-                        if let assistant = LockfileAssistant.loadLatest(), !assistant.isManaged {
+                        if let assistant = LockfileAssistant.loadLatest(), !assistant.isRemote {
                             await performLocalBootstrap(assistant: assistant)
                         }
                     }

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -13,6 +13,8 @@ struct OnboardingFlowView: View {
     @State private var isAdvancingFromWakeUp = false
     @State private var isBootstrappingManaged = false
     @State private var managedBootstrapError: String?
+    @State private var isBootstrappingLocal = false
+    @State private var localBootstrapError: String?
 
     private static let appIcon: NSImage? = {
         guard let path = ResourceBundle.bundle.path(forResource: "vellum-app-icon", ofType: "png") else { return nil }
@@ -64,6 +66,8 @@ struct OnboardingFlowView: View {
                     Group {
                         if isBootstrappingManaged {
                             managedBootstrapView
+                        } else if isBootstrappingLocal {
+                            localBootstrapView
                         } else {
                             switch state.currentStep {
                             case 0:
@@ -100,7 +104,7 @@ struct OnboardingFlowView: View {
                             removal: .opacity.combined(with: .offset(y: -8))
                         )
                     )
-                    .id(isBootstrappingManaged ? -1 : state.currentStep)
+                    .id(isBootstrappingManaged ? -1 : isBootstrappingLocal ? -2 : state.currentStep)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(
@@ -129,7 +133,18 @@ struct OnboardingFlowView: View {
         }
         .onChange(of: authManager.isAuthenticated) { _, isAuthenticated in
             if isAuthenticated {
-                if managedBootstrapEnabled {
+                let currentAssistant = LockfileAssistant.loadLatest()
+                if let assistant = currentAssistant {
+                    if assistant.isManaged {
+                        Task {
+                            await performManagedBootstrap()
+                        }
+                    } else {
+                        Task {
+                            await performLocalBootstrap(assistant: assistant)
+                        }
+                    }
+                } else if managedBootstrapEnabled {
                     Task {
                         await performManagedBootstrap()
                     }
@@ -161,7 +176,7 @@ struct OnboardingFlowView: View {
                 }
             } else {
                 Text("Setup failed")
-                    .font(.system(size: 20, weight: .semibold))
+                    .font(VFont.title)
                     .foregroundColor(VColor.textPrimary)
 
                 if let error = managedBootstrapError {
@@ -221,6 +236,83 @@ struct OnboardingFlowView: View {
             onComplete()
         } catch {
             managedBootstrapError = error.localizedDescription
+        }
+    }
+
+    // MARK: - Local Bootstrap
+
+    @ViewBuilder
+    private var localBootstrapView: some View {
+        VStack(spacing: VSpacing.lg) {
+            if localBootstrapError == nil {
+                HStack(spacing: VSpacing.sm) {
+                    ProgressView()
+                        .controlSize(.small)
+                        .progressViewStyle(.circular)
+                    Text("Registering your assistant...")
+                        .font(VFont.monoMedium)
+                        .foregroundColor(VColor.textSecondary)
+                }
+            } else {
+                Text("Registration failed")
+                    .font(VFont.title)
+                    .foregroundColor(VColor.textPrimary)
+
+                if let error = localBootstrapError {
+                    Text(error)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.error)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 280)
+                }
+
+                OnboardingButton(title: "Try again", style: .primary) {
+                    Task {
+                        if let assistant = LockfileAssistant.loadLatest(), !assistant.isManaged {
+                            await performLocalBootstrap(assistant: assistant)
+                        }
+                    }
+                }
+                .frame(maxWidth: 280)
+            }
+        }
+
+        Spacer()
+    }
+
+    private func performLocalBootstrap(assistant: LockfileAssistant) async {
+        isBootstrappingLocal = true
+        localBootstrapError = nil
+
+        // Resolve the daemon's HTTP base URL and bearer token
+        let portString = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "7821"
+        let port = Int(portString) ?? 7821
+        let daemonBaseURL = "http://localhost:\(port)"
+
+        guard let daemonToken = ActorTokenManager.getToken(), !daemonToken.isEmpty else {
+            localBootstrapError = "No assistant credentials available. Please restart the assistant and try again."
+            return
+        }
+
+        do {
+            let outcome = try await LocalAssistantBootstrapService.shared.bootstrap(
+                runtimeAssistantId: assistant.assistantId,
+                clientPlatform: "macos",
+                daemonBaseURL: daemonBaseURL,
+                daemonToken: daemonToken
+            )
+
+            switch outcome {
+            case .registeredWithExistingKey(let assistantId):
+                UserDefaults.standard.set(assistantId, forKey: "connectedAssistantId")
+            case .registeredAndProvisioned(let assistantId):
+                UserDefaults.standard.set(assistantId, forKey: "connectedAssistantId")
+            }
+
+            isBootstrappingLocal = false
+            onComplete()
+        } catch {
+            localBootstrapError = error.localizedDescription
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingFlowView.swift
@@ -139,10 +139,12 @@ struct OnboardingFlowView: View {
                         Task {
                             await performManagedBootstrap()
                         }
-                    } else {
+                    } else if !assistant.isRemote {
                         Task {
                             await performLocalBootstrap(assistant: assistant)
                         }
+                    } else {
+                        onComplete()
                     }
                 } else if managedBootstrapEnabled {
                     Task {

--- a/clients/macos/vellum-assistant/Security/KeychainCredentialStorage.swift
+++ b/clients/macos/vellum-assistant/Security/KeychainCredentialStorage.swift
@@ -1,0 +1,18 @@
+#if os(macOS)
+import Foundation
+import VellumAssistantShared
+
+/// Bridges KeychainBrokerService to the CredentialStorage protocol
+/// used by LocalAssistantBootstrapService.
+struct KeychainCredentialStorage: CredentialStorage {
+    func get(account: String) -> String? {
+        KeychainBrokerService.get(account: account)
+    }
+    func set(account: String, value: String) -> Bool {
+        KeychainBrokerService.set(account: account, value: value)
+    }
+    func delete(account: String) -> Bool {
+        KeychainBrokerService.delete(account: account)
+    }
+}
+#endif

--- a/clients/shared/App/Auth/AuthModels.swift
+++ b/clients/shared/App/Auth/AuthModels.swift
@@ -180,3 +180,68 @@ public enum PlatformAPIError: LocalizedError, Sendable {
         }
     }
 }
+
+// MARK: - Self-Hosted Local Registration
+
+public struct EnsureSelfHostedLocalRegistrationRequest: Codable, Sendable {
+    public let clientInstallationId: String
+    public let runtimeAssistantId: String
+    public let clientPlatform: String
+
+    enum CodingKeys: String, CodingKey {
+        case clientInstallationId = "client_installation_id"
+        case runtimeAssistantId = "runtime_assistant_id"
+        case clientPlatform = "client_platform"
+    }
+}
+
+public struct EnsureSelfHostedLocalRegistrationResponse: Codable, Sendable {
+    public let assistant: SelfHostedAssistantInfo
+    public let registration: SelfHostedRegistrationInfo
+}
+
+public struct SelfHostedAssistantInfo: Codable, Sendable {
+    public let id: String
+    public let name: String?
+}
+
+public struct SelfHostedRegistrationInfo: Codable, Sendable {
+    public let clientInstallationId: String
+    public let runtimeAssistantId: String
+    public let clientPlatform: String
+
+    enum CodingKeys: String, CodingKey {
+        case clientInstallationId = "client_installation_id"
+        case runtimeAssistantId = "runtime_assistant_id"
+        case clientPlatform = "client_platform"
+    }
+}
+
+public struct ReprovisionSelfHostedLocalApiKeyRequest: Codable, Sendable {
+    public let clientInstallationId: String
+    public let runtimeAssistantId: String
+    public let clientPlatform: String
+
+    enum CodingKeys: String, CodingKey {
+        case clientInstallationId = "client_installation_id"
+        case runtimeAssistantId = "runtime_assistant_id"
+        case clientPlatform = "client_platform"
+    }
+}
+
+public struct ReprovisionSelfHostedLocalApiKeyResponse: Codable, Sendable {
+    public let assistant: SelfHostedAssistantInfo
+    public let provisioning: SelfHostedProvisioningInfo
+}
+
+public struct SelfHostedProvisioningInfo: Codable, Sendable {
+    public let credentialName: String
+    public let assistantApiKey: String
+    public let rotated: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case credentialName = "credential_name"
+        case assistantApiKey = "assistant_api_key"
+        case rotated
+    }
+}

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -301,6 +301,130 @@ public final class AuthService {
         }
     }
 
+    // MARK: - Self-Hosted Local Registration
+
+    /// Ensure a self-hosted local assistant registration exists on the platform.
+    public func ensureSelfHostedLocalRegistration(
+        organizationId: String,
+        clientInstallationId: String,
+        runtimeAssistantId: String,
+        clientPlatform: String
+    ) async throws -> EnsureSelfHostedLocalRegistrationResponse {
+        let urlString = "\(baseURL)/v1/assistants/self-hosted-local/ensure-registration/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        let requestBody = EnsureSelfHostedLocalRegistrationRequest(
+            clientInstallationId: clientInstallationId,
+            runtimeAssistantId: runtimeAssistantId,
+            clientPlatform: clientPlatform
+        )
+        let encoder = JSONEncoder()
+        urlRequest.httpBody = try encoder.encode(requestBody)
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request POST assistants/self-hosted-local/ensure-registration/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(EnsureSelfHostedLocalRegistrationResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    /// Reprovision (rotate) the API key for a self-hosted local assistant.
+    public func reprovisionSelfHostedLocalAssistantApiKey(
+        organizationId: String,
+        clientInstallationId: String,
+        runtimeAssistantId: String,
+        clientPlatform: String
+    ) async throws -> ReprovisionSelfHostedLocalApiKeyResponse {
+        let urlString = "\(baseURL)/v1/assistants/self-hosted-local/reprovision-api-key/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        if let token = await SessionTokenManager.getTokenAsync() {
+            urlRequest.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        let requestBody = ReprovisionSelfHostedLocalApiKeyRequest(
+            clientInstallationId: clientInstallationId,
+            runtimeAssistantId: runtimeAssistantId,
+            clientPlatform: clientPlatform
+        )
+        let encoder = JSONEncoder()
+        urlRequest.httpBody = try encoder.encode(requestBody)
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+
+        let httpResponse = response as? HTTPURLResponse
+        let statusCode = httpResponse?.statusCode ?? 0
+
+        log.debug("Platform request POST assistants/self-hosted-local/reprovision-api-key/ -> \(statusCode)")
+
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(ReprovisionSelfHostedLocalApiKeyResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
     // MARK: - Allauth Requests
 
     private func request<T: Codable>(

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -3,6 +3,14 @@ import os
 
 private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "LocalAssistantBootstrap")
 
+/// Platform-agnostic credential storage abstraction.
+/// On macOS, callers should supply a Keychain-backed implementation.
+public protocol CredentialStorage: Sendable {
+    func get(account: String) -> String?
+    func set(account: String, value: String) -> Bool
+    func delete(account: String) -> Bool
+}
+
 /// Outcome of a local assistant bootstrap attempt.
 public enum LocalBootstrapOutcome: Sendable {
     case registeredWithExistingKey(assistantId: String)
@@ -42,17 +50,18 @@ public enum LocalBootstrapError: LocalizedError, Sendable {
 /// Does NOT write cloud = "vellum" into the lockfile.
 @MainActor
 public final class LocalAssistantBootstrapService {
-    public static let shared = LocalAssistantBootstrapService()
 
     private let authService: AuthService
+    private let credentialStorage: CredentialStorage?
 
-    /// Returns the keychain/UserDefaults storage provider name for the provisioned credential, scoped to the assistant.
-    private static func credentialProvider(for runtimeAssistantId: String) -> String {
+    /// Returns the credential account name for the provisioned credential, scoped to the assistant.
+    static func credentialAccount(for runtimeAssistantId: String) -> String {
         "vellum_assistant_credential_\(runtimeAssistantId)"
     }
 
-    public init(authService: AuthService? = nil) {
+    public init(authService: AuthService? = nil, credentialStorage: CredentialStorage? = nil) {
         self.authService = authService ?? AuthService.shared
+        self.credentialStorage = credentialStorage
     }
 
     /// Bootstrap a local assistant with the platform.
@@ -114,12 +123,18 @@ public final class LocalAssistantBootstrapService {
         let platformAssistantId = registration.assistant.id
         log.info("Registered local assistant: \(platformAssistantId, privacy: .public)")
 
+        let credentialAccount = Self.credentialAccount(for: runtimeAssistantId)
+
         // Step 2: Check if we already have the key stored locally
-        if let existingKey = APIKeyManager.shared.getAPIKey(provider: Self.credentialProvider(for: runtimeAssistantId)), !existingKey.isEmpty {
-            // Key exists locally — re-sync to daemon (it may have restarted)
-            try await injectKeyIntoDaemon(key: existingKey, daemonBaseURL: daemonBaseURL, daemonToken: daemonToken)
-            log.info("Re-synced existing API key to daemon")
-            return .registeredWithExistingKey(assistantId: platformAssistantId)
+        if let existingKey = credentialStorage?.get(account: credentialAccount), !existingKey.isEmpty {
+            do {
+                try await injectKeyIntoDaemon(key: existingKey, daemonBaseURL: daemonBaseURL, daemonToken: daemonToken)
+                log.info("Re-synced existing API key to daemon")
+                return .registeredWithExistingKey(assistantId: platformAssistantId)
+            } catch {
+                log.warning("Failed to inject existing key into daemon, will reprovision: \(error.localizedDescription)")
+                // Fall through to Step 3 — key may be stale
+            }
         }
 
         // Step 3: No key stored — reprovision
@@ -141,12 +156,31 @@ public final class LocalAssistantBootstrapService {
         log.info("Provisioned new API key for assistant: \(platformAssistantId, privacy: .public)")
 
         // Step 4: Store locally for future sign-ins
-        _ = APIKeyManager.shared.setAPIKey(rawKey, provider: Self.credentialProvider(for: runtimeAssistantId))
+        _ = credentialStorage?.set(account: credentialAccount, value: rawKey)
 
         // Step 5: Inject into daemon
         try await injectKeyIntoDaemon(key: rawKey, daemonBaseURL: daemonBaseURL, daemonToken: daemonToken)
 
         return .registeredAndProvisioned(assistantId: platformAssistantId)
+    }
+
+    /// Clear the stored credential and re-run bootstrap to obtain a fresh key.
+    /// Call this when a 401 indicates the cached key has been revoked.
+    public func reprovision(
+        runtimeAssistantId: String,
+        clientPlatform: String = "macos",
+        daemonBaseURL: String,
+        daemonToken: String
+    ) async throws -> LocalBootstrapOutcome {
+        let account = Self.credentialAccount(for: runtimeAssistantId)
+        _ = credentialStorage?.delete(account: account)
+
+        return try await bootstrap(
+            runtimeAssistantId: runtimeAssistantId,
+            clientPlatform: clientPlatform,
+            daemonBaseURL: daemonBaseURL,
+            daemonToken: daemonToken
+        )
     }
 
     /// Inject the assistant API key into the daemon's secret store.

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -46,8 +46,10 @@ public final class LocalAssistantBootstrapService {
 
     private let authService: AuthService
 
-    /// The keychain/UserDefaults storage provider name for the provisioned credential.
-    private static let credentialProvider = "vellum_assistant_credential"
+    /// Returns the keychain/UserDefaults storage provider name for the provisioned credential, scoped to the assistant.
+    private static func credentialProvider(for runtimeAssistantId: String) -> String {
+        "vellum_assistant_credential_\(runtimeAssistantId)"
+    }
 
     public init(authService: AuthService? = nil) {
         self.authService = authService ?? AuthService.shared
@@ -113,7 +115,7 @@ public final class LocalAssistantBootstrapService {
         log.info("Registered local assistant: \(platformAssistantId, privacy: .public)")
 
         // Step 2: Check if we already have the key stored locally
-        if let existingKey = APIKeyManager.shared.getAPIKey(provider: Self.credentialProvider), !existingKey.isEmpty {
+        if let existingKey = APIKeyManager.shared.getAPIKey(provider: Self.credentialProvider(for: runtimeAssistantId)), !existingKey.isEmpty {
             // Key exists locally — re-sync to daemon (it may have restarted)
             try await injectKeyIntoDaemon(key: existingKey, daemonBaseURL: daemonBaseURL, daemonToken: daemonToken)
             log.info("Re-synced existing API key to daemon")
@@ -139,7 +141,7 @@ public final class LocalAssistantBootstrapService {
         log.info("Provisioned new API key for assistant: \(platformAssistantId, privacy: .public)")
 
         // Step 4: Store locally for future sign-ins
-        _ = APIKeyManager.shared.setAPIKey(rawKey, provider: Self.credentialProvider)
+        _ = APIKeyManager.shared.setAPIKey(rawKey, provider: Self.credentialProvider(for: runtimeAssistantId))
 
         // Step 5: Inject into daemon
         try await injectKeyIntoDaemon(key: rawKey, daemonBaseURL: daemonBaseURL, daemonToken: daemonToken)

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -1,0 +1,202 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "LocalAssistantBootstrap")
+
+/// Outcome of a local assistant bootstrap attempt.
+public enum LocalBootstrapOutcome: Sendable {
+    case registeredWithExistingKey(assistantId: String)
+    case registeredAndProvisioned(assistantId: String)
+}
+
+/// Errors that can occur during local assistant bootstrapping.
+public enum LocalBootstrapError: LocalizedError, Sendable {
+    case authenticationRequired
+    case registrationFailed(String)
+    case provisioningFailed(String)
+    case daemonInjectionFailed
+    case multipleOrganizations
+
+    public var errorDescription: String? {
+        switch self {
+        case .authenticationRequired:
+            return "Sign in required to register your assistant"
+        case .registrationFailed(let message):
+            return "Registration failed: \(message)"
+        case .provisioningFailed(let message):
+            return "API key provisioning failed: \(message)"
+        case .daemonInjectionFailed:
+            return "Failed to inject API key into the assistant"
+        case .multipleOrganizations:
+            return "Multiple organizations found. Multi-org support is not yet available — please contact support."
+        }
+    }
+}
+
+/// Bootstraps a locally hosted assistant with the platform:
+/// 1. Calls ensure-registration to register (or re-confirm) the local assistant
+/// 2. Checks whether an assistant API key is already stored locally
+/// 3. If missing, calls reprovision-api-key and injects the key into the daemon
+///
+/// Does NOT reuse ManagedAssistantBootstrapService.
+/// Does NOT write cloud = "vellum" into the lockfile.
+@MainActor
+public final class LocalAssistantBootstrapService {
+    public static let shared = LocalAssistantBootstrapService()
+
+    private let authService: AuthService
+
+    /// The keychain/UserDefaults storage provider name for the provisioned credential.
+    private static let credentialProvider = "vellum_assistant_credential"
+
+    public init(authService: AuthService? = nil) {
+        self.authService = authService ?? AuthService.shared
+    }
+
+    /// Bootstrap a local assistant with the platform.
+    /// - Parameters:
+    ///   - runtimeAssistantId: The local assistant's ID from the lockfile
+    ///   - clientPlatform: e.g., "macos"
+    ///   - daemonBaseURL: The local daemon's HTTP base URL
+    ///   - daemonToken: The bearer token for authenticating with the local daemon
+    public func bootstrap(
+        runtimeAssistantId: String,
+        clientPlatform: String = "macos",
+        daemonBaseURL: String,
+        daemonToken: String
+    ) async throws -> LocalBootstrapOutcome {
+        let installId = LocalInstallationIdStore.getOrCreate()
+
+        // Resolve the user's organization ID — required for all platform API calls.
+        let organizationId: String
+        if let persistedOrgId = UserDefaults.standard.string(forKey: "connectedOrganizationId") {
+            organizationId = persistedOrgId
+            log.info("Using persisted organization: \(organizationId, privacy: .public)")
+        } else {
+            do {
+                let orgs = try await authService.getOrganizations()
+                switch orgs.count {
+                case 0:
+                    throw LocalBootstrapError.registrationFailed("No organizations found for this account")
+                case 1:
+                    organizationId = orgs[0].id
+                default:
+                    throw LocalBootstrapError.multipleOrganizations
+                }
+                UserDefaults.standard.set(organizationId, forKey: "connectedOrganizationId")
+                log.info("Resolved organization: \(organizationId, privacy: .public)")
+            } catch let error as LocalBootstrapError {
+                throw error
+            } catch let error as PlatformAPIError {
+                throw mapPlatformError(error, context: .registration)
+            } catch {
+                throw LocalBootstrapError.registrationFailed(error.localizedDescription)
+            }
+        }
+
+        // Step 1: Ensure registration (idempotent)
+        let registration: EnsureSelfHostedLocalRegistrationResponse
+        do {
+            registration = try await authService.ensureSelfHostedLocalRegistration(
+                organizationId: organizationId,
+                clientInstallationId: installId,
+                runtimeAssistantId: runtimeAssistantId,
+                clientPlatform: clientPlatform
+            )
+        } catch let error as PlatformAPIError {
+            throw mapPlatformError(error, context: .registration)
+        } catch {
+            throw LocalBootstrapError.registrationFailed(error.localizedDescription)
+        }
+
+        let platformAssistantId = registration.assistant.id
+        log.info("Registered local assistant: \(platformAssistantId, privacy: .public)")
+
+        // Step 2: Check if we already have the key stored locally
+        if let existingKey = APIKeyManager.shared.getAPIKey(provider: Self.credentialProvider), !existingKey.isEmpty {
+            // Key exists locally — re-sync to daemon (it may have restarted)
+            try await injectKeyIntoDaemon(key: existingKey, daemonBaseURL: daemonBaseURL, daemonToken: daemonToken)
+            log.info("Re-synced existing API key to daemon")
+            return .registeredWithExistingKey(assistantId: platformAssistantId)
+        }
+
+        // Step 3: No key stored — reprovision
+        let provisionResponse: ReprovisionSelfHostedLocalApiKeyResponse
+        do {
+            provisionResponse = try await authService.reprovisionSelfHostedLocalAssistantApiKey(
+                organizationId: organizationId,
+                clientInstallationId: installId,
+                runtimeAssistantId: runtimeAssistantId,
+                clientPlatform: clientPlatform
+            )
+        } catch let error as PlatformAPIError {
+            throw mapPlatformError(error, context: .provisioning)
+        } catch {
+            throw LocalBootstrapError.provisioningFailed(error.localizedDescription)
+        }
+
+        let rawKey = provisionResponse.provisioning.assistantApiKey
+        log.info("Provisioned new API key for assistant: \(platformAssistantId, privacy: .public)")
+
+        // Step 4: Store locally for future sign-ins
+        _ = APIKeyManager.shared.setAPIKey(rawKey, provider: Self.credentialProvider)
+
+        // Step 5: Inject into daemon
+        try await injectKeyIntoDaemon(key: rawKey, daemonBaseURL: daemonBaseURL, daemonToken: daemonToken)
+
+        return .registeredAndProvisioned(assistantId: platformAssistantId)
+    }
+
+    /// Inject the assistant API key into the daemon's secret store.
+    private func injectKeyIntoDaemon(key: String, daemonBaseURL: String, daemonToken: String) async throws {
+        guard let url = URL(string: "\(daemonBaseURL)/v1/secrets") else {
+            throw LocalBootstrapError.daemonInjectionFailed
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(daemonToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 10
+
+        let body: [String: String] = [
+            "type": "credential",
+            "name": "vellum:assistant_api_key",
+            "value": key
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw LocalBootstrapError.daemonInjectionFailed
+        }
+    }
+
+    private enum ErrorContext {
+        case registration
+        case provisioning
+    }
+
+    private func mapPlatformError(_ error: Error, context: ErrorContext) -> LocalBootstrapError {
+        if let platformErr = error as? PlatformAPIError {
+            switch platformErr {
+            case .authenticationRequired:
+                return .authenticationRequired
+            default:
+                switch context {
+                case .registration:
+                    return .registrationFailed(platformErr.localizedDescription)
+                case .provisioning:
+                    return .provisioningFailed(platformErr.localizedDescription)
+                }
+            }
+        }
+        switch context {
+        case .registration:
+            return .registrationFailed(error.localizedDescription)
+        case .provisioning:
+            return .provisioningFailed(error.localizedDescription)
+        }
+    }
+}

--- a/clients/shared/App/Auth/LocalInstallationIdStore.swift
+++ b/clients/shared/App/Auth/LocalInstallationIdStore.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Generates and persists an install-scoped random UUID for local assistant registration.
+/// This ID is stable across app launches but unique per installation.
+/// Do NOT use PairingQRCodeSheet.computeHostId() — that derives from hardware.
+public enum LocalInstallationIdStore {
+    private static let key = "vellum_local_installation_id"
+    private static let lock = NSLock()
+
+    /// Returns the persisted installation ID, generating one on first access.
+    /// Uses NSLock to prevent concurrent first-launch calls from generating different UUIDs.
+    public static func getOrCreate() -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        if let existing = UserDefaults.standard.string(forKey: key) {
+            return existing
+        }
+        let newId = UUID().uuidString.lowercased()
+        UserDefaults.standard.set(newId, forKey: key)
+        return newId
+    }
+}


### PR DESCRIPTION
## Summary
Enable locally hosted macOS assistants to call platform APIs requiring `AssistantAPIKey` auth by adding Swift client support for self-hosted local registration and API key reprovision endpoints. This includes shared models, AuthService methods, a local installation ID store, a bootstrap service, and macOS onboarding UI integration.

## Changes
- Added `EnsureSelfHostedLocalRegistration` and `ReprovisionSelfHostedLocalApiKey` request/response models with Codable+Sendable conformance
- Added `SelfHostedAssistantInfo`, `SelfHostedRegistrationInfo`, and `SelfHostedProvisioningInfo` shared models
- Added `ensureSelfHostedLocalRegistration()` and `reprovisionSelfHostedLocalAssistantApiKey()` methods to AuthService with X-Session-Token auth and Vellum-Organization-Id header
- Added `LocalInstallationIdStore` for install-scoped UUID persistence with thread-safe NSLock
- Added `LocalAssistantBootstrapService` singleton for registration → key check → reprovision → daemon injection flow
- Added `performLocalBootstrap()` and `localBootstrapView` to OnboardingFlowView with proper routing logic based on lockfile assistant type

## Milestone PRs (merged into feature branch)
- #13601: M1: Shared Swift client + install-scoped local ID
- #13605: M2: macOS local registration and conditional key reprovision

## Project issue
Closes #13598

## Test plan
- [ ] Verify local assistant with `cloud: "local"` in lockfile triggers `performLocalBootstrap` flow
- [ ] Verify managed assistant with `cloud: "vellum"` in lockfile triggers managed bootstrap flow
- [ ] Verify `ensureSelfHostedLocalRegistration` API call succeeds with valid session token
- [ ] Verify `reprovisionSelfHostedLocalAssistantApiKey` returns key and injects into daemon
- [ ] Verify `LocalInstallationIdStore` persists and returns consistent UUID across calls
- [ ] Verify error states show correct messages (registration vs provisioning failures)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
