### PR TITLE
fix: align guardian tests with unified session API actions

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -672,7 +672,7 @@ exports[`IPC message snapshots ClientMessage types telegram_config serializes to
 
 exports[`IPC message snapshots ClientMessage types guardian_verification serializes to expected JSON 1`] = `
 {
-  "action": "create_challenge",
+  "action": "create_session",
   "channel": "telegram",
   "sessionId": "sess-001",
   "type": "guardian_verification",

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -2899,14 +2899,14 @@ describe("outbound SMS verification", () => {
     expect(resp!.error).toBe("unsupported_channel");
   });
 
-  test("start_outbound rejects missing destination", async () => {
+  test("create_session without destination falls through to inbound challenge", async () => {
     const { ctx, lastResponse } = createMockCtx();
     await handleGuardianVerification(
       {
         type: "guardian_verification",
         action: "create_session",
         channel: "sms",
-        // no destination
+        // no destination — unified create_session creates an inbound challenge
       },
       mockSocket,
       ctx,
@@ -2914,8 +2914,8 @@ describe("outbound SMS verification", () => {
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
-    expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe("missing_destination");
+    expect(resp!.success).toBe(true);
+    expect(resp!.secret).toBeDefined();
   });
 
   test("start_outbound rejects unparseable phone number", async () => {
@@ -2981,7 +2981,7 @@ describe("outbound SMS verification", () => {
     expect(sms).not.toContain("999999");
   });
 
-  test("cancel_outbound returns error when no active session", async () => {
+  test("cancel_session succeeds even when no active session (idempotent)", async () => {
     const { ctx, lastResponse } = createMockCtx();
     await handleGuardianVerification(
       {
@@ -2995,8 +2995,7 @@ describe("outbound SMS verification", () => {
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
-    expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe("no_active_session");
+    expect(resp!.success).toBe(true);
   });
 });
 
@@ -3438,7 +3437,7 @@ describe("outbound Telegram verification", () => {
     expect(msg).not.toContain("999999");
   });
 
-  test("start_outbound for telegram with missing destination fails", async () => {
+  test("create_session for telegram without destination falls through to inbound challenge", async () => {
     const { ctx, lastResponse } = createMockCtx();
     await handleGuardianVerification(
       {
@@ -3452,8 +3451,8 @@ describe("outbound Telegram verification", () => {
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
-    expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe("missing_destination");
+    expect(resp!.success).toBe(true);
+    expect(resp!.secret).toBeDefined();
   });
 
   test("rate limits apply to telegram outbound (per-session send cap)", async () => {
@@ -3773,7 +3772,7 @@ describe("outbound voice verification", () => {
     expect(resp!.error).toBe("rate_limited");
   });
 
-  test("start_outbound for voice requires destination", async () => {
+  test("create_session for voice without destination falls through to inbound challenge", async () => {
     const { ctx, lastResponse } = createMockCtx();
     await handleGuardianVerification(
       {
@@ -3787,8 +3786,8 @@ describe("outbound voice verification", () => {
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
-    expect(resp!.success).toBe(false);
-    expect(resp!.error).toBe("missing_destination");
+    expect(resp!.success).toBe(true);
+    expect(resp!.secret).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- Update 4 channel-guardian tests that expected old `start_outbound`/`cancel_outbound` error behavior — the unified `create_session` action without destination now correctly falls through to inbound challenge creation, and `cancel_session` is idempotent (succeeds even with no active session)
- Update stale ipc-snapshot for `guardian_verification` to reflect the `create_challenge` → `create_session` action rename

## Original prompt
fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22788689260

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
