### PR TITLE
Add macOS unread thread action

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1121,6 +1121,16 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
     }
 
+    internal func markConversationUnread(threadId: UUID) {
+        guard let idx = threads.firstIndex(where: { $0.id == threadId }),
+              let sessionId = threads[idx].sessionId,
+              !threads[idx].hasUnseenLatestAssistantMessage,
+              threads[idx].latestAssistantMessageAt != nil else { return }
+
+        threads[idx].hasUnseenLatestAssistantMessage = true
+        emitConversationUnreadSignal(conversationId: sessionId)
+    }
+
     /// Set a pending anchor message for scroll-to behavior on notification deep links.
     /// Only takes effect when the specified thread is currently active.
     func setPendingAnchorMessage(threadId: UUID, messageId: UUID) {
@@ -1218,6 +1228,22 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             try daemonClient.send(signal)
         } catch {
             log.warning("Failed to send conversation_seen_signal for \(conversationId): \(error.localizedDescription)")
+        }
+    }
+
+    private func emitConversationUnreadSignal(conversationId: String) {
+        let signal = IPCConversationUnreadSignal(
+            conversationId: conversationId,
+            sourceChannel: "vellum",
+            signalType: "macos_conversation_opened",
+            confidence: "explicit",
+            source: "ui-navigation",
+            evidenceText: "User selected Mark as unread"
+        )
+        do {
+            try daemonClient.send(signal)
+        } catch {
+            log.warning("Failed to send conversation_unread_signal for \(conversationId): \(error.localizedDescription)")
         }
     }
 

--- a/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
@@ -280,6 +280,69 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         XCTAssertEqual(seenSignals.last?.conversationId, "session-mark-seen")
     }
 
+    func testMarkConversationUnreadEmitsSignalAndSetsFlag() {
+        guard let threadId = threadManager.activeThreadId,
+              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active thread")
+            return
+        }
+
+        threadManager.threads[index].sessionId = "session-mark-unread"
+        threadManager.threads[index].hasUnseenLatestAssistantMessage = false
+        threadManager.threads[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 9)
+
+        sentMessages.removeAll()
+
+        threadManager.markConversationUnread(threadId: threadId)
+
+        XCTAssertTrue(threadManager.threads[index].hasUnseenLatestAssistantMessage,
+                      "markConversationUnread should set the unseen flag")
+
+        let unreadSignals = sentMessages.compactMap { $0 as? IPCConversationUnreadSignal }
+        XCTAssertEqual(unreadSignals.count, 1, "markConversationUnread should emit a single unread signal")
+        XCTAssertEqual(unreadSignals.last?.conversationId, "session-mark-unread")
+    }
+
+    func testMarkConversationUnreadDoesNotEmitDuplicateSignalForUnreadThread() {
+        guard let threadId = threadManager.activeThreadId,
+              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active thread")
+            return
+        }
+
+        threadManager.threads[index].sessionId = "session-already-unread"
+        threadManager.threads[index].hasUnseenLatestAssistantMessage = true
+        threadManager.threads[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 9)
+
+        sentMessages.removeAll()
+
+        threadManager.markConversationUnread(threadId: threadId)
+
+        let unreadSignals = sentMessages.compactMap { $0 as? IPCConversationUnreadSignal }
+        XCTAssertTrue(unreadSignals.isEmpty, "Already-unread threads should not emit duplicate unread signals")
+        XCTAssertTrue(threadManager.threads[index].hasUnseenLatestAssistantMessage)
+    }
+
+    func testMarkConversationUnreadIgnoresThreadsWithoutAssistantReply() {
+        guard let threadId = threadManager.activeThreadId,
+              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active thread")
+            return
+        }
+
+        threadManager.threads[index].sessionId = "session-no-assistant-reply"
+        threadManager.threads[index].hasUnseenLatestAssistantMessage = false
+        threadManager.threads[index].latestAssistantMessageAt = nil
+
+        sentMessages.removeAll()
+
+        threadManager.markConversationUnread(threadId: threadId)
+
+        let unreadSignals = sentMessages.compactMap { $0 as? IPCConversationUnreadSignal }
+        XCTAssertTrue(unreadSignals.isEmpty, "Threads without assistant replies should not emit unread signals")
+        XCTAssertFalse(threadManager.threads[index].hasUnseenLatestAssistantMessage)
+    }
+
     func testActiveThreadDoesNotEmitSeenSignalOnEveryStreamingDelta() {
         guard let threadId = threadManager.activeThreadId,
               let index = threadManager.threads.firstIndex(where: { $0.id == threadId }),


### PR DESCRIPTION
## Summary
- add a thread-manager helper that marks a macOS thread unread through the daemon unread signal
- make the helper idempotent and ignore threads with no assistant reply yet
- cover the new unread behavior with focused unseen-state tests

## Testing
- ./build.sh test *(fails due an unrelated pre-existing crash in PrivateThreadPersistenceTests)*
- swift test --filter "ThreadManagerUnseenStateTests/testMarkConversationUnread"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
