### PR TITLE
Add runtime conversations unread route

### DIFF
--- a/assistant/src/__tests__/conversation-unread-route.test.ts
+++ b/assistant/src/__tests__/conversation-unread-route.test.ts
@@ -1,0 +1,155 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = realpathSync(
+  mkdtempSync(join(tmpdir(), "conversation-unread-route-test-")),
+);
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getSocketPath: () => join(testDir, "test.sock"),
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+  getGatewayPort: () => 7830,
+  getRuntimeHttpPort: () => 7821,
+  getRuntimeHttpHost: () => "127.0.0.1",
+  getRuntimeGatewayOriginSecret: () => undefined,
+  getIngressPublicBaseUrl: () => undefined,
+  setIngressPublicBaseUrl: () => {},
+}));
+
+const mockMarkConversationUnread = mock((_conversationId: string) => {});
+
+mock.module("../memory/conversation-attention-store.js", () => ({
+  getAttentionStateByConversationIds: () => new Map(),
+  recordConversationSeenSignal: () => ({}),
+  markConversationUnread: mockMarkConversationUnread,
+}));
+
+import { getPolicy } from "../runtime/auth/route-policy.js";
+import { RuntimeHttpServer } from "../runtime/http-server.js";
+import { UserError } from "../util/errors.js";
+
+describe("POST /v1/conversations/unread", () => {
+  let server: RuntimeHttpServer;
+  let port: number;
+
+  beforeEach(() => {
+    mockMarkConversationUnread.mockReset();
+  });
+
+  afterAll(async () => {
+    await server?.stop();
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  });
+
+  async function startServer(): Promise<void> {
+    port = 20000 + Math.floor(Math.random() * 1000);
+    server = new RuntimeHttpServer({ port, bearerToken: "test-bearer-token" });
+    await server.start();
+  }
+
+  async function stopServer(): Promise<void> {
+    await server?.stop();
+  }
+
+  function unreadUrl(): string {
+    return `http://127.0.0.1:${port}/v1/conversations/unread`;
+  }
+
+  test("registers the unread route with chat.write policy", () => {
+    expect(getPolicy("conversations/unread")).toEqual({
+      requiredScopes: ["chat.write"],
+      allowedPrincipalTypes: ["actor", "svc_gateway", "ipc"],
+    });
+  });
+
+  test("returns BAD_REQUEST when conversationId is missing", async () => {
+    await startServer();
+
+    const res = await fetch(unreadUrl(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: {
+        code: "BAD_REQUEST",
+        message: "Missing conversationId",
+      },
+    });
+    expect(mockMarkConversationUnread).not.toHaveBeenCalled();
+
+    await stopServer();
+  });
+
+  test("marks a conversation unread", async () => {
+    await startServer();
+
+    const res = await fetch(unreadUrl(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ conversationId: "conv-123" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockMarkConversationUnread).toHaveBeenCalledTimes(1);
+    expect(mockMarkConversationUnread).toHaveBeenCalledWith("conv-123");
+
+    await stopServer();
+  });
+
+  test("returns UNPROCESSABLE_ENTITY when the conversation has no assistant message", async () => {
+    mockMarkConversationUnread.mockImplementationOnce(() => {
+      throw new UserError(
+        "Conversation has no assistant message to mark unread",
+      );
+    });
+
+    await startServer();
+
+    const res = await fetch(unreadUrl(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ conversationId: "conv-no-assistant" }),
+    });
+
+    expect(res.status).toBe(422);
+    expect(await res.json()).toEqual({
+      error: {
+        code: "UNPROCESSABLE_ENTITY",
+        message: "Conversation has no assistant message to mark unread",
+      },
+    });
+
+    await stopServer();
+  });
+});

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -129,6 +129,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "conversations", scopes: ["chat.read"] },
   { endpoint: "conversations/attention", scopes: ["chat.read"] },
   { endpoint: "conversations/seen", scopes: ["chat.write"] },
+  { endpoint: "conversations/unread", scopes: ["chat.write"] },
   { endpoint: "search", scopes: ["chat.read"] },
   { endpoint: "search/global", scopes: ["chat.read"] },
   { endpoint: "suggestion", scopes: ["chat.read"] },

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -38,6 +38,7 @@ import { PairingStore } from "../daemon/pairing-store.js";
 import {
   type Confidence,
   getAttentionStateByConversationIds,
+  markConversationUnread,
   recordConversationSeenSignal,
   type SignalType,
 } from "../memory/conversation-attention-store.js";
@@ -47,6 +48,7 @@ import {
   consumeCallback,
   consumeCallbackError,
 } from "../security/oauth-callback-registry.js";
+import { UserError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { buildAssistantEvent } from "./assistant-event.js";
 import { assistantEventHub } from "./assistant-event-hub.js";
@@ -826,6 +828,34 @@ export class RuntimeHttpServer {
             return httpError(
               "INTERNAL_ERROR",
               "Failed to record seen signal",
+              500,
+            );
+          }
+        },
+      },
+
+      {
+        endpoint: "conversations/unread",
+        method: "POST",
+        handler: async ({ req }) => {
+          const body = (await req.json()) as Record<string, unknown>;
+          const conversationId = body.conversationId as string | undefined;
+          if (!conversationId)
+            return httpError("BAD_REQUEST", "Missing conversationId", 400);
+          try {
+            markConversationUnread(conversationId);
+            return Response.json({ ok: true });
+          } catch (err) {
+            if (err instanceof UserError) {
+              return httpError("UNPROCESSABLE_ENTITY", err.message, 422);
+            }
+            log.error(
+              { err, conversationId },
+              "POST /v1/conversations/unread: failed",
+            );
+            return httpError(
+              "INTERNAL_ERROR",
+              "Failed to mark conversation unread",
               500,
             );
           }


### PR DESCRIPTION
## Summary
- add `POST /v1/conversations/unread` beside the existing seen route in the runtime HTTP server
- register the new route under the same `chat.write` policy as `conversations/seen`
- cover missing `conversationId`, success, and no-assistant-message rejection with a focused HTTP test file

## Validation
- `cd assistant && bun test src/__tests__/conversation-unread-route.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
