### PR TITLE
fix: [macOS] make shift-enter the desktop chat newline shortcut

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
@@ -27,8 +27,9 @@ extension EnvironmentValues {
 /// - Intercepts Cmd+V when the pasteboard contains image content.
 /// - Intercepts Cmd+Return when `cmdEnterToSend` is enabled to trigger send
 ///   before SwiftUI's `.onSubmit` fires.
-/// - Intercepts Shift+Return in default send mode to insert a newline
-///   before SwiftUI's `.onSubmit` fires.
+/// - Intercepts Shift+Return in default send mode to insert a newline, and
+///   routes default-mode Option+Return through the same bridge send path used
+///   by Cmd+Return, before SwiftUI's `.onSubmit` fires.
 struct ComposerFocusBridge: NSViewRepresentable {
     let isFocused: Bool
     let cmdEnterToSend: Bool
@@ -103,7 +104,9 @@ struct ComposerFocusBridge: NSViewRepresentable {
                 }
 
                 // Return-key routing. The bridge handles modifier-specific
-                // interception (Shift+Enter newline, Cmd+Enter send).
+                // interception for its dedicated paths: Shift+Enter newline in
+                // default mode, Option+Enter send in default mode, and
+                // Cmd+Enter send when the preference is enabled.
                 // Plain Enter flows through to SwiftUI's .onSubmit which
                 // calls performSendAction() — the canonical send path that
                 // handles slash-menu, ghost-text, and pending-confirmation.

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerReturnKeyRouting.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerReturnKeyRouting.swift
@@ -2,7 +2,8 @@
 import AppKit
 
 /// Routes Return key presses in the composer based on modifier keys and the user's send-mode preference.
-/// Only Shift+Return (default mode) and Cmd+Return (cmd-enter mode) are intercepted;
+/// In default mode, Shift+Return is the only newline shortcut and Option+Return
+/// is treated as send via the bridge. In cmd-enter mode, only Cmd+Return sends;
 /// all other combinations defer to SwiftUI's `.onSubmit` handler.
 enum ComposerReturnKeyRouting {
     enum Action: Equatable {
@@ -17,8 +18,13 @@ enum ComposerReturnKeyRouting {
         // equality checks.
         let keys = modifiers.intersection([.shift, .command, .control, .option])
 
-        if !cmdEnterToSend && keys == .shift {
-            return .bridgeInsertNewline
+        if !cmdEnterToSend {
+            if keys == .shift {
+                return .bridgeInsertNewline
+            }
+            if keys == .option {
+                return .bridgeSend
+            }
         }
         if cmdEnterToSend && keys == .command {
             return .bridgeSend

--- a/clients/macos/vellum-assistantTests/ComposerReturnKeyRoutingTests.swift
+++ b/clients/macos/vellum-assistantTests/ComposerReturnKeyRoutingTests.swift
@@ -16,6 +16,11 @@ final class ComposerReturnKeyRoutingTests: XCTestCase {
         XCTAssertEqual(action, .bridgeInsertNewline)
     }
 
+    func testDefaultMode_optionReturn_sends() {
+        let action = ComposerReturnKeyRouting.resolve(cmdEnterToSend: false, modifiers: [.option])
+        XCTAssertEqual(action, .bridgeSend)
+    }
+
     func testDefaultMode_cmdReturn_defersToSubmit() {
         let action = ComposerReturnKeyRouting.resolve(cmdEnterToSend: false, modifiers: [.command])
         XCTAssertEqual(action, .deferToSubmit)
@@ -53,6 +58,11 @@ final class ComposerReturnKeyRoutingTests: XCTestCase {
     func testDefaultMode_shiftReturnWithCapsLock_insertsNewline() {
         let action = ComposerReturnKeyRouting.resolve(cmdEnterToSend: false, modifiers: [.shift, .capsLock])
         XCTAssertEqual(action, .bridgeInsertNewline)
+    }
+
+    func testDefaultMode_optionReturnWithCapsLock_sends() {
+        let action = ComposerReturnKeyRouting.resolve(cmdEnterToSend: false, modifiers: [.option, .capsLock])
+        XCTAssertEqual(action, .bridgeSend)
     }
 
     func testCmdEnterMode_cmdReturnWithCapsLock_sends() {


### PR DESCRIPTION
## Summary
- make the default composer routing treat Option+Return as send while keeping Shift+Return as newline
- refresh the composer bridge comments to match the new routing contract
- add regression coverage for default-mode Option+Return routing
- Apple refs checked (2026-03-07): NSEvent modifier handling and SwiftUI submit behavior in Apple Developer Documentation

Part of plan: desktop-shift-enter-newline.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
