### PR TITLE
fix: remove duplicate visual chrome from SlackChannelPickerView

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sharing/SlackChannelPickerView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/SlackChannelPickerView.swift
@@ -68,13 +68,6 @@ struct SlackChannelPickerView: View {
                 hoveredChannelID = nil
             }
         }
-        .background(VColor.surfaceSubtle)
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(VColor.surfaceBorder, lineWidth: 1)
-        )
-        .shadow(color: .black.opacity(0.15), radius: 6, y: 2)
         .task {
             await loadChannels()
         }


### PR DESCRIPTION
## Summary
- Remove standalone background, clipShape, border overlay, and shadow from SlackChannelPickerView
- Parent AppSharePanelView already provides these decorations

Addresses review feedback on #13620.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
