### PR TITLE
fix: add missing requestBody to DELETE /sessions OpenAPI schema

### DIFF
--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1402,6 +1402,14 @@ export function buildSchema(): Record<string, unknown> {
           description: "Cancel the active guardian verification session.",
           operationId: "guardianSessionCancel",
           security: [{ BearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", additionalProperties: true },
+              },
+            },
+          },
           responses: {
             "200": { description: "Session cancelled" },
             "400": { description: "Invalid request payload" },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for guardian-api-consolidation.md.

**Gap:** Missing requestBody in OpenAPI schema for DELETE /sessions
**What was expected:** DELETE operation should declare requestBody since handler reads channel from body
**What was found:** No requestBody defined, unlike the POST operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
