### PR TITLE
fix: cache directory size computation to avoid blocking main thread

### DIFF
--- a/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/AppSharePanelView.swift
@@ -17,6 +17,7 @@ struct AppSharePanelView: View {
     @State private var showChannelPicker = false
     @State private var isSendingToSlack = false
     @State private var slackError: String?
+    @State private var formattedFileSize: String = ""
 
     @available(macOS, deprecated: 13.0)
     var body: some View {
@@ -43,6 +44,9 @@ struct AppSharePanelView: View {
         .shadow(color: .black.opacity(0.15), radius: 6, y: 2)
         .onAppear {
             services = Self.availableSharingServices(for: fileURL)
+        }
+        .task {
+            formattedFileSize = await computeFileSize()
         }
     }
 
@@ -273,13 +277,17 @@ struct AppSharePanelView: View {
         NSSharingService.sharingServices(forItems: [url])
     }
 
-    private var formattedFileSize: String {
+    private func computeFileSize() async -> String {
         var isDirectory: ObjCBool = false
         guard FileManager.default.fileExists(atPath: fileURL.path, isDirectory: &isDirectory) else {
             return ""
         }
         if isDirectory.boolValue {
-            return directorySize(at: fileURL)
+            let url = fileURL
+            let size = await Task.detached {
+                Self.directorySize(at: url)
+            }.value
+            return size
                 .map { ByteCountFormatter.string(fromByteCount: Int64($0), countStyle: .file) }
                 ?? "App Bundle"
         }
@@ -291,7 +299,7 @@ struct AppSharePanelView: View {
     }
 
     /// Recursively computes the total size of all files within a directory.
-    private func directorySize(at url: URL) -> UInt64? {
+    private static func directorySize(at url: URL) -> UInt64? {
         guard let enumerator = FileManager.default.enumerator(
             at: url,
             includingPropertiesForKeys: [.fileSizeKey, .isDirectoryKey],


### PR DESCRIPTION
## Summary
- Replace formattedFileSize computed property with cached @State
- Compute directory size asynchronously on appear instead of every body evaluation

Addresses review feedback on #13628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
