### PR TITLE
fix: preserve iOS pin metadata across remote session merges

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -153,6 +153,24 @@ class IOSThreadStore: ObservableObject {
         )
     }
 
+    private func existingThreadIndex(forSessionId sessionId: String) -> Int? {
+        if let threadIndex = threads.firstIndex(where: { $0.sessionId == sessionId }) {
+            return threadIndex
+        }
+        return threads.firstIndex(where: { viewModels[$0.id]?.sessionId == sessionId })
+    }
+
+    private func mergeThreadMetadata(from restored: IOSThread, into thread: inout IOSThread) {
+        thread.sessionId = restored.sessionId ?? thread.sessionId
+        thread.scheduleJobId = restored.scheduleJobId
+        thread.isPinned = restored.isPinned
+        thread.displayOrder = restored.displayOrder
+        thread.hasUnseenLatestAssistantMessage = restored.hasUnseenLatestAssistantMessage
+        thread.latestAssistantMessageAt = restored.latestAssistantMessageAt
+        thread.lastSeenAssistantMessageAt = restored.lastSeenAssistantMessageAt
+        applyPendingAttentionOverride(to: &thread)
+    }
+
     private func applyPendingAttentionOverride(to thread: inout IOSThread) {
         guard let sessionId = thread.sessionId,
               let override = pendingAttentionOverrides[sessionId] else { return }
@@ -516,14 +534,9 @@ class IOSThreadStore: ObservableObject {
                 var newThreads: [IOSThread] = []
                 for restored in restoredThreads {
                     if let sid = restored.sessionId, existingSessionIds.contains(sid) {
-                        if let existingIndex = threads.firstIndex(where: { $0.sessionId == sid }) {
+                        if let existingIndex = existingThreadIndex(forSessionId: sid) {
                             var mergedThread = threads[existingIndex]
-                            mergedThread.isPinned = restored.isPinned
-                            mergedThread.displayOrder = restored.displayOrder
-                            mergedThread.hasUnseenLatestAssistantMessage = restored.hasUnseenLatestAssistantMessage
-                            mergedThread.latestAssistantMessageAt = restored.latestAssistantMessageAt
-                            mergedThread.lastSeenAssistantMessageAt = restored.lastSeenAssistantMessageAt
-                            applyPendingAttentionOverride(to: &mergedThread)
+                            mergeThreadMetadata(from: restored, into: &mergedThread)
                             threads[existingIndex] = mergedThread
                         }
                         viewModels.removeValue(forKey: restored.id)
@@ -544,14 +557,9 @@ class IOSThreadStore: ObservableObject {
             })
             for restored in restoredThreads {
                 if let sid = restored.sessionId, existingSessionIds.contains(sid) {
-                    if let existingIndex = threads.firstIndex(where: { $0.sessionId == sid }) {
+                    if let existingIndex = existingThreadIndex(forSessionId: sid) {
                         var mergedThread = threads[existingIndex]
-                        mergedThread.isPinned = restored.isPinned
-                        mergedThread.displayOrder = restored.displayOrder
-                        mergedThread.hasUnseenLatestAssistantMessage = restored.hasUnseenLatestAssistantMessage
-                        mergedThread.latestAssistantMessageAt = restored.latestAssistantMessageAt
-                        mergedThread.lastSeenAssistantMessageAt = restored.lastSeenAssistantMessageAt
-                        applyPendingAttentionOverride(to: &mergedThread)
+                        mergeThreadMetadata(from: restored, into: &mergedThread)
                         threads[existingIndex] = mergedThread
                     }
                     viewModels.removeValue(forKey: restored.id)

--- a/clients/ios/Tests/ThreadLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ThreadLifecycleIOSTests.swift
@@ -382,6 +382,48 @@ final class ThreadLifecycleIOSTests: XCTestCase {
         XCTAssertEqual(cachedThread.lastSeenAssistantMessageAt?.timeIntervalSince1970, 4.0)
     }
 
+    func testConnectedThreadMergeAppliesMetadataWhenMatchedViaViewModelSessionId() {
+        let daemonClient = DaemonClient()
+        let store = IOSThreadStore(daemonClient: daemonClient)
+
+        guard let placeholderThread = store.threads.first else {
+            XCTFail("Expected placeholder thread")
+            return
+        }
+
+        let viewModel = store.viewModel(for: placeholderThread.id)
+        viewModel.sessionId = "connected-session-vm"
+
+        let response = makeSessionListResponse(sessions: [[
+            "id": "connected-session-vm",
+            "title": "Connected thread",
+            "createdAt": 1_000,
+            "updatedAt": 2_000,
+            "displayOrder": 9,
+            "isPinned": true,
+            "assistantAttention": [
+                "hasUnseenLatestAssistantMessage": true,
+                "latestAssistantMessageAt": 5_000,
+                "lastSeenAssistantMessageAt": 4_000,
+            ],
+        ]])
+
+        daemonClient.onSessionListResponse?(response)
+
+        XCTAssertEqual(store.threads.count, 1)
+        guard let updatedThread = store.threads.first else {
+            XCTFail("Expected merged thread")
+            return
+        }
+
+        XCTAssertEqual(updatedThread.sessionId, "connected-session-vm")
+        XCTAssertTrue(updatedThread.isPinned)
+        XCTAssertEqual(updatedThread.displayOrder, 9)
+        XCTAssertTrue(updatedThread.hasUnseenLatestAssistantMessage)
+        XCTAssertEqual(updatedThread.latestAssistantMessageAt?.timeIntervalSince1970, 5.0)
+        XCTAssertEqual(updatedThread.lastSeenAssistantMessageAt?.timeIntervalSince1970, 4.0)
+    }
+
     func testOpeningUnreadConnectedThreadMarksItSeenAndEmitsSignal() {
         let daemonClient = DaemonClient()
         var sentSignals: [IPCConversationSeenSignal] = []

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -33,6 +33,8 @@ struct ConversationsListResponse: Decodable {
         let conversationOriginChannel: String?
         let conversationOriginInterface: String?
         let assistantAttention: IPCAssistantAttention?
+        let displayOrder: Double?
+        let isPinned: Bool?
     }
     let sessions: [Session]
     let hasMore: Bool?
@@ -1722,7 +1724,7 @@ public final class HTTPTransport {
             do {
                 let decoded = try decoder.decode(ConversationsListResponse.self, from: data)
                 let sessions = decoded.sessions.map {
-                    IPCSessionListResponseSession(id: $0.id, title: $0.title, createdAt: $0.createdAt ?? $0.updatedAt, updatedAt: $0.updatedAt, threadType: $0.threadType, source: $0.source, channelBinding: $0.channelBinding, conversationOriginChannel: $0.conversationOriginChannel, conversationOriginInterface: $0.conversationOriginInterface, assistantAttention: $0.assistantAttention)
+                    IPCSessionListResponseSession(id: $0.id, title: $0.title, createdAt: $0.createdAt ?? $0.updatedAt, updatedAt: $0.updatedAt, threadType: $0.threadType, source: $0.source, channelBinding: $0.channelBinding, conversationOriginChannel: $0.conversationOriginChannel, conversationOriginInterface: $0.conversationOriginInterface, assistantAttention: $0.assistantAttention, displayOrder: $0.displayOrder, isPinned: $0.isPinned)
                 }
                 onMessage?(.sessionListResponse(SessionListResponseMessage(type: "session_list_response", sessions: sessions, hasMore: decoded.hasMore)))
             } catch {

--- a/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
+++ b/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
@@ -290,4 +290,54 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
         XCTAssertEqual(metadata["view"] as? String, "inbox")
         XCTAssertEqual(metadata["attempt"] as? Int, 1)
     }
+
+    func testSessionListResponsePreservesPinMetadataFromHTTPTransport() async throws {
+        let responseExpectation = expectation(description: "session list response")
+        var capturedResponse: SessionListResponseMessage?
+
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let body = """
+            {
+              "sessions": [
+                {
+                  "id": "session-123",
+                  "title": "Pinned thread",
+                  "createdAt": 1000,
+                  "updatedAt": 2000,
+                  "displayOrder": 7,
+                  "isPinned": true
+                }
+              ],
+              "hasMore": false
+            }
+            """
+            return (response, Data(body.utf8))
+        }
+
+        let transport = HTTPTransport(
+            baseURL: "https://example.com",
+            bearerToken: "test-token",
+            conversationKey: "conv-local"
+        )
+        transport.onMessage = { message in
+            if case let .sessionListResponse(response) = message {
+                capturedResponse = response
+                responseExpectation.fulfill()
+            }
+        }
+
+        try transport.send(SessionListRequestMessage(offset: 0, limit: 50))
+
+        await fulfillment(of: [responseExpectation], timeout: 1.0)
+
+        let session = try XCTUnwrap(capturedResponse?.sessions.first)
+        XCTAssertEqual(session.displayOrder, 7)
+        XCTAssertEqual(session.isPinned, true)
+    }
 }


### PR DESCRIPTION
## Summary
- keep pin and display-order metadata on the HTTP session-list transport path
- update iOS merge logic so VM-matched threads also receive refreshed metadata
- add focused verification for HTTP transport session metadata mapping
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
