### PR TITLE
feat: [macOS] normalize sidebar thread menu wording and rename access

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
@@ -165,20 +165,18 @@ struct SidebarThreadItem: View {
                     }
                 }
             } label: {
-                Label { Text(thread.isPinned ? "Unpin" : "Pin to Top") } icon: { VIconView(thread.isPinned ? .pinOff : .pin, size: 14) }
+                Label { Text(thread.isPinned ? "Unpin thread" : "Pin thread") } icon: { VIconView(thread.isPinned ? .pinOff : .pin, size: 14) }
             }
-            if thread.sessionId != nil {
-                Button {
-                    sidebar.renamingThreadId = thread.id
-                    sidebar.renameText = thread.title
-                } label: {
-                    Label { Text("Rename") } icon: { VIconView(.pencil, size: 14) }
-                }
+            Button {
+                sidebar.renamingThreadId = thread.id
+                sidebar.renameText = thread.title
+            } label: {
+                Label { Text("Rename thread") } icon: { VIconView(.pencil, size: 14) }
             }
             Button {
                 threadManager.archiveThread(id: thread.id)
             } label: {
-                Label { Text("Archive") } icon: { VIconView(.archive, size: 14) }
+                Label { Text("Archive thread") } icon: { VIconView(.archive, size: 14) }
             }
         }
         .pointerCursor()


### PR DESCRIPTION
## Summary
- rename the existing sidebar context-menu actions to the requested thread-focused wording
- make rename available for unsaved threads by removing the `sessionId` guard

Part of plan: cross-client-thread-actions-unread.md (PR 8 of 21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
