### PR TITLE
fix: remove redundant cancelOutbound call from HTTP revoke handler

### DIFF
--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -299,11 +299,7 @@ export async function handleRevokeGuardianBinding(
     channel?: ChannelId;
   };
 
-  // Cancel any active outbound session before revoking
-  const resolvedChannel = body.channel ?? "telegram";
-  cancelOutbound({ channel: resolvedChannel });
-
-  // revokeGuardianForChannel already handles revokePendingChallenges + binding revocation
+  // revokeGuardianForChannel already handles cancelOutbound + revokePendingChallenges + binding revocation
   const result = revokeGuardianForChannel(body.channel);
   const status = result.success ? 200 : 400;
   return Response.json(result, { status });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for guardian-api-consolidation.md.

**Gap:** Redundant cancelOutbound in handleRevokeGuardianBinding
**What was expected:** Single call path matching IPC handler
**What was found:** cancelOutbound called twice — once explicitly, once inside revokeGuardianForChannel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
