### PR TITLE
refactor: update guardian control-plane policy paths for unified session endpoints

### DIFF
--- a/assistant/src/tools/guardian-control-plane-policy.ts
+++ b/assistant/src/tools/guardian-control-plane-policy.ts
@@ -4,19 +4,17 @@
  * conversationally via tools.
  *
  * Protected endpoints:
- *   /v1/integrations/guardian/challenge
+ *   /v1/integrations/guardian/sessions
+ *   /v1/integrations/guardian/sessions/resend
  *   /v1/integrations/guardian/status
- *   /v1/integrations/guardian/outbound/start
- *   /v1/integrations/guardian/outbound/resend
- *   /v1/integrations/guardian/outbound/cancel
+ *   /v1/integrations/guardian/revoke
  */
 
 const GUARDIAN_ENDPOINT_PATHS = [
-  "/v1/integrations/guardian/challenge",
+  "/v1/integrations/guardian/sessions",
+  "/v1/integrations/guardian/sessions/resend",
   "/v1/integrations/guardian/status",
-  "/v1/integrations/guardian/outbound/start",
-  "/v1/integrations/guardian/outbound/resend",
-  "/v1/integrations/guardian/outbound/cancel",
+  "/v1/integrations/guardian/revoke",
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary
- Update GUARDIAN_ENDPOINT_PATHS to match the new unified session API paths
- Update doc comment to reflect new endpoint names
- Broad regex fallback already covers all /v1/integrations/guardian/ paths

Part of plan: guardian-api-consolidation.md (PR 5 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
