### PR TITLE
fix: rollback unread state when delivery fails

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -899,6 +899,10 @@ class IOSThreadStore: ObservableObject {
         let latestAssistantMessageAt =
             threads[idx].latestAssistantMessageAt
             ?? latestLoadedAssistantMessageTimestamp(for: threads[idx].id)
+        guard let latestAssistantMessageAt else { return }
+
+        let previousLastSeenAssistantMessageAt = threads[idx].lastSeenAssistantMessageAt
+        let previousOverride = pendingAttentionOverrides[sessionId]
 
         pendingAttentionOverrides[sessionId] = .unread(
             latestAssistantMessageAt: latestAssistantMessageAt
@@ -916,7 +920,20 @@ class IOSThreadStore: ObservableObject {
             source: "ui-navigation",
             evidenceText: "User selected Mark as unread"
         )
-        try? daemonClient.send(signal)
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await self.daemonClient.sendConversationUnread(signal)
+            } catch {
+                self.rollbackUnreadMutationIfNeeded(
+                    threadId: thread.id,
+                    sessionId: sessionId,
+                    latestAssistantMessageAt: latestAssistantMessageAt,
+                    previousLastSeenAssistantMessageAt: previousLastSeenAssistantMessageAt,
+                    previousOverride: previousOverride
+                )
+            }
+        }
     }
 
     func unarchiveThread(_ thread: IOSThread) {
@@ -932,6 +949,28 @@ class IOSThreadStore: ObservableObject {
         guard let idx = threads.firstIndex(where: { $0.id == threadId }) else { return }
         threads[idx].lastActivityAt = Date()
         save()
+    }
+
+    private func rollbackUnreadMutationIfNeeded(
+        threadId: UUID,
+        sessionId: String,
+        latestAssistantMessageAt: Date,
+        previousLastSeenAssistantMessageAt: Date?,
+        previousOverride: PendingAttentionOverride?
+    ) {
+        guard let idx = threads.firstIndex(where: { $0.id == threadId }),
+              threads[idx].sessionId == sessionId,
+              case .unread(let pendingLatestAssistantMessageAt) = pendingAttentionOverrides[sessionId],
+              pendingLatestAssistantMessageAt == latestAssistantMessageAt else { return }
+
+        if let previousOverride {
+            pendingAttentionOverrides[sessionId] = previousOverride
+        } else {
+            pendingAttentionOverrides.removeValue(forKey: sessionId)
+        }
+        threads[idx].hasUnseenLatestAssistantMessage = false
+        threads[idx].lastSeenAssistantMessageAt = previousLastSeenAssistantMessageAt
+        saveConnectedCache()
     }
 
     /// Returns the last message text for a thread, if available.

--- a/clients/ios/Tests/ThreadLifecycleIOSTests.swift
+++ b/clients/ios/Tests/ThreadLifecycleIOSTests.swift
@@ -540,6 +540,7 @@ final class ThreadLifecycleIOSTests: XCTestCase {
         }
 
         store.markThreadUnread(storedThread)
+        waitForAsyncMutation()
 
         guard let updatedThread = store.threads.first(where: { $0.id == storedThread.id }) else {
             XCTFail("Expected updated thread")
@@ -596,6 +597,45 @@ final class ThreadLifecycleIOSTests: XCTestCase {
 
         XCTAssertTrue(sentSignals.isEmpty)
         XCTAssertTrue(store.threads.first(where: { $0.id == storedThread.id })?.hasUnseenLatestAssistantMessage ?? false)
+    }
+
+    func testMarkingSeenConnectedThreadUnreadRollsBackWhenSendFails() {
+        let daemonClient = DaemonClient()
+        daemonClient.sendOverride = { _ in
+            throw NSError(domain: "ThreadLifecycleIOSTests", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "offline"
+            ])
+        }
+
+        let store = IOSThreadStore(daemonClient: daemonClient)
+        let response = makeSessionListResponse(sessions: [[
+            "id": "connected-session-unread-failure",
+            "title": "Seen thread",
+            "createdAt": 1_000,
+            "updatedAt": 2_000,
+            "assistantAttention": [
+                "hasUnseenLatestAssistantMessage": false,
+                "latestAssistantMessageAt": 5_000,
+                "lastSeenAssistantMessageAt": 5_000,
+            ],
+        ]])
+
+        daemonClient.onSessionListResponse?(response)
+        guard let storedThread = store.threads.first(where: { $0.sessionId == "connected-session-unread-failure" }) else {
+            XCTFail("Expected connected thread")
+            return
+        }
+
+        store.markThreadUnread(storedThread)
+        waitForAsyncMutation()
+
+        guard let updatedThread = store.threads.first(where: { $0.id == storedThread.id }) else {
+            XCTFail("Expected updated thread")
+            return
+        }
+
+        XCTAssertFalse(updatedThread.hasUnseenLatestAssistantMessage)
+        XCTAssertEqual(updatedThread.lastSeenAssistantMessageAt?.timeIntervalSince1970, 5.0)
     }
 
     func testMarkingThreadWithoutAssistantReplyUnreadDoesNothing() {
@@ -929,6 +969,14 @@ final class ThreadLifecycleIOSTests: XCTestCase {
 
         XCTAssertFalse(store.threads[0].isPinned)
         XCTAssertNil(store.threads[0].displayOrder)
+    }
+
+    private func waitForAsyncMutation() {
+        let expectation = XCTestExpectation(description: "async mutation")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
     }
     #endif
 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1132,13 +1132,32 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
               let sessionId = threads[idx].sessionId,
               canMarkConversationUnread(threadId: threadId, at: idx) else { return }
 
+        let latestAssistantMessageAt = threads[idx].latestAssistantMessageAt
+
+        let previousLastSeenAssistantMessageAt = threads[idx].lastSeenAssistantMessageAt
+        let previousOverride = pendingAttentionOverrides[sessionId]
+
         pendingSeenSessionIds.removeAll { $0 == sessionId }
         pendingAttentionOverrides[sessionId] = .unread(
-            latestAssistantMessageAt: threads[idx].latestAssistantMessageAt
+            latestAssistantMessageAt: latestAssistantMessageAt
         )
         threads[idx].hasUnseenLatestAssistantMessage = true
         threads[idx].lastSeenAssistantMessageAt = nil
-        emitConversationUnreadSignal(conversationId: sessionId)
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await self.emitConversationUnreadSignal(conversationId: sessionId)
+            } catch {
+                self.rollbackUnreadMutationIfNeeded(
+                    threadId: threadId,
+                    sessionId: sessionId,
+                    latestAssistantMessageAt: latestAssistantMessageAt,
+                    previousLastSeenAssistantMessageAt: previousLastSeenAssistantMessageAt,
+                    previousOverride: previousOverride
+                )
+                log.warning("Failed to send conversation_unread_signal for \(sessionId): \(error.localizedDescription)")
+            }
+        }
     }
 
     /// Set a pending anchor message for scroll-to behavior on notification deep links.
@@ -1241,7 +1260,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
     }
 
-    private func emitConversationUnreadSignal(conversationId: String) {
+    private func emitConversationUnreadSignal(conversationId: String) async throws {
         let signal = IPCConversationUnreadSignal(
             conversationId: conversationId,
             sourceChannel: "vellum",
@@ -1250,11 +1269,28 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
             source: "ui-navigation",
             evidenceText: "User selected Mark as unread"
         )
-        do {
-            try daemonClient.send(signal)
-        } catch {
-            log.warning("Failed to send conversation_unread_signal for \(conversationId): \(error.localizedDescription)")
+        try await daemonClient.sendConversationUnread(signal)
+    }
+
+    private func rollbackUnreadMutationIfNeeded(
+        threadId: UUID,
+        sessionId: String,
+        latestAssistantMessageAt: Date?,
+        previousLastSeenAssistantMessageAt: Date?,
+        previousOverride: PendingAttentionOverride?
+    ) {
+        guard let idx = threads.firstIndex(where: { $0.id == threadId }),
+              threads[idx].sessionId == sessionId,
+              case .unread(let pendingLatestAssistantMessageAt) = pendingAttentionOverrides[sessionId],
+              pendingLatestAssistantMessageAt == latestAssistantMessageAt else { return }
+
+        if let previousOverride {
+            pendingAttentionOverrides[sessionId] = previousOverride
+        } else {
+            pendingAttentionOverrides.removeValue(forKey: sessionId)
         }
+        threads[idx].hasUnseenLatestAssistantMessage = false
+        threads[idx].lastSeenAssistantMessageAt = previousLastSeenAssistantMessageAt
     }
 
     /// Trim the previously active thread's view model to shed memory before

--- a/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
@@ -294,6 +294,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         sentMessages.removeAll()
 
         threadManager.markConversationUnread(threadId: threadId)
+        waitForPropagation()
 
         XCTAssertTrue(threadManager.threads[index].hasUnseenLatestAssistantMessage,
                       "markConversationUnread should set the unseen flag")
@@ -345,6 +346,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         sentMessages.removeAll()
 
         threadManager.markConversationUnread(threadId: threadId)
+        waitForPropagation()
 
         XCTAssertTrue(threadManager.threads[index].hasUnseenLatestAssistantMessage,
                       "Live assistant replies should allow unread even before hydration backfills timestamps")
@@ -352,6 +354,34 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         let unreadSignals = sentMessages.compactMap { $0 as? IPCConversationUnreadSignal }
         XCTAssertEqual(unreadSignals.count, 1)
         XCTAssertEqual(unreadSignals.last?.conversationId, "session-live-unread")
+    }
+
+    func testMarkConversationUnreadRollsBackWhenSendFails() {
+        guard let threadId = threadManager.activeThreadId,
+              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active thread")
+            return
+        }
+
+        daemonClient.sendOverride = { _ in
+            throw NSError(domain: "ThreadManagerUnseenStateTests", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "offline"
+            ])
+        }
+
+        threadManager.threads[index].sessionId = "session-unread-failure"
+        threadManager.threads[index].hasUnseenLatestAssistantMessage = false
+        threadManager.threads[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 9)
+        threadManager.threads[index].lastSeenAssistantMessageAt = Date(timeIntervalSince1970: 9)
+
+        threadManager.markConversationUnread(threadId: threadId)
+        waitForPropagation()
+
+        XCTAssertFalse(threadManager.threads[index].hasUnseenLatestAssistantMessage)
+        XCTAssertEqual(
+            threadManager.threads[index].lastSeenAssistantMessageAt,
+            Date(timeIntervalSince1970: 9)
+        )
     }
 
     func testMarkConversationUnreadIgnoresThreadsWithoutAssistantReply() {
@@ -479,6 +509,7 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
 
         threadManager.markConversationUnread(threadId: firstThreadId)
         threadManager.commitPendingSeenSignals()
+        waitForPropagation()
 
         let unreadSignals = sentMessages.compactMap { $0 as? IPCConversationUnreadSignal }
         XCTAssertEqual(unreadSignals.map(\.conversationId), ["session-first"])

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -142,6 +142,7 @@ public protocol DaemonClientProtocol {
     var isBlobTransportAvailable: Bool { get }
     func subscribe() -> AsyncStream<ServerMessage>
     func send<T: Encodable>(_ message: T) throws
+    func sendConversationUnread(_ signal: IPCConversationUnreadSignal) async throws
     func connect() async throws
     func disconnect()
     func startSSE()
@@ -153,6 +154,10 @@ public protocol DaemonClientProtocol {
 }
 
 extension DaemonClientProtocol {
+    public func sendConversationUnread(_ signal: IPCConversationUnreadSignal) async throws {
+        try send(signal)
+    }
+
     /// Default no-op implementation for clients that don't support HTTP surface fetches.
     public func fetchSurfaceData(surfaceId: String, sessionId: String) async -> SurfaceData? { nil }
     public func fetchUsageTotals(from: Int, to: Int) async -> UsageTotalsResponse? { nil }
@@ -927,6 +932,23 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                 log.error("Send failed: \(error.localizedDescription)")
             }
         })
+    }
+
+    public func sendConversationUnread(_ signal: IPCConversationUnreadSignal) async throws {
+        if let override = sendOverride {
+            try override(signal)
+            return
+        }
+
+        if let httpTransport {
+            guard httpTransport.isConnected else {
+                throw SendError.notConnected
+            }
+            try await httpTransport.sendConversationUnread(signal)
+            return
+        }
+
+        try send(signal)
     }
 
     // MARK: - Surface Actions

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -40,6 +40,14 @@ struct ConversationsListResponse: Decodable {
     let hasMore: Bool?
 }
 
+private struct HTTPErrorEnvelope: Decodable {
+    struct ErrorBody: Decodable {
+        let message: String
+    }
+
+    let error: ErrorBody
+}
+
 // MARK: - HTTP Transport
 
 /// Internal helper that handles HTTP REST + SSE communication with a remote
@@ -658,7 +666,13 @@ public final class HTTPTransport {
         } else if let msg = message as? IPCConversationSeenSignal {
             Task { await self.sendConversationSeen(msg) }
         } else if let msg = message as? IPCConversationUnreadSignal {
-            Task { await self.sendConversationUnread(msg) }
+            Task {
+                do {
+                    try await self.sendConversationUnread(msg)
+                } catch {
+                    log.error("Conversation unread signal error: \(error.localizedDescription)")
+                }
+            }
         } else if let msg = message as? GuardianActionsPendingRequestMessage {
             Task { await self.fetchGuardianActionsPending(conversationId: msg.conversationId) }
         } else if let msg = message as? GuardianActionDecisionMessage {
@@ -1003,8 +1017,10 @@ public final class HTTPTransport {
         }
     }
 
-    private func sendConversationUnread(_ signal: IPCConversationUnreadSignal, isRetry: Bool = false) async {
-        guard let url = buildURL(for: .conversationsUnread) else { return }
+    func sendConversationUnread(_ signal: IPCConversationUnreadSignal, isRetry: Bool = false) async throws {
+        guard let url = buildURL(for: .conversationsUnread) else {
+            throw HTTPTransportError.invalidURL
+        }
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -1032,19 +1048,46 @@ public final class HTTPTransport {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
             let (data, response) = try await URLSession.shared.data(for: request)
 
-            if let http = response as? HTTPURLResponse {
-                if http.statusCode == 401 && !isRetry {
-                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
-                    if case .success = refreshResult {
-                        await sendConversationUnread(signal, isRetry: true)
-                    }
-                } else if http.statusCode != 200 {
-                    log.error("Conversation unread signal failed (\(http.statusCode))")
+            guard let http = response as? HTTPURLResponse else {
+                throw HTTPTransportError.healthCheckFailed
+            }
+
+            if http.statusCode == 401 && !isRetry {
+                let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                switch refreshResult {
+                case .success:
+                    try await sendConversationUnread(signal, isRetry: true)
+                    return
+                case .transientFailure:
+                    throw HTTPTransportError.authenticationFailed(
+                        message: decodeHTTPErrorMessage(from: data) ?? "Authentication refresh failed"
+                    )
+                case .terminalFailure:
+                    throw HTTPTransportError.authenticationFailed(
+                        message: decodeHTTPErrorMessage(from: data) ?? "Authentication failed"
+                    )
                 }
             }
+
+            guard http.statusCode == 200 else {
+                throw HTTPTransportError.requestFailed(
+                    statusCode: http.statusCode,
+                    message: decodeHTTPErrorMessage(from: data)
+                )
+            }
         } catch {
-            log.error("Conversation unread signal error: \(error.localizedDescription)")
+            throw error
         }
+    }
+
+    private func decodeHTTPErrorMessage(from data: Data) -> String? {
+        if let envelope = try? decoder.decode(HTTPErrorEnvelope.self, from: data) {
+            return envelope.error.message
+        }
+        guard let body = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !body.isEmpty else { return nil }
+        return body
     }
 
     // MARK: - Contacts
@@ -2282,6 +2325,8 @@ public final class HTTPTransport {
     enum HTTPTransportError: Error, LocalizedError {
         case healthCheckFailed
         case invalidURL
+        case requestFailed(statusCode: Int, message: String?)
+        case authenticationFailed(message: String)
 
         var errorDescription: String? {
             switch self {
@@ -2289,6 +2334,10 @@ public final class HTTPTransport {
                 return "Remote assistant health check failed"
             case .invalidURL:
                 return "Invalid remote assistant URL"
+            case .requestFailed(let statusCode, let message):
+                return message ?? "HTTP request failed (\(statusCode))"
+            case .authenticationFailed(let message):
+                return message
             }
         }
     }

--- a/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
+++ b/clients/shared/Tests/HTTPDaemonClientUnreadTests.swift
@@ -133,6 +133,47 @@ final class HTTPDaemonClientUnreadTests: XCTestCase {
         )
     }
 
+    func testAwaitedUnreadSignalThrowsDecodedRuntimeError() async throws {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 422,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (
+                response,
+                Data(#"{"error":{"code":"UNPROCESSABLE_ENTITY","message":"Conversation has no assistant message to mark unread"}}"#.utf8)
+            )
+        }
+
+        let transport = HTTPTransport(
+            baseURL: "https://example.com",
+            bearerToken: "test-token",
+            conversationKey: "conv-local"
+        )
+
+        do {
+            try await transport.sendConversationUnread(
+                IPCConversationUnreadSignal(
+                    conversationId: "conv-123",
+                    sourceChannel: "vellum",
+                    signalType: "macos_conversation_opened",
+                    confidence: "explicit",
+                    source: "ui-navigation"
+                )
+            )
+            XCTFail("Expected sendConversationUnread to throw")
+        } catch let error as HTTPTransport.HTTPTransportError {
+            XCTAssertEqual(
+                error.errorDescription,
+                "Conversation has no assistant message to mark unread"
+            )
+        } catch {
+            XCTFail("Expected HTTPTransportError, got \(error)")
+        }
+    }
+
     func testPlatformProxyUnreadSignalPostsExpectedRequest() async throws {
         let requestExpectation = expectation(description: "platform unread request")
         var capturedRequest: URLRequest?


### PR DESCRIPTION
## Summary
- await mark-unread delivery in the shared daemon client so HTTP failures surface back to callers
- roll back optimistic unread state in macOS and iOS when the unread write is rejected or cannot be sent
- add focused unread transport and native store regression coverage

## Original prompt
Can you address these items in separate PRs?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
