### PR TITLE
fix: clear stale reason fields in contacts channels update-status CLI

### DIFF
--- a/assistant/src/cli/contacts.ts
+++ b/assistant/src/cli/contacts.ts
@@ -386,15 +386,18 @@ Examples:
           const status = opts.status as ChannelStatus | undefined;
           const policy = opts.policy as ChannelPolicy | undefined;
 
-          let revokedReason: string | null | undefined;
-          let blockedReason: string | null | undefined;
-          if (opts.reason) {
-            if (status === "revoked") {
-              revokedReason = opts.reason;
-            } else if (status === "blocked") {
-              blockedReason = opts.reason;
-            }
-          }
+          const revokedReason: string | null | undefined =
+            status !== undefined
+              ? status === "revoked"
+                ? (opts.reason ?? null)
+                : null
+              : undefined;
+          const blockedReason: string | null | undefined =
+            status !== undefined
+              ? status === "blocked"
+                ? (opts.reason ?? null)
+                : null
+              : undefined;
 
           const result = updateChannelStatus(channelId, {
             status,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for contacts-skill-cli-migration.md.

**Gap:** CLI update-status does not clear stale reason fields when changing status
**What was expected:** When changing status from revoked/blocked to active, revokedReason/blockedReason should be cleared (set to null), matching gateway and daemon handler behavior.
**What was found:** CLI only set reasons when --reason was provided, never cleared stale ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
