### PR TITLE
fix: gate telegram side effects on credentials being present

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -891,7 +891,7 @@ async function main() {
     );
 
     // Side effects keyed by service name
-    if (changed.has("telegram")) {
+    if (changed.has("telegram") && isTelegramConfigured()) {
       registerTelegramCommands();
       reconcileTelegramWebhook(config).catch((err) => {
         log.error(


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for genericize-gateway-config.md.

**Gap:** Telegram side effects fire on credential REMOVAL, not just addition
**What was expected:** registerTelegramCommands() and reconcileTelegramWebhook() should only fire when credentials are present
**What was found:** Side effects fired unconditionally on any telegram credential change, causing spurious errors on removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
