### PR TITLE
test: add missing /revoke path assertion to gateway schema test

### DIFF
--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -76,6 +76,7 @@ describe("/schema route", () => {
     expect(
       body.paths["/v1/integrations/guardian/sessions/resend"],
     ).toBeDefined();
+    expect(body.paths["/v1/integrations/guardian/revoke"]).toBeDefined();
     expect(body.paths["/deliver/telegram"]).toBeDefined();
     expect(body.paths["/{path}"]).toBeDefined();
   });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for guardian-api-consolidation.md.

**Gap:** Gateway schema test missing assertion for /revoke
**What was expected:** All 4 guardian endpoints verified
**What was found:** Only 3 of 4 guardian paths asserted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13764" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
