### PR TITLE
refactor: replace hard-coded credential consumer with declarative mapping table

### DIFF
--- a/gateway/src/credential-mappings.ts
+++ b/gateway/src/credential-mappings.ts
@@ -1,0 +1,98 @@
+import type { GatewayConfig } from "./config.js";
+import type { CredentialChangeEvent } from "./credential-watcher.js";
+
+type CredentialServiceMapping = {
+  /** Key on CredentialChangeEvent indicating whether this service changed. */
+  changedKey: keyof CredentialChangeEvent & `${string}Changed`;
+  /** Key on CredentialChangeEvent containing the credentials object. */
+  credentialsKey: keyof CredentialChangeEvent & `${string}Credentials`;
+  /** Whether to skip updates when env vars provide these credentials. */
+  envGuarded: boolean;
+  /** Maps credential object fields to GatewayConfig fields. */
+  fields: Array<{
+    credField: string;
+    configField: keyof GatewayConfig;
+  }>;
+};
+
+export function buildCredentialServiceMappings(opts: {
+  telegramFromEnv: boolean;
+  slackFromEnv: boolean;
+}): CredentialServiceMapping[] {
+  return [
+    {
+      changedKey: "telegramChanged",
+      credentialsKey: "telegramCredentials",
+      envGuarded: opts.telegramFromEnv,
+      fields: [
+        { credField: "botToken", configField: "telegramBotToken" },
+        { credField: "webhookSecret", configField: "telegramWebhookSecret" },
+      ],
+    },
+    {
+      changedKey: "twilioChanged",
+      credentialsKey: "twilioCredentials",
+      envGuarded: false,
+      fields: [
+        { credField: "accountSid", configField: "twilioAccountSid" },
+        { credField: "authToken", configField: "twilioAuthToken" },
+      ],
+    },
+    {
+      changedKey: "whatsappChanged",
+      credentialsKey: "whatsappCredentials",
+      envGuarded: false,
+      fields: [
+        { credField: "phoneNumberId", configField: "whatsappPhoneNumberId" },
+        { credField: "accessToken", configField: "whatsappAccessToken" },
+        { credField: "appSecret", configField: "whatsappAppSecret" },
+        {
+          credField: "webhookVerifyToken",
+          configField: "whatsappWebhookVerifyToken",
+        },
+      ],
+    },
+    {
+      changedKey: "slackChannelChanged",
+      credentialsKey: "slackChannelCredentials",
+      envGuarded: opts.slackFromEnv,
+      fields: [
+        { credField: "botToken", configField: "slackChannelBotToken" },
+        { credField: "appToken", configField: "slackChannelAppToken" },
+      ],
+    },
+  ];
+}
+
+export function applyCredentialChanges(
+  event: CredentialChangeEvent,
+  config: GatewayConfig,
+  mappings: CredentialServiceMapping[],
+  log: { info: (msg: string) => void },
+): Set<string> {
+  const changedServices = new Set<string>();
+  for (const mapping of mappings) {
+    if (!event[mapping.changedKey]) continue;
+    if (mapping.envGuarded) continue;
+    const creds = event[mapping.credentialsKey] as Record<
+      string,
+      unknown
+    > | null;
+    for (const { credField, configField } of mapping.fields) {
+      (config as Record<string, unknown>)[configField] = creds
+        ? (creds as Record<string, unknown>)[credField]
+        : undefined;
+    }
+    // Extract a human-friendly service name from the changedKey (e.g. "telegramChanged" -> "Telegram")
+    const serviceName = mapping.changedKey.replace("Changed", "");
+    const capitalizedName =
+      serviceName.charAt(0).toUpperCase() + serviceName.slice(1);
+    log.info(
+      creds
+        ? `${capitalizedName} credentials loaded from credential vault`
+        : `${capitalizedName} credentials cleared`,
+    );
+    changedServices.add(serviceName);
+  }
+  return changedServices;
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -12,6 +12,10 @@ import {
 } from "./auth/token-exchange.js";
 import { ConfigFileWatcher } from "./config-file-watcher.js";
 import { loadConfig, isSlackChannelConfigured } from "./config.js";
+import {
+  buildCredentialServiceMappings,
+  applyCredentialChanges,
+} from "./credential-mappings.js";
 import { CredentialWatcher } from "./credential-watcher.js";
 import { createRuntimeProxyHandler } from "./http/routes/runtime-proxy.js";
 import {
@@ -872,65 +876,30 @@ async function main() {
     process.env.SLACK_CHANNEL_BOT_TOKEN && process.env.SLACK_CHANNEL_APP_TOKEN
   );
 
+  const credentialMappings = buildCredentialServiceMappings({
+    telegramFromEnv,
+    slackFromEnv,
+  });
+
   const credentialWatcher = new CredentialWatcher((event) => {
-    if (event.telegramChanged && !telegramFromEnv) {
-      if (event.telegramCredentials) {
-        config.telegramBotToken = event.telegramCredentials.botToken;
-        config.telegramWebhookSecret = event.telegramCredentials.webhookSecret;
-        log.info("Telegram credentials loaded from credential vault");
-        registerTelegramCommands();
-        reconcileTelegramWebhook(config).catch((err) => {
-          log.error(
-            { err },
-            "Failed to reconcile Telegram webhook after credential change",
-          );
-        });
-      } else {
-        config.telegramBotToken = undefined;
-        config.telegramWebhookSecret = undefined;
-        log.info("Telegram credentials cleared");
-      }
-    }
+    const changed = applyCredentialChanges(
+      event,
+      config,
+      credentialMappings,
+      log,
+    );
 
-    if (event.twilioChanged) {
-      if (event.twilioCredentials) {
-        config.twilioAccountSid = event.twilioCredentials.accountSid;
-        config.twilioAuthToken = event.twilioCredentials.authToken;
-        log.info("Twilio credentials loaded from credential vault");
-      } else {
-        config.twilioAccountSid = undefined;
-        config.twilioAuthToken = undefined;
-        log.info("Twilio credentials cleared");
-      }
+    // Side effects keyed by service name
+    if (changed.has("telegram")) {
+      registerTelegramCommands();
+      reconcileTelegramWebhook(config).catch((err) => {
+        log.error(
+          { err },
+          "Failed to reconcile Telegram webhook after credential change",
+        );
+      });
     }
-
-    if (event.whatsappChanged) {
-      if (event.whatsappCredentials) {
-        config.whatsappPhoneNumberId = event.whatsappCredentials.phoneNumberId;
-        config.whatsappAccessToken = event.whatsappCredentials.accessToken;
-        config.whatsappAppSecret = event.whatsappCredentials.appSecret;
-        config.whatsappWebhookVerifyToken =
-          event.whatsappCredentials.webhookVerifyToken;
-        log.info("WhatsApp credentials loaded from credential vault");
-      } else {
-        config.whatsappPhoneNumberId = undefined;
-        config.whatsappAccessToken = undefined;
-        config.whatsappAppSecret = undefined;
-        config.whatsappWebhookVerifyToken = undefined;
-        log.info("WhatsApp credentials cleared");
-      }
-    }
-
-    if (event.slackChannelChanged && !slackFromEnv) {
-      if (event.slackChannelCredentials) {
-        config.slackChannelBotToken = event.slackChannelCredentials.botToken;
-        config.slackChannelAppToken = event.slackChannelCredentials.appToken;
-        log.info("Slack channel credentials loaded from credential vault");
-      } else {
-        config.slackChannelBotToken = undefined;
-        config.slackChannelAppToken = undefined;
-        log.info("Slack channel credentials cleared");
-      }
+    if (changed.has("slackChannel")) {
       startSlackSocket();
     }
   });


### PR DESCRIPTION
## Summary
- Extract credential service mappings and applyCredentialChanges() helper into new credential-mappings.ts
- Replace per-channel if blocks in CredentialWatcher consumer with single applyCredentialChanges() call
- Side effects (telegram webhook reconciliation, slack socket restart) remain as explicit post-update hooks

Part of plan: genericize-gateway-config.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
