### PR TITLE
feat: add `contacts upsert` CLI subcommand

### DIFF
--- a/assistant/src/cli/contacts.ts
+++ b/assistant/src/cli/contacts.ts
@@ -8,7 +8,12 @@ import {
   searchContacts,
   upsertContact,
 } from "../contacts/contact-store.js";
-import type { ContactRole } from "../contacts/types.js";
+import type {
+  ChannelPolicy,
+  ChannelStatus,
+  ContactRole,
+  ContactType,
+} from "../contacts/types.js";
 import { initializeDb } from "../memory/db.js";
 import {
   createIngressInvite,
@@ -248,7 +253,7 @@ Examples:
             displayName: opts.displayName,
             notes: opts.notes,
             role: opts.role as ContactRole | undefined,
-            contactType: opts.contactType as "human" | "assistant" | undefined,
+            contactType: opts.contactType as ContactType | undefined,
             channels: channels as
               | {
                   type: string;
@@ -256,8 +261,8 @@ Examples:
                   isPrimary?: boolean;
                   externalUserId?: string;
                   externalChatId?: string;
-                  status?: string;
-                  policy?: string;
+                  status?: ChannelStatus;
+                  policy?: ChannelPolicy;
                 }[]
               | undefined,
           });

--- a/assistant/src/cli/contacts.ts
+++ b/assistant/src/cli/contacts.ts
@@ -6,6 +6,7 @@ import {
   listContacts,
   mergeContacts,
   searchContacts,
+  upsertContact,
 } from "../contacts/contact-store.js";
 import type { ContactRole } from "../contacts/types.js";
 import { initializeDb } from "../memory/db.js";
@@ -36,6 +37,7 @@ is the source of truth for identity resolution across all channels.
 Examples:
   $ assistant contacts list
   $ assistant contacts get abc-123
+  $ assistant contacts upsert --display-name "Alice"
   $ assistant contacts merge keep-id merge-id
   $ assistant contacts invites list`,
   );
@@ -158,6 +160,109 @@ Examples:
           initializeDb();
           const contact = mergeContacts(keepId, mergeId);
           writeOutput(cmd, { ok: true, contact });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          writeOutput(cmd, { ok: false, error: message });
+          process.exitCode = 1;
+        }
+      },
+    );
+
+  contacts
+    .command("upsert")
+    .description("Create or update a contact")
+    .requiredOption("--display-name <name>", "Display name for the contact")
+    .option("--id <id>", "Contact ID — provide to update an existing contact")
+    .option("--notes <notes>", "Free-text notes about the contact")
+    .option(
+      "--role <role>",
+      "Contact role: contact or guardian (default: contact)",
+      "contact",
+    )
+    .option(
+      "--contact-type <type>",
+      "Contact type: human or assistant (default: human)",
+      "human",
+    )
+    .option(
+      "--channels <json>",
+      "JSON array of channel objects, each with type, address, and optional isPrimary, externalUserId, externalChatId, status, policy",
+    )
+    .addHelpText(
+      "after",
+      `
+Creates a new contact or updates an existing one. When --id is provided and
+matches an existing contact, that contact is updated. When --id is omitted,
+a new contact is created with a generated UUID.
+
+The --channels flag accepts a JSON array of channel objects. Each object must
+have "type" (e.g. telegram, sms, voice, email, whatsapp) and "address" fields.
+Optional channel fields: isPrimary (boolean), externalUserId, externalChatId,
+status (active, revoked, blocked), policy (allow, deny).
+
+Examples:
+  $ assistant contacts upsert --display-name "Alice" --json
+  $ assistant contacts upsert --display-name "Alice" --id abc-123 --notes "Updated notes" --json
+  $ assistant contacts upsert --display-name "Bob" --role guardian --json
+  $ assistant contacts upsert --display-name "Bob" --channels '[{"type":"telegram","address":"12345","externalUserId":"12345","status":"active","policy":"allow"}]' --json`,
+    )
+    .action(
+      async (
+        opts: {
+          displayName: string;
+          id?: string;
+          notes?: string;
+          role?: string;
+          contactType?: string;
+          channels?: string;
+        },
+        cmd: Command,
+      ) => {
+        try {
+          initializeDb();
+
+          let channels: unknown[] | undefined;
+          if (opts.channels) {
+            try {
+              channels = JSON.parse(opts.channels);
+              if (!Array.isArray(channels)) {
+                writeOutput(cmd, {
+                  ok: false,
+                  error: "--channels must be a JSON array",
+                });
+                process.exitCode = 1;
+                return;
+              }
+            } catch {
+              writeOutput(cmd, {
+                ok: false,
+                error: `Invalid JSON for --channels: ${opts.channels}`,
+              });
+              process.exitCode = 1;
+              return;
+            }
+          }
+
+          const result = upsertContact({
+            id: opts.id,
+            displayName: opts.displayName,
+            notes: opts.notes,
+            role: opts.role as ContactRole | undefined,
+            contactType: opts.contactType as "human" | "assistant" | undefined,
+            channels: channels as
+              | {
+                  type: string;
+                  address: string;
+                  isPrimary?: boolean;
+                  externalUserId?: string;
+                  externalChatId?: string;
+                  status?: string;
+                  policy?: string;
+                }[]
+              | undefined,
+          });
+
+          writeOutput(cmd, { ok: true, contact: result });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           writeOutput(cmd, { ok: false, error: message });


### PR DESCRIPTION
## Summary
- Adds a new `contacts upsert` CLI subcommand for creating/updating contacts directly from the command line
- Accepts `--display-name`, `--id`, `--notes`, `--role`, `--contact-type`, and `--channels` (JSON) flags
- Calls the contact-store service layer directly (no gateway HTTP proxy)

Part of plan: contacts-skill-cli-migration.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
