### PR TITLE
fix: dedupe migration auth headers case-insensitively

### DIFF
--- a/assistant/src/__tests__/migration-transport.test.ts
+++ b/assistant/src/__tests__/migration-transport.test.ts
@@ -240,6 +240,50 @@ describe("Auth headers", () => {
     expect(headers["X-Session-Token"]).toBe("test-session-token");
   });
 
+  test("auth header wins over case-insensitive entry in defaultHeaders", async () => {
+    const managed = capturingFetch(200, {
+      is_valid: true,
+      errors: [],
+      manifest: {},
+    });
+
+    await validateBundle(
+      managedConfig({
+        fetchFn: managed.fetchFn,
+        defaultHeaders: { "x-session-token": "should-be-overridden" },
+      }),
+      sampleFileData,
+    );
+
+    const managedHeaders = managed.captured[0].init.headers as Record<
+      string,
+      string
+    >;
+    expect(managedHeaders["X-Session-Token"]).toBe("test-session-token");
+    expect(managedHeaders["x-session-token"]).toBeUndefined();
+
+    const runtime = capturingFetch(200, {
+      is_valid: true,
+      errors: [],
+      manifest: {},
+    });
+
+    await validateBundle(
+      runtimeConfig({
+        fetchFn: runtime.fetchFn,
+        defaultHeaders: { authorization: "should-be-overridden" },
+      }),
+      sampleFileData,
+    );
+
+    const runtimeHeaders = runtime.captured[0].init.headers as Record<
+      string,
+      string
+    >;
+    expect(runtimeHeaders.Authorization).toBe("Bearer test-jwt");
+    expect(runtimeHeaders.authorization).toBeUndefined();
+  });
+
   test("no auth header when authHeader is not provided", async () => {
     const { fetchFn, captured } = capturingFetch(200, {
       is_valid: true,

--- a/assistant/src/runtime/migrations/migration-transport.ts
+++ b/assistant/src/runtime/migrations/migration-transport.ts
@@ -279,14 +279,29 @@ function buildHeaders(
   contentType?: string,
 ): Record<string, string> {
   const headers: Record<string, string> = {};
+  const headerKeysByLowerName = new Map<string, string>();
+
+  const setHeader = (headerName: string, headerValue: string): void => {
+    const lowerName = headerName.toLowerCase();
+    const existingHeaderName = headerKeysByLowerName.get(lowerName);
+    if (existingHeaderName && existingHeaderName !== headerName) {
+      delete headers[existingHeaderName];
+    }
+    headerKeysByLowerName.set(lowerName, headerName);
+    headers[headerName] = headerValue;
+  };
 
   if (contentType) {
-    headers["Content-Type"] = contentType;
+    setHeader("Content-Type", contentType);
   }
 
   // Merge defaultHeaders after Content-Type but before auth injection
   if (config.defaultHeaders) {
-    Object.assign(headers, config.defaultHeaders);
+    for (const [headerName, headerValue] of Object.entries(
+      config.defaultHeaders,
+    )) {
+      setHeader(headerName, headerValue);
+    }
   }
 
   // Auth header is applied last so it always wins over defaultHeaders
@@ -294,7 +309,7 @@ function buildHeaders(
     const headerName =
       config.authHeaderName ??
       (config.target === "managed" ? "X-Session-Token" : "Authorization");
-    headers[headerName] = config.authHeader;
+    setHeader(headerName, config.authHeader);
   }
 
   return headers;


### PR DESCRIPTION
## Summary
- make migration transport header merging case-insensitive so auth headers replace same-named defaults regardless of casing
- preserve the transport’s canonical auth header casing instead of leaking duplicate variants into fetch
- add regressions for lowercase authorization and x-session-token collisions

## Original prompt
Address the reviewer feedback with one-issue worktree PRs, including the runtime migration auth-header collision bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
