### PR TITLE
fix: [assistant] backfill historical Anthropic usage ledger rows

### DIFF
--- a/assistant/src/__tests__/usage-cache-backfill-migration.test.ts
+++ b/assistant/src/__tests__/usage-cache-backfill-migration.test.ts
@@ -1,0 +1,299 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "usage-cache-backfill-test-"));
+
+mock.module("../util/platform.js", () => ({
+  getDataDir: () => testDir,
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getSocketPath: () => join(testDir, "test.sock"),
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  getDb,
+  getSqlite,
+  initializeDb,
+  rawGet,
+  rawRun,
+  resetDb,
+} from "../memory/db.js";
+import { migrateBackfillUsageCacheAccounting } from "../memory/migrations/140-backfill-usage-cache-accounting.js";
+import type { PricingUsage } from "../usage/types.js";
+import { estimateCost, resolvePricingForUsage } from "../util/pricing.js";
+
+initializeDb();
+
+const CHECKPOINT_KEY = "migration_backfill_usage_cache_accounting_v1";
+
+interface UsageEventRow {
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens: number | null;
+  cache_read_input_tokens: number | null;
+  estimated_cost_usd: number | null;
+  pricing_status: string;
+}
+
+function insertUsageEvent(args: {
+  id: string;
+  conversationId: string;
+  createdAt: number;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationInputTokens?: number | null;
+  cacheReadInputTokens?: number | null;
+  estimatedCostUsd: number | null;
+  pricingStatus?: string;
+}): void {
+  rawRun(
+    /*sql*/ `
+    INSERT INTO llm_usage_events (
+      id,
+      created_at,
+      conversation_id,
+      run_id,
+      request_id,
+      actor,
+      provider,
+      model,
+      input_tokens,
+      output_tokens,
+      cache_creation_input_tokens,
+      cache_read_input_tokens,
+      estimated_cost_usd,
+      pricing_status,
+      metadata_json
+    ) VALUES (?, ?, ?, NULL, NULL, 'main_agent', 'anthropic', ?, ?, ?, ?, ?, ?, ?, NULL)
+    `,
+    args.id,
+    args.createdAt,
+    args.conversationId,
+    args.model,
+    args.inputTokens,
+    args.outputTokens,
+    args.cacheCreationInputTokens ?? null,
+    args.cacheReadInputTokens ?? null,
+    args.estimatedCostUsd,
+    args.pricingStatus ?? "priced",
+  );
+}
+
+function insertRequestLog(args: {
+  id: string;
+  conversationId: string;
+  createdAt: number;
+  responsePayload: string;
+}): void {
+  rawRun(
+    /*sql*/ `
+    INSERT INTO llm_request_logs (
+      id,
+      conversation_id,
+      request_payload,
+      response_payload,
+      created_at
+    ) VALUES (?, ?, '{}', ?, ?)
+    `,
+    args.id,
+    args.conversationId,
+    args.responsePayload,
+    args.createdAt,
+  );
+}
+
+function anthropicResponsePayload(args: {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens?: number;
+  ephemeral5mInputTokens?: number;
+  ephemeral1hInputTokens?: number;
+}): string {
+  return JSON.stringify({
+    usage: {
+      input_tokens: args.inputTokens,
+      output_tokens: args.outputTokens,
+      cache_read_input_tokens: args.cacheReadInputTokens ?? 0,
+      cache_creation: {
+        ephemeral_5m_input_tokens: args.ephemeral5mInputTokens ?? 0,
+        ephemeral_1h_input_tokens: args.ephemeral1hInputTokens ?? 0,
+      },
+    },
+  });
+}
+
+afterAll(() => {
+  resetDb();
+  try {
+    rmSync(testDir, { recursive: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("migrateBackfillUsageCacheAccounting", () => {
+  beforeEach(() => {
+    getSqlite().run(`DELETE FROM llm_request_logs`);
+    getSqlite().run(`DELETE FROM llm_usage_events`);
+    rawRun(`DELETE FROM memory_checkpoints WHERE key = ?`, CHECKPOINT_KEY);
+  });
+
+  test("rewrites historical Anthropic rows from request logs and leaves missing-log rows unchanged", () => {
+    const model = "claude-opus-4-6";
+
+    insertUsageEvent({
+      id: "usage-prev",
+      conversationId: "conv-usage-1",
+      createdAt: 1_000,
+      model,
+      inputTokens: 700,
+      outputTokens: 70,
+      estimatedCostUsd: estimateCost(700, 70, model, "anthropic"),
+    });
+    insertRequestLog({
+      id: "log-prev",
+      conversationId: "conv-usage-1",
+      createdAt: 900,
+      responsePayload: anthropicResponsePayload({
+        inputTokens: 500,
+        outputTokens: 70,
+        cacheReadInputTokens: 100,
+        ephemeral5mInputTokens: 100,
+      }),
+    });
+
+    const flattenedHistoricalCost = estimateCost(
+      3_420_218,
+      11_768,
+      model,
+      "anthropic",
+    );
+    insertUsageEvent({
+      id: "usage-target",
+      conversationId: "conv-usage-1",
+      createdAt: 3_000,
+      model,
+      inputTokens: 3_420_218,
+      outputTokens: 11_768,
+      estimatedCostUsd: flattenedHistoricalCost,
+    });
+    insertRequestLog({
+      id: "log-target-1",
+      conversationId: "conv-usage-1",
+      createdAt: 1_500,
+      responsePayload: anthropicResponsePayload({
+        inputTokens: 100,
+        outputTokens: 6_000,
+        cacheReadInputTokens: 1_523_230,
+        ephemeral5mInputTokens: 173_619,
+      }),
+    });
+    insertRequestLog({
+      id: "log-target-2",
+      conversationId: "conv-usage-1",
+      createdAt: 2_500,
+      responsePayload: anthropicResponsePayload({
+        inputTokens: 38,
+        outputTokens: 5_768,
+        cacheReadInputTokens: 1_523_231,
+        ephemeral1hInputTokens: 200_000,
+      }),
+    });
+
+    const noLogCost = estimateCost(1_234, 56, model, "anthropic");
+    insertUsageEvent({
+      id: "usage-no-logs",
+      conversationId: "conv-usage-2",
+      createdAt: 4_000,
+      model,
+      inputTokens: 1_234,
+      outputTokens: 56,
+      estimatedCostUsd: noLogCost,
+    });
+
+    migrateBackfillUsageCacheAccounting(getDb());
+
+    const expectedUsage: PricingUsage = {
+      directInputTokens: 138,
+      outputTokens: 11_768,
+      cacheCreationInputTokens: 373_619,
+      cacheReadInputTokens: 3_046_461,
+      anthropicCacheCreation: {
+        ephemeral_5m_input_tokens: 173_619,
+        ephemeral_1h_input_tokens: 200_000,
+      },
+    };
+    const expectedPricing = resolvePricingForUsage(
+      "anthropic",
+      model,
+      expectedUsage,
+    );
+
+    const targetRow = rawGet<UsageEventRow>(
+      `SELECT
+         input_tokens,
+         output_tokens,
+         cache_creation_input_tokens,
+         cache_read_input_tokens,
+         estimated_cost_usd,
+         pricing_status
+       FROM llm_usage_events
+       WHERE id = ?`,
+      "usage-target",
+    );
+    expect(targetRow).not.toBeNull();
+    expect(targetRow?.input_tokens).toBe(138);
+    expect(targetRow?.output_tokens).toBe(11_768);
+    expect(targetRow?.cache_creation_input_tokens).toBe(373_619);
+    expect(targetRow?.cache_read_input_tokens).toBe(3_046_461);
+    expect(targetRow?.pricing_status).toBe("priced");
+    expect(targetRow?.estimated_cost_usd).toBeCloseTo(
+      expectedPricing.estimatedCostUsd ?? 0,
+      12,
+    );
+    expect(targetRow?.estimated_cost_usd).not.toBe(flattenedHistoricalCost);
+
+    const untouchedRow = rawGet<UsageEventRow>(
+      `SELECT
+         input_tokens,
+         output_tokens,
+         cache_creation_input_tokens,
+         cache_read_input_tokens,
+         estimated_cost_usd,
+         pricing_status
+       FROM llm_usage_events
+       WHERE id = ?`,
+      "usage-no-logs",
+    );
+    expect(untouchedRow).not.toBeNull();
+    expect(untouchedRow).toEqual({
+      input_tokens: 1_234,
+      output_tokens: 56,
+      cache_creation_input_tokens: null,
+      cache_read_input_tokens: null,
+      estimated_cost_usd: noLogCost,
+      pricing_status: "priced",
+    });
+
+    const checkpoint = rawGet<{ value: string }>(
+      `SELECT value FROM memory_checkpoints WHERE key = ?`,
+      CHECKPOINT_KEY,
+    );
+    expect(checkpoint?.value).toBe("1");
+  });
+});

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -35,6 +35,7 @@ import {
   migrateAssistantContactMetadata,
   migrateBackfillContactInteractionStats,
   migrateBackfillGuardianPrincipalId,
+  migrateBackfillUsageCacheAccounting,
   migrateCallSessionMode,
   migrateCanonicalGuardianDeliveriesDestinationIndex,
   migrateCanonicalGuardianRequesterChatId,
@@ -303,6 +304,9 @@ export function initializeDb(): void {
 
   // 43. Drop all composite usage indexes — they don't eliminate temp B-trees for GROUP BY
   migrateDropUsageCompositeIndexes(database);
+
+  // 44. Backfill historical Anthropic usage rows from request-log truth before dashboard reads
+  migrateBackfillUsageCacheAccounting(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/140-backfill-usage-cache-accounting.ts
+++ b/assistant/src/memory/migrations/140-backfill-usage-cache-accounting.ts
@@ -1,0 +1,353 @@
+import type {
+  AnthropicCacheCreationTokenDetails,
+  PricingUsage,
+} from "../../usage/types.js";
+import { getLogger } from "../../util/logger.js";
+import { resolvePricingForUsage } from "../../util/pricing.js";
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+const log = getLogger("memory-db");
+
+const CHECKPOINT_KEY = "migration_backfill_usage_cache_accounting_v1";
+
+interface UsageEventRow {
+  id: string;
+  conversation_id: string | null;
+  created_at: number;
+  provider: string;
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens: number | null;
+  cache_read_input_tokens: number | null;
+}
+
+interface RequestLogRow {
+  id: string;
+  conversation_id: string;
+  response_payload: string;
+  created_at: number;
+}
+
+interface ReconstructedUsage extends PricingUsage {
+  totalInputTokens: number;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value == null) return null;
+  return value as Record<string, unknown>;
+}
+
+function parseRequiredTokenCount(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  if (value < 0) return null;
+  return value;
+}
+
+function parseOptionalTokenCount(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return Math.max(value, 0);
+}
+
+function parseResponseUsage(
+  responsePayload: string,
+): ReconstructedUsage | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(responsePayload);
+  } catch {
+    return null;
+  }
+
+  const payloads = Array.isArray(parsed) ? parsed : [parsed];
+  if (payloads.length === 0) return null;
+
+  let directInputTokens = 0;
+  let outputTokens = 0;
+  let cacheReadInputTokens = 0;
+  let ephemeral5mInputTokens = 0;
+  let ephemeral1hInputTokens = 0;
+
+  for (const payload of payloads) {
+    const response = asRecord(payload);
+    const usage = asRecord(response?.usage);
+    if (!usage) return null;
+
+    const inputTokens = parseRequiredTokenCount(usage.input_tokens);
+    const responseOutputTokens = parseRequiredTokenCount(usage.output_tokens);
+    if (inputTokens == null || responseOutputTokens == null) {
+      return null;
+    }
+
+    const cacheReadTokens = parseOptionalTokenCount(
+      usage.cache_read_input_tokens,
+    );
+    const cacheCreation = asRecord(usage.cache_creation);
+
+    directInputTokens += inputTokens;
+    outputTokens += responseOutputTokens;
+    cacheReadInputTokens += cacheReadTokens;
+    ephemeral5mInputTokens += parseOptionalTokenCount(
+      cacheCreation?.ephemeral_5m_input_tokens,
+    );
+    ephemeral1hInputTokens += parseOptionalTokenCount(
+      cacheCreation?.ephemeral_1h_input_tokens,
+    );
+  }
+
+  const cacheCreationInputTokens =
+    ephemeral5mInputTokens + ephemeral1hInputTokens;
+  const anthropicCacheCreation: AnthropicCacheCreationTokenDetails | null =
+    cacheCreationInputTokens > 0
+      ? {
+          ephemeral_5m_input_tokens: ephemeral5mInputTokens,
+          ephemeral_1h_input_tokens: ephemeral1hInputTokens,
+        }
+      : null;
+
+  return {
+    directInputTokens,
+    outputTokens,
+    cacheCreationInputTokens,
+    cacheReadInputTokens,
+    anthropicCacheCreation,
+    totalInputTokens:
+      directInputTokens + cacheCreationInputTokens + cacheReadInputTokens,
+  };
+}
+
+function buildRequestLogMap(
+  rows: RequestLogRow[],
+): Map<string, RequestLogRow[]> {
+  const requestLogsByConversation = new Map<string, RequestLogRow[]>();
+  for (const row of rows) {
+    const conversationRows =
+      requestLogsByConversation.get(row.conversation_id) ?? [];
+    conversationRows.push(row);
+    requestLogsByConversation.set(row.conversation_id, conversationRows);
+  }
+  return requestLogsByConversation;
+}
+
+export function migrateBackfillUsageCacheAccounting(database: DrizzleDb): void {
+  withCrashRecovery(database, CHECKPOINT_KEY, () => {
+    const raw = getSqliteFrom(database);
+
+    const usageEventsTableExists = raw
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'llm_usage_events'`,
+      )
+      .get();
+    const requestLogsTableExists = raw
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'llm_request_logs'`,
+      )
+      .get();
+    if (!usageEventsTableExists || !requestLogsTableExists) return;
+
+    const usageRows = raw
+      .query(
+        /*sql*/ `
+        SELECT
+          id,
+          conversation_id,
+          created_at,
+          provider,
+          model,
+          input_tokens,
+          output_tokens,
+          cache_creation_input_tokens,
+          cache_read_input_tokens
+        FROM llm_usage_events
+        ORDER BY conversation_id ASC, created_at ASC, id ASC
+        `,
+      )
+      .all() as UsageEventRow[];
+
+    const requestLogRows = raw
+      .query(
+        /*sql*/ `
+        SELECT
+          id,
+          conversation_id,
+          response_payload,
+          created_at
+        FROM llm_request_logs
+        ORDER BY conversation_id ASC, created_at ASC, id ASC
+        `,
+      )
+      .all() as RequestLogRow[];
+
+    const requestLogsByConversation = buildRequestLogMap(requestLogRows);
+    const requestOffsets = new Map<string, number>();
+    const previousUsageEventCreatedAt = new Map<string, number>();
+
+    let scannedAnthropicRows = 0;
+    let updatedRows = 0;
+    let skippedNoConversation = 0;
+    let skippedNoLogs = 0;
+    let skippedInvalidLogs = 0;
+    let skippedInconsistentRows = 0;
+
+    const updateRow = raw.prepare(/*sql*/ `
+      UPDATE llm_usage_events
+      SET
+        input_tokens = ?,
+        output_tokens = ?,
+        cache_creation_input_tokens = ?,
+        cache_read_input_tokens = ?,
+        estimated_cost_usd = ?,
+        pricing_status = ?
+      WHERE id = ?
+      `);
+
+    try {
+      raw.exec("BEGIN");
+
+      for (const usageRow of usageRows) {
+        const conversationId = usageRow.conversation_id;
+        if (conversationId == null) {
+          if (usageRow.provider === "anthropic") {
+            scannedAnthropicRows += 1;
+            skippedNoConversation += 1;
+          }
+          continue;
+        }
+
+        const previousCreatedAt =
+          previousUsageEventCreatedAt.get(conversationId) ?? null;
+        const conversationRequestLogs =
+          requestLogsByConversation.get(conversationId) ?? [];
+        let requestOffset = requestOffsets.get(conversationId) ?? 0;
+        const windowLogs: RequestLogRow[] = [];
+
+        while (
+          requestOffset < conversationRequestLogs.length &&
+          conversationRequestLogs[requestOffset]!.created_at <=
+            usageRow.created_at
+        ) {
+          const requestLog = conversationRequestLogs[requestOffset]!;
+          if (
+            previousCreatedAt == null ||
+            requestLog.created_at > previousCreatedAt
+          ) {
+            windowLogs.push(requestLog);
+          }
+          requestOffset += 1;
+        }
+
+        requestOffsets.set(conversationId, requestOffset);
+        previousUsageEventCreatedAt.set(conversationId, usageRow.created_at);
+
+        if (usageRow.provider !== "anthropic") continue;
+
+        scannedAnthropicRows += 1;
+        if (windowLogs.length === 0) {
+          skippedNoLogs += 1;
+          continue;
+        }
+
+        let directInputTokens = 0;
+        let outputTokens = 0;
+        let cacheReadInputTokens = 0;
+        let cacheCreationInputTokens = 0;
+        let cacheCreation5mInputTokens = 0;
+        let cacheCreation1hInputTokens = 0;
+
+        let invalidLogFound = false;
+        for (const requestLog of windowLogs) {
+          const reconstructedUsage = parseResponseUsage(
+            requestLog.response_payload,
+          );
+          if (!reconstructedUsage) {
+            invalidLogFound = true;
+            break;
+          }
+          directInputTokens += reconstructedUsage.directInputTokens;
+          outputTokens += reconstructedUsage.outputTokens;
+          cacheReadInputTokens += reconstructedUsage.cacheReadInputTokens;
+          cacheCreationInputTokens +=
+            reconstructedUsage.cacheCreationInputTokens;
+          cacheCreation5mInputTokens +=
+            reconstructedUsage.anthropicCacheCreation
+              ?.ephemeral_5m_input_tokens ?? 0;
+          cacheCreation1hInputTokens +=
+            reconstructedUsage.anthropicCacheCreation
+              ?.ephemeral_1h_input_tokens ?? 0;
+        }
+
+        if (invalidLogFound) {
+          skippedInvalidLogs += 1;
+          continue;
+        }
+
+        const totalInputTokens =
+          directInputTokens + cacheCreationInputTokens + cacheReadInputTokens;
+        const existingTotalInputTokens =
+          Math.max(usageRow.input_tokens, 0) +
+          Math.max(usageRow.cache_creation_input_tokens ?? 0, 0) +
+          Math.max(usageRow.cache_read_input_tokens ?? 0, 0);
+
+        // This lets the migration safely rewrite both flattened historical rows
+        // and already-correct rows, while skipping mismatched request-log windows.
+        if (
+          totalInputTokens < 0 ||
+          directInputTokens < 0 ||
+          totalInputTokens !== existingTotalInputTokens ||
+          outputTokens !== Math.max(usageRow.output_tokens, 0)
+        ) {
+          skippedInconsistentRows += 1;
+          continue;
+        }
+
+        const pricingUsage: PricingUsage = {
+          directInputTokens,
+          outputTokens,
+          cacheCreationInputTokens,
+          cacheReadInputTokens,
+          anthropicCacheCreation:
+            cacheCreationInputTokens > 0
+              ? {
+                  ephemeral_5m_input_tokens: cacheCreation5mInputTokens,
+                  ephemeral_1h_input_tokens: cacheCreation1hInputTokens,
+                }
+              : null,
+        };
+        const pricing = resolvePricingForUsage(
+          usageRow.provider,
+          usageRow.model,
+          pricingUsage,
+        );
+
+        updateRow.run(
+          directInputTokens,
+          outputTokens,
+          cacheCreationInputTokens,
+          cacheReadInputTokens,
+          pricing.estimatedCostUsd,
+          pricing.pricingStatus,
+          usageRow.id,
+        );
+        updatedRows += 1;
+      }
+
+      raw.exec("COMMIT");
+    } catch (err) {
+      raw.exec("ROLLBACK");
+      throw err;
+    }
+
+    log.info(
+      {
+        scannedAnthropicRows,
+        updatedRows,
+        skippedNoConversation,
+        skippedNoLogs,
+        skippedInvalidLogs,
+        skippedInconsistentRows,
+      },
+      "Backfilled historical Anthropic usage rows from request-log accounting",
+    );
+  });
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -81,6 +81,7 @@ export { migrateBackfillContactInteractionStats } from "./135-backfill-contact-i
 export { migrateDropAssistantIdColumns } from "./136-drop-assistant-id-columns.js";
 export { migrateUsageDashboardIndexes } from "./137-usage-dashboard-indexes.js";
 export { migrateDropUsageCompositeIndexes } from "./139-drop-usage-composite-indexes.js";
+export { migrateBackfillUsageCacheAccounting } from "./140-backfill-usage-cache-accounting.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -141,6 +141,12 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Drop assistant_id columns from all 16 daemon tables after normalization to single-tenant identity",
   },
+  {
+    key: "migration_backfill_usage_cache_accounting_v1",
+    version: 20,
+    description:
+      "Backfill historical Anthropic llm_usage_events rows from llm_request_logs with cache-aware pricing",
+  },
 ];
 
 export interface MigrationValidationResult {


### PR DESCRIPTION
## Summary
- add a checkpointed migration that reconstructs Anthropic usage events from llm_request_logs and rewrites historical rows to direct input plus cache totals
- recompute historical estimated cost with the cache-aware pricing helper while preserving rows that cannot be reconstructed confidently
- add a migration test covering a flattened March 6-7 style row and a missing-log row that should remain untouched

Part of plan: anthropic-usage-cost-fix.md (PR 7 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
