### PR TITLE
docs: align client AppKit bridge shortcut guidance

### DIFF
--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -110,8 +110,7 @@ Prefer built-in SwiftUI primitives over custom `NSViewRepresentable` / AppKit wr
 
 **When AppKit bridges are still needed** (keep them minimal — only AppKit-specific logic, no business logic or layout):
 - Intercepting `Cmd+V` for image paste detection (pasteboard inspection not available in SwiftUI)
-- Intercepting `Cmd+Enter` as a key equivalent before the field editor consumes it
-- Intercepting `Shift+Return` to insert a newline before `.onSubmit` fires (SwiftUI cannot distinguish modifier+Return combos)
+- Intercepting return-key shortcuts that SwiftUI cannot route precisely before `.onSubmit` fires, including `Cmd+Enter` send, `Shift+Return` newline, and default-mode `Option+Return` send
 - Registering window-level event monitors (`NSEvent.addLocalMonitorForEvents`)
 - Accessing `NSWindow` properties (e.g., typing redirect handlers, container view registration)
 


### PR DESCRIPTION
## Summary
- update the AppKit bridge guidance in `clients/AGENTS.md` to include default-mode `Option+Return` send routing
- keep the canonical macOS client shortcut guidance aligned with the shipped desktop composer behavior

## Original prompt
Can you address these items in separate PRs?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
