### PR TITLE
fix: reduce permission chip size

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -456,17 +456,17 @@ struct AssistantProgressView: View {
         let isDenied = confirmation.state == .denied
         let chipColor: Color = isApproved ? VColor.iconAccent : isDenied ? VColor.error : VColor.textMuted
 
-        return HStack(spacing: VSpacing.xs) {
+        return HStack(spacing: VSpacing.xxs) {
             Group {
                 switch confirmation.state {
                 case .approved:
-                    VIconView(.circleCheck, size: 12)
+                    VIconView(.circleCheck, size: 10)
                         .foregroundColor(chipColor)
                 case .denied:
-                    VIconView(.circleAlert, size: 12)
+                    VIconView(.circleAlert, size: 10)
                         .foregroundColor(chipColor)
                 case .timedOut:
-                    VIconView(.clock, size: 12)
+                    VIconView(.clock, size: 10)
                         .foregroundColor(chipColor)
                 default:
                     EmptyView()
@@ -475,11 +475,11 @@ struct AssistantProgressView: View {
 
             Text(isApproved ? "\(confirmation.toolCategory) Allowed" :
                  isDenied ? "\(confirmation.toolCategory) Denied" : "Timed Out")
-                .font(VFont.captionMedium)
+                .font(VFont.small)
                 .foregroundColor(chipColor)
         }
-        .padding(.horizontal, VSpacing.sm)
-        .padding(.vertical, VSpacing.xs)
+        .padding(.horizontal, VSpacing.xs)
+        .padding(.vertical, VSpacing.xxs)
         .background(
             Capsule().fill(Color.clear)
         )


### PR DESCRIPTION
## Summary
- Shrink permission chip icons (12→10), font (captionMedium→small), spacing (xs→xxs) and padding (sm/xs→xs/xxs) so badges don't visually compete with headline text

## Test plan
- [ ] Permission chips appear smaller and proportionate to headline
- [ ] Chips remain readable in both collapsed (inline) and expanded (FlowLayout) modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
