### PR TITLE
fix: add backward-compat fallback for old flat Twitter config keys

### DIFF
--- a/assistant/src/daemon/handlers/config-integrations.ts
+++ b/assistant/src/daemon/handlers/config-integrations.ts
@@ -113,18 +113,19 @@ export async function handleTwitterIntegrationConfig(
     if (msg.action === "get") {
       const raw = loadRawConfig();
       const mode =
-        (getNestedValue(raw, "twitter.integrationMode") as
-          | "local_byo"
-          | "managed"
-          | undefined) ?? "local_byo";
+        ((getNestedValue(raw, "twitter.integrationMode") ??
+          raw.twitterIntegrationMode) as "local_byo" | "managed" | undefined) ??
+        "local_byo";
       const strategy =
-        (getNestedValue(raw, "twitter.operationStrategy") as
+        ((getNestedValue(raw, "twitter.operationStrategy") ??
+          raw.twitterOperationStrategy) as
           | "oauth"
           | "browser"
           | "auto"
           | undefined) ?? "auto";
       const strategyConfigured =
-        getNestedValue(raw, "twitter.operationStrategy") !== undefined;
+        (getNestedValue(raw, "twitter.operationStrategy") ??
+          raw.twitterOperationStrategy) !== undefined;
       const localClientConfigured = hasTwitterClientId();
       const connected = !!getSecureKey(
         "credential:integration:twitter:access_token",
@@ -144,13 +145,15 @@ export async function handleTwitterIntegrationConfig(
     } else if (msg.action === "get_strategy") {
       const raw = loadRawConfig();
       const strategy =
-        (getNestedValue(raw, "twitter.operationStrategy") as
+        ((getNestedValue(raw, "twitter.operationStrategy") ??
+          raw.twitterOperationStrategy) as
           | "oauth"
           | "browser"
           | "auto"
           | undefined) ?? "auto";
       const strategyConfigured =
-        getNestedValue(raw, "twitter.operationStrategy") !== undefined;
+        (getNestedValue(raw, "twitter.operationStrategy") ??
+          raw.twitterOperationStrategy) !== undefined;
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: true,
@@ -178,6 +181,8 @@ export async function handleTwitterIntegrationConfig(
       }
       const raw = loadRawConfig();
       setNestedValue(raw, "twitter.operationStrategy", value);
+      // Migrate: remove legacy flat key if present
+      delete raw.twitterOperationStrategy;
       saveRawConfig(raw);
       ctx.send(socket, {
         type: "twitter_integration_config_response",
@@ -193,6 +198,8 @@ export async function handleTwitterIntegrationConfig(
     } else if (msg.action === "set_mode") {
       const raw = loadRawConfig();
       setNestedValue(raw, "twitter.integrationMode", msg.mode ?? "local_byo");
+      // Migrate: remove legacy flat key if present
+      delete raw.twitterIntegrationMode;
       saveRawConfig(raw);
       ctx.send(socket, {
         type: "twitter_integration_config_response",

--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -55,8 +55,8 @@ export async function handleTwitterAuthStart(
   try {
     const raw = loadRawConfig();
     const mode =
-      (getNestedValue(raw, "twitter.integrationMode") as string | undefined) ??
-      "local_byo";
+      ((getNestedValue(raw, "twitter.integrationMode") ??
+        raw.twitterIntegrationMode) as string | undefined) ?? "local_byo";
     if (mode !== "local_byo") {
       ctx.send(socket, {
         type: "twitter_auth_result",
@@ -191,10 +191,9 @@ export function handleTwitterAuthStatus(
     );
     const raw = loadRawConfig();
     const mode =
-      (getNestedValue(raw, "twitter.integrationMode") as
-        | "local_byo"
-        | "managed"
-        | undefined) ?? "local_byo";
+      ((getNestedValue(raw, "twitter.integrationMode") ??
+        raw.twitterIntegrationMode) as "local_byo" | "managed" | undefined) ??
+      "local_byo";
     const meta = getCredentialMetadata("integration:twitter", "access_token");
 
     ctx.send(socket, {


### PR DESCRIPTION
Both Codex and Devin flagged that PR #13532 renamed Twitter config keys without a fallback for existing configs. This adds fallback reads from the old flat key names (twitterOperationStrategy, twitterIntegrationMode) so existing users don't silently lose their settings on upgrade.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
