### PR TITLE
fix: align twilio CLI integration commands

### DIFF
--- a/assistant/src/__tests__/avatar-e2e.test.ts
+++ b/assistant/src/__tests__/avatar-e2e.test.ts
@@ -54,19 +54,35 @@ mock.module("../util/platform.js", () => ({
   getWorkspaceDir: () => mockWorkspaceDir,
 }));
 
-mock.module("../util/logger.js", () => ({
-  getLogger: () => ({
-    debug: () => {},
-    info: (...args: unknown[]) => {
-      logInfoCalls.push(args as [unknown, string]);
-    },
-    warn: (...args: unknown[]) => {
-      logWarnCalls.push(args as [unknown, string]);
-    },
-    error: (...args: unknown[]) => {
-      logErrorCalls.push(args as [unknown, string]);
-    },
-  }),
+mock.module("pino", () => {
+  function createLogger() {
+    return {
+      child: () => createLogger(),
+      debug: () => {},
+      info: (...args: unknown[]) => {
+        logInfoCalls.push(args as [unknown, string]);
+      },
+      warn: (...args: unknown[]) => {
+        logWarnCalls.push(args as [unknown, string]);
+      },
+      error: (...args: unknown[]) => {
+        logErrorCalls.push(args as [unknown, string]);
+      },
+    };
+  }
+
+  const pino = Object.assign(() => createLogger(), {
+    destination: () => ({ write: () => true }),
+    multistream: () => ({ write: () => true }),
+  });
+
+  return {
+    default: pino,
+  };
+});
+
+mock.module("pino-pretty", () => ({
+  default: () => ({ write: () => true }),
 }));
 
 mock.module("node:fs", () => ({
@@ -439,5 +455,18 @@ describe("avatar E2E integration", () => {
     // The managed path succeeded and wrote the avatar file
     expect(result.isError).toBe(false);
     expect(writeFileSyncFn).toHaveBeenCalled();
+
+    const correlationLogged = logInfoCalls.some(([meta, message]) => {
+      if (message !== "Avatar saved successfully") return false;
+      if (!meta || typeof meta !== "object" || !("correlationId" in meta)) {
+        return false;
+      }
+      return (
+        (meta as { correlationId?: unknown }).correlationId ===
+        "unique-corr-id-xyz"
+      );
+    });
+
+    expect(correlationLogged).toBe(true);
   });
 });

--- a/assistant/src/__tests__/integrations-cli.test.ts
+++ b/assistant/src/__tests__/integrations-cli.test.ts
@@ -8,6 +8,18 @@ let initCalls = 0;
 let loadCalls = 0;
 let mintCalls = 0;
 let rawConfig: Record<string, unknown> = {};
+let twilioHasCredentials = false;
+let twilioAccountSid = "AC1234567890";
+let twilioAuthToken = "twilio-auth-token";
+let twilioNumbers = [
+  {
+    phoneNumber: "+15550001111",
+    friendlyName: "Primary number",
+    capabilities: { voice: true, sms: true },
+  },
+];
+let twilioListError: Error | undefined;
+let twilioListCalls: Array<{ accountSid: string; authToken: string }> = [];
 
 mock.module("../config/env.js", () => ({
   getGatewayInternalBaseUrl: () => gatewayBase,
@@ -34,6 +46,24 @@ mock.module("../runtime/auth/token-service.js", () => ({
   mintEdgeRelayToken: () => {
     mintCalls += 1;
     return "minted-edge-token";
+  },
+}));
+
+mock.module("../calls/twilio-rest.js", () => ({
+  hasTwilioCredentials: () => twilioHasCredentials,
+  getTwilioCredentials: () => {
+    if (!twilioHasCredentials) {
+      throw new Error("Twilio credentials not configured");
+    }
+    return {
+      accountSid: twilioAccountSid,
+      authToken: twilioAuthToken,
+    };
+  },
+  listIncomingPhoneNumbers: async (accountSid: string, authToken: string) => {
+    twilioListCalls.push({ accountSid, authToken });
+    if (twilioListError) throw twilioListError;
+    return twilioNumbers;
   },
 }));
 
@@ -94,6 +124,38 @@ async function runCli(
   };
 }
 
+async function runHelp(args: string[]): Promise<string> {
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  const stdoutChunks: string[] = [];
+
+  process.stdout.write = ((chunk: unknown) => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    registerIntegrationsCommand(program);
+
+    try {
+      await program.parseAsync(["node", "vellum", ...args]);
+    } catch (error) {
+      const code =
+        error && typeof error === "object" && "code" in error
+          ? String((error as { code?: unknown }).code)
+          : "";
+      if (code !== "commander.helpDisplayed") {
+        throw error;
+      }
+    }
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+
+  return stdoutChunks.join("");
+}
+
 describe("assistant integrations CLI", () => {
   beforeEach(() => {
     gatewayBase = "http://gateway.test";
@@ -102,6 +164,18 @@ describe("assistant integrations CLI", () => {
     loadCalls = 0;
     mintCalls = 0;
     rawConfig = {};
+    twilioHasCredentials = false;
+    twilioAccountSid = "AC1234567890";
+    twilioAuthToken = "twilio-auth-token";
+    twilioNumbers = [
+      {
+        phoneNumber: "+15550001111",
+        friendlyName: "Primary number",
+        capabilities: { voice: true, sms: true },
+      },
+    ];
+    twilioListError = undefined;
+    twilioListCalls = [];
     delete process.env.GATEWAY_AUTH_TOKEN;
     process.exitCode = 0;
   });
@@ -113,14 +187,14 @@ describe("assistant integrations CLI", () => {
 
   test("uses GATEWAY_AUTH_TOKEN from env when present", async () => {
     process.env.GATEWAY_AUTH_TOKEN = "env-token";
-    const result = await runCli(["--json", "twilio", "config"], {
+    const result = await runCli(["--json", "telegram", "config"], {
       success: true,
     });
 
     expect(result.exitCode).toBe(0);
     expect(result.fetchCalls.length).toBe(1);
     expect(result.fetchCalls[0]?.url).toBe(
-      "http://gateway.test/v1/integrations/twilio/config",
+      "http://gateway.test/v1/integrations/telegram/config",
     );
     expect(result.fetchCalls[0]?.authHeader).toBe("Bearer env-token");
     expect(loadCalls).toBe(0);
@@ -142,12 +216,12 @@ describe("assistant integrations CLI", () => {
 
   test("uses configured gateway base for requests", async () => {
     gatewayBase = "http://gateway.internal:9900";
-    const result = await runCli(["--json", "twilio", "config"], {
+    const result = await runCli(["--json", "telegram", "config"], {
       success: true,
     });
     expect(result.exitCode).toBe(0);
     expect(result.fetchCalls[0]?.url).toBe(
-      "http://gateway.internal:9900/v1/integrations/twilio/config",
+      "http://gateway.internal:9900/v1/integrations/telegram/config",
     );
   });
 
@@ -217,16 +291,117 @@ describe("assistant integrations CLI", () => {
     });
   });
 
-  test("returns structured error output when gateway request fails", async () => {
-    const result = await runCli(
-      ["--json", "twilio", "numbers"],
-      { error: "Unauthorized" },
-      401,
-    );
+  test("lists twilio in integrations help output", async () => {
+    const help = await runHelp(["integrations", "--help"]);
+
+    expect(help).toContain("twilio");
+    expect(help).toContain("assistant integrations twilio config");
+    expect(help).toContain("assistant integrations twilio numbers --json");
+  });
+
+  test("includes extended help text for twilio namespace and subcommands", async () => {
+    const twilioHelp = await runHelp(["integrations", "twilio", "--help"]);
+    const configHelp = await runHelp([
+      "integrations",
+      "twilio",
+      "config",
+      "--help",
+    ]);
+    const numbersHelp = await runHelp([
+      "integrations",
+      "twilio",
+      "numbers",
+      "--help",
+    ]);
+
+    expect(twilioHelp).toContain("runtime routes");
+    expect(twilioHelp).toContain("assistant integrations twilio numbers");
+    expect(configHelp).toContain("Arguments:");
+    expect(configHelp).toContain("does not call the gateway or Twilio");
+    expect(numbersHelp).toContain("Arguments:");
+    expect(numbersHelp).toContain("Calls the Twilio REST API directly");
+  });
+
+  test("reads twilio config without gateway fetch", async () => {
+    rawConfig = {
+      sms: {
+        phoneNumber: "+15550001111",
+      },
+    };
+    twilioHasCredentials = true;
+    twilioAccountSid = "AC9999999999";
+
+    const result = await runCli(["--json", "twilio", "config"], { ok: true });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.fetchCalls.length).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      success: true,
+      hasCredentials: true,
+      accountSid: "AC9999999999",
+      phoneNumber: "+15550001111",
+    });
+  });
+
+  test("reads twilio numbers through the shared service without gateway fetch", async () => {
+    twilioHasCredentials = true;
+    twilioAccountSid = "AC5555555555";
+    twilioAuthToken = "auth-555";
+    twilioNumbers = [
+      {
+        phoneNumber: "+15550002222",
+        friendlyName: "Support line",
+        capabilities: { voice: true, sms: true },
+      },
+    ];
+
+    const result = await runCli(["--json", "twilio", "numbers"], {
+      ok: true,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.fetchCalls.length).toBe(0);
+    expect(twilioListCalls).toEqual([
+      { accountSid: "AC5555555555", authToken: "auth-555" },
+    ]);
+    expect(JSON.parse(result.stdout)).toEqual({
+      success: true,
+      hasCredentials: true,
+      numbers: [
+        {
+          phoneNumber: "+15550002222",
+          friendlyName: "Support line",
+          capabilities: { voice: true, sms: true },
+        },
+      ],
+    });
+  });
+
+  test("returns a structured twilio status when credentials are missing", async () => {
+    const result = await runCli(["--json", "twilio", "numbers"], {
+      ok: true,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.fetchCalls.length).toBe(0);
+    expect(twilioListCalls).toEqual([]);
+    expect(JSON.parse(result.stdout)).toEqual({
+      success: false,
+      hasCredentials: false,
+      error: "Twilio credentials not configured. Set credentials first.",
+    });
+  });
+
+  test("returns structured error output when twilio numbers lookup fails", async () => {
+    twilioHasCredentials = true;
+    twilioListError = new Error("Twilio API error 401: Unauthorized");
+
+    const result = await runCli(["--json", "twilio", "numbers"], { ok: true });
+
     expect(result.exitCode).toBe(1);
     expect(JSON.parse(result.stdout)).toEqual({
       ok: false,
-      error: "Unauthorized [401]",
+      error: "Twilio API error 401: Unauthorized",
     });
   });
 });

--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -1,5 +1,10 @@
 import type { Command } from "commander";
 
+import {
+  getTwilioCredentials,
+  hasTwilioCredentials,
+  listIncomingPhoneNumbers,
+} from "../calls/twilio-rest.js";
 import { DEFAULT_ELEVENLABS_VOICE_ID } from "../config/elevenlabs-schema.js";
 import { getGatewayInternalBaseUrl } from "../config/env.js";
 import { loadRawConfig } from "../config/loader.js";
@@ -105,6 +110,48 @@ function readVoiceConfig(): {
   };
 }
 
+function readTwilioConfig(): {
+  success: true;
+  hasCredentials: boolean;
+  accountSid?: string;
+  phoneNumber?: string;
+} {
+  const hasCredentials = hasTwilioCredentials();
+  const accountSid = hasCredentials
+    ? getTwilioCredentials().accountSid
+    : undefined;
+  const raw = loadRawConfig();
+  const sms = asRecord(raw.sms);
+  const phoneNumber =
+    typeof sms.phoneNumber === "string" ? sms.phoneNumber.trim() : "";
+
+  return {
+    success: true,
+    hasCredentials,
+    accountSid: accountSid || undefined,
+    phoneNumber: phoneNumber || undefined,
+  };
+}
+
+async function readTwilioNumbers(): Promise<unknown> {
+  if (!hasTwilioCredentials()) {
+    return {
+      success: false,
+      hasCredentials: false,
+      error: "Twilio credentials not configured. Set credentials first.",
+    };
+  }
+
+  const { accountSid, authToken } = getTwilioCredentials();
+  const numbers = await listIncomingPhoneNumbers(accountSid, authToken);
+
+  return {
+    success: true,
+    hasCredentials: true,
+    numbers,
+  };
+}
+
 // CLI-specific gateway helper — uses GATEWAY_AUTH_TOKEN env var for out-of-process
 // access. See runtime/gateway-internal-client.ts for daemon-internal usage which
 // mints fresh tokens.
@@ -198,24 +245,26 @@ export async function runRead(
 export function registerIntegrationsCommand(program: Command): void {
   const integrations = program
     .command("integrations")
-    .description("Read integration and ingress status through the gateway API")
+    .description("Read integration configuration and readiness status")
     .option("--json", "Machine-readable compact JSON output");
 
   integrations.addHelpText(
     "after",
     `
-Reads integration configuration and status through the gateway API. The
-assistant must be running for most subcommands (telegram, guardian)
-since they query the gateway. Exceptions: "ingress config" and "voice config"
-read from the local config file and do not require the gateway.
+Reads integration configuration and readiness from shared assistant services.
+Some subcommands query the running assistant gateway (\`telegram\`, \`guardian\`);
+others read local config or call the underlying provider directly (\`twilio\`, \`ingress\`, \`voice\`).
 
 Integration categories:
+  twilio       Twilio SMS/voice credential and phone number status
   telegram     Telegram bot configuration and webhook status
   guardian     Guardian trust verification system for contacts
   ingress      Public ingress URL and local gateway target (config-only)
   voice        Voice/call readiness and ElevenLabs voice ID (config-only)
 
 Examples:
+  $ assistant integrations twilio config
+  $ assistant integrations twilio numbers --json
   $ assistant integrations telegram config
   $ assistant integrations guardian status --channel sms`,
   );
@@ -224,22 +273,59 @@ Examples:
     .command("twilio")
     .description("Twilio SMS/voice integration status");
 
+  twilio.addHelpText(
+    "after",
+    `
+Reads Twilio integration state from the same assistant-side services used by
+the runtime routes. These commands do not require the gateway to be running.
+\`config\` only reads local assistant state; \`numbers\` also calls the Twilio REST API.
+
+Examples:
+  $ assistant integrations twilio config
+  $ assistant integrations twilio numbers
+  $ assistant integrations twilio numbers --json`,
+  );
+
   twilio
     .command("config")
     .description("Get Twilio integration configuration status")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  (none)
+
+Returns whether Twilio credentials are configured and whether a phone number is
+assigned in the assistant SMS config. Reads local assistant state only; it
+does not call the gateway or Twilio.
+
+Examples:
+  $ assistant integrations twilio config
+  $ assistant integrations twilio config --json`,
+    )
     .action(async (_opts: unknown, cmd: Command) => {
-      await runRead(cmd, async () =>
-        gatewayGet("/v1/integrations/twilio/config"),
-      );
+      await runRead(cmd, async () => readTwilioConfig());
     });
 
   twilio
     .command("numbers")
     .description("Get Twilio phone numbers")
+    .addHelpText(
+      "after",
+      `
+Arguments:
+  (none)
+
+Lists incoming Twilio phone numbers for the configured account. Returns
+\`success: false\` with \`hasCredentials: false\` when credentials are missing.
+Calls the Twilio REST API directly; it does not proxy through the gateway.
+
+Examples:
+  $ assistant integrations twilio numbers
+  $ assistant integrations twilio numbers --json`,
+    )
     .action(async (_opts: unknown, cmd: Command) => {
-      await runRead(cmd, async () =>
-        gatewayGet("/v1/integrations/twilio/numbers"),
-      );
+      await runRead(cmd, async () => readTwilioNumbers());
     });
 
   const telegram = integrations


### PR DESCRIPTION
## Summary
- add required Twilio CLI help text and list the Twilio category in integrations help
- route Twilio CLI reads through the underlying assistant service/store layer instead of gateway proxying
- restore avatar correlation-id propagation coverage in the focused end-to-end test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
