### PR TITLE
Add conversation unread IPC signal

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -1024,6 +1024,22 @@ exports[`IPC message snapshots ClientMessage types conversation_seen_signal seri
 }
 `;
 
+exports[`IPC message snapshots ClientMessage types conversation_unread_signal serializes to expected JSON 1`] = `
+{
+  "confidence": "explicit",
+  "conversationId": "conv-001",
+  "evidenceText": "User selected Mark as unread",
+  "metadata": {
+    "trigger": "context-menu",
+  },
+  "observedAt": 1700000000000,
+  "signalType": "macos_conversation_opened",
+  "source": "ui-navigation",
+  "sourceChannel": "vellum",
+  "type": "conversation_unread_signal",
+}
+`;
+
 exports[`IPC message snapshots ClientMessage types recording_status serializes to expected JSON 1`] = `
 {
   "sessionId": "rec-001",

--- a/assistant/src/__tests__/daemon-server-session-init.test.ts
+++ b/assistant/src/__tests__/daemon-server-session-init.test.ts
@@ -258,6 +258,7 @@ mock.module("../memory/conversation-attention-store.js", () => ({
   getAttentionStateByConversationIds: () => new Map(),
   recordAttentionSignal: () => {},
   recordConversationSeenSignal: () => {},
+  markConversationUnread: () => {},
 }));
 
 mock.module("../memory/canonical-guardian-store.js", () => ({

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -632,6 +632,17 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
     observedAt: 1700000000000,
     metadata: { notificationCategory: "NOTIFICATION_INTENT" },
   },
+  conversation_unread_signal: {
+    type: "conversation_unread_signal",
+    conversationId: "conv-001",
+    sourceChannel: "vellum",
+    signalType: "macos_conversation_opened",
+    confidence: "explicit",
+    source: "ui-navigation",
+    evidenceText: "User selected Mark as unread",
+    observedAt: 1700000000000,
+    metadata: { trigger: "context-menu" },
+  },
   recording_status: {
     type: "recording_status",
     sessionId: "rec-001",

--- a/assistant/src/daemon/handlers/index.ts
+++ b/assistant/src/daemon/handlers/index.ts
@@ -2,6 +2,7 @@ import * as net from "node:net";
 
 import {
   type Confidence,
+  markConversationUnread,
   recordConversationSeenSignal,
   type SignalType,
 } from "../../memory/conversation-attention-store.js";
@@ -131,6 +132,18 @@ const inlineHandlers = defineHandlers({
       log.error(
         { err, conversationId: msg.conversationId },
         "conversation_seen_signal: failed to record seen signal",
+      );
+    }
+  },
+
+  // Client signal: user explicitly wants the latest assistant reply marked unread.
+  conversation_unread_signal: (msg) => {
+    try {
+      markConversationUnread(msg.conversationId);
+    } catch (err) {
+      log.error(
+        { err, conversationId: msg.conversationId },
+        "conversation_unread_signal: failed to mark conversation unread",
       );
     }
   },

--- a/assistant/src/daemon/ipc-contract-inventory.json
+++ b/assistant/src/daemon/ipc-contract-inventory.json
@@ -72,6 +72,7 @@
     "contacts_invite",
     "conversation_search",
     "conversation_seen_signal",
+    "conversation_unread_signal",
     "cu_observation",
     "cu_session_abort",
     "cu_session_create",

--- a/assistant/src/daemon/ipc-contract/notifications.ts
+++ b/assistant/src/daemon/ipc-contract/notifications.ts
@@ -51,11 +51,25 @@ export interface ConversationSeenSignal {
   metadata?: Record<string, unknown>;
 }
 
+/** Client signal indicating the user wants a conversation marked unread again. */
+export interface ConversationUnreadSignal {
+  type: "conversation_unread_signal";
+  conversationId: string;
+  sourceChannel: string;
+  signalType: string;
+  confidence: string;
+  source: string;
+  evidenceText?: string;
+  observedAt?: number;
+  metadata?: Record<string, unknown>;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
 export type _NotificationsClientMessages =
   | NotificationIntentResult
-  | ConversationSeenSignal;
+  | ConversationSeenSignal
+  | ConversationUnreadSignal;
 
 export type _NotificationsServerMessages =
   | NotificationIntent

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1145,6 +1145,31 @@ public struct IPCConversationSeenSignal: Codable, Sendable {
     }
 }
 
+/// Client signal indicating the user wants a conversation marked unread again.
+public struct IPCConversationUnreadSignal: Codable, Sendable {
+    public let type: String
+    public let conversationId: String
+    public let sourceChannel: String
+    public let signalType: String
+    public let confidence: String
+    public let source: String
+    public let evidenceText: String?
+    public let observedAt: Int?
+    public let metadata: [String: AnyCodable]?
+
+    public init(type: String, conversationId: String, sourceChannel: String, signalType: String, confidence: String, source: String, evidenceText: String? = nil, observedAt: Int? = nil, metadata: [String: AnyCodable]? = nil) {
+        self.type = type
+        self.conversationId = conversationId
+        self.sourceChannel = sourceChannel
+        self.signalType = signalType
+        self.confidence = confidence
+        self.source = source
+        self.evidenceText = evidenceText
+        self.observedAt = observedAt
+        self.metadata = metadata
+    }
+}
+
 public struct IPCCuAction: Codable, Sendable {
     public let type: String
     public let sessionId: String


### PR DESCRIPTION
## Summary
- add a `conversation_unread_signal` client IPC message beside the existing seen signal
- handle the new message in the daemon by calling `markConversationUnread()` and update the IPC inventory/snapshot baselines
- regenerate the shared Swift IPC contract so the new message type exists in generated models without wiring transport behavior yet

## Validation
- `cd assistant && bun test src/__tests__/ipc-snapshot.test.ts -u`
- `cd assistant && bun test src/__tests__/ipc-contract-inventory.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
