### PR TITLE
fix: resolve lint errors in managed-avatar-client test

### DIFF
--- a/assistant/src/__tests__/managed-avatar-client.test.ts
+++ b/assistant/src/__tests__/managed-avatar-client.test.ts
@@ -36,23 +36,26 @@ mock.module("../util/logger.js", () => ({
 
 // Mock global fetch
 let lastFetchArgs: [string, RequestInit] | null = null;
-let fetchResponse: { ok: boolean; status: number; json: () => Promise<unknown> } = {
+let fetchResponse: {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+} = {
   ok: true,
   status: 200,
   json: async () => ({}),
 };
 
-const originalFetch = globalThis.fetch;
 globalThis.fetch = (async (url: string, init: RequestInit) => {
   lastFetchArgs = [url, init];
   return fetchResponse;
 }) as typeof globalThis.fetch;
 
 // Import after mocking
+// eslint-disable-next-line simple-import-sort/imports
 import {
   isManagedAvailable,
   generateManagedAvatar,
-  getAssistantApiKey,
 } from "../media/managed-avatar-client.js";
 import {
   ManagedAvatarError,
@@ -195,7 +198,10 @@ describe("generateManagedAvatar", () => {
       status: 200,
       json: async () => ({
         ...successResponse(),
-        image: { ...successResponse().image, bytes: AVATAR_MAX_DECODED_BYTES + 1 },
+        image: {
+          ...successResponse().image,
+          bytes: AVATAR_MAX_DECODED_BYTES + 1,
+        },
       }),
     };
 
@@ -213,13 +219,19 @@ describe("generateManagedAvatar", () => {
   test("response with oversized base64 estimated decoded size throws validation error", async () => {
     // Create a base64 string whose estimated decoded size exceeds the limit,
     // even though the server-reported bytes field is under the limit
-    const oversizedBase64 = "A".repeat(Math.ceil((AVATAR_MAX_DECODED_BYTES + 100) * 4 / 3));
+    const oversizedBase64 = "A".repeat(
+      Math.ceil(((AVATAR_MAX_DECODED_BYTES + 100) * 4) / 3),
+    );
     fetchResponse = {
       ok: true,
       status: 200,
       json: async () => ({
         ...successResponse(),
-        image: { ...successResponse().image, data_base64: oversizedBase64, bytes: 1024 },
+        image: {
+          ...successResponse().image,
+          data_base64: oversizedBase64,
+          bytes: 1024,
+        },
       }),
     };
 


### PR DESCRIPTION
## Summary
- Remove unused `originalFetch` variable
- Remove unused `getAssistantApiKey` import
- Add eslint-disable for `simple-import-sort/imports` (imports must follow mock.module calls)

## Original prompt
fix these lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
