### PR TITLE
fix: auto-focus composer input when switching threads

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatEmptyStateView.swift
@@ -25,6 +25,7 @@ struct ChatEmptyStateView: View {
     var onDropImageData: ((Data, String?) -> Void)? = nil
     let onMicrophoneToggle: () -> Void
     let onDismissError: () -> Void
+    var threadId: UUID?
 
     @State private var visible = false
     @State private var title: String = titles.randomElement()!
@@ -116,7 +117,8 @@ struct ChatEmptyStateView: View {
                     onFileDrop: onFileDrop,
                     onDropImageData: onDropImageData,
                     onMicrophoneToggle: onMicrophoneToggle,
-                    placeholderText: placeholder
+                    placeholderText: placeholder,
+                    threadId: threadId
                 )
             }
             .frame(maxWidth: 500)
@@ -162,6 +164,7 @@ struct ChatTemporaryChatEmptyStateView: View {
     var onDropImageData: ((Data, String?) -> Void)? = nil
     let onMicrophoneToggle: () -> Void
     let onDismissError: () -> Void
+    var threadId: UUID?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -221,7 +224,8 @@ struct ChatTemporaryChatEmptyStateView: View {
                     onFileDrop: onFileDrop,
                     onDropImageData: onDropImageData,
                     onMicrophoneToggle: onMicrophoneToggle,
-                    placeholderText: "Ask anything..."
+                    placeholderText: "Ask anything...",
+                    threadId: threadId
                 )
             }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatView.swift
@@ -138,7 +138,8 @@ struct ChatView: View {
                             onFileDrop: onDropFiles,
                             onDropImageData: onDropImageData,
                             onMicrophoneToggle: onMicrophoneToggle,
-                            onDismissError: onDismissError
+                            onDismissError: onDismissError,
+                            threadId: threadId
                         )
                     } else {
                         ChatEmptyStateView(
@@ -159,7 +160,8 @@ struct ChatView: View {
                             onFileDrop: onDropFiles,
                             onDropImageData: onDropImageData,
                             onMicrophoneToggle: onMicrophoneToggle,
-                            onDismissError: onDismissError
+                            onDismissError: onDismissError,
+                            threadId: threadId
                         )
                     }
                 } else {
@@ -251,7 +253,8 @@ struct ChatView: View {
                             idleHint: idleHint,
                             voiceModeManager: voiceModeManager,
                             voiceService: voiceService,
-                            onEndVoiceMode: onEndVoiceMode
+                            onEndVoiceMode: onEndVoiceMode,
+                            threadId: threadId
                         )
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerSection.swift
@@ -41,6 +41,7 @@ struct ComposerSection: View {
     var voiceModeManager: VoiceModeManager? = nil
     var voiceService: OpenAIVoiceService? = nil
     var onEndVoiceMode: (() -> Void)? = nil
+    var threadId: UUID?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -95,7 +96,8 @@ struct ComposerSection: View {
                 voiceModeManager: voiceModeManager,
                 voiceService: voiceService,
                 onEndVoiceMode: onEndVoiceMode,
-                placeholderText: isSending ? "Working on it..." : "What would you like to do?"
+                placeholderText: isSending ? "Working on it..." : "What would you like to do?",
+                threadId: threadId
             )
         }
         .background(

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -130,6 +130,7 @@ struct ComposerView: View {
             avatarSeed = identity?.name ?? "default"
         }
         .onChange(of: threadId) {
+            guard !hasPendingConfirmation else { return }
             composerFocus = true
         }
     }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -32,6 +32,7 @@ struct ComposerView: View {
     var onEndVoiceMode: (() -> Void)? = nil
     var placeholderText: String = "What would you like to do?"
     var composerCompactHeight: CGFloat = 34
+    var threadId: UUID?
 
     @Environment(\.conversationZoomScale) private var zoomScale
     @Environment(\.cmdEnterToSend) private var cmdEnterToSend
@@ -127,6 +128,9 @@ struct ComposerView: View {
             composerFocus = true
             let identity = IdentityInfo.load()
             avatarSeed = identity?.name ?? "default"
+        }
+        .onChange(of: threadId) {
+            composerFocus = true
         }
     }
 


### PR DESCRIPTION
## Summary
- Pass `threadId` through ChatView → ComposerSection/EmptyStateViews → ComposerView
- Add `.onChange(of: threadId)` in ComposerView to set `composerFocus = true` when the active thread changes
- Previously, focus was only set via `onAppear` which doesn't re-fire when the view is reused across thread switches

## Original prompt
when i open a new thread it should auto focus to input

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
