### PR TITLE
fix: re-mark visible iOS threads seen after reconnect refreshes

### DIFF
--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -211,6 +211,12 @@ struct ThreadListView: View {
                 store.markConversationSeenIfNeeded(threadId: threadId)
                 store.viewModel(for: threadId).consumeDeepLinkIfNeeded()
             }
+            .onChange(of: thread.hasUnseenLatestAssistantMessage) { _, hasUnseen in
+                guard hasUnseen else { return }
+                // The detail view can stay mounted across reconnects, so re-run
+                // the explicit seen path when the visible thread flips unread.
+                store.markConversationSeenIfNeeded(threadId: threadId)
+            }
             .onOpenURL { _ in
                 DispatchQueue.main.async {
                     store.viewModel(for: threadId).consumeDeepLinkIfNeeded()


### PR DESCRIPTION
## Summary
- re-run the existing iOS seen helper when the currently visible thread flips back to unread while its detail view is still mounted
- close the reconnect case where a foreground session refresh can make an already-open conversation look unread until the user reselects it

## Original prompt
Can you address these items in separate PRs?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
