### PR TITLE
fix: add timeout protection to browser download tracking

### DIFF
--- a/assistant/src/__tests__/browser-download-timeout.test.ts
+++ b/assistant/src/__tests__/browser-download-timeout.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+
+import { withTimeout } from "../tools/browser/browser-manager.js";
+
+describe("withTimeout", () => {
+  it("resolves normally for a fast promise", async () => {
+    const result = await withTimeout(Promise.resolve("ok"), 1_000, "fast");
+    expect(result).toBe("ok");
+  });
+
+  it("rejects with timeout error for a hanging promise", async () => {
+    const hanging = new Promise<string>(() => {
+      // never resolves
+    });
+
+    await expect(withTimeout(hanging, 50, "slow op")).rejects.toThrow(
+      "slow op timed out after 50ms",
+    );
+  });
+
+  it("propagates the original rejection if it happens before the timeout", async () => {
+    const failing = Promise.reject(new Error("original error"));
+
+    await expect(withTimeout(failing, 1_000, "failing")).rejects.toThrow(
+      "original error",
+    );
+  });
+});

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -25,6 +25,30 @@ function getDownloadsDir(): string {
   return dir;
 }
 
+/** Wraps a promise with a timeout to prevent indefinite hangs. */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms,
+    );
+    promise.then(
+      (val) => {
+        clearTimeout(timer);
+        resolve(val);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
 export type DownloadInfo = { path: string; filename: string };
 
 type BrowserContext = {
@@ -679,7 +703,7 @@ class BrowserManager {
       try {
         const filename = dl.suggestedFilename();
         const destPath = join(getDownloadsDir(), `${Date.now()}-${filename}`);
-        await dl.saveAs(destPath);
+        await withTimeout(dl.saveAs(destPath), 120_000, "Download save");
         const info: DownloadInfo = { path: destPath, filename };
 
         // Resolve a pending waiter if one exists, otherwise store for later retrieval
@@ -696,7 +720,11 @@ class BrowserManager {
 
         log.info({ sessionId, filename, path: destPath }, "Download completed");
       } catch (err) {
-        const failure = await dl.failure();
+        const failure = await withTimeout(
+          dl.failure(),
+          5_000,
+          "Download failure check",
+        ).catch(() => null);
         log.warn({ err, failure, sessionId }, "Download failed");
 
         // Reject any pending waiters


### PR DESCRIPTION
Wraps dl.saveAs() with 120s timeout and dl.failure() with 5s timeout in setupDownloadTracking to prevent indefinite hangs during browser file downloads. Part of #13615.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
