### PR TITLE
test: handle lookahead route regexes in gateway schema guard

### DIFF
--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -99,6 +99,10 @@ function regexToOpenApiPath(escaped: string): string | null {
   // Unescape forward slashes
   let path = escaped.replace(/\\\//g, "/");
 
+  // Zero-width lookarounds constrain which parameter values are accepted,
+  // but they do not change the structural path shape we compare to the schema.
+  path = path.replace(/\(\?(?:=|!|<=|<!).*?\)/g, "");
+
   // Replace capture groups with numbered params.
   // Handles both `([^/]+)` (single segment) and `(.+)` (greedy) patterns.
   let paramIndex = 0;
@@ -257,6 +261,12 @@ describe("route-schema sync guard", () => {
     );
 
     expect(stale).toEqual([]);
+  });
+
+  test("regex route normalization ignores negative lookaheads", () => {
+    expect(
+      regexToOpenApiPath(String.raw`\/v1\/contacts\/(?!invites$)([^/]+)`),
+    ).toBe("/v1/contacts/{param1}");
   });
 });
 


### PR DESCRIPTION
## Summary
- normalize zero-width lookarounds when converting regex routes to OpenAPI-style paths in the gateway route/schema guard
- add a focused regression test for the negative-lookahead contacts DELETE route shape
- fix the failing CI guard without changing gateway runtime behavior

## Original prompt
$do Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22789235322/job/66112516741

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
