### PR TITLE
M3: Async markdown segment parsing for large messages

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -31,6 +31,9 @@ struct ChatBubble: View {
     var processingStatusText: String?
     @State private var appearance = AvatarAppearanceManager.shared
     @State private var isHovered = false
+    /// Stores async-parsed segments for large messages (>2000 chars) that missed the
+    /// synchronous cache. Keyed by text content so multiple segments can be in flight.
+    @State var asyncSegments: [String: [MarkdownSegment]] = [:]
 
     @State private var showCopyConfirmation = false
     @State private var copyConfirmationTimer: DispatchWorkItem?
@@ -316,7 +319,7 @@ struct ChatBubble: View {
                             .fixedSize(horizontal: false, vertical: true)
                     }
                 } else if hasText {
-                    let segments = Self.cachedSegments(for: message.text, isStreaming: message.isStreaming)
+                    let segments = resolveSegments(for: message.text, isStreaming: message.isStreaming)
                     let hasRichContent = segments.contains(where: {
                         switch $0 {
                         case .table, .image, .heading, .codeBlock, .horizontalRule, .list: return true
@@ -383,6 +386,20 @@ struct ChatBubble: View {
                 }
             }
         }
+        .task(id: message.text) {
+            // Async-parse large messages that missed the synchronous cache
+            let text = message.text
+            guard !message.isStreaming,
+                  text.count > Self.asyncParseThreshold,
+                  Self.segmentCache[text] == nil,
+                  asyncSegments[text] == nil else { return }
+            let result = await MarkdownParseActor.shared.parse(text)
+            guard !Task.isCancelled else { return }
+            asyncSegments[text] = result
+            // Backfill synchronous cache for future renders
+            Self.lruCounter += 1
+            Self.segmentCache[text] = (result, Self.lruCounter)
+        }
     }
 
     // MARK: - Document Widget
@@ -408,6 +425,10 @@ struct ChatBubble: View {
             .padding(.top, VSpacing.sm)
         }
     }
+
+    /// Length threshold above which a segment cache miss triggers async parsing
+    /// instead of blocking the main thread.
+    static let asyncParseThreshold = 2000
 
     // MARK: - LRU Caches
     //

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -386,7 +386,7 @@ struct ChatBubble: View {
                 }
             }
         }
-        .task(id: message.text) {
+        .task(id: "\(message.text)|\(message.isStreaming)") {
             // Async-parse large messages that missed the synchronous cache
             let text = message.text
             guard !message.isStreaming,
@@ -396,9 +396,21 @@ struct ChatBubble: View {
             let result = await MarkdownParseActor.shared.parse(text)
             guard !Task.isCancelled else { return }
             asyncSegments[text] = result
-            // Backfill synchronous cache for future renders
-            Self.lruCounter += 1
-            Self.segmentCache[text] = (result, Self.lruCounter)
+            // Backfill synchronous cache with guardrails (size limit, byte
+            // tracking, eviction) — mirrors the logic in cachedSegments.
+            if text.count <= Self.maxCacheableTextLength {
+                if Self.segmentCache.count >= Self.maxCacheSize {
+                    if let lruKey = Self.segmentCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
+                        Self.estimatedCacheBytes -= Self.estimatedBytes(for: lruKey)
+                        Self.segmentCache.removeValue(forKey: lruKey)
+                    }
+                }
+                Self.lruCounter += 1
+                let cost = Self.estimatedBytes(for: text)
+                Self.segmentCache[text] = (result, Self.lruCounter)
+                Self.estimatedCacheBytes += cost
+                Self.evictIfOverBudget()
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -5,10 +5,12 @@ import VellumAssistantShared
 
 extension ChatBubble {
     /// Render a single text segment as a styled bubble, with table and image support.
+    /// For large messages (>2000 chars) with a segment cache miss, renders plain text
+    /// immediately and parses rich formatting asynchronously to avoid blocking scroll.
     @ViewBuilder
     func textBubble(for segmentText: String) -> some View {
         let streaming = message.isStreaming
-        let segments = Self.cachedSegments(for: segmentText, isStreaming: streaming)
+        let segments = resolveSegments(for: segmentText, isStreaming: streaming)
         let hasRichContent = segments.contains(where: {
             switch $0 {
             case .table, .image, .heading, .codeBlock, .horizontalRule, .list: return true
@@ -34,6 +36,40 @@ extension ChatBubble {
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
+        .task(id: segmentText) {
+            // Only run async parsing for large, non-streaming text with a cache miss
+            guard !streaming,
+                  segmentText.count > Self.asyncParseThreshold,
+                  Self.segmentCache[segmentText] == nil,
+                  asyncSegments[segmentText] == nil else { return }
+            let result = await MarkdownParseActor.shared.parse(segmentText)
+            guard !Task.isCancelled else { return }
+            asyncSegments[segmentText] = result
+            // Backfill the synchronous cache so subsequent renders hit it directly
+            Self.lruCounter += 1
+            Self.segmentCache[segmentText] = (result, Self.lruCounter)
+        }
+    }
+
+    /// Resolves markdown segments for the given text, using the async result for
+    /// large messages that haven't been synchronously cached yet.
+    func resolveSegments(for text: String, isStreaming: Bool) -> [MarkdownSegment] {
+        // Check the synchronous cache first (fast path for all sizes)
+        if let cached = Self.segmentCache[text] {
+            Self.lruCounter += 1
+            Self.segmentCache[text] = (cached.value, Self.lruCounter)
+            return cached.value
+        }
+        // For large text with a cache miss, return async result or plain placeholder
+        if !isStreaming, text.count > Self.asyncParseThreshold {
+            if let async = asyncSegments[text] {
+                return async
+            }
+            // Fast placeholder: single plain-text segment avoids expensive parsing
+            return [.text(text)]
+        }
+        // Small text or streaming: parse synchronously (cheap enough)
+        return Self.cachedSegments(for: text, isStreaming: isStreaming)
     }
 
     /// Cached inline markdown AttributedString to avoid re-parsing on every render.

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -36,7 +36,7 @@ extension ChatBubble {
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
-        .task(id: segmentText) {
+        .task(id: "\(segmentText)|\(streaming)") {
             // Only run async parsing for large, non-streaming text with a cache miss
             guard !streaming,
                   segmentText.count > Self.asyncParseThreshold,
@@ -45,9 +45,21 @@ extension ChatBubble {
             let result = await MarkdownParseActor.shared.parse(segmentText)
             guard !Task.isCancelled else { return }
             asyncSegments[segmentText] = result
-            // Backfill the synchronous cache so subsequent renders hit it directly
-            Self.lruCounter += 1
-            Self.segmentCache[segmentText] = (result, Self.lruCounter)
+            // Backfill the synchronous cache with guardrails (size limit,
+            // byte tracking, eviction) — mirrors the logic in cachedSegments.
+            if segmentText.count <= Self.maxCacheableTextLength {
+                if Self.segmentCache.count >= Self.maxCacheSize {
+                    if let lruKey = Self.segmentCache.min(by: { $0.value.accessTime < $1.value.accessTime })?.key {
+                        Self.estimatedCacheBytes -= Self.estimatedBytes(for: lruKey)
+                        Self.segmentCache.removeValue(forKey: lruKey)
+                    }
+                }
+                Self.lruCounter += 1
+                let cost = Self.estimatedBytes(for: segmentText)
+                Self.segmentCache[segmentText] = (result, Self.lruCounter)
+                Self.estimatedCacheBytes += cost
+                Self.evictIfOverBudget()
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -251,6 +251,39 @@ func isTableSeparator(_ line: String) -> Bool {
     }
 }
 
+// MARK: - Async Markdown Parse Actor
+
+/// Actor that runs markdown parsing off the main thread.
+/// Used for large messages (>2000 chars) to avoid blocking scroll on cache miss.
+actor MarkdownParseActor {
+    static let shared = MarkdownParseActor()
+
+    private let cache = NSCache<NSString, CacheEntry>()
+
+    private class CacheEntry: NSObject {
+        let segments: [MarkdownSegment]
+        init(_ segments: [MarkdownSegment]) { self.segments = segments }
+    }
+
+    init() {
+        cache.countLimit = 256
+    }
+
+    func parse(_ text: String) -> [MarkdownSegment] {
+        let key = text as NSString
+        if let cached = cache.object(forKey: key) {
+            return cached.segments
+        }
+        let result = parseMarkdownSegments(text)
+        cache.setObject(CacheEntry(result), forKey: key)
+        return result
+    }
+
+    func clearCache() {
+        cache.removeAllObjects()
+    }
+}
+
 func parseTableCells(_ line: String) -> [String] {
     let trimmed = line.trimmingCharacters(in: .whitespaces)
     let inner = String(trimmed.dropFirst().dropLast())  // strip outer pipes


### PR DESCRIPTION
Part of #13636. Adds MarkdownParseActor for off-main-thread parsing of large messages (>2000 chars). On cache miss for large text, shows plain text immediately then swaps in rich formatting when parsing completes. Prevents main thread blocking during initial render of long messages. Closes #13639.

## Summary
- Adds `MarkdownParseActor` Swift actor with its own 256-entry `NSCache` for background markdown parsing
- For messages >2000 chars with a segment cache miss, returns a plain-text placeholder immediately (fast layout)
- Triggers async parsing via `.task(id:)` modifier; swaps in rich content when complete
- Backfills the synchronous `segmentCache` after async parse so future renders hit the fast path
- Applied to both `bubbleContent` (main message) and `textBubble(for:)` (interleaved segments)

## Test plan
- [ ] Open a thread with long messages (>2000 chars) — verify rich formatting appears after brief plain text flash
- [ ] Scroll rapidly through many messages — verify no hang or stutter on first load
- [ ] Short messages (<2000 chars) render identically to before (synchronous path unchanged)
- [ ] Streaming messages still render correctly without async path interference

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
