### PR TITLE
fix: serialize conversation signal metadata safely

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -947,6 +947,16 @@ public final class HTTPTransport {
         let prompts: [GuardianDecisionPromptWire]
     }
 
+    /// JSONSerialization cannot encode AnyCodable wrappers directly, so unwrap
+    /// them before inserting arbitrary payloads into request bodies.
+    private func jsonCompatibleDictionary(_ values: [String: AnyCodable]) -> [String: Any] {
+        var jsonCompatible: [String: Any] = [:]
+        for (key, value) in values {
+            jsonCompatible[key] = value.value
+        }
+        return jsonCompatible
+    }
+
     private func sendConversationSeen(_ signal: IPCConversationSeenSignal, isRetry: Bool = false) async {
         guard let url = buildURL(for: .conversationsSeen) else { return }
 
@@ -969,7 +979,7 @@ public final class HTTPTransport {
             body["observedAt"] = observedAt
         }
         if let metadata = signal.metadata {
-            body["metadata"] = metadata
+            body["metadata"] = jsonCompatibleDictionary(metadata)
         }
 
         do {
@@ -1013,7 +1023,7 @@ public final class HTTPTransport {
             body["observedAt"] = observedAt
         }
         if let metadata = signal.metadata {
-            body["metadata"] = metadata
+            body["metadata"] = jsonCompatibleDictionary(metadata)
         }
 
         do {
@@ -1478,12 +1488,7 @@ public final class HTTPTransport {
             "actionId": action.actionId,
         ]
         if let data = action.data {
-            // Convert [String: AnyCodable] to [String: Any] for JSONSerialization
-            var dataDict: [String: Any] = [:]
-            for (key, value) in data {
-                dataDict[key] = value.value
-            }
-            body["data"] = dataDict
+            body["data"] = jsonCompatibleDictionary(data)
         }
 
         do {

--- a/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
+++ b/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
@@ -190,4 +190,104 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
         XCTAssertEqual(json["conversationId"] as? String, "conv-456")
         XCTAssertEqual(json["signalType"] as? String, "macos_conversation_opened")
     }
+
+    func testUnreadSignalSerializesMetadataIntoJSONBody() async throws {
+        let requestExpectation = expectation(description: "unread metadata request")
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            requestExpectation.fulfill()
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"ok":true}"#.utf8))
+        }
+
+        let transport = HTTPTransport(
+            baseURL: "https://example.com",
+            bearerToken: "test-token",
+            conversationKey: "conv-local"
+        )
+
+        try transport.send(
+            IPCConversationUnreadSignal(
+                conversationId: "conv-789",
+                sourceChannel: "vellum",
+                signalType: "macos_conversation_opened",
+                confidence: "explicit",
+                source: "ui-navigation",
+                metadata: [
+                    "threadOrigin": AnyCodable("inbox"),
+                    "badgeCount": AnyCodable(3),
+                    "userInitiated": AnyCodable(true),
+                ]
+            )
+        )
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        let request = try XCTUnwrap(capturedRequest)
+        let body = try requestBody(from: request)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: body) as? [String: Any]
+        )
+        let metadata = try XCTUnwrap(json["metadata"] as? [String: Any])
+
+        XCTAssertEqual(metadata["threadOrigin"] as? String, "inbox")
+        XCTAssertEqual(metadata["badgeCount"] as? Int, 3)
+        XCTAssertEqual(metadata["userInitiated"] as? Bool, true)
+    }
+
+    func testSeenSignalSerializesMetadataIntoJSONBody() async throws {
+        let requestExpectation = expectation(description: "seen metadata request")
+        var capturedRequest: URLRequest?
+
+        MockURLProtocol.requestHandler = { request in
+            capturedRequest = request
+            requestExpectation.fulfill()
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(#"{"ok":true}"#.utf8))
+        }
+
+        let transport = HTTPTransport(
+            baseURL: "https://example.com",
+            bearerToken: "test-token",
+            conversationKey: "conv-local"
+        )
+
+        try transport.send(
+            IPCConversationSeenSignal(
+                conversationId: "conv-321",
+                sourceChannel: "vellum",
+                signalType: "macos_conversation_seen",
+                confidence: "explicit",
+                source: "thread-selection",
+                metadata: [
+                    "view": AnyCodable("inbox"),
+                    "attempt": AnyCodable(1),
+                ]
+            )
+        )
+
+        await fulfillment(of: [requestExpectation], timeout: 1.0)
+
+        let request = try XCTUnwrap(capturedRequest)
+        let body = try requestBody(from: request)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: body) as? [String: Any]
+        )
+        let metadata = try XCTUnwrap(json["metadata"] as? [String: Any])
+
+        XCTAssertEqual(metadata["view"] as? String, "inbox")
+        XCTAssertEqual(metadata["attempt"] as? Int, 1)
+    }
 }


### PR DESCRIPTION
## Summary
- serialize conversation signal metadata into JSON-compatible values before encoding
- remove the unread-signal failure mode when metadata is present
- align the adjacent seen/unread transport paths if the shared fix is low-risk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
