### PR TITLE
fix: fall back to daemon HTML when app has no files on disk

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
@@ -151,6 +151,16 @@ extension AppDelegate {
                         messageId: nil
                     )
                     self.surfaceManager.showSurface(surfaceMsg)
+
+                    // Register in the app list so it appears in Things
+                    self.mainWindow?.appListManager.recordAppOpen(
+                        id: surfaceId,
+                        name: manifest.name,
+                        icon: manifest.icon,
+                        appType: "app",
+                        description: manifest.description
+                    )
+
                     onSuccess?()
                 }
             } catch {

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -459,11 +459,18 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 <script>setTimeout(()=>{window.location.href='\(distSchemeURL)'},2000)</script></body></html>
                 """
                 webView.loadHTMLString(buildingHTML, baseURL: URL(string: origin))
+            } else if FileManager.default.fileExists(atPath: distIndex.path) {
+                let schemeURL = URL(string: "vellumapp://\(appId)/dist/index.html")!
+                webView.load(URLRequest(url: schemeURL))
+            } else if FileManager.default.fileExists(atPath: appDir.appendingPathComponent("index.html").path) {
+                let schemeURL = URL(string: "vellumapp://\(appId)/index.html")!
+                webView.load(URLRequest(url: schemeURL))
+            } else if !data.html.isEmpty {
+                // No files on disk — use daemon-provided HTML from the surface message
+                let origin = "vellumapp://\(appId)/"
+                webView.loadHTMLString(data.html, baseURL: URL(string: origin))
             } else {
-                let entryPath = FileManager.default.fileExists(atPath: distIndex.path)
-                    ? "dist/index.html"
-                    : "index.html"
-                let schemeURL = URL(string: "vellumapp://\(appId)/\(entryPath)")!
+                let schemeURL = URL(string: "vellumapp://\(appId)/index.html")!
                 webView.load(URLRequest(url: schemeURL))
             }
         } else {

--- a/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/DynamicPageSurfaceView.swift
@@ -466,8 +466,9 @@ struct DynamicPageSurfaceView: NSViewRepresentable {
                 let schemeURL = URL(string: "vellumapp://\(appId)/index.html")!
                 webView.load(URLRequest(url: schemeURL))
             } else if !data.html.isEmpty {
-                // No files on disk — use daemon-provided HTML from the surface message
-                let origin = "vellumapp://\(appId)/"
+                // No files on disk — use daemon-provided HTML from the surface message.
+                // Use the same origin as updateNSView so localStorage persists across reloads.
+                let origin = "https://\(appId).vellum.local/"
                 webView.loadHTMLString(data.html, baseURL: URL(string: origin))
             } else {
                 let schemeURL = URL(string: "vellumapp://\(appId)/index.html")!


### PR DESCRIPTION
## Summary

- When opening a multifile app from the Things page, the `DynamicPageSurfaceView` tried to load from disk via the scheme handler even when no `dist/` or `index.html` existed on disk
- This caused "File not found: dist/index.html" errors for apps whose compilation output wasn't on disk yet
- Now falls back to `data.html` from the daemon's `ui_surface_show` response when no files are found on disk

The root cause: `sendAppOpen` triggers daemon compilation which writes `dist/` and sends `ui_surface_show` with compiled HTML, but the Swift view loaded from disk before the daemon had responded. The "Building..." placeholder only triggers when `src/` exists, missing the case where a formatVersion 2 app has no source files on disk.

## Test plan

- [ ] Open a multifile app from Things page → should load correctly
- [ ] Open a multifile app from chat → still works (unchanged path)
- [ ] Open a single-file app from Things → still works (has index.html on disk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
