### PR TITLE
fix: compute correct file size for directory-based shared apps

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
@@ -279,13 +279,36 @@ struct AppSharePanelView: View {
             return ""
         }
         if isDirectory.boolValue {
-            return "App Bundle"
+            return directorySize(at: fileURL)
+                .map { ByteCountFormatter.string(fromByteCount: Int64($0), countStyle: .file) }
+                ?? "App Bundle"
         }
         guard let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
               let size = attrs[.size] as? UInt64 else {
             return ""
         }
         return ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .file)
+    }
+
+    /// Recursively computes the total size of all files within a directory.
+    private func directorySize(at url: URL) -> UInt64? {
+        guard let enumerator = FileManager.default.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.fileSizeKey, .isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return nil
+        }
+        var total: UInt64 = 0
+        for case let fileURL as URL in enumerator {
+            guard let resourceValues = try? fileURL.resourceValues(forKeys: [.fileSizeKey, .isDirectoryKey]),
+                  resourceValues.isDirectory != true,
+                  let fileSize = resourceValues.fileSize else {
+                continue
+            }
+            total += UInt64(fileSize)
+        }
+        return total
     }
 
     private func handleSlackShare() {


### PR DESCRIPTION
## Summary
- Fix formattedFileSize to handle directory URLs correctly in share panel header
- Instead of showing "App Bundle" for directories, now recursively computes total file size using FileManager.enumerator with fileSizeKey
- Falls back to "App Bundle" if enumeration fails

Addresses review feedback on #13517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
