### PR TITLE
fix: apply --query filter when combined with --channel-address in contacts search

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -416,6 +416,12 @@ export function searchContacts(params: {
     const contactIds = [...new Set(channelRows.map((r) => r.contactId))];
     if (contactIds.length === 0) return [];
 
+    // Pre-compute the sanitized query for display-name filtering so the
+    // loop body stays cheap.
+    const sanitizedQuery = params.query
+      ? escapeLike(params.query).toLowerCase()
+      : undefined;
+
     const results: ContactWithChannels[] = [];
     for (const id of contactIds) {
       if (results.length >= limit) break;
@@ -423,7 +429,10 @@ export function searchContacts(params: {
       if (
         contact &&
         (!params.role || contact.role === params.role) &&
-        (!params.contactType || contact.contactType === params.contactType)
+        (!params.contactType || contact.contactType === params.contactType) &&
+        (!sanitizedQuery ||
+          (contact.displayName &&
+            contact.displayName.toLowerCase().includes(sanitizedQuery)))
       ) {
         results.push(contact);
       }


### PR DESCRIPTION
The `searchContacts()` channel-address branch returned early without applying the `--query` text filter, silently ignoring it. This adds display-name filtering to the channel-address code path so all filters can be combined as documented in the CLI help text.

Addresses review feedback on #13678.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13742" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
