### PR TITLE
fix: revert progress view styling, inline permission chips, fix rehydration crash

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -427,8 +427,8 @@ struct AssistantProgressView: View {
                     .overlay(
                         Capsule().stroke(VColor.surfaceBorder, lineWidth: 1)
                     )
-                    .onHover { hovering in
-                        isOverflowPopoverShown = hovering
+                    .onTapGesture {
+                        isOverflowPopoverShown.toggle()
                     }
                     .popover(isPresented: $isOverflowPopoverShown, arrowEdge: .bottom) {
                         VStack(alignment: .leading, spacing: VSpacing.xs) {

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -35,6 +35,7 @@ struct AssistantProgressView: View {
     @State private var startDate: Date = Date()
     @State private var processingStartDate: Date?
     @State private var isOverflowPopoverShown: Bool = false
+    @State private var suppressNextExpand: Bool = false
 
     // MARK: - Derived State
 
@@ -224,6 +225,10 @@ struct AssistantProgressView: View {
 
     private var headerRow: some View {
         Button(action: {
+            if suppressNextExpand {
+                suppressNextExpand = false
+                return
+            }
             guard hasChevron else { return }
             suppressAutoScroll?()
             withAnimation(VAnimation.fast) {
@@ -428,6 +433,7 @@ struct AssistantProgressView: View {
                         Capsule().stroke(VColor.surfaceBorder, lineWidth: 1)
                     )
                     .onTapGesture {
+                        suppressNextExpand = true
                         isOverflowPopoverShown.toggle()
                     }
                     .popover(isPresented: $isOverflowPopoverShown, arrowEdge: .bottom) {

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -421,29 +421,32 @@ struct AssistantProgressView: View {
 
             // +N overflow badge with popover
             if overflow > 0 {
-                Text("+\(overflow)")
-                    .font(VFont.captionMedium)
-                    .foregroundColor(VColor.textSecondary)
-                    .padding(.horizontal, VSpacing.xs)
-                    .padding(.vertical, VSpacing.xxs)
-                    .background(
-                        Capsule().fill(VColor.backgroundSubtle)
-                    )
-                    .overlay(
-                        Capsule().stroke(VColor.surfaceBorder, lineWidth: 1)
-                    )
-                    .onTapGesture {
-                        suppressNextExpand = true
-                        isOverflowPopoverShown.toggle()
-                    }
-                    .popover(isPresented: $isOverflowPopoverShown, arrowEdge: .bottom) {
-                        VStack(alignment: .leading, spacing: VSpacing.xs) {
-                            ForEach(Array(resolved.dropFirst(2).enumerated()), id: \.offset) { _, confirmation in
-                                compactPermissionChip(confirmation)
-                            }
+                Button(action: {
+                    suppressNextExpand = true
+                    isOverflowPopoverShown.toggle()
+                }) {
+                    Text("+\(overflow)")
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textSecondary)
+                        .padding(.horizontal, VSpacing.xs)
+                        .padding(.vertical, VSpacing.xxs)
+                        .background(
+                            Capsule().fill(VColor.backgroundSubtle)
+                        )
+                        .overlay(
+                            Capsule().stroke(VColor.surfaceBorder, lineWidth: 1)
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("\(overflow) more permissions")
+                .popover(isPresented: $isOverflowPopoverShown, arrowEdge: .bottom) {
+                    VStack(alignment: .leading, spacing: VSpacing.xs) {
+                        ForEach(Array(resolved.dropFirst(2).enumerated()), id: \.offset) { _, confirmation in
+                            compactPermissionChip(confirmation)
                         }
-                        .padding(VSpacing.sm)
                     }
+                    .padding(VSpacing.sm)
+                }
             }
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -34,6 +34,7 @@ struct AssistantProgressView: View {
     @State private var isExpanded: Bool = false
     @State private var startDate: Date = Date()
     @State private var processingStartDate: Date?
+    @State private var isOverflowPopoverShown: Bool = false
 
     // MARK: - Derived State
 
@@ -146,10 +147,6 @@ struct AssistantProgressView: View {
                 }
                 return "Completed with blocked permissions"
             }
-            // Use the last tool call's reason as a summary of what was done
-            if let lastReason = toolCalls.last(where: { $0.reasonDescription != nil && !$0.reasonDescription!.isEmpty })?.reasonDescription {
-                return lastReason
-            }
             return "Completed \(toolCalls.count) step\(toolCalls.count == 1 ? "" : "s")"
         case .denied:
             let uniqueNames = Array(Set(toolCalls.map(\.toolName))).sorted()
@@ -169,21 +166,14 @@ struct AssistantProgressView: View {
             // Header row (always visible)
             headerRow
 
-            // Permission chips below header (when not expanded)
-            if !isExpanded {
-                permissionChips
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.bottom, VSpacing.sm)
-            }
-
             // Expanded content
             if isExpanded {
                 expandedContent
+                    .padding(.bottom, VSpacing.xs)
 
                 // Permission chips at bottom of expanded list
                 permissionChips
                     .padding(.horizontal, VSpacing.sm)
-                    .padding(.top, VSpacing.sm)
                     .padding(.bottom, VSpacing.sm)
             }
 
@@ -191,12 +181,11 @@ struct AssistantProgressView: View {
             if phase == .streamingCode, let code = streamingCodePreview {
                 CodePreviewView(code: code)
                     .padding(.horizontal, VSpacing.sm)
-                    .padding(.bottom, VSpacing.sm)
+                    .padding(.bottom, VSpacing.xs)
             }
         }
-        .padding(.bottom, isExpanded ? VSpacing.sm : 0)
         .background(VColor.surface.opacity(0.5))
-        .clipShape(RoundedRectangle(cornerRadius: VRadius.lg))
+        .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
         .onChange(of: phase) { _, newPhase in
             if newPhase == .processing {
                 processingStartDate = Date()
@@ -248,6 +237,11 @@ struct AssistantProgressView: View {
                 // Headline text with cross-fade
                 headlineLabel
 
+                // Inline permission chips (collapsed only, max 2 + overflow)
+                if !isExpanded {
+                    inlinePermissionChips
+                }
+
                 Spacer()
 
                 // Elapsed time: live counter when active, final duration when complete
@@ -267,7 +261,7 @@ struct AssistantProgressView: View {
         }
         .buttonStyle(.plain)
         .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.sm)
+        .padding(.vertical, VSpacing.xs)
     }
 
     // MARK: - Status Icon
@@ -276,24 +270,15 @@ struct AssistantProgressView: View {
     private var statusIcon: some View {
         switch phase {
         case .complete:
-            statusIconTile(
-                icon: hasDeniedTools ? .triangleAlert : .circleCheck,
-                iconColor: hasDeniedTools ? VColor.warning : VColor.iconAccent,
-                tileColor: hasDeniedTools ? Amber._200 : Forest._200
-            )
+            VIconView(hasDeniedTools ? .triangleAlert : .circleCheck, size: 12)
+                .foregroundColor(hasDeniedTools ? VColor.warning : VColor.iconAccent)
         case .denied:
             if decidedConfirmations.contains(where: { $0.state == .timedOut }) {
-                statusIconTile(
-                    icon: .clock,
-                    iconColor: VColor.textMuted,
-                    tileColor: Moss._200
-                )
+                VIconView(.clock, size: 12)
+                    .foregroundColor(VColor.textMuted)
             } else {
-                statusIconTile(
-                    icon: .circleAlert,
-                    iconColor: VColor.error,
-                    tileColor: Danger._200
-                )
+                VIconView(.circleAlert, size: 12)
+                    .foregroundColor(VColor.error)
             }
         default:
             Circle()
@@ -301,16 +286,6 @@ struct AssistantProgressView: View {
                 .frame(width: 8, height: 8)
                 .modifier(AssistantProgressPulsingModifier())
         }
-    }
-
-    private func statusIconTile(icon: VIcon, iconColor: Color, tileColor: Color) -> some View {
-        VIconView(icon, size: 14)
-            .foregroundColor(iconColor)
-            .padding(VSpacing.sm)
-            .background(
-                RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(tileColor)
-            )
     }
 
     // MARK: - Headline Label
@@ -413,10 +388,56 @@ struct AssistantProgressView: View {
     private var permissionChips: some View {
         let resolved = decidedConfirmations.filter { $0.state != .pending }
         if !resolved.isEmpty {
-            HStack(spacing: VSpacing.xs) {
+            FlowLayout(spacing: VSpacing.xs) {
                 ForEach(Array(resolved.enumerated()), id: \.offset) { _, confirmation in
                     compactPermissionChip(confirmation)
                 }
+            }
+        }
+    }
+
+    // MARK: - Inline Permission Chips (Collapsed Header)
+
+    @ViewBuilder
+    private var inlinePermissionChips: some View {
+        let resolved = decidedConfirmations.filter { $0.state != .pending }
+        if !resolved.isEmpty {
+            // Vertical divider
+            Divider()
+                .frame(height: 16)
+
+            // Show up to 2 chips inline
+            let visible = Array(resolved.prefix(2))
+            let overflow = resolved.count - visible.count
+
+            ForEach(Array(visible.enumerated()), id: \.offset) { _, confirmation in
+                compactPermissionChip(confirmation)
+            }
+
+            // +N overflow badge with popover
+            if overflow > 0 {
+                Text("+\(overflow)")
+                    .font(VFont.captionMedium)
+                    .foregroundColor(VColor.textSecondary)
+                    .padding(.horizontal, VSpacing.xs)
+                    .padding(.vertical, VSpacing.xxs)
+                    .background(
+                        Capsule().fill(VColor.backgroundSubtle)
+                    )
+                    .overlay(
+                        Capsule().stroke(VColor.surfaceBorder, lineWidth: 1)
+                    )
+                    .onHover { hovering in
+                        isOverflowPopoverShown = hovering
+                    }
+                    .popover(isPresented: $isOverflowPopoverShown, arrowEdge: .bottom) {
+                        VStack(alignment: .leading, spacing: VSpacing.xs) {
+                            ForEach(Array(resolved.dropFirst(2).enumerated()), id: \.offset) { _, confirmation in
+                                compactPermissionChip(confirmation)
+                            }
+                        }
+                        .padding(VSpacing.sm)
+                    }
             }
         }
     }
@@ -509,11 +530,11 @@ private struct StepDetailRow: View {
                 HStack(spacing: VSpacing.sm) {
                     // Status icon
                     if toolCall.isComplete {
-                        VIconView(toolCall.isError ? .circleAlert : .circleCheck, size: 14)
+                        VIconView(toolCall.isError ? .circleAlert : .circleCheck, size: 12)
                             .foregroundColor(toolCall.isError ? VColor.error : VColor.iconAccent)
                             .frame(width: 16)
                     } else if phase == .denied {
-                        VIconView(.circleAlert, size: 14)
+                        VIconView(.circleAlert, size: 12)
                             .foregroundColor(VColor.textMuted)
                             .frame(width: 16)
                     } else {
@@ -837,6 +858,59 @@ private struct AssistantProgressPulsingModifier: ViewModifier {
                 value: isPulsing
             )
             .onAppear { isPulsing = true }
+    }
+}
+
+// MARK: - Flow Layout
+
+/// A simple wrapping layout that arranges children left-to-right and wraps
+/// to the next row when the available width is exceeded.
+private struct FlowLayout: Layout {
+    var spacing: CGFloat = VSpacing.xs
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let rows = computeRows(proposal: proposal, subviews: subviews)
+        let height = rows.enumerated().reduce(CGFloat.zero) { total, pair in
+            let rowHeight = pair.element.map(\.size.height).max() ?? 0
+            return total + rowHeight + (pair.offset > 0 ? spacing : 0)
+        }
+        return CGSize(width: proposal.width ?? .infinity, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let rows = computeRows(proposal: proposal, subviews: subviews)
+        var y = bounds.minY
+        for row in rows {
+            let rowHeight = row.map(\.size.height).max() ?? 0
+            var x = bounds.minX
+            for item in row {
+                item.subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(item.size))
+                x += item.size.width + spacing
+            }
+            y += rowHeight + spacing
+        }
+    }
+
+    private struct LayoutItem {
+        let subview: LayoutSubview
+        let size: CGSize
+    }
+
+    private func computeRows(proposal: ProposedViewSize, subviews: Subviews) -> [[LayoutItem]] {
+        let maxWidth = proposal.width ?? .infinity
+        var rows: [[LayoutItem]] = [[]]
+        var rowWidth: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            let needed = rowWidth > 0 ? size.width + spacing : size.width
+            if rowWidth + needed > maxWidth && !rows[rows.count - 1].isEmpty {
+                rows.append([])
+                rowWidth = 0
+            }
+            rows[rows.count - 1].append(LayoutItem(subview: subview, size: size))
+            rowWidth += rowWidth > 0 ? size.width + spacing : size.width
+        }
+        return rows
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -874,7 +874,12 @@ private struct FlowLayout: Layout {
             let rowHeight = pair.element.map(\.size.height).max() ?? 0
             return total + rowHeight + (pair.offset > 0 ? spacing : 0)
         }
-        return CGSize(width: proposal.width ?? .infinity, height: height)
+        let width: CGFloat = proposal.width ?? rows.map { row in
+            row.enumerated().reduce(CGFloat.zero) { total, pair in
+                total + pair.element.size.width + (pair.offset > 0 ? spacing : 0)
+            }
+        }.max() ?? 0
+        return CGSize(width: width, height: height)
     }
 
     func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -39,6 +39,18 @@ extension ChatBubble {
         case texts([Int])
         case toolCalls([Int])
         case surface(Int)
+
+        /// Stable identity based on the first index in the group.
+        /// Using \.self as ForEach identity causes SwiftUI to destroy and recreate
+        /// views when new items are appended (e.g. a new tool call), which resets
+        /// @State like isExpanded. This ID stays constant as the group grows.
+        var stableId: String {
+            switch self {
+            case .texts(let indices): return "t\(indices.first ?? 0)"
+            case .toolCalls(let indices): return "tc\(indices.first ?? 0)"
+            case .surface(let i): return "s\(i)"
+            }
+        }
     }
 
     func groupContentBlocks() -> [ContentGroup] {
@@ -198,7 +210,7 @@ extension ChatBubble {
         // \.offset so SwiftUI can skip re-evaluating children whose content
         // hasn't changed — prevents a view-update death spiral on long
         // conversations with many interleaved blocks.
-        ForEach(groups, id: \.self) { group in
+        ForEach(groups, id: \.stableId) { group in
             switch group {
             case .texts(let indices):
                 let joined = indices

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -206,10 +206,9 @@ extension ChatBubble {
         }.first
 
         // Render all content groups in order: text, tool calls, and surfaces.
-        // Uses \.self identity (backed by Hashable conformance) instead of
-        // \.offset so SwiftUI can skip re-evaluating children whose content
-        // hasn't changed — prevents a view-update death spiral on long
-        // conversations with many interleaved blocks.
+        // Uses \.stableId (based on the first index in each group) so SwiftUI
+        // preserves @State (like isExpanded) when new items are appended to a
+        // group, and skips re-evaluating children whose identity hasn't changed.
         ForEach(groups, id: \.stableId) { group in
             switch group {
             case .texts(let indices):

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -641,10 +641,12 @@ public final class ChatViewModel: ObservableObject {
         // causes separate tool groups to merge into one massive progress view.
         // Text is already displayed correctly from the original segments — rehydration
         // is primarily needed for tool call details (inputs, results, images).
+        var didUpdateText = false
         if let fullText = response.text {
             let hasInterleavedText = messages[idx].textSegments.count > 1
             if !hasInterleavedText {
                 messages[idx].textSegments = fullText.isEmpty ? [] : [fullText]
+                didUpdateText = true
             }
         }
 
@@ -675,7 +677,12 @@ public final class ChatViewModel: ObservableObject {
             }
         }
 
-        messages[idx].wasTruncated = false
+        // Only clear wasTruncated if text was actually updated; interleaved
+        // messages skip text replacement to preserve contentOrder, so leaving
+        // wasTruncated true would allow a future rehydration to retry.
+        if didUpdateText || response.text == nil {
+            messages[idx].wasTruncated = false
+        }
         messages[idx].isContentStripped = false
     }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -635,21 +635,16 @@ public final class ChatViewModel: ObservableObject {
     public func handleMessageContentResponse(_ response: IPCMessageContentResponse) {
         guard let idx = messages.firstIndex(where: { $0.daemonMessageId == response.messageId }) else { return }
 
-        // Update text with full content. When collapsing multiple text segments
-        // into one, also update contentOrder so stale .text(N>0) references are
-        // removed — otherwise interleaved content orders become invalid.
+        // Only update text when the message has a single segment (non-interleaved).
+        // Interleaved messages have multiple text segments separated by tool calls;
+        // collapsing them into one destroys the contentOrder interleaving, which
+        // causes separate tool groups to merge into one massive progress view.
+        // Text is already displayed correctly from the original segments — rehydration
+        // is primarily needed for tool call details (inputs, results, images).
         if let fullText = response.text {
-            messages[idx].textSegments = fullText.isEmpty ? [] : [fullText]
-            if !messages[idx].contentOrder.isEmpty {
-                var seenText = false
-                messages[idx].contentOrder = messages[idx].contentOrder.compactMap { entry in
-                    if case .text = entry {
-                        if seenText { return nil }
-                        seenText = true
-                        return .text(0)
-                    }
-                    return entry
-                }
+            let hasInterleavedText = messages[idx].textSegments.count > 1
+            if !hasInterleavedText {
+                messages[idx].textSegments = fullText.isEmpty ? [] : [fullText]
             }
         }
 

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -641,12 +641,10 @@ public final class ChatViewModel: ObservableObject {
         // causes separate tool groups to merge into one massive progress view.
         // Text is already displayed correctly from the original segments — rehydration
         // is primarily needed for tool call details (inputs, results, images).
-        var didUpdateText = false
         if let fullText = response.text {
             let hasInterleavedText = messages[idx].textSegments.count > 1
             if !hasInterleavedText {
                 messages[idx].textSegments = fullText.isEmpty ? [] : [fullText]
-                didUpdateText = true
             }
         }
 
@@ -677,12 +675,10 @@ public final class ChatViewModel: ObservableObject {
             }
         }
 
-        // Only clear wasTruncated if text was actually updated; interleaved
-        // messages skip text replacement to preserve contentOrder, so leaving
-        // wasTruncated true would allow a future rehydration to retry.
-        if didUpdateText || response.text == nil {
-            messages[idx].wasTruncated = false
-        }
+        // Clear unconditionally — even when text replacement was skipped for
+        // interleaved messages, tool call data has been rehydrated. Leaving
+        // wasTruncated true would cause infinite rehydration requests.
+        messages[idx].wasTruncated = false
         messages[idx].isContentStripped = false
     }
 


### PR DESCRIPTION
## Summary
- **Revert styling from PR #13030**: Remove tiled icon backgrounds (`statusIconTile()`), revert padding/radius values to smaller originals, remove `reasonDescription` headline override (always show "Completed N steps")
- **Inline permission chips**: In collapsed mode, show permission badges inline in the header row (divider + max 2 chips + overflow popover). In expanded mode, use `FlowLayout` for wrapping chips instead of `HStack`
- **Fix expanded view collapsing**: Add `stableId` to `ContentGroup` for stable `ForEach` identity so `@State isExpanded` persists when new tool calls are appended
- **Fix rehydration crash/freeze**: `handleMessageContentResponse` was collapsing all text segments into one, destroying `contentOrder` interleaving and merging separate tool groups into one massive view. Now skips text collapsing for interleaved messages

## Changes

### AssistantProgressView.swift
- Removed `statusIconTile()` function — replaced 3 call sites with plain `VIconView` at size 12
- Removed `reasonDescription` headline override — `.complete` always shows "Completed N steps"
- Header padding: `VSpacing.sm` → `VSpacing.xs`
- Container radius: `VRadius.lg` → `VRadius.md`
- Code preview padding: `VSpacing.sm` → `VSpacing.xs`
- Removed extra bottom/top padding on expanded content and permission chips
- Added `inlinePermissionChips` view (collapsed mode: divider + max 2 chips + `+N` overflow badge with hover popover)
- Permission chips in expanded mode now use `FlowLayout` (wrapping) instead of `HStack`
- Step detail row icons: size 14 → 12

### ChatBubbleInterleavedContent.swift
- Added `stableId` property to `ContentGroup` enum (stable identity based on first index)
- Changed `ForEach` identity from `\.self` to `\.stableId`

### ChatViewModel.swift
- Fixed `handleMessageContentResponse` to skip text segment collapsing for interleaved messages, preserving `contentOrder` structure

## Test plan
- [ ] Non-permission completion → green "Completed N steps"
- [ ] Permission denied → amber warning with inline chips in collapsed mode
- [ ] 3+ permissions → max 2 chips shown, +N overflow badge with hover popover
- [ ] Expanded mode → chips wrap via FlowLayout at bottom
- [ ] Expanding a progress view stays expanded when new tool calls stream in
- [ ] Clicking to expand a rehydrated interleaved message does not freeze the app
- [ ] Individual tool step icons are same size as main status icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
