### PR TITLE
Add Swift unread signal transport support

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -161,6 +161,7 @@ public final class HTTPTransport {
         case guardianActionsPending(conversationId: String)
         case guardianActionsDecision
         case conversationsSeen
+        case conversationsUnread
         case identity
         case featureFlags
         case featureFlagUpdate(key: String)
@@ -235,6 +236,8 @@ public final class HTTPTransport {
             return ("/v1/guardian-actions/decision", nil)
         case .conversationsSeen:
             return ("/v1/conversations/seen", nil)
+        case .conversationsUnread:
+            return ("/v1/conversations/unread", nil)
         case .identity:
             return ("/v1/identity", nil)
         case .featureFlags:
@@ -327,6 +330,8 @@ public final class HTTPTransport {
             return ("\(prefix)/guardian-actions/decision/", nil)
         case .conversationsSeen:
             return ("\(prefix)/conversations/seen/", nil)
+        case .conversationsUnread:
+            return ("\(prefix)/conversations/unread/", nil)
         case .identity:
             return ("\(prefix)/identity/", nil)
         case .featureFlags:
@@ -650,6 +655,8 @@ public final class HTTPTransport {
             Task { await self.fetchHistory(sessionId: msg.sessionId) }
         } else if let msg = message as? IPCConversationSeenSignal {
             Task { await self.sendConversationSeen(msg) }
+        } else if let msg = message as? IPCConversationUnreadSignal {
+            Task { await self.sendConversationUnread(msg) }
         } else if let msg = message as? GuardianActionsPendingRequestMessage {
             Task { await self.fetchGuardianActionsPending(conversationId: msg.conversationId) }
         } else if let msg = message as? GuardianActionDecisionMessage {
@@ -981,6 +988,50 @@ public final class HTTPTransport {
             }
         } catch {
             log.error("Conversation seen signal error: \(error.localizedDescription)")
+        }
+    }
+
+    private func sendConversationUnread(_ signal: IPCConversationUnreadSignal, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .conversationsUnread) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        var body: [String: Any] = [
+            "conversationId": signal.conversationId,
+            "sourceChannel": signal.sourceChannel,
+            "signalType": signal.signalType,
+            "confidence": signal.confidence,
+            "source": signal.source
+        ]
+        if let evidenceText = signal.evidenceText {
+            body["evidenceText"] = evidenceText
+        }
+        if let observedAt = signal.observedAt {
+            body["observedAt"] = observedAt
+        }
+        if let metadata = signal.metadata {
+            body["metadata"] = metadata
+        }
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        await sendConversationUnread(signal, isRetry: true)
+                    }
+                } else if http.statusCode != 200 {
+                    log.error("Conversation unread signal failed (\(http.statusCode))")
+                }
+            }
+        } catch {
+            log.error("Conversation unread signal error: \(error.localizedDescription)")
         }
     }
 

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -2108,6 +2108,31 @@ extension IPCConversationSeenSignal {
     }
 }
 
+extension IPCConversationUnreadSignal {
+    public init(
+        conversationId: String,
+        sourceChannel: String,
+        signalType: String,
+        confidence: String,
+        source: String,
+        evidenceText: String? = nil,
+        observedAt: Int? = nil,
+        metadata: [String: AnyCodable]? = nil
+    ) {
+        self.init(
+            type: "conversation_unread_signal",
+            conversationId: conversationId,
+            sourceChannel: sourceChannel,
+            signalType: signalType,
+            confidence: confidence,
+            source: source,
+            evidenceText: evidenceText,
+            observedAt: observedAt,
+            metadata: metadata
+        )
+    }
+}
+
 /// Sent by the client to request subagent detail (events) for a completed subagent.
 public struct SubagentDetailRequestMessage: Encodable, Sendable {
     public let type: String = "subagent_detail_request"

--- a/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
+++ b/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
@@ -1,0 +1,193 @@
+import XCTest
+
+@testable import VellumAssistantShared
+
+private final class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            XCTFail("requestHandler not set")
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+@MainActor
+final class HTTPDaemonClientUnreadTests: XCTestCase {
+    private func requestBody(from request: URLRequest) throws -> Data {
+        if let body = request.httpBody {
+            return body
+        }
+
+        let stream = try XCTUnwrap(request.httpBodyStream)
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1024)
+
+        while stream.hasBytesAvailable {
+            let bytesRead = stream.read(&buffer, maxLength: buffer.count)
+            if bytesRead < 0 {
+                throw try XCTUnwrap(stream.streamError)
+            }
+            if bytesRead == 0 {
+                break
+            }
+            data.append(buffer, count: bytesRead)
+        }
+
+        return data
+    }
+
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.requestHandler = nil
+        URLProtocol.registerClass(MockURLProtocol.self)
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(MockURLProtocol.self)
+        MockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func testRuntimeFlatUnreadSignalPostsExpectedRequest() async throws {
+        let requestExpectation = expectation(description: "runtime unread request")
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            requestExpectation.fulfill()
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"ok":true}"#.utf8))
+        }
+
+        let transport = HTTPTransport(
+            baseURL: "https://example.com",
+            bearerToken: "test-token",
+            conversationKey: "conv-local"
+        )
+
+        try transport.send(
+            IPCConversationUnreadSignal(
+                conversationId: "conv-123",
+                sourceChannel: "vellum",
+                signalType: "macos_conversation_opened",
+                confidence: "explicit",
+                source: "ui-navigation",
+                evidenceText: "User selected Mark as unread"
+            )
+        )
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        XCTAssertEqual(
+            capturedRequest?.url?.absoluteString,
+            "https://example.com/v1/conversations/unread"
+        )
+        XCTAssertEqual(capturedRequest?.httpMethod, "POST")
+        XCTAssertEqual(
+            capturedRequest?.value(forHTTPHeaderField: "Authorization"),
+            "Bearer test-token"
+        )
+
+        let request = try XCTUnwrap(capturedRequest)
+        let body = try requestBody(from: request)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: body) as? [String: Any]
+        )
+        XCTAssertEqual(json["conversationId"] as? String, "conv-123")
+        XCTAssertEqual(json["sourceChannel"] as? String, "vellum")
+        XCTAssertEqual(json["signalType"] as? String, "macos_conversation_opened")
+        XCTAssertEqual(json["confidence"] as? String, "explicit")
+        XCTAssertEqual(json["source"] as? String, "ui-navigation")
+        XCTAssertEqual(
+            json["evidenceText"] as? String,
+            "User selected Mark as unread"
+        )
+    }
+
+    func testPlatformProxyUnreadSignalPostsExpectedRequest() async throws {
+        let requestExpectation = expectation(description: "platform unread request")
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            requestExpectation.fulfill()
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"ok":true}"#.utf8))
+        }
+
+        let transport = HTTPTransport(
+            baseURL: "https://platform.example.com",
+            bearerToken: "test-token",
+            conversationKey: "conv-local",
+            transportMetadata: TransportMetadata(
+                routeMode: .platformAssistantProxy,
+                authMode: .bearerToken,
+                platformAssistantId: "assistant-123"
+            )
+        )
+
+        try transport.send(
+            IPCConversationUnreadSignal(
+                conversationId: "conv-456",
+                sourceChannel: "vellum",
+                signalType: "macos_conversation_opened",
+                confidence: "explicit",
+                source: "ui-navigation"
+            )
+        )
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        XCTAssertEqual(
+            capturedRequest?.url?.absoluteString,
+            "https://platform.example.com/v1/assistants/assistant-123/conversations/unread/"
+        )
+        XCTAssertEqual(capturedRequest?.httpMethod, "POST")
+        XCTAssertEqual(
+            capturedRequest?.value(forHTTPHeaderField: "Authorization"),
+            "Bearer test-token"
+        )
+
+        let request = try XCTUnwrap(capturedRequest)
+        let body = try requestBody(from: request)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: body) as? [String: Any]
+        )
+        XCTAssertEqual(json["conversationId"] as? String, "conv-456")
+        XCTAssertEqual(json["signalType"] as? String, "macos_conversation_opened")
+    }
+}


### PR DESCRIPTION
## Summary
- add unread endpoint routing to the shared Swift HTTP transport
- send IPC unread signals over HTTP for both runtime-flat and platform-proxy modes
- cover both request shapes with focused transport tests

## Testing
- swift test --filter HTTPDaemonClientUnreadTests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
