### PR TITLE
refactor: replace hard-coded config-file handling with declarative mapping table

### DIFF
--- a/gateway/src/config-file-mappings.ts
+++ b/gateway/src/config-file-mappings.ts
@@ -1,0 +1,85 @@
+import type { GatewayConfig } from "./config.js";
+
+type ConfigFileMapping =
+  | {
+      key: string;
+      field: string;
+      configField: keyof GatewayConfig;
+      type: "string";
+    }
+  | {
+      key: string;
+      field: string;
+      configField: keyof GatewayConfig;
+      type: "record";
+    };
+
+export const CONFIG_FILE_MAPPINGS: ConfigFileMapping[] = [
+  {
+    key: "sms",
+    field: "phoneNumber",
+    configField: "twilioPhoneNumber",
+    type: "string",
+  },
+  {
+    key: "sms",
+    field: "assistantPhoneNumbers",
+    configField: "assistantPhoneNumbers",
+    type: "record",
+  },
+  {
+    key: "email",
+    field: "address",
+    configField: "assistantEmail",
+    type: "string",
+  },
+  {
+    key: "twilio",
+    field: "accountSid",
+    configField: "twilioAccountSid",
+    type: "string",
+  },
+  {
+    key: "ingress",
+    field: "publicBaseUrl",
+    configField: "ingressPublicBaseUrl",
+    type: "string",
+  },
+];
+
+export function applyConfigFileMappings(
+  data: Record<string, unknown>,
+  changedKeys: Set<string>,
+  config: GatewayConfig,
+): void {
+  for (const mapping of CONFIG_FILE_MAPPINGS) {
+    if (!changedKeys.has(mapping.key)) continue;
+    const section = data[mapping.key] as Record<string, unknown> | undefined;
+    const raw = section?.[mapping.field];
+    if (mapping.type === "string") {
+      (config as Record<string, unknown>)[mapping.configField] =
+        typeof raw === "string" ? raw || undefined : undefined;
+    } else {
+      (config as Record<string, unknown>)[mapping.configField] =
+        raw && typeof raw === "object" && !Array.isArray(raw) ? raw : undefined;
+    }
+  }
+}
+
+export function readConfigFileDefaults(
+  data: Record<string, unknown>,
+): Partial<Record<keyof GatewayConfig, unknown>> {
+  const defaults: Partial<Record<keyof GatewayConfig, unknown>> = {};
+  for (const mapping of CONFIG_FILE_MAPPINGS) {
+    const section = data[mapping.key] as Record<string, unknown> | undefined;
+    const raw = section?.[mapping.field];
+    if (mapping.type === "string") {
+      defaults[mapping.configField] =
+        typeof raw === "string" ? raw || undefined : undefined;
+    } else {
+      defaults[mapping.configField] =
+        raw && typeof raw === "object" && !Array.isArray(raw) ? raw : undefined;
+    }
+  }
+  return defaults;
+}

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { getLogger, type LogFileConfig } from "./logger.js";
+import { readConfigFileDefaults } from "./config-file-mappings.js";
 import {
   getRootDir,
   readCredential,
@@ -311,51 +312,31 @@ export async function loadConfig(): Promise<GatewayConfig> {
   let twilioAccountSid =
     process.env.TWILIO_ACCOUNT_SID || twilioCreds?.accountSid || undefined;
 
-  // Phone number: env var > config file sms.phoneNumber > credential store
-  let twilioPhoneNumber: string | undefined =
-    process.env.TWILIO_PHONE_NUMBER || undefined;
-  let assistantPhoneNumbers: Record<string, string> | undefined;
-  let assistantEmail: string | undefined;
+  // Read config.json defaults for fields that can come from the config file
+  let configFileData: Record<string, unknown> = {};
   try {
     const cfgPath = join(getRootDir(), "workspace", "config.json");
     const raw = readFileSync(cfgPath, "utf-8");
     const data = JSON.parse(raw);
-    if (
-      !twilioPhoneNumber &&
-      data?.sms?.phoneNumber &&
-      typeof data.sms.phoneNumber === "string"
-    ) {
-      twilioPhoneNumber = data.sms.phoneNumber;
-    }
-    if (
-      !twilioAccountSid &&
-      data?.twilio?.accountSid &&
-      typeof data.twilio.accountSid === "string"
-    ) {
-      twilioAccountSid = data.twilio.accountSid;
-    }
-    const rawMapping = data?.sms?.assistantPhoneNumbers;
-    if (
-      rawMapping &&
-      typeof rawMapping === "object" &&
-      !Array.isArray(rawMapping)
-    ) {
-      const normalized: Record<string, string> = {};
-      for (const [assistantId, phoneNumber] of Object.entries(
-        rawMapping as Record<string, unknown>,
-      )) {
-        if (typeof phoneNumber === "string" && phoneNumber.trim().length > 0) {
-          normalized[assistantId] = phoneNumber;
-        }
-      }
-      assistantPhoneNumbers = normalized;
-    }
-    if (data?.email?.address && typeof data.email.address === "string") {
-      assistantEmail = data.email.address;
+    if (data && typeof data === "object" && !Array.isArray(data)) {
+      configFileData = data as Record<string, unknown>;
     }
   } catch {
     // config file may not exist yet
   }
+  const configDefaults = readConfigFileDefaults(configFileData);
+
+  // Phone number: env var > config file > credential store
+  let twilioPhoneNumber: string | undefined =
+    process.env.TWILIO_PHONE_NUMBER ||
+    (configDefaults.twilioPhoneNumber as string | undefined);
+  if (!twilioAccountSid) {
+    twilioAccountSid = configDefaults.twilioAccountSid as string | undefined;
+  }
+  const assistantPhoneNumbers = configDefaults.assistantPhoneNumbers as
+    | Record<string, string>
+    | undefined;
+  const assistantEmail = configDefaults.assistantEmail as string | undefined;
   if (!twilioPhoneNumber) {
     twilioPhoneNumber =
       (await readCredential("credential:twilio:phone_number")) || undefined;
@@ -503,7 +484,9 @@ export async function loadConfig(): Promise<GatewayConfig> {
   }
   const trustProxy = trustProxyRaw === "true";
 
-  const ingressPublicBaseUrl = process.env.INGRESS_PUBLIC_BASE_URL || undefined;
+  const ingressPublicBaseUrl =
+    process.env.INGRESS_PUBLIC_BASE_URL ||
+    (configDefaults.ingressPublicBaseUrl as string | undefined);
 
   const logFileDir = process.env.GATEWAY_LOG_DIR || undefined;
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -63,6 +63,7 @@ import {
   type RouteDefinition,
   type GetClientIp,
 } from "./http/router.js";
+import { applyConfigFileMappings } from "./config-file-mappings.js";
 import { callTelegramApi } from "./telegram/api.js";
 import { reconcileTelegramWebhook } from "./telegram/webhook-manager.js";
 
@@ -938,63 +939,16 @@ async function main() {
   credentialWatcher.start();
 
   const configFileWatcher = new ConfigFileWatcher((event) => {
-    if (event.changedKeys.has("sms")) {
-      const sms = event.data.sms as
-        | {
-            phoneNumber?: string;
-            assistantPhoneNumbers?: Record<string, string>;
-          }
-        | undefined;
-      config.twilioPhoneNumber =
-        typeof sms?.phoneNumber === "string"
-          ? sms.phoneNumber || undefined
-          : undefined;
-      if (
-        sms?.assistantPhoneNumbers &&
-        typeof sms.assistantPhoneNumbers === "object" &&
-        !Array.isArray(sms.assistantPhoneNumbers)
-      ) {
-        config.assistantPhoneNumbers = sms.assistantPhoneNumbers as Record<
-          string,
-          string
-        >;
-      } else {
-        config.assistantPhoneNumbers = undefined;
-      }
-    }
+    applyConfigFileMappings(event.data, event.changedKeys, config);
 
-    if (event.changedKeys.has("email")) {
-      const email = event.data.email as { address?: string } | undefined;
-      config.assistantEmail =
-        typeof email?.address === "string"
-          ? email.address || undefined
-          : undefined;
-    }
-
-    if (event.changedKeys.has("twilio")) {
-      const twilio = event.data.twilio as { accountSid?: string } | undefined;
-      config.twilioAccountSid =
-        typeof twilio?.accountSid === "string"
-          ? twilio.accountSid || undefined
-          : undefined;
-    }
-
-    if (event.changedKeys.has("ingress")) {
-      const ingress = event.data.ingress as
-        | { publicBaseUrl?: string }
-        | undefined;
-      config.ingressPublicBaseUrl =
-        typeof ingress?.publicBaseUrl === "string"
-          ? ingress.publicBaseUrl || undefined
-          : undefined;
-      if (isTelegramConfigured()) {
-        reconcileTelegramWebhook(config).catch((err) => {
-          log.error(
-            { err },
-            "Failed to reconcile Telegram webhook after ingress URL change",
-          );
-        });
-      }
+    // Side effect: reconcile Telegram webhook when ingress URL changes
+    if (event.changedKeys.has("ingress") && isTelegramConfigured()) {
+      reconcileTelegramWebhook(config).catch((err) => {
+        log.error(
+          { err },
+          "Failed to reconcile Telegram webhook after ingress URL change",
+        );
+      });
     }
   });
 


### PR DESCRIPTION
## Summary
- Extract CONFIG_FILE_MAPPINGS table and generic helpers (applyConfigFileMappings, readConfigFileDefaults) into new config-file-mappings.ts
- Replace per-key if blocks in ConfigFileWatcher consumer with single applyConfigFileMappings() call
- Replace hard-coded config.json reads at startup in config.ts with readConfigFileDefaults()

Part of plan: genericize-gateway-config.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13657" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
