### PR TITLE
feat: [assistant] add conversation attention unread rewind helper

### DIFF
--- a/assistant/src/__tests__/conversation-attention-store.test.ts
+++ b/assistant/src/__tests__/conversation-attention-store.test.ts
@@ -33,6 +33,7 @@ import { eq } from "drizzle-orm";
 import {
   getAttentionStateByConversationIds,
   listConversationAttention,
+  markConversationUnread,
   projectAssistantMessage,
   recordConversationSeenSignal,
 } from "../memory/conversation-attention-store.js";
@@ -41,6 +42,7 @@ import {
   conversationAssistantAttentionState,
   conversationAttentionEvents,
   conversations,
+  messages,
 } from "../memory/schema.js";
 
 initializeDb();
@@ -62,7 +64,26 @@ function clearTables(): void {
   const db = getDb();
   db.delete(conversationAttentionEvents).run();
   db.delete(conversationAssistantAttentionState).run();
+  db.delete(messages).run();
   db.delete(conversations).run();
+}
+
+function insertAssistantMessage(
+  conversationId: string,
+  messageId: string,
+  createdAt: number,
+): void {
+  const db = getDb();
+  db.insert(messages)
+    .values({
+      id: messageId,
+      conversationId,
+      role: "assistant",
+      content: `Assistant message ${messageId}`,
+      createdAt,
+      metadata: null,
+    })
+    .run();
 }
 
 afterAll(() => {
@@ -332,6 +353,120 @@ describe("conversation-attention-store", () => {
       expect(state.lastSeenAssistantMessageAt).toBe(1000);
       // Signal metadata should reflect the latest signal
       expect(state.lastSeenSignalType).toBe("telegram_inbound_message");
+    });
+  });
+
+  // ── markConversationUnread ───────────────────────────────────────
+
+  describe("markConversationUnread", () => {
+    test("rewinds the seen cursor to null when the latest assistant message is the first one", () => {
+      ensureConversation("conv-1");
+      insertAssistantMessage("conv-1", "msg-1", 1000);
+      projectAssistantMessage({
+        conversationId: "conv-1",
+        messageId: "msg-1",
+        messageAt: 1000,
+      });
+      recordConversationSeenSignal({
+        conversationId: "conv-1",
+        sourceChannel: "vellum",
+        signalType: "macos_conversation_opened",
+        confidence: "explicit",
+        source: "desktop-client",
+      });
+
+      markConversationUnread("conv-1");
+
+      const states = getAttentionStateByConversationIds(["conv-1"]);
+      const state = states.get("conv-1")!;
+      expect(state.latestAssistantMessageId).toBe("msg-1");
+      expect(state.lastSeenAssistantMessageId).toBeNull();
+      expect(state.lastSeenAssistantMessageAt).toBeNull();
+      expect(
+        listConversationAttention({ state: "unseen" }).map(
+          (entry) => entry.conversationId,
+        ),
+      ).toEqual(["conv-1"]);
+    });
+
+    test("rewinds the seen cursor to the prior assistant message", () => {
+      ensureConversation("conv-1");
+      insertAssistantMessage("conv-1", "msg-1", 1000);
+      insertAssistantMessage("conv-1", "msg-2", 2000);
+      projectAssistantMessage({
+        conversationId: "conv-1",
+        messageId: "msg-1",
+        messageAt: 1000,
+      });
+      projectAssistantMessage({
+        conversationId: "conv-1",
+        messageId: "msg-2",
+        messageAt: 2000,
+      });
+      recordConversationSeenSignal({
+        conversationId: "conv-1",
+        sourceChannel: "vellum",
+        signalType: "macos_conversation_opened",
+        confidence: "explicit",
+        source: "desktop-client",
+      });
+
+      markConversationUnread("conv-1");
+
+      const states = getAttentionStateByConversationIds(["conv-1"]);
+      const state = states.get("conv-1")!;
+      expect(state.latestAssistantMessageId).toBe("msg-2");
+      expect(state.latestAssistantMessageAt).toBe(2000);
+      expect(state.lastSeenAssistantMessageId).toBe("msg-1");
+      expect(state.lastSeenAssistantMessageAt).toBe(1000);
+    });
+
+    test("is idempotent when the conversation is already unread", () => {
+      ensureConversation("conv-1");
+      insertAssistantMessage("conv-1", "msg-1", 1000);
+      insertAssistantMessage("conv-1", "msg-2", 2000);
+      projectAssistantMessage({
+        conversationId: "conv-1",
+        messageId: "msg-1",
+        messageAt: 1000,
+      });
+      projectAssistantMessage({
+        conversationId: "conv-1",
+        messageId: "msg-2",
+        messageAt: 2000,
+      });
+      recordConversationSeenSignal({
+        conversationId: "conv-1",
+        sourceChannel: "vellum",
+        signalType: "macos_conversation_opened",
+        confidence: "explicit",
+        source: "desktop-client",
+      });
+
+      markConversationUnread("conv-1");
+      const onceUnread = getAttentionStateByConversationIds(["conv-1"]).get(
+        "conv-1",
+      )!;
+
+      markConversationUnread("conv-1");
+
+      const twiceUnread = getAttentionStateByConversationIds(["conv-1"]).get(
+        "conv-1",
+      )!;
+      expect(twiceUnread.lastSeenAssistantMessageId).toBe(
+        onceUnread.lastSeenAssistantMessageId,
+      );
+      expect(twiceUnread.lastSeenAssistantMessageAt).toBe(
+        onceUnread.lastSeenAssistantMessageAt,
+      );
+    });
+
+    test("rejects conversations with no assistant message", () => {
+      ensureConversation("conv-1");
+
+      expect(() => markConversationUnread("conv-1")).toThrow(
+        "Conversation has no assistant message to mark unread",
+      );
     });
   });
 

--- a/assistant/src/memory/conversation-attention-store.ts
+++ b/assistant/src/memory/conversation-attention-store.ts
@@ -9,6 +9,7 @@
 import { and, desc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { UserError } from "../util/errors.js";
 import { getDb } from "./db.js";
 import {
   conversationAssistantAttentionState,
@@ -301,6 +302,149 @@ export function recordConversationSeenSignal(params: {
   });
 
   return rowToEvent(event as typeof conversationAttentionEvents.$inferSelect);
+}
+
+// ── markConversationUnread ───────────────────────────────────────────
+
+function resolveAssistantCursor(params: {
+  db: Pick<ReturnType<typeof getDb>, "select">;
+  conversationId: string;
+  latestAssistantMessageId?: string | null;
+  latestAssistantMessageAt?: number | null;
+}): {
+  latestAssistantMessageId: string;
+  latestAssistantMessageAt: number;
+  previousAssistantMessageId: string | null;
+  previousAssistantMessageAt: number | null;
+} | null {
+  const {
+    db,
+    conversationId,
+    latestAssistantMessageId,
+    latestAssistantMessageAt,
+  } = params;
+
+  if (latestAssistantMessageId && latestAssistantMessageAt != null) {
+    const previousMessage = db
+      .select({ id: messages.id, createdAt: messages.createdAt })
+      .from(messages)
+      .where(
+        and(
+          eq(messages.conversationId, conversationId),
+          eq(messages.role, "assistant"),
+          lt(messages.createdAt, latestAssistantMessageAt),
+        ),
+      )
+      .orderBy(desc(messages.createdAt))
+      .limit(1)
+      .get();
+
+    return {
+      latestAssistantMessageId,
+      latestAssistantMessageAt,
+      previousAssistantMessageId: previousMessage?.id ?? null,
+      previousAssistantMessageAt: previousMessage?.createdAt ?? null,
+    };
+  }
+
+  const assistantMessages = db
+    .select({ id: messages.id, createdAt: messages.createdAt })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        eq(messages.role, "assistant"),
+      ),
+    )
+    .orderBy(desc(messages.createdAt), desc(messages.id))
+    .limit(2)
+    .all();
+
+  if (assistantMessages.length === 0) {
+    return null;
+  }
+
+  const [latestMessage, previousMessage] = assistantMessages;
+  return {
+    latestAssistantMessageId: latestMessage.id,
+    latestAssistantMessageAt: latestMessage.createdAt,
+    previousAssistantMessageId: previousMessage?.id ?? null,
+    previousAssistantMessageAt: previousMessage?.createdAt ?? null,
+  };
+}
+
+/**
+ * Rewind the seen cursor so the current latest assistant reply becomes unread.
+ * This uses the existing attention projection instead of adding a separate
+ * manual-unread state machine.
+ */
+export function markConversationUnread(conversationId: string): void {
+  const db = getDb();
+  const now = Date.now();
+
+  db.transaction((tx) => {
+    const state = tx
+      .select()
+      .from(conversationAssistantAttentionState)
+      .where(
+        eq(conversationAssistantAttentionState.conversationId, conversationId),
+      )
+      .get();
+
+    const cursor = resolveAssistantCursor({
+      db: tx,
+      conversationId,
+      latestAssistantMessageId: state?.latestAssistantMessageId,
+      latestAssistantMessageAt: state?.latestAssistantMessageAt,
+    });
+
+    if (!cursor) {
+      throw new UserError(
+        "Conversation has no assistant message to mark unread",
+      );
+    }
+
+    const isAlreadyUnread =
+      state != null &&
+      (state.lastSeenAssistantMessageAt == null ||
+        state.lastSeenAssistantMessageAt < cursor.latestAssistantMessageAt);
+
+    if (isAlreadyUnread) {
+      return;
+    }
+
+    if (!state) {
+      tx.insert(conversationAssistantAttentionState)
+        .values({
+          conversationId,
+          latestAssistantMessageId: cursor.latestAssistantMessageId,
+          latestAssistantMessageAt: cursor.latestAssistantMessageAt,
+          lastSeenAssistantMessageId: cursor.previousAssistantMessageId,
+          lastSeenAssistantMessageAt: cursor.previousAssistantMessageAt,
+          lastSeenEventAt: null,
+          lastSeenConfidence: null,
+          lastSeenSignalType: null,
+          lastSeenSourceChannel: null,
+          lastSeenSource: null,
+          lastSeenEvidenceText: null,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+      return;
+    }
+
+    tx.update(conversationAssistantAttentionState)
+      .set({
+        lastSeenAssistantMessageId: cursor.previousAssistantMessageId,
+        lastSeenAssistantMessageAt: cursor.previousAssistantMessageAt,
+        updatedAt: now,
+      })
+      .where(
+        eq(conversationAssistantAttentionState.conversationId, conversationId),
+      )
+      .run();
+  });
 }
 
 // ── getAttentionStateByConversationIds ───────────────────────────────


### PR DESCRIPTION
## Summary
- add a projection-only `markConversationUnread()` helper to rewind the seen cursor without introducing new unread state
- cover first-message rewind, multi-message rewind, idempotence, and no-assistant rejection in the attention-store tests

Part of plan: cross-client-thread-actions-unread.md (PR 1 of 21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
