### PR TITLE
refactor: consolidate guardian IPC actions to match unified session API

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -1986,7 +1986,7 @@ describe("IPC handler voice guardian verification", () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
       type: "guardian_verification",
-      action: "create_challenge",
+      action: "create_session",
       channel: "voice",
     };
 
@@ -2572,7 +2572,7 @@ describe("outbound SMS verification", () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
       type: "guardian_verification",
-      action: "start_outbound",
+      action: "create_session",
       channel: "sms",
       destination: "+15551234567",
     };
@@ -2608,7 +2608,7 @@ describe("outbound SMS verification", () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
       type: "guardian_verification",
-      action: "start_outbound",
+      action: "create_session",
       channel: "sms",
       destination: "+15559876543",
       rebind: false,
@@ -2634,7 +2634,7 @@ describe("outbound SMS verification", () => {
     const { ctx, lastResponse } = createMockCtx();
     const msg: GuardianVerificationRequest = {
       type: "guardian_verification",
-      action: "start_outbound",
+      action: "create_session",
       channel: "sms",
       destination: "+15559876543",
       rebind: true,
@@ -2654,7 +2654,7 @@ describe("outbound SMS verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "sms",
         destination: "+15551234567",
       },
@@ -2667,7 +2667,7 @@ describe("outbound SMS verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "resend_outbound",
+        action: "resend_session",
         channel: "sms",
       },
       mockSocket,
@@ -2686,7 +2686,7 @@ describe("outbound SMS verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "sms",
         destination: "+15551234567",
       },
@@ -2712,7 +2712,7 @@ describe("outbound SMS verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "resend_outbound",
+        action: "resend_session",
         channel: "sms",
       },
       mockSocket,
@@ -2732,7 +2732,7 @@ describe("outbound SMS verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "sms",
         destination: "+15551234567",
       },
@@ -2755,7 +2755,7 @@ describe("outbound SMS verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "resend_outbound",
+        action: "resend_session",
         channel: "sms",
       },
       mockSocket,
@@ -2774,7 +2774,7 @@ describe("outbound SMS verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "sms",
         destination: "+15551234567",
       },
@@ -2791,7 +2791,7 @@ describe("outbound SMS verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "cancel_outbound",
+        action: "cancel_session",
         channel: "sms",
       },
       mockSocket,
@@ -2885,7 +2885,7 @@ describe("outbound SMS verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "email",
         destination: "user@example.com",
       },
@@ -2904,7 +2904,7 @@ describe("outbound SMS verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "sms",
         // no destination
       },
@@ -2923,7 +2923,7 @@ describe("outbound SMS verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "sms",
         destination: "not-a-phone",
       },
@@ -2942,7 +2942,7 @@ describe("outbound SMS verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "sms",
         destination: "(555) 123-4567",
       },
@@ -2986,7 +2986,7 @@ describe("outbound SMS verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "cancel_outbound",
+        action: "cancel_session",
         channel: "sms",
       },
       mockSocket,
@@ -3014,7 +3014,7 @@ describe("outbound Telegram verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "telegram",
         destination: "@someuser",
       },
@@ -3049,7 +3049,7 @@ describe("outbound Telegram verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "telegram",
         destination: "someuser",
       },
@@ -3071,7 +3071,7 @@ describe("outbound Telegram verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "telegram",
         destination: "123456789",
       },
@@ -3112,7 +3112,7 @@ describe("outbound Telegram verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "telegram",
         destination: "@someuser",
       },
@@ -3138,7 +3138,7 @@ describe("outbound Telegram verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "telegram",
         destination: "@newuser",
         rebind: false,
@@ -3302,7 +3302,7 @@ describe("outbound Telegram verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "telegram",
         destination: "123456789",
       },
@@ -3324,7 +3324,7 @@ describe("outbound Telegram verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "resend_outbound",
+        action: "resend_session",
         channel: "telegram",
       },
       mockSocket,
@@ -3348,7 +3348,7 @@ describe("outbound Telegram verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "telegram",
         destination: "@someuser",
       },
@@ -3360,7 +3360,7 @@ describe("outbound Telegram verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "resend_outbound",
+        action: "resend_session",
         channel: "telegram",
       },
       mockSocket,
@@ -3379,7 +3379,7 @@ describe("outbound Telegram verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "telegram",
         destination: "123456789",
       },
@@ -3394,7 +3394,7 @@ describe("outbound Telegram verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "cancel_outbound",
+        action: "cancel_session",
         channel: "telegram",
       },
       mockSocket,
@@ -3443,7 +3443,7 @@ describe("outbound Telegram verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "telegram",
       },
       mockSocket,
@@ -3462,7 +3462,7 @@ describe("outbound Telegram verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "telegram",
         destination: "123456789",
       },
@@ -3485,7 +3485,7 @@ describe("outbound Telegram verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "resend_outbound",
+        action: "resend_session",
         channel: "telegram",
       },
       mockSocket,
@@ -3504,7 +3504,7 @@ describe("outbound Telegram verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "telegram",
         destination: "123456789",
       },
@@ -3517,7 +3517,7 @@ describe("outbound Telegram verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "resend_outbound",
+        action: "resend_session",
         channel: "telegram",
       },
       mockSocket,
@@ -3545,7 +3545,7 @@ describe("outbound voice verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "voice",
         destination: "+15551234567",
       },
@@ -3589,7 +3589,7 @@ describe("outbound voice verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "voice",
         destination: "not-a-phone",
       },
@@ -3608,7 +3608,7 @@ describe("outbound voice verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "voice",
         destination: "555-123-4567",
       },
@@ -3651,7 +3651,7 @@ describe("outbound voice verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "voice",
         destination: "+15559876543",
         rebind: false,
@@ -3672,7 +3672,7 @@ describe("outbound voice verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "voice",
         destination: "+15551234567",
       },
@@ -3685,7 +3685,7 @@ describe("outbound voice verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "resend_outbound",
+        action: "resend_session",
         channel: "voice",
       },
       mockSocket,
@@ -3704,7 +3704,7 @@ describe("outbound voice verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "voice",
         destination: "+15551234567",
       },
@@ -3717,7 +3717,7 @@ describe("outbound voice verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "cancel_outbound",
+        action: "cancel_session",
         channel: "voice",
       },
       mockSocket,
@@ -3759,7 +3759,7 @@ describe("outbound voice verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "voice",
         destination: "+15551234567",
       },
@@ -3778,7 +3778,7 @@ describe("outbound voice verification", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "voice",
       },
       mockSocket,
@@ -3814,7 +3814,7 @@ describe("M1–M4 hardening coverage", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "sms",
         destination: "+15551234567",
       },
@@ -3838,7 +3838,7 @@ describe("M1–M4 hardening coverage", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "sms",
         destination: "+15551234567",
       },
@@ -3861,7 +3861,7 @@ describe("M1–M4 hardening coverage", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "resend_outbound",
+        action: "resend_session",
         channel: "sms",
       },
       mockSocket,
@@ -3883,7 +3883,7 @@ describe("M1–M4 hardening coverage", () => {
     await handleGuardianVerification(
       {
         type: "guardian_verification",
-        action: "start_outbound",
+        action: "create_session",
         channel: "telegram",
         destination: "@someuser",
       },

--- a/assistant/src/__tests__/handlers-telegram-config.test.ts
+++ b/assistant/src/__tests__/handlers-telegram-config.test.ts
@@ -1276,7 +1276,7 @@ describe("Guardian verification IPC actions", () => {
   test("create_challenge action returns a secret and instruction", () => {
     const msg: GuardianVerificationRequest = {
       type: "guardian_verification",
-      action: "create_challenge",
+      action: "create_session",
       channel: "telegram",
     };
 

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -424,7 +424,7 @@ const clientMessages: Record<ClientMessageType, ClientMessage> = {
   },
   guardian_verification: {
     type: "guardian_verification",
-    action: "create_challenge",
+    action: "create_session",
     channel: "telegram",
     sessionId: "sess-001",
   },

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -229,35 +229,42 @@ export async function handleGuardianVerification(
   const channel = msg.channel ?? "telegram";
 
   try {
-    if (msg.action === "create_challenge") {
-      const result = createGuardianChallenge(
-        channel,
-        msg.rebind,
-        msg.sessionId,
-      );
-      ctx.send(socket, { type: "guardian_verification_response", ...result });
+    if (msg.action === "create_session") {
+      if (msg.destination) {
+        const result = await startOutbound({
+          channel,
+          destination: msg.destination,
+          rebind: msg.rebind,
+          originConversationId: msg.originConversationId,
+        });
+        ctx.send(socket, { type: "guardian_verification_response", ...result });
+      } else {
+        const result = createGuardianChallenge(
+          channel,
+          msg.rebind,
+          msg.sessionId,
+        );
+        ctx.send(socket, { type: "guardian_verification_response", ...result });
+      }
     } else if (msg.action === "status") {
       const result = getGuardianStatus(channel);
       ctx.send(socket, { type: "guardian_verification_response", ...result });
+    } else if (msg.action === "cancel_session") {
+      cancelOutbound({ channel });
+      revokePendingChallenges(channel);
+      ctx.send(socket, {
+        type: "guardian_verification_response",
+        success: true,
+        channel,
+      });
     } else if (msg.action === "revoke") {
       const result = revokeGuardianForChannel(channel);
       ctx.send(socket, { type: "guardian_verification_response", ...result });
-    } else if (msg.action === "start_outbound") {
-      const result = await startOutbound({
-        channel,
-        destination: msg.destination,
-        rebind: msg.rebind,
-        originConversationId: msg.originConversationId,
-      });
-      ctx.send(socket, { type: "guardian_verification_response", ...result });
-    } else if (msg.action === "resend_outbound") {
+    } else if (msg.action === "resend_session") {
       const result = resendOutbound({
         channel,
         originConversationId: msg.originConversationId,
       });
-      ctx.send(socket, { type: "guardian_verification_response", ...result });
-    } else if (msg.action === "cancel_outbound") {
-      const result = cancelOutbound({ channel });
       ctx.send(socket, { type: "guardian_verification_response", ...result });
     } else {
       ctx.send(socket, {

--- a/assistant/src/daemon/ipc-contract/integrations.ts
+++ b/assistant/src/daemon/ipc-contract/integrations.ts
@@ -55,12 +55,11 @@ export interface TelegramConfigRequest {
 export interface GuardianVerificationRequest {
   type: "guardian_verification";
   action:
-    | "create_challenge"
+    | "create_session"
     | "status"
+    | "cancel_session"
     | "revoke"
-    | "start_outbound"
-    | "resend_outbound"
-    | "cancel_outbound";
+    | "resend_session";
   channel?: ChannelId; // Defaults to 'telegram'
   sessionId?: string;
   rebind?: boolean; // When true, allows creating a challenge even if a binding already exists


### PR DESCRIPTION
## Summary
- Update GuardianVerificationRequest action union to use create_session, cancel_session, resend_session
- Update IPC handler dispatch to route unified actions with destination-based branching
- cancel_session now cancels both inbound challenges and outbound sessions
- Update test files to use new action names

Part of plan: guardian-api-consolidation.md (PR 3 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13734" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
