### PR TITLE
fix: update stale guardian endpoint reference in call-start error message

### DIFF
--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -29,7 +29,7 @@ export async function executeCallStart(
       return {
         content: [
           "Error: A guardian voice verification call is already active for this number.",
-          "Use the guardian outbound verification flow via the gateway API (`/v1/integrations/guardian/outbound/start` or `/resend`) and wait for completion before using `call_start`.",
+          "Use the guardian outbound verification flow via the gateway API (`/v1/integrations/guardian/sessions` or `/sessions/resend`) and wait for completion before using `call_start`.",
         ].join(" "),
         isError: true,
       };


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for guardian-api-consolidation.md.

**Gap:** Stale old endpoint reference in call-start.ts
**What was expected:** References to new unified session endpoints
**What was found:** Error message still references /outbound/start and /resend

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
