### PR TITLE
feat: add a gateway Twilio reconcile endpoint for live config refresh

### DIFF
--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -121,6 +121,9 @@ const EXCLUDED_FROM_SCHEMA = new Set([
   // Internal-only route, not reachable from the public internet
   "/internal/telegram/reconcile",
 
+  // Internal-only route, used only for daemon-triggered Twilio refreshes
+  "/internal/twilio/reconcile",
+
   // Duplicate webhook paths for Twilio call routing — the canonical
   // paths under /webhooks/ are documented instead
   "/v1/calls/twilio/voice-webhook",

--- a/gateway/src/__tests__/twilio-reconcile-route.test.ts
+++ b/gateway/src/__tests__/twilio-reconcile-route.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { GatewayConfig } from "../config.js";
+import { initSigningKey, mintToken } from "../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
+
+const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
+initSigningKey(TEST_SIGNING_KEY);
+
+function mintDaemonToken(): string {
+  return mintToken({
+    aud: "vellum-daemon",
+    sub: "svc:gateway:self",
+    scope_profile: "gateway_service_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+const TOKEN = mintDaemonToken();
+
+type TwilioCredentials = {
+  accountSid: string;
+  authToken: string;
+};
+
+let rootDir = "";
+let twilioCredentials: TwilioCredentials | null = null;
+let storedPhoneNumber: string | null = null;
+let readTwilioCredentialsImpl: () => Promise<TwilioCredentials | null> =
+  async () => twilioCredentials;
+
+const readTwilioCredentialsMock = mock(async () => readTwilioCredentialsImpl());
+const readCredentialMock = mock(async (key: string) => {
+  if (key === "credential:twilio:phone_number") {
+    return storedPhoneNumber;
+  }
+  return null;
+});
+
+mock.module("../credential-reader.js", () => ({
+  getRootDir: () => rootDir,
+  readCredential: (key: string) => readCredentialMock(key),
+  readTwilioCredentials: () => readTwilioCredentialsMock(),
+}));
+
+const { createTwilioReconcileHandler } =
+  await import("../http/routes/twilio-reconcile.js");
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    defaultAssistantId: undefined,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: 20 * 1024 * 1024,
+    maxAttachmentConcurrency: 3,
+    maxWebhookPayloadBytes: 1024 * 1024,
+    port: 7830,
+    routingEntries: [],
+    runtimeInitialBackoffMs: 500,
+    runtimeMaxRetries: 2,
+    runtimeProxyEnabled: false,
+    runtimeProxyRequireAuth: true,
+    runtimeTimeoutMs: 30000,
+    shutdownDrainMs: 5000,
+    telegramApiBaseUrl: "https://api.telegram.org",
+    telegramBotToken: "bot-token",
+    telegramDeliverAuthBypass: false,
+    telegramInitialBackoffMs: 1000,
+    telegramMaxRetries: 0,
+    telegramTimeoutMs: 15000,
+    telegramWebhookSecret: "webhook-secret",
+    twilioAuthToken: "initial-auth-token",
+    twilioAccountSid: "AC-initial",
+    twilioPhoneNumber: "+15550000000",
+    smsDeliverAuthBypass: false,
+    ingressPublicBaseUrl: "https://initial.example.com",
+    unmappedPolicy: "reject",
+    whatsappPhoneNumberId: undefined,
+    whatsappAccessToken: undefined,
+    whatsappAppSecret: undefined,
+    whatsappWebhookVerifyToken: undefined,
+    whatsappDeliverAuthBypass: false,
+    whatsappTimeoutMs: 15000,
+    whatsappMaxRetries: 3,
+    whatsappInitialBackoffMs: 1000,
+    slackChannelBotToken: undefined,
+    slackChannelAppToken: undefined,
+    slackDeliverAuthBypass: false,
+    trustProxy: false,
+    ...overrides,
+  };
+}
+
+function makeRequest(
+  method: string,
+  token?: string,
+  body?: Record<string, unknown>,
+): Request {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+  return new Request("http://localhost:7830/internal/twilio/reconcile", {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+function writeWorkspaceConfig(data: Record<string, unknown>): void {
+  const workspaceDir = join(rootDir, "workspace");
+  mkdirSync(workspaceDir, { recursive: true });
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2),
+    "utf-8",
+  );
+}
+
+describe("POST /internal/twilio/reconcile", () => {
+  beforeEach(() => {
+    rootDir = mkdtempSync(join(tmpdir(), "gateway-twilio-reconcile-"));
+    twilioCredentials = {
+      accountSid: "AC-credential",
+      authToken: "credential-auth-token",
+    };
+    storedPhoneNumber = "+15551112222";
+    readTwilioCredentialsImpl = async () => twilioCredentials;
+    readTwilioCredentialsMock.mockClear();
+    readCredentialMock.mockClear();
+    writeWorkspaceConfig({
+      twilio: {
+        accountSid: "AC-config",
+      },
+      sms: {
+        phoneNumber: "+15553334444",
+      },
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.TWILIO_ACCOUNT_SID;
+    delete process.env.TWILIO_AUTH_TOKEN;
+    delete process.env.TWILIO_PHONE_NUMBER;
+    if (rootDir) {
+      rmSync(rootDir, { force: true, recursive: true });
+    }
+    rootDir = "";
+    twilioCredentials = null;
+    storedPhoneNumber = null;
+    readTwilioCredentialsImpl = async () => twilioCredentials;
+  });
+
+  test("rejects non-POST methods", async () => {
+    const config = makeConfig();
+    const handler = createTwilioReconcileHandler(config);
+    const res = await handler(
+      new Request("http://localhost:7830/internal/twilio/reconcile", {
+        method: "GET",
+      }),
+    );
+    expect(res.status).toBe(405);
+  });
+
+  test("returns 401 for unauthorized requests", async () => {
+    const config = makeConfig();
+    const handler = createTwilioReconcileHandler(config);
+
+    const missingAuthResponse = await handler(makeRequest("POST"));
+    const invalidTokenResponse = await handler(makeRequest("POST", "wrong"));
+
+    expect(missingAuthResponse.status).toBe(401);
+    expect(invalidTokenResponse.status).toBe(401);
+  });
+
+  test("normalizes ingressPublicBaseUrl before refreshing config", async () => {
+    const config = makeConfig({
+      ingressPublicBaseUrl: "https://old.example.com",
+    });
+    const handler = createTwilioReconcileHandler(config);
+
+    const res = await handler(
+      makeRequest("POST", TOKEN, {
+        ingressPublicBaseUrl: "  https://new.example.com///  ",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(config.ingressPublicBaseUrl).toBe("https://new.example.com");
+    expect(config.twilioAccountSid).toBe("AC-credential");
+    expect(config.twilioAuthToken).toBe("credential-auth-token");
+    expect(config.twilioPhoneNumber).toBe("+15553334444");
+  });
+
+  test("refreshes Twilio credentials after the auth token changes", async () => {
+    const config = makeConfig({
+      twilioAuthToken: "stale-auth-token",
+      twilioAccountSid: "AC-stale",
+      twilioPhoneNumber: "+15550009999",
+    });
+    const handler = createTwilioReconcileHandler(config);
+
+    const firstResponse = await handler(makeRequest("POST", TOKEN));
+    expect(firstResponse.status).toBe(200);
+    expect(config.twilioAuthToken).toBe("credential-auth-token");
+    expect(config.twilioAccountSid).toBe("AC-credential");
+    expect(config.twilioPhoneNumber).toBe("+15553334444");
+
+    twilioCredentials = {
+      accountSid: "AC-credential",
+      authToken: "rotated-auth-token",
+    };
+
+    const secondResponse = await handler(makeRequest("POST", TOKEN));
+    expect(secondResponse.status).toBe(200);
+    expect(config.twilioAuthToken).toBe("rotated-auth-token");
+    expect(config.twilioAccountSid).toBe("AC-credential");
+    expect(config.twilioPhoneNumber).toBe("+15553334444");
+  });
+
+  test("serializes overlapping refreshes so the latest state wins", async () => {
+    const config = makeConfig({
+      ingressPublicBaseUrl: "https://initial.example.com",
+      twilioAuthToken: "stale-auth-token",
+      twilioAccountSid: "AC-stale",
+    });
+    const handler = createTwilioReconcileHandler(config);
+
+    let readCount = 0;
+    let startFirstRead: (() => void) | null = null;
+    let releaseFirstRead: (() => void) | null = null;
+    const firstReadStarted = new Promise<void>((resolve) => {
+      startFirstRead = resolve;
+    });
+    const continueFirstRead = new Promise<void>((resolve) => {
+      releaseFirstRead = resolve;
+    });
+
+    readTwilioCredentialsImpl = async () => {
+      readCount += 1;
+      if (readCount === 1) {
+        startFirstRead?.();
+        await continueFirstRead;
+        return {
+          accountSid: "AC-first",
+          authToken: "first-auth-token",
+        };
+      }
+      return {
+        accountSid: "AC-second",
+        authToken: "second-auth-token",
+      };
+    };
+
+    const firstReconcile = handler(
+      makeRequest("POST", TOKEN, {
+        ingressPublicBaseUrl: "https://first.example.com/",
+      }),
+    );
+    await firstReadStarted;
+
+    const secondReconcile = handler(
+      makeRequest("POST", TOKEN, {
+        ingressPublicBaseUrl: "https://second.example.com/",
+      }),
+    );
+
+    releaseFirstRead?.();
+
+    const [firstResponse, secondResponse] = await Promise.all([
+      firstReconcile,
+      secondReconcile,
+    ]);
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(config.ingressPublicBaseUrl).toBe("https://second.example.com");
+    expect(config.twilioAccountSid).toBe("AC-second");
+    expect(config.twilioAuthToken).toBe("second-auth-token");
+    expect(config.twilioPhoneNumber).toBe("+15553334444");
+  });
+});

--- a/gateway/src/http/routes/twilio-reconcile.ts
+++ b/gateway/src/http/routes/twilio-reconcile.ts
@@ -1,0 +1,149 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { verifyToken } from "../../auth/token-service.js";
+import type { GatewayConfig } from "../../config.js";
+import { readConfigFileDefaults } from "../../config-file-mappings.js";
+import {
+  getRootDir,
+  readCredential,
+  readTwilioCredentials,
+} from "../../credential-reader.js";
+import { getLogger } from "../../logger.js";
+
+const log = getLogger("twilio-reconcile");
+
+function normalizeIngressPublicBaseUrl(value: string): string | undefined {
+  const normalized = value.trim().replace(/\/+$/, "");
+  return normalized || undefined;
+}
+
+async function readLatestTwilioConfigState(): Promise<
+  Pick<
+    GatewayConfig,
+    "twilioAccountSid" | "twilioAuthToken" | "twilioPhoneNumber"
+  >
+> {
+  const twilioCreds = await readTwilioCredentials();
+
+  let configFileData: Record<string, unknown> = {};
+  try {
+    const cfgPath = join(getRootDir(), "workspace", "config.json");
+    const raw = readFileSync(cfgPath, "utf-8");
+    const data = JSON.parse(raw);
+    if (data && typeof data === "object" && !Array.isArray(data)) {
+      configFileData = data as Record<string, unknown>;
+    }
+  } catch {
+    // The workspace config may not exist yet; fall back to env + credentials.
+  }
+
+  const configDefaults = readConfigFileDefaults(configFileData);
+
+  const twilioAuthToken =
+    process.env.TWILIO_AUTH_TOKEN || twilioCreds?.authToken || undefined;
+
+  let twilioAccountSid =
+    process.env.TWILIO_ACCOUNT_SID || twilioCreds?.accountSid || undefined;
+  if (!twilioAccountSid) {
+    twilioAccountSid = configDefaults.twilioAccountSid as string | undefined;
+  }
+
+  let twilioPhoneNumber =
+    process.env.TWILIO_PHONE_NUMBER ||
+    (configDefaults.twilioPhoneNumber as string | undefined);
+  if (!twilioPhoneNumber) {
+    twilioPhoneNumber =
+      (await readCredential("credential:twilio:phone_number")) || undefined;
+  }
+
+  return {
+    twilioAccountSid,
+    twilioAuthToken,
+    twilioPhoneNumber,
+  };
+}
+
+/**
+ * Internal endpoint that refreshes Twilio validation state after ingress or
+ * credential changes so webhook validation can use the latest config without
+ * waiting for file watchers or a gateway restart.
+ */
+export function createTwilioReconcileHandler(config: GatewayConfig) {
+  // Serialize reconcile operations so concurrent requests cannot interleave
+  // a stale ingress URL or credential snapshot over a later refresh.
+  let reconcileChain: Promise<void> = Promise.resolve();
+
+  return async (req: Request): Promise<Response> => {
+    if (req.method !== "POST") {
+      return Response.json({ error: "Method not allowed" }, { status: 405 });
+    }
+
+    const authHeader = req.headers.get("authorization");
+    if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const token = authHeader.slice(7);
+    const authResult = verifyToken(token, "vellum-daemon");
+    if (!authResult.ok) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    let body: { ingressPublicBaseUrl?: string } = {};
+    try {
+      const text = await req.text();
+      if (text) {
+        body = JSON.parse(text) as typeof body;
+      }
+    } catch {
+      return Response.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const ingressPublicBaseUrlProvided =
+      typeof body.ingressPublicBaseUrl === "string";
+    const normalizedIngressPublicBaseUrl = ingressPublicBaseUrlProvided
+      ? normalizeIngressPublicBaseUrl(body.ingressPublicBaseUrl)
+      : undefined;
+
+    const result = new Promise<Response>((resolve) => {
+      reconcileChain = reconcileChain
+        .then(async () => {
+          try {
+            const latestState = await readLatestTwilioConfigState();
+            const nextIngressPublicBaseUrl = ingressPublicBaseUrlProvided
+              ? normalizedIngressPublicBaseUrl
+              : config.ingressPublicBaseUrl;
+
+            config.ingressPublicBaseUrl = nextIngressPublicBaseUrl;
+            config.twilioAccountSid = latestState.twilioAccountSid;
+            config.twilioAuthToken = latestState.twilioAuthToken;
+            config.twilioPhoneNumber = latestState.twilioPhoneNumber;
+
+            log.info(
+              {
+                ingressPublicBaseUrl: config.ingressPublicBaseUrl,
+                twilioAccountSidConfigured: !!config.twilioAccountSid,
+                twilioAuthTokenConfigured: !!config.twilioAuthToken,
+                twilioPhoneNumberConfigured: !!config.twilioPhoneNumber,
+              },
+              "Twilio validation state reconciled via internal endpoint",
+            );
+            resolve(Response.json({ ok: true }));
+          } catch (err) {
+            log.error(
+              { err },
+              "Failed to reconcile Twilio validation state via internal endpoint",
+            );
+            resolve(
+              Response.json(
+                { error: "Reconciliation failed" },
+                { status: 502 },
+              ),
+            );
+          }
+        })
+        .catch(() => {});
+    });
+
+    return result;
+  };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -27,6 +27,7 @@ import {
 import { createTelegramDeliverHandler } from "./http/routes/telegram-deliver.js";
 import { createTelegramReconcileHandler } from "./http/routes/telegram-reconcile.js";
 import { createTelegramWebhookHandler } from "./http/routes/telegram-webhook.js";
+import { createTwilioReconcileHandler } from "./http/routes/twilio-reconcile.js";
 import { createTwilioVoiceWebhookHandler } from "./http/routes/twilio-voice-webhook.js";
 import { createTwilioStatusWebhookHandler } from "./http/routes/twilio-status-webhook.js";
 import { createTwilioConnectActionWebhookHandler } from "./http/routes/twilio-connect-action-webhook.js";
@@ -124,6 +125,7 @@ async function main() {
     createTelegramWebhookHandler(config);
   const handleTelegramDeliver = createTelegramDeliverHandler(config);
   const handleTelegramReconcile = createTelegramReconcileHandler(config);
+  const handleTwilioReconcile = createTwilioReconcileHandler(config);
 
   const isTelegramConfigured = () =>
     !!(config.telegramBotToken && config.telegramWebhookSecret);
@@ -200,6 +202,10 @@ async function main() {
     {
       path: "/internal/telegram/reconcile",
       handler: (req) => handleTelegramReconcile(req),
+    },
+    {
+      path: "/internal/twilio/reconcile",
+      handler: (req) => handleTwilioReconcile(req),
     },
 
     // ── Webhooks (unauthenticated, validated by provider-specific mechanisms) ──


### PR DESCRIPTION
## Summary
- add an internal gateway Twilio reconcile route that refreshes live ingress and credential-backed validation state
- register the route and cover it with focused gateway tests and route-schema exclusions

Part of plan: twilio-voice-call-stability.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13752" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
