### PR TITLE
feat: add runtime Slack channel list/share routes with auth policy coverage

### DIFF
--- a/assistant/src/__tests__/slack-share-routes.test.ts
+++ b/assistant/src/__tests__/slack-share-routes.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any imports that pull in mocked modules
+// ---------------------------------------------------------------------------
+
+const secureKeyValues = new Map<string, string>();
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKey: (key: string) => secureKeyValues.get(key),
+  setSecureKeyAsync: async () => {},
+}));
+
+let listConversationsResult: unknown = { ok: true, channels: [] };
+let postMessageResult: unknown = {
+  ok: true,
+  ts: "1234567890.123456",
+  channel: "C123",
+  message: { ts: "1234567890.123456", text: "", type: "message" },
+};
+let userInfoResults: Map<string, unknown> = new Map();
+
+mock.module("../messaging/providers/slack/client.js", () => ({
+  listConversations: async () => listConversationsResult,
+  postMessage: async (
+    _token: string,
+    _channel: string,
+    _text: string,
+    _opts?: unknown,
+  ) => postMessageResult,
+  userInfo: async (_token: string, userId: string) => {
+    const result = userInfoResults.get(userId);
+    if (result) return result;
+    throw new Error(`User not found: ${userId}`);
+  },
+}));
+
+let appStoreResult: unknown = null;
+mock.module("../memory/app-store.js", () => ({
+  getApp: (_id: string) => appStoreResult,
+  getAppsDir: () => "/tmp/apps",
+  isMultifileApp: () => false,
+  listApps: () => [],
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after mocks)
+// ---------------------------------------------------------------------------
+
+const { handleListSlackChannels, handleShareToSlackChannel } =
+  await import("../runtime/routes/slack-share-routes.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/v1/slack/share", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  secureKeyValues.clear();
+  listConversationsResult = { ok: true, channels: [] };
+  userInfoResults = new Map();
+  appStoreResult = null;
+  postMessageResult = {
+    ok: true,
+    ts: "1234567890.123456",
+    channel: "C123",
+    message: { ts: "1234567890.123456", text: "", type: "message" },
+  };
+});
+
+describe("handleListSlackChannels", () => {
+  test("returns 503 when no token is configured", async () => {
+    const res = await handleListSlackChannels();
+    expect(res.status).toBe(503);
+    const json = (await res.json()) as { error: { code: string } };
+    expect(json.error.code).toBe("SERVICE_UNAVAILABLE");
+  });
+
+  test("returns channels sorted by type then name", async () => {
+    secureKeyValues.set(
+      "credential:integration:slack:access_token",
+      "xoxb-test",
+    );
+
+    listConversationsResult = {
+      ok: true,
+      channels: [
+        {
+          id: "D1",
+          name: undefined,
+          is_im: true,
+          user: "U1",
+          is_private: true,
+        },
+        { id: "C2", name: "beta-channel", is_channel: true },
+        { id: "C1", name: "alpha-channel", is_channel: true },
+        { id: "G1", name: "group-chat", is_mpim: true, is_private: true },
+      ],
+    };
+
+    userInfoResults.set("U1", {
+      ok: true,
+      user: {
+        id: "U1",
+        name: "alice",
+        profile: { display_name: "Alice Smith" },
+      },
+    });
+
+    const res = await handleListSlackChannels();
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      channels: Array<{
+        id: string;
+        name: string;
+        type: string;
+        isPrivate: boolean;
+      }>;
+    };
+
+    expect(json.channels).toHaveLength(4);
+    // Channels first (alphabetical)
+    expect(json.channels[0]).toEqual({
+      id: "C1",
+      name: "alpha-channel",
+      type: "channel",
+      isPrivate: false,
+    });
+    expect(json.channels[1]).toEqual({
+      id: "C2",
+      name: "beta-channel",
+      type: "channel",
+      isPrivate: false,
+    });
+    // Groups
+    expect(json.channels[2]).toEqual({
+      id: "G1",
+      name: "group-chat",
+      type: "group",
+      isPrivate: true,
+    });
+    // DMs (name resolved from userInfo)
+    expect(json.channels[3]).toEqual({
+      id: "D1",
+      name: "Alice Smith",
+      type: "dm",
+      isPrivate: true,
+    });
+  });
+
+  test("falls back to legacy bot token", async () => {
+    secureKeyValues.set("credential:slack_channel:bot_token", "xoxb-legacy");
+
+    listConversationsResult = { ok: true, channels: [] };
+
+    const res = await handleListSlackChannels();
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("handleShareToSlackChannel", () => {
+  test("returns 503 when no token is configured", async () => {
+    const req = makeRequest({ appId: "app1", channelId: "C1" });
+    const res = await handleShareToSlackChannel(req);
+    expect(res.status).toBe(503);
+  });
+
+  test("returns 400 for malformed JSON", async () => {
+    secureKeyValues.set(
+      "credential:integration:slack:access_token",
+      "xoxb-test",
+    );
+    const req = new Request("http://localhost/v1/slack/share", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const res = await handleShareToSlackChannel(req);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 400 when missing required fields", async () => {
+    secureKeyValues.set(
+      "credential:integration:slack:access_token",
+      "xoxb-test",
+    );
+    const req = makeRequest({ appId: "app1" });
+    const res = await handleShareToSlackChannel(req);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: { message: string } };
+    expect(json.error.message).toContain("Missing required fields");
+  });
+
+  test("returns 404 when app not found", async () => {
+    secureKeyValues.set(
+      "credential:integration:slack:access_token",
+      "xoxb-test",
+    );
+    appStoreResult = null;
+    const req = makeRequest({ appId: "missing-app", channelId: "C1" });
+    const res = await handleShareToSlackChannel(req);
+    expect(res.status).toBe(404);
+  });
+
+  test("posts message and returns success", async () => {
+    secureKeyValues.set(
+      "credential:integration:slack:access_token",
+      "xoxb-test",
+    );
+    appStoreResult = {
+      id: "app1",
+      name: "My App",
+      description: "A great app",
+      htmlDefinition: "<div></div>",
+      schemaJson: "{}",
+      createdAt: 0,
+      updatedAt: 0,
+    };
+
+    const req = makeRequest({
+      appId: "app1",
+      channelId: "C123",
+      message: "Check this out!",
+    });
+    const res = await handleShareToSlackChannel(req);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      ok: boolean;
+      ts: string;
+      channel: string;
+    };
+    expect(json.ok).toBe(true);
+    expect(json.ts).toBe("1234567890.123456");
+    expect(json.channel).toBe("C123");
+  });
+});

--- a/assistant/src/config/bundled-skills/frontend-design/icon.svg
+++ b/assistant/src/config/bundled-skills/frontend-design/icon.svg
@@ -1,0 +1,16 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="16" height="16" fill="#f5f5f5"/>
+  <rect x="2" y="2" width="12" height="11" fill="#ffffff" stroke="#333333" stroke-width="1"/>
+  <rect x="2" y="2" width="12" height="2" fill="#ff6b6b"/>
+  <rect x="3" y="3" width="10" height="1" fill="#ffffff"/>
+  <rect x="3" y="5" width="2" height="1" fill="#4ecdc4"/>
+  <rect x="6" y="5" width="2" height="1" fill="#4ecdc4"/>
+  <rect x="9" y="5" width="2" height="1" fill="#4ecdc4"/>
+  <rect x="3" y="7" width="4" height="1" fill="#95e1d3"/>
+  <rect x="3" y="8" width="4" height="1" fill="#95e1d3"/>
+  <rect x="3" y="9" width="3" height="1" fill="#95e1d3"/>
+  <rect x="8" y="7" width="5" height="1" fill="#ffd93d"/>
+  <rect x="8" y="8" width="5" height="1" fill="#ffd93d"/>
+  <rect x="8" y="9" width="3" height="1" fill="#ffd93d"/>
+  <rect x="3" y="11" width="10" height="1" fill="#e8e8e8"/>
+</svg>

--- a/assistant/src/messaging/providers/slack/client.ts
+++ b/assistant/src/messaging/providers/slack/client.ts
@@ -231,14 +231,24 @@ export async function userInfo(
   return request<SlackUserInfoResponse>(token, "users.info", { user: userId });
 }
 
+export interface PostMessageOptions {
+  threadTs?: string;
+  blocks?: unknown[];
+}
+
 export async function postMessage(
   token: string,
   channel: string,
   text: string,
-  threadTs?: string,
+  optionsOrThreadTs?: PostMessageOptions | string,
 ): Promise<SlackPostMessageResponse> {
+  const opts: PostMessageOptions =
+    typeof optionsOrThreadTs === "string"
+      ? { threadTs: optionsOrThreadTs }
+      : (optionsOrThreadTs ?? {});
   const body: Record<string, unknown> = { channel, text };
-  if (threadTs) body.thread_ts = threadTs;
+  if (opts.threadTs) body.thread_ts = opts.threadTs;
+  if (opts.blocks) body.blocks = opts.blocks;
   return request<SlackPostMessageResponse>(
     token,
     "chat.postMessage",

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -244,6 +244,10 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "integrations/twilio/sms/test", scopes: ["settings.write"] },
   { endpoint: "integrations/twilio/sms/doctor", scopes: ["settings.write"] },
 
+  // Slack share
+  { endpoint: "slack/channels", scopes: ["settings.read"] },
+  { endpoint: "slack/share", scopes: ["settings.write"] },
+
   // Channel readiness
   { endpoint: "channels/readiness", scopes: ["settings.read"] },
   { endpoint: "channels/readiness/refresh", scopes: ["settings.write"] },

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -126,6 +126,7 @@ import {
   pairingRouteDefinitions,
 } from "./routes/pairing-routes.js";
 import { secretRouteDefinitions } from "./routes/secret-routes.js";
+import { slackShareRouteDefinitions } from "./routes/slack-share-routes.js";
 import { surfaceActionRouteDefinitions } from "./routes/surface-action-routes.js";
 import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.js";
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";
@@ -851,6 +852,7 @@ export class RuntimeHttpServer {
       ...contactCatchAllRouteDefinitions(),
 
       ...integrationRouteDefinitions(),
+      ...slackShareRouteDefinitions(),
       ...twilioRouteDefinitions(),
       ...channelReadinessRouteDefinitions(),
       ...attachmentRouteDefinitions(),

--- a/assistant/src/runtime/routes/slack-share-routes.ts
+++ b/assistant/src/runtime/routes/slack-share-routes.ts
@@ -1,0 +1,215 @@
+/**
+ * Route handlers for Slack channel listing and direct sharing.
+ *
+ * These endpoints let the UI post app links directly to Slack channels
+ * without going through the legacy IPC-based Slack share flow.
+ */
+
+import { getApp } from "../../memory/app-store.js";
+import {
+  listConversations,
+  postMessage,
+  userInfo,
+} from "../../messaging/providers/slack/client.js";
+import type { SlackConversation } from "../../messaging/providers/slack/types.js";
+import { getSecureKey } from "../../security/secure-keys.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+const log = getLogger("slack-share-routes");
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the Slack bot token from secure storage.
+ * Prefers the OAuth integration token, falls back to the legacy channel token.
+ */
+function resolveSlackToken(): string | undefined {
+  return (
+    getSecureKey("credential:integration:slack:access_token") ??
+    getSecureKey("credential:slack_channel:bot_token")
+  );
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/slack/channels
+// ---------------------------------------------------------------------------
+
+interface NormalizedChannel {
+  id: string;
+  name: string;
+  type: "channel" | "group" | "dm";
+  isPrivate: boolean;
+}
+
+function classifyConversation(
+  conv: SlackConversation,
+): "channel" | "group" | "dm" {
+  if (conv.is_im) return "dm";
+  if (conv.is_mpim) return "group";
+  if (conv.is_group) return "group";
+  return "channel";
+}
+
+const TYPE_SORT_ORDER: Record<string, number> = {
+  channel: 0,
+  group: 1,
+  dm: 2,
+};
+
+export async function handleListSlackChannels(): Promise<Response> {
+  const token = resolveSlackToken();
+  if (!token) {
+    return httpError("SERVICE_UNAVAILABLE", "No Slack token configured", 503);
+  }
+
+  const resp = await listConversations(
+    token,
+    "public_channel,private_channel,mpim,im",
+    true,
+    200,
+  );
+
+  // Resolve DM display names in parallel, tolerating individual failures.
+  const dmUserIds = resp.channels
+    .filter((c) => c.is_im && c.user)
+    .map((c) => c.user!);
+  const uniqueUserIds = [...new Set(dmUserIds)];
+  const nameResults = await Promise.allSettled(
+    uniqueUserIds.map((uid) =>
+      userInfo(token, uid).then((r) => ({
+        uid,
+        name:
+          r.user.profile?.display_name ||
+          r.user.profile?.real_name ||
+          r.user.real_name ||
+          r.user.name,
+      })),
+    ),
+  );
+  const nameMap = new Map<string, string>();
+  for (const r of nameResults) {
+    if (r.status === "fulfilled") {
+      nameMap.set(r.value.uid, r.value.name);
+    }
+  }
+
+  const channels: NormalizedChannel[] = resp.channels.map((c) => {
+    const type = classifyConversation(c);
+    let name = c.name ?? c.id;
+    if (type === "dm" && c.user) {
+      name = nameMap.get(c.user) ?? c.user;
+    }
+    return {
+      id: c.id,
+      name,
+      type,
+      isPrivate: c.is_private ?? c.is_group ?? false,
+    };
+  });
+
+  // Sort: channels first, then groups, then DMs — alphabetical within each.
+  channels.sort((a, b) => {
+    const typeOrder =
+      (TYPE_SORT_ORDER[a.type] ?? 9) - (TYPE_SORT_ORDER[b.type] ?? 9);
+    if (typeOrder !== 0) return typeOrder;
+    return a.name.localeCompare(b.name);
+  });
+
+  return Response.json({ channels });
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/slack/share
+// ---------------------------------------------------------------------------
+
+export async function handleShareToSlackChannel(
+  req: Request,
+): Promise<Response> {
+  const token = resolveSlackToken();
+  if (!token) {
+    return httpError("SERVICE_UNAVAILABLE", "No Slack token configured", 503);
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return httpError("BAD_REQUEST", "Malformed JSON body", 400);
+  }
+
+  const appId = body.appId as string | undefined;
+  const channelId = body.channelId as string | undefined;
+  const message = body.message as string | undefined;
+
+  if (!appId || !channelId) {
+    return httpError(
+      "BAD_REQUEST",
+      "Missing required fields: appId, channelId",
+      400,
+    );
+  }
+
+  const app = getApp(appId);
+  if (!app) {
+    return httpError("NOT_FOUND", "App not found", 404);
+  }
+
+  // Build a Block Kit message with a deterministic fallback text.
+  const fallbackText = message
+    ? `${message} — ${app.name}`
+    : `Shared app: ${app.name}`;
+
+  const blocks: unknown[] = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: message ? `${message}\n\n*${app.name}*` : `*${app.name}*`,
+      },
+    },
+  ];
+
+  if (app.description) {
+    blocks.push({
+      type: "context",
+      elements: [{ type: "mrkdwn", text: app.description }],
+    });
+  }
+
+  try {
+    const result = await postMessage(token, channelId, fallbackText, {
+      blocks,
+    });
+    return Response.json({
+      ok: true,
+      ts: result.ts,
+      channel: result.channel,
+    });
+  } catch (err) {
+    log.error({ err, appId, channelId }, "Failed to share app to Slack");
+    return httpError("INTERNAL_ERROR", "Failed to post message to Slack", 500);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function slackShareRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "slack/channels",
+      method: "GET",
+      handler: () => handleListSlackChannels(),
+    },
+    {
+      endpoint: "slack/share",
+      method: "POST",
+      handler: async ({ req }) => handleShareToSlackChannel(req),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add GET /v1/slack/channels and POST /v1/slack/share runtime HTTP endpoints
- Refactor postMessage to accept options object with blocks support
- Register auth policy and add focused tests

Part of plan: slack-channel-picker.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
