### PR TITLE
chore: remove SMS from guardian outbound verification flows

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -32,13 +32,6 @@ mock.module("../util/logger.js", () => ({
 
 import type * as net from "node:net";
 
-// SMS delivery calls are tracked via the globalThis.fetch mock below.
-const smsSendCalls: Array<{
-  to: string;
-  text: string;
-  assistantId?: string;
-}> = [];
-
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => true,
   getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
@@ -87,15 +80,6 @@ globalThis.fetch = (async (
       : input instanceof URL
         ? input.toString()
         : input.url;
-  if (url.includes("/deliver/sms") && init?.method === "POST") {
-    const body = JSON.parse(init.body as string) as {
-      to: string;
-      text: string;
-      assistantId?: string;
-    };
-    smsSendCalls.push(body);
-    return new Response(JSON.stringify({ ok: true }), { status: 200 });
-  }
   if (url.includes("/deliver/telegram") && init?.method === "POST") {
     const body = JSON.parse(init.body as string) as {
       chatId: string;
@@ -161,7 +145,6 @@ import {
   validateAndConsumeChallenge,
 } from "../runtime/channel-guardian-service.js";
 import {
-  composeVerificationSms,
   composeVerificationTelegram,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,
 } from "../runtime/guardian-verification-templates.js";
@@ -186,7 +169,6 @@ function resetTables(): void {
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
   db.run("DELETE FROM external_conversation_bindings");
-  smsSendCalls.length = 0;
   telegramDeliverCalls.length = 0;
   voiceCallInitCalls.length = 0;
   mockBotUsername = "test_bot";
@@ -2854,29 +2836,6 @@ describe("outbound SMS verification", () => {
     }
   });
 
-  test("template composer returns expected SMS format", () => {
-    const challengeSms = composeVerificationSms(
-      GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST,
-      { code: "123456", expiresInMinutes: 10 },
-    );
-    // Code should NOT appear in the message — user sees it in the app
-    expect(challengeSms).not.toContain("123456");
-    expect(challengeSms).toContain("code you were given");
-
-    const resendSms = composeVerificationSms(
-      GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND,
-      { code: "ABCDEF", expiresInMinutes: 5 },
-    );
-    expect(resendSms).not.toContain("ABCDEF");
-    expect(resendSms).toContain("resent");
-
-    const alreadySms = composeVerificationSms(
-      GUARDIAN_VERIFY_TEMPLATE_KEYS.ALREADY_VERIFIED,
-      { code: "unused", expiresInMinutes: 0 },
-    );
-    expect(alreadySms).toContain("already verified");
-  });
-
   test("start_outbound rejects unsupported channels", async () => {
     const { ctx, lastResponse } = createMockCtx();
     await handleGuardianVerification(
@@ -2896,14 +2855,14 @@ describe("outbound SMS verification", () => {
     expect(resp!.error).toBe("unsupported_channel");
   });
 
-  test("start_outbound rejects missing destination", async () => {
+  test("start_outbound rejects SMS as unsupported channel", async () => {
     const { ctx, lastResponse } = createMockCtx();
     await handleGuardianVerification(
       {
         type: "guardian_verification",
         action: "start_outbound",
         channel: "sms",
-        // no destination
+        destination: "+15551234567",
       },
       mockSocket,
       ctx,
@@ -2912,70 +2871,7 @@ describe("outbound SMS verification", () => {
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe("missing_destination");
-  });
-
-  test("start_outbound rejects unparseable phone number", async () => {
-    const { ctx, lastResponse } = createMockCtx();
-    await handleGuardianVerification(
-      {
-        type: "guardian_verification",
-        action: "start_outbound",
-        channel: "sms",
-        destination: "not-a-phone",
-      },
-      mockSocket,
-      ctx,
-    );
-
-    const resp = lastResponse();
-    expect(resp).not.toBeNull();
-    expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe("invalid_destination");
-  });
-
-  test("start_outbound normalizes formatted phone number for SMS", async () => {
-    const { ctx, lastResponse } = createMockCtx();
-    await handleGuardianVerification(
-      {
-        type: "guardian_verification",
-        action: "start_outbound",
-        channel: "sms",
-        destination: "(555) 123-4567",
-      },
-      mockSocket,
-      ctx,
-    );
-
-    const resp = lastResponse();
-    expect(resp).not.toBeNull();
-    expect(resp!.success).toBe(true);
-    expect(resp!.verificationSessionId).toBeDefined();
-    expect(resp!.secret).toBeDefined();
-
-    // Verify the session was created with the normalized E.164 number
-    const session = serviceFindActiveSession("sms");
-    expect(session).not.toBeNull();
-    expect(session!.expectedPhoneE164).toBe("+15551234567");
-    expect(session!.destinationAddress).toBe("+15551234567");
-
-    // Allow fire-and-forget SMS delivery to complete
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    // Verify SMS was sent to the normalized number
-    expect(smsSendCalls.length).toBeGreaterThanOrEqual(1);
-    const lastSms = smsSendCalls[smsSendCalls.length - 1];
-    expect(lastSms.to).toBe("+15551234567");
-  });
-
-  test("template composer includes Vellum assistant prefix", () => {
-    const sms = composeVerificationSms(
-      GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST,
-      { code: "999999", expiresInMinutes: 10, assistantName: "MyBot" },
-    );
-    expect(sms).toContain("Vellum assistant");
-    // Code should NOT appear in the message
-    expect(sms).not.toContain("999999");
+    expect(resp!.error).toBe("unsupported_channel");
   });
 
   test("cancel_outbound returns error when no active session", async () => {
@@ -2984,7 +2880,7 @@ describe("outbound SMS verification", () => {
       {
         type: "guardian_verification",
         action: "cancel_outbound",
-        channel: "sms",
+        channel: "telegram",
       },
       mockSocket,
       ctx,

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -43,13 +43,6 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-// SMS delivery calls are tracked via the globalThis.fetch mock below.
-const smsSendCalls: Array<{
-  to: string;
-  text: string;
-  assistantId?: string;
-}> = [];
-
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => true,
   getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
@@ -83,7 +76,7 @@ mock.module("../calls/call-domain.js", () => ({
   },
 }));
 
-// SMS and Telegram delivery mock via fetch
+// Telegram delivery mock via fetch
 const telegramDeliverCalls: Array<{
   chatId: string;
   text: string;
@@ -100,15 +93,6 @@ globalThis.fetch = (async (
       : input instanceof URL
         ? input.toString()
         : input.url;
-  if (url.includes("/deliver/sms") && init?.method === "POST") {
-    const body = JSON.parse(init.body as string) as {
-      to: string;
-      text: string;
-      assistantId?: string;
-    };
-    smsSendCalls.push(body);
-    return new Response(JSON.stringify({ ok: true }), { status: 200 });
-  }
   if (url.includes("/deliver/telegram") && init?.method === "POST") {
     const body = JSON.parse(init.body as string) as {
       chatId: string;
@@ -181,7 +165,6 @@ function jsonRequest(body: Record<string, unknown>): Request {
 // Reset mutable state between tests
 beforeEach(() => {
   resetTables();
-  smsSendCalls.length = 0;
   telegramDeliverCalls.length = 0;
   voiceCallInitCalls.length = 0;
   mockBotUsername = "test_bot";
@@ -192,45 +175,6 @@ beforeEach(() => {
 // ===========================================================================
 
 describe("startOutbound", () => {
-  test("SMS: returns missing_destination when destination is absent", async () => {
-    const result = await startOutbound({ channel: "sms" });
-    expect(result.success).toBe(false);
-    expect(result.error).toBe("missing_destination");
-    expect(result.channel).toBe("sms");
-  });
-
-  test("SMS: returns invalid_destination for garbage phone number", async () => {
-    const result = await startOutbound({
-      channel: "sms",
-      destination: "notaphone",
-    });
-    expect(result.success).toBe(false);
-    expect(result.error).toBe("invalid_destination");
-  });
-
-  test("SMS: succeeds with valid E.164 number", async () => {
-    const result = await startOutbound({
-      channel: "sms",
-      destination: "+15551234567",
-    });
-    expect(result.success).toBe(true);
-    expect(result.verificationSessionId).toBeDefined();
-    expect(result.secret).toBeDefined();
-    expect(result.expiresAt).toBeGreaterThan(Date.now());
-    expect(result.nextResendAt).toBeGreaterThan(Date.now());
-    expect(result.sendCount).toBe(1);
-    expect(result.channel).toBe("sms");
-  });
-
-  test("SMS: succeeds with loose phone format (parentheses + dashes)", async () => {
-    const result = await startOutbound({
-      channel: "sms",
-      destination: "(555) 987-6543",
-    });
-    expect(result.success).toBe(true);
-    expect(result.verificationSessionId).toBeDefined();
-  });
-
   test("Telegram: returns missing_destination when absent", async () => {
     const result = await startOutbound({ channel: "telegram" });
     expect(result.success).toBe(false);
@@ -335,6 +279,13 @@ describe("startOutbound", () => {
     expect(result.success).toBe(false);
     expect(result.error).toBe("unsupported_channel");
   });
+
+  test("SMS returns unsupported_channel (removed)", async () => {
+    const result = await startOutbound({ channel: "sms" as never });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("unsupported_channel");
+    expect(result.channel).toBe("sms");
+  });
 });
 
 // ===========================================================================
@@ -343,15 +294,15 @@ describe("startOutbound", () => {
 
 describe("resendOutbound", () => {
   test("returns no_active_session when no session exists", () => {
-    const result = resendOutbound({ channel: "sms" });
+    const result = resendOutbound({ channel: "voice" });
     expect(result.success).toBe(false);
     expect(result.error).toBe("no_active_session");
   });
 
-  test("SMS: succeeds when an active session exists and cooldown has passed", async () => {
+  test("voice: succeeds when an active session exists and cooldown has passed", async () => {
     // Start a session first
     const startResult = await startOutbound({
-      channel: "sms",
+      channel: "voice",
       destination: "+15551112222",
     });
     expect(startResult.success).toBe(true);
@@ -366,34 +317,10 @@ describe("resendOutbound", () => {
       );
     }
 
-    const resendResult = resendOutbound({ channel: "sms" });
+    const resendResult = resendOutbound({ channel: "voice" });
     expect(resendResult.success).toBe(true);
     expect(resendResult.verificationSessionId).toBeDefined();
     expect(resendResult.sendCount).toBe(2);
-  });
-
-  test("SMS: preserves originConversationId on resend", async () => {
-    const startResult = await startOutbound({
-      channel: "sms",
-      destination: "+15551113333",
-    });
-    expect(startResult.success).toBe(true);
-
-    if (startResult.verificationSessionId) {
-      updateSessionDelivery(
-        startResult.verificationSessionId,
-        Date.now() - 60_000,
-        1,
-        Date.now() - 1,
-      );
-    }
-
-    const resendResult = resendOutbound({
-      channel: "sms",
-      originConversationId: "conv-resend-sms-origin",
-    });
-    expect(resendResult.success).toBe(true);
-    expect(resendResult.originConversationId).toBe("conv-resend-sms-origin");
   });
 
   test("voice: preserves originConversationId on resend and passes it to call initiation", async () => {
@@ -438,21 +365,21 @@ describe("resendOutbound", () => {
 
 describe("cancelOutbound", () => {
   test("returns no_active_session when no session exists", () => {
-    const result = cancelOutbound({ channel: "sms" });
+    const result = cancelOutbound({ channel: "voice" });
     expect(result.success).toBe(false);
     expect(result.error).toBe("no_active_session");
   });
 
   test("succeeds when an active session exists", async () => {
     const startResult = await startOutbound({
-      channel: "sms",
+      channel: "voice",
       destination: "+15553334444",
     });
     expect(startResult.success).toBe(true);
 
-    const cancelResult = cancelOutbound({ channel: "sms" });
+    const cancelResult = cancelOutbound({ channel: "voice" });
     expect(cancelResult.success).toBe(true);
-    expect(cancelResult.channel).toBe("sms");
+    expect(cancelResult.channel).toBe("voice");
   });
 });
 
@@ -472,16 +399,16 @@ describe("HTTP route: handleStartOutbound", () => {
     expect(body.error.message).toContain("channel");
   });
 
-  test("returns 400 for missing destination (SMS)", async () => {
-    const req = jsonRequest({ channel: "sms" });
+  test("returns 400 for missing destination (voice)", async () => {
+    const req = jsonRequest({ channel: "voice" });
     const resp = await handleStartOutbound(req);
     expect(resp.status).toBe(400);
     const body = (await resp.json()) as { error?: string };
     expect(body.error).toBe("missing_destination");
   });
 
-  test("returns 200 for valid SMS start", async () => {
-    const req = jsonRequest({ channel: "sms", destination: "+15559999999" });
+  test("returns 200 for valid voice start", async () => {
+    const req = jsonRequest({ channel: "voice", destination: "+15559999999" });
     const resp = await handleStartOutbound(req);
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as Record<string, unknown>;
@@ -503,7 +430,7 @@ describe("HTTP route: handleResendOutbound", () => {
   });
 
   test("returns 400 for no_active_session", async () => {
-    const req = jsonRequest({ channel: "sms" });
+    const req = jsonRequest({ channel: "voice" });
     const resp = await handleResendOutbound(req);
     expect(resp.status).toBe(400);
     const body = (await resp.json()) as { error?: string };
@@ -513,7 +440,7 @@ describe("HTTP route: handleResendOutbound", () => {
   test("passes originConversationId through on successful resend", async () => {
     // Start a session first
     const startReq = jsonRequest({
-      channel: "sms",
+      channel: "voice",
       destination: "+15556667777",
     });
     const startResp = await handleStartOutbound(startReq);
@@ -531,7 +458,7 @@ describe("HTTP route: handleResendOutbound", () => {
     }
 
     const resendReq = jsonRequest({
-      channel: "sms",
+      channel: "voice",
       originConversationId: "conv-resend-http-origin",
     });
     const resendResp = await handleResendOutbound(resendReq);
@@ -555,7 +482,7 @@ describe("HTTP route: handleCancelOutbound", () => {
   });
 
   test("returns 400 for no_active_session", async () => {
-    const req = jsonRequest({ channel: "sms" });
+    const req = jsonRequest({ channel: "voice" });
     const resp = await handleCancelOutbound(req);
     expect(resp.status).toBe(400);
     const body = (await resp.json()) as { error?: string };
@@ -565,14 +492,14 @@ describe("HTTP route: handleCancelOutbound", () => {
   test("returns 200 when active session is cancelled", async () => {
     // Start a session
     const startReq = jsonRequest({
-      channel: "sms",
+      channel: "voice",
       destination: "+15558887777",
     });
     const startResp = await handleStartOutbound(startReq);
     expect(startResp.status).toBe(200);
 
     // Cancel it
-    const cancelReq = jsonRequest({ channel: "sms" });
+    const cancelReq = jsonRequest({ channel: "voice" });
     const cancelResp = await handleCancelOutbound(cancelReq);
     expect(cancelResp.status).toBe(200);
     const body = (await cancelResp.json()) as Record<string, unknown>;
@@ -585,16 +512,6 @@ describe("HTTP route: handleCancelOutbound", () => {
 // ===========================================================================
 
 describe("origin conversation linkage", () => {
-  test("startOutbound SMS echoes originConversationId in result", async () => {
-    const result = await startOutbound({
-      channel: "sms",
-      destination: "+15551119999",
-      originConversationId: "conv-origin-sms-test",
-    });
-    expect(result.success).toBe(true);
-    expect(result.originConversationId).toBe("conv-origin-sms-test");
-  });
-
   test("startOutbound voice echoes originConversationId in result", async () => {
     const result = await startOutbound({
       channel: "voice",
@@ -617,7 +534,7 @@ describe("origin conversation linkage", () => {
 
   test("startOutbound without originConversationId returns undefined for field", async () => {
     const result = await startOutbound({
-      channel: "sms",
+      channel: "voice",
       destination: "+15553338888",
     });
     expect(result.success).toBe(true);
@@ -626,7 +543,7 @@ describe("origin conversation linkage", () => {
 
   test("HTTP handleStartOutbound passes originConversationId through", async () => {
     const req = jsonRequest({
-      channel: "sms",
+      channel: "voice",
       destination: "+15557776666",
       originConversationId: "conv-origin-http-test",
     });

--- a/assistant/src/runtime/guardian-outbound-actions.ts
+++ b/assistant/src/runtime/guardian-outbound-actions.ts
@@ -2,7 +2,7 @@
  * Shared outbound guardian verification action logic.
  *
  * These pure functions encapsulate the business logic for starting, resending,
- * and cancelling outbound guardian verification flows (SMS, Telegram, voice).
+ * and cancelling outbound guardian verification flows (Telegram, voice, Slack).
  * They return transport-agnostic result objects and are consumed by both the
  * IPC handler (config-channels.ts) and the HTTP route layer (integration-routes.ts).
  */
@@ -27,7 +27,6 @@ import {
 } from "./channel-guardian-service.js";
 import {
   composeVerificationSlack,
-  composeVerificationSms,
   composeVerificationTelegram,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,
 } from "./guardian-verification-templates.js";
@@ -38,7 +37,7 @@ const log = getLogger("guardian-outbound-actions");
 // Rate limit constants for outbound verification
 // ---------------------------------------------------------------------------
 
-/** Maximum SMS sends per verification session. */
+/** Maximum sends per verification session. */
 export const MAX_SENDS_PER_SESSION = 5;
 
 /** Cooldown between resends in milliseconds (15 seconds). */
@@ -133,49 +132,6 @@ export interface OutboundActionResult {
   pendingBootstrap?: boolean;
   /** Echoed back so consumers know which conversation to target for pointers. */
   originConversationId?: string;
-}
-
-// ---------------------------------------------------------------------------
-// SMS delivery helper
-// ---------------------------------------------------------------------------
-
-/**
- * Deliver a verification SMS via the gateway. Fire-and-forget with error
- * logging -- the response is returned before delivery completes because
- * the caller should not be blocked on Twilio API latency.
- */
-export function deliverVerificationSms(
-  to: string,
-  text: string,
-  assistantId: string,
-): void {
-  (async () => {
-    try {
-      const gatewayUrl = getGatewayInternalBaseUrl();
-      const bearerToken = mintDaemonDeliveryToken();
-      const url = `${gatewayUrl}/deliver/sms`;
-      const resp = await fetch(url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${bearerToken}`,
-        },
-        body: JSON.stringify({ to, text, assistantId }),
-        signal: AbortSignal.timeout(30_000),
-      });
-      if (!resp.ok) {
-        const body = await resp.text().catch(() => "<unreadable>");
-        log.error(
-          { to, assistantId, status: resp.status, body },
-          "Gateway /deliver/sms failed for verification",
-        );
-      } else {
-        log.info({ to, assistantId }, "Verification SMS delivered");
-      }
-    } catch (err) {
-      log.error({ err, to, assistantId }, "Failed to deliver verification SMS");
-    }
-  })();
 }
 
 // ---------------------------------------------------------------------------
@@ -282,15 +238,7 @@ export async function startOutbound(
   const channel = params.channel;
   const originConversationId = params.originConversationId;
 
-  if (channel === "sms") {
-    return startOutboundSms(
-      params.destination,
-      assistantId,
-      channel,
-      params.rebind,
-      originConversationId,
-    );
-  } else if (channel === "telegram") {
+  if (channel === "telegram") {
     return await startOutboundTelegram(
       params.destination,
       assistantId,
@@ -319,97 +267,8 @@ export async function startOutbound(
   return {
     success: false,
     error: "unsupported_channel",
-    message: `Outbound verification is only supported for SMS, Telegram, voice, and Slack. Got: ${channel}`,
+    message: `Outbound verification is only supported for Telegram, voice, and Slack. Got: ${channel}`,
     channel,
-  };
-}
-
-function startOutboundSms(
-  rawDestination: string | undefined,
-  assistantId: string,
-  channel: ChannelId,
-  rebind?: boolean,
-  originConversationId?: string,
-): OutboundActionResult {
-  if (!rawDestination) {
-    return {
-      success: false,
-      error: "missing_destination",
-      message:
-        "A destination phone number is required for outbound SMS verification.",
-      channel,
-    };
-  }
-
-  const destination = normalizePhoneNumber(rawDestination);
-  if (!destination) {
-    return {
-      success: false,
-      error: "invalid_destination",
-      message:
-        "Could not parse phone number. Please enter a valid number (e.g. +15551234567, (555) 123-4567, or 555-123-4567).",
-      channel,
-    };
-  }
-
-  const existingBinding = getGuardianBinding(assistantId, channel);
-  if (existingBinding && !rebind) {
-    return {
-      success: false,
-      error: "already_bound",
-      message:
-        "A guardian is already bound for this channel. Set rebind: true to replace.",
-      channel,
-    };
-  }
-
-  const recentSendCount = countRecentSendsToDestination(
-    channel,
-    destination,
-    DESTINATION_RATE_WINDOW_MS,
-  );
-  if (recentSendCount >= MAX_SENDS_PER_DESTINATION_WINDOW) {
-    return {
-      success: false,
-      error: "rate_limited",
-      message:
-        "Too many verification attempts to this phone number. Please try again later.",
-      channel,
-    };
-  }
-
-  const sessionResult = createOutboundSession({
-    channel,
-    expectedPhoneE164: destination,
-    expectedExternalUserId: destination,
-    destinationAddress: destination,
-    verificationPurpose: "guardian",
-  });
-
-  const smsBody = composeVerificationSms(
-    GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST,
-    {
-      code: sessionResult.secret,
-      expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
-    },
-  );
-
-  const now = Date.now();
-  const nextResendAt = now + RESEND_COOLDOWN_MS;
-  const sendCount = 1;
-
-  updateSessionDelivery(sessionResult.sessionId, now, sendCount, nextResendAt);
-  deliverVerificationSms(destination, smsBody, assistantId);
-
-  return {
-    success: true,
-    verificationSessionId: sessionResult.sessionId,
-    secret: sessionResult.secret,
-    expiresAt: sessionResult.expiresAt,
-    nextResendAt,
-    sendCount,
-    channel,
-    originConversationId,
   };
 }
 
@@ -958,35 +817,11 @@ export function resendOutbound(
     };
   }
 
-  // SMS resend
-  const newSession = createOutboundSession({
-    channel,
-    expectedPhoneE164: destination,
-    expectedExternalUserId: destination,
-    destinationAddress: destination,
-    verificationPurpose: "guardian",
-  });
-
-  const smsBody = composeVerificationSms(GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND, {
-    code: newSession.secret,
-    expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
-  });
-
-  const now = Date.now();
-  const newSendCount = currentSendCount + 1;
-  const nextResendAt = now + RESEND_COOLDOWN_MS;
-
-  updateSessionDelivery(newSession.sessionId, now, newSendCount, nextResendAt);
-  deliverVerificationSms(destination, smsBody, assistantId);
-
   return {
-    success: true,
-    verificationSessionId: newSession.sessionId,
-    secret: newSession.secret,
-    nextResendAt,
-    sendCount: newSendCount,
+    success: false,
+    error: "unsupported_channel",
+    message: `Resend is only supported for Telegram, voice, and Slack. Got: ${channel}`,
     channel,
-    originConversationId,
   };
 }
 

--- a/assistant/src/runtime/guardian-verification-templates.ts
+++ b/assistant/src/runtime/guardian-verification-templates.ts
@@ -1,5 +1,5 @@
 /**
- * Template-only copy for outbound guardian verification messages (SMS, Telegram, and voice).
+ * Template-only copy for outbound guardian verification messages (Telegram, voice, and Slack).
  *
  * All outbound verification messages are composed from these templates
  * to prevent free-form caller/user text injection. Only typed variables
@@ -11,10 +11,6 @@
 // ---------------------------------------------------------------------------
 
 export const GUARDIAN_VERIFY_TEMPLATE_KEYS = {
-  /** Initial outbound SMS with verification code. */
-  CHALLENGE_REQUEST: "guardian_verify.sms.challenge_request",
-  /** Resend SMS with verification code. */
-  RESEND: "guardian_verify.sms.resend",
   /** Response when the user is already verified. */
   ALREADY_VERIFIED: "guardian_verify.already_verified",
   /** Initial outbound Telegram verification prompt (code is not included). */
@@ -49,10 +45,8 @@ export const GUARDIAN_VERIFY_TEMPLATE_KEYS = {
 export type GuardianVerifyTemplateKey =
   (typeof GUARDIAN_VERIFY_TEMPLATE_KEYS)[keyof typeof GUARDIAN_VERIFY_TEMPLATE_KEYS];
 
-/** Template keys for SMS/Telegram/Slack text-based verification messages. */
+/** Template keys for Telegram/Slack text-based verification messages. */
 type TextVerifyTemplateKey =
-  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST
-  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.ALREADY_VERIFIED
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_RESEND
@@ -97,14 +91,6 @@ const templates: Record<
   TextVerifyTemplateKey,
   (vars: GuardianVerifyTemplateVars) => string
 > = {
-  [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST]: (_vars) => {
-    return "Vellum assistant guardian verification requested. Reply with the 6-digit code you were given.";
-  },
-
-  [GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND]: (_vars) => {
-    return "Vellum assistant guardian verification requested. Reply with the 6-digit code you were given. (resent)";
-  },
-
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.ALREADY_VERIFIED]: (_vars) => {
     return "This channel is already verified. No further action is needed.";
   },
@@ -133,18 +119,6 @@ const templates: Record<
     return `Vellum assistant verification: your code is ${vars.code}. Reply with this code to verify your identity. It expires in ${vars.expiresInMinutes} minutes. (resent)`;
   },
 };
-
-/**
- * Compose an outbound verification SMS body from a template key and typed variables.
- * Returns plain string content suitable for SMS delivery.
- */
-export function composeVerificationSms(
-  templateKey: TextVerifyTemplateKey,
-  vars: GuardianVerifyTemplateVars,
-): string {
-  const composer = templates[templateKey];
-  return composer(vars);
-}
 
 /**
  * Compose an outbound verification Slack DM from a template key and typed variables.

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -35,7 +35,6 @@ import type {
   ContactType,
 } from "../../contacts/types.js";
 import { getCredentialMetadata } from "../../tools/credentials/metadata-store.js";
-import { normalizePhoneNumber } from "../../util/phone.js";
 import {
   countRecentSendsToDestination,
   createOutboundSession,
@@ -43,7 +42,6 @@ import {
 } from "../channel-guardian-service.js";
 import {
   deliverVerificationSlack,
-  deliverVerificationSms,
   deliverVerificationTelegram,
   DESTINATION_RATE_WINDOW_MS,
   MAX_SENDS_PER_DESTINATION_WINDOW,
@@ -51,7 +49,6 @@ import {
 } from "../guardian-outbound-actions.js";
 import {
   composeVerificationSlack,
-  composeVerificationSms,
   composeVerificationTelegram,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,
 } from "../guardian-verification-templates.js";
@@ -446,8 +443,6 @@ const SESSION_TTL_SECONDS = 600;
  */
 function toVerificationChannel(channelType: string): ChannelId | null {
   switch (channelType) {
-    case "phone":
-      return "sms";
     case "telegram":
       return "telegram";
     case "slack":
@@ -477,8 +472,8 @@ function getTelegramBotUsername(): string | undefined {
  * POST /v1/contact-channels/:contactChannelId/verify
  *
  * Initiate trusted contact verification for a specific channel. Sends a
- * verification code via SMS, Telegram, Slack, or voice and returns session
- * info so the client can track the verification flow.
+ * verification code via Telegram or Slack and returns session info so the
+ * client can track the verification flow.
  */
 export async function handleVerifyContactChannel(
   contactChannelId: string,
@@ -544,46 +539,6 @@ export async function handleVerifyContactChannel(
       "Too many verification attempts to this destination. Please try again later.",
       429,
     );
-  }
-
-  // --- SMS verification ---
-  if (verificationChannel === "sms") {
-    const phoneE164 = normalizePhoneNumber(destination);
-    if (!phoneE164) {
-      return httpError(
-        "BAD_REQUEST",
-        "Channel address is not a valid phone number",
-        400,
-      );
-    }
-
-    const sessionResult = createOutboundSession({
-      channel: verificationChannel,
-      expectedPhoneE164: phoneE164,
-      expectedExternalUserId: channel.externalUserId ?? undefined,
-      destinationAddress: phoneE164,
-      verificationPurpose: "trusted_contact",
-    });
-
-    const smsBody = composeVerificationSms(
-      GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST,
-      {
-        code: sessionResult.secret,
-        expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
-      },
-    );
-
-    const now = Date.now();
-    const sendCount = 1;
-    updateSessionDelivery(sessionResult.sessionId, now, sendCount, null);
-    deliverVerificationSms(phoneE164, smsBody, assistantId);
-
-    return Response.json({
-      ok: true,
-      verificationSessionId: sessionResult.sessionId,
-      expiresAt: sessionResult.expiresAt,
-      sendCount,
-    });
   }
 
   // --- Telegram verification ---

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -220,7 +220,7 @@ export async function handleStartOutbound(req: Request): Promise<Response> {
   // (e.g. "+15551234567" vs "(555) 123-4567", or "@User" vs "user")
   let rateLimitKey = body.destination;
   if (rateLimitKey) {
-    if (body.channel === "sms" || body.channel === "voice") {
+    if (body.channel === "voice") {
       rateLimitKey = normalizePhoneNumber(rateLimitKey) ?? rateLimitKey;
     } else if (body.channel === "telegram") {
       rateLimitKey = normalizeTelegramDestination(rateLimitKey);


### PR DESCRIPTION
## Summary
- Remove SMS delivery helper, verification flow, and resend logic from guardian-outbound-actions
- Remove SMS template keys and composer from guardian-verification-templates
- Remove SMS verification branch from contact-routes
- Remove SMS template tests from channel-guardian test
- Update JSDoc comments to remove SMS references

Part of plan: remove-sms-functionality.md (PR 5 of 7)
Closes #13675

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
