### PR TITLE
Add connected iOS unread helper

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -795,6 +795,27 @@ class IOSThreadStore: ObservableObject {
         saveConnectedCache()
     }
 
+    func markThreadUnread(_ thread: IOSThread) {
+        guard isConnectedMode,
+              let idx = threads.firstIndex(where: { $0.id == thread.id }),
+              let sessionId = threads[idx].sessionId,
+              !threads[idx].hasUnseenLatestAssistantMessage,
+              threads[idx].latestAssistantMessageAt != nil else { return }
+
+        threads[idx].hasUnseenLatestAssistantMessage = true
+        saveConnectedCache()
+
+        let signal = IPCConversationUnreadSignal(
+            conversationId: sessionId,
+            sourceChannel: "vellum",
+            signalType: "macos_conversation_opened",
+            confidence: "explicit",
+            source: "ui-navigation",
+            evidenceText: "User selected Mark as unread"
+        )
+        try? daemonClient.send(signal)
+    }
+
     func unarchiveThread(_ thread: IOSThread) {
         guard let idx = threads.firstIndex(where: { $0.id == thread.id }) else { return }
         threads[idx].isArchived = false

--- a/clients/ios/Tests/ThreadLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ThreadLifecycleIOSTests.swift
@@ -469,6 +469,125 @@ final class ThreadLifecycleIOSTests: XCTestCase {
         XCTAssertFalse(store.threads.first(where: { $0.id == storedThread.id })?.hasUnseenLatestAssistantMessage ?? true)
     }
 
+    func testMarkingSeenConnectedThreadUnreadUpdatesLocalStateAndEmitsSignal() {
+        let daemonClient = DaemonClient()
+        var sentSignals: [IPCConversationUnreadSignal] = []
+        daemonClient.sendOverride = { message in
+            if let signal = message as? IPCConversationUnreadSignal {
+                sentSignals.append(signal)
+            }
+        }
+
+        let store = IOSThreadStore(daemonClient: daemonClient)
+        let response = makeSessionListResponse(sessions: [[
+            "id": "connected-session-4",
+            "title": "Seen thread",
+            "createdAt": 1_000,
+            "updatedAt": 2_000,
+            "assistantAttention": [
+                "hasUnseenLatestAssistantMessage": false,
+                "latestAssistantMessageAt": 5_000,
+                "lastSeenAssistantMessageAt": 5_000,
+            ],
+        ]])
+
+        daemonClient.onSessionListResponse?(response)
+        guard let storedThread = store.threads.first(where: { $0.sessionId == "connected-session-4" }) else {
+            XCTFail("Expected connected thread")
+            return
+        }
+
+        store.markThreadUnread(storedThread)
+
+        guard let updatedThread = store.threads.first(where: { $0.id == storedThread.id }) else {
+            XCTFail("Expected updated thread")
+            return
+        }
+
+        XCTAssertTrue(updatedThread.hasUnseenLatestAssistantMessage)
+        XCTAssertEqual(sentSignals.count, 1)
+        XCTAssertEqual(sentSignals[0].conversationId, "connected-session-4")
+        XCTAssertEqual(sentSignals[0].sourceChannel, "vellum")
+        XCTAssertEqual(sentSignals[0].signalType, "macos_conversation_opened")
+        XCTAssertEqual(sentSignals[0].confidence, "explicit")
+        XCTAssertEqual(sentSignals[0].source, "ui-navigation")
+        XCTAssertEqual(sentSignals[0].evidenceText, "User selected Mark as unread")
+
+        let reloadedStore = IOSThreadStore(daemonClient: daemonClient)
+        guard let cachedThread = reloadedStore.threads.first(where: { $0.sessionId == "connected-session-4" }) else {
+            XCTFail("Expected cached connected thread")
+            return
+        }
+
+        XCTAssertTrue(cachedThread.hasUnseenLatestAssistantMessage)
+    }
+
+    func testMarkingAlreadyUnreadConnectedThreadUnreadDoesNothing() {
+        let daemonClient = DaemonClient()
+        var sentSignals: [IPCConversationUnreadSignal] = []
+        daemonClient.sendOverride = { message in
+            if let signal = message as? IPCConversationUnreadSignal {
+                sentSignals.append(signal)
+            }
+        }
+
+        let store = IOSThreadStore(daemonClient: daemonClient)
+        let response = makeSessionListResponse(sessions: [[
+            "id": "connected-session-5",
+            "title": "Unread thread",
+            "createdAt": 1_000,
+            "updatedAt": 2_000,
+            "assistantAttention": [
+                "hasUnseenLatestAssistantMessage": true,
+                "latestAssistantMessageAt": 5_000,
+                "lastSeenAssistantMessageAt": 4_000,
+            ],
+        ]])
+
+        daemonClient.onSessionListResponse?(response)
+        guard let storedThread = store.threads.first(where: { $0.sessionId == "connected-session-5" }) else {
+            XCTFail("Expected unread connected thread")
+            return
+        }
+
+        store.markThreadUnread(storedThread)
+
+        XCTAssertTrue(sentSignals.isEmpty)
+        XCTAssertTrue(store.threads.first(where: { $0.id == storedThread.id })?.hasUnseenLatestAssistantMessage ?? false)
+    }
+
+    func testMarkingThreadWithoutAssistantReplyUnreadDoesNothing() {
+        let daemonClient = DaemonClient()
+        var sentSignals: [IPCConversationUnreadSignal] = []
+        daemonClient.sendOverride = { message in
+            if let signal = message as? IPCConversationUnreadSignal {
+                sentSignals.append(signal)
+            }
+        }
+
+        let store = IOSThreadStore(daemonClient: daemonClient)
+        let response = makeSessionListResponse(sessions: [[
+            "id": "connected-session-6",
+            "title": "No assistant reply yet",
+            "createdAt": 1_000,
+            "updatedAt": 2_000,
+            "assistantAttention": [
+                "hasUnseenLatestAssistantMessage": false,
+            ],
+        ]])
+
+        daemonClient.onSessionListResponse?(response)
+        guard let storedThread = store.threads.first(where: { $0.sessionId == "connected-session-6" }) else {
+            XCTFail("Expected connected thread")
+            return
+        }
+
+        store.markThreadUnread(storedThread)
+
+        XCTAssertTrue(sentSignals.isEmpty)
+        XCTAssertFalse(store.threads.first(where: { $0.id == storedThread.id })?.hasUnseenLatestAssistantMessage ?? true)
+    }
+
     func testPinningConnectedThreadUpdatesLocalStateAndEmitsReorder() {
         let daemonClient = DaemonClient()
         var reorderRequests: [IPCReorderThreadsRequest] = []


### PR DESCRIPTION
## Summary
- add a connected-mode iOS helper that marks a thread unread through the daemon-backed unread signal
- guard the helper for already-unread threads and threads with no assistant reply
- cover the helper with connected-thread lifecycle tests

## Testing
- ./build.sh build *(fails in this environment: Xcode is missing the iOS Simulator platform)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
