### PR TITLE
feat: wire Slack share panel to channel picker and HTTP post flow

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowGroupedState.swift
@@ -15,6 +15,7 @@ final class SharingState {
     var shareFileURL: URL?
     var shareAppName: String = ""
     var shareAppIcon: NSImage?
+    var shareAppId: String?
     var isPublishing = false
     var publishedUrl: String?
     var publishError: String?

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sharing.swift
@@ -117,6 +117,7 @@ extension MainWindowView {
     func bundleAndShare(appId: String) {
         guard !sharing.isBundling else { return }
         sharing.isBundling = true
+        sharing.shareAppId = appId
 
         Task { @MainActor in
             let previousHandler = daemonClient.onBundleAppResponse

--- a/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/PanelCoordinator.swift
@@ -62,6 +62,7 @@ extension MainWindowView {
                     set: { windowState.isDynamicExpanded = $0 }
                 ),
                 daemonClient: daemonClient,
+                gatewayBaseURL: settingsStore.localGatewayTarget,
                 onOpenApp: { surfaceMsg in
                     windowState.activeDynamicSurface = surfaceMsg
                     windowState.activeDynamicParsedSurface = Surface.from(surfaceMsg)
@@ -78,6 +79,7 @@ extension MainWindowView {
             AppsGridView(
                 appListManager: appListManager,
                 daemonClient: daemonClient,
+                gatewayBaseURL: settingsStore.localGatewayTarget,
                 onOpenApp: { appId in
                     try? daemonClient.sendAppOpen(appId: appId)
                     windowState.selection = .app(appId)
@@ -343,6 +345,7 @@ extension MainWindowView {
                 AppsGridView(
                     appListManager: appListManager,
                     daemonClient: daemonClient,
+                    gatewayBaseURL: settingsStore.localGatewayTarget,
                     onOpenApp: { appId in
                         try? daemonClient.sendAppOpen(appId: appId)
                         windowState.selection = .app(appId)
@@ -492,6 +495,7 @@ extension MainWindowView {
             AppsGridView(
                 appListManager: appListManager,
                 daemonClient: daemonClient,
+                gatewayBaseURL: settingsStore.localGatewayTarget,
                 onOpenApp: { appId in
                     try? daemonClient.sendAppOpen(appId: appId)
                     windowState.selection = .app(appId)
@@ -573,6 +577,7 @@ extension MainWindowView {
                 trafficLightPadding: trafficLightPadding,
                 isSidebarOpen: sidebarExpanded,
                 sharing: sharing,
+                gatewayBaseURL: settingsStore.localGatewayTarget,
                 onPublishPage: publishPage,
                 onBundleAndShare: bundleAndShare,
                 isChatDockOpen: windowState.isChatDockOpen,
@@ -819,6 +824,7 @@ struct DynamicWorkspaceWrapper: View {
     let trafficLightPadding: CGFloat
     let isSidebarOpen: Bool
     var sharing: SharingState
+    let gatewayBaseURL: String
     let onPublishPage: (String, String?, String?) -> Void
     let onBundleAndShare: (String) -> Void
     let isChatDockOpen: Bool
@@ -899,7 +905,9 @@ struct DynamicWorkspaceWrapper: View {
                                             set: { sharing.showSharePicker = $0 }
                                         ),
                                         appName: sharing.shareAppName,
-                                        appIcon: sharing.shareAppIcon
+                                        appIcon: sharing.shareAppIcon,
+                                        appId: sharing.shareAppId,
+                                        gatewayBaseURL: gatewayBaseURL
                                     )
                                     .allowsHitTesting(false)
                                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AppsGridView.swift
@@ -5,6 +5,7 @@ import VellumAssistantShared
 struct AppsGridView: View {
     @ObservedObject var appListManager: AppListManager
     let daemonClient: DaemonClient
+    let gatewayBaseURL: String
     let onOpenApp: (String) -> Void
 
     @State private var searchText = ""
@@ -233,7 +234,9 @@ struct AppsGridView: View {
                                 }
                             ),
                             appName: shareAppName,
-                            appIcon: shareAppIcon
+                            appIcon: shareAppIcon,
+                            appId: sharingAppId == app.id ? app.id : nil,
+                            gatewayBaseURL: gatewayBaseURL
                         )
                         .allowsHitTesting(false)
                     }
@@ -421,6 +424,7 @@ struct AppsGridView_Previews: PreviewProvider {
             AppsGridView(
                 appListManager: appListManager,
                 daemonClient: DaemonClient(),
+                gatewayBaseURL: "http://127.0.0.1:3000",
                 onOpenApp: { _ in }
             )
             .onAppear {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/GeneratedPanel.swift
@@ -26,6 +26,7 @@ struct GeneratedPanel: View {
     var onClose: () -> Void
     @Binding var isExpanded: Bool
     let daemonClient: DaemonClient
+    let gatewayBaseURL: String
     /// When set, app opens route to the workspace instead of a floating NSPanel.
     var onOpenApp: ((UiSurfaceShowMessage) -> Void)?
     /// Called to record an app open in the sidebar's recent apps list.
@@ -57,10 +58,11 @@ struct GeneratedPanel: View {
     @State private var slackShareResult: (appId: String, success: Bool)?
     @State private var slackClearTask: Task<Void, Never>?
 
-    init(onClose: @escaping () -> Void, isExpanded: Binding<Bool> = .constant(false), daemonClient: DaemonClient, onOpenApp: ((UiSurfaceShowMessage) -> Void)? = nil, onRecordAppOpen: ((_ id: String, _ name: String, _ icon: String?, _ appType: String?) -> Void)? = nil) {
+    init(onClose: @escaping () -> Void, isExpanded: Binding<Bool> = .constant(false), daemonClient: DaemonClient, gatewayBaseURL: String = "", onOpenApp: ((UiSurfaceShowMessage) -> Void)? = nil, onRecordAppOpen: ((_ id: String, _ name: String, _ icon: String?, _ appType: String?) -> Void)? = nil) {
         self.onClose = onClose
         self._isExpanded = isExpanded
         self.daemonClient = daemonClient
+        self.gatewayBaseURL = gatewayBaseURL
         self.onOpenApp = onOpenApp
         self.onRecordAppOpen = onRecordAppOpen
     }
@@ -434,7 +436,9 @@ struct GeneratedPanel: View {
                         }
                     ),
                     appName: shareAppName,
-                    appIcon: shareAppIcon
+                    appIcon: shareAppIcon,
+                    appId: sharingAppId == item.id ? localId : nil,
+                    gatewayBaseURL: gatewayBaseURL
                 )
                 .frame(width: 0, height: 0)
                 .opacity(0)
@@ -455,7 +459,8 @@ struct GeneratedPanel: View {
                         }
                     ),
                     appName: shareAppName,
-                    appIcon: shareAppIcon
+                    appIcon: shareAppIcon,
+                    gatewayBaseURL: gatewayBaseURL
                 )
                 .frame(width: 0, height: 0)
                 .opacity(0)
@@ -836,6 +841,6 @@ struct GeneratedPanel: View {
 
 struct GeneratedPanel_Previews: PreviewProvider {
     static var previews: some View {
-        GeneratedPanel(onClose: {}, isExpanded: .constant(false), daemonClient: DaemonClient())
+        GeneratedPanel(onClose: {}, isExpanded: .constant(false), daemonClient: DaemonClient(), gatewayBaseURL: "http://127.0.0.1:3000")
     }
 }

--- a/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
@@ -8,13 +8,48 @@ struct AppSharePanelView: View {
     let fileURL: URL
     let appName: String
     let appIcon: NSImage?
+    let appId: String?
+    let gatewayBaseURL: String
     let onDismiss: () -> Void
 
     @State private var services: [NSSharingService] = []
     @State private var hoveredServiceIndex: Int?
+    @State private var showChannelPicker = false
+    @State private var isSendingToSlack = false
+    @State private var slackError: String?
 
     @available(macOS, deprecated: 13.0)
     var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if showChannelPicker {
+                channelPickerView
+            } else {
+                servicesListView
+            }
+        }
+        .frame(width: 240)
+        .onDisappear {
+            if hoveredServiceIndex != nil {
+                NSCursor.pop()
+                hoveredServiceIndex = nil
+            }
+        }
+        .background(VColor.surfaceSubtle)
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.15), radius: 6, y: 2)
+        .onAppear {
+            services = Self.availableSharingServices(for: fileURL)
+        }
+    }
+
+    // MARK: - Services List
+
+    @available(macOS, deprecated: 13.0)
+    private var servicesListView: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Header: app icon, name, file size
             header
@@ -25,13 +60,17 @@ struct AppSharePanelView: View {
             // Services list
             ScrollView {
                 VStack(spacing: 0) {
-                    // Slack row
-                    serviceRow(
-                        icon: NSWorkspace.shared.icon(forFile: "/Applications/Slack.app"),
-                        title: "Slack",
-                        index: -2
-                    ) {
-                        handleSlackShare()
+                    // Slack row — only enabled when appId is available
+                    if appId != nil {
+                        serviceRow(
+                            icon: NSWorkspace.shared.icon(forFile: "/Applications/Slack.app"),
+                            title: "Slack",
+                            index: -2
+                        ) {
+                            handleSlackShare()
+                        }
+                    } else {
+                        disabledSlackRow
                     }
 
                     // System sharing services
@@ -65,22 +104,62 @@ struct AppSharePanelView: View {
             }
             .frame(maxHeight: 300)
         }
-        .frame(width: 240)
-        .onDisappear {
-            if hoveredServiceIndex != nil {
-                NSCursor.pop()
-                hoveredServiceIndex = nil
+    }
+
+    // MARK: - Channel Picker
+
+    private var channelPickerView: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if isSendingToSlack {
+                VStack(spacing: VSpacing.sm) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Sending...")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                .frame(maxWidth: .infinity)
+                .frame(width: 240)
+                .padding(.vertical, VSpacing.xxl)
+            } else if let error = slackError {
+                VStack(spacing: VSpacing.sm) {
+                    Text(error)
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.error)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, VSpacing.md)
+
+                    HStack(spacing: VSpacing.md) {
+                        Button("Back") {
+                            slackError = nil
+                            showChannelPicker = false
+                        }
+                        .buttonStyle(.plain)
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textSecondary)
+
+                        Button("Retry") {
+                            slackError = nil
+                        }
+                        .buttonStyle(.plain)
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.accent)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .frame(width: 240)
+                .padding(.vertical, VSpacing.xxl)
+            } else {
+                SlackChannelPickerView(
+                    gatewayBaseURL: gatewayBaseURL,
+                    onSelect: { channel in
+                        shareToChannel(channel)
+                    },
+                    onCancel: {
+                        showChannelPicker = false
+                    }
+                )
             }
-        }
-        .background(VColor.surfaceSubtle)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(VColor.surfaceBorder, lineWidth: 1)
-        )
-        .shadow(color: .black.opacity(0.15), radius: 6, y: 2)
-        .onAppear {
-            services = Self.availableSharingServices(for: fileURL)
         }
     }
 
@@ -158,6 +237,32 @@ struct AppSharePanelView: View {
         }
     }
 
+    // MARK: - Disabled Slack Row
+
+    private var disabledSlackRow: some View {
+        HStack(spacing: VSpacing.sm) {
+            Image(nsImage: NSWorkspace.shared.icon(forFile: "/Applications/Slack.app"))
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 18, height: 18)
+                .opacity(0.5)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Slack")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textMuted)
+
+                Text("Unavailable for this app")
+                    .font(VFont.small)
+                    .foregroundColor(VColor.textMuted)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, VSpacing.md)
+        .padding(.vertical, VSpacing.sm)
+    }
+
     // MARK: - Helpers
 
     /// Queries available sharing services. The API was deprecated in macOS 13 in favor of
@@ -184,19 +289,55 @@ struct AppSharePanelView: View {
     }
 
     private func handleSlackShare() {
-        let downloadsURL = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first!
-        let destinationURL = downloadsURL.appendingPathComponent(fileURL.lastPathComponent)
+        showChannelPicker = true
+    }
 
-        if fileURL.standardizedFileURL != destinationURL.standardizedFileURL {
-            try? FileManager.default.removeItem(at: destinationURL)
-            try? FileManager.default.copyItem(at: fileURL, to: destinationURL)
+    private func shareToChannel(_ channel: SlackChannel) {
+        guard !isSendingToSlack, let appId else { return }
+        isSendingToSlack = true
+        slackError = nil
+
+        Task {
+            do {
+                guard let url = URL(string: "\(gatewayBaseURL)/v1/slack/share") else {
+                    isSendingToSlack = false
+                    slackError = "Invalid gateway URL"
+                    return
+                }
+
+                var request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+                if let token = ActorTokenManager.getToken(), !token.isEmpty {
+                    request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                }
+
+                let body: [String: String] = ["appId": appId, "channelId": channel.id]
+                request.httpBody = try JSONEncoder().encode(body)
+
+                let (_, response) = try await URLSession.shared.data(for: request)
+
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    isSendingToSlack = false
+                    slackError = "Unexpected response"
+                    return
+                }
+
+                guard (200...299).contains(httpResponse.statusCode) else {
+                    isSendingToSlack = false
+                    slackError = "Failed to share (\(httpResponse.statusCode))"
+                    return
+                }
+
+                isSendingToSlack = false
+                onDismiss()
+            } catch is CancellationError {
+                isSendingToSlack = false
+            } catch {
+                isSendingToSlack = false
+                slackError = "Failed to share to Slack"
+            }
         }
-
-        if let slackURL = URL(string: "slack://") {
-            NSWorkspace.shared.open(slackURL)
-        }
-
-        NSWorkspace.shared.activateFileViewerSelecting([destinationURL])
-        onDismiss()
     }
 }

--- a/clients/macos/vellum-assistant/Features/Sharing/ShareSheetHelper.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/ShareSheetHelper.swift
@@ -9,6 +9,8 @@ struct AppSharePanel: NSViewRepresentable {
     @Binding var isPresented: Bool
     let appName: String
     let appIcon: NSImage?
+    var appId: String?
+    var gatewayBaseURL: String = ""
 
     func makeNSView(context: Context) -> NSView {
         let view = NSView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
@@ -19,6 +21,8 @@ struct AppSharePanel: NSViewRepresentable {
         context.coordinator.items = items
         context.coordinator.appName = appName
         context.coordinator.appIcon = appIcon
+        context.coordinator.appId = appId
+        context.coordinator.gatewayBaseURL = gatewayBaseURL
         if isPresented && !context.coordinator.isPopoverShown {
             context.coordinator.presentWhenReady(nsView: nsView) {
                 self.isPresented = false
@@ -29,21 +33,25 @@ struct AppSharePanel: NSViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(items: items, appName: appName, appIcon: appIcon)
+        Coordinator(items: items, appName: appName, appIcon: appIcon, appId: appId, gatewayBaseURL: gatewayBaseURL)
     }
 
     class Coordinator: NSObject, NSPopoverDelegate {
         var items: [Any]
         var appName: String
         var appIcon: NSImage?
+        var appId: String?
+        var gatewayBaseURL: String
         var isPopoverShown = false
         var onDismiss: (() -> Void)?
         private var popover: NSPopover?
 
-        init(items: [Any], appName: String, appIcon: NSImage?) {
+        init(items: [Any], appName: String, appIcon: NSImage?, appId: String?, gatewayBaseURL: String) {
             self.items = items
             self.appName = appName
             self.appIcon = appIcon
+            self.appId = appId
+            self.gatewayBaseURL = gatewayBaseURL
         }
 
         /// Waits for the NSView to be added to a window before showing the popover.
@@ -77,6 +85,8 @@ struct AppSharePanel: NSViewRepresentable {
                 fileURL: fileURL,
                 appName: appName,
                 appIcon: appIcon,
+                appId: appId,
+                gatewayBaseURL: gatewayBaseURL,
                 onDismiss: { [weak self] in
                     self?.dismissPopover()
                 }


### PR DESCRIPTION
## Summary
- Replace Slack share button behavior: opens channel picker instead of Finder
- POST to gateway /v1/slack/share on channel selection with sending lock
- Thread appId and gatewayBaseURL through all AppSharePanel call sites
- When appId is unavailable, Slack row is disabled with inline explanation

Part of plan: slack-channel-picker.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
