### PR TITLE
fix: preserve optimistic thread attention across stale refreshes

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -122,6 +122,14 @@ class IOSThreadStore: ObservableObject {
     /// since the cache was loaded. Only these threads preserve local overrides
     /// when the daemon response arrives; all others accept daemon data.
     private var locallyEditedSessionIds: Set<String> = []
+    /// Local seen/unread mutations must survive a stale session-list replay until
+    /// the daemon acknowledges them or returns a newer assistant reply.
+    private var pendingAttentionOverrides: [String: PendingAttentionOverride] = [:]
+
+    private enum PendingAttentionOverride {
+        case seen(latestAssistantMessageAt: Date?)
+        case unread(latestAssistantMessageAt: Date?)
+    }
 
     private func assistantTimestamp(_ timestampMs: Int?) -> Date? {
         guard let timestampMs else { return nil }
@@ -142,6 +150,51 @@ class IOSThreadStore: ObservableObject {
         thread.lastSeenAssistantMessageAt = assistantTimestamp(
             session.assistantAttention?.lastSeenAssistantMessageAt
         )
+    }
+
+    private func applyPendingAttentionOverride(to thread: inout IOSThread) {
+        guard let sessionId = thread.sessionId,
+              let override = pendingAttentionOverrides[sessionId] else { return }
+
+        switch override {
+        case .seen(let targetLatestAssistantMessageAt):
+            if !thread.hasUnseenLatestAssistantMessage {
+                pendingAttentionOverrides.removeValue(forKey: sessionId)
+                return
+            }
+            if let targetLatestAssistantMessageAt,
+               let serverLatestAssistantMessageAt = thread.latestAssistantMessageAt,
+               serverLatestAssistantMessageAt > targetLatestAssistantMessageAt {
+                pendingAttentionOverrides.removeValue(forKey: sessionId)
+                return
+            }
+
+            if let targetLatestAssistantMessageAt,
+               thread.latestAssistantMessageAt == nil {
+                thread.latestAssistantMessageAt = targetLatestAssistantMessageAt
+            }
+            thread.hasUnseenLatestAssistantMessage = false
+            thread.lastSeenAssistantMessageAt = thread.latestAssistantMessageAt
+
+        case .unread(let targetLatestAssistantMessageAt):
+            if thread.hasUnseenLatestAssistantMessage {
+                pendingAttentionOverrides.removeValue(forKey: sessionId)
+                return
+            }
+            if let targetLatestAssistantMessageAt,
+               let serverLatestAssistantMessageAt = thread.latestAssistantMessageAt,
+               serverLatestAssistantMessageAt > targetLatestAssistantMessageAt {
+                pendingAttentionOverrides.removeValue(forKey: sessionId)
+                return
+            }
+
+            if let targetLatestAssistantMessageAt,
+               thread.latestAssistantMessageAt == nil {
+                thread.latestAssistantMessageAt = targetLatestAssistantMessageAt
+            }
+            thread.hasUnseenLatestAssistantMessage = true
+            thread.lastSeenAssistantMessageAt = nil
+        }
     }
 
     init(daemonClient: any DaemonClientProtocol) {
@@ -297,6 +350,7 @@ class IOSThreadStore: ObservableObject {
         viewModels.removeAll()
         observedActivityThreadIds.removeAll()
         pendingHistoryBySessionId.removeAll()
+        pendingAttentionOverrides.removeAll()
 
         if let daemon = newClient as? DaemonClient {
             // Connected mode — show cached threads instantly or spinner on first launch.
@@ -320,6 +374,7 @@ class IOSThreadStore: ObservableObject {
             isConnectedMode = false
             isLoadingInitialThreads = false
             locallyEditedSessionIds.removeAll()
+            pendingAttentionOverrides.removeAll()
             clearConnectedCache()
             let loaded = Self.load()
             if loaded.isEmpty {
@@ -361,6 +416,7 @@ class IOSThreadStore: ObservableObject {
             hasMoreThreads = response.hasMore ?? false
             clearConnectedCache()
             locallyEditedSessionIds.removeAll()
+            pendingAttentionOverrides.removeAll()
             return
         }
 
@@ -440,6 +496,7 @@ class IOSThreadStore: ObservableObject {
                             lastSeenAssistantMessageAt: restored.lastSeenAssistantMessageAt
                         )
                     }
+                    applyPendingAttentionOverride(to: &restored)
                     merged.append(restored)
                 }
 
@@ -459,15 +516,20 @@ class IOSThreadStore: ObservableObject {
                 for restored in restoredThreads {
                     if let sid = restored.sessionId, existingSessionIds.contains(sid) {
                         if let existingIndex = threads.firstIndex(where: { $0.sessionId == sid }) {
-                            threads[existingIndex].isPinned = restored.isPinned
-                            threads[existingIndex].displayOrder = restored.displayOrder
-                            threads[existingIndex].hasUnseenLatestAssistantMessage = restored.hasUnseenLatestAssistantMessage
-                            threads[existingIndex].latestAssistantMessageAt = restored.latestAssistantMessageAt
-                            threads[existingIndex].lastSeenAssistantMessageAt = restored.lastSeenAssistantMessageAt
+                            var mergedThread = threads[existingIndex]
+                            mergedThread.isPinned = restored.isPinned
+                            mergedThread.displayOrder = restored.displayOrder
+                            mergedThread.hasUnseenLatestAssistantMessage = restored.hasUnseenLatestAssistantMessage
+                            mergedThread.latestAssistantMessageAt = restored.latestAssistantMessageAt
+                            mergedThread.lastSeenAssistantMessageAt = restored.lastSeenAssistantMessageAt
+                            applyPendingAttentionOverride(to: &mergedThread)
+                            threads[existingIndex] = mergedThread
                         }
                         viewModels.removeValue(forKey: restored.id)
                     } else {
-                        newThreads.append(restored)
+                        var mergedThread = restored
+                        applyPendingAttentionOverride(to: &mergedThread)
+                        newThreads.append(mergedThread)
                     }
                 }
                 threads = newThreads + threads
@@ -482,15 +544,20 @@ class IOSThreadStore: ObservableObject {
             for restored in restoredThreads {
                 if let sid = restored.sessionId, existingSessionIds.contains(sid) {
                     if let existingIndex = threads.firstIndex(where: { $0.sessionId == sid }) {
-                        threads[existingIndex].isPinned = restored.isPinned
-                        threads[existingIndex].displayOrder = restored.displayOrder
-                        threads[existingIndex].hasUnseenLatestAssistantMessage = restored.hasUnseenLatestAssistantMessage
-                        threads[existingIndex].latestAssistantMessageAt = restored.latestAssistantMessageAt
-                        threads[existingIndex].lastSeenAssistantMessageAt = restored.lastSeenAssistantMessageAt
+                        var mergedThread = threads[existingIndex]
+                        mergedThread.isPinned = restored.isPinned
+                        mergedThread.displayOrder = restored.displayOrder
+                        mergedThread.hasUnseenLatestAssistantMessage = restored.hasUnseenLatestAssistantMessage
+                        mergedThread.latestAssistantMessageAt = restored.latestAssistantMessageAt
+                        mergedThread.lastSeenAssistantMessageAt = restored.lastSeenAssistantMessageAt
+                        applyPendingAttentionOverride(to: &mergedThread)
+                        threads[existingIndex] = mergedThread
                     }
                     viewModels.removeValue(forKey: restored.id)
                 } else {
-                    threads.append(restored)
+                    var mergedThread = restored
+                    applyPendingAttentionOverride(to: &mergedThread)
+                    threads.append(mergedThread)
                 }
             }
             saveConnectedCache()
@@ -582,7 +649,11 @@ class IOSThreadStore: ObservableObject {
               let sessionId = threads[idx].sessionId,
               threads[idx].hasUnseenLatestAssistantMessage else { return }
 
+        pendingAttentionOverrides[sessionId] = .seen(
+            latestAssistantMessageAt: threads[idx].latestAssistantMessageAt
+        )
         threads[idx].hasUnseenLatestAssistantMessage = false
+        threads[idx].lastSeenAssistantMessageAt = threads[idx].latestAssistantMessageAt
         saveConnectedCache()
 
         let signal = IPCConversationSeenSignal(
@@ -740,7 +811,10 @@ class IOSThreadStore: ObservableObject {
 
     func deleteThread(_ thread: IOSThread) {
         viewModels.removeValue(forKey: thread.id)
-        if let sid = thread.sessionId { locallyEditedSessionIds.remove(sid) }
+        if let sid = thread.sessionId {
+            locallyEditedSessionIds.remove(sid)
+            pendingAttentionOverrides.removeValue(forKey: sid)
+        }
         threads.removeAll { $0.id == thread.id }
         // Always keep at least one active (non-archived) non-private thread.
         // Private threads are managed separately and should not prevent the
@@ -802,7 +876,11 @@ class IOSThreadStore: ObservableObject {
               !threads[idx].hasUnseenLatestAssistantMessage,
               threads[idx].latestAssistantMessageAt != nil else { return }
 
+        pendingAttentionOverrides[sessionId] = .unread(
+            latestAssistantMessageAt: threads[idx].latestAssistantMessageAt
+        )
         threads[idx].hasUnseenLatestAssistantMessage = true
+        threads[idx].lastSeenAssistantMessageAt = nil
         saveConnectedCache()
 
         let signal = IPCConversationUnreadSignal(

--- a/clients/ios/Tests/ThreadLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ThreadLifecycleIOSTests.swift
@@ -588,6 +588,90 @@ final class ThreadLifecycleIOSTests: XCTestCase {
         XCTAssertFalse(store.threads.first(where: { $0.id == storedThread.id })?.hasUnseenLatestAssistantMessage ?? true)
     }
 
+    func testSessionListRefreshPreservesLocalSeenUntilDaemonCatchesUp() {
+        let daemonClient = DaemonClient()
+        let store = IOSThreadStore(daemonClient: daemonClient)
+
+        let initialResponse = makeSessionListResponse(sessions: [[
+            "id": "connected-session-refresh-seen",
+            "title": "Unread thread",
+            "createdAt": 1_000,
+            "updatedAt": 2_000,
+            "assistantAttention": [
+                "hasUnseenLatestAssistantMessage": true,
+                "latestAssistantMessageAt": 5_000,
+                "lastSeenAssistantMessageAt": 4_000,
+            ],
+        ]])
+        daemonClient.onSessionListResponse?(initialResponse)
+
+        guard let storedThread = store.threads.first(where: { $0.sessionId == "connected-session-refresh-seen" }) else {
+            XCTFail("Expected connected thread")
+            return
+        }
+
+        store.markConversationSeenIfNeeded(threadId: storedThread.id)
+
+        let staleResponse = makeSessionListResponse(sessions: [[
+            "id": "connected-session-refresh-seen",
+            "title": "Unread thread",
+            "createdAt": 1_000,
+            "updatedAt": 2_100,
+            "assistantAttention": [
+                "hasUnseenLatestAssistantMessage": true,
+                "latestAssistantMessageAt": 5_000,
+                "lastSeenAssistantMessageAt": 4_000,
+            ],
+        ]])
+        daemonClient.onSessionListResponse?(staleResponse)
+
+        XCTAssertFalse(
+            store.threads.first(where: { $0.sessionId == "connected-session-refresh-seen" })?.hasUnseenLatestAssistantMessage ?? true
+        )
+    }
+
+    func testSessionListRefreshPreservesLocalUnreadUntilDaemonCatchesUp() {
+        let daemonClient = DaemonClient()
+        let store = IOSThreadStore(daemonClient: daemonClient)
+
+        let initialResponse = makeSessionListResponse(sessions: [[
+            "id": "connected-session-refresh-unread",
+            "title": "Seen thread",
+            "createdAt": 1_000,
+            "updatedAt": 2_000,
+            "assistantAttention": [
+                "hasUnseenLatestAssistantMessage": false,
+                "latestAssistantMessageAt": 5_000,
+                "lastSeenAssistantMessageAt": 5_000,
+            ],
+        ]])
+        daemonClient.onSessionListResponse?(initialResponse)
+
+        guard let storedThread = store.threads.first(where: { $0.sessionId == "connected-session-refresh-unread" }) else {
+            XCTFail("Expected connected thread")
+            return
+        }
+
+        store.markThreadUnread(storedThread)
+
+        let staleResponse = makeSessionListResponse(sessions: [[
+            "id": "connected-session-refresh-unread",
+            "title": "Seen thread",
+            "createdAt": 1_000,
+            "updatedAt": 2_100,
+            "assistantAttention": [
+                "hasUnseenLatestAssistantMessage": false,
+                "latestAssistantMessageAt": 5_000,
+                "lastSeenAssistantMessageAt": 5_000,
+            ],
+        ]])
+        daemonClient.onSessionListResponse?(staleResponse)
+
+        XCTAssertTrue(
+            store.threads.first(where: { $0.sessionId == "connected-session-refresh-unread" })?.hasUnseenLatestAssistantMessage ?? false
+        )
+    }
+
     func testPinningConnectedThreadUpdatesLocalStateAndEmitsReorder() {
         let daemonClient = DaemonClient()
         var reorderRequests: [IPCReorderThreadsRequest] = []

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -120,6 +120,14 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     private var pendingSeenSessionIds: [String] = []
     /// Task that auto-commits deferred seen signals after the undo window.
     private var pendingSeenSignalTask: Task<Void, Never>?
+    /// Local seen/unread toggles should survive a stale daemon session-list
+    /// replay until the daemon either acknowledges them or reports a newer reply.
+    private var pendingAttentionOverrides: [String: PendingAttentionOverride] = [:]
+
+    private enum PendingAttentionOverride {
+        case seen(latestAssistantMessageAt: Date?)
+        case unread(latestAssistantMessageAt: Date?)
+    }
 
     /// Threads that are not archived — used by the UI to populate the sidebar.
     /// Sorted: pinned first (by pinnedOrder ascending), then threads with explicit
@@ -602,13 +610,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 threads[existingIdx].isPinned = isPinned
                 threads[existingIdx].pinnedOrder = isPinned ? (session.displayOrder.map { Int($0) } ?? nextPinnedOrder) : nil
                 threads[existingIdx].displayOrder = session.displayOrder.map { Int($0) }
-                threads[existingIdx].hasUnseenLatestAssistantMessage = session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
-                threads[existingIdx].latestAssistantMessageAt = session.assistantAttention?.latestAssistantMessageAt.map {
-                    Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
-                }
-                threads[existingIdx].lastSeenAssistantMessageAt = session.assistantAttention?.lastSeenAssistantMessageAt.map {
-                    Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
-                }
+                mergeAssistantAttention(from: session, intoThreadAt: existingIdx)
                 if isPinned && session.displayOrder == nil { nextPinnedOrder += 1 }
                 continue
             }
@@ -1117,6 +1119,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         guard let idx = threads.firstIndex(where: { $0.id == threadId }) else { return }
         threads[idx].hasUnseenLatestAssistantMessage = false
         if let sessionId = threads[idx].sessionId {
+            pendingAttentionOverrides[sessionId] = .seen(
+                latestAssistantMessageAt: threads[idx].latestAssistantMessageAt
+            )
+            threads[idx].lastSeenAssistantMessageAt = threads[idx].latestAssistantMessageAt
             emitConversationSeenSignal(conversationId: sessionId)
         }
     }
@@ -1127,7 +1133,11 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
               !threads[idx].hasUnseenLatestAssistantMessage,
               threads[idx].latestAssistantMessageAt != nil else { return }
 
+        pendingAttentionOverrides[sessionId] = .unread(
+            latestAssistantMessageAt: threads[idx].latestAssistantMessageAt
+        )
         threads[idx].hasUnseenLatestAssistantMessage = true
+        threads[idx].lastSeenAssistantMessageAt = nil
         emitConversationUnreadSignal(conversationId: sessionId)
     }
 
@@ -1287,6 +1297,66 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                 sessionId: sessionId,
                 title: pendingTitle
             ))
+        }
+    }
+
+    func mergeAssistantAttention(
+        from session: IPCSessionListResponseSession,
+        intoThreadAt index: Int
+    ) {
+        threads[index].hasUnseenLatestAssistantMessage =
+            session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
+        threads[index].latestAssistantMessageAt =
+            session.assistantAttention?.latestAssistantMessageAt.map {
+                Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+            }
+        threads[index].lastSeenAssistantMessageAt =
+            session.assistantAttention?.lastSeenAssistantMessageAt.map {
+                Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+            }
+
+        guard let sessionId = threads[index].sessionId,
+              let override = pendingAttentionOverrides[sessionId] else { return }
+
+        switch override {
+        case .seen(let targetLatestAssistantMessageAt):
+            if !threads[index].hasUnseenLatestAssistantMessage {
+                pendingAttentionOverrides.removeValue(forKey: sessionId)
+                return
+            }
+            if let targetLatestAssistantMessageAt,
+               let serverLatestAssistantMessageAt = threads[index].latestAssistantMessageAt,
+               serverLatestAssistantMessageAt > targetLatestAssistantMessageAt {
+                pendingAttentionOverrides.removeValue(forKey: sessionId)
+                return
+            }
+
+            if let targetLatestAssistantMessageAt,
+               threads[index].latestAssistantMessageAt == nil {
+                threads[index].latestAssistantMessageAt = targetLatestAssistantMessageAt
+            }
+            threads[index].hasUnseenLatestAssistantMessage = false
+            threads[index].lastSeenAssistantMessageAt =
+                threads[index].latestAssistantMessageAt
+
+        case .unread(let targetLatestAssistantMessageAt):
+            if threads[index].hasUnseenLatestAssistantMessage {
+                pendingAttentionOverrides.removeValue(forKey: sessionId)
+                return
+            }
+            if let targetLatestAssistantMessageAt,
+               let serverLatestAssistantMessageAt = threads[index].latestAssistantMessageAt,
+               serverLatestAssistantMessageAt > targetLatestAssistantMessageAt {
+                pendingAttentionOverrides.removeValue(forKey: sessionId)
+                return
+            }
+
+            if let targetLatestAssistantMessageAt,
+               threads[index].latestAssistantMessageAt == nil {
+                threads[index].latestAssistantMessageAt = targetLatestAssistantMessageAt
+            }
+            threads[index].hasUnseenLatestAssistantMessage = true
+            threads[index].lastSeenAssistantMessageAt = nil
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadSessionRestorer.swift
@@ -28,6 +28,13 @@ protocol ThreadRestorerDelegate: AnyObject {
     func appendThreads(from response: SessionListResponseMessage)
     /// Returns an existing ChatViewModel matching the given session ID, if any.
     func existingChatViewModel(forSessionId sessionId: String) -> ChatViewModel?
+    /// Merge daemon attention metadata into an existing thread, allowing the
+    /// owner to preserve optimistic local seen/unread state until the daemon
+    /// catches up or returns a newer reply.
+    func mergeAssistantAttention(
+        from session: IPCSessionListResponseSession,
+        intoThreadAt index: Int
+    )
 }
 
 /// Handles daemon session restoration: fetching the session list on connect,
@@ -198,13 +205,7 @@ final class ThreadSessionRestorer {
                 delegate.threads[existingIdx].isPinned = isPinned
                 delegate.threads[existingIdx].pinnedOrder = isPinned ? (session.displayOrder.map { Int($0) } ?? pinnedCount) : nil
                 delegate.threads[existingIdx].displayOrder = session.displayOrder.map { Int($0) }
-                delegate.threads[existingIdx].hasUnseenLatestAssistantMessage = session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
-                delegate.threads[existingIdx].latestAssistantMessageAt = session.assistantAttention?.latestAssistantMessageAt.map {
-                    Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
-                }
-                delegate.threads[existingIdx].lastSeenAssistantMessageAt = session.assistantAttention?.lastSeenAssistantMessageAt.map {
-                    Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
-                }
+                delegate.mergeAssistantAttention(from: session, intoThreadAt: existingIdx)
                 if isPinned && session.displayOrder == nil { pinnedCount += 1 }
                 continue
             }

--- a/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
@@ -343,6 +343,80 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         XCTAssertFalse(threadManager.threads[index].hasUnseenLatestAssistantMessage)
     }
 
+    func testAttentionMergePreservesLocalSeenUntilDaemonAcknowledgesIt() {
+        guard let threadId = threadManager.activeThreadId,
+              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active thread")
+            return
+        }
+
+        threadManager.threads[index].sessionId = "session-refresh-seen"
+        threadManager.threads[index].hasUnseenLatestAssistantMessage = true
+        threadManager.threads[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 9)
+        threadManager.threads[index].lastSeenAssistantMessageAt = Date(timeIntervalSince1970: 8)
+
+        threadManager.markConversationSeen(threadId: threadId)
+
+        let staleResponse = makeSessionListResponse(
+            sessions: [[
+                "id": "session-refresh-seen",
+                "title": "Restored thread",
+                "createdAt": 5_000,
+                "updatedAt": 6_000,
+                "assistantAttention": [
+                    "hasUnseenLatestAssistantMessage": true,
+                    "latestAssistantMessageAt": 9_000,
+                    "lastSeenAssistantMessageAt": 8_000,
+                ],
+            ]]
+        )
+        guard let session = staleResponse.sessions.first else {
+            XCTFail("Expected response session")
+            return
+        }
+
+        threadManager.mergeAssistantAttention(from: session, intoThreadAt: index)
+
+        XCTAssertFalse(
+            threadManager.threads.first(where: { $0.sessionId == "session-refresh-seen" })?.hasUnseenLatestAssistantMessage ?? true
+        )
+    }
+
+    func testAppendThreadsPreservesLocalUnreadUntilDaemonAcknowledgesIt() {
+        guard let threadId = threadManager.activeThreadId,
+              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active thread")
+            return
+        }
+
+        threadManager.threads[index].sessionId = "session-refresh-unread"
+        threadManager.threads[index].hasUnseenLatestAssistantMessage = false
+        threadManager.threads[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 9)
+        threadManager.threads[index].lastSeenAssistantMessageAt = Date(timeIntervalSince1970: 9)
+
+        threadManager.markConversationUnread(threadId: threadId)
+
+        let staleResponse = makeSessionListResponse(
+            sessions: [[
+                "id": "session-refresh-unread",
+                "title": "Paginated thread",
+                "createdAt": 5_000,
+                "updatedAt": 6_000,
+                "assistantAttention": [
+                    "hasUnseenLatestAssistantMessage": false,
+                    "latestAssistantMessageAt": 9_000,
+                    "lastSeenAssistantMessageAt": 9_000,
+                ],
+            ]]
+        )
+
+        threadManager.appendThreads(from: staleResponse)
+
+        XCTAssertTrue(
+            threadManager.threads.first(where: { $0.sessionId == "session-refresh-unread" })?.hasUnseenLatestAssistantMessage ?? false
+        )
+    }
+
     func testActiveThreadDoesNotEmitSeenSignalOnEveryStreamingDelta() {
         guard let threadId = threadManager.activeThreadId,
               let index = threadManager.threads.firstIndex(where: { $0.id == threadId }),

--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -73,6 +73,22 @@ final class MockThreadRestorerDelegate: ThreadRestorerDelegate {
     func appendThreads(from response: SessionListResponseMessage) {
         // no-op for tests
     }
+
+    func mergeAssistantAttention(
+        from session: IPCSessionListResponseSession,
+        intoThreadAt index: Int
+    ) {
+        threads[index].hasUnseenLatestAssistantMessage =
+            session.assistantAttention?.hasUnseenLatestAssistantMessage ?? false
+        threads[index].latestAssistantMessageAt =
+            session.assistantAttention?.latestAssistantMessageAt.map {
+                Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+            }
+        threads[index].lastSeenAssistantMessageAt =
+            session.assistantAttention?.lastSeenAssistantMessageAt.map {
+                Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+            }
+    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
## Summary
- preserve local seen/unread mutations on iOS and macOS until the daemon either acknowledges them or reports a newer assistant reply
- update native clients to keep local attention timestamps in sync with optimistic seen/unread actions instead of letting stale session-list payloads roll them back
- add focused client regressions for stale refreshes clobbering local attention state

## Original prompt
Can you address these items in separate PRs?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
