### PR TITLE
fix: sort unordered pinned iOS threads last

### DIFF
--- a/clients/ios/Tests/ThreadListOrderingIOSTests.swift
+++ b/clients/ios/Tests/ThreadListOrderingIOSTests.swift
@@ -60,6 +60,48 @@ final class ThreadListOrderingIOSTests: XCTestCase {
         )
     }
 
+    func testConnectedModeSortsPinnedThreadsWithoutOrderAfterOrderedPins() {
+        let threads = [
+            IOSThread(
+                title: "pinned-unordered",
+                lastActivityAt: Date(timeIntervalSince1970: 60),
+                sessionId: "pinned-unordered",
+                isPinned: true
+            ),
+            IOSThread(
+                title: "pinned-second",
+                lastActivityAt: Date(timeIntervalSince1970: 20),
+                sessionId: "pinned-second",
+                isPinned: true,
+                displayOrder: 1
+            ),
+            IOSThread(
+                title: "regular",
+                lastActivityAt: Date(timeIntervalSince1970: 50),
+                sessionId: "regular"
+            ),
+            IOSThread(
+                title: "pinned-first",
+                lastActivityAt: Date(timeIntervalSince1970: 10),
+                sessionId: "pinned-first",
+                isPinned: true,
+                displayOrder: 0
+            ),
+        ]
+
+        let sorted = sortThreadsForDisplay(threads, isConnectedMode: true)
+
+        XCTAssertEqual(
+            sorted.map(\.title),
+            [
+                "pinned-first",
+                "pinned-second",
+                "pinned-unordered",
+                "regular",
+            ]
+        )
+    }
+
     func testStandaloneModePreservesOriginalOrder() {
         let threads = [
             IOSThread(title: "first", sessionId: "first", isPinned: true, displayOrder: 1),

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -11,7 +11,12 @@ func sortThreadsForDisplay(
 
     return threads.sorted { a, b in
         if a.isPinned && b.isPinned {
-            return (a.displayOrder ?? 0) < (b.displayOrder ?? 0)
+            if a.displayOrder == nil && b.displayOrder == nil {
+                return a.lastActivityAt > b.lastActivityAt
+            }
+            if a.displayOrder == nil { return false }
+            if b.displayOrder == nil { return true }
+            return a.displayOrder! < b.displayOrder!
         }
         if a.isPinned { return true }
         if b.isPinned { return false }


### PR DESCRIPTION
## Summary
- treat pinned iOS threads without display order as trailing instead of leading
- keep connected-mode sort behavior aligned with macOS ordering expectations
- add focused verification if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
