### PR TITLE
fix: disable iOS pin action for unsynced threads

### DIFF
--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -246,6 +246,10 @@ struct ThreadListView: View {
         renameText = thread.title
     }
 
+    private func canToggleThreadPin(_ thread: IOSThread) -> Bool {
+        store.isConnectedMode && thread.sessionId != nil
+    }
+
     private func canMarkThreadUnread(_ thread: IOSThread) -> Bool {
         store.isConnectedMode &&
             thread.sessionId != nil &&
@@ -255,17 +259,19 @@ struct ThreadListView: View {
 
     @ViewBuilder
     private func connectedThreadContextMenu(_ thread: IOSThread) -> some View {
-        Button {
-            if thread.isPinned {
-                store.unpinThread(thread)
-            } else {
-                store.pinThread(thread)
-            }
-        } label: {
-            Label {
-                Text(thread.isPinned ? "Unpin thread" : "Pin thread")
-            } icon: {
-                VIconView(thread.isPinned ? .pinOff : .pin, size: 14)
+        if canToggleThreadPin(thread) {
+            Button {
+                if thread.isPinned {
+                    store.unpinThread(thread)
+                } else {
+                    store.pinThread(thread)
+                }
+            } label: {
+                Label {
+                    Text(thread.isPinned ? "Unpin thread" : "Pin thread")
+                } icon: {
+                    VIconView(thread.isPinned ? .pinOff : .pin, size: 14)
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- hide or disable the iOS pin context-menu action until a connected thread has a session id
- avoid presenting a silent no-op in the connected thread menu
- add focused verification if needed

## Verification
- attempted `xcodegen --quiet` plus `xcodebuild build -project vellum-assistant-ios.xcodeproj -scheme VellumAssistantIOS -destination 'generic/platform=iOS Simulator' -configuration Debug CODE_SIGNING_ALLOWED=NO`, but this machine has no available iOS Simulator and Xcode reports the iOS device platform is not installed

Apple refs checked (2026-03-07): SwiftUI `contextMenu(menuItems:)`, `View.disabled(_:)`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
