### PR TITLE
M1: Update VoiceModeManager tests for PermissionDecision refactor

### DIFF
--- a/clients/macos/vellum-assistantTests/VoiceModeManagerExtendedTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceModeManagerExtendedTests.swift
@@ -133,11 +133,11 @@ final class VoiceModeManagerExtendedTests: XCTestCase {
     }
 
     func testClassifyYesWithNoise() {
-        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("umm yes I think so"), .approved)
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("umm yes I think so"), .allow)
     }
 
     func testClassifyOkayVariant() {
-        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("okay fine"), .approved)
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("okay fine"), .allow)
     }
 
     func testClassifyNopeDont() {
@@ -145,11 +145,11 @@ final class VoiceModeManagerExtendedTests: XCTestCase {
     }
 
     func testClassifyAllowIt() {
-        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("allow it"), .approved)
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("allow it"), .allow)
     }
 
     func testClassifyApproveIt() {
-        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("I approve"), .approved)
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("I approve"), .allow)
     }
 
     func testClassifyStopIt() {

--- a/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/VoiceModeManagerTests.swift
@@ -233,7 +233,7 @@ final class VoiceModeManagerTests: XCTestCase {
     // MARK: - Permission Keyword Classification
 
     func testClassifyYes() {
-        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("yes"), .approved)
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("yes"), .allow)
     }
 
     func testClassifyNo() {
@@ -241,11 +241,11 @@ final class VoiceModeManagerTests: XCTestCase {
     }
 
     func testClassifyYeahSure() {
-        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("yeah sure"), .approved)
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("yeah sure"), .allow)
     }
 
     func testClassifyGoAhead() {
-        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("go ahead"), .approved)
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("go ahead"), .allow)
     }
 
     func testClassifyNoDontDoIt() {
@@ -262,7 +262,7 @@ final class VoiceModeManagerTests: XCTestCase {
     }
 
     func testClassifyProceed() {
-        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("please proceed"), .approved)
+        XCTAssertEqual(VoiceModeManager.classifyPermissionResponse("please proceed"), .allow)
     }
 
     func testClassifyStopCancel() {


### PR DESCRIPTION
Replace all .approved references with .allow in VoiceModeManagerTests.swift and VoiceModeManagerExtendedTests.swift to match the refactored PermissionDecision enum cases. Closes #13613.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
