### PR TITLE
fix: staged scroll restore for thread switch / app restart blank screen

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -234,11 +234,12 @@ struct MessageListView: View {
         scrollRestoreTask?.cancel()
         hasFreshAnchorMeasurement = false
         scrollRestoreTask = Task { @MainActor in
+            guard !Task.isCancelled else { return }
             // Stage 0: immediate — covers the happy path where layout is already ready.
+            log.debug("Scroll restore: stage 0 (immediate)")
             if anchorMessageId == nil {
                 proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
             }
-            log.debug("Scroll restore: stage 0 (immediate)")
 
             // Stage 1: ~3 frames — handles most thread switches.
             try? await Task.sleep(nanoseconds: 50_000_000)

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -149,6 +149,13 @@ struct MessageListView: View {
     @State private var lastHandledContainerWidth: CGFloat = 0
     /// In-flight resize scroll stabilization task; cancelled on each new resize.
     @State private var resizeScrollTask: Task<Void, Never>?
+    /// In-flight staged scroll-to-bottom task used after thread switches and
+    /// app restarts to reliably anchor the viewport once layout settles.
+    @State private var scrollRestoreTask: Task<Void, Never>?
+    /// Whether the AnchorMinYKey preference has fired since the last scroll
+    /// restore began. Ensures anchorTracker.isVisible reflects real geometry
+    /// rather than the manual reset applied on thread switch.
+    @State private var hasFreshAnchorMeasurement: Bool = false
 
     /// The subset of messages actually shown, honoring the pagination window.
     private var visibleMessages: [ChatMessage] {
@@ -216,6 +223,45 @@ struct MessageListView: View {
             guard !Task.isCancelled else { return }
             isThreadContentHovered = false
             hoverExitDebounceTask = nil
+        }
+    }
+
+    /// Staged scroll-to-bottom that retries after increasing delays to handle
+    /// cases where SwiftUI hasn't committed the new content's layout yet (e.g.
+    /// after a thread switch or app restart). Cancelled by user scroll-up,
+    /// user scroll-to-bottom, anchor message set, or view disappearance.
+    private func restoreScrollToBottom(proxy: ScrollViewProxy) {
+        scrollRestoreTask?.cancel()
+        hasFreshAnchorMeasurement = false
+        scrollRestoreTask = Task { @MainActor in
+            // Stage 0: immediate — covers the happy path where layout is already ready.
+            if anchorMessageId == nil {
+                proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+            }
+            log.debug("Scroll restore: stage 0 (immediate)")
+
+            // Stage 1: ~3 frames — handles most thread switches.
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            guard !Task.isCancelled else { return }
+            if anchorMessageId == nil {
+                proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+            }
+            log.debug("Scroll restore: stage 1 (50ms)")
+
+            // Stage 2: ~9 frames — catches slower layout/materialization.
+            // scrollLanded is computed after the full wait so it reflects
+            // the latest geometry, not a stale snapshot from before the delay.
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            guard !Task.isCancelled else { return }
+            let scrollLanded = hasFreshAnchorMeasurement && anchorTracker.isVisible
+            log.debug("Scroll restore: stage 2 check — scrollLanded=\(scrollLanded) hasReceivedScrollEvent=\(hasReceivedScrollEvent)")
+            if anchorMessageId == nil && !hasReceivedScrollEvent && !scrollLanded {
+                proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                log.debug("Scroll restore: stage 2 (200ms) — retrying scrollTo")
+            } else {
+                log.debug("Scroll restore: stage 2 skipped")
+            }
+            if !Task.isCancelled { scrollRestoreTask = nil }
         }
     }
 
@@ -473,10 +519,14 @@ struct MessageListView: View {
                     onScrollUp: {
                         scrollDebounceTask?.cancel()
                         scrollDebounceTask = nil
+                        scrollRestoreTask?.cancel()
+                        scrollRestoreTask = nil
                         isNearBottom = false
                         hasReceivedScrollEvent = true
                     },
                     onScrollToBottom: {
+                        scrollRestoreTask?.cancel()
+                        scrollRestoreTask = nil
                         isNearBottom = true
                         hasReceivedScrollEvent = true
                     }
@@ -491,6 +541,7 @@ struct MessageListView: View {
             .onPreferenceChange(AnchorMinYKey.self) { minY in
                 os_signpost(.begin, log: PerfSignposts.log, name: "anchorPreferenceChange")
                 anchorTracker.update(minY: minY, viewportHeight: scrollViewportHeight)
+                if !hasFreshAnchorMeasurement { hasFreshAnchorMeasurement = true }
                 os_signpost(.end, log: PerfSignposts.log, name: "anchorPreferenceChange")
             }
             .overlay(alignment: .bottom) {
@@ -555,7 +606,7 @@ struct MessageListView: View {
                         }
                     }
                 } else {
-                    proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
+                    restoreScrollToBottom(proxy: proxy)
                 }
                 // When anchorMessageId is set but the target message isn't loaded
                 // yet, skip scrolling entirely — onChange(of: messages.count) will
@@ -573,6 +624,8 @@ struct MessageListView: View {
                 resizeScrollTask = nil
                 expandSuppressionTask?.cancel()
                 expandSuppressionTask = nil
+                scrollRestoreTask?.cancel()
+                scrollRestoreTask = nil
             }
             .onChange(of: isSending) {
                 if isSending {
@@ -713,6 +766,7 @@ struct MessageListView: View {
                 isSuppressingBottomScroll = false
                 isNearBottom = true
                 anchorTracker.isVisible = true
+                anchorTracker.lastMinY = 0
                 hasReceivedScrollEvent = false
                 lastHandledContainerWidth = containerWidth
                 hoverExitDebounceTask?.cancel()
@@ -734,18 +788,16 @@ struct MessageListView: View {
                     threadSwitchSuppressionTask = nil
                 }
                 isThreadContentHovered = false
-                DispatchQueue.main.async {
-                    // Skip scroll-to-bottom when an anchor message is pending —
-                    // the anchorMessageId onChange handler will scroll to the
-                    // specific message instead. Stale anchors from other threads
-                    // are cleared by ThreadManager.activeThreadId.didSet, so
-                    // anchorMessageId here always belongs to the current thread.
-                    if anchorMessageId == nil {
-                        proxy.scrollTo("scroll-bottom-anchor", anchor: .bottom)
-                    }
-                }
+                restoreScrollToBottom(proxy: proxy)
             }
             .onChange(of: anchorMessageId) {
+                // Only cancel scroll restore when a new anchor is set (non-nil).
+                // The nil transition fires during thread switches (stale anchor
+                // cleanup) and must not cancel the restore just started.
+                if anchorMessageId != nil {
+                    scrollRestoreTask?.cancel()
+                    scrollRestoreTask = nil
+                }
                 // Record the timestamp when a new anchor is set so the
                 // pagination-exhaustion guard can measure elapsed time.
                 anchorSetTime = anchorMessageId != nil ? Date() : nil


### PR DESCRIPTION
## Summary
Fixes blank message area when switching threads or restarting the app. The root cause was a race condition where `proxy.scrollTo` fired via `DispatchQueue.main.async` before SwiftUI committed the new thread's layout, making it a no-op while the NSScrollView retained a stale scroll offset.

## Changes
- Added `restoreScrollToBottom(proxy:)` — a staged, cancellable scroll-to-bottom helper with 3 attempts (immediate, 50ms, 200ms) that replaces the unreliable single-tick `DispatchQueue.main.async`
- Added `hasFreshAnchorMeasurement` flag to distinguish real geometry data from manual `anchorTracker.isVisible` resets, preventing false-positive `scrollLanded` checks
- Reset `anchorTracker.lastMinY = 0` on thread switch to prevent stale values from flashing the "Scroll to latest" button
- Guarded `scrollRestoreTask` cancellation in `onChange(of: anchorMessageId)` to only fire on non-nil transitions (nil fires during thread switch cleanup)
- Added `os.Logger` diagnostics to all scroll restore stages
- Wired cancellation into `onScrollUp`, `onScrollToBottom`, `onChange(of: anchorMessageId)`, and `onDisappear`

## Milestone PRs (merged into feature branch)
- #13695: Staged scroll restore with stale-state guards in MessageListView

## Project issue
Closes #13692

## Test plan
- [ ] Switch between threads with different message counts — no blank screen
- [ ] Restart app with a thread selected — messages appear immediately
- [ ] Switch to a thread, immediately scroll up — restore doesn't fight user intent
- [ ] Switch threads rapidly — no stale scroll snaps
- [ ] Verify "Scroll to latest" button doesn't flash on thread switch

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
