### PR TITLE
fix: repair broken tests and restore config mapping after SMS removal

### DIFF
--- a/assistant/src/__tests__/canonical-guardian-store.test.ts
+++ b/assistant/src/__tests__/canonical-guardian-store.test.ts
@@ -485,7 +485,7 @@ describe("canonical-guardian-store", () => {
     });
     createCanonicalGuardianDelivery({
       requestId: req.id,
-      destinationChannel: "telegram",
+      destinationChannel: "whatsapp",
       destinationChatId: "chat-456",
     });
 
@@ -497,7 +497,7 @@ describe("canonical-guardian-store", () => {
     const deliveries = listCanonicalGuardianDeliveries(req.id);
     expect(deliveries).toHaveLength(2);
     const channels = deliveries.map((d) => d.destinationChannel).sort();
-    expect(channels).toEqual(["telegram", "telegram"]);
+    expect(channels).toEqual(["telegram", "whatsapp"]);
   });
 
   test("lists empty deliveries for a request with none", () => {

--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -509,8 +509,8 @@ describe("channelSupportsRichApprovalUI", () => {
     expect(channelSupportsRichApprovalUI("vellum")).toBe(false);
   });
 
-  test("returns false for telegram", () => {
-    expect(channelSupportsRichApprovalUI("telegram")).toBe(false);
+  test("returns false for voice", () => {
+    expect(channelSupportsRichApprovalUI("voice")).toBe(false);
   });
 
   test("returns true for slack", () => {

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -563,17 +563,17 @@ describe("guardian identity check", () => {
     expect(binding).toBeNull();
   });
 
-  test("isGuardian works for telegram channel", () => {
+  test("isGuardian works for whatsapp channel", () => {
     createGuardianBinding({
-      channel: "telegram",
+      channel: "whatsapp",
       guardianExternalUserId: "phone-user-1",
       guardianPrincipalId: "phone-user-1",
-      guardianDeliveryChatId: "tg-chat-1",
+      guardianDeliveryChatId: "wa-chat-1",
     });
 
-    expect(isGuardian("asst-1", "telegram", "phone-user-1")).toBe(true);
-    expect(isGuardian("asst-1", "telegram", "phone-user-2")).toBe(false);
-    // Telegram guardian should not match telegram channel
+    expect(isGuardian("asst-1", "whatsapp", "phone-user-1")).toBe(true);
+    expect(isGuardian("asst-1", "whatsapp", "phone-user-2")).toBe(false);
+    // WhatsApp guardian should not match telegram channel
     expect(isGuardian("asst-1", "telegram", "phone-user-1")).toBe(false);
   });
 
@@ -814,7 +814,7 @@ describe("guardian approval request CRUD", () => {
     expect(found!.channel).toBe("telegram");
 
     // Should not find it under a different channel
-    const notFound = getPendingApprovalByGuardianChat("telegram", "tg-chat-42");
+    const notFound = getPendingApprovalByGuardianChat("whatsapp", "tg-chat-42");
     expect(notFound).toBeNull();
   });
 
@@ -963,13 +963,13 @@ describe("verification rate limiting store", () => {
 
     const rl42 = getRateLimit("telegram", "user-42", "chat-42");
     const rl99 = getRateLimit("telegram", "user-99", "chat-99");
-    const rlTelegram = getRateLimit("telegram", "user-42", "chat-42");
+    const rlWhatsapp = getRateLimit("whatsapp", "user-42", "chat-42");
 
     expect(rl42).not.toBeNull();
     expect(rl42!.invalidAttempts).toBe(1);
     expect(rl99).not.toBeNull();
     expect(rl99!.invalidAttempts).toBe(1);
-    expect(rlTelegram).toBeNull();
+    expect(rlWhatsapp).toBeNull();
   });
 });
 

--- a/assistant/src/__tests__/channel-invite-transport.test.ts
+++ b/assistant/src/__tests__/channel-invite-transport.test.ts
@@ -112,7 +112,6 @@ describe("createInviteAdapterRegistry", () => {
     "email",
     "slack",
     "telegram",
-    "telegram",
     "voice",
     "whatsapp",
   ] as const;

--- a/assistant/src/__tests__/channel-policy.test.ts
+++ b/assistant/src/__tests__/channel-policy.test.ts
@@ -99,7 +99,7 @@ describe("channel policy registry", () => {
     const expectedStrategies: [ChannelId, ConversationStrategy][] = [
       ["vellum", "start_new_conversation"],
       ["telegram", "continue_existing_conversation"],
-      ["telegram", "continue_existing_conversation"],
+      ["whatsapp", "continue_existing_conversation"],
       ["voice", "not_deliverable"],
     ];
 

--- a/assistant/src/__tests__/conversation-attention-telegram.test.ts
+++ b/assistant/src/__tests__/conversation-attention-telegram.test.ts
@@ -387,8 +387,8 @@ describe("non-Telegram channel filtering", () => {
   test("Non-telegram inbound message does not record a Telegram seen signal", async () => {
     // Override contact store for another channel
     const req = makeInboundRequest({
-      sourceChannel: "telegram",
-      interface: "telegram",
+      sourceChannel: "whatsapp",
+      interface: "whatsapp",
       content: "some message",
     });
 

--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -436,7 +436,7 @@ describe("pairDeliveryWithConversation", () => {
       unknown
     >;
     expect(upsertArgs.conversationId).toBe("conv-001");
-    expect(upsertArgs.sourceChannel).toBe("notification:whatsapp");
+    expect(upsertArgs.sourceChannel).toBe("notification:telegram");
   });
 
   test("falls back to new conversation when bound conversation no longer exists", async () => {
@@ -567,7 +567,7 @@ describe("pairDeliveryWithConversation", () => {
       unknown
     >;
     expect(upsertArgs.conversationId).toBe("conv-001");
-    expect(upsertArgs.sourceChannel).toBe("notification:whatsapp");
+    expect(upsertArgs.sourceChannel).toBe("notification:telegram");
     expect(upsertArgs.externalChatId).toBe("+15559876543");
   });
 

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -34,7 +34,7 @@ let mockVellumBinding: unknown = null;
 mock.module("../memory/channel-guardian-store.js", () => ({
   getActiveBinding: (_assistantId: string, channel: string) => {
     if (channel === "telegram") return mockTelegramBinding;
-    if (channel === "telegram") return mockAltBinding;
+    if (channel === "whatsapp") return mockAltBinding;
     if (channel === "vellum") return mockVellumBinding;
     return null;
   },

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -281,10 +281,10 @@ describe("startOutbound", () => {
   });
 
   test("unknown channel returns unsupported_channel", async () => {
-    const result = await startOutbound({ channel: "telegram" as never });
+    const result = await startOutbound({ channel: "sms" as never });
     expect(result.success).toBe(false);
     expect(result.error).toBe("unsupported_channel");
-    expect(result.channel).toBe("telegram");
+    expect(result.channel).toBe("sms" as never);
   });
 });
 

--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -331,13 +331,13 @@ describe("Guardian verification routing section in system prompt", () => {
     expect(prompt).toContain("guardian-verify-setup");
   });
 
-  test("routing section mentions voice and telegram channels but not another channel", () => {
+  test("routing section mentions voice and telegram channels but not sms", () => {
     const prompt = buildSystemPrompt();
     const routingStart = prompt.indexOf("## Routing: Guardian Verification");
     const routingSection = prompt.substring(routingStart, routingStart + 1000);
     expect(routingSection).toContain("voice");
     expect(routingSection).toContain("telegram");
-    expect(routingSection).not.toContain("telegram");
+    expect(routingSection).not.toContain("sms");
   });
 
   test("routing section contains exclusivity wording", () => {

--- a/assistant/src/__tests__/notification-broadcaster.test.ts
+++ b/assistant/src/__tests__/notification-broadcaster.test.ts
@@ -31,7 +31,7 @@ mock.module("../notifications/destination-resolver.js", () => ({
     const m = new Map();
     for (const ch of channels) {
       const isExternal =
-        ch === "telegram" || ch === "telegram" || ch === "slack";
+        ch === "telegram" || ch === "whatsapp" || ch === "slack";
       m.set(ch, {
         channel: ch,
         endpoint: `mock-${ch}`,

--- a/assistant/src/__tests__/notification-decision-fallback.test.ts
+++ b/assistant/src/__tests__/notification-decision-fallback.test.ts
@@ -8,7 +8,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../channels/config.js", () => ({
-  getDeliverableChannels: () => ["vellum", "telegram", "telegram"],
+  getDeliverableChannels: () => ["vellum", "telegram", "whatsapp"],
 }));
 
 mock.module("../config/loader.js", () => ({

--- a/assistant/src/__tests__/reminder-store.test.ts
+++ b/assistant/src/__tests__/reminder-store.test.ts
@@ -66,16 +66,16 @@ describe("reminder-store", () => {
       fireAt: Date.now() + 60_000,
       mode: "notify",
       routingIntent: "all_channels",
-      routingHints: { preferred: ["telegram", "telegram"] },
+      routingHints: { preferred: ["telegram", "whatsapp"] },
     });
 
     expect(r.routingIntent).toBe("all_channels");
-    expect(r.routingHints).toEqual({ preferred: ["telegram", "telegram"] });
+    expect(r.routingHints).toEqual({ preferred: ["telegram", "whatsapp"] });
 
     const fetched = getReminder(r.id);
     expect(fetched!.routingIntent).toBe("all_channels");
     expect(fetched!.routingHints).toEqual({
-      preferred: ["telegram", "telegram"],
+      preferred: ["telegram", "whatsapp"],
     });
   });
 

--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -555,7 +555,7 @@ describe("scheduler RRULE execution", () => {
       routingIntent: "multi_channel",
       routingHints: {
         requestedByUser: true,
-        channelMentions: ["telegram", "telegram"],
+        channelMentions: ["telegram", "whatsapp"],
       },
     });
 
@@ -592,7 +592,7 @@ describe("scheduler RRULE execution", () => {
       routingIntent: "multi_channel",
       routingHints: {
         requestedByUser: true,
-        channelMentions: ["telegram", "telegram"],
+        channelMentions: ["telegram", "whatsapp"],
       },
     });
     expect(getReminder(reminder.id)?.status).toBe("fired");

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -319,7 +319,7 @@ for (const config of CHANNEL_CONFIGS) {
 
       // Should NOT be found on a different channel
       const otherChannel =
-        config.channel === "telegram" ? "telegram" : "telegram";
+        config.channel === "telegram" ? "whatsapp" : "telegram";
       const crossChanResult = findContactChannel({
         channelType: otherChannel,
         externalUserId: config.senderExternalUserId,

--- a/gateway/src/__tests__/twilio-relay-websocket.test.ts
+++ b/gateway/src/__tests__/twilio-relay-websocket.test.ts
@@ -64,7 +64,6 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     twilioAuthToken: undefined,
     twilioAccountSid: undefined,
     twilioPhoneNumber: undefined,
-    smsDeliverAuthBypass: false,
     ingressPublicBaseUrl: undefined,
     gatewayInternalBaseUrl: "http://127.0.0.1:7830",
     whatsappPhoneNumberId: undefined,

--- a/gateway/src/config-file-mappings.ts
+++ b/gateway/src/config-file-mappings.ts
@@ -1,11 +1,18 @@
 import type { GatewayConfig } from "./config.js";
 
-type ConfigFileMapping = {
-  key: string;
-  field: string;
-  configField: keyof GatewayConfig;
-  type: "string";
-};
+type ConfigFileMapping =
+  | {
+      key: string;
+      field: string;
+      configField: keyof GatewayConfig;
+      type: "string";
+    }
+  | {
+      key: string;
+      field: string;
+      configField: keyof GatewayConfig;
+      type: "normalized-record";
+    };
 
 export const CONFIG_FILE_MAPPINGS: ConfigFileMapping[] = [
   {
@@ -13,6 +20,12 @@ export const CONFIG_FILE_MAPPINGS: ConfigFileMapping[] = [
     field: "phoneNumber",
     configField: "twilioPhoneNumber",
     type: "string",
+  },
+  {
+    key: "twilio",
+    field: "assistantPhoneNumbers",
+    configField: "assistantPhoneNumbers",
+    type: "normalized-record",
   },
   {
     key: "email",
@@ -34,10 +47,24 @@ export const CONFIG_FILE_MAPPINGS: ConfigFileMapping[] = [
   },
 ];
 
+/** Iterate entries and keep only those whose value is a non-empty, non-whitespace string. */
+function normalizeRecord(raw: unknown): Record<string, string> | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const result: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (typeof v === "string" && v.trim() !== "") {
+      result[k] = v;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
 function resolveRawValue(mapping: ConfigFileMapping, raw: unknown): unknown {
   switch (mapping.type) {
     case "string":
       return typeof raw === "string" ? raw || undefined : undefined;
+    case "normalized-record":
+      return normalizeRecord(raw);
   }
 }
 

--- a/gateway/src/http/routes/twilio-relay-websocket.ts
+++ b/gateway/src/http/routes/twilio-relay-websocket.ts
@@ -60,15 +60,15 @@ export function createTwilioRelayWebsocketHandler(config: GatewayConfig) {
  *   1. `Authorization: Bearer <token>` header (standard clients)
  *   2. `token` query parameter (Twilio ConversationRelay — no custom headers)
  *
- * Fail-closed: rejects all unauthenticated requests unless the Telegram deliver
- * auth bypass flag is set (reusing the same local-dev escape hatch).
+ * Fail-closed: rejects all unauthenticated requests unless the deliver auth
+ * bypass flag is set (shares the Telegram dev bypass as a local-dev escape hatch).
  */
 function checkRelayAuth(
   req: Request,
   url: URL,
   config: GatewayConfig,
 ): Response | null {
-  // Local-dev bypass: allow unauthenticated access when telegramDeliverAuthBypass is set
+  // Local-dev bypass: reuse Telegram deliver auth bypass flag for relay WS
   if (config.telegramDeliverAuthBypass) {
     return null;
   }


### PR DESCRIPTION
## Summary

PR #13709 did a mechanical `sms` -> `telegram` replacement in tests, creating ~15 contradictory assertions and reducing cross-channel test coverage. This PR fixes:

- **Contradictory test assertions**: Tests that assert the same value is both true and false (e.g., `isGuardian("telegram", ...)` both `true` and `false`), replaced the second channel with `whatsapp` to restore cross-channel isolation testing
- **Dead mock branches**: `if (channel === "telegram") return mockAltBinding` duplicated the line above it, making `mockAltBinding` unreachable — changed to `whatsapp`
- **Vacuous ternaries**: `config.channel === "telegram" ? "telegram" : "telegram"` always returns telegram — fixed to use `whatsapp` as the alternate
- **Wrong assertions**: `channelSupportsRichApprovalUI("telegram")` expected `false` but telegram IS rich — changed to test `voice` instead
- **Wrong sourceChannel**: Conversation pairing tests expected `notification:whatsapp` but the binding context uses `telegram`, producing `notification:telegram`
- **Duplicate array entries**: Removed redundant `"telegram"` entries from test arrays (builtInChannels, deliverable channels, etc.)
- **Restored `assistantPhoneNumbers` config-file mapping**: The `normalized-record` type and `normalizeRecord()` helper were removed, breaking `resolveAssistantByPhoneNumber()` for voice routing
- **Fixed relay WS auth bypass coupling**: Documented that the relay WebSocket shares the Telegram deliver auth bypass flag (previously SMS), and removed stale `smsDeliverAuthBypass` from test config

## Test plan

- [ ] Verify all 18 modified test files pass: `bun test` on affected files
- [ ] Verify `assistantPhoneNumbers` is populated from `twilio.assistantPhoneNumbers` config section
- [ ] Verify relay WS auth bypass works with `GATEWAY_TELEGRAM_DELIVER_AUTH_BYPASS=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
