### PR TITLE
fix: make /update SKILL.md launch block self-contained

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -77,7 +77,8 @@ The user may pass `$ARGUMENTS` as the branch name (e.g., `/update feature/phone-
 
    Then launch with file-watching in the background (the build is cached, so this just launches + watches):
    ```bash
-   VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh run &
+   REPO_ROOT="$(pwd)"
+   cd clients/macos && VELLUM_GATEWAY_DIR="$REPO_ROOT/gateway" ./build.sh run &
    ```
 
 9. Verify fresh state — run `vellum ps` to confirm processes are running:


### PR DESCRIPTION
## Summary
- Codex flagged that PR #13572 split the build+launch step into two code blocks, but the launch block depends on shell state (`REPO_ROOT`, CWD) from the build block
- Made the launch code block self-contained by adding `REPO_ROOT="$(pwd)"` and `cd clients/macos` so it works when executed in a separate shell invocation

## Test plan
- [ ] Run `/update` and verify macOS app builds and launches successfully
- [ ] Confirm the launch step works when code blocks are executed in separate shell invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
