### PR TITLE
fix: resolve twilio reconcile typecheck regression

### DIFF
--- a/gateway/src/__tests__/twilio-reconcile-route.test.ts
+++ b/gateway/src/__tests__/twilio-reconcile-route.test.ts
@@ -26,6 +26,14 @@ type TwilioCredentials = {
   authToken: string;
 };
 
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
 let rootDir = "";
 let twilioCredentials: TwilioCredentials | null = null;
 let storedPhoneNumber: string | null = null;
@@ -233,20 +241,14 @@ describe("POST /internal/twilio/reconcile", () => {
     const handler = createTwilioReconcileHandler(config);
 
     let readCount = 0;
-    let startFirstRead: (() => void) | null = null;
-    let releaseFirstRead: (() => void) | null = null;
-    const firstReadStarted = new Promise<void>((resolve) => {
-      startFirstRead = resolve;
-    });
-    const continueFirstRead = new Promise<void>((resolve) => {
-      releaseFirstRead = resolve;
-    });
+    const firstReadStarted = createDeferred();
+    const continueFirstRead = createDeferred();
 
     readTwilioCredentialsImpl = async () => {
       readCount += 1;
       if (readCount === 1) {
-        startFirstRead?.();
-        await continueFirstRead;
+        firstReadStarted.resolve();
+        await continueFirstRead.promise;
         return {
           accountSid: "AC-first",
           authToken: "first-auth-token",
@@ -263,7 +265,7 @@ describe("POST /internal/twilio/reconcile", () => {
         ingressPublicBaseUrl: "https://first.example.com/",
       }),
     );
-    await firstReadStarted;
+    await firstReadStarted.promise;
 
     const secondReconcile = handler(
       makeRequest("POST", TOKEN, {
@@ -271,7 +273,7 @@ describe("POST /internal/twilio/reconcile", () => {
       }),
     );
 
-    releaseFirstRead?.();
+    continueFirstRead.resolve();
 
     const [firstResponse, secondResponse] = await Promise.all([
       firstReconcile,

--- a/gateway/src/http/routes/twilio-reconcile.ts
+++ b/gateway/src/http/routes/twilio-reconcile.ts
@@ -98,10 +98,13 @@ export function createTwilioReconcileHandler(config: GatewayConfig) {
       return Response.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
-    const ingressPublicBaseUrlProvided =
-      typeof body.ingressPublicBaseUrl === "string";
-    const normalizedIngressPublicBaseUrl = ingressPublicBaseUrlProvided
-      ? normalizeIngressPublicBaseUrl(body.ingressPublicBaseUrl)
+    const ingressPublicBaseUrl =
+      typeof body.ingressPublicBaseUrl === "string"
+        ? body.ingressPublicBaseUrl
+        : undefined;
+    const ingressPublicBaseUrlProvided = ingressPublicBaseUrl !== undefined;
+    const normalizedIngressPublicBaseUrl = ingressPublicBaseUrl
+      ? normalizeIngressPublicBaseUrl(ingressPublicBaseUrl)
       : undefined;
 
     const result = new Promise<Response>((resolve) => {


### PR DESCRIPTION
## Summary
- fix the Twilio reconcile route type narrowing so `ingressPublicBaseUrl` is only normalized after it is captured as a definite string
- replace the test's nullable callback gates with an explicit deferred helper so strict TypeScript can follow the overlapping refresh serialization scenario
- verify the CI failure path with `bun run typecheck` and `bun test src/__tests__/twilio-reconcile-route.test.ts`

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22789144823/job/66112254857

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
