### PR TITLE
Show pin and unread state in iOS rows

### DIFF
--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -462,7 +462,21 @@ struct ThreadListView: View {
                 VIconView(.messageCircle, size: 12)
                     .foregroundStyle(.secondary)
                 Text(thread.title)
+                    .fontWeight(
+                        store.isConnectedMode && thread.hasUnseenLatestAssistantMessage
+                            ? .semibold
+                            : .regular
+                    )
                     .lineLimit(1)
+                if store.isConnectedMode && thread.isPinned {
+                    VIconView(.pin, size: 10)
+                        .foregroundColor(VColor.accent)
+                        .accessibilityLabel("Pinned")
+                }
+                if store.isConnectedMode && thread.hasUnseenLatestAssistantMessage {
+                    VBadge(style: .dot, color: VColor.accent)
+                        .accessibilityLabel("Unread")
+                }
                 Spacer()
                 Text(relativeDate(thread.lastActivityAt))
                     .font(.caption2)


### PR DESCRIPTION
## Summary
- show connected-thread pin state directly in the iOS thread row
- show a lightweight unread indicator and stronger title emphasis for unread connected threads
- leave standalone thread rows unchanged

## Testing
- ./build.sh build *(fails in this environment: Xcode is missing the iOS Simulator platform)*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
