### PR TITLE
fix: add secure key store fallback for Twilio account SID resolution

### DIFF
--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -16,8 +16,9 @@ export interface TwilioCredentials {
 }
 
 /**
- * Resolve the Twilio Account SID from config.
- * Returns undefined if not found.
+ * Resolve the Twilio Account SID from config, falling back to the secure
+ * key store for backward compatibility with users who configured credentials
+ * before the config migration.
  */
 function resolveAccountSid(): string | undefined {
   try {
@@ -26,7 +27,7 @@ function resolveAccountSid(): string | undefined {
   } catch {
     // Config may not be available during early startup
   }
-  return undefined;
+  return getSecureKey("credential:twilio:account_sid") || undefined;
 }
 
 /** Resolve Twilio credentials from config and secure key store. Throws if not configured. */

--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -215,7 +215,9 @@ export async function handleSetTwilioCredentials(
     });
   }
 
-  // Store credentials securely (async — writes broker + encrypted store)
+  // Dual-write: secure key store is still read by the gateway for HMAC
+  // validation (gateway/src/credential-reader.ts), while the assistant reads
+  // from config via resolveAccountSid(). Both stores must stay in sync.
   const sidStored = await setSecureKeyAsync(
     "credential:twilio:account_sid",
     body.accountSid,


### PR DESCRIPTION
## Summary
- Adds backward-compatible fallback to `resolveAccountSid()` in `twilio-rest.ts`: after checking config, falls back to `getSecureKey("credential:twilio:account_sid")` so existing users who stored their SID in the secure key store before the config migration don't lose Twilio functionality on upgrade.
- Documents the dual-write pattern in `twilio-routes.ts` explaining why credentials are written to both the secure key store (for gateway HMAC validation) and config (for assistant use).

Addresses review feedback on #13574.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
