### PR TITLE
feat: [assistant] expose cache totals in usage dashboard breakdowns

### DIFF
--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -284,10 +284,15 @@ describe("getUsageTotals", () => {
     expect(totals.unpricedEventCount).toBe(0);
   });
 
-  test("sums tokens and cost across priced events", () => {
+  test("sums direct input, cache tokens, and cost across priced events", () => {
     insertEventAt(
       1000,
-      { inputTokens: 100, outputTokens: 50 },
+      {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheCreationInputTokens: 25,
+        cacheReadInputTokens: 50,
+      },
       {
         estimatedCostUsd: 0.01,
         pricingStatus: "priced",
@@ -295,7 +300,12 @@ describe("getUsageTotals", () => {
     );
     insertEventAt(
       2000,
-      { inputTokens: 200, outputTokens: 100 },
+      {
+        inputTokens: 200,
+        outputTokens: 100,
+        cacheCreationInputTokens: 75,
+        cacheReadInputTokens: 125,
+      },
       {
         estimatedCostUsd: 0.02,
         pricingStatus: "priced",
@@ -305,6 +315,8 @@ describe("getUsageTotals", () => {
     const totals = getUsageTotals({ from: 0, to: 5000 });
     expect(totals.totalInputTokens).toBe(300);
     expect(totals.totalOutputTokens).toBe(150);
+    expect(totals.totalCacheCreationTokens).toBe(100);
+    expect(totals.totalCacheReadTokens).toBe(175);
     expect(totals.totalEstimatedCostUsd).toBeCloseTo(0.03);
     expect(totals.eventCount).toBe(2);
     expect(totals.pricedEventCount).toBe(2);
@@ -375,14 +387,24 @@ describe("getUsageDayBuckets", () => {
     expect(buckets).toHaveLength(0);
   });
 
-  test("groups events into correct day buckets", () => {
+  test("groups direct input into correct day buckets without double-counting cache tokens", () => {
     const day1Start = utcMs(2025, 3, 1, 0);
     const day1Mid = utcMs(2025, 3, 1, 12);
     const day2Start = utcMs(2025, 3, 2, 6);
 
     insertEventAt(day1Start, { inputTokens: 100, outputTokens: 10 });
-    insertEventAt(day1Mid, { inputTokens: 200, outputTokens: 20 });
-    insertEventAt(day2Start, { inputTokens: 300, outputTokens: 30 });
+    insertEventAt(day1Mid, {
+      inputTokens: 200,
+      outputTokens: 20,
+      cacheCreationInputTokens: 50,
+      cacheReadInputTokens: 100,
+    });
+    insertEventAt(day2Start, {
+      inputTokens: 300,
+      outputTokens: 30,
+      cacheCreationInputTokens: 20,
+      cacheReadInputTokens: 30,
+    });
 
     const buckets = getUsageDayBuckets({
       from: utcMs(2025, 3, 1),
@@ -463,10 +485,15 @@ describe("getUsageGroupBreakdown", () => {
     expect(groups).toHaveLength(0);
   });
 
-  test("groups by actor", () => {
+  test("groups by actor with direct input and cache totals kept separate", () => {
     insertEventAt(
       1000,
-      { actor: "main_agent", inputTokens: 100 },
+      {
+        actor: "main_agent",
+        inputTokens: 100,
+        cacheCreationInputTokens: 30,
+        cacheReadInputTokens: 50,
+      },
       {
         estimatedCostUsd: 0.01,
         pricingStatus: "priced",
@@ -474,7 +501,12 @@ describe("getUsageGroupBreakdown", () => {
     );
     insertEventAt(
       2000,
-      { actor: "main_agent", inputTokens: 200 },
+      {
+        actor: "main_agent",
+        inputTokens: 200,
+        cacheCreationInputTokens: 20,
+        cacheReadInputTokens: 25,
+      },
       {
         estimatedCostUsd: 0.02,
         pricingStatus: "priced",
@@ -495,11 +527,15 @@ describe("getUsageGroupBreakdown", () => {
     // Ordered by cost descending
     expect(groups[0].group).toBe("main_agent");
     expect(groups[0].totalInputTokens).toBe(300);
+    expect(groups[0].totalCacheCreationTokens).toBe(50);
+    expect(groups[0].totalCacheReadTokens).toBe(75);
     expect(groups[0].totalEstimatedCostUsd).toBeCloseTo(0.03);
     expect(groups[0].eventCount).toBe(2);
 
     expect(groups[1].group).toBe("title_generator");
     expect(groups[1].totalInputTokens).toBe(50);
+    expect(groups[1].totalCacheCreationTokens).toBe(0);
+    expect(groups[1].totalCacheReadTokens).toBe(0);
     expect(groups[1].eventCount).toBe(1);
   });
 

--- a/assistant/src/__tests__/usage-routes.test.ts
+++ b/assistant/src/__tests__/usage-routes.test.ts
@@ -82,7 +82,7 @@ function seedEvents() {
       actor: "main_agent",
       provider: "anthropic",
       model: "claude-sonnet-4-20250514",
-      inputTokens: 1000,
+      inputTokens: 850,
       outputTokens: 200,
       cacheCreationInputTokens: 50,
       cacheReadInputTokens: 100,
@@ -201,7 +201,7 @@ describe("usage routes", () => {
       const res = await dispatch("GET", `usage/totals?from=${from}&to=${to}`);
       expect(res.status).toBe(200);
       const body = (await res.json()) as Record<string, number>;
-      expect(body.totalInputTokens).toBe(3500);
+      expect(body.totalInputTokens).toBe(3350);
       expect(body.totalOutputTokens).toBe(700);
       expect(body.totalCacheCreationTokens).toBe(50);
       expect(body.totalCacheReadTokens).toBe(100);
@@ -219,7 +219,9 @@ describe("usage routes", () => {
       const res = await dispatch("GET", `usage/totals?from=${from}&to=${to}`);
       const body = (await res.json()) as Record<string, number>;
       expect(body.eventCount).toBe(2);
-      expect(body.totalInputTokens).toBe(1500);
+      expect(body.totalInputTokens).toBe(1350);
+      expect(body.totalCacheCreationTokens).toBe(50);
+      expect(body.totalCacheReadTokens).toBe(100);
     });
   });
 
@@ -249,8 +251,10 @@ describe("usage routes", () => {
       };
       expect(body.buckets).toHaveLength(2);
       expect(body.buckets[0].date).toBe("2025-01-15");
+      expect(body.buckets[0].totalInputTokens).toBe(1350);
       expect(body.buckets[0].eventCount).toBe(2);
       expect(body.buckets[1].date).toBe("2025-01-16");
+      expect(body.buckets[1].totalInputTokens).toBe(2000);
       expect(body.buckets[1].eventCount).toBe(1);
     });
   });
@@ -292,12 +296,26 @@ describe("usage routes", () => {
         breakdown: Array<{
           group: string;
           totalInputTokens: number;
+          totalCacheCreationTokens: number;
+          totalCacheReadTokens: number;
+          totalEstimatedCostUsd: number;
           eventCount: number;
         }>;
       };
       expect(body.breakdown).toHaveLength(2);
-      const groups = body.breakdown.map((b) => b.group).sort();
-      expect(groups).toEqual(["anthropic", "openai"]);
+      expect(body.breakdown[0].group).toBe("anthropic");
+      expect(body.breakdown[0].totalInputTokens).toBe(1350);
+      expect(body.breakdown[0].totalCacheCreationTokens).toBe(50);
+      expect(body.breakdown[0].totalCacheReadTokens).toBe(100);
+      expect(body.breakdown[0].totalEstimatedCostUsd).toBeCloseTo(0.006);
+      expect(body.breakdown[0].eventCount).toBe(2);
+
+      expect(body.breakdown[1].group).toBe("openai");
+      expect(body.breakdown[1].totalInputTokens).toBe(2000);
+      expect(body.breakdown[1].totalCacheCreationTokens).toBe(0);
+      expect(body.breakdown[1].totalCacheReadTokens).toBe(0);
+      expect(body.breakdown[1].totalEstimatedCostUsd).toBe(0);
+      expect(body.breakdown[1].eventCount).toBe(1);
     });
 
     test("groups by actor", async () => {

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -90,6 +90,7 @@ export interface UsageTimeRange {
 
 /** Aggregate totals across a time range. */
 export interface UsageTotals {
+  /** Direct input tokens only; cache traffic is reported separately below. */
   totalInputTokens: number;
   totalOutputTokens: number;
   totalCacheCreationTokens: number;
@@ -104,6 +105,7 @@ export interface UsageTotals {
 export interface UsageDayBucket {
   /** ISO date string (YYYY-MM-DD) in UTC. */
   date: string;
+  /** Direct input tokens only; cache traffic is tracked separately in totals. */
   totalInputTokens: number;
   totalOutputTokens: number;
   totalEstimatedCostUsd: number;
@@ -113,8 +115,11 @@ export interface UsageDayBucket {
 /** A grouped breakdown row (by actor, provider, or model). */
 export interface UsageGroupBreakdown {
   group: string;
+  /** Direct input tokens only; cache traffic is reported separately below. */
   totalInputTokens: number;
   totalOutputTokens: number;
+  totalCacheCreationTokens: number;
+  totalCacheReadTokens: number;
   totalEstimatedCostUsd: number;
   eventCount: number;
 }
@@ -144,6 +149,8 @@ interface GroupRow {
   group_key: string;
   total_input_tokens: number;
   total_output_tokens: number;
+  total_cache_creation_tokens: number;
+  total_cache_read_tokens: number;
   total_estimated_cost_usd: number | null;
   event_count: number;
 }
@@ -236,6 +243,8 @@ export function getUsageGroupBreakdown(
       ${column}                                      AS group_key,
       COALESCE(SUM(input_tokens), 0)                 AS total_input_tokens,
       COALESCE(SUM(output_tokens), 0)                AS total_output_tokens,
+      COALESCE(SUM(cache_creation_input_tokens), 0)  AS total_cache_creation_tokens,
+      COALESCE(SUM(cache_read_input_tokens), 0)      AS total_cache_read_tokens,
       COALESCE(SUM(estimated_cost_usd), 0)           AS total_estimated_cost_usd,
       COUNT(*)                                        AS event_count
     FROM llm_usage_events
@@ -250,6 +259,8 @@ export function getUsageGroupBreakdown(
     group: r.group_key,
     totalInputTokens: r.total_input_tokens,
     totalOutputTokens: r.total_output_tokens,
+    totalCacheCreationTokens: r.total_cache_creation_tokens,
+    totalCacheReadTokens: r.total_cache_read_tokens,
     totalEstimatedCostUsd: r.total_estimated_cost_usd ?? 0,
     eventCount: r.event_count,
   }));


### PR DESCRIPTION
## Summary
- add cache creation and cache read totals to usage dashboard breakdown rows while keeping `totalInputTokens` as direct-input usage
- expand the usage store tests with mixed direct/cache ledger rows so totals, daily buckets, and grouped results avoid double-counting cache traffic
- update usage route tests to assert the new breakdown JSON fields and corrected cost ordering

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
