### PR TITLE
fix: preserve macOS unread actions

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1130,9 +1130,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     internal func markConversationUnread(threadId: UUID) {
         guard let idx = threads.firstIndex(where: { $0.id == threadId }),
               let sessionId = threads[idx].sessionId,
-              !threads[idx].hasUnseenLatestAssistantMessage,
-              threads[idx].latestAssistantMessageAt != nil else { return }
+              canMarkConversationUnread(threadId: threadId, at: idx) else { return }
 
+        pendingSeenSessionIds.removeAll { $0 == sessionId }
         pendingAttentionOverrides[sessionId] = .unread(
             latestAssistantMessageAt: threads[idx].latestAssistantMessageAt
         )
@@ -1670,12 +1670,17 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
         guard let index = threads.firstIndex(where: { $0.id == threadId }) else { return }
         updateLastInteracted(threadId: threadId)
+        let isNewMessage = previousSnapshot?.messageId != currentSnapshot.messageId
+        // Keep the local attention timestamp current for live assistant replies
+        // so unread eligibility survives until the next session-list refresh.
+        if threads[index].latestAssistantMessageAt == nil || isNewMessage {
+            threads[index].latestAssistantMessageAt = Date()
+        }
         if threadId == activeThreadId {
             threads[index].hasUnseenLatestAssistantMessage = false
             // Only emit the IPC seen signal on meaningful transitions:
             // 1. A new assistant message appeared (different messageId)
             // 2. Streaming just completed (isStreaming went true -> false)
-            let isNewMessage = previousSnapshot?.messageId != currentSnapshot.messageId
             let streamingJustCompleted = previousSnapshot?.isStreaming == true && !currentSnapshot.isStreaming
             if isNewMessage || streamingJustCompleted {
                 if let sessionId = threads[index].sessionId {
@@ -1685,5 +1690,14 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         } else {
             threads[index].hasUnseenLatestAssistantMessage = true
         }
+    }
+
+    private func canMarkConversationUnread(threadId: UUID, at threadIndex: Int) -> Bool {
+        guard threads[threadIndex].sessionId != nil,
+              !threads[threadIndex].hasUnseenLatestAssistantMessage else { return false }
+        // Live assistant replies update the in-memory activity snapshot before
+        // session-list hydration backfills latestAssistantMessageAt.
+        return threads[threadIndex].latestAssistantMessageAt != nil
+            || latestAssistantActivitySnapshots[threadId] != nil
     }
 }

--- a/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
@@ -323,6 +323,37 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         XCTAssertTrue(threadManager.threads[index].hasUnseenLatestAssistantMessage)
     }
 
+    func testMarkConversationUnreadAllowsLiveAssistantReplyWithoutHydratedTimestamp() {
+        guard let threadId = threadManager.activeThreadId,
+              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }),
+              let vm = threadManager.chatViewModel(for: threadId) else {
+            XCTFail("Expected an initial active thread and view model")
+            return
+        }
+
+        threadManager.threads[index].sessionId = "session-live-unread"
+        threadManager.threads[index].hasUnseenLatestAssistantMessage = false
+        threadManager.threads[index].latestAssistantMessageAt = nil
+        vm.sessionId = "session-live-unread"
+
+        vm.handleServerMessage(.assistantTextDelta(
+            AssistantTextDeltaMessage(text: "Live reply", sessionId: "session-live-unread")
+        ))
+        waitForPropagation()
+
+        threadManager.threads[index].latestAssistantMessageAt = nil
+        sentMessages.removeAll()
+
+        threadManager.markConversationUnread(threadId: threadId)
+
+        XCTAssertTrue(threadManager.threads[index].hasUnseenLatestAssistantMessage,
+                      "Live assistant replies should allow unread even before hydration backfills timestamps")
+
+        let unreadSignals = sentMessages.compactMap { $0 as? IPCConversationUnreadSignal }
+        XCTAssertEqual(unreadSignals.count, 1)
+        XCTAssertEqual(unreadSignals.last?.conversationId, "session-live-unread")
+    }
+
     func testMarkConversationUnreadIgnoresThreadsWithoutAssistantReply() {
         guard let threadId = threadManager.activeThreadId,
               let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
@@ -415,6 +446,52 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         XCTAssertTrue(
             threadManager.threads.first(where: { $0.sessionId == "session-refresh-unread" })?.hasUnseenLatestAssistantMessage ?? false
         )
+    }
+
+    func testMarkConversationUnreadRemovesPendingSeenSignalForSameSession() {
+        guard let firstThreadId = threadManager.activeThreadId,
+              let firstIndex = threadManager.threads.firstIndex(where: { $0.id == firstThreadId }) else {
+            XCTFail("Expected an initial active thread")
+            return
+        }
+
+        threadManager.threads[firstIndex].sessionId = "session-first"
+        threadManager.threads[firstIndex].hasUnseenLatestAssistantMessage = true
+        threadManager.threads[firstIndex].latestAssistantMessageAt = Date(timeIntervalSince1970: 1)
+        threadManager.chatViewModel(for: firstThreadId)?.messages.append(ChatMessage(role: .user, text: "Seed"))
+
+        threadManager.createThread()
+
+        guard let secondThreadId = threadManager.activeThreadId,
+              let secondIndex = threadManager.threads.firstIndex(where: { $0.id == secondThreadId }) else {
+            XCTFail("Expected a second active thread")
+            return
+        }
+
+        threadManager.threads[secondIndex].sessionId = "session-second"
+        threadManager.threads[secondIndex].hasUnseenLatestAssistantMessage = true
+        threadManager.threads[secondIndex].latestAssistantMessageAt = Date(timeIntervalSince1970: 2)
+
+        sentMessages.removeAll()
+
+        let markedIds = Set(threadManager.markAllThreadsSeen())
+        XCTAssertEqual(markedIds, Set([firstThreadId, secondThreadId]))
+
+        threadManager.markConversationUnread(threadId: firstThreadId)
+        threadManager.commitPendingSeenSignals()
+
+        let unreadSignals = sentMessages.compactMap { $0 as? IPCConversationUnreadSignal }
+        XCTAssertEqual(unreadSignals.map(\.conversationId), ["session-first"])
+
+        let seenSignals = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+        XCTAssertEqual(seenSignals.map(\.conversationId), ["session-second"])
+
+        XCTAssertTrue(threadManager.threads.contains(where: {
+            $0.id == firstThreadId && $0.hasUnseenLatestAssistantMessage
+        }))
+        XCTAssertTrue(threadManager.threads.contains(where: {
+            $0.id == secondThreadId && !$0.hasUnseenLatestAssistantMessage
+        }))
     }
 
     func testActiveThreadDoesNotEmitSeenSignalOnEveryStreamingDelta() {


### PR DESCRIPTION
## Summary
- remove the stale timestamp gate from the macOS mark-unread helper
- clear deferred seen state before emitting an unread signal
- add focused verification if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
