### PR TITLE
feat: enable Gmail messaging by default

### DIFF
--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -55,7 +55,7 @@
       "key": "feature_flags.messaging.gmail.enabled",
       "label": "Messaging: Gmail",
       "description": "Allow messaging tools to operate on the Gmail platform",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "messaging-telegram",

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -55,7 +55,7 @@
       "key": "feature_flags.messaging.gmail.enabled",
       "label": "Messaging: Gmail",
       "description": "Allow messaging tools to operate on the Gmail platform",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "messaging-telegram",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -55,7 +55,7 @@
       "key": "feature_flags.messaging.gmail.enabled",
       "label": "Messaging: Gmail",
       "description": "Allow messaging tools to operate on the Gmail platform",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "messaging-telegram",


### PR DESCRIPTION
## Summary
- Flips `messaging.gmail.enabled` feature flag from `false` to `true` so Gmail messaging tools work out of the box
- Users who need Gmail setup will ask for it — no need to gate behind a manual settings toggle

## Test plan
- [x] Feature flag registry guard test passes
- [ ] Verify assistant can handle email requests without requiring manual Gmail enable in Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
