### PR TITLE
Add connected iOS pin helpers

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -769,6 +769,32 @@ class IOSThreadStore: ObservableObject {
         saveConnectedCache()
     }
 
+    func pinThread(_ thread: IOSThread) {
+        guard isConnectedMode,
+              let idx = threads.firstIndex(where: { $0.id == thread.id }),
+              threads[idx].sessionId != nil,
+              !threads[idx].isPinned else { return }
+
+        threads[idx].isPinned = true
+        threads[idx].displayOrder = Int.max
+        recompactPinnedDisplayOrders()
+        sendReorderThreads()
+        saveConnectedCache()
+    }
+
+    func unpinThread(_ thread: IOSThread) {
+        guard isConnectedMode,
+              let idx = threads.firstIndex(where: { $0.id == thread.id }),
+              threads[idx].sessionId != nil,
+              threads[idx].isPinned else { return }
+
+        threads[idx].isPinned = false
+        threads[idx].displayOrder = nil
+        recompactPinnedDisplayOrders()
+        sendReorderThreads()
+        saveConnectedCache()
+    }
+
     func unarchiveThread(_ thread: IOSThread) {
         guard let idx = threads.firstIndex(where: { $0.id == thread.id }) else { return }
         threads[idx].isArchived = false
@@ -791,6 +817,38 @@ class IOSThreadStore: ObservableObject {
         let text = last.text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return nil }
         return String(text.prefix(80))
+    }
+
+    private func recompactPinnedDisplayOrders() {
+        let pinned = threads.enumerated()
+            .filter { $0.element.isPinned }
+            .sorted { ($0.element.displayOrder ?? Int.max) < ($1.element.displayOrder ?? Int.max) }
+
+        for (order, item) in pinned.enumerated() {
+            threads[item.offset].displayOrder = order
+        }
+    }
+
+    private func sendReorderThreads() {
+        let updates = threads.compactMap { thread -> IPCReorderThreadsRequestUpdate? in
+            guard let sessionId = thread.sessionId, !thread.isArchived, !thread.isPrivate else {
+                return nil
+            }
+
+            return IPCReorderThreadsRequestUpdate(
+                sessionId: sessionId,
+                displayOrder: thread.displayOrder.map(Double.init),
+                isPinned: thread.isPinned
+            )
+        }
+        guard !updates.isEmpty else { return }
+
+        do {
+            try daemonClient.send(IPCReorderThreadsRequest(
+                type: "reorder_threads",
+                updates: updates
+            ))
+        } catch {}
     }
 
     // MARK: - Persistence

--- a/clients/ios/Tests/ThreadLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ThreadLifecycleIOSTests.swift
@@ -468,5 +468,126 @@ final class ThreadLifecycleIOSTests: XCTestCase {
         XCTAssertTrue(sentSignals.isEmpty)
         XCTAssertFalse(store.threads.first(where: { $0.id == storedThread.id })?.hasUnseenLatestAssistantMessage ?? true)
     }
+
+    func testPinningConnectedThreadUpdatesLocalStateAndEmitsReorder() {
+        let daemonClient = DaemonClient()
+        var reorderRequests: [IPCReorderThreadsRequest] = []
+        daemonClient.sendOverride = { message in
+            if let request = message as? IPCReorderThreadsRequest {
+                reorderRequests.append(request)
+            }
+        }
+
+        let store = IOSThreadStore(daemonClient: daemonClient)
+        let response = makeSessionListResponse(sessions: [
+            [
+                "id": "connected-session-pinned",
+                "title": "Pinned thread",
+                "createdAt": 1_000,
+                "updatedAt": 2_000,
+                "displayOrder": 0,
+                "isPinned": true,
+            ],
+            [
+                "id": "connected-session-unpinned",
+                "title": "Unpinned thread",
+                "createdAt": 1_000,
+                "updatedAt": 3_000,
+            ],
+        ])
+
+        daemonClient.onSessionListResponse?(response)
+        guard let thread = store.threads.first(where: { $0.sessionId == "connected-session-unpinned" }) else {
+            XCTFail("Expected unpinned connected thread")
+            return
+        }
+
+        store.pinThread(thread)
+
+        guard let updatedThread = store.threads.first(where: { $0.id == thread.id }) else {
+            XCTFail("Expected updated thread")
+            return
+        }
+
+        XCTAssertTrue(updatedThread.isPinned)
+        XCTAssertEqual(updatedThread.displayOrder, 1)
+        XCTAssertEqual(reorderRequests.count, 1)
+
+        let updatesBySessionId = Dictionary(
+            uniqueKeysWithValues: reorderRequests[0].updates.map { ($0.sessionId, $0) }
+        )
+        XCTAssertEqual(updatesBySessionId["connected-session-pinned"]?.displayOrder, 0)
+        XCTAssertEqual(updatesBySessionId["connected-session-pinned"]?.isPinned, true)
+        XCTAssertEqual(updatesBySessionId["connected-session-unpinned"]?.displayOrder, 1)
+        XCTAssertEqual(updatesBySessionId["connected-session-unpinned"]?.isPinned, true)
+    }
+
+    func testUnpinningConnectedThreadRecompactsPinnedOrderAndEmitsReorder() {
+        let daemonClient = DaemonClient()
+        var reorderRequests: [IPCReorderThreadsRequest] = []
+        daemonClient.sendOverride = { message in
+            if let request = message as? IPCReorderThreadsRequest {
+                reorderRequests.append(request)
+            }
+        }
+
+        let store = IOSThreadStore(daemonClient: daemonClient)
+        let response = makeSessionListResponse(sessions: [
+            [
+                "id": "connected-session-first",
+                "title": "First pinned thread",
+                "createdAt": 1_000,
+                "updatedAt": 2_000,
+                "displayOrder": 0,
+                "isPinned": true,
+            ],
+            [
+                "id": "connected-session-second",
+                "title": "Second pinned thread",
+                "createdAt": 1_000,
+                "updatedAt": 3_000,
+                "displayOrder": 1,
+                "isPinned": true,
+            ],
+        ])
+
+        daemonClient.onSessionListResponse?(response)
+        guard let thread = store.threads.first(where: { $0.sessionId == "connected-session-first" }) else {
+            XCTFail("Expected pinned connected thread")
+            return
+        }
+
+        store.unpinThread(thread)
+
+        guard let firstThread = store.threads.first(where: { $0.sessionId == "connected-session-first" }),
+              let secondThread = store.threads.first(where: { $0.sessionId == "connected-session-second" }) else {
+            XCTFail("Expected connected threads")
+            return
+        }
+
+        XCTAssertFalse(firstThread.isPinned)
+        XCTAssertNil(firstThread.displayOrder)
+        XCTAssertTrue(secondThread.isPinned)
+        XCTAssertEqual(secondThread.displayOrder, 0)
+        XCTAssertEqual(reorderRequests.count, 1)
+
+        let updatesBySessionId = Dictionary(
+            uniqueKeysWithValues: reorderRequests[0].updates.map { ($0.sessionId, $0) }
+        )
+        XCTAssertNil(updatesBySessionId["connected-session-first"]?.displayOrder)
+        XCTAssertEqual(updatesBySessionId["connected-session-first"]?.isPinned, false)
+        XCTAssertEqual(updatesBySessionId["connected-session-second"]?.displayOrder, 0)
+        XCTAssertEqual(updatesBySessionId["connected-session-second"]?.isPinned, true)
+    }
+
+    func testPinningStandaloneThreadDoesNothing() {
+        let store = IOSThreadStore(daemonClient: mockClient)
+        let thread = store.threads[0]
+
+        store.pinThread(thread)
+
+        XCTAssertFalse(store.threads[0].isPinned)
+        XCTAssertNil(store.threads[0].displayOrder)
+    }
     #endif
 }


### PR DESCRIPTION
## Summary
- add connected-mode `pinThread` and `unpinThread` helpers to the iOS thread store
- keep local `isPinned` and `displayOrder` in sync, compact pinned ordering, and emit the existing `reorder_threads` IPC request
- add focused tests for pin, unpin, and standalone no-op behavior

## Validation
- `clients/ios/./build.sh test` *(fails in this environment: no available iPhone simulator found; Xcode asks to install one via Settings > Platforms)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
