### PR TITLE
refactor: update guardian route policy registrations for unified session endpoints

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -192,21 +192,17 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
     endpoint: "integrations/slack/channel/config:DELETE",
     scopes: ["settings.write"],
   },
-  { endpoint: "integrations/guardian/challenge", scopes: ["settings.write"] },
+  { endpoint: "integrations/guardian/sessions", scopes: ["settings.write"] },
+  {
+    endpoint: "integrations/guardian/sessions:DELETE",
+    scopes: ["settings.write"],
+  },
+  {
+    endpoint: "integrations/guardian/sessions/resend",
+    scopes: ["settings.write"],
+  },
   { endpoint: "integrations/guardian/status", scopes: ["settings.read"] },
   { endpoint: "integrations/guardian/revoke", scopes: ["settings.write"] },
-  {
-    endpoint: "integrations/guardian/outbound/start",
-    scopes: ["settings.write"],
-  },
-  {
-    endpoint: "integrations/guardian/outbound/resend",
-    scopes: ["settings.write"],
-  },
-  {
-    endpoint: "integrations/guardian/outbound/cancel",
-    scopes: ["settings.write"],
-  },
   { endpoint: "integrations/twilio/config", scopes: ["settings.read"] },
   {
     endpoint: "integrations/twilio/credentials:POST",


### PR DESCRIPTION
## Summary
- Replace 6 stale guardian endpoint policy entries with 5 entries matching the new unified session API
- POST/DELETE /sessions, POST /sessions/resend, GET /status, POST /revoke

Part of plan: guardian-api-consolidation.md (PR 4 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
