### PR TITLE
fix: sync API key to daemon immediately during onboarding

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -52,22 +52,23 @@ enum APIKeyManager {
     }
 
     /// Push an API key to the daemon's encrypted store via its HTTP endpoint.
-    /// Fire-and-forget — failures are silently ignored (the reconnect sync
-    /// will retry). Call this from onboarding or any path that saves a key
-    /// outside of SettingsStore.
+    /// Waits up to 15s for the actor token if it's not yet available (e.g.
+    /// during initial onboarding before JWT bootstrap completes). Failures
+    /// are silently ignored — the reconnect sync will retry.
     static func syncKeyToDaemon(provider: String, value: String) {
-        let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
-            .flatMap(Int.init) ?? 7821
-        guard let token = ActorTokenManager.getToken(), !token.isEmpty else { return }
-        guard let url = URL(string: "http://localhost:\(port)/v1/secrets") else { return }
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.timeoutInterval = 5
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        let body: [String: String] = ["type": "api_key", "name": provider, "value": value]
-        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
         Task.detached {
+            guard let token = await ActorTokenManager.waitForToken(timeout: 15),
+                  !token.isEmpty else { return }
+            let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
+                .flatMap(Int.init) ?? 7821
+            guard let url = URL(string: "http://localhost:\(port)/v1/secrets") else { return }
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.timeoutInterval = 5
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            let body: [String: String] = ["type": "api_key", "name": provider, "value": value]
+            request.httpBody = try? JSONSerialization.data(withJSONObject: body)
             _ = try? await URLSession.shared.data(for: request)
         }
     }

--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import VellumAssistantShared
 
 extension Notification.Name {
     static let apiKeyManagerDidChange = Notification.Name("APIKeyManager.didChange")
@@ -48,6 +49,27 @@ enum APIKeyManager {
     static func deleteKey(for provider: String) {
         UserDefaults.standard.removeObject(forKey: udPrefix + provider)
         notifyKeyDidChange()
+    }
+
+    /// Push an API key to the daemon's encrypted store via its HTTP endpoint.
+    /// Fire-and-forget — failures are silently ignored (the reconnect sync
+    /// will retry). Call this from onboarding or any path that saves a key
+    /// outside of SettingsStore.
+    static func syncKeyToDaemon(provider: String, value: String) {
+        let port = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"]
+            .flatMap(Int.init) ?? 7821
+        guard let token = ActorTokenManager.getToken(), !token.isEmpty else { return }
+        guard let url = URL(string: "http://localhost:\(port)/v1/secrets") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 5
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: String] = ["type": "api_key", "name": provider, "value": value]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        Task.detached {
+            _ = try? await URLSession.shared.data(for: request)
+        }
     }
 
     private static func notifyKeyDidChange() {

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -258,6 +258,7 @@ struct APIKeyStepView: View {
         let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         APIKeyManager.setKey(trimmed)
+        APIKeyManager.syncKeyToDaemon(provider: "anthropic", value: trimmed)
 
             saveModelToConfig("claude-opus-4-6")
             if userHostedEnabled && hostingMode != .local {


### PR DESCRIPTION
## Summary
- Added `APIKeyManager.syncKeyToDaemon()` static method that pushes an API key to the daemon's encrypted store via HTTP POST to `v1/secrets`
- Called it from `APIKeyStepView.saveAndContinue()` immediately after saving the key to UserDefaults
- Fixes "No providers available. Requested: anthropic. Registered: openai" errors when the daemon is already connected during onboarding

## Original prompt
In APIKeyStepView.swift's saveAndContinue(), after APIKeyManager.setKey(trimmed) on line 260, the Anthropic API key is saved to UserDefaults but never directly pushed to the daemon. It relies on a daemonDidReconnect event to sync, which is fragile and can fail silently (e.g., daemon already connected, JWT timeout). This causes "No providers available. Requested: anthropic. Registered: openai" errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
