### PR TITLE
perf: guard ThreadScrollbarVisibilityController against redundant layout updates

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -1017,7 +1017,7 @@ private struct MessageCellView: View {
     }
 }
 
-private struct ThreadScrollbarVisibilityController: NSViewRepresentable {
+private struct ThreadScrollbarVisibilityController: NSViewRepresentable, Equatable {
     let shouldShow: Bool
 
     func makeCoordinator() -> Coordinator {
@@ -1040,10 +1040,14 @@ private struct ThreadScrollbarVisibilityController: NSViewRepresentable {
 
     final class Coordinator {
         weak var lastResolvedScrollView: NSScrollView?
+        private var lastShouldShow: Bool?
 
         func update(from markerView: NSView, shouldShow: Bool) {
             guard let scrollView = findEnclosingScrollView(from: markerView) ?? lastResolvedScrollView else { return }
+            // Skip redundant reconfiguration
+            if scrollView === lastResolvedScrollView && lastShouldShow == shouldShow { return }
             lastResolvedScrollView = scrollView
+            lastShouldShow = shouldShow
             // Keep the scroller instantiated and styled consistently; only toggle
             // visibility. Toggling `hasVerticalScroller` can recreate scroller
             // internals, which causes visible flicker and brief legacy-style flashes.


### PR DESCRIPTION
Adds Equatable conformance and a redundant-update guard to ThreadScrollbarVisibilityController to prevent unnecessary NSViewRepresentable reconfiguration on every SwiftUI layout pass. This reduces main-thread layout overhead that was contributing to a 1.07s hang during view graph updates. Part of #13615.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13626" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
