### PR TITLE
fix: unify Twilio phone number resolution with legacy fallbacks

### DIFF
--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -1,3 +1,4 @@
+import { getTwilioPhoneNumberEnv } from "../config/env.js";
 import { loadConfig } from "../config/loader.js";
 import {
   getPublicBaseUrl,
@@ -17,11 +18,38 @@ export interface TwilioConfig {
   wssBaseUrl: string;
 }
 
+/**
+ * Resolve the Twilio phone number using a unified fallback chain so that
+ * all callers (calls, SMS adapter, readiness checks, invite transports)
+ * agree on the same number.
+ *
+ * Resolution order:
+ *   1. TWILIO_PHONE_NUMBER env var
+ *   2. config.twilio?.phoneNumber
+ *   3. config.sms?.phoneNumber  (legacy)
+ *   4. secure store credential:twilio:phone_number  (legacy)
+ *   5. ""
+ */
+export function resolveTwilioPhoneNumber(): string {
+  const fromEnv = getTwilioPhoneNumberEnv();
+  if (fromEnv) return fromEnv;
+
+  try {
+    const config = loadConfig();
+    if (config.twilio?.phoneNumber) return config.twilio.phoneNumber;
+    if (config.sms?.phoneNumber) return config.sms.phoneNumber;
+  } catch {
+    // Config may not be available yet during early startup
+  }
+
+  return getSecureKey("credential:twilio:phone_number") || "";
+}
+
 export function getTwilioConfig(): TwilioConfig {
   const config = loadConfig();
   const accountSid = config.twilio?.accountSid || "";
   const authToken = getSecureKey("credential:twilio:auth_token");
-  const phoneNumber = config.twilio?.phoneNumber || "";
+  const phoneNumber = resolveTwilioPhoneNumber();
   const webhookBaseUrl = getPublicBaseUrl(config);
 
   let wssBaseUrl: string;

--- a/assistant/src/messaging/providers/sms/adapter.ts
+++ b/assistant/src/messaging/providers/sms/adapter.ts
@@ -6,28 +6,25 @@
  * the gateway which owns the Twilio credentials and handles the Messages API.
  *
  * Twilio credentials (account_sid, auth_token) and a configured phone number
- * are required for connectivity. The phone number is resolved from the config
- * (sms.phoneNumber), env var (TWILIO_PHONE_NUMBER), or secure key fallback.
+ * are required for connectivity. The phone number is resolved via the
+ * centralized resolveTwilioPhoneNumber() fallback chain in twilio-config.ts.
  *
  * The `token` parameter in MessagingProvider methods is unused for SMS
  * because delivery is authenticated via the gateway's bearer token, not
  * a per-user OAuth token.
  */
 
+import { resolveTwilioPhoneNumber } from "../../../calls/twilio-config.js";
 import {
   getTwilioCredentials,
   hasTwilioCredentials,
 } from "../../../calls/twilio-rest.js";
-import {
-  getGatewayInternalBaseUrl,
-  getTwilioPhoneNumberEnv,
-} from "../../../config/env.js";
+import { getGatewayInternalBaseUrl } from "../../../config/env.js";
 import { loadConfig } from "../../../config/loader.js";
 import { getOrCreateConversation } from "../../../memory/conversation-key-store.js";
 import * as externalConversationStore from "../../../memory/external-conversation-store.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../../runtime/assistant-scope.js";
 import { mintDaemonDeliveryToken } from "../../../runtime/auth/token-service.js";
-import { getSecureKey } from "../../../security/secure-keys.js";
 import type { MessagingProvider } from "../../provider.js";
 import type {
   ConnectionInfo,
@@ -54,17 +51,7 @@ function getBearerToken(): string {
 
 /** Resolve the configured SMS phone number. */
 function getPhoneNumber(): string | undefined {
-  const fromEnv = getTwilioPhoneNumberEnv();
-  if (fromEnv) return fromEnv;
-
-  try {
-    const config = loadConfig();
-    if (config.sms?.phoneNumber) return config.sms.phoneNumber;
-  } catch {
-    // Config may not be available yet during early startup
-  }
-
-  return getSecureKey("credential:twilio:phone_number") || undefined;
+  return resolveTwilioPhoneNumber() || undefined;
 }
 
 export const smsMessagingProvider: MessagingProvider = {

--- a/assistant/src/runtime/channel-invite-transports/sms.ts
+++ b/assistant/src/runtime/channel-invite-transports/sms.ts
@@ -7,38 +7,9 @@
  * no `buildShareLink` or `extractInboundToken` needed.
  */
 
+import { resolveTwilioPhoneNumber } from "../../calls/twilio-config.js";
 import type { ChannelId } from "../../channels/types.js";
-import { getTwilioPhoneNumberEnv } from "../../config/env.js";
-import { loadRawConfig } from "../../config/loader.js";
-import { getSecureKey } from "../../security/secure-keys.js";
 import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
-
-// ---------------------------------------------------------------------------
-// Phone number resolution
-// ---------------------------------------------------------------------------
-
-/**
- * Keep Twilio-backed invite transports on a single secure-key reader so the
- * credential boundary stays narrow.
- */
-export function resolveTwilioInvitePhoneNumber(): string | undefined {
-  try {
-    const raw = loadRawConfig();
-    const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
-    return (
-      getTwilioPhoneNumberEnv() ||
-      (smsConfig.phoneNumber as string) ||
-      getSecureKey("credential:twilio:phone_number") ||
-      undefined
-    );
-  } catch {
-    return (
-      getTwilioPhoneNumberEnv() ||
-      getSecureKey("credential:twilio:phone_number") ||
-      undefined
-    );
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Adapter implementation
@@ -48,6 +19,6 @@ export const smsInviteAdapter: ChannelInviteAdapter = {
   channel: "sms" as ChannelId,
 
   resolveChannelHandle(): string | undefined {
-    return resolveTwilioInvitePhoneNumber();
+    return resolveTwilioPhoneNumber() || undefined;
   },
 };

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -1,3 +1,4 @@
+import { resolveTwilioPhoneNumber } from "../calls/twilio-config.js";
 import {
   getPhoneNumberSid,
   getTollFreeVerificationStatus,
@@ -5,7 +6,6 @@ import {
   hasTwilioCredentials,
 } from "../calls/twilio-rest.js";
 import { getChannelInvitePolicy } from "../channels/config.js";
-import { getTwilioPhoneNumberEnv } from "../config/env.js";
 import { loadRawConfig } from "../config/loader.js";
 import { getEmailService } from "../email/service.js";
 import { getSecureKey } from "../security/secure-keys.js";
@@ -22,31 +22,6 @@ import type {
 export const REMOTE_TTL_MS = 5 * 60 * 1000;
 
 // ── SMS Probe ───────────────────────────────────────────────────────────────
-
-// Keep Twilio phone-number resolution inside an already-authorized module so
-// the secure-key import boundary does not expand for shared config helpers.
-function resolveSmsPhoneNumber(): string {
-  return resolveTwilioPhoneNumber();
-}
-
-function resolveTwilioPhoneNumber(): string {
-  try {
-    const raw = loadRawConfig();
-    const smsConfig = (raw?.sms ?? {}) as Record<string, unknown>;
-    return (
-      getTwilioPhoneNumberEnv() ||
-      (smsConfig.phoneNumber as string) ||
-      getSecureKey("credential:twilio:phone_number") ||
-      ""
-    );
-  } catch {
-    return (
-      getTwilioPhoneNumberEnv() ||
-      getSecureKey("credential:twilio:phone_number") ||
-      ""
-    );
-  }
-}
 
 function hasIngressConfigured(): boolean {
   try {
@@ -76,7 +51,7 @@ const smsProbe: ChannelProbe = {
         : "Twilio Account SID and Auth Token are not configured",
     });
 
-    const resolvedNumber = resolveSmsPhoneNumber();
+    const resolvedNumber = resolveTwilioPhoneNumber();
     const hasPhone = !!resolvedNumber;
     results.push({
       name: "phone_number",
@@ -108,7 +83,7 @@ const smsProbe: ChannelProbe = {
       return [];
     }
 
-    const phoneNumber = resolveSmsPhoneNumber();
+    const phoneNumber = resolveTwilioPhoneNumber();
     if (!phoneNumber) return [];
 
     // Only toll-free numbers need verification checks
@@ -195,7 +170,7 @@ const voiceProbe: ChannelProbe = {
         : "Twilio Account SID and Auth Token are not configured",
     });
 
-    const resolvedNumber = resolveSmsPhoneNumber();
+    const resolvedNumber = resolveTwilioPhoneNumber();
     const hasPhone = !!resolvedNumber;
     results.push({
       name: "phone_number",

--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -16,6 +16,7 @@
  * POST   /v1/integrations/twilio/sms/doctor                          — run SMS diagnostics
  */
 
+import { resolveTwilioPhoneNumber } from "../../calls/twilio-config.js";
 import {
   deleteTollFreeVerification,
   fetchMessageStatus,
@@ -885,12 +886,7 @@ export async function handleSmsSendTest(req: Request): Promise<Response> {
     );
   }
 
-  const raw = loadRawConfig();
-  const smsSection = (raw?.sms ?? {}) as Record<string, unknown>;
-  const from =
-    (smsSection.phoneNumber as string | undefined) ||
-    getSecureKey("credential:twilio:phone_number") ||
-    "";
+  const from = resolveTwilioPhoneNumber();
   if (!from) {
     return Response.json({
       success: false,
@@ -1008,12 +1004,7 @@ export async function handleSmsDoctor(): Promise<Response> {
   let complianceRemediation: string | undefined;
   if (hasCredentials) {
     try {
-      const raw = loadRawConfig();
-      const smsSection = (raw?.sms ?? {}) as Record<string, unknown>;
-      const phoneNumber =
-        (smsSection.phoneNumber as string | undefined) ||
-        getSecureKey("credential:twilio:phone_number") ||
-        "";
+      const phoneNumber = resolveTwilioPhoneNumber();
       if (phoneNumber) {
         const { accountSid, authToken } = getTwilioCredentials();
         const isTollFree =


### PR DESCRIPTION
Codex flagged that PR #13551 left phone number resolution inconsistent: getTwilioConfig() reads only from config while channel-readiness-service.ts still uses legacy fallbacks. This unifies resolution in resolveTwilioPhoneNumber() with the full fallback chain (env -> config -> legacy config -> secure store) and updates callers to use it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
