### PR TITLE
refactor: consolidate guardian verification HTTP handlers into unified session API

### DIFF
--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -5,8 +5,8 @@
  * Verifies:
  * - startOutbound / resendOutbound / cancelOutbound return correct result
  *   shapes and stable error codes.
- * - HTTP route handlers (handleStartOutbound / handleResendOutbound /
- *   handleCancelOutbound) wire through to the shared module and return
+ * - HTTP route handlers (handleCreateGuardianSession / handleResendGuardianSession /
+ *   handleCancelGuardianSession) wire through to the shared module and return
  *   appropriate HTTP status codes.
  * - Rate limiting, missing/invalid destination, already_bound, and
  *   no_active_session error paths all produce the expected error codes.
@@ -136,9 +136,9 @@ import {
   startOutbound,
 } from "../runtime/guardian-outbound-actions.js";
 import {
-  handleCancelOutbound,
-  handleResendOutbound,
-  handleStartOutbound,
+  handleCancelGuardianSession,
+  handleCreateGuardianSession,
+  handleResendGuardianSession,
 } from "../runtime/routes/integration-routes.js";
 
 // Initialize the database (creates all tables)
@@ -463,10 +463,10 @@ describe("cancelOutbound", () => {
 // HTTP route handlers
 // ===========================================================================
 
-describe("HTTP route: handleStartOutbound", () => {
+describe("HTTP route: handleCreateGuardianSession", () => {
   test("returns 400 when channel is missing", async () => {
     const req = jsonRequest({ destination: "+15551234567" });
-    const resp = await handleStartOutbound(req);
+    const resp = await handleCreateGuardianSession(req);
     expect(resp.status).toBe(400);
     const body = (await resp.json()) as {
       error: { message: string; code: string };
@@ -475,17 +475,19 @@ describe("HTTP route: handleStartOutbound", () => {
     expect(body.error.message).toContain("channel");
   });
 
-  test("returns 400 for missing destination (SMS)", async () => {
+  test("creates inbound challenge when destination is absent", async () => {
+    // Without a destination, the unified handler takes the inbound challenge path.
     const req = jsonRequest({ channel: "sms" });
-    const resp = await handleStartOutbound(req);
-    expect(resp.status).toBe(400);
-    const body = (await resp.json()) as { error?: string };
-    expect(body.error).toBe("missing_destination");
+    const resp = await handleCreateGuardianSession(req);
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    expect(body.success).toBe(true);
+    expect(body.channel).toBe("sms");
   });
 
   test("returns 200 for valid SMS start", async () => {
     const req = jsonRequest({ channel: "sms", destination: "+15559999999" });
-    const resp = await handleStartOutbound(req);
+    const resp = await handleCreateGuardianSession(req);
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as Record<string, unknown>;
     expect(body.success).toBe(true);
@@ -493,10 +495,10 @@ describe("HTTP route: handleStartOutbound", () => {
   });
 });
 
-describe("HTTP route: handleResendOutbound", () => {
+describe("HTTP route: handleResendGuardianSession", () => {
   test("returns 400 when channel is missing", async () => {
     const req = jsonRequest({});
-    const resp = await handleResendOutbound(req);
+    const resp = await handleResendGuardianSession(req);
     expect(resp.status).toBe(400);
     const body = (await resp.json()) as {
       error: { message: string; code: string };
@@ -507,7 +509,7 @@ describe("HTTP route: handleResendOutbound", () => {
 
   test("returns 400 for no_active_session", async () => {
     const req = jsonRequest({ channel: "sms" });
-    const resp = await handleResendOutbound(req);
+    const resp = await handleResendGuardianSession(req);
     expect(resp.status).toBe(400);
     const body = (await resp.json()) as { error?: string };
     expect(body.error).toBe("no_active_session");
@@ -519,7 +521,7 @@ describe("HTTP route: handleResendOutbound", () => {
       channel: "sms",
       destination: "+15556667777",
     });
-    const startResp = await handleStartOutbound(startReq);
+    const startResp = await handleCreateGuardianSession(startReq);
     expect(startResp.status).toBe(200);
     const startBody = (await startResp.json()) as Record<string, unknown>;
 
@@ -537,7 +539,7 @@ describe("HTTP route: handleResendOutbound", () => {
       channel: "sms",
       originConversationId: "conv-resend-http-origin",
     });
-    const resendResp = await handleResendOutbound(resendReq);
+    const resendResp = await handleResendGuardianSession(resendReq);
     expect(resendResp.status).toBe(200);
     const resendBody = (await resendResp.json()) as Record<string, unknown>;
     expect(resendBody.success).toBe(true);
@@ -545,10 +547,10 @@ describe("HTTP route: handleResendOutbound", () => {
   });
 });
 
-describe("HTTP route: handleCancelOutbound", () => {
+describe("HTTP route: handleCancelGuardianSession", () => {
   test("returns 400 when channel is missing", async () => {
     const req = jsonRequest({});
-    const resp = await handleCancelOutbound(req);
+    const resp = await handleCancelGuardianSession(req);
     expect(resp.status).toBe(400);
     const body = (await resp.json()) as {
       error: { message: string; code: string };
@@ -557,12 +559,14 @@ describe("HTTP route: handleCancelOutbound", () => {
     expect(body.error.message).toContain("channel");
   });
 
-  test("returns 400 for no_active_session", async () => {
+  test("returns 200 even when no active session exists", async () => {
+    // The unified cancel handler silently cancels both inbound and outbound —
+    // no error if nothing is active.
     const req = jsonRequest({ channel: "sms" });
-    const resp = await handleCancelOutbound(req);
-    expect(resp.status).toBe(400);
-    const body = (await resp.json()) as { error?: string };
-    expect(body.error).toBe("no_active_session");
+    const resp = await handleCancelGuardianSession(req);
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    expect(body.success).toBe(true);
   });
 
   test("returns 200 when active session is cancelled", async () => {
@@ -571,12 +575,12 @@ describe("HTTP route: handleCancelOutbound", () => {
       channel: "sms",
       destination: "+15558887777",
     });
-    const startResp = await handleStartOutbound(startReq);
+    const startResp = await handleCreateGuardianSession(startReq);
     expect(startResp.status).toBe(200);
 
     // Cancel it
     const cancelReq = jsonRequest({ channel: "sms" });
-    const cancelResp = await handleCancelOutbound(cancelReq);
+    const cancelResp = await handleCancelGuardianSession(cancelReq);
     expect(cancelResp.status).toBe(200);
     const body = (await cancelResp.json()) as Record<string, unknown>;
     expect(body.success).toBe(true);
@@ -627,13 +631,13 @@ describe("origin conversation linkage", () => {
     expect(result.originConversationId).toBeUndefined();
   });
 
-  test("HTTP handleStartOutbound passes originConversationId through", async () => {
+  test("HTTP handleCreateGuardianSession passes originConversationId through", async () => {
     const req = jsonRequest({
       channel: "sms",
       destination: "+15557776666",
       originConversationId: "conv-origin-http-test",
     });
-    const resp = await handleStartOutbound(req);
+    const resp = await handleCreateGuardianSession(req);
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as Record<string, unknown>;
     expect(body.success).toBe(true);

--- a/assistant/src/__tests__/provider-error-scenarios.test.ts
+++ b/assistant/src/__tests__/provider-error-scenarios.test.ts
@@ -9,7 +9,7 @@ mock.module("../util/logger.js", () => ({
 // Only mock sleep so retries complete instantly; keep real retry logic.
 // NOTE: We must NOT use `await import()` inside mock.module — it deadlocks
 // bun's module resolver. Instead, inline the real exports and only replace sleep.
-const sleepSpy = mock(() => Promise.resolve());
+const sleepSpy = mock((_ms: number) => Promise.resolve());
 
 mock.module("../util/retry.js", () => {
   const DEFAULT_MAX_RETRIES = 3;

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -166,6 +166,9 @@ export function revokeGuardianForChannel(
   const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
   const resolvedChannel = channel ?? "telegram";
 
+  // Cancel any active outbound session so revoke is a complete teardown.
+  cancelOutbound({ channel: resolvedChannel });
+
   // Always revoke pending challenges first — the macOS app uses
   // action: "revoke" to cancel an in-flight challenge even before
   // a binding exists (e.g. during verification setup).

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -13,13 +13,12 @@
  * POST   /v1/integrations/slack/channel/config — validate and store credentials
  * DELETE /v1/integrations/slack/channel/config — clear credentials
  *
- * Guardian verification:
- * POST   /v1/integrations/guardian/challenge        — create a verification challenge
+ * Guardian verification (unified session API):
+ * POST   /v1/integrations/guardian/sessions        — create session (inbound challenge or outbound verification)
+ * POST   /v1/integrations/guardian/sessions/resend  — resend outbound verification code
+ * DELETE /v1/integrations/guardian/sessions         — cancel all active sessions (inbound + outbound)
+ * POST   /v1/integrations/guardian/revoke           — cancel all sessions and revoke binding
  * GET    /v1/integrations/guardian/status            — check guardian binding status
- * POST   /v1/integrations/guardian/revoke            — revoke active guardian binding
- * POST   /v1/integrations/guardian/outbound/start    — start outbound verification
- * POST   /v1/integrations/guardian/outbound/resend   — resend outbound verification
- * POST   /v1/integrations/guardian/outbound/cancel   — cancel outbound verification
  */
 
 import type { ChannelId } from "../../channels/types.js";
@@ -41,6 +40,7 @@ import {
   setupTelegram,
 } from "../../daemon/handlers/config-telegram.js";
 import { normalizePhoneNumber } from "../../util/phone.js";
+import { revokePendingChallenges } from "../channel-guardian-service.js";
 import {
   cancelOutbound,
   normalizeTelegramDestination,
@@ -145,22 +145,73 @@ export async function handleClearSlackChannelConfig(): Promise<Response> {
 }
 
 // ---------------------------------------------------------------------------
-// Guardian verification
+// Guardian verification (unified session API)
 // ---------------------------------------------------------------------------
 
 /**
- * POST /v1/integrations/guardian/challenge
+ * POST /v1/integrations/guardian/sessions
  *
- * Body: { channel?: ChannelId; rebind?: boolean; sessionId?: string }
+ * Unified session creation: if `destination` is present, starts outbound
+ * verification; otherwise creates an inbound challenge.
+ *
+ * Body: { channel?: ChannelId; destination?: string; rebind?: boolean; sessionId?: string; originConversationId?: string }
  */
-export async function handleCreateGuardianChallenge(
+export async function handleCreateGuardianSession(
   req: Request,
 ): Promise<Response> {
   const body = (await req.json()) as {
     channel?: ChannelId;
+    destination?: string;
     rebind?: boolean;
     sessionId?: string;
+    originConversationId?: string;
   };
+
+  if (body.destination) {
+    // Outbound verification path — requires a channel
+    if (!body.channel) {
+      return httpError("BAD_REQUEST", 'The "channel" field is required.', 400);
+    }
+
+    // Normalize destination to prevent rate-limit bypass via format variations
+    // (e.g. "+15551234567" vs "(555) 123-4567", or "@User" vs "user")
+    let rateLimitKey: string | undefined = body.destination;
+    if (rateLimitKey) {
+      if (body.channel === "sms" || body.channel === "voice") {
+        rateLimitKey = normalizePhoneNumber(rateLimitKey) ?? rateLimitKey;
+      } else if (body.channel === "telegram") {
+        rateLimitKey = normalizeTelegramDestination(rateLimitKey);
+      }
+    }
+
+    if (rateLimitKey && guardianVerificationLimiter.isBlocked(rateLimitKey)) {
+      return httpError(
+        "RATE_LIMITED",
+        "Too many verification attempts for this identity. Please try again later.",
+        429,
+      );
+    }
+
+    const result = await startOutbound({
+      channel: body.channel,
+      destination: body.destination,
+      rebind: body.rebind,
+      originConversationId: body.originConversationId,
+    });
+
+    if (!result.success && rateLimitKey) {
+      guardianVerificationLimiter.recordFailure(rateLimitKey);
+    }
+
+    const status = result.success
+      ? 200
+      : result.error === "rate_limited"
+        ? 429
+        : 400;
+    return Response.json(result, { status });
+  }
+
+  // Inbound challenge path
   const result = createGuardianChallenge(
     body.channel,
     body.rebind,
@@ -183,83 +234,13 @@ export function handleGetGuardianStatus(url: URL): Response {
 }
 
 /**
- * POST /v1/integrations/guardian/revoke
- *
- * Body: { channel?: ChannelId }
- */
-export async function handleRevokeGuardian(req: Request): Promise<Response> {
-  const body = (await req.json()) as {
-    channel?: ChannelId;
-  };
-  const result = revokeGuardianForChannel(body.channel);
-  const status = result.success ? 200 : 400;
-  return Response.json(result, { status });
-}
-
-// ---------------------------------------------------------------------------
-// Guardian outbound verification
-// ---------------------------------------------------------------------------
-
-/**
- * POST /v1/integrations/guardian/outbound/start
- *
- * Body: { channel: ChannelId; destination?: string; rebind?: boolean; originConversationId?: string }
- */
-export async function handleStartOutbound(req: Request): Promise<Response> {
-  const body = (await req.json()) as {
-    channel?: ChannelId;
-    destination?: string;
-    rebind?: boolean;
-    originConversationId?: string;
-  };
-  if (!body.channel) {
-    return httpError("BAD_REQUEST", 'The "channel" field is required.', 400);
-  }
-
-  // Normalize destination to prevent rate-limit bypass via format variations
-  // (e.g. "+15551234567" vs "(555) 123-4567", or "@User" vs "user")
-  let rateLimitKey = body.destination;
-  if (rateLimitKey) {
-    if (body.channel === "sms" || body.channel === "voice") {
-      rateLimitKey = normalizePhoneNumber(rateLimitKey) ?? rateLimitKey;
-    } else if (body.channel === "telegram") {
-      rateLimitKey = normalizeTelegramDestination(rateLimitKey);
-    }
-  }
-
-  if (rateLimitKey && guardianVerificationLimiter.isBlocked(rateLimitKey)) {
-    return httpError(
-      "RATE_LIMITED",
-      "Too many verification attempts for this identity. Please try again later.",
-      429,
-    );
-  }
-
-  const result = await startOutbound({
-    channel: body.channel,
-    destination: body.destination,
-    rebind: body.rebind,
-    originConversationId: body.originConversationId,
-  });
-
-  if (!result.success && rateLimitKey) {
-    guardianVerificationLimiter.recordFailure(rateLimitKey);
-  }
-
-  const status = result.success
-    ? 200
-    : result.error === "rate_limited"
-      ? 429
-      : 400;
-  return Response.json(result, { status });
-}
-
-/**
- * POST /v1/integrations/guardian/outbound/resend
+ * POST /v1/integrations/guardian/sessions/resend
  *
  * Body: { channel: ChannelId; originConversationId?: string }
  */
-export async function handleResendOutbound(req: Request): Promise<Response> {
+export async function handleResendGuardianSession(
+  req: Request,
+): Promise<Response> {
   const body = (await req.json()) as {
     channel?: ChannelId;
     originConversationId?: string;
@@ -280,20 +261,50 @@ export async function handleResendOutbound(req: Request): Promise<Response> {
 }
 
 /**
- * POST /v1/integrations/guardian/outbound/cancel
+ * DELETE /v1/integrations/guardian/sessions
+ *
+ * Cancels both inbound challenges and outbound sessions.
  *
  * Body: { channel: ChannelId }
  */
-export async function handleCancelOutbound(req: Request): Promise<Response> {
+export async function handleCancelGuardianSession(
+  req: Request,
+): Promise<Response> {
   const body = (await req.json()) as {
     channel?: ChannelId;
   };
   if (!body.channel) {
     return httpError("BAD_REQUEST", 'The "channel" field is required.', 400);
   }
-  const result = cancelOutbound({
-    channel: body.channel,
-  });
+
+  // Cancel any active outbound session
+  cancelOutbound({ channel: body.channel });
+  // Cancel any pending inbound challenge
+  revokePendingChallenges(body.channel);
+
+  return Response.json({ success: true, channel: body.channel });
+}
+
+/**
+ * POST /v1/integrations/guardian/revoke
+ *
+ * Cancels all active sessions and revokes the guardian binding.
+ *
+ * Body: { channel?: ChannelId }
+ */
+export async function handleRevokeGuardianBinding(
+  req: Request,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    channel?: ChannelId;
+  };
+
+  // Cancel any active outbound session before revoking
+  const resolvedChannel = body.channel ?? "telegram";
+  cancelOutbound({ channel: resolvedChannel });
+
+  // revokeGuardianForChannel already handles revokePendingChallenges + binding revocation
+  const result = revokeGuardianForChannel(body.channel);
   const status = result.success ? 200 : 400;
   return Response.json(result, { status });
 }
@@ -346,36 +357,31 @@ export function integrationRouteDefinitions(): RouteDefinition[] {
       method: "DELETE",
       handler: () => handleClearSlackChannelConfig(),
     },
-    // Guardian
+    // Guardian (unified session API)
     {
-      endpoint: "integrations/guardian/challenge",
+      endpoint: "integrations/guardian/sessions",
       method: "POST",
-      handler: async ({ req }) => handleCreateGuardianChallenge(req),
+      handler: async ({ req }) => handleCreateGuardianSession(req),
+    },
+    {
+      endpoint: "integrations/guardian/sessions/resend",
+      method: "POST",
+      handler: async ({ req }) => handleResendGuardianSession(req),
+    },
+    {
+      endpoint: "integrations/guardian/sessions",
+      method: "DELETE",
+      handler: async ({ req }) => handleCancelGuardianSession(req),
+    },
+    {
+      endpoint: "integrations/guardian/revoke",
+      method: "POST",
+      handler: async ({ req }) => handleRevokeGuardianBinding(req),
     },
     {
       endpoint: "integrations/guardian/status",
       method: "GET",
       handler: ({ url }) => handleGetGuardianStatus(url),
-    },
-    {
-      endpoint: "integrations/guardian/revoke",
-      method: "POST",
-      handler: async ({ req }) => handleRevokeGuardian(req),
-    },
-    {
-      endpoint: "integrations/guardian/outbound/start",
-      method: "POST",
-      handler: async ({ req }) => handleStartOutbound(req),
-    },
-    {
-      endpoint: "integrations/guardian/outbound/resend",
-      method: "POST",
-      handler: async ({ req }) => handleResendOutbound(req),
-    },
-    {
-      endpoint: "integrations/guardian/outbound/cancel",
-      method: "POST",
-      handler: async ({ req }) => handleCancelOutbound(req),
     },
   ];
 }


### PR DESCRIPTION
## Summary
- Merge 6 guardian verification HTTP handlers (challenge, status, revoke, outbound/start, outbound/resend, outbound/cancel) into 4 unified session-based handlers
- POST /sessions (with or without destination), POST /sessions/resend, DELETE /sessions, POST /revoke
- Fix gap where revoke didn't cancel outbound sessions and cancel didn't cancel inbound challenges

Part of plan: guardian-api-consolidation.md (PR 1 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
