### PR TITLE
fix: restore reserved contact delete subpath guard

### DIFF
--- a/gateway/src/__tests__/contacts-control-plane-route-match.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-route-match.test.ts
@@ -34,10 +34,7 @@ describe("matchContactsControlPlaneRoute", () => {
 
     // Only POST is supported
     expect(
-      matchContactsControlPlaneRoute(
-        "/v1/contact-channels/ch_1/verify",
-        "GET",
-      ),
+      matchContactsControlPlaneRoute("/v1/contact-channels/ch_1/verify", "GET"),
     ).toBeNull();
   });
 
@@ -95,6 +92,9 @@ describe("matchContactsControlPlaneRoute", () => {
   });
 
   test("returns null for unsupported method/path combinations", () => {
+    expect(
+      matchContactsControlPlaneRoute("/v1/contacts/invites", "DELETE"),
+    ).toBeNull();
     expect(
       matchContactsControlPlaneRoute("/v1/contacts/invites/redeem", "GET"),
     ).toBeNull();

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -419,7 +419,9 @@ async function main() {
         contactsControlPlaneProxy.handleRevokeInvite(req, params[0]),
     },
     {
-      path: /^\/v1\/contacts\/([^/]+)$/,
+      // Keep DELETE on the invite collection unsupported; only /invites/:id
+      // should revoke an invite.
+      path: /^\/v1\/contacts\/(?!invites$)([^/]+)$/,
       method: "DELETE",
       auth: "edge",
       handler: (req, params) =>


### PR DESCRIPTION
## Summary
- restore the reserved contacts subpath guard for the contact DELETE route in gateway routing
- keep gateway routing aligned with the canonical contacts route matcher
- add or update focused coverage if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
