### PR TITLE
feat: gate multifile app builder prompt behind feature flag

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -25,7 +25,16 @@ You are an expert app builder and visual designer. When the user asks you to cre
 
 **Make creative decisions on behalf of the user.** They want to be delighted, not consulted. Pick the accent color. Choose between a dark moody aesthetic or a light airy one. Decide if cards should have glassmorphism or layered shadows. Add a background pattern or gradient. These are YOUR decisions as the designer.
 
+<!-- feature:app-builder-multifile:start -->
+
 **Prefer multi-file TSX projects** for any non-trivial app. They give you component reuse, TypeScript safety, and cleaner organization. Fall back to single-file HTML only for the simplest one-off pages.
+
+<!-- feature:app-builder-multifile:end -->
+<!-- feature:app-builder-multifile:alt -->
+
+**Always build single-file HTML apps.** Write a complete, self-contained HTML document with all CSS in `<style>` and all JavaScript in `<script>`. Do not use multi-file projects or TSX.
+
+<!-- feature:app-builder-multifile:alt:end -->
 
 **Only ask questions when the request is genuinely ambiguous** — e.g., "build me an app" with no indication of what kind. Even then, prefer building something impressive based on context clues over asking a battery of questions.
 
@@ -69,7 +78,11 @@ Example schema for a project tracker:
 
 ### 3. Build the App
 
-Apps are rendered inside a sandboxed WebView on macOS. You can build them in two formats: **multi-file TSX** (preferred) or **single-file HTML** (legacy).
+Apps are rendered inside a sandboxed WebView on macOS.
+
+<!-- feature:app-builder-multifile:start -->
+
+You can build them in two formats: **multi-file TSX** (preferred) or **single-file HTML** (legacy).
 
 #### Multi-file TSX projects (preferred)
 
@@ -198,10 +211,11 @@ app_file_write(app_id, "src/styles.css", `.app { padding: var(--v-spacing-lg); }
 - No external fonts, images, or resources — use system fonts and CSS/SVG for visuals
 - Design for 400-600px width with graceful resizing
 - The WebView blocks all navigation — links and form `action` attributes won't work
+<!-- feature:app-builder-multifile:end -->
 
-#### Single HTML file (legacy)
+#### Single HTML file
 
-Use this format only for the simplest one-off pages. Write a complete, self-contained HTML document.
+Write a complete, self-contained HTML document.
 
 **Technical constraints (single-file):**
 

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -25,6 +25,8 @@ import { parseToolManifestFile } from "../skills/tool-manifest.js";
 import { computeSkillVersionHash } from "../skills/version-hash.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceSkillsDir } from "../util/platform.js";
+import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
+import { getConfig } from "./loader.js";
 import { stripCommentLines } from "./system-prompt.js";
 
 const log = getLogger("skills");
@@ -968,6 +970,39 @@ export function loadSkillCatalog(
   return catalog;
 }
 
+/**
+ * Process feature-gated sections in skill body markdown.
+ *
+ * Markers:
+ *   <!-- feature:<flag-id>:start --> ... <!-- feature:<flag-id>:end -->
+ *     Content included only when the flag is enabled.
+ *   <!-- feature:<flag-id>:alt --> ... <!-- feature:<flag-id>:alt:end -->
+ *     Fallback content included only when the flag is disabled.
+ */
+function applyFeatureGatedSections(body: string): string {
+  const config = getConfig();
+  // Match feature:*:start/end blocks
+  const mainRe =
+    /<!-- feature:([^:]+):start -->\n?([\s\S]*?)<!-- feature:\1:end -->\n?/g;
+  // Match feature:*:alt/alt:end blocks
+  const altRe =
+    /<!-- feature:([^:]+):alt -->\n?([\s\S]*?)<!-- feature:\1:alt:end -->\n?/g;
+
+  let result = body;
+
+  result = result.replace(mainRe, (_match, flagId: string, content: string) => {
+    const key = `feature_flags.${flagId}.enabled`;
+    return isAssistantFeatureFlagEnabled(key, config) ? content : "";
+  });
+
+  result = result.replace(altRe, (_match, flagId: string, content: string) => {
+    const key = `feature_flags.${flagId}.enabled`;
+    return isAssistantFeatureFlagEnabled(key, config) ? "" : content;
+  });
+
+  return result;
+}
+
 function loadSkillDefinition(skill: SkillSummary): SkillLookupResult {
   let loaded: SkillDefinition | null;
   if (skill.bundled) {
@@ -992,6 +1027,8 @@ function loadSkillDefinition(skill: SkillSummary): SkillLookupResult {
   }
   // Replace {baseDir} placeholders with the actual skill directory path
   loaded.body = loaded.body.replaceAll("{baseDir}", loaded.directoryPath);
+  // Strip feature-gated sections based on assistant feature flags
+  loaded.body = applyFeatureGatedSections(loaded.body);
   return { skill: loaded };
 }
 


### PR DESCRIPTION
## Summary

- When `app-builder-multifile` flag is off (default), the skill prompt tells Claude to always build single-file HTML apps and strips all multifile TSX documentation
- When enabled, the full multifile docs and "prefer multifile" guidance are included
- Adds a generic `<!-- feature:<flag-id>:start/end -->` marker system for conditionally including SKILL.md sections based on feature flags

## Test plan

- [ ] With flag off (default): load `app-builder` skill, verify prompt says "Always build single-file HTML apps" and has no multifile/TSX/Preact docs
- [ ] With flag on: verify full multifile documentation is present
- [ ] Create an app with flag off → should produce single-file HTML
- [ ] Create an app with flag on → should produce multifile TSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
