### PR TITLE
fix: underline links in chat messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -74,6 +74,10 @@ extension ChatBubble {
             leading.backgroundColor = VColor.codeBackground
             result.insert(leading, at: range.lowerBound)
         }
+        // Underline links so they are visually distinct from plain text
+        for run in result.runs where result[run.range].link != nil {
+            result[run.range].underlineStyle = .single
+        }
         if isStreaming {
             lastStreamingInlineMarkdown = (text, result)
             return result
@@ -184,6 +188,10 @@ extension ChatBubble {
             var leading = AttributedString("\u{2009}")
             leading.backgroundColor = inlineCodeBgColor
             parsed.insert(leading, at: range.lowerBound)
+        }
+        // Underline links so they are visually distinct from plain text
+        for run in parsed.runs where parsed[run.range].link != nil {
+            parsed[run.range].underlineStyle = .single
         }
 
         // Highlight slash command token (e.g. /model) in blue

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -318,6 +318,10 @@ struct MarkdownSegmentView: View {
             leading.backgroundColor = codeBackgroundColor
             result.insert(leading, at: range.lowerBound)
         }
+        // Underline links so they are visually distinct from plain text
+        for run in result.runs where result[run.range].link != nil {
+            result[run.range].underlineStyle = .single
+        }
         return result
     }
 
@@ -366,6 +370,10 @@ struct MarkdownSegmentView: View {
             var leading = AttributedString("\u{2009}")
             leading.backgroundColor = codeBackgroundColor
             result.insert(leading, at: range.lowerBound)
+        }
+        // Underline links so they are visually distinct from plain text
+        for run in result.runs where result[run.range].link != nil {
+            result[run.range].underlineStyle = .single
         }
 
         return result


### PR DESCRIPTION
## Summary
- Links in chat bubbles were styled as bold text with no underline, making them hard to distinguish from emphasized text
- Added `.underlineStyle = .single` to all `AttributedString` link runs across all four rendering paths (inline markdown, rich segments, list items, and the main `markdownText` property)

## Test plan
- [ ] Verify links in assistant messages appear underlined
- [ ] Verify links in user messages appear underlined
- [ ] Verify non-link bold text is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
