### PR TITLE
feat: add local gateway health checks for voice readiness

### DIFF
--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -1,14 +1,70 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+let mockTwilioPhoneNumberEnv: string | undefined;
+let mockRawConfig: Record<string, unknown> | undefined;
+let mockSecureKeys: Record<string, string>;
+let mockHasTwilioCredentials: boolean;
+let mockGatewayHealth = {
+  target: "http://127.0.0.1:7830",
+  healthy: true,
+  localDeployment: true,
+  error: undefined as string | undefined,
+};
+
+mock.module("../calls/twilio-rest.js", () => ({
+  getPhoneNumberSid: async () => null,
+  getTollFreeVerificationStatus: async () => null,
+  getTwilioCredentials: () => ({
+    accountSid: "AC_test",
+    authToken: "test-auth-token",
+  }),
+  hasTwilioCredentials: () => mockHasTwilioCredentials,
+}));
+
+mock.module("../channels/config.js", () => ({
+  getChannelInvitePolicy: () => ({
+    codeRedemptionEnabled: true,
+  }),
+}));
+
+mock.module("../config/env.js", () => ({
+  getTwilioPhoneNumberEnv: () => mockTwilioPhoneNumberEnv,
+}));
+
+mock.module("../config/loader.js", () => ({
+  loadRawConfig: () => mockRawConfig,
+  getConfig: () => ({
+    whatsapp: {
+      phoneNumber: "",
+    },
+  }),
+}));
+
+mock.module("../email/service.js", () => ({
+  getEmailService: () => ({
+    getPrimaryInboxAddress: async () => undefined,
+  }),
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKey: (key: string) => mockSecureKeys[key] ?? null,
+}));
+
+mock.module("../runtime/channel-invite-transports/whatsapp.js", () => ({
+  resolveWhatsAppDisplayNumber: () => "",
+}));
 
 import type { ChannelId } from "../channels/types.js";
 import {
   ChannelReadinessService,
+  createReadinessService,
   REMOTE_TTL_MS,
 } from "../runtime/channel-readiness-service.js";
 import type {
   ChannelProbe,
   ReadinessCheckResult,
 } from "../runtime/channel-readiness-types.js";
+import * as localGatewayHealth from "../runtime/local-gateway-health.js";
 
 // ── Test helpers ────────────────────────────────────────────────────────────
 
@@ -44,6 +100,16 @@ describe("ChannelReadinessService", () => {
 
   beforeEach(() => {
     service = new ChannelReadinessService();
+    mockTwilioPhoneNumberEnv = undefined;
+    mockRawConfig = undefined;
+    mockSecureKeys = {};
+    mockHasTwilioCredentials = false;
+    mockGatewayHealth = {
+      target: "http://127.0.0.1:7830",
+      healthy: true,
+      localDeployment: true,
+      error: undefined,
+    };
   });
 
   test("local checks run on every call (no caching of local results)", async () => {
@@ -336,5 +402,50 @@ describe("ChannelReadinessService", () => {
     await service.getReadiness("sms", true);
 
     expect(probe.remoteCallCount).toBe(1);
+  });
+
+  test("voice readiness includes gateway_health when ingress is configured", async () => {
+    mockHasTwilioCredentials = true;
+    mockTwilioPhoneNumberEnv = "+15550001111";
+    mockRawConfig = {
+      ingress: {
+        enabled: true,
+        publicBaseUrl: "https://voice.example.com",
+      },
+    };
+    mockGatewayHealth = {
+      target: "http://127.0.0.1:7830",
+      healthy: false,
+      localDeployment: true,
+      error: "connect ECONNREFUSED 127.0.0.1:7830",
+    };
+
+    const probeLocalGatewayHealthSpy = spyOn(
+      localGatewayHealth,
+      "probeLocalGatewayHealth",
+    ).mockImplementation(async () => ({
+      ...mockGatewayHealth,
+    }));
+
+    let snapshot: Awaited<
+      ReturnType<ChannelReadinessService["getReadiness"]>
+    >[number];
+    try {
+      const readinessService = createReadinessService();
+      [snapshot] = await readinessService.getReadiness("voice");
+    } finally {
+      probeLocalGatewayHealthSpy.mockRestore();
+    }
+
+    const gatewayHealthCheck = snapshot.localChecks.find(
+      (check) => check.name === "gateway_health",
+    );
+    expect(gatewayHealthCheck).toBeDefined();
+    expect(gatewayHealthCheck?.passed).toBe(false);
+    expect(snapshot.reasons).toContainEqual({
+      code: "gateway_health",
+      text: "Local gateway is not serving requests at http://127.0.0.1:7830: connect ECONNREFUSED 127.0.0.1:7830",
+    });
+    expect(snapshot.ready).toBe(false);
   });
 });

--- a/assistant/src/__tests__/local-gateway-health.test.ts
+++ b/assistant/src/__tests__/local-gateway-health.test.ts
@@ -49,7 +49,7 @@ describe("local gateway health", () => {
             : input.url,
       );
       return new Response("ok", { status: 200 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const result = await probeLocalGatewayHealth({
       fetchImpl,
@@ -67,7 +67,7 @@ describe("local gateway health", () => {
   test("probeLocalGatewayHealth returns an unhealthy result when /healthz fails", async () => {
     const fetchImpl: typeof fetch = (async (): Promise<Response> => {
       return new Response("unavailable", { status: 503 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const result = await probeLocalGatewayHealth({
       fetchImpl,
@@ -87,7 +87,7 @@ describe("local gateway health", () => {
     const fetchImpl: typeof fetch = (async (): Promise<Response> => {
       const status = healthStatuses.shift() ?? 200;
       return new Response(status === 200 ? "ok" : "unavailable", { status });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const wakeCalls: number[] = [];
     const result = await ensureLocalGatewayReady({
@@ -126,7 +126,7 @@ describe("local gateway health", () => {
 
     const fetchImpl: typeof fetch = (async (): Promise<Response> => {
       return new Response("unavailable", { status: 503 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     let wakeCallCount = 0;
     const result = await ensureLocalGatewayReady({

--- a/assistant/src/__tests__/local-gateway-health.test.ts
+++ b/assistant/src/__tests__/local-gateway-health.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let mockGatewayInternalBaseUrl = "http://127.0.0.1:7830";
+let mockIsContainerized = false;
+let mockLockfile: Record<string, unknown> | null = null;
+
+mock.module("../config/env.js", () => ({
+  getGatewayInternalBaseUrl: () => mockGatewayInternalBaseUrl,
+}));
+
+mock.module("../config/env-registry.js", () => ({
+  getIsContainerized: () => mockIsContainerized,
+}));
+
+mock.module("../util/platform.js", () => ({
+  readLockfile: () => mockLockfile,
+}));
+
+import {
+  ensureLocalGatewayReady,
+  probeLocalGatewayHealth,
+} from "../runtime/local-gateway-health.js";
+
+describe("local gateway health", () => {
+  beforeEach(() => {
+    mockGatewayInternalBaseUrl = "http://127.0.0.1:7830";
+    mockIsContainerized = false;
+    mockLockfile = {
+      assistants: [
+        {
+          assistantId: "local-dev",
+          cloud: "local",
+          hatchedAt: "2026-03-07T00:00:00.000Z",
+        },
+      ],
+    };
+  });
+
+  test("probeLocalGatewayHealth returns healthy result when /healthz succeeds", async () => {
+    const requests: string[] = [];
+    const fetchImpl: typeof fetch = (async (
+      input: string | URL | Request,
+    ): Promise<Response> => {
+      requests.push(
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url,
+      );
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+
+    const result = await probeLocalGatewayHealth({
+      fetchImpl,
+      timeoutMs: 50,
+    });
+
+    expect(requests).toEqual(["http://127.0.0.1:7830/healthz"]);
+    expect(result).toEqual({
+      target: "http://127.0.0.1:7830",
+      healthy: true,
+      localDeployment: true,
+    });
+  });
+
+  test("probeLocalGatewayHealth returns an unhealthy result when /healthz fails", async () => {
+    const fetchImpl: typeof fetch = (async (): Promise<Response> => {
+      return new Response("unavailable", { status: 503 });
+    }) as typeof fetch;
+
+    const result = await probeLocalGatewayHealth({
+      fetchImpl,
+      timeoutMs: 50,
+    });
+
+    expect(result).toEqual({
+      target: "http://127.0.0.1:7830",
+      healthy: false,
+      localDeployment: true,
+      error: "Gateway health check returned HTTP 503",
+    });
+  });
+
+  test("ensureLocalGatewayReady runs recovery for local assistants until the gateway becomes healthy", async () => {
+    const healthStatuses = [503, 503, 200];
+    const fetchImpl: typeof fetch = (async (): Promise<Response> => {
+      const status = healthStatuses.shift() ?? 200;
+      return new Response(status === 200 ? "ok" : "unavailable", { status });
+    }) as typeof fetch;
+
+    const wakeCalls: number[] = [];
+    const result = await ensureLocalGatewayReady({
+      fetchImpl,
+      timeoutMs: 50,
+      pollTimeoutMs: 100,
+      pollIntervalMs: 0,
+      sleepImpl: async () => {},
+      runWakeCommand: async () => {
+        wakeCalls.push(Date.now());
+        return { exitCode: 0, stdout: "Wake complete.", stderr: "" };
+      },
+    });
+
+    expect(wakeCalls).toHaveLength(1);
+    expect(result).toEqual({
+      target: "http://127.0.0.1:7830",
+      healthy: true,
+      localDeployment: true,
+      recovered: true,
+      recoveryAttempted: true,
+      recoverySkipped: false,
+    });
+  });
+
+  test("ensureLocalGatewayReady skips recovery for non-local assistants", async () => {
+    mockLockfile = {
+      assistants: [
+        {
+          assistantId: "remote-prod",
+          cloud: "gcp",
+          hatchedAt: "2026-03-07T00:00:00.000Z",
+        },
+      ],
+    };
+
+    const fetchImpl: typeof fetch = (async (): Promise<Response> => {
+      return new Response("unavailable", { status: 503 });
+    }) as typeof fetch;
+
+    let wakeCallCount = 0;
+    const result = await ensureLocalGatewayReady({
+      fetchImpl,
+      timeoutMs: 50,
+      runWakeCommand: async () => {
+        wakeCallCount++;
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    });
+
+    expect(wakeCallCount).toBe(0);
+    expect(result).toEqual({
+      target: "http://127.0.0.1:7830",
+      healthy: false,
+      localDeployment: false,
+      error: "Gateway health check returned HTTP 503",
+      recovered: false,
+      recoveryAttempted: false,
+      recoverySkipped: true,
+    });
+  });
+});

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -17,6 +17,7 @@ import type {
   ChannelReadinessSnapshot,
   ReadinessCheckResult,
 } from "./channel-readiness-types.js";
+import { probeLocalGatewayHealth } from "./local-gateway-health.js";
 
 /** Remote check results are cached for 5 minutes before being considered stale. */
 export const REMOTE_TTL_MS = 5 * 60 * 1000;
@@ -183,7 +184,7 @@ const smsProbe: ChannelProbe = {
 
 const voiceProbe: ChannelProbe = {
   channel: "voice",
-  runLocalChecks(): ReadinessCheckResult[] {
+  async runLocalChecks(): Promise<ReadinessCheckResult[]> {
     const results: ReadinessCheckResult[] = [];
 
     const hasCreds = hasTwilioCredentials();
@@ -213,6 +214,19 @@ const voiceProbe: ChannelProbe = {
         ? "Public ingress URL is configured"
         : "Public ingress URL is not configured or disabled",
     });
+
+    if (hasIngress) {
+      const gatewayHealth = await probeLocalGatewayHealth();
+      results.push({
+        name: "gateway_health",
+        passed: gatewayHealth.healthy,
+        message: gatewayHealth.healthy
+          ? `Local gateway is serving requests at ${gatewayHealth.target}`
+          : `Local gateway is not serving requests at ${gatewayHealth.target}${
+              gatewayHealth.error ? `: ${gatewayHealth.error}` : ""
+            }`,
+      });
+    }
 
     return results;
   },
@@ -446,8 +460,9 @@ export class ChannelReadinessService {
 
   /**
    * Get readiness snapshots for the specified channel (or all registered channels).
-   * Local checks always run inline. Remote checks run only when `includeRemote`
-   * is true and the cache is stale or missing.
+   * Local checks always run on demand, including async loopback probes. Remote
+   * checks run only when `includeRemote` is true and the cache is stale or
+   * missing.
    */
   async getReadiness(
     channel?: ChannelId,
@@ -464,7 +479,7 @@ export class ChannelReadinessService {
       }
 
       const probeContext: ChannelProbeContext = {};
-      const localChecks = probe.runLocalChecks(probeContext);
+      const localChecks = await probe.runLocalChecks(probeContext);
       let remoteChecks: ReadinessCheckResult[] | undefined;
       let remoteChecksFreshlyFetched = false;
       let remoteChecksAffectReadiness = false;

--- a/assistant/src/runtime/channel-readiness-types.ts
+++ b/assistant/src/runtime/channel-readiness-types.ts
@@ -26,10 +26,14 @@ export interface ChannelReadinessSnapshot {
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface ChannelProbeContext {}
 
+export type Awaitable<T> = T | Promise<T>;
+
 /** Probe interface that channels implement to provide readiness checks. */
 export interface ChannelProbe {
   channel: ChannelId;
-  runLocalChecks(context?: ChannelProbeContext): ReadinessCheckResult[];
+  runLocalChecks(
+    context?: ChannelProbeContext,
+  ): Awaitable<ReadinessCheckResult[]>;
   runRemoteChecks?(
     context?: ChannelProbeContext,
   ): Promise<ReadinessCheckResult[]>;

--- a/assistant/src/runtime/local-gateway-health.ts
+++ b/assistant/src/runtime/local-gateway-health.ts
@@ -10,9 +10,9 @@ const DEFAULT_RECOVERY_POLL_INTERVAL_MS = 250;
 const DEFAULT_WAKE_TIMEOUT_MS = 90_000;
 
 interface LockfileAssistantEntry {
-  assistantId?: unknown;
-  cloud?: unknown;
-  hatchedAt?: unknown;
+  assistantId?: string;
+  cloud?: string;
+  hatchedAt?: string | number | Date;
 }
 
 export interface WakeCommandResult {

--- a/assistant/src/runtime/local-gateway-health.ts
+++ b/assistant/src/runtime/local-gateway-health.ts
@@ -1,0 +1,223 @@
+import { getGatewayInternalBaseUrl } from "../config/env.js";
+import { getIsContainerized } from "../config/env-registry.js";
+import { readLockfile } from "../util/platform.js";
+import { sleep } from "../util/retry.js";
+import { spawnWithTimeout } from "../util/spawn.js";
+
+const DEFAULT_PROBE_TIMEOUT_MS = 2_000;
+const DEFAULT_RECOVERY_POLL_TIMEOUT_MS = 30_000;
+const DEFAULT_RECOVERY_POLL_INTERVAL_MS = 250;
+const DEFAULT_WAKE_TIMEOUT_MS = 90_000;
+
+interface LockfileAssistantEntry {
+  assistantId?: unknown;
+  cloud?: unknown;
+  hatchedAt?: unknown;
+}
+
+export interface WakeCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface LocalGatewayHealthResult {
+  target: string;
+  healthy: boolean;
+  localDeployment: boolean;
+  error?: string;
+}
+
+export interface EnsureLocalGatewayReadyResult extends LocalGatewayHealthResult {
+  recovered: boolean;
+  recoveryAttempted: boolean;
+  recoverySkipped: boolean;
+}
+
+export interface ProbeLocalGatewayHealthOptions {
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export interface EnsureLocalGatewayReadyOptions extends ProbeLocalGatewayHealthOptions {
+  pollTimeoutMs?: number;
+  pollIntervalMs?: number;
+  wakeTimeoutMs?: number;
+  runWakeCommand?: () => Promise<WakeCommandResult>;
+  sleepImpl?: (ms: number) => Promise<void>;
+}
+
+function getLatestAssistantEntry(): LockfileAssistantEntry | null {
+  try {
+    const lockData = readLockfile();
+    const assistants = lockData?.assistants;
+    if (!Array.isArray(assistants) || assistants.length === 0) {
+      return null;
+    }
+
+    const sorted = [...assistants].sort((a, b) => {
+      const dateA = new Date(
+        (a as LockfileAssistantEntry).hatchedAt || 0,
+      ).getTime();
+      const dateB = new Date(
+        (b as LockfileAssistantEntry).hatchedAt || 0,
+      ).getTime();
+      return dateB - dateA;
+    });
+
+    return (sorted[0] as LockfileAssistantEntry) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveLocalDeployment(): boolean {
+  if (getIsContainerized()) {
+    return false;
+  }
+
+  const latestAssistant = getLatestAssistantEntry();
+  if (typeof latestAssistant?.cloud === "string") {
+    return latestAssistant.cloud === "local";
+  }
+
+  return true;
+}
+
+function resolveLocalAssistantName(): string | undefined {
+  const latestAssistant = getLatestAssistantEntry();
+  if (
+    latestAssistant &&
+    typeof latestAssistant.assistantId === "string" &&
+    latestAssistant.assistantId.trim().length > 0
+  ) {
+    return latestAssistant.assistantId.trim();
+  }
+
+  return undefined;
+}
+
+function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function runDefaultWakeCommand(
+  timeoutMs: number,
+): Promise<WakeCommandResult> {
+  const assistantName = resolveLocalAssistantName();
+  const command = assistantName
+    ? ["vellum", "wake", assistantName]
+    : ["vellum", "wake"];
+  return spawnWithTimeout(command, timeoutMs);
+}
+
+export async function probeLocalGatewayHealth(
+  options: ProbeLocalGatewayHealthOptions = {},
+): Promise<LocalGatewayHealthResult> {
+  const target = getGatewayInternalBaseUrl();
+  const localDeployment = resolveLocalDeployment();
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+
+  try {
+    const response = await fetchImpl(`${target}/healthz`, {
+      method: "GET",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) {
+      return {
+        target,
+        healthy: false,
+        localDeployment,
+        error: `Gateway health check returned HTTP ${response.status}`,
+      };
+    }
+
+    return {
+      target,
+      healthy: true,
+      localDeployment,
+    };
+  } catch (err) {
+    return {
+      target,
+      healthy: false,
+      localDeployment,
+      error: formatError(err),
+    };
+  }
+}
+
+export async function ensureLocalGatewayReady(
+  options: EnsureLocalGatewayReadyOptions = {},
+): Promise<EnsureLocalGatewayReadyResult> {
+  const initialProbe = await probeLocalGatewayHealth(options);
+  if (initialProbe.healthy) {
+    return {
+      ...initialProbe,
+      recovered: false,
+      recoveryAttempted: false,
+      recoverySkipped: false,
+    };
+  }
+
+  if (!initialProbe.localDeployment) {
+    return {
+      ...initialProbe,
+      recovered: false,
+      recoveryAttempted: false,
+      recoverySkipped: true,
+      error:
+        initialProbe.error ??
+        "Skipped gateway recovery because this assistant is not locally managed",
+    };
+  }
+
+  const runWakeCommand =
+    options.runWakeCommand ??
+    (() =>
+      runDefaultWakeCommand(options.wakeTimeoutMs ?? DEFAULT_WAKE_TIMEOUT_MS));
+  const sleepImpl = options.sleepImpl ?? sleep;
+  const pollTimeoutMs =
+    options.pollTimeoutMs ?? DEFAULT_RECOVERY_POLL_TIMEOUT_MS;
+  const pollIntervalMs =
+    options.pollIntervalMs ?? DEFAULT_RECOVERY_POLL_INTERVAL_MS;
+
+  let wakeError: string | undefined;
+  try {
+    const wakeResult = await runWakeCommand();
+    if (wakeResult.exitCode !== 0) {
+      const detail = wakeResult.stderr.trim() || wakeResult.stdout.trim();
+      wakeError = detail
+        ? `vellum wake exited with code ${wakeResult.exitCode}: ${detail}`
+        : `vellum wake exited with code ${wakeResult.exitCode}`;
+    }
+  } catch (err) {
+    wakeError = `Failed to run vellum wake: ${formatError(err)}`;
+  }
+
+  const deadline = Date.now() + pollTimeoutMs;
+  let probe = await probeLocalGatewayHealth(options);
+  while (!probe.healthy && Date.now() < deadline) {
+    await sleepImpl(pollIntervalMs);
+    probe = await probeLocalGatewayHealth(options);
+  }
+
+  if (probe.healthy) {
+    return {
+      ...probe,
+      recovered: true,
+      recoveryAttempted: true,
+      recoverySkipped: false,
+    };
+  }
+
+  const combinedError = [wakeError, probe.error].filter(Boolean).join("; ");
+  return {
+    ...probe,
+    recovered: false,
+    recoveryAttempted: true,
+    recoverySkipped: false,
+    error: combinedError || undefined,
+  };
+}


### PR DESCRIPTION
## Summary
- add reusable local gateway health and recovery helpers for voice callback readiness
- extend voice readiness checks and focused tests to surface gateway health when ingress is configured

Part of plan: twilio-voice-call-stability.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
