### PR TITLE
Mark unread iOS threads seen on open

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -575,6 +575,27 @@ class IOSThreadStore: ObservableObject {
         try? daemon.sendHistoryRequest(sessionId: sessionId, limit: 50, mode: "light", maxToolResultChars: 1000)
     }
 
+    /// Mark a connected conversation as seen when the user explicitly opens it.
+    func markConversationSeenIfNeeded(threadId: UUID) {
+        guard isConnectedMode,
+              let idx = threads.firstIndex(where: { $0.id == threadId }),
+              let sessionId = threads[idx].sessionId,
+              threads[idx].hasUnseenLatestAssistantMessage else { return }
+
+        threads[idx].hasUnseenLatestAssistantMessage = false
+        saveConnectedCache()
+
+        let signal = IPCConversationSeenSignal(
+            conversationId: sessionId,
+            sourceChannel: "vellum",
+            signalType: "macos_conversation_opened",
+            confidence: "explicit",
+            source: "ui-navigation",
+            evidenceText: "User opened conversation in app"
+        )
+        try? daemonClient.send(signal)
+    }
+
     /// Request an older page of history for pagination.
     private func requestPaginatedHistory(sessionId: String, beforeTimestamp: Double) {
         guard let daemon = daemonClient as? DaemonClient,

--- a/clients/ios/Tests/ThreadLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ThreadLifecycleIOSTests.swift
@@ -381,5 +381,92 @@ final class ThreadLifecycleIOSTests: XCTestCase {
         XCTAssertEqual(cachedThread.latestAssistantMessageAt?.timeIntervalSince1970, 5.0)
         XCTAssertEqual(cachedThread.lastSeenAssistantMessageAt?.timeIntervalSince1970, 4.0)
     }
+
+    func testOpeningUnreadConnectedThreadMarksItSeenAndEmitsSignal() {
+        let daemonClient = DaemonClient()
+        var sentSignals: [IPCConversationSeenSignal] = []
+        daemonClient.sendOverride = { message in
+            if let signal = message as? IPCConversationSeenSignal {
+                sentSignals.append(signal)
+            }
+        }
+
+        let store = IOSThreadStore(daemonClient: daemonClient)
+        let response = makeSessionListResponse(sessions: [[
+            "id": "connected-session-2",
+            "title": "Unread thread",
+            "createdAt": 1_000,
+            "updatedAt": 2_000,
+            "assistantAttention": [
+                "hasUnseenLatestAssistantMessage": true,
+                "latestAssistantMessageAt": 5_000,
+                "lastSeenAssistantMessageAt": 4_000,
+            ],
+        ]])
+
+        daemonClient.onSessionListResponse?(response)
+        guard let storedThread = store.threads.first(where: { $0.sessionId == "connected-session-2" }) else {
+            XCTFail("Expected unread connected thread")
+            return
+        }
+
+        store.markConversationSeenIfNeeded(threadId: storedThread.id)
+
+        guard let updatedThread = store.threads.first(where: { $0.id == storedThread.id }) else {
+            XCTFail("Expected updated thread")
+            return
+        }
+
+        XCTAssertFalse(updatedThread.hasUnseenLatestAssistantMessage)
+        XCTAssertEqual(sentSignals.count, 1)
+        XCTAssertEqual(sentSignals[0].conversationId, "connected-session-2")
+        XCTAssertEqual(sentSignals[0].sourceChannel, "vellum")
+        XCTAssertEqual(sentSignals[0].signalType, "macos_conversation_opened")
+        XCTAssertEqual(sentSignals[0].confidence, "explicit")
+        XCTAssertEqual(sentSignals[0].source, "ui-navigation")
+        XCTAssertEqual(sentSignals[0].evidenceText, "User opened conversation in app")
+
+        let reloadedStore = IOSThreadStore(daemonClient: daemonClient)
+        guard let cachedThread = reloadedStore.threads.first(where: { $0.sessionId == "connected-session-2" }) else {
+            XCTFail("Expected cached connected thread")
+            return
+        }
+
+        XCTAssertFalse(cachedThread.hasUnseenLatestAssistantMessage)
+    }
+
+    func testOpeningAlreadySeenConnectedThreadDoesNotEmitSignal() {
+        let daemonClient = DaemonClient()
+        var sentSignals: [IPCConversationSeenSignal] = []
+        daemonClient.sendOverride = { message in
+            if let signal = message as? IPCConversationSeenSignal {
+                sentSignals.append(signal)
+            }
+        }
+
+        let store = IOSThreadStore(daemonClient: daemonClient)
+        let response = makeSessionListResponse(sessions: [[
+            "id": "connected-session-3",
+            "title": "Seen thread",
+            "createdAt": 1_000,
+            "updatedAt": 2_000,
+            "assistantAttention": [
+                "hasUnseenLatestAssistantMessage": false,
+                "latestAssistantMessageAt": 5_000,
+                "lastSeenAssistantMessageAt": 5_000,
+            ],
+        ]])
+
+        daemonClient.onSessionListResponse?(response)
+        guard let storedThread = store.threads.first(where: { $0.sessionId == "connected-session-3" }) else {
+            XCTFail("Expected connected thread")
+            return
+        }
+
+        store.markConversationSeenIfNeeded(threadId: storedThread.id)
+
+        XCTAssertTrue(sentSignals.isEmpty)
+        XCTAssertFalse(store.threads.first(where: { $0.id == storedThread.id })?.hasUnseenLatestAssistantMessage ?? true)
+    }
     #endif
 }

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -176,6 +176,7 @@ struct ThreadListView: View {
             )
             .onAppear {
                 store.loadHistoryIfNeeded(for: threadId)
+                store.markConversationSeenIfNeeded(threadId: threadId)
                 store.viewModel(for: threadId).consumeDeepLinkIfNeeded()
             }
             .onOpenURL { _ in


### PR DESCRIPTION
## Summary
- add an iOS thread-store helper that clears unread state and emits the existing seen signal when a connected thread is explicitly opened
- call that helper from the thread detail on-appear path so opening a thread clears the unread indicator once
- add focused iOS tests for the emit-on-open and already-seen no-op cases

## Validation
- `clients/ios/./build.sh test` *(fails in this environment: no available iPhone simulator found; Xcode asks to install one via Settings > Platforms)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
