### PR TITLE
M2: Add concurrency throttle to ImageMIMEProbe and batch resolve

### DIFF
--- a/clients/shared/Features/Chat/MediaEmbeds/ImageMIMEProbe.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/ImageMIMEProbe.swift
@@ -1,5 +1,36 @@
 import Foundation
 
+/// Limits concurrent async operations to a fixed number of slots.
+///
+/// Used by `ImageMIMEProbe` to cap in-flight HTTP HEAD requests so that
+/// a burst of extensionless URLs (e.g. many messages scrolling into view)
+/// doesn't saturate the network.
+private actor AsyncSemaphore {
+    private var count: Int
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(value: Int) { self.count = value }
+
+    func wait() async {
+        if count > 0 {
+            count -= 1
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func signal() {
+        if let waiter = waiters.first {
+            waiters.removeFirst()
+            waiter.resume()
+        } else {
+            count += 1
+        }
+    }
+}
+
 /// Probes URLs via HTTP HEAD to determine whether they serve image content.
 ///
 /// This is the second stage of image detection, used for extensionless URLs
@@ -10,6 +41,7 @@ public final class ImageMIMEProbe {
 
     private let cache = NSCache<NSString, CacheEntry>()
     private let session: URLSession
+    private let semaphore = AsyncSemaphore(value: 4)
 
     /// Wraps the classification value so it can be stored in `NSCache`.
     private class CacheEntry: NSObject {
@@ -43,6 +75,9 @@ public final class ImageMIMEProbe {
         var request = URLRequest(url: url)
         request.httpMethod = "HEAD"
         request.timeoutInterval = 5
+
+        await semaphore.wait()
+        defer { Task { await semaphore.signal() } }
 
         let result: ImageURLClassification
         do {

--- a/clients/shared/Features/Chat/MediaEmbeds/MediaEmbedResolver.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/MediaEmbedResolver.swift
@@ -58,11 +58,12 @@ public enum MediaEmbedResolver {
         guard !urls.isEmpty else { return [] }
 
         var seen = Set<String>()
-        var intents: [MediaEmbedIntent] = []
 
-        // Synchronous first pass: video parsers and extension-based image
-        // classification are pure string matching — no I/O needed.
-        var urlsToProbe: [URL] = []
+        // First pass: classify each URL synchronously where possible,
+        // recording placeholder indices for URLs that need async probing.
+        // This preserves the original URL source order in the final array.
+        var intents: [MediaEmbedIntent?] = []
+        var probeTargets: [(index: Int, url: URL)] = []
 
         for url in urls {
             if let videoResult = tryVideoParsers(url, allowedDomains: settings.allowedDomains) {
@@ -87,35 +88,41 @@ public enum MediaEmbedResolver {
                 let canonical = url.absoluteString
                 guard !seen.contains(canonical) else { continue }
                 seen.insert(canonical)
-                urlsToProbe.append(url)
+                // Reserve a slot so probed images appear in source order.
+                let placeholderIndex = intents.count
+                intents.append(nil)
+                probeTargets.append((index: placeholderIndex, url: url))
             }
         }
 
-        // Parallel second pass: probe extensionless URLs concurrently.
-        // Actual concurrency is bounded by the semaphore inside ImageMIMEProbe.
-        if !urlsToProbe.isEmpty {
-            let probeResults: [(URL, ImageURLClassification)] = await withTaskGroup(
-                of: (URL, ImageURLClassification).self
+        // Second pass: probe extensionless URLs concurrently, then fill
+        // placeholders. Concurrency is bounded by ImageMIMEProbe's semaphore.
+        if !probeTargets.isEmpty {
+            let probeResults: [String: ImageURLClassification] = await withTaskGroup(
+                of: (String, ImageURLClassification).self
             ) { group in
-                for url in urlsToProbe {
+                for (_, url) in probeTargets {
                     group.addTask {
                         let result = await ImageMIMEProbe.shared.probe(url)
-                        return (url, result)
+                        return (url.absoluteString, result)
                     }
                 }
-                var collected: [(URL, ImageURLClassification)] = []
-                for await pair in group {
-                    collected.append(pair)
+                var map: [String: ImageURLClassification] = [:]
+                for await (key, classification) in group {
+                    map[key] = classification
                 }
-                return collected
+                return map
             }
 
-            for (url, classification) in probeResults where classification == .image {
-                intents.append(.image(url: url))
+            for (index, url) in probeTargets {
+                if probeResults[url.absoluteString] == .image {
+                    intents[index] = .image(url: url)
+                }
             }
         }
 
-        return intents
+        // Strip nil placeholders (probed URLs that were not images).
+        return intents.compactMap { $0 }
     }
 
     // MARK: - Private helpers

--- a/clients/shared/Features/Chat/MediaEmbeds/MediaEmbedResolver.swift
+++ b/clients/shared/Features/Chat/MediaEmbeds/MediaEmbedResolver.swift
@@ -60,8 +60,11 @@ public enum MediaEmbedResolver {
         var seen = Set<String>()
         var intents: [MediaEmbedIntent] = []
 
+        // Synchronous first pass: video parsers and extension-based image
+        // classification are pure string matching — no I/O needed.
+        var urlsToProbe: [URL] = []
+
         for url in urls {
-            // Try each video parser in order.
             if let videoResult = tryVideoParsers(url, allowedDomains: settings.allowedDomains) {
                 let canonical = videoResult.embedURL.absoluteString
                 guard !seen.contains(canonical) else { continue }
@@ -74,7 +77,6 @@ public enum MediaEmbedResolver {
                 continue
             }
 
-            // Two-stage image detection: try extension first, then MIME probe.
             let classification = ImageURLClassifier.classify(url)
             if classification == .image {
                 let canonical = url.absoluteString
@@ -82,14 +84,34 @@ public enum MediaEmbedResolver {
                 seen.insert(canonical)
                 intents.append(.image(url: url))
             } else if classification == .unknown {
-                // Extensionless URL — fall back to async HTTP HEAD probe.
-                let probeResult = await ImageMIMEProbe.shared.probe(url)
-                if probeResult == .image {
-                    let canonical = url.absoluteString
-                    guard !seen.contains(canonical) else { continue }
-                    seen.insert(canonical)
-                    intents.append(.image(url: url))
+                let canonical = url.absoluteString
+                guard !seen.contains(canonical) else { continue }
+                seen.insert(canonical)
+                urlsToProbe.append(url)
+            }
+        }
+
+        // Parallel second pass: probe extensionless URLs concurrently.
+        // Actual concurrency is bounded by the semaphore inside ImageMIMEProbe.
+        if !urlsToProbe.isEmpty {
+            let probeResults: [(URL, ImageURLClassification)] = await withTaskGroup(
+                of: (URL, ImageURLClassification).self
+            ) { group in
+                for url in urlsToProbe {
+                    group.addTask {
+                        let result = await ImageMIMEProbe.shared.probe(url)
+                        return (url, result)
+                    }
                 }
+                var collected: [(URL, ImageURLClassification)] = []
+                for await pair in group {
+                    collected.append(pair)
+                }
+                return collected
+            }
+
+            for (url, classification) in probeResults where classification == .image {
+                intents.append(.image(url: url))
             }
         }
 


### PR DESCRIPTION
Part of #13636. Adds an AsyncSemaphore to ImageMIMEProbe limiting concurrent HTTP HEAD probes to 4, preventing network stampede when many messages with extensionless URLs scroll into view. Updates MediaEmbedResolver to use TaskGroup for bounded parallel URL resolution. Closes #13638.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
