### PR TITLE
refactor: consolidate gateway guardian proxy to match unified session API

### DIFF
--- a/gateway/src/http/routes/guardian-control-plane-proxy.ts
+++ b/gateway/src/http/routes/guardian-control-plane-proxy.ts
@@ -98,8 +98,24 @@ export function createGuardianControlPlaneProxyHandler(config: GatewayConfig) {
   }
 
   return {
-    async handleCreateGuardianChallenge(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/integrations/guardian/challenge", "");
+    async handleCreateGuardianSession(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/integrations/guardian/sessions", "");
+    },
+
+    async handleResendGuardianSession(req: Request): Promise<Response> {
+      return proxyToRuntime(
+        req,
+        "/v1/integrations/guardian/sessions/resend",
+        "",
+      );
+    },
+
+    async handleCancelGuardianSession(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/integrations/guardian/sessions", "");
+    },
+
+    async handleRevokeGuardianBinding(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/integrations/guardian/revoke", "");
     },
 
     async handleGetGuardianStatus(req: Request): Promise<Response> {
@@ -108,34 +124,6 @@ export function createGuardianControlPlaneProxyHandler(config: GatewayConfig) {
         req,
         "/v1/integrations/guardian/status",
         url.search,
-      );
-    },
-
-    async handleRevokeGuardian(req: Request): Promise<Response> {
-      return proxyToRuntime(req, "/v1/integrations/guardian/revoke", "");
-    },
-
-    async handleStartGuardianOutbound(req: Request): Promise<Response> {
-      return proxyToRuntime(
-        req,
-        "/v1/integrations/guardian/outbound/start",
-        "",
-      );
-    },
-
-    async handleResendGuardianOutbound(req: Request): Promise<Response> {
-      return proxyToRuntime(
-        req,
-        "/v1/integrations/guardian/outbound/resend",
-        "",
-      );
-    },
-
-    async handleCancelGuardianOutbound(req: Request): Promise<Response> {
-      return proxyToRuntime(
-        req,
-        "/v1/integrations/guardian/outbound/cancel",
-        "",
       );
     },
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -442,11 +442,25 @@ async function main() {
         guardianControlPlaneProxy.handleGuardianVellumBootstrap(req),
     },
     {
-      path: "/v1/integrations/guardian/challenge",
+      path: "/v1/integrations/guardian/sessions",
       method: "POST",
       auth: "edge",
       handler: (req) =>
-        guardianControlPlaneProxy.handleCreateGuardianChallenge(req),
+        guardianControlPlaneProxy.handleCreateGuardianSession(req),
+    },
+    {
+      path: "/v1/integrations/guardian/sessions",
+      method: "DELETE",
+      auth: "edge",
+      handler: (req) =>
+        guardianControlPlaneProxy.handleCancelGuardianSession(req),
+    },
+    {
+      path: "/v1/integrations/guardian/sessions/resend",
+      method: "POST",
+      auth: "edge",
+      handler: (req) =>
+        guardianControlPlaneProxy.handleResendGuardianSession(req),
     },
     {
       path: "/v1/integrations/guardian/status",
@@ -458,28 +472,8 @@ async function main() {
       path: "/v1/integrations/guardian/revoke",
       method: "POST",
       auth: "edge",
-      handler: (req) => guardianControlPlaneProxy.handleRevokeGuardian(req),
-    },
-    {
-      path: "/v1/integrations/guardian/outbound/start",
-      method: "POST",
-      auth: "edge",
       handler: (req) =>
-        guardianControlPlaneProxy.handleStartGuardianOutbound(req),
-    },
-    {
-      path: "/v1/integrations/guardian/outbound/resend",
-      method: "POST",
-      auth: "edge",
-      handler: (req) =>
-        guardianControlPlaneProxy.handleResendGuardianOutbound(req),
-    },
-    {
-      path: "/v1/integrations/guardian/outbound/cancel",
-      method: "POST",
-      auth: "edge",
-      handler: (req) =>
-        guardianControlPlaneProxy.handleCancelGuardianOutbound(req),
+        guardianControlPlaneProxy.handleRevokeGuardianBinding(req),
     },
 
     // ── Guardian refresh (custom auth: accepts expired JWTs) ──

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1370,12 +1370,12 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
-      "/v1/integrations/guardian/challenge": {
+      "/v1/integrations/guardian/sessions": {
         post: {
-          summary: "Create guardian verification challenge",
+          summary: "Create guardian verification session",
           description:
-            "Authenticated gateway endpoint that forwards guardian challenge creation to the assistant runtime.",
-          operationId: "guardianChallenge",
+            "Create a guardian verification session (inbound challenge or outbound verification).",
+          operationId: "guardianSessionCreate",
           security: [{ BearerAuth: [] }],
           requestBody: {
             required: true,
@@ -1386,13 +1386,57 @@ export function buildSchema(): Record<string, unknown> {
             },
           },
           responses: {
-            "200": { description: "Challenge created" },
+            "200": { description: "Session created" },
             "400": { description: "Invalid request payload" },
             "401": {
               description: "Unauthorized — missing or invalid bearer token",
             },
-            "503": { description: "Bearer token not configured" },
+            "429": { description: "Rate limited by verification policy" },
             "502": { description: "Failed to reach assistant runtime" },
+            "503": { description: "Bearer token not configured" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+        delete: {
+          summary: "Cancel guardian verification session",
+          description: "Cancel the active guardian verification session.",
+          operationId: "guardianSessionCancel",
+          security: [{ BearerAuth: [] }],
+          responses: {
+            "200": { description: "Session cancelled" },
+            "400": { description: "Invalid request payload" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "502": { description: "Failed to reach assistant runtime" },
+            "503": { description: "Bearer token not configured" },
+            "504": { description: "Assistant runtime request timed out" },
+          },
+        },
+      },
+      "/v1/integrations/guardian/sessions/resend": {
+        post: {
+          summary: "Resend guardian verification code",
+          description: "Resend the outbound guardian verification code.",
+          operationId: "guardianSessionResend",
+          security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Verification code resent" },
+            "400": { description: "Invalid request payload" },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+            "429": { description: "Rate limited by verification policy" },
+            "502": { description: "Failed to reach assistant runtime" },
+            "503": { description: "Bearer token not configured" },
             "504": { description: "Assistant runtime request timed out" },
           },
         },
@@ -1415,89 +1459,6 @@ export function buildSchema(): Record<string, unknown> {
           ],
           responses: {
             "200": { description: "Guardian status returned" },
-            "401": {
-              description: "Unauthorized — missing or invalid bearer token",
-            },
-            "503": { description: "Bearer token not configured" },
-            "502": { description: "Failed to reach assistant runtime" },
-            "504": { description: "Assistant runtime request timed out" },
-          },
-        },
-      },
-      "/v1/integrations/guardian/outbound/start": {
-        post: {
-          summary: "Start outbound guardian verification",
-          description:
-            "Authenticated gateway endpoint that starts outbound guardian verification (sms, voice, or telegram).",
-          operationId: "guardianOutboundStart",
-          security: [{ BearerAuth: [] }],
-          requestBody: {
-            required: true,
-            content: {
-              "application/json": {
-                schema: { type: "object", additionalProperties: true },
-              },
-            },
-          },
-          responses: {
-            "200": { description: "Outbound verification started" },
-            "400": { description: "Invalid request payload" },
-            "401": {
-              description: "Unauthorized — missing or invalid bearer token",
-            },
-            "429": { description: "Rate limited by verification policy" },
-            "503": { description: "Bearer token not configured" },
-            "502": { description: "Failed to reach assistant runtime" },
-            "504": { description: "Assistant runtime request timed out" },
-          },
-        },
-      },
-      "/v1/integrations/guardian/outbound/resend": {
-        post: {
-          summary: "Resend outbound guardian verification",
-          description:
-            "Authenticated gateway endpoint that resends the current outbound guardian verification code.",
-          operationId: "guardianOutboundResend",
-          security: [{ BearerAuth: [] }],
-          requestBody: {
-            required: true,
-            content: {
-              "application/json": {
-                schema: { type: "object", additionalProperties: true },
-              },
-            },
-          },
-          responses: {
-            "200": { description: "Verification resent" },
-            "400": { description: "Invalid request payload" },
-            "401": {
-              description: "Unauthorized — missing or invalid bearer token",
-            },
-            "429": { description: "Rate limited by verification policy" },
-            "503": { description: "Bearer token not configured" },
-            "502": { description: "Failed to reach assistant runtime" },
-            "504": { description: "Assistant runtime request timed out" },
-          },
-        },
-      },
-      "/v1/integrations/guardian/outbound/cancel": {
-        post: {
-          summary: "Cancel outbound guardian verification",
-          description:
-            "Authenticated gateway endpoint that cancels an active outbound guardian verification session.",
-          operationId: "guardianOutboundCancel",
-          security: [{ BearerAuth: [] }],
-          requestBody: {
-            required: true,
-            content: {
-              "application/json": {
-                schema: { type: "object", additionalProperties: true },
-              },
-            },
-          },
-          responses: {
-            "200": { description: "Verification cancelled" },
-            "400": { description: "Invalid request payload" },
             "401": {
               description: "Unauthorized — missing or invalid bearer token",
             },


### PR DESCRIPTION
## Summary
- Replace 6 gateway guardian proxy handlers with 4 unified session-based handlers
- Update gateway route definitions to use new paths: POST/DELETE /sessions, POST /sessions/resend, POST /revoke
- Update OpenAPI schema to reflect consolidated endpoint structure

Part of plan: guardian-api-consolidation.md (PR 2 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
