### PR TITLE
M1: Move NSDataDetector URL extraction to background actor with caching

### DIFF
--- a/clients/shared/Features/Chat/MediaEmbeds/MediaEmbedResolver.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/MediaEmbedResolver.swift
@@ -54,7 +54,7 @@ public enum MediaEmbedResolver {
             return []
         }
 
-        let urls = MessageURLExtractor.extractAllURLs(from: message.text)
+        let urls = await URLExtractionCache.shared.extractAllURLs(from: message.text)
         guard !urls.isEmpty else { return [] }
 
         var seen = Set<String>()

--- a/clients/shared/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
@@ -6,20 +6,18 @@ import Foundation
 public actor URLExtractionCache {
     public static let shared = URLExtractionCache()
 
-    private var cache: [Int: [URL]] = [:]
+    private var cache: [String: [URL]] = [:]
     /// Tracks access order for LRU eviction — most recently used at the end.
-    private var accessOrder: [Int] = []
+    private var accessOrder: [String] = []
     private let maxEntries = 500
 
     public func extractAllURLs(from text: String) -> [URL] {
-        let key = Self.hashKey(for: text)
-
-        if let cached = cache[key] {
+        if let cached = cache[text] {
             // Move to end of access order (most recent).
-            if let idx = accessOrder.firstIndex(of: key) {
+            if let idx = accessOrder.firstIndex(of: text) {
                 accessOrder.remove(at: idx)
             }
-            accessOrder.append(key)
+            accessOrder.append(text)
             return cached
         }
 
@@ -31,15 +29,16 @@ public actor URLExtractionCache {
             cache.removeValue(forKey: evictKey)
         }
 
-        cache[key] = result
-        accessOrder.append(key)
+        cache[text] = result
+        accessOrder.append(text)
         return result
     }
 
-    private static func hashKey(for text: String) -> Int {
-        var hasher = Hasher()
-        hasher.combine(text)
-        return hasher.finalize()
+    /// Removes all cached entries. Useful for memory-pressure relief or
+    /// thread-switch cleanup.
+    public func clearCache() {
+        cache.removeAll()
+        accessOrder.removeAll()
     }
 }
 

--- a/clients/shared/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
@@ -1,5 +1,48 @@
 import Foundation
 
+/// Actor that wraps `MessageURLExtractor.extractAllURLs(from:)` with an
+/// in-memory LRU cache, moving the expensive `NSDataDetector` work off
+/// the main thread via actor isolation.
+public actor URLExtractionCache {
+    public static let shared = URLExtractionCache()
+
+    private var cache: [Int: [URL]] = [:]
+    /// Tracks access order for LRU eviction — most recently used at the end.
+    private var accessOrder: [Int] = []
+    private let maxEntries = 500
+
+    public func extractAllURLs(from text: String) -> [URL] {
+        let key = Self.hashKey(for: text)
+
+        if let cached = cache[key] {
+            // Move to end of access order (most recent).
+            if let idx = accessOrder.firstIndex(of: key) {
+                accessOrder.remove(at: idx)
+            }
+            accessOrder.append(key)
+            return cached
+        }
+
+        let result = MessageURLExtractor.extractAllURLs(from: text)
+
+        // Evict least-recently-used entry if at capacity.
+        if cache.count >= maxEntries, let evictKey = accessOrder.first {
+            accessOrder.removeFirst()
+            cache.removeValue(forKey: evictKey)
+        }
+
+        cache[key] = result
+        accessOrder.append(key)
+        return result
+    }
+
+    private static func hashKey(for text: String) -> Int {
+        var hasher = Hasher()
+        hasher.combine(text)
+        return hasher.finalize()
+    }
+}
+
 /// Extracts plain `http` / `https` URLs from message text.
 ///
 /// This is the first stage of the media-embed pipeline: deterministic,

--- a/clients/shared/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/MessageURLExtractor.swift
@@ -1,44 +1,43 @@
 import Foundation
 
 /// Actor that wraps `MessageURLExtractor.extractAllURLs(from:)` with an
-/// in-memory LRU cache, moving the expensive `NSDataDetector` work off
+/// in-memory cache, moving the expensive `NSDataDetector` work off
 /// the main thread via actor isolation.
+///
+/// Backed by `NSCache`, which automatically evicts entries under memory
+/// pressure — no manual LRU bookkeeping required.
 public actor URLExtractionCache {
     public static let shared = URLExtractionCache()
 
-    private var cache: [String: [URL]] = [:]
-    /// Tracks access order for LRU eviction — most recently used at the end.
-    private var accessOrder: [String] = []
-    private let maxEntries = 500
+    /// Wraps `[URL]` so it can be stored in `NSCache`.
+    private class CacheEntry: NSObject {
+        let urls: [URL]
+        init(_ urls: [URL]) {
+            self.urls = urls
+        }
+    }
+
+    private let cache = NSCache<NSString, CacheEntry>()
+
+    private init() {
+        cache.countLimit = 500
+    }
 
     public func extractAllURLs(from text: String) -> [URL] {
-        if let cached = cache[text] {
-            // Move to end of access order (most recent).
-            if let idx = accessOrder.firstIndex(of: text) {
-                accessOrder.remove(at: idx)
-            }
-            accessOrder.append(text)
-            return cached
+        let key = text as NSString
+
+        if let cached = cache.object(forKey: key) {
+            return cached.urls
         }
 
         let result = MessageURLExtractor.extractAllURLs(from: text)
-
-        // Evict least-recently-used entry if at capacity.
-        if cache.count >= maxEntries, let evictKey = accessOrder.first {
-            accessOrder.removeFirst()
-            cache.removeValue(forKey: evictKey)
-        }
-
-        cache[text] = result
-        accessOrder.append(text)
+        cache.setObject(CacheEntry(result), forKey: key)
         return result
     }
 
-    /// Removes all cached entries. Useful for memory-pressure relief or
-    /// thread-switch cleanup.
+    /// Removes all cached entries.
     public func clearCache() {
-        cache.removeAll()
-        accessOrder.removeAll()
+        cache.removeAllObjects()
     }
 }
 


### PR DESCRIPTION
Part of #13636. Moves NSDataDetector URL extraction off the main thread by routing through a URLExtractionCache actor. Adds LRU caching (500 entries) so repeated renders of the same message text skip the expensive NSDataDetector pass entirely. Closes #13637.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
