### PR TITLE
refactor: update Swift client guardian IPC actions for unified session API

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1544,7 +1544,7 @@ public final class SettingsStore: ObservableObject {
             pendingGuardianChallengeChannel = channel
             armGuardianChallengeTimeout(for: channel)
             try daemonClient.sendGuardianVerification(
-                action: "create_challenge",
+                action: "create_session",
                 channel: channel,
                 rebind: rebind ? true : nil
             )
@@ -1833,7 +1833,7 @@ public final class SettingsStore: ObservableObject {
                 return
             }
             try daemonClient.sendGuardianVerification(
-                action: "start_outbound",
+                action: "create_session",
                 channel: channel,
                 destination: destination
             )
@@ -1861,7 +1861,7 @@ public final class SettingsStore: ObservableObject {
     func resendOutboundGuardian(channel: String) {
         do {
             try daemonClient?.sendGuardianVerification(
-                action: "resend_outbound",
+                action: "resend_session",
                 channel: channel
             )
         } catch {
@@ -1886,7 +1886,7 @@ public final class SettingsStore: ObservableObject {
         }
         do {
             try daemonClient?.sendGuardianVerification(
-                action: "cancel_outbound",
+                action: "cancel_session",
                 channel: channel
             )
         } catch {

--- a/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
@@ -86,7 +86,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         XCTAssertNil(store.telegramGuardianError)
 
         let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
-        let challengeMessages = guardianMessages.filter { $0.action == "create_challenge" && $0.channel == "telegram" }
+        let challengeMessages = guardianMessages.filter { $0.action == "create_session" && $0.channel == "telegram" }
         XCTAssertEqual(challengeMessages.count, 1)
     }
 
@@ -99,7 +99,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         XCTAssertNil(store.smsGuardianError)
 
         let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
-        let challengeMessages = guardianMessages.filter { $0.action == "create_challenge" && $0.channel == "sms" }
+        let challengeMessages = guardianMessages.filter { $0.action == "create_session" && $0.channel == "sms" }
         XCTAssertEqual(challengeMessages.count, 1)
     }
 
@@ -153,7 +153,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         XCTAssertNil(store.smsGuardianError)
     }
 
-    // MARK: - Successful create_challenge response provides instruction
+    // MARK: - Successful create_session response provides instruction
 
     func testSuccessfulChallengeResponseProvidesInstruction() {
         store.telegramGuardianVerificationInProgress = true
@@ -518,12 +518,12 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
 
     func testStartVerificationWithUnknownChannelIsNoOp() {
         let messageCountBefore = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
-            .filter { $0.action == "create_challenge" }.count
+            .filter { $0.action == "create_session" }.count
 
         store.startChannelGuardianVerification(channel: "discord")
 
         let messageCountAfter = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
-            .filter { $0.action == "create_challenge" }.count
+            .filter { $0.action == "create_session" }.count
         XCTAssertEqual(messageCountAfter, messageCountBefore)
     }
 
@@ -702,7 +702,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         XCTAssertNil(store.voiceGuardianError)
 
         let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
-        let challengeMessages = guardianMessages.filter { $0.action == "create_challenge" && $0.channel == "voice" }
+        let challengeMessages = guardianMessages.filter { $0.action == "create_session" && $0.channel == "voice" }
         XCTAssertEqual(challengeMessages.count, 1)
     }
 
@@ -824,7 +824,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         store.startOutboundGuardianVerification(channel: "sms", destination: "+15551234567")
 
         let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
-        let outboundMessages = guardianMessages.filter { $0.action == "start_outbound" && $0.channel == "sms" }
+        let outboundMessages = guardianMessages.filter { $0.action == "create_session" && $0.channel == "sms" }
         XCTAssertEqual(outboundMessages.count, 1)
         XCTAssertEqual(outboundMessages.first?.destination, "+15551234567")
         XCTAssertTrue(store.smsGuardianVerificationInProgress)
@@ -846,7 +846,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         store.startOutboundGuardianVerification(channel: "telegram", destination: "@guardian_user")
 
         let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
-        let outboundMessages = guardianMessages.filter { $0.action == "start_outbound" && $0.channel == "telegram" }
+        let outboundMessages = guardianMessages.filter { $0.action == "create_session" && $0.channel == "telegram" }
         XCTAssertEqual(outboundMessages.count, 1)
         XCTAssertEqual(outboundMessages.first?.destination, "@guardian_user")
         XCTAssertTrue(store.telegramGuardianVerificationInProgress)
@@ -909,12 +909,12 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
 
     func testResendOutboundSendsCorrectIPCMessage() {
         let guardianMessagesBefore = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
-        let resendCountBefore = guardianMessagesBefore.filter { $0.action == "resend_outbound" }.count
+        let resendCountBefore = guardianMessagesBefore.filter { $0.action == "resend_session" }.count
 
         store.resendOutboundGuardian(channel: "sms")
 
         let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
-        let resendMessages = guardianMessages.filter { $0.action == "resend_outbound" && $0.channel == "sms" }
+        let resendMessages = guardianMessages.filter { $0.action == "resend_session" && $0.channel == "sms" }
         XCTAssertEqual(resendMessages.count, resendCountBefore + 1)
     }
 
@@ -935,7 +935,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         XCTAssertFalse(store.smsGuardianVerificationInProgress)
 
         let guardianMessages = sentMessages.compactMap { $0 as? GuardianVerificationRequestMessage }
-        let cancelMessages = guardianMessages.filter { $0.action == "cancel_outbound" && $0.channel == "sms" }
+        let cancelMessages = guardianMessages.filter { $0.action == "cancel_session" && $0.channel == "sms" }
         XCTAssertEqual(cancelMessages.count, 1)
     }
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1390,7 +1390,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(VercelApiConfigRequestMessage(action: action, apiToken: apiToken))
     }
 
-    /// Create a guardian verification challenge, check status, revoke, or manage outbound verification for a channel.
+    /// Guardian verification session management: "create_session", "status", "cancel_session", "revoke", "resend_session".
     public func sendGuardianVerification(
         action: String,
         channel: String? = nil,

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1963,7 +1963,7 @@ public struct TwilioNumberInfo: Codable, Sendable {
 
 // MARK: - Guardian Verification Messages
 
-/// Guardian verification request (create challenge, check status, revoke).
+/// Guardian verification request (create_session, status, cancel_session, revoke, resend_session).
 /// Backed by generated `IPCGuardianVerificationRequest`.
 public typealias GuardianVerificationRequestMessage = IPCGuardianVerificationRequest
 


### PR DESCRIPTION
## Summary
- Update macOS app to use new IPC action names: create_session, cancel_session, resend_session
- Replace create_challenge and start_outbound with unified create_session action
- Revoke and status actions unchanged

Part of plan: guardian-api-consolidation.md (PR 6 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
