### PR TITLE
chore: add Twilio webhook validation diagnostics in the gateway

### DIFF
--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -13,9 +13,33 @@ type FetchFn = (
 let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(
   async () => new Response(),
 );
+const logCalls: { args: unknown[]; method: string }[] = [];
 
 mock.module("../fetch.js", () => ({
   fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+function createMockLogger(): Record<string, unknown> {
+  const target = {} as Record<string, unknown>;
+  const proxy = new Proxy(target, {
+    get: (_innerTarget, prop) => {
+      if (prop === "child") {
+        return () => proxy;
+      }
+
+      if (typeof prop !== "string") return undefined;
+
+      return (...args: unknown[]) => {
+        logCalls.push({ method: prop, args });
+      };
+    },
+  });
+
+  return proxy;
+}
+
+mock.module("../logger.js", () => ({
+  getLogger: () => createMockLogger(),
 }));
 
 const { createTwilioVoiceWebhookHandler } =
@@ -26,6 +50,66 @@ const { createTwilioConnectActionWebhookHandler } =
   await import("../http/routes/twilio-connect-action-webhook.js");
 
 const AUTH_TOKEN = "test-twilio-auth-token";
+
+afterEach(() => {
+  fetchMock = mock(async () => new Response());
+  logCalls.length = 0;
+});
+
+function findLogCall(message: string): {
+  args: unknown[];
+  data: Record<string, unknown> | undefined;
+  message: string | undefined;
+  method: string;
+} {
+  for (const call of logCalls) {
+    const [firstArg, secondArg] = call.args;
+    const data =
+      firstArg && typeof firstArg === "object" && !Array.isArray(firstArg)
+        ? (firstArg as Record<string, unknown>)
+        : undefined;
+    const loggedMessage =
+      typeof firstArg === "string"
+        ? firstArg
+        : typeof secondArg === "string"
+          ? secondArg
+          : undefined;
+
+    if (loggedMessage === message) {
+      return {
+        method: call.method,
+        args: call.args,
+        data,
+        message: loggedMessage,
+      };
+    }
+  }
+
+  throw new Error(`Missing log call for message: ${message}`);
+}
+
+function expectFailureDiagnosticLog(params: {
+  candidateCount: number;
+  candidateSources: string[];
+  candidateUrls: string[];
+  invalidSignature: string;
+  webhookKind: string;
+}): void {
+  const failureLog = findLogCall("Twilio webhook signature validation failed");
+
+  expect(failureLog.method).toBe("warn");
+  expect(failureLog.data).toMatchObject({
+    webhookKind: params.webhookKind,
+    authTokenConfigured: true,
+    candidateCount: params.candidateCount,
+    candidateSources: params.candidateSources,
+    candidateUrls: params.candidateUrls,
+  });
+
+  const serializedLogs = JSON.stringify(logCalls);
+  expect(serializedLogs).not.toContain(params.invalidSignature);
+  expect(serializedLogs).not.toContain(AUTH_TOKEN);
+}
 
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   const merged: GatewayConfig = {
@@ -113,10 +197,6 @@ function buildSignedRequest(
 }
 
 describe("Twilio voice webhook", () => {
-  afterEach(() => {
-    fetchMock = mock(async () => new Response());
-  });
-
   test("rejects GET requests with 405", async () => {
     const handler = createTwilioVoiceWebhookHandler(makeConfig());
     const req = new Request("http://localhost:7830/webhooks/twilio/voice", {
@@ -261,22 +341,26 @@ describe("Twilio voice webhook", () => {
 });
 
 describe("Twilio status webhook", () => {
-  afterEach(() => {
-    fetchMock = mock(async () => new Response());
-  });
-
   test("rejects invalid signature with 403", async () => {
     const handler = createTwilioStatusWebhookHandler(makeConfig());
+    const invalidSignature = "bad";
     const req = new Request("http://localhost:7830/webhooks/twilio/status", {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
-        "X-Twilio-Signature": "bad",
+        "X-Twilio-Signature": invalidSignature,
       },
       body: "CallSid=CA123&CallStatus=completed",
     });
     const res = await handler(req);
     expect(res.status).toBe(403);
+    expectFailureDiagnosticLog({
+      webhookKind: "status",
+      invalidSignature,
+      candidateCount: 1,
+      candidateSources: ["raw_request"],
+      candidateUrls: ["http://localhost:7830/webhooks/twilio/status"],
+    });
   });
 
   test("forwards valid signed request to runtime", async () => {
@@ -310,25 +394,29 @@ describe("Twilio status webhook", () => {
 });
 
 describe("Twilio connect-action webhook", () => {
-  afterEach(() => {
-    fetchMock = mock(async () => new Response());
-  });
-
   test("rejects invalid signature with 403", async () => {
     const handler = createTwilioConnectActionWebhookHandler(makeConfig());
+    const invalidSignature = "wrong";
     const req = new Request(
       "http://localhost:7830/webhooks/twilio/connect-action",
       {
         method: "POST",
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
-          "X-Twilio-Signature": "wrong",
+          "X-Twilio-Signature": invalidSignature,
         },
         body: "CallSid=CA123",
       },
     );
     const res = await handler(req);
     expect(res.status).toBe(403);
+    expectFailureDiagnosticLog({
+      webhookKind: "connect-action",
+      invalidSignature,
+      candidateCount: 1,
+      candidateSources: ["raw_request"],
+      candidateUrls: ["http://localhost:7830/webhooks/twilio/connect-action"],
+    });
   });
 
   test("forwards valid signed request to runtime", async () => {
@@ -358,10 +446,6 @@ describe("Twilio connect-action webhook", () => {
 });
 
 describe("Twilio webhook signature with canonical ingress base URL", () => {
-  afterEach(() => {
-    fetchMock = mock(async () => new Response());
-  });
-
   test("validates signature against ingressPublicBaseUrl when configured", async () => {
     const twiml = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
     fetchMock = mock(
@@ -382,6 +466,28 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
     const publicUrl =
       publicBaseUrl + "/webhooks/twilio/voice?callSessionId=sig-test";
     const params = { CallSid: "CA123" };
+    const invalidSignature = "invalid-canonical-signature";
+
+    const invalidReq = new Request(localUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Twilio-Signature": invalidSignature,
+      },
+      body: new URLSearchParams(params).toString(),
+    });
+
+    const invalidRes = await handler(invalidReq);
+    expect(invalidRes.status).toBe(403);
+    expectFailureDiagnosticLog({
+      webhookKind: "voice",
+      invalidSignature,
+      candidateCount: 2,
+      candidateSources: ["configured_ingress", "raw_request"],
+      candidateUrls: [publicUrl, localUrl],
+    });
+
+    logCalls.length = 0;
 
     // Sign against the PUBLIC URL (as Twilio would)
     const signature = computeSignature(publicUrl, params, AUTH_TOKEN);
@@ -397,6 +503,17 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
 
     const res = await handler(req);
     expect(res.status).toBe(200);
+
+    const successLog = findLogCall("Twilio webhook signature validated");
+    expect(successLog.method).toBe("info");
+    expect(successLog.data).toMatchObject({
+      webhookKind: "voice",
+      validatedCandidateSource: "configured_ingress",
+      validatedCandidateUrl: publicUrl,
+      candidateCount: 2,
+      candidateSources: ["configured_ingress", "raw_request"],
+      candidateUrls: [publicUrl, localUrl],
+    });
   });
 
   test("accepts when signature matches raw request URL even with public URL configured", async () => {
@@ -415,7 +532,31 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
     // Use callSessionId to bypass inbound routing — this test is about signature validation
     const localUrl =
       "http://localhost:7830/webhooks/twilio/voice?callSessionId=sig-test";
+    const publicUrl =
+      publicBaseUrl + "/webhooks/twilio/voice?callSessionId=sig-test";
     const params = { CallSid: "CA123" };
+    const invalidSignature = "invalid-raw-fallback-signature";
+
+    const invalidReq = new Request(localUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Twilio-Signature": invalidSignature,
+      },
+      body: new URLSearchParams(params).toString(),
+    });
+
+    const invalidRes = await handler(invalidReq);
+    expect(invalidRes.status).toBe(403);
+    expectFailureDiagnosticLog({
+      webhookKind: "voice",
+      invalidSignature,
+      candidateCount: 2,
+      candidateSources: ["configured_ingress", "raw_request"],
+      candidateUrls: [publicUrl, localUrl],
+    });
+
+    logCalls.length = 0;
 
     // Sign against the raw request URL — the raw URL is always included as
     // a final fallback candidate to prevent false 403s in mixed setups.
@@ -432,6 +573,20 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
 
     const res = await handler(req);
     expect(res.status).toBe(200);
+
+    const successLog = findLogCall(
+      "Twilio signature validated against raw request URL fallback — " +
+        "INGRESS_PUBLIC_BASE_URL may be stale or mismatched with the actual webhook registration",
+    );
+    expect(successLog.method).toBe("warn");
+    expect(successLog.data).toMatchObject({
+      webhookKind: "voice",
+      validatedCandidateSource: "raw_request",
+      validatedCandidateUrl: localUrl,
+      candidateCount: 2,
+      candidateSources: ["configured_ingress", "raw_request"],
+      candidateUrls: [publicUrl, localUrl],
+    });
   });
 
   test("accepts signature from forwarded public URL headers when configured URL is stale", async () => {
@@ -453,6 +608,38 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
     const forwardedBase = "https://fresh-tunnel.example.com";
     const signedPublicUrl = `${forwardedBase}/webhooks/twilio/voice?callSessionId=sig-test`;
     const params = { CallSid: "CA123" };
+    const invalidSignature = "invalid-forwarded-signature";
+    const invalidReq = new Request(localUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "X-Twilio-Signature": invalidSignature,
+        "X-Forwarded-Proto": "https",
+        "X-Forwarded-Host": "fresh-tunnel.example.com",
+      },
+      body: new URLSearchParams(params).toString(),
+    });
+
+    const invalidRes = await handler(invalidReq);
+    expect(invalidRes.status).toBe(403);
+    expectFailureDiagnosticLog({
+      webhookKind: "voice",
+      invalidSignature,
+      candidateCount: 3,
+      candidateSources: [
+        "configured_ingress",
+        "forwarded_headers",
+        "raw_request",
+      ],
+      candidateUrls: [
+        staleConfiguredBase + "/webhooks/twilio/voice?callSessionId=sig-test",
+        signedPublicUrl,
+        localUrl,
+      ],
+    });
+
+    logCalls.length = 0;
+
     const req = buildSignedRequest(signedPublicUrl, params, AUTH_TOKEN, {
       "X-Forwarded-Proto": "https",
       "X-Forwarded-Host": "fresh-tunnel.example.com",
@@ -468,5 +655,24 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
 
     const res = await handler(tunneledReq);
     expect(res.status).toBe(200);
+
+    const successLog = findLogCall("Twilio webhook signature validated");
+    expect(successLog.method).toBe("info");
+    expect(successLog.data).toMatchObject({
+      webhookKind: "voice",
+      validatedCandidateSource: "forwarded_headers",
+      validatedCandidateUrl: signedPublicUrl,
+      candidateCount: 3,
+      candidateSources: [
+        "configured_ingress",
+        "forwarded_headers",
+        "raw_request",
+      ],
+      candidateUrls: [
+        staleConfiguredBase + "/webhooks/twilio/voice?callSessionId=sig-test",
+        signedPublicUrl,
+        localUrl,
+      ],
+    });
   });
 });

--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -4,10 +4,142 @@ import { verifyTwilioSignature } from "./verify.js";
 
 const log = getLogger("twilio-validate");
 
+type TwilioWebhookKind =
+  | "voice"
+  | "status"
+  | "connect-action"
+  | "sms"
+  | "unknown";
+
+type SignatureUrlCandidateSource =
+  | "configured_ingress"
+  | "forwarded_headers"
+  | "raw_request";
+
+type SignatureUrlCandidate = {
+  source: SignatureUrlCandidateSource;
+  url: string;
+};
+
 function firstHeaderValue(value: string | null): string | undefined {
   if (!value) return undefined;
   const first = value.split(",")[0]?.trim();
   return first ? first : undefined;
+}
+
+function inferWebhookKind(reqUrl: string): TwilioWebhookKind {
+  const pathname = new URL(reqUrl).pathname;
+
+  if (
+    pathname === "/webhooks/twilio/voice" ||
+    pathname === "/v1/calls/twilio/voice-webhook"
+  ) {
+    return "voice";
+  }
+
+  if (
+    pathname === "/webhooks/twilio/status" ||
+    pathname === "/v1/calls/twilio/status"
+  ) {
+    return "status";
+  }
+
+  if (
+    pathname === "/webhooks/twilio/connect-action" ||
+    pathname === "/v1/calls/twilio/connect-action"
+  ) {
+    return "connect-action";
+  }
+
+  if (pathname === "/webhooks/twilio/sms") {
+    return "sms";
+  }
+
+  return "unknown";
+}
+
+function normalizeUrlForLog(url: string): string {
+  return new URL(url).toString();
+}
+
+function buildSignatureUrlCandidateDetails(
+  req: Request,
+  config: GatewayConfig,
+): SignatureUrlCandidate[] {
+  const parsedUrl = new URL(req.url);
+  const pathAndQuery = parsedUrl.pathname + parsedUrl.search;
+  const candidates: SignatureUrlCandidate[] = [];
+
+  const addCandidate = (
+    url: string | undefined,
+    source: SignatureUrlCandidateSource,
+  ): void => {
+    if (!url) return;
+    if (!candidates.some((candidate) => candidate.url === url)) {
+      candidates.push({ source, url });
+    }
+  };
+
+  const addBase = (
+    base: string | undefined,
+    source: SignatureUrlCandidateSource,
+  ): void => {
+    if (!base) return;
+    const normalized = base.trim().replace(/\/+$/, "");
+    if (!normalized) return;
+    addCandidate(`${normalized}${pathAndQuery}`, source);
+  };
+
+  addBase(config.ingressPublicBaseUrl, "configured_ingress");
+
+  const forwardedProto =
+    firstHeaderValue(req.headers.get("x-forwarded-proto")) ??
+    firstHeaderValue(req.headers.get("x-original-proto"));
+  const forwardedHost =
+    firstHeaderValue(req.headers.get("x-forwarded-host")) ??
+    firstHeaderValue(req.headers.get("x-original-host"));
+  if (forwardedProto && forwardedHost) {
+    addBase(`${forwardedProto}://${forwardedHost}`, "forwarded_headers");
+  }
+
+  // Always include the raw request URL as the final fallback candidate so
+  // valid signatures are not rejected when the other candidates are stale or
+  // incorrectly reconstructed (e.g. mixed proxy/tunnel setups).
+  addCandidate(req.url, "raw_request");
+
+  return candidates;
+}
+
+function buildValidationDiagnostics(
+  req: Request,
+  config: GatewayConfig,
+): {
+  logContext: {
+    authTokenConfigured: boolean;
+    candidateCount: number;
+    candidateSources: SignatureUrlCandidateSource[];
+    candidateUrls: string[];
+    webhookKind: TwilioWebhookKind;
+  };
+  signatureUrlCandidates: SignatureUrlCandidate[];
+} {
+  const signatureUrlCandidates = buildSignatureUrlCandidateDetails(req, config);
+  const logContext = {
+    webhookKind: inferWebhookKind(req.url),
+    authTokenConfigured: Boolean(config.twilioAuthToken),
+    candidateCount: signatureUrlCandidates.length,
+    candidateSources: signatureUrlCandidates.map(
+      (candidate) => candidate.source,
+    ),
+    candidateUrls: signatureUrlCandidates.map((candidate) =>
+      normalizeUrlForLog(candidate.url),
+    ),
+  };
+
+  return {
+    logContext,
+    signatureUrlCandidates,
+  };
 }
 
 /**
@@ -30,40 +162,9 @@ function buildSignatureUrlCandidates(
   req: Request,
   config: GatewayConfig,
 ): string[] {
-  const parsedUrl = new URL(req.url);
-  const pathAndQuery = parsedUrl.pathname + parsedUrl.search;
-  const candidates: string[] = [];
-
-  const addBase = (base: string | undefined): void => {
-    if (!base) return;
-    const normalized = base.trim().replace(/\/+$/, "");
-    if (!normalized) return;
-    const candidate = `${normalized}${pathAndQuery}`;
-    if (!candidates.includes(candidate)) {
-      candidates.push(candidate);
-    }
-  };
-
-  addBase(config.ingressPublicBaseUrl);
-
-  const forwardedProto =
-    firstHeaderValue(req.headers.get("x-forwarded-proto")) ??
-    firstHeaderValue(req.headers.get("x-original-proto"));
-  const forwardedHost =
-    firstHeaderValue(req.headers.get("x-forwarded-host")) ??
-    firstHeaderValue(req.headers.get("x-original-host"));
-  if (forwardedProto && forwardedHost) {
-    addBase(`${forwardedProto}://${forwardedHost}`);
-  }
-
-  // Always include the raw request URL as the final fallback candidate so
-  // valid signatures are not rejected when the other candidates are stale or
-  // incorrectly reconstructed (e.g. mixed proxy/tunnel setups).
-  if (!candidates.includes(req.url)) {
-    candidates.push(req.url);
-  }
-
-  return candidates;
+  return buildSignatureUrlCandidateDetails(req, config).map(
+    (candidate) => candidate.url,
+  );
 }
 
 /**
@@ -111,14 +212,21 @@ export async function validateTwilioWebhookRequest(
 
   // Payload size guard (Content-Length header)
   const contentLength = req.headers.get("content-length");
+  const validationDiagnostics = buildValidationDiagnostics(req, config);
+  const { logContext: validationLogContext, signatureUrlCandidates } =
+    validationDiagnostics;
   if (contentLength && Number(contentLength) > config.maxWebhookPayloadBytes) {
-    log.warn({ contentLength }, "Twilio webhook payload too large");
+    log.warn(
+      { contentLength, ...validationLogContext },
+      "Twilio webhook payload too large",
+    );
     return Response.json({ error: "Payload too large" }, { status: 413 });
   }
 
   // Fail-closed: reject if no auth token is configured
   if (!config.twilioAuthToken) {
     log.error(
+      validationLogContext,
       "Twilio auth token not configured — rejecting webhook (fail-closed)",
     );
     return Response.json({ error: "Forbidden" }, { status: 403 });
@@ -134,7 +242,7 @@ export async function validateTwilioWebhookRequest(
   // Payload size guard (actual body size)
   if (Buffer.byteLength(rawBody) > config.maxWebhookPayloadBytes) {
     log.warn(
-      { bodyLength: Buffer.byteLength(rawBody) },
+      { bodyLength: Buffer.byteLength(rawBody), ...validationLogContext },
       "Twilio webhook payload too large",
     );
     return Response.json({ error: "Payload too large" }, { status: 413 });
@@ -150,13 +258,16 @@ export async function validateTwilioWebhookRequest(
   // Validate signature
   const signature = req.headers.get("x-twilio-signature");
   if (!signature) {
-    log.warn("Twilio webhook request missing X-Twilio-Signature header");
+    log.warn(
+      validationLogContext,
+      "Twilio webhook request missing X-Twilio-Signature header",
+    );
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const signatureUrlCandidates = buildSignatureUrlCandidates(req, config);
+  const signatureCandidateUrls = buildSignatureUrlCandidates(req, config);
   const validatingIndex = findValidatingCandidateIndex(
-    signatureUrlCandidates,
+    signatureCandidateUrls,
     params,
     signature,
     config.twilioAuthToken!,
@@ -164,11 +275,18 @@ export async function validateTwilioWebhookRequest(
 
   if (validatingIndex === -1) {
     log.warn(
-      { candidateCount: signatureUrlCandidates.length },
+      validationLogContext,
       "Twilio webhook signature validation failed",
     );
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
+
+  const validatingCandidate = signatureUrlCandidates[validatingIndex];
+  const successLogContext = {
+    ...validationLogContext,
+    validatedCandidateSource: validatingCandidate.source,
+    validatedCandidateUrl: normalizeUrlForLog(validatingCandidate.url),
+  };
 
   // When ingressPublicBaseUrl is configured and the signature only validated
   // against the raw local URL (last candidate), log a warning. This indicates
@@ -176,17 +294,19 @@ export async function validateTwilioWebhookRequest(
   // registration — the ingress URL should match what Twilio is signing against.
   if (
     config.ingressPublicBaseUrl &&
-    validatingIndex === signatureUrlCandidates.length - 1 &&
-    signatureUrlCandidates.length > 1
+    validatingIndex === signatureCandidateUrls.length - 1 &&
+    signatureCandidateUrls.length > 1
   ) {
     log.warn(
       {
+        ...successLogContext,
         ingressPublicBaseUrl: config.ingressPublicBaseUrl,
-        validatedAgainst: signatureUrlCandidates[validatingIndex],
       },
       "Twilio signature validated against raw request URL fallback — " +
         "INGRESS_PUBLIC_BASE_URL may be stale or mismatched with the actual webhook registration",
     );
+  } else {
+    log.info(successLogContext, "Twilio webhook signature validated");
   }
 
   return { rawBody, params };


### PR DESCRIPTION
## Summary
- add richer Twilio webhook validation diagnostics with secret-safe candidate metadata
- extend Twilio webhook tests to cover the new logging context and preserve current signature acceptance behavior

Part of plan: twilio-voice-call-stability.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
