### PR TITLE
docs: update guardian API documentation for unified session endpoints

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -207,11 +207,11 @@ Guardian verification can be initiated through gateway HTTP endpoints (which for
 
 **HTTP Endpoints:**
 
-| Endpoint                                    | Method | Description                                                                                         |
-| ------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------- |
-| `/v1/integrations/guardian/outbound/start`  | POST   | Start a new outbound verification session. Body: `{ channel, destination?, assistantId?, rebind? }` |
-| `/v1/integrations/guardian/outbound/resend` | POST   | Resend the verification code for an active session. Body: `{ channel, assistantId? }`               |
-| `/v1/integrations/guardian/outbound/cancel` | POST   | Cancel an active outbound verification session. Body: `{ channel, assistantId? }`                   |
+| Endpoint                                    | Method | Description                                                                                                                                                               |
+| ------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/v1/integrations/guardian/sessions`        | POST   | Create a guardian session. If `destination` is provided, starts outbound verification; otherwise creates an inbound challenge. Body: `{ channel, destination?, rebind? }` |
+| `/v1/integrations/guardian/sessions/resend` | POST   | Resend the verification code for an active outbound session. Body: `{ channel }`                                                                                          |
+| `/v1/integrations/guardian/sessions`        | DELETE | Cancel all active sessions (inbound + outbound) for a channel. Body: `{ channel }`                                                                                        |
 
 All endpoints are JWT-authenticated via `Authorization: Bearer <jwt>`. Skills and user-facing tooling should target the gateway URL (default `http://localhost:7830`), not the runtime port.
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -292,7 +292,7 @@ This section documents the end-to-end flow from guardian verification through in
 
 Guardian verification establishes a cryptographic trust binding between a human identity and an `(assistantId, channel)` pair. The flow is:
 
-1. **Challenge creation** — The owner initiates verification from the desktop UI, which sends a guardian-verification IPC message (`create_challenge` action) to the assistant. The assistant generates a random secret (32-byte hex for unbound inbound/bootstrap sessions, 6-digit numeric for identity-bound sessions), hashes it with SHA-256, stores the hash with a 10-minute TTL, and returns the raw secret to the desktop.
+1. **Challenge creation** — The owner initiates verification from the desktop UI, which sends a guardian-verification IPC message (`create_session` action) to the assistant. The assistant generates a random secret (32-byte hex for unbound inbound/bootstrap sessions, 6-digit numeric for identity-bound sessions), hashes it with SHA-256, stores the hash with a 10-minute TTL, and returns the raw secret to the desktop.
 2. **Code sharing** — The desktop displays the code and instructs the owner to reply with that code in the target channel conversation (e.g., Telegram or SMS).
 3. **Verification** — When the message arrives at `/channels/inbound`, the handler intercepts valid verification-code replies before normal message processing. It hashes the provided code, looks up a matching pending challenge, validates expiry, and consumes the challenge (preventing replay).
 4. **Binding** — On success, any existing active binding for the `(assistantId, channel)` pair is revoked, and a new guardian binding is created with the verifier's `actorExternalId` and `chatId` (DB columns: `externalUserId`, `chatId`). The verifier receives a confirmation message.
@@ -353,11 +353,11 @@ Guardian verification can also be initiated through normal desktop chat. When th
 
 **Outbound HTTP Endpoints** (exposed via the gateway API and forwarded to the runtime):
 
-| Endpoint                                    | Method | Description                                                                           |
-| ------------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
-| `/v1/integrations/guardian/outbound/start`  | POST   | Start outbound verification. Body: `{ channel, destination?, assistantId?, rebind? }` |
-| `/v1/integrations/guardian/outbound/resend` | POST   | Resend verification code. Body: `{ channel, assistantId? }`                           |
-| `/v1/integrations/guardian/outbound/cancel` | POST   | Cancel active session. Body: `{ channel, assistantId? }`                              |
+| Endpoint                                    | Method | Description                                                                                                                                                               |
+| ------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/v1/integrations/guardian/sessions`        | POST   | Create a guardian session. If `destination` is provided, starts outbound verification; otherwise creates an inbound challenge. Body: `{ channel, destination?, rebind? }` |
+| `/v1/integrations/guardian/sessions/resend` | POST   | Resend verification code for an active outbound session. Body: `{ channel }`                                                                                              |
+| `/v1/integrations/guardian/sessions`        | DELETE | Cancel all active sessions (inbound + outbound) for a channel. Body: `{ channel }`                                                                                        |
 
 These endpoints share the same business logic as the IPC-based verification flow via `guardian-outbound-actions.ts`. Skills and clients should call the gateway URL (default `http://localhost:7830`) rather than the runtime port directly.
 

--- a/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
@@ -40,7 +40,7 @@ Based on the chosen channel, ask for the required destination:
 Execute the outbound start request:
 
 ```bash
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/outbound/start" \
+curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/sessions" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
   -d '{"channel": "<channel>", "destination": "<destination>"}'
@@ -52,7 +52,7 @@ Replace `<channel>` with `voice`, `telegram`, or `slack`, and `<destination>` wi
 
 Report the exact next action based on the channel:
 
-- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/start` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
+- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `POST /v1/integrations/guardian/sessions` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
 - **Telegram with chat ID** (no `telegramBootstrapUrl` in response): The response includes a `secret` field. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and reply with that 6-digit code to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4).
 - **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."
 - **Slack**: The response includes a `secret` field with the verification code. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to you as a Slack DM. Open the DM from the Vellum bot in Slack and reply with that 6-digit code to complete verification." The DM channel ID is captured automatically during this process for future message delivery. If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4). **After delivering the code, immediately begin the Slack auto-check polling loop** (see [Slack Auto-Check Polling](#slack-auto-check-polling) below).
@@ -77,7 +77,7 @@ Handle each error code:
 If the user says they did not receive the code or asks to resend:
 
 ```bash
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/outbound/resend" \
+curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/sessions/resend" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
   -d '{"channel": "<channel>"}'
@@ -85,7 +85,7 @@ curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/outbound/re
 
 On success, report the next action based on the channel:
 
-- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `/outbound/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
+- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `POST /v1/integrations/guardian/sessions/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
 - **Telegram**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and reply with that 6-digit code to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3.
 - **Slack**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to you as a Slack DM. Reply to the DM with that 6-digit code to complete verification. (resent)" If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3. **After delivering the code, immediately begin the Slack auto-check polling loop** (see [Slack Auto-Check Polling](#slack-auto-check-polling) below).
 
@@ -106,7 +106,7 @@ Handle each error code from the resend endpoint:
 If the user wants to cancel the verification:
 
 ```bash
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/outbound/cancel" \
+curl -s -X DELETE "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/sessions" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
   -d '{"channel": "<channel>"}'
@@ -133,7 +133,7 @@ assistant integrations guardian status --channel voice --json
 6. If the 2-minute timeout is reached without `bound: true`: proactively tell the user — "I've been checking for about 2 minutes but verification hasn't completed yet. The code may have expired or wasn't entered. Would you like me to resend a new code (Step 4) or start a new session (Step 3)?"
 
 **Rebind guard:**
-When in a **rebind flow** (i.e., the `start_outbound` request included `"rebind": true` because a binding already existed), do NOT treat `bound: true` alone as success. The pre-existing binding will show `bound: true` before the user has entered the new code, which would be a false positive. To guard against this:
+When in a **rebind flow** (i.e., the session creation request included `"rebind": true` because a binding already existed), do NOT treat `bound: true` alone as success. The pre-existing binding will show `bound: true` before the user has entered the new code, which would be a false positive. To guard against this:
 
 - Only report success when BOTH conditions are met: `bound: true` AND `verificationSessionId` is **absent** from the status response. The `verificationSessionId` field is present while a verification session is still active (pending). When the user enters the correct code, the session is consumed and `verificationSessionId` disappears from subsequent status responses. This proves the new outbound session was consumed and the binding is fresh.
 - If a poll shows `bound: true` but `verificationSessionId` is still present, the old binding is still active and the new code has not yet been consumed — continue polling.
@@ -164,7 +164,7 @@ assistant integrations guardian status --channel slack --json
 6. If the 2-minute timeout is reached without `bound: true`: proactively tell the user — "I've been checking for about 2 minutes but verification hasn't completed yet. The code may have expired or wasn't entered. Would you like me to resend a new code (Step 4) or start a new session (Step 3)?"
 
 **Rebind guard:**
-When in a **rebind flow** (i.e., the `start_outbound` request included `"rebind": true` because a binding already existed), do NOT treat `bound: true` alone as success. The pre-existing binding will show `bound: true` before the user has entered the new code, which would be a false positive. To guard against this:
+When in a **rebind flow** (i.e., the session creation request included `"rebind": true` because a binding already existed), do NOT treat `bound: true` alone as success. The pre-existing binding will show `bound: true` before the user has entered the new code, which would be a false positive. To guard against this:
 
 - Only report success when BOTH conditions are met: `bound: true` AND `verificationSessionId` is **absent** from the status response. The `verificationSessionId` field is present while a verification session is still active (pending). When the user enters the correct code, the session is consumed and `verificationSessionId` disappears from subsequent status responses. This proves the new outbound session was consumed and the binding is fresh.
 - If a poll shows `bound: true` but `verificationSessionId` is still present, the old binding is still active and the new code has not yet been consumed — continue polling.

--- a/assistant/src/config/bundled-skills/slack-app-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack-app-setup/SKILL.md
@@ -148,7 +148,7 @@ Load the **guardian-verify-setup** skill to handle the verification flow:
 The guardian-verify-setup skill manages the full outbound verification flow for Slack, including:
 
 - Collecting the user's Slack user ID as the destination
-- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/outbound/start` with `channel: "slack"`
+- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/sessions` with `channel: "slack"` and the user's destination
 - Sending a verification code via Slack DM
 - Auto-polling for completion (the guardian-verify-setup skill handles this)
 - Checking guardian status to confirm the binding was created

--- a/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
@@ -74,7 +74,7 @@ Load the **guardian-verify-setup** skill to handle the verification flow:
 The guardian-verify-setup skill manages the full outbound verification flow for Telegram, including:
 
 - Collecting the user's Telegram chat ID or @handle as the destination
-- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/outbound/start` with `channel: "telegram"`
+- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/sessions` with `channel: "telegram"` and the user's destination
 - Handling the bootstrap deep-link flow when the user provides an @handle (the response includes a `telegramBootstrapUrl` that the user must click before receiving the code)
 - Guiding the user to send the verification code back in the Telegram bot chat
 - Checking guardian status to confirm the binding was created

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -83,11 +83,10 @@ Guardian verification endpoints are exposed directly by the gateway and forwarde
 
 | Method | Path                                        |
 | ------ | ------------------------------------------- |
-| POST   | `/v1/integrations/guardian/challenge`       |
+| POST   | `/v1/integrations/guardian/sessions`        |
+| DELETE | `/v1/integrations/guardian/sessions`        |
+| POST   | `/v1/integrations/guardian/sessions/resend` |
 | GET    | `/v1/integrations/guardian/status`          |
-| POST   | `/v1/integrations/guardian/outbound/start`  |
-| POST   | `/v1/integrations/guardian/outbound/resend` |
-| POST   | `/v1/integrations/guardian/outbound/cancel` |
 | POST   | `/v1/integrations/guardian/vellum/refresh`  |
 
 The `/vellum/refresh` endpoint is the only public ingress for rotating JWT access + refresh token credentials. Clients must call this through the gateway; the runtime endpoint is not directly exposed. The gateway validates the caller's JWT and forwards to the runtime, which handles refresh token validation, rotation, and replay detection (see [`assistant/ARCHITECTURE.md`](../assistant/ARCHITECTURE.md) for the JWT auth lifecycle).
@@ -136,15 +135,15 @@ Telegram integration setup/config endpoints and contacts/invites endpoints are a
 
 **Forwarded contact & invite endpoints:**
 
-| Method   | Path                             |
-| -------- | -------------------------------- |
-| GET/POST | `/v1/contacts`                   |
-| GET      | `/v1/contacts/:contactId`        |
-| POST     | `/v1/contacts/merge`             |
+| Method   | Path                                     |
+| -------- | ---------------------------------------- |
+| GET/POST | `/v1/contacts`                           |
+| GET      | `/v1/contacts/:contactId`                |
+| POST     | `/v1/contacts/merge`                     |
 | PATCH    | `/v1/contact-channels/:contactChannelId` |
-| GET/POST | `/v1/contacts/invites`           |
-| DELETE   | `/v1/contacts/invites/:inviteId` |
-| POST     | `/v1/contacts/invites/redeem`    |
+| GET/POST | `/v1/contacts/invites`                   |
+| DELETE   | `/v1/contacts/invites/:inviteId`         |
+| POST     | `/v1/contacts/invites/redeem`            |
 
 **Authentication boundary:**
 
@@ -390,7 +389,7 @@ sequenceDiagram
     participant GW as Gateway
     participant Daemon as Daemon (Runtime)
 
-    Desktop->>Daemon: guardian_verify IPC (action: create_challenge)
+    Desktop->>Daemon: guardian_verify IPC (action: create_session)
     Daemon->>Daemon: Generate random secret, hash (SHA-256), store challenge (10min TTL)
     Daemon-->>Desktop: Return secret + instruction
     Desktop-->>User: Display verification code
@@ -407,7 +406,7 @@ sequenceDiagram
     GW->>TG: sendMessage: "You are now the guardian"
 ```
 
-The raw secret is shown only once in the desktop UI and must be sent by the user in-channel to complete verification. (Outbound `start_outbound` verification flows separately send template messages/calls with the code.) Only the SHA-256 hash is persisted. Challenges expire after 10 minutes. Consumed challenges cannot be reused. Rate limiting (5 invalid attempts per 15-minute window, 30-minute lockout) protects against brute-force attacks.
+The raw secret is shown only once in the desktop UI and must be sent by the user in-channel to complete verification. (Outbound session creation via `POST /v1/integrations/guardian/sessions` with a `destination` separately sends template messages/calls with the code.) Only the SHA-256 hash is persisted. Challenges expire after 10 minutes. Consumed challenges cannot be reused. Rate limiting (5 invalid attempts per 15-minute window, 30-minute lockout) protects against brute-force attacks.
 
 #### Inbound Message Decision Chain
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -214,11 +214,10 @@ The gateway serves as the single public ingress point for all external callbacks
 | `/webhooks/twilio/sms`                      | POST            | Twilio SMS webhook — validates X-Twilio-Signature (HMAC-SHA1), normalizes into `GatewayInboundEvent` with `sourceChannel: "sms"`, deduplicates by `MessageSid`, and forwards to runtime |
 | `/deliver/sms`                              | POST            | Internal endpoint for the assistant runtime to deliver outbound SMS messages via the Twilio Messages API                                                                                |
 | `/webhooks/oauth/callback`                  | GET             | OAuth2 callback endpoint — receives authorization codes from OAuth providers (Google, Slack, etc.) and forwards them to the assistant runtime                                           |
-| `/v1/integrations/guardian/challenge`       | POST            | Authenticated control-plane proxy for creating guardian verification challenges                                                                                                         |
+| `/v1/integrations/guardian/sessions`        | POST            | Authenticated control-plane proxy for creating guardian sessions (inbound challenge or outbound verification)                                                                           |
+| `/v1/integrations/guardian/sessions`        | DELETE          | Authenticated control-plane proxy for cancelling active guardian sessions                                                                                                               |
+| `/v1/integrations/guardian/sessions/resend` | POST            | Authenticated control-plane proxy for resending outbound guardian verification code                                                                                                     |
 | `/v1/integrations/guardian/status`          | GET             | Authenticated control-plane proxy for guardian binding status                                                                                                                           |
-| `/v1/integrations/guardian/outbound/start`  | POST            | Authenticated control-plane proxy for starting outbound guardian verification                                                                                                           |
-| `/v1/integrations/guardian/outbound/resend` | POST            | Authenticated control-plane proxy for resending outbound guardian verification                                                                                                          |
-| `/v1/integrations/guardian/outbound/cancel` | POST            | Authenticated control-plane proxy for cancelling outbound guardian verification                                                                                                         |
 | `/v1/integrations/telegram/config`          | GET/POST/DELETE | Authenticated control-plane proxy for Telegram integration config                                                                                                                       |
 | `/v1/integrations/telegram/commands`        | POST            | Authenticated control-plane proxy for Telegram command registration                                                                                                                     |
 | `/v1/integrations/telegram/setup`           | POST            | Authenticated control-plane proxy for Telegram setup orchestration                                                                                                                      |
@@ -299,7 +298,7 @@ When `INGRESS_PUBLIC_BASE_URL` is configured, the gateway prioritizes it as the 
 
 ## Default Mode: Dedicated Routes Only
 
-By default, the broad runtime proxy is disabled. Dedicated gateway-managed routes (webhooks, delivery endpoints, explicit control-plane proxies such as `/v1/integrations/guardian/*`, `/v1/integrations/telegram/*`, and `/v1/contacts/invites/*`, plus the authenticated runtime health route `/v1/health`) remain available, but arbitrary runtime passthrough routes return `404` unless `GATEWAY_RUNTIME_PROXY_ENABLED=true`.
+By default, the broad runtime proxy is disabled. Dedicated gateway-managed routes (webhooks, delivery endpoints, explicit control-plane proxies such as `/v1/integrations/guardian/*`, `/v1/integrations/telegram/*`, `/v1/integrations/slack/*`, and `/v1/contacts/invites/*`, plus the authenticated runtime health route `/v1/health`) remain available, but arbitrary runtime passthrough routes return `404` unless `GATEWAY_RUNTIME_PROXY_ENABLED=true`.
 
 ## Runtime Proxy Mode
 


### PR DESCRIPTION
## Summary
- Update all documentation references to old guardian endpoint paths
- Replace /challenge, /outbound/start, /outbound/resend, /outbound/cancel with unified session paths
- Ensure no stale endpoint references remain across all docs

Part of plan: guardian-api-consolidation.md (PR 9 of 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
