### PR TITLE
fix: [assistant] persist Anthropic cache usage separately in the ledger

### DIFF
--- a/assistant/src/__tests__/session-usage.test.ts
+++ b/assistant/src/__tests__/session-usage.test.ts
@@ -1,0 +1,180 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "session-usage-test-"));
+
+const updateConversationUsageCalls: Array<{
+  conversationId: string;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCost: number;
+}> = [];
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getSocketPath: () => join(testDir, "test.sock"),
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    pricingOverrides: [],
+  }),
+}));
+
+mock.module("../memory/conversation-store.js", () => ({
+  updateConversationUsage: (
+    conversationId: string,
+    inputTokens: number,
+    outputTokens: number,
+    estimatedCost: number,
+  ) => {
+    updateConversationUsageCalls.push({
+      conversationId,
+      inputTokens,
+      outputTokens,
+      estimatedCost,
+    });
+  },
+}));
+
+import { recordUsage } from "../daemon/session-usage.js";
+import { getDb, initializeDb, resetDb } from "../memory/db.js";
+import { listUsageEvents } from "../memory/llm-usage-store.js";
+import type { PricingUsage } from "../usage/types.js";
+import { resolvePricingForUsageWithOverrides } from "../util/pricing.js";
+
+initializeDb();
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("recordUsage", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM llm_usage_events`);
+    updateConversationUsageCalls.length = 0;
+  });
+
+  test("stores direct input separately from Anthropic cache usage while keeping live totals combined", () => {
+    const usageStats = {
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCost: 0,
+    };
+    const onEventMessages: unknown[] = [];
+
+    const rawResponses = [
+      {
+        usage: {
+          cache_creation: {
+            ephemeral_5m_input_tokens: 173_619,
+          },
+        },
+      },
+      {
+        usage: {
+          cache_creation: {
+            ephemeral_1h_input_tokens: 200_000,
+          },
+        },
+      },
+    ];
+
+    recordUsage(
+      {
+        conversationId: "conv-usage-1",
+        providerName: "anthropic",
+        usageStats,
+      },
+      3_420_218,
+      11_768,
+      "claude-opus-4-6",
+      (msg) => onEventMessages.push(msg),
+      "main_agent",
+      "req-usage-1",
+      373_619,
+      3_046_461,
+      rawResponses,
+    );
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+
+    const expectedUsage: PricingUsage = {
+      directInputTokens: 138,
+      outputTokens: 11_768,
+      cacheCreationInputTokens: 373_619,
+      cacheReadInputTokens: 3_046_461,
+      anthropicCacheCreation: {
+        ephemeral_5m_input_tokens: 173_619,
+        ephemeral_1h_input_tokens: 200_000,
+      },
+    };
+    const expectedPricing = resolvePricingForUsageWithOverrides(
+      "anthropic",
+      "claude-opus-4-6",
+      expectedUsage,
+      [],
+    );
+
+    expect(events[0].conversationId).toBe("conv-usage-1");
+    expect(events[0].requestId).toBe("req-usage-1");
+    expect(events[0].inputTokens).toBe(138);
+    expect(events[0].outputTokens).toBe(11_768);
+    expect(events[0].cacheCreationInputTokens).toBe(373_619);
+    expect(events[0].cacheReadInputTokens).toBe(3_046_461);
+    expect(events[0].pricingStatus).toBe("priced");
+    expect(events[0].estimatedCostUsd).toBe(
+      expectedPricing.estimatedCostUsd ?? null,
+    );
+
+    expect(usageStats.inputTokens).toBe(3_420_218);
+    expect(usageStats.outputTokens).toBe(11_768);
+    expect(usageStats.estimatedCost).toBe(
+      expectedPricing.estimatedCostUsd ?? 0,
+    );
+
+    expect(updateConversationUsageCalls).toEqual([
+      {
+        conversationId: "conv-usage-1",
+        inputTokens: 3_420_218,
+        outputTokens: 11_768,
+        estimatedCost: expectedPricing.estimatedCostUsd ?? 0,
+      },
+    ]);
+
+    expect(onEventMessages).toEqual([
+      {
+        type: "usage_update",
+        inputTokens: 3_420_218,
+        outputTokens: 11_768,
+        totalInputTokens: 3_420_218,
+        totalOutputTokens: 11_768,
+        estimatedCost: expectedPricing.estimatedCostUsd ?? 0,
+        model: "claude-opus-4-6",
+      },
+    ]);
+  });
+});

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -45,7 +45,10 @@ export interface EventHandlerState {
   pendingDirectiveDisplayBuffer: string;
   firstAssistantText: string;
   exchangeInputTokens: number;
+  exchangeCacheCreationInputTokens: number;
+  exchangeCacheReadInputTokens: number;
   exchangeOutputTokens: number;
+  readonly exchangeRawResponses: unknown[];
   model: string;
   orderingErrorDetected: boolean;
   deferredOrderingError: string | null;
@@ -106,7 +109,10 @@ export function createEventHandlerState(): EventHandlerState {
     pendingDirectiveDisplayBuffer: "",
     firstAssistantText: "",
     exchangeInputTokens: 0,
+    exchangeCacheCreationInputTokens: 0,
+    exchangeCacheReadInputTokens: 0,
     exchangeOutputTokens: 0,
+    exchangeRawResponses: [],
     model: "",
     orderingErrorDetected: false,
     deferredOrderingError: null,
@@ -691,8 +697,13 @@ export function handleUsage(
   event: Extract<AgentEvent, { type: "usage" }>,
 ): void {
   state.exchangeInputTokens += event.inputTokens;
+  state.exchangeCacheCreationInputTokens += event.cacheCreationInputTokens ?? 0;
+  state.exchangeCacheReadInputTokens += event.cacheReadInputTokens ?? 0;
   state.exchangeOutputTokens += event.outputTokens;
   state.model = event.model;
+  if (event.rawResponse !== undefined) {
+    state.exchangeRawResponses.push(event.rawResponse);
+  }
 
   if (event.rawRequest && event.rawResponse) {
     try {

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -1244,6 +1244,11 @@ export async function runAgentLoopImpl(
       onEvent,
       "main_agent",
       reqId,
+      state.exchangeCacheCreationInputTokens,
+      state.exchangeCacheReadInputTokens,
+      state.exchangeRawResponses.length <= 1
+        ? state.exchangeRawResponses[0]
+        : state.exchangeRawResponses,
     );
 
     void getHookManager().trigger("post-message", {
@@ -1449,6 +1454,9 @@ function emitUsage(
   onEvent: (msg: ServerMessage) => void,
   actor: UsageActor,
   requestId: string | null = null,
+  cacheCreationInputTokens = 0,
+  cacheReadInputTokens = 0,
+  rawResponse?: unknown,
 ): void {
   recordUsage(
     {
@@ -1462,5 +1470,8 @@ function emitUsage(
     onEvent,
     actor,
     requestId,
+    cacheCreationInputTokens,
+    cacheReadInputTokens,
+    rawResponse,
   );
 }

--- a/assistant/src/daemon/session-usage.ts
+++ b/assistant/src/daemon/session-usage.ts
@@ -2,8 +2,13 @@ import { getConfig } from "../config/loader.js";
 import * as conversationStore from "../memory/conversation-store.js";
 import { recordUsageEvent } from "../memory/llm-usage-store.js";
 import type { UsageActor } from "../usage/actors.js";
+import type {
+  AnthropicCacheCreationTokenDetails,
+  PricingResult,
+  PricingUsage,
+} from "../usage/types.js";
 import { getLogger } from "../util/logger.js";
-import { estimateCost, resolvePricingWithOverrides } from "../util/pricing.js";
+import { resolvePricingForUsageWithOverrides } from "../util/pricing.js";
 import type { ServerMessage, UsageStats } from "./ipc-protocol.js";
 
 const log = getLogger("session-usage");
@@ -14,6 +19,81 @@ export interface UsageContext {
   usageStats: UsageStats;
 }
 
+function normalizeTokenCount(value: number | null | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return Math.max(value, 0);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value == null) return null;
+  return value as Record<string, unknown>;
+}
+
+function extractAnthropicCacheCreationFromResponse(
+  response: unknown,
+): AnthropicCacheCreationTokenDetails | null {
+  const rawResponse = asRecord(response);
+  const usage = asRecord(rawResponse?.usage);
+  const cacheCreation = asRecord(usage?.cache_creation);
+  if (!cacheCreation) return null;
+
+  return {
+    ephemeral_5m_input_tokens: normalizeTokenCount(
+      cacheCreation.ephemeral_5m_input_tokens as number | null | undefined,
+    ),
+    ephemeral_1h_input_tokens: normalizeTokenCount(
+      cacheCreation.ephemeral_1h_input_tokens as number | null | undefined,
+    ),
+  };
+}
+
+function extractAnthropicCacheCreation(
+  rawResponse: unknown,
+): AnthropicCacheCreationTokenDetails | null {
+  const responses = Array.isArray(rawResponse) ? rawResponse : [rawResponse];
+  let foundDetails = false;
+  let ephemeral5mInputTokens = 0;
+  let ephemeral1hInputTokens = 0;
+
+  for (const response of responses) {
+    const details = extractAnthropicCacheCreationFromResponse(response);
+    if (!details) continue;
+    foundDetails = true;
+    ephemeral5mInputTokens += normalizeTokenCount(
+      details.ephemeral_5m_input_tokens,
+    );
+    ephemeral1hInputTokens += normalizeTokenCount(
+      details.ephemeral_1h_input_tokens,
+    );
+  }
+
+  if (!foundDetails) return null;
+
+  return {
+    ephemeral_5m_input_tokens: ephemeral5mInputTokens,
+    ephemeral_1h_input_tokens: ephemeral1hInputTokens,
+  };
+}
+
+function resolveStructuredPricing(
+  providerName: string,
+  model: string,
+  usage: PricingUsage,
+): PricingResult {
+  try {
+    const config = getConfig();
+    return resolvePricingForUsageWithOverrides(
+      providerName,
+      model,
+      usage,
+      config.pricingOverrides,
+    );
+  } catch (err) {
+    log.warn({ err, model, providerName }, "Failed to resolve usage pricing");
+    return { estimatedCostUsd: null, pricingStatus: "unpriced" };
+  }
+}
+
 export function recordUsage(
   ctx: UsageContext,
   inputTokens: number,
@@ -22,15 +102,44 @@ export function recordUsage(
   onEvent: (msg: ServerMessage) => void,
   actor: UsageActor,
   requestId: string | null = null,
+  cacheCreationInputTokens = 0,
+  cacheReadInputTokens = 0,
+  rawResponse?: unknown,
 ): void {
   if (inputTokens <= 0 && outputTokens <= 0) return;
 
-  const estimatedCost = estimateCost(
-    inputTokens,
-    outputTokens,
-    model,
-    ctx.providerName,
+  const normalizedCacheCreationInputTokens = normalizeTokenCount(
+    cacheCreationInputTokens,
   );
+  const normalizedCacheReadInputTokens =
+    normalizeTokenCount(cacheReadInputTokens);
+  const directInputTokens = Math.max(
+    normalizeTokenCount(inputTokens) -
+      normalizedCacheCreationInputTokens -
+      normalizedCacheReadInputTokens,
+    0,
+  );
+
+  const pricingUsage: PricingUsage = {
+    directInputTokens,
+    outputTokens,
+    cacheCreationInputTokens: normalizedCacheCreationInputTokens,
+    cacheReadInputTokens: normalizedCacheReadInputTokens,
+    anthropicCacheCreation:
+      ctx.providerName === "anthropic"
+        ? extractAnthropicCacheCreation(rawResponse)
+        : null,
+  };
+  const pricing = resolveStructuredPricing(
+    ctx.providerName,
+    model,
+    pricingUsage,
+  );
+  const estimatedCost =
+    pricing.pricingStatus === "priced" && pricing.estimatedCostUsd != null
+      ? pricing.estimatedCostUsd
+      : 0;
+
   ctx.usageStats.inputTokens += inputTokens;
   ctx.usageStats.outputTokens += outputTokens;
   ctx.usageStats.estimatedCost += estimatedCost;
@@ -53,23 +162,15 @@ export function recordUsage(
 
   // Dual-write: persist per-turn usage event to the new ledger table
   try {
-    const config = getConfig();
-    const pricing = resolvePricingWithOverrides(
-      ctx.providerName,
-      model,
-      inputTokens,
-      outputTokens,
-      config.pricingOverrides,
-    );
     recordUsageEvent(
       {
         actor,
         provider: ctx.providerName,
         model,
-        inputTokens,
+        inputTokens: directInputTokens,
         outputTokens,
-        cacheCreationInputTokens: null,
-        cacheReadInputTokens: null,
+        cacheCreationInputTokens: normalizedCacheCreationInputTokens,
+        cacheReadInputTokens: normalizedCacheReadInputTokens,
         conversationId: ctx.conversationId,
         runId: null,
         requestId,


### PR DESCRIPTION
## Summary
- thread Anthropic cache creation and cache read totals through the session agent loop without changing the live combined token counters
- compute live/session cost from structured direct-input plus cache usage and persist direct input separately in llm_usage_events
- add a session-usage test covering multi-response Anthropic cache pricing and ledger writes

Part of plan: anthropic-usage-cost-fix.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
