### PR TITLE
fix: prevent contacts upsert from silently overwriting role/contactType on update

### DIFF
--- a/assistant/src/cli/contacts.ts
+++ b/assistant/src/cli/contacts.ts
@@ -207,13 +207,11 @@ Examples:
     .option("--notes <notes>", "Free-text notes about the contact")
     .option(
       "--role <role>",
-      "Contact role: contact or guardian (default: contact)",
-      "contact",
+      "Contact role: contact or guardian (default: contact for new contacts)",
     )
     .option(
       "--contact-type <type>",
-      "Contact type: human or assistant (default: human)",
-      "human",
+      "Contact type: human or assistant (default: human for new contacts)",
     )
     .option(
       "--channels <json>",


### PR DESCRIPTION
## Summary
- Removes Commander default values for `--role` and `--contact-type` in `contacts upsert` CLI command
- Previously, these options defaulted to `"contact"` and `"human"` via Commander, meaning `opts.role` and `opts.contactType` were always defined strings even when omitted by the user
- This caused `upsertContact` to always overwrite stored role/contactType values during updates, silently demoting guardians to `contact` and assistant-type contacts to `human`
- The `upsertContact` function already applies correct defaults (`"contact"` / `"human"`) on the create path via `??` fallback, so removing the Commander defaults preserves create behavior while fixing update behavior

Addresses review feedback on #13680.

## Test plan
- [ ] Verify `contacts upsert --display-name "Alice"` creates a new contact with role `contact` and contactType `human` (defaults applied)
- [ ] Verify `contacts upsert --display-name "Alice" --role guardian` creates a guardian contact
- [ ] Verify `contacts upsert --id <guardian-id> --display-name "New Name"` updates name without overwriting role/contactType
- [ ] Verify `contacts upsert --id <id> --role guardian` explicitly changes role

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
