### PR TITLE
fix: ensure unread rewind moves attention backward

### DIFF
--- a/assistant/src/__tests__/conversation-attention-store.test.ts
+++ b/assistant/src/__tests__/conversation-attention-store.test.ts
@@ -421,6 +421,27 @@ describe("conversation-attention-store", () => {
       expect(state.lastSeenAssistantMessageAt).toBe(1000);
     });
 
+    test("bootstraps unread rewind to a strictly older assistant timestamp", () => {
+      ensureConversation("conv-1");
+      insertAssistantMessage("conv-1", "msg-1", 1000);
+      insertAssistantMessage("conv-1", "msg-2", 2000);
+      insertAssistantMessage("conv-1", "msg-3", 2000);
+
+      markConversationUnread("conv-1");
+
+      const states = getAttentionStateByConversationIds(["conv-1"]);
+      const state = states.get("conv-1")!;
+      expect(state.latestAssistantMessageId).toBe("msg-3");
+      expect(state.latestAssistantMessageAt).toBe(2000);
+      expect(state.lastSeenAssistantMessageId).toBe("msg-1");
+      expect(state.lastSeenAssistantMessageAt).toBe(1000);
+      expect(
+        listConversationAttention({ state: "unseen" }).map(
+          (entry) => entry.conversationId,
+        ),
+      ).toEqual(["conv-1"]);
+    });
+
     test("is idempotent when the conversation is already unread", () => {
       ensureConversation("conv-1");
       insertAssistantMessage("conv-1", "msg-1", 1000);

--- a/assistant/src/memory/conversation-attention-store.ts
+++ b/assistant/src/memory/conversation-attention-store.ts
@@ -324,20 +324,27 @@ function resolveAssistantCursor(params: {
     latestAssistantMessageAt,
   } = params;
 
-  if (latestAssistantMessageId && latestAssistantMessageAt != null) {
-    const previousMessage = db
+  // Unread classification compares timestamps strictly, so rewinding to a
+  // same-timestamp sibling would leave the latest reply classified as seen.
+  const previousAssistantMessageBefore = (before: number) =>
+    db
       .select({ id: messages.id, createdAt: messages.createdAt })
       .from(messages)
       .where(
         and(
           eq(messages.conversationId, conversationId),
           eq(messages.role, "assistant"),
-          lt(messages.createdAt, latestAssistantMessageAt),
+          lt(messages.createdAt, before),
         ),
       )
-      .orderBy(desc(messages.createdAt))
+      .orderBy(desc(messages.createdAt), desc(messages.id))
       .limit(1)
       .get();
+
+  if (latestAssistantMessageId && latestAssistantMessageAt != null) {
+    const previousMessage = previousAssistantMessageBefore(
+      latestAssistantMessageAt,
+    );
 
     return {
       latestAssistantMessageId,
@@ -347,7 +354,7 @@ function resolveAssistantCursor(params: {
     };
   }
 
-  const assistantMessages = db
+  const latestMessage = db
     .select({ id: messages.id, createdAt: messages.createdAt })
     .from(messages)
     .where(
@@ -357,14 +364,16 @@ function resolveAssistantCursor(params: {
       ),
     )
     .orderBy(desc(messages.createdAt), desc(messages.id))
-    .limit(2)
-    .all();
+    .limit(1)
+    .get();
 
-  if (assistantMessages.length === 0) {
+  if (!latestMessage) {
     return null;
   }
 
-  const [latestMessage, previousMessage] = assistantMessages;
+  const previousMessage = previousAssistantMessageBefore(
+    latestMessage.createdAt,
+  );
   return {
     latestAssistantMessageId: latestMessage.id,
     latestAssistantMessageAt: latestMessage.createdAt,


### PR DESCRIPTION
## Summary
- make unread rewind robust when adjacent assistant messages share timestamps
- preserve unread classification by ensuring the rewind cursor moves backward
- add focused verification if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
