### PR TITLE
test: lock desktop composer return-key behavior

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerBridge.swift
@@ -112,26 +112,23 @@ struct ComposerFocusBridge: NSViewRepresentable {
                 // handles slash-menu, ghost-text, and pending-confirmation.
                 let isReturn = event.keyCode == 36 || event.keyCode == 76
                 if isReturn {
-                    switch ComposerReturnKeyRouting.resolve(
+                    let action = ComposerReturnKeyRouting.resolve(
                         cmdEnterToSend: self.parent.cmdEnterToSend,
                         modifiers: modifiers
+                    )
+                    let textView = (event.window?.firstResponder as? NSTextView)
+                        ?? (NSApp.keyWindow?.firstResponder as? NSTextView)
+
+                    // Still consume newline routes when the field editor is
+                    // missing so SwiftUI cannot accidentally treat them as send.
+                    if ComposerReturnKeyRouting.performBridgeAction(
+                        action,
+                        textView: textView,
+                        onSend: self.parent.onSend
                     ) {
-                    case .bridgeSend:
-                        self.parent.onSend()
                         return nil
-                    case .bridgeInsertNewline:
-                        // Insert newline via the field editor. If the text view
-                        // can't be found, still consume the event to prevent
-                        // .onSubmit from firing (which would send the message).
-                        let textView = (event.window?.firstResponder as? NSTextView)
-                            ?? (NSApp.keyWindow?.firstResponder as? NSTextView)
-                        if let textView {
-                            textView.insertText("\n", replacementRange: textView.selectedRange())
-                        }
-                        return nil
-                    case .deferToSubmit:
-                        return event
                     }
+                    return event
                 }
 
                 // Let zoom shortcuts propagate instead of being consumed

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerReturnKeyRouting.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerReturnKeyRouting.swift
@@ -31,5 +31,42 @@ enum ComposerReturnKeyRouting {
         }
         return .deferToSubmit
     }
+
+    // Keep bridge interception and `.onSubmit` on the same execution contract
+    // so routing tweaks cannot silently diverge from the user-visible behavior.
+    @discardableResult
+    static func performBridgeAction(
+        _ action: Action,
+        textView: NSTextView?,
+        onSend: () -> Void
+    ) -> Bool {
+        switch action {
+        case .bridgeSend:
+            onSend()
+            return true
+        case .bridgeInsertNewline:
+            insertNewline(into: textView)
+            return true
+        case .deferToSubmit:
+            return false
+        }
+    }
+
+    static func handleSubmit(
+        cmdEnterToSend: Bool,
+        textView: NSTextView?,
+        onSend: () -> Void
+    ) {
+        if cmdEnterToSend {
+            insertNewline(into: textView)
+            return
+        }
+        onSend()
+    }
+
+    private static func insertNewline(into textView: NSTextView?) {
+        guard let textView else { return }
+        textView.insertText("\n", replacementRange: textView.selectedRange())
+    }
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -185,21 +185,7 @@ struct ComposerView: View {
         .tint(VColor.accent)
         .focused($composerFocus)
         .disabled(!hasAPIKey)
-        .onSubmit {
-            #if os(macOS)
-            // In Cmd+Enter mode, plain Return should insert a newline.
-            // `.onSubmit` fires on all Return variants and consumes the
-            // event, so we insert the newline manually via the field editor.
-            // Cmd+Return → send is handled by the bridge before `.onSubmit`.
-            if cmdEnterToSend {
-                if let textView = NSApp.keyWindow?.firstResponder as? NSTextView {
-                    textView.insertText("\n", replacementRange: textView.selectedRange())
-                }
-                return
-            }
-            #endif
-            performSendAction()
-        }
+        .onSubmit { handleComposerSubmit() }
         .onKeyPress(.tab, phases: .down) { press in
             if !press.modifiers.contains(.shift), showSlashMenu {
                 handleSlashNavigation(.tab)
@@ -383,6 +369,21 @@ struct ComposerView: View {
         }
     }
 
+    private func handleComposerSubmit() {
+        #if os(macOS)
+        // `.onSubmit` fires on all Return variants, so keep the actual
+        // send-vs-newline behavior in the shared return-key contract.
+        ComposerReturnKeyRouting.handleSubmit(
+            cmdEnterToSend: cmdEnterToSend,
+            textView: NSApp.keyWindow?.firstResponder as? NSTextView
+        ) {
+            performSendAction()
+        }
+        #else
+        performSendAction()
+        #endif
+    }
+
     @ViewBuilder
     private var composerActionButtons: some View {
         HStack(spacing: 2) {
@@ -533,4 +534,3 @@ struct ComposerView: View {
     }
 
 }
-

--- a/clients/macos/vellum-assistantTests/ComposerReturnKeyRoutingTests.swift
+++ b/clients/macos/vellum-assistantTests/ComposerReturnKeyRoutingTests.swift
@@ -1,4 +1,5 @@
 #if os(macOS)
+import AppKit
 import XCTest
 @testable import VellumAssistantLib
 
@@ -68,6 +69,69 @@ final class ComposerReturnKeyRoutingTests: XCTestCase {
     func testCmdEnterMode_cmdReturnWithCapsLock_sends() {
         let action = ComposerReturnKeyRouting.resolve(cmdEnterToSend: true, modifiers: [.command, .capsLock])
         XCTAssertEqual(action, .bridgeSend)
+    }
+
+    // MARK: - Execution contract
+
+    func testBridgeSendConsumesEventAndCallsOnSend() {
+        var sendCount = 0
+
+        let consumed = ComposerReturnKeyRouting.performBridgeAction(.bridgeSend, textView: nil) {
+            sendCount += 1
+        }
+
+        XCTAssertTrue(consumed)
+        XCTAssertEqual(sendCount, 1)
+    }
+
+    func testBridgeInsertNewlineConsumesEventWithoutSending() {
+        let textView = makeTextView(with: "hello")
+        var sendCount = 0
+
+        let consumed = ComposerReturnKeyRouting.performBridgeAction(.bridgeInsertNewline, textView: textView) {
+            sendCount += 1
+        }
+
+        XCTAssertTrue(consumed)
+        XCTAssertEqual(textView.string, "hello\n")
+        XCTAssertEqual(sendCount, 0)
+    }
+
+    func testCmdEnterModeSubmitInsertsNewlineInsteadOfSending() {
+        let textView = makeTextView(with: "hello")
+        var sendCount = 0
+
+        ComposerReturnKeyRouting.handleSubmit(
+            cmdEnterToSend: true,
+            textView: textView
+        ) {
+            sendCount += 1
+        }
+
+        XCTAssertEqual(textView.string, "hello\n")
+        XCTAssertEqual(sendCount, 0)
+    }
+
+    func testDefaultModeSubmitSendsInsteadOfInsertingNewline() {
+        let textView = makeTextView(with: "hello")
+        var sendCount = 0
+
+        ComposerReturnKeyRouting.handleSubmit(
+            cmdEnterToSend: false,
+            textView: textView
+        ) {
+            sendCount += 1
+        }
+
+        XCTAssertEqual(textView.string, "hello")
+        XCTAssertEqual(sendCount, 1)
+    }
+
+    private func makeTextView(with text: String) -> NSTextView {
+        let textView = NSTextView(frame: .zero)
+        textView.string = text
+        textView.setSelectedRange(NSRange(location: (text as NSString).length, length: 0))
+        return textView
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- extract shared macOS composer return-key execution helpers so the AppKit bridge and `.onSubmit` path stay on the same send-vs-newline contract
- add regression coverage for bridge send/newline behavior and for `cmdEnterToSend` plain-Return newline handling with a real `NSTextView`
- keep the existing routing contract intact while actually locking the user-visible behavior the rollout plan promised

## Original prompt
Can you address this?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
