### PR TITLE
feat: add explicit gateway proxy routes for Slack share endpoints

### DIFF
--- a/gateway/src/__tests__/slack-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/slack-control-plane-proxy.test.ts
@@ -1,0 +1,184 @@
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+import { initSigningKey } from "../auth/token-service.js";
+
+const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
+initSigningKey(TEST_SIGNING_KEY);
+
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(
+  async () => new Response(),
+);
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+const { createSlackControlPlaneProxyHandler } =
+  await import("../http/routes/slack-control-plane-proxy.js");
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  const merged: GatewayConfig = {
+    telegramBotToken: undefined,
+    telegramWebhookSecret: undefined,
+    telegramApiBaseUrl: "https://api.telegram.org",
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    defaultAssistantId: undefined,
+    unmappedPolicy: "reject",
+    port: 7830,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 3,
+    telegramTimeoutMs: 15000,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20971520,
+    maxAttachmentConcurrency: 3,
+    twilioAuthToken: undefined,
+    twilioAccountSid: undefined,
+    twilioPhoneNumber: undefined,
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    whatsappPhoneNumberId: undefined,
+    whatsappAccessToken: undefined,
+    whatsappAppSecret: undefined,
+    whatsappWebhookVerifyToken: undefined,
+    whatsappDeliverAuthBypass: false,
+    whatsappTimeoutMs: 15000,
+    whatsappMaxRetries: 3,
+    whatsappInitialBackoffMs: 1000,
+    slackChannelBotToken: undefined,
+    slackChannelAppToken: undefined,
+    slackDeliverAuthBypass: false,
+    trustProxy: false,
+    ...overrides,
+  };
+  return merged;
+}
+
+afterEach(() => {
+  fetchMock = mock(async () => new Response());
+});
+
+describe("slack control-plane proxy", () => {
+  test("forwards slack share endpoints to the runtime", async () => {
+    const captured: string[] = [];
+    fetchMock = mock(async (input: string | URL | Request) => {
+      captured.push(String(input));
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const handler = createSlackControlPlaneProxyHandler(makeConfig());
+
+    await handler.handleListSlackChannels(
+      new Request("http://localhost:7830/v1/slack/channels"),
+    );
+    await handler.handleShareToSlack(
+      new Request("http://localhost:7830/v1/slack/share", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ channel: "C123", text: "hello" }),
+      }),
+    );
+
+    expect(captured).toEqual([
+      "http://localhost:7821/v1/slack/channels",
+      "http://localhost:7821/v1/slack/share",
+    ]);
+  });
+
+  test("forwards query string for channel listing", async () => {
+    const captured: string[] = [];
+    fetchMock = mock(async (input: string | URL | Request) => {
+      captured.push(String(input));
+      return new Response(JSON.stringify({ channels: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const handler = createSlackControlPlaneProxyHandler(makeConfig());
+
+    await handler.handleListSlackChannels(
+      new Request("http://localhost:7830/v1/slack/channels?types=public"),
+    );
+
+    expect(captured).toEqual([
+      "http://localhost:7821/v1/slack/channels?types=public",
+    ]);
+  });
+
+  test("replaces caller auth with service token", async () => {
+    let capturedHeaders: Headers | undefined;
+    fetchMock = mock(
+      async (_input: string | URL | Request, init?: RequestInit) => {
+        capturedHeaders = init?.headers as unknown as Headers;
+        return new Response("ok", { status: 200 });
+      },
+    );
+
+    const handler = createSlackControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleShareToSlack(
+      new Request("http://localhost:7830/v1/slack/share", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer caller-token",
+          "content-type": "application/json",
+          host: "localhost:7830",
+        },
+        body: JSON.stringify({ channel: "C123", text: "hello" }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(capturedHeaders?.get("authorization")).toMatch(/^Bearer ey/);
+    expect(capturedHeaders?.has("host")).toBe(false);
+  });
+
+  test("passes through upstream client errors", async () => {
+    fetchMock = mock(async () => {
+      return new Response(JSON.stringify({ error: "slack_not_configured" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const handler = createSlackControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleShareToSlack(
+      new Request("http://localhost:7830/v1/slack/share", {
+        method: "POST",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "slack_not_configured" });
+  });
+
+  test("returns 502 when runtime is unreachable", async () => {
+    fetchMock = mock(async () => {
+      throw new Error("Connection refused");
+    });
+
+    const handler = createSlackControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleListSlackChannels(
+      new Request("http://localhost:7830/v1/slack/channels"),
+    );
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "Bad Gateway" });
+  });
+});

--- a/gateway/src/http/routes/slack-control-plane-proxy.ts
+++ b/gateway/src/http/routes/slack-control-plane-proxy.ts
@@ -1,0 +1,108 @@
+/**
+ * Gateway proxy endpoints for Slack share control-plane routes.
+ *
+ * These routes remain available even when the broad runtime proxy is
+ * disabled, so skills and clients can use gateway URLs exclusively.
+ */
+
+import { mintServiceToken } from "../../auth/token-exchange.js";
+import type { GatewayConfig } from "../../config.js";
+import { fetchImpl } from "../../fetch.js";
+import { getLogger } from "../../logger.js";
+import { stripHopByHop } from "../../util/strip-hop-by-hop.js";
+
+const log = getLogger("slack-control-plane-proxy");
+
+export function createSlackControlPlaneProxyHandler(config: GatewayConfig) {
+  async function proxyToRuntime(
+    req: Request,
+    upstreamPath: string,
+    upstreamSearch: string,
+  ): Promise<Response> {
+    const start = performance.now();
+    const upstream = `${config.assistantRuntimeBaseUrl}${upstreamPath}${upstreamSearch}`;
+
+    const reqHeaders = stripHopByHop(new Headers(req.headers));
+    reqHeaders.delete("host");
+    reqHeaders.delete("authorization");
+
+    reqHeaders.set("authorization", `Bearer ${mintServiceToken()}`);
+
+    const hasBody = req.method !== "GET" && req.method !== "HEAD";
+    const bodyBuffer = hasBody ? await req.arrayBuffer() : null;
+    if (bodyBuffer !== null) {
+      reqHeaders.set("content-length", String(bodyBuffer.byteLength));
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(
+        new DOMException(
+          "The operation was aborted due to timeout",
+          "TimeoutError",
+        ),
+      );
+    }, config.runtimeTimeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetchImpl(upstream, {
+        method: req.method,
+        headers: reqHeaders,
+        body: bodyBuffer,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const duration = Math.round(performance.now() - start);
+      if (err instanceof DOMException && err.name === "TimeoutError") {
+        log.error(
+          { path: upstreamPath, duration },
+          "Slack control-plane proxy upstream timed out",
+        );
+        return Response.json({ error: "Gateway Timeout" }, { status: 504 });
+      }
+      log.error(
+        { err, path: upstreamPath, duration },
+        "Slack control-plane proxy upstream connection failed",
+      );
+      return Response.json({ error: "Bad Gateway" }, { status: 502 });
+    }
+
+    const resHeaders = stripHopByHop(new Headers(response.headers));
+    const duration = Math.round(performance.now() - start);
+
+    if (response.status >= 400) {
+      const body = await response.text();
+      log.warn(
+        { path: upstreamPath, status: response.status, duration },
+        "Slack control-plane proxy upstream error",
+      );
+      return new Response(body, {
+        status: response.status,
+        headers: resHeaders,
+      });
+    }
+
+    log.info(
+      { path: upstreamPath, status: response.status, duration },
+      "Slack control-plane proxy completed",
+    );
+    return new Response(response.body, {
+      status: response.status,
+      headers: resHeaders,
+    });
+  }
+
+  return {
+    async handleListSlackChannels(req: Request): Promise<Response> {
+      const url = new URL(req.url);
+      return proxyToRuntime(req, "/v1/slack/channels", url.search);
+    },
+
+    async handleShareToSlack(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/slack/share", "");
+    },
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -45,6 +45,7 @@ import { createGuardianControlPlaneProxyHandler } from "./http/routes/guardian-c
 import { createTelegramControlPlaneProxyHandler } from "./http/routes/telegram-control-plane-proxy.js";
 import { createContactsControlPlaneProxyHandler } from "./http/routes/contacts-control-plane-proxy.js";
 import { createTwilioControlPlaneProxyHandler } from "./http/routes/twilio-control-plane-proxy.js";
+import { createSlackControlPlaneProxyHandler } from "./http/routes/slack-control-plane-proxy.js";
 import { createChannelReadinessProxyHandler } from "./http/routes/channel-readiness-proxy.js";
 import { createRuntimeHealthProxyHandler } from "./http/routes/runtime-health-proxy.js";
 import { createBrainGraphProxyHandler } from "./http/routes/brain-graph-proxy.js";
@@ -151,6 +152,7 @@ async function main() {
   const contactsControlPlaneProxy =
     createContactsControlPlaneProxyHandler(config);
   const twilioControlPlaneProxy = createTwilioControlPlaneProxyHandler(config);
+  const slackControlPlaneProxy = createSlackControlPlaneProxyHandler(config);
   const channelReadinessProxy = createChannelReadinessProxyHandler(config);
   const runtimeHealthProxy = createRuntimeHealthProxyHandler(config);
   const brainGraphProxy = createBrainGraphProxyHandler(config);
@@ -589,6 +591,20 @@ async function main() {
       method: "POST",
       auth: "edge",
       handler: (req) => twilioControlPlaneProxy.handleSmsDoctor(req),
+    },
+
+    // ── Slack control plane ──
+    {
+      path: "/v1/slack/channels",
+      method: "GET",
+      auth: "edge",
+      handler: (req) => slackControlPlaneProxy.handleListSlackChannels(req),
+    },
+    {
+      path: "/v1/slack/share",
+      method: "POST",
+      auth: "edge",
+      handler: (req) => slackControlPlaneProxy.handleShareToSlack(req),
     },
 
     // ── Channel readiness ──


### PR DESCRIPTION
## Summary
- Add gateway control-plane proxy for GET /v1/slack/channels and POST /v1/slack/share
- Follow existing telegram/twilio control-plane proxy pattern with service token auth
- Add tests validating success/error forwarding

Part of plan: slack-channel-picker.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
