### PR TITLE
fix: [assistant] add cache-aware Anthropic pricing helpers

### DIFF
--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -1,14 +1,39 @@
 import { describe, expect, test } from "bun:test";
 
 import type { ModelPricingOverride } from "../config/schema.js";
+import type { PricingUsage } from "../usage/types.js";
 import {
   estimateCost,
   resolvePricing,
+  resolvePricingForUsage,
+  resolvePricingForUsageWithOverrides,
   resolvePricingWithOverrides,
 } from "../util/pricing.js";
 
 describe("resolvePricing", () => {
   describe("Anthropic models", () => {
+    test("returns priced for claude-opus-4-6", () => {
+      const result = resolvePricing(
+        "anthropic",
+        "claude-opus-4-6",
+        1_000_000,
+        1_000_000,
+      );
+      expect(result.pricingStatus).toBe("priced");
+      expect(result.estimatedCostUsd).toBe(5 + 25);
+    });
+
+    test("returns priced for claude-opus-4-6-fast", () => {
+      const result = resolvePricing(
+        "anthropic",
+        "claude-opus-4-6-fast",
+        1_000_000,
+        1_000_000,
+      );
+      expect(result.pricingStatus).toBe("priced");
+      expect(result.estimatedCostUsd).toBe(30 + 150);
+    });
+
     test("returns priced for claude-opus-4", () => {
       const result = resolvePricing(
         "anthropic",
@@ -159,6 +184,17 @@ describe("resolvePricing", () => {
   });
 
   describe("prefix matching", () => {
+    test("matches claude-opus-4-6-20260205 via claude-opus-4-6 prefix", () => {
+      const result = resolvePricing(
+        "anthropic",
+        "claude-opus-4-6-20260205",
+        1_000_000,
+        1_000_000,
+      );
+      expect(result.pricingStatus).toBe("priced");
+      expect(result.estimatedCostUsd).toBe(5 + 25);
+    });
+
     test("matches claude-sonnet-4-6 via claude-sonnet-4 prefix", () => {
       const result = resolvePricing(
         "anthropic",
@@ -222,6 +258,52 @@ describe("resolvePricing", () => {
       expect(result.pricingStatus).toBe("priced");
       expect(result.estimatedCostUsd).toBe(0);
     });
+  });
+});
+
+describe("resolvePricingForUsage", () => {
+  test("prices mixed direct, cache read, and cache write Anthropic usage", () => {
+    const usage: PricingUsage = {
+      directInputTokens: 1_000_000,
+      outputTokens: 2_000_000,
+      cacheCreationInputTokens: 300_000,
+      cacheReadInputTokens: 300_000,
+      anthropicCacheCreation: {
+        ephemeral_5m_input_tokens: 200_000,
+        ephemeral_1h_input_tokens: 100_000,
+      },
+    };
+
+    const result = resolvePricingForUsage(
+      "anthropic",
+      "claude-opus-4-6",
+      usage,
+    );
+
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBeCloseTo(57.4, 10);
+  });
+
+  test("returns unpriced with null cost for unknown provider", () => {
+    const usage: PricingUsage = {
+      directInputTokens: 10,
+      outputTokens: 20,
+      cacheCreationInputTokens: 30,
+      cacheReadInputTokens: 40,
+      anthropicCacheCreation: {
+        ephemeral_5m_input_tokens: 10,
+        ephemeral_1h_input_tokens: 20,
+      },
+    };
+
+    const result = resolvePricingForUsage(
+      "unknown-provider",
+      "some-model",
+      usage,
+    );
+
+    expect(result.pricingStatus).toBe("unpriced");
+    expect(result.estimatedCostUsd).toBeNull();
   });
 });
 
@@ -357,6 +439,39 @@ describe("resolvePricingWithOverrides", () => {
   });
 });
 
+describe("resolvePricingForUsageWithOverrides", () => {
+  test("uses override pricing for structured Anthropic usage", () => {
+    const usage: PricingUsage = {
+      directInputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheCreationInputTokens: 200_000,
+      cacheReadInputTokens: 100_000,
+      anthropicCacheCreation: {
+        ephemeral_5m_input_tokens: 200_000,
+        ephemeral_1h_input_tokens: 0,
+      },
+    };
+    const overrides: ModelPricingOverride[] = [
+      {
+        provider: "anthropic",
+        modelPattern: "claude-opus-4-6",
+        inputPer1M: 10,
+        outputPer1M: 20,
+      },
+    ];
+
+    const result = resolvePricingForUsageWithOverrides(
+      "anthropic",
+      "claude-opus-4-6",
+      usage,
+      overrides,
+    );
+
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBeCloseTo(33.5, 10);
+  });
+});
+
 describe("estimateCost", () => {
   test("returns a number for known Anthropic model", () => {
     const cost = estimateCost(
@@ -367,6 +482,16 @@ describe("estimateCost", () => {
     );
     expect(typeof cost).toBe("number");
     expect(cost).toBe(3 + 15);
+  });
+
+  test("returns correct cost for standard claude-opus-4-6", () => {
+    const cost = estimateCost(
+      1_000_000,
+      1_000_000,
+      "claude-opus-4-6",
+      "anthropic",
+    );
+    expect(cost).toBe(5 + 25);
   });
 
   test("returns 0 for unknown model", () => {

--- a/assistant/src/usage/types.ts
+++ b/assistant/src/usage/types.ts
@@ -1,6 +1,27 @@
 import type { UsageActor } from "./actors.js";
 
 /**
+ * Anthropic prompt caching exposes write-tier detail so callers can price
+ * 5-minute and 1-hour cache writes differently.
+ */
+export interface AnthropicCacheCreationTokenDetails {
+  ephemeral_5m_input_tokens: number | null;
+  ephemeral_1h_input_tokens: number | null;
+}
+
+/**
+ * Structured token categories used for provider-aware pricing.
+ * `directInputTokens` excludes cache reads and cache writes.
+ */
+export interface PricingUsage {
+  directInputTokens: number;
+  outputTokens: number;
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+  anthropicCacheCreation: AnthropicCacheCreationTokenDetails | null;
+}
+
+/**
  * Input data required to record a single LLM usage event.
  * Matches the token fields from `ProviderResponse.usage`.
  */

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -1,10 +1,16 @@
 import type { ModelPricingOverride } from "../config/schema.js";
-import type { PricingResult } from "../usage/types.js";
+import type { PricingResult, PricingUsage } from "../usage/types.js";
 
 interface ModelPricing {
   inputPer1M: number; // USD per 1M input tokens
   outputPer1M: number; // USD per 1M output tokens
 }
+
+const ANTHROPIC_PROMPT_CACHE_MULTIPLIERS = {
+  read: 0.1,
+  write5m: 1.25,
+  write1h: 2,
+} as const;
 
 /**
  * Multi-provider pricing catalog keyed by provider then model pattern.
@@ -12,6 +18,7 @@ interface ModelPricing {
  */
 const PROVIDER_PRICING: Record<string, Record<string, ModelPricing>> = {
   anthropic: {
+    "claude-opus-4-6": { inputPer1M: 5, outputPer1M: 25 },
     "claude-opus-4": { inputPer1M: 15, outputPer1M: 75 },
     "claude-opus-4-6-fast": { inputPer1M: 30, outputPer1M: 150 },
     "claude-sonnet-4": { inputPer1M: 3, outputPer1M: 15 },
@@ -64,29 +71,140 @@ function findPricing(
   return bestMatch;
 }
 
-/**
- * Calculate cost from pricing and token counts.
- */
-function calculateCost(
-  pricing: ModelPricing,
-  inputTokens: number,
-  outputTokens: number,
-): number {
-  return (
-    (inputTokens / 1_000_000) * pricing.inputPer1M +
-    (outputTokens / 1_000_000) * pricing.outputPer1M
-  );
+function findOverride(
+  overrides: ModelPricingOverride[] | undefined,
+  provider: string,
+  model: string,
+): ModelPricingOverride | undefined {
+  if (!overrides || overrides.length === 0) return undefined;
+
+  let bestOverride: ModelPricingOverride | undefined;
+  let bestLen = 0;
+  for (const override of overrides) {
+    if (override.provider !== provider) continue;
+    if (
+      model === override.modelPattern ||
+      model.startsWith(override.modelPattern)
+    ) {
+      if (override.modelPattern.length > bestLen) {
+        bestOverride = override;
+        bestLen = override.modelPattern.length;
+      }
+    }
+  }
+
+  return bestOverride;
 }
 
 /**
- * Resolve pricing for a provider/model combination using the built-in catalog.
- * Returns a PricingResult with explicit priced/unpriced status.
+ * Calculate cost from a rate and token count.
  */
-export function resolvePricing(
+function calculateTokenCost(ratePer1M: number, tokens: number): number {
+  return (Math.max(tokens, 0) / 1_000_000) * ratePer1M;
+}
+
+function getAnthropicCacheWriteTokens(usage: PricingUsage): {
+  ephemeral5mInputTokens: number;
+  ephemeral1hInputTokens: number;
+} {
+  const totalCacheCreationTokens = Math.max(usage.cacheCreationInputTokens, 0);
+  const explicit5mTokens = Math.max(
+    usage.anthropicCacheCreation?.ephemeral_5m_input_tokens ?? 0,
+    0,
+  );
+  const explicit1hTokens = Math.max(
+    usage.anthropicCacheCreation?.ephemeral_1h_input_tokens ?? 0,
+    0,
+  );
+
+  if (explicit5mTokens === 0 && explicit1hTokens === 0) {
+    return {
+      ephemeral5mInputTokens: totalCacheCreationTokens,
+      ephemeral1hInputTokens: 0,
+    };
+  }
+
+  const remaining5mTokens = Math.max(
+    totalCacheCreationTokens - explicit5mTokens - explicit1hTokens,
+    0,
+  );
+
+  return {
+    ephemeral5mInputTokens: explicit5mTokens + remaining5mTokens,
+    ephemeral1hInputTokens: explicit1hTokens,
+  };
+}
+
+/**
+ * Calculate provider-aware usage cost from normalized token categories.
+ */
+function calculateUsageCost(
   provider: string,
-  model: string,
+  pricing: ModelPricing,
+  usage: PricingUsage,
+): number {
+  const directInputCost = calculateTokenCost(
+    pricing.inputPer1M,
+    usage.directInputTokens,
+  );
+  const outputCost = calculateTokenCost(
+    pricing.outputPer1M,
+    usage.outputTokens,
+  );
+
+  if (provider !== "anthropic") {
+    return (
+      directInputCost +
+      outputCost +
+      calculateTokenCost(
+        pricing.inputPer1M,
+        usage.cacheCreationInputTokens + usage.cacheReadInputTokens,
+      )
+    );
+  }
+
+  const { ephemeral5mInputTokens, ephemeral1hInputTokens } =
+    getAnthropicCacheWriteTokens(usage);
+
+  return (
+    directInputCost +
+    outputCost +
+    calculateTokenCost(
+      pricing.inputPer1M * ANTHROPIC_PROMPT_CACHE_MULTIPLIERS.read,
+      usage.cacheReadInputTokens,
+    ) +
+    calculateTokenCost(
+      pricing.inputPer1M * ANTHROPIC_PROMPT_CACHE_MULTIPLIERS.write5m,
+      ephemeral5mInputTokens,
+    ) +
+    calculateTokenCost(
+      pricing.inputPer1M * ANTHROPIC_PROMPT_CACHE_MULTIPLIERS.write1h,
+      ephemeral1hInputTokens,
+    )
+  );
+}
+
+function createDirectUsage(
   inputTokens: number,
   outputTokens: number,
+): PricingUsage {
+  return {
+    directInputTokens: inputTokens,
+    outputTokens,
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
+    anthropicCacheCreation: null,
+  };
+}
+
+/**
+ * Resolve pricing for a normalized usage breakdown using the built-in catalog.
+ * Returns a PricingResult with explicit priced/unpriced status.
+ */
+export function resolvePricingForUsage(
+  provider: string,
+  model: string,
+  usage: PricingUsage,
 ): PricingResult {
   const providerCatalog = PROVIDER_PRICING[provider];
   if (!providerCatalog) {
@@ -99,9 +217,53 @@ export function resolvePricing(
   }
 
   return {
-    estimatedCostUsd: calculateCost(pricing, inputTokens, outputTokens),
+    estimatedCostUsd: calculateUsageCost(provider, pricing, usage),
     pricingStatus: "priced",
   };
+}
+
+/**
+ * Resolve provider-aware pricing with optional custom model overrides checked first.
+ */
+export function resolvePricingForUsageWithOverrides(
+  provider: string,
+  model: string,
+  usage: PricingUsage,
+  overrides?: ModelPricingOverride[],
+): PricingResult {
+  const bestOverride = findOverride(overrides, provider, model);
+  if (bestOverride) {
+    return {
+      estimatedCostUsd: calculateUsageCost(
+        provider,
+        {
+          inputPer1M: bestOverride.inputPer1M,
+          outputPer1M: bestOverride.outputPer1M,
+        },
+        usage,
+      ),
+      pricingStatus: "priced",
+    };
+  }
+
+  return resolvePricingForUsage(provider, model, usage);
+}
+
+/**
+ * Resolve pricing for a provider/model combination using the built-in catalog.
+ * Returns a PricingResult with explicit priced/unpriced status.
+ */
+export function resolvePricing(
+  provider: string,
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+): PricingResult {
+  return resolvePricingForUsage(
+    provider,
+    model,
+    createDirectUsage(inputTokens, outputTokens),
+  );
 }
 
 /**
@@ -116,37 +278,12 @@ export function resolvePricingWithOverrides(
   outputTokens: number,
   overrides?: ModelPricingOverride[],
 ): PricingResult {
-  if (overrides && overrides.length > 0) {
-    // Find matching overrides for this provider, use longest modelPattern prefix match
-    let bestOverride: ModelPricingOverride | undefined;
-    let bestLen = 0;
-    for (const override of overrides) {
-      if (override.provider !== provider) continue;
-      // Exact match or prefix match on modelPattern
-      if (
-        model === override.modelPattern ||
-        model.startsWith(override.modelPattern)
-      ) {
-        if (override.modelPattern.length > bestLen) {
-          bestOverride = override;
-          bestLen = override.modelPattern.length;
-        }
-      }
-    }
-    if (bestOverride) {
-      const cost = calculateCost(
-        {
-          inputPer1M: bestOverride.inputPer1M,
-          outputPer1M: bestOverride.outputPer1M,
-        },
-        inputTokens,
-        outputTokens,
-      );
-      return { estimatedCostUsd: cost, pricingStatus: "priced" };
-    }
-  }
-
-  return resolvePricing(provider, model, inputTokens, outputTokens);
+  return resolvePricingForUsageWithOverrides(
+    provider,
+    model,
+    createDirectUsage(inputTokens, outputTokens),
+    overrides,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- add structured usage primitives for cache-aware pricing
- price standard Opus 4.6 and Anthropic cache tokens correctly
- extend pricing tests for direct/cache Anthropic usage

Part of plan: anthropic-usage-cost-fix.md (PR 1 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
