### PR TITLE
feat: [macOS] keep assistant attention timestamps on thread models

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -602,6 +602,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 threads[existingIdx].isPinned = isPinned
                 threads[existingIdx].pinnedOrder = isPinned ? (session.displayOrder.map { Int($0) } ?? nextPinnedOrder) : nil
                 threads[existingIdx].displayOrder = session.displayOrder.map { Int($0) }
+                threads[existingIdx].hasUnseenLatestAssistantMessage = session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
+                threads[existingIdx].latestAssistantMessageAt = session.assistantAttention?.latestAssistantMessageAt.map {
+                    Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+                }
+                threads[existingIdx].lastSeenAssistantMessageAt = session.assistantAttention?.lastSeenAssistantMessageAt.map {
+                    Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+                }
                 if isPinned && session.displayOrder == nil { nextPinnedOrder += 1 }
                 continue
             }
@@ -620,7 +627,13 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 kind: session.threadType == "private" ? .private : .standard,
                 source: session.source,
                 scheduleJobId: session.scheduleJobId,
-                hasUnseenLatestAssistantMessage: session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
+                hasUnseenLatestAssistantMessage: session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false,
+                latestAssistantMessageAt: session.assistantAttention?.latestAssistantMessageAt.map {
+                    Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+                },
+                lastSeenAssistantMessageAt: session.assistantAttention?.lastSeenAssistantMessageAt.map {
+                    Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+                }
             )
             if isPinned && session.displayOrder == nil { nextPinnedOrder += 1 }
             // VM creation is lazy — getOrCreateViewModel() will instantiate

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadModel.swift
@@ -25,8 +25,10 @@ struct ThreadModel: Identifiable, Hashable {
     /// Threads sharing the same scheduleJobId belong to the same schedule group.
     var scheduleJobId: String?
     var hasUnseenLatestAssistantMessage: Bool = false
+    var latestAssistantMessageAt: Date?
+    var lastSeenAssistantMessageAt: Date?
 
-    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, displayOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ThreadKind = .standard, source: String? = nil, scheduleJobId: String? = nil, hasUnseenLatestAssistantMessage: Bool = false) {
+    init(id: UUID = UUID(), title: String = "New Conversation", createdAt: Date = Date(), sessionId: String? = nil, isArchived: Bool = false, isPinned: Bool = false, pinnedOrder: Int? = nil, displayOrder: Int? = nil, lastInteractedAt: Date? = nil, kind: ThreadKind = .standard, source: String? = nil, scheduleJobId: String? = nil, hasUnseenLatestAssistantMessage: Bool = false, latestAssistantMessageAt: Date? = nil, lastSeenAssistantMessageAt: Date? = nil) {
         self.id = id
         self.title = title
         self.createdAt = createdAt
@@ -40,6 +42,8 @@ struct ThreadModel: Identifiable, Hashable {
         self.source = source
         self.scheduleJobId = scheduleJobId
         self.hasUnseenLatestAssistantMessage = hasUnseenLatestAssistantMessage
+        self.latestAssistantMessageAt = latestAssistantMessageAt
+        self.lastSeenAssistantMessageAt = lastSeenAssistantMessageAt
     }
 
     /// Whether this thread was created by a schedule or reminder trigger.

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -198,6 +198,13 @@ final class ThreadSessionRestorer {
                 delegate.threads[existingIdx].isPinned = isPinned
                 delegate.threads[existingIdx].pinnedOrder = isPinned ? (session.displayOrder.map { Int($0) } ?? pinnedCount) : nil
                 delegate.threads[existingIdx].displayOrder = session.displayOrder.map { Int($0) }
+                delegate.threads[existingIdx].hasUnseenLatestAssistantMessage = session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
+                delegate.threads[existingIdx].latestAssistantMessageAt = session.assistantAttention?.latestAssistantMessageAt.map {
+                    Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+                }
+                delegate.threads[existingIdx].lastSeenAssistantMessageAt = session.assistantAttention?.lastSeenAssistantMessageAt.map {
+                    Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+                }
                 if isPinned && session.displayOrder == nil { pinnedCount += 1 }
                 continue
             }
@@ -226,7 +233,13 @@ final class ThreadSessionRestorer {
                 kind: kind,
                 source: session.source,
                 scheduleJobId: session.scheduleJobId,
-                hasUnseenLatestAssistantMessage: session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
+                hasUnseenLatestAssistantMessage: session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false,
+                latestAssistantMessageAt: session.assistantAttention?.latestAssistantMessageAt.map {
+                    Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+                },
+                lastSeenAssistantMessageAt: session.assistantAttention?.lastSeenAssistantMessageAt.map {
+                    Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+                }
             )
             if isPinned && session.displayOrder == nil { pinnedCount += 1 }
             // VM creation is lazy — only the active thread will get a VM via

--- a/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
@@ -9,6 +9,21 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
     private var threadManager: ThreadManager!
     private var sentMessages: [Any] = []
 
+    private func makeSessionListResponse(
+        sessions: [[String: Any]],
+        hasMore: Bool? = nil
+    ) -> SessionListResponseMessage {
+        var payload: [String: Any] = [
+            "type": "session_list_response",
+            "sessions": sessions,
+        ]
+        if let hasMore {
+            payload["hasMore"] = hasMore
+        }
+        let data = try! JSONSerialization.data(withJSONObject: payload)
+        return try! JSONDecoder().decode(SessionListResponseMessage.self, from: data)
+    }
+
     override func setUp() {
         super.setUp()
         daemonClient = DaemonClient()
@@ -17,6 +32,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
             self?.sentMessages.append(message)
         }
         threadManager = ThreadManager(daemonClient: daemonClient)
+        threadManager.createThread()
     }
 
     override func tearDown() {
@@ -326,6 +342,34 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
 
         let seenSignals = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
         XCTAssertEqual(seenSignals.last?.conversationId, "session-active")
+    }
+
+    func testAppendThreadsPreservesAssistantAttentionTimestamps() {
+        let response = makeSessionListResponse(
+            sessions: [[
+                "id": "session-paginated",
+                "title": "Paginated thread",
+                "createdAt": 5_000,
+                "updatedAt": 6_000,
+                "assistantAttention": [
+                    "hasUnseenLatestAssistantMessage": false,
+                    "latestAssistantMessageAt": 9_000,
+                    "lastSeenAssistantMessageAt": 9_000,
+                ],
+            ]],
+            hasMore: false
+        )
+
+        threadManager.appendThreads(from: response)
+
+        guard let appendedThread = threadManager.threads.first(where: { $0.sessionId == "session-paginated" }) else {
+            XCTFail("Expected appended thread")
+            return
+        }
+
+        XCTAssertFalse(appendedThread.hasUnseenLatestAssistantMessage)
+        XCTAssertEqual(appendedThread.latestAssistantMessageAt?.timeIntervalSince1970, 9.0)
+        XCTAssertEqual(appendedThread.lastSeenAssistantMessageAt?.timeIntervalSince1970, 9.0)
     }
 
     private func waitForPropagation() {

--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -94,6 +94,17 @@ private func makeSessionListResponse(sessions: [(id: String, title: String, crea
     return try! JSONDecoder().decode(SessionListResponseMessage.self, from: data)
 }
 
+private func makeSessionListResponse(
+    sessionDicts: [[String: Any]]
+) -> SessionListResponseMessage {
+    let dict: [String: Any] = [
+        "type": "session_list_response",
+        "sessions": sessionDicts,
+    ]
+    let data = try! JSONSerialization.data(withJSONObject: dict)
+    return try! JSONDecoder().decode(SessionListResponseMessage.self, from: data)
+}
+
 /// Convenience overload with threadType and optional channelBinding.
 private func makeSessionListResponse(sessions: [(id: String, title: String, updatedAt: Int, threadType: String?, channelBinding: [String: Any]?)]) -> SessionListResponseMessage {
     makeSessionListResponse(sessions: sessions.map { ($0.id, $0.title, $0.updatedAt, $0.updatedAt, $0.threadType, $0.channelBinding) })
@@ -305,6 +316,41 @@ struct ThreadSessionRestorerTests {
 
         // Most recent thread should be activated
         #expect(delegate.activatedThreadId == delegate.threads[0].id)
+    }
+
+    @Test @MainActor
+    func sessionListPreservesAssistantAttentionTimestamps() {
+        let dc = DaemonClient()
+        let restorer = ThreadSessionRestorer(daemonClient: dc)
+        let delegate = MockThreadRestorerDelegate(daemonClient: dc)
+        restorer.delegate = delegate
+
+        let defaultThread = ThreadModel()
+        delegate.threads = [defaultThread]
+        delegate.viewModels[defaultThread.id] = delegate.makeViewModel()
+
+        let response = makeSessionListResponse(sessionDicts: [[
+            "id": "s-attention",
+            "title": "Attention thread",
+            "createdAt": 1000,
+            "updatedAt": 2000,
+            "assistantAttention": [
+                "hasUnseenLatestAssistantMessage": true,
+                "latestAssistantMessageAt": 4000,
+                "lastSeenAssistantMessageAt": 3000,
+            ],
+        ]])
+
+        restorer.handleSessionListResponse(response)
+
+        guard let restoredThread = delegate.threads.first(where: { $0.sessionId == "s-attention" }) else {
+            Issue.record("Expected restored attention thread")
+            return
+        }
+
+        #expect(restoredThread.hasUnseenLatestAssistantMessage)
+        #expect(restoredThread.latestAssistantMessageAt?.timeIntervalSince1970 == 4.0)
+        #expect(restoredThread.lastSeenAssistantMessageAt?.timeIntervalSince1970 == 3.0)
     }
 
     @Test @MainActor


### PR DESCRIPTION
## Summary
- store assistant attention timestamps on macOS thread models during both restore and pagination
- preserve the timestamps when daemon session metadata merges into existing local threads
- add focused restore and append test coverage for the new metadata mapping

Part of plan: cross-client-thread-actions-unread.md (PR 7 of 21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
