### PR TITLE
fix: correct prerequisites gateway dependency claim in contacts SKILL.md

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -9,7 +9,8 @@ Manage the user's contacts, relationship graph, access control (trusted contacts
 
 ## Prerequisites
 
-- This skill uses `assistant contacts` CLI commands and `assistant channels` CLI commands. The CLI calls the service layer directly — no gateway dependency.
+- `assistant contacts` CLI commands call the service layer directly and do not require the assistant to be running.
+- `assistant channels` and `assistant integrations` CLI commands (e.g. `assistant channels readiness`, `assistant integrations telegram config`) require the assistant to be running because they call the gateway.
 - All CLI commands support `--json` for machine-readable output.
 
 ## Contact Management


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contacts-skill-cli-migration.md.

**Gap:** SKILL.md prerequisites incorrectly claim no gateway dependency
**What was expected:** Prerequisites should accurately describe which commands need the gateway
**What was found:** `assistant channels readiness` and `assistant integrations telegram config` both call the gateway via `gatewayGet()`, contradicting the 'no gateway dependency' claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
