### PR TITLE
Sort connected iOS threads like macOS

### DIFF
--- a/clients/ios/Tests/ThreadListOrderingIOSTests.swift
+++ b/clients/ios/Tests/ThreadListOrderingIOSTests.swift
@@ -1,0 +1,75 @@
+#if canImport(UIKit)
+import XCTest
+
+@testable import vellum_assistant_ios
+
+@MainActor
+final class ThreadListOrderingIOSTests: XCTestCase {
+    func testConnectedModeSortsPinnedThenRecencyThenExplicitOrder() {
+        let threads = [
+            IOSThread(
+                title: "explicit-late",
+                lastActivityAt: Date(timeIntervalSince1970: 20),
+                sessionId: "explicit-late",
+                displayOrder: 2
+            ),
+            IOSThread(
+                title: "recent",
+                lastActivityAt: Date(timeIntervalSince1970: 50),
+                sessionId: "recent"
+            ),
+            IOSThread(
+                title: "pinned-second",
+                lastActivityAt: Date(timeIntervalSince1970: 10),
+                sessionId: "pinned-second",
+                isPinned: true,
+                displayOrder: 2
+            ),
+            IOSThread(
+                title: "explicit-first",
+                lastActivityAt: Date(timeIntervalSince1970: 30),
+                sessionId: "explicit-first",
+                displayOrder: 1
+            ),
+            IOSThread(
+                title: "pinned-first",
+                lastActivityAt: Date(timeIntervalSince1970: 40),
+                sessionId: "pinned-first",
+                isPinned: true,
+                displayOrder: 1
+            ),
+            IOSThread(
+                title: "older",
+                lastActivityAt: Date(timeIntervalSince1970: 5),
+                sessionId: "older"
+            ),
+        ]
+
+        let sorted = sortThreadsForDisplay(threads, isConnectedMode: true)
+
+        XCTAssertEqual(
+            sorted.map(\.title),
+            [
+                "pinned-first",
+                "pinned-second",
+                "recent",
+                "older",
+                "explicit-first",
+                "explicit-late",
+            ]
+        )
+    }
+
+    func testStandaloneModePreservesOriginalOrder() {
+        let threads = [
+            IOSThread(title: "first", sessionId: "first", isPinned: true, displayOrder: 1),
+            IOSThread(title: "second", sessionId: "second"),
+            IOSThread(title: "third", sessionId: "third", displayOrder: 1),
+        ]
+
+        let sorted = sortThreadsForDisplay(threads, isConnectedMode: false)
+
+        XCTAssertEqual(sorted.map(\.title), ["first", "second", "third"])
+    }
+}
+#endif

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -3,6 +3,27 @@ import SwiftUI
 import UIKit
 import VellumAssistantShared
 
+func sortThreadsForDisplay(
+    _ threads: [IOSThread],
+    isConnectedMode: Bool
+) -> [IOSThread] {
+    guard isConnectedMode else { return threads }
+
+    return threads.sorted { a, b in
+        if a.isPinned && b.isPinned {
+            return (a.displayOrder ?? 0) < (b.displayOrder ?? 0)
+        }
+        if a.isPinned { return true }
+        if b.isPinned { return false }
+        if a.displayOrder == nil && b.displayOrder == nil {
+            return a.lastActivityAt > b.lastActivityAt
+        }
+        if a.displayOrder == nil { return true }
+        if b.displayOrder == nil { return false }
+        return a.displayOrder! < b.displayOrder!
+    }
+}
+
 // MARK: - Tab Entry Point
 
 /// The tab-level Chats entry point. Switches between connected and disconnected
@@ -70,7 +91,10 @@ struct ThreadListView: View {
     private var activeThreads: [IOSThread] {
         // Exclude private threads — they are managed separately via the Private Threads
         // settings panel and must not appear in the main chat list.
-        store.threads.filter { !$0.isArchived && !$0.isPrivate }
+        sortThreadsForDisplay(
+            store.threads.filter { !$0.isArchived && !$0.isPrivate },
+            isConnectedMode: store.isConnectedMode
+        )
     }
 
     /// Active threads that are NOT from a schedule.
@@ -112,7 +136,10 @@ struct ThreadListView: View {
     }
 
     private var archivedThreads: [IOSThread] {
-        store.threads.filter { $0.isArchived && !$0.isPrivate }
+        sortThreadsForDisplay(
+            store.threads.filter { $0.isArchived && !$0.isPrivate },
+            isConnectedMode: store.isConnectedMode
+        )
     }
 
     private var filteredActiveThreads: [IOSThread] {


### PR DESCRIPTION
## Summary
- add a small iOS thread-display sorting helper that applies the macOS ordering rules in connected mode
- use that helper for both active and archived thread lists while leaving standalone ordering untouched
- add focused ordering tests for the connected and standalone cases

## Validation
- `clients/ios/./build.sh test` *(fails in this environment: no available iPhone simulator found; Xcode asks to install one via Settings > Platforms)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13720" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
