### PR TITLE
Add macOS unread sidebar menu item

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
@@ -31,6 +31,11 @@ struct SidebarThreadItem: View {
     private var interactionState: ThreadInteractionState { threadManager.interactionState(for: thread.id) }
     // Reserve trailing space when hovered for archive button overlay.
     private var hasTrailingIcon: Bool { isHovered || sidebar.threadPendingDeletion == thread.id }
+    private var canMarkUnread: Bool {
+        !thread.hasUnseenLatestAssistantMessage &&
+            thread.sessionId != nil &&
+            thread.latestAssistantMessageAt != nil
+    }
 
     var body: some View {
         // Always reserve 20pt leading slot so text never shifts.
@@ -178,6 +183,12 @@ struct SidebarThreadItem: View {
             } label: {
                 Label { Text("Archive thread") } icon: { VIconView(.archive, size: 14) }
             }
+            Button {
+                threadManager.markConversationUnread(threadId: thread.id)
+            } label: {
+                Label { Text("Mark as unread") } icon: { VIconView(.circle, size: 14) }
+            }
+            .disabled(!canMarkUnread)
         }
         .pointerCursor()
         .onHover { hovering in


### PR DESCRIPTION
## Summary
- add the fourth sidebar thread context-menu action on macOS
- disable the action when the thread is already unread or has no assistant reply yet
- keep the menu order aligned with the requested mock

## Testing
- swift test --filter "ThreadManagerUnseenStateTests/testMarkConversationUnread"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
