### PR TITLE
fix: update stale SMS test references after SMS removal

### DIFF
--- a/assistant/src/__tests__/bundled-skill-retrieval-guard.test.ts
+++ b/assistant/src/__tests__/bundled-skill-retrieval-guard.test.ts
@@ -52,12 +52,6 @@ const GATEWAY_RETRIEVAL_BANLIST: Array<{
     ],
   },
   {
-    skillPath: "sms-setup/SKILL.md",
-    bannedSnippets: [
-      'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/twilio/sms/compliance"',
-    ],
-  },
-  {
     skillPath: "contacts/SKILL.md",
     bannedSnippets: [
       'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/ingress/members',

--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -1044,11 +1044,11 @@ describe("SMS channel approval decisions", () => {
 // 16. SMS guardian verify intercept
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe("SMS guardian verify intercept", () => {
-  test("verification code reply works with sourceChannel sms", async () => {
+describe("telegram guardian verify intercept", () => {
+  test("verification code reply works with sourceChannel telegram", async () => {
     const { createVerificationChallenge } =
       await import("../runtime/channel-guardian-service.js");
-    const { secret } = createVerificationChallenge("sms");
+    const { secret } = createVerificationChallenge("telegram");
 
     const deliverSpy = spyOn(
       gatewayClient,
@@ -1061,12 +1061,12 @@ describe("SMS guardian verify intercept", () => {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        sourceChannel: "sms",
-        interface: "sms",
-        conversationExternalId: "sms-chat-verify",
+        sourceChannel: "telegram",
+        interface: "telegram",
+        conversationExternalId: "tg-chat-verify",
         externalMessageId: `msg-${Date.now()}-${Math.random()}`,
         content: secret,
-        actorExternalId: "sms-user-42",
+        actorExternalId: "tg-user-42",
         replyCallbackUrl: "https://gateway.test/deliver",
       }),
     });
@@ -1080,7 +1080,7 @@ describe("SMS guardian verify intercept", () => {
     expect(deliverSpy).toHaveBeenCalled();
     const replyArgs = deliverSpy.mock.calls[0];
     const replyPayload = replyArgs[1] as { chatId: string; text: string };
-    expect(replyPayload.chatId).toBe("sms-chat-verify");
+    expect(replyPayload.chatId).toBe("tg-chat-verify");
     expect(typeof replyPayload.text).toBe("string");
     expect(replyPayload.text.toLowerCase()).toContain("guardian");
     expect(replyPayload.text.toLowerCase()).toContain("verif");
@@ -1088,11 +1088,11 @@ describe("SMS guardian verify intercept", () => {
     deliverSpy.mockRestore();
   });
 
-  test("invalid verification code returns failed via SMS", async () => {
+  test("invalid verification code returns failed via telegram", async () => {
     const { createVerificationChallenge } =
       await import("../runtime/channel-guardian-service.js");
     // Ensure there is a pending challenge so bare-code verification is intercepted.
-    createVerificationChallenge("sms");
+    createVerificationChallenge("telegram");
 
     const deliverSpy = spyOn(
       gatewayClient,
@@ -1105,12 +1105,12 @@ describe("SMS guardian verify intercept", () => {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        sourceChannel: "sms",
-        interface: "sms",
-        conversationExternalId: "sms-chat-verify-fail",
+        sourceChannel: "telegram",
+        interface: "telegram",
+        conversationExternalId: "tg-chat-verify-fail",
         externalMessageId: `msg-${Date.now()}-${Math.random()}`,
         content: "000000",
-        actorExternalId: "sms-user-43",
+        actorExternalId: "tg-user-43",
         replyCallbackUrl: "https://gateway.test/deliver",
       }),
     });
@@ -1140,7 +1140,7 @@ describe("SMS guardian verify intercept", () => {
     const challengeHash = createHash("sha256").update(secret).digest("hex");
     createChallenge({
       id: `challenge-hex-${Date.now()}`,
-      channel: "sms",
+      channel: "telegram",
       challengeHash,
       expiresAt: Date.now() + 600_000,
     });
@@ -1157,12 +1157,12 @@ describe("SMS guardian verify intercept", () => {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        sourceChannel: "sms",
-        interface: "sms",
-        conversationExternalId: "sms-chat-hex-message",
+        sourceChannel: "telegram",
+        interface: "telegram",
+        conversationExternalId: "tg-chat-hex-message",
         externalMessageId: `msg-${Date.now()}-${Math.random()}`,
         content: secret,
-        actorExternalId: "sms-user-hex",
+        actorExternalId: "tg-user-hex",
         replyCallbackUrl: "https://gateway.test/deliver",
       }),
     });

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -32,25 +32,6 @@ mock.module("../util/logger.js", () => ({
 
 import type * as net from "node:net";
 
-// SMS client mock — outbound SMS delivery is fire-and-forget, so we just track calls.
-const smsSendCalls: Array<{
-  to: string;
-  text: string;
-  assistantId?: string;
-}> = [];
-mock.module("../messaging/providers/sms/client.js", () => ({
-  sendMessage: async (
-    _gatewayUrl: string,
-    _bearerToken: string,
-    to: string,
-    text: string,
-    assistantId?: string,
-  ) => {
-    smsSendCalls.push({ to, text, assistantId });
-    return { messageSid: "SM-mock", status: "queued" };
-  },
-}));
-
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => true,
   getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
@@ -189,7 +170,6 @@ function resetTables(): void {
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
   db.run("DELETE FROM external_conversation_bindings");
-  smsSendCalls.length = 0;
   telegramDeliverCalls.length = 0;
   voiceCallInitCalls.length = 0;
   mockBotUsername = "test_bot";
@@ -2937,7 +2917,7 @@ describe("outbound SMS verification", () => {
     expect(resp!.error).toBe("invalid_destination");
   });
 
-  test("start_outbound normalizes formatted phone number for SMS", async () => {
+  test("start_outbound normalizes formatted phone number for voice", async () => {
     const { ctx, lastResponse } = createMockCtx();
     await handleGuardianVerification(
       {
@@ -2962,13 +2942,13 @@ describe("outbound SMS verification", () => {
     expect(session!.expectedPhoneE164).toBe("+15551234567");
     expect(session!.destinationAddress).toBe("+15551234567");
 
-    // Allow fire-and-forget SMS delivery to complete
+    // Allow fire-and-forget voice call delivery to complete
     await new Promise((resolve) => setTimeout(resolve, 50));
 
-    // Verify SMS was sent to the normalized number
-    expect(smsSendCalls.length).toBeGreaterThanOrEqual(1);
-    const lastSms = smsSendCalls[smsSendCalls.length - 1];
-    expect(lastSms.to).toBe("+15551234567");
+    // Verify voice call was initiated to the normalized number
+    expect(voiceCallInitCalls.length).toBeGreaterThanOrEqual(1);
+    const lastCall = voiceCallInitCalls[voiceCallInitCalls.length - 1];
+    expect(lastCall.phoneNumber).toBe("+15551234567");
   });
 
   test("template composer includes Vellum assistant prefix", () => {

--- a/assistant/src/__tests__/channel-invite-transport.test.ts
+++ b/assistant/src/__tests__/channel-invite-transport.test.ts
@@ -111,7 +111,6 @@ describe("createInviteAdapterRegistry", () => {
   const builtInChannels = [
     "email",
     "slack",
-    "voice",
     "telegram",
     "voice",
     "whatsapp",

--- a/assistant/src/__tests__/channel-policy.test.ts
+++ b/assistant/src/__tests__/channel-policy.test.ts
@@ -99,7 +99,7 @@ describe("channel policy registry", () => {
     const expectedStrategies: [ChannelId, ConversationStrategy][] = [
       ["vellum", "start_new_conversation"],
       ["telegram", "continue_existing_conversation"],
-      ["voice", "continue_existing_conversation"],
+      ["slack", "continue_existing_conversation"],
       ["voice", "not_deliverable"],
     ];
 
@@ -121,24 +121,21 @@ describe("channel policy registry", () => {
     }
   });
 
-  // ── SMS channel policy ───────────────────────────────────────────────
+  // ── Voice channel policy ─────────────────────────────────────────────
 
-  test("SMS is a deliverable notification channel", () => {
-    expect(isNotificationDeliverable("voice")).toBe(true);
-    expect(getDeliverableChannels()).toContain("voice");
+  test("voice is not a deliverable notification channel", () => {
+    expect(isNotificationDeliverable("voice")).toBe(false);
+    expect(getDeliverableChannels()).not.toContain("voice");
   });
 
-  test("SMS uses continue_existing_conversation strategy", () => {
-    expect(getConversationStrategy("voice")).toBe(
-      "continue_existing_conversation",
-    );
+  test("voice uses not_deliverable strategy", () => {
+    expect(getConversationStrategy("voice")).toBe("not_deliverable");
   });
 
-  test("all_channels includes SMS when SMS is deliverable", () => {
+  test("deliverable channels include vellum and telegram", () => {
     const deliverable = getDeliverableChannels();
     expect(deliverable).toContain("vellum");
     expect(deliverable).toContain("telegram");
-    expect(deliverable).toContain("voice");
   });
 
   // ── Consistency checks ────────────────────────────────────────────────

--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -190,7 +190,7 @@ describe("ChannelReadinessService", () => {
       service as unknown as {
         snapshots: Map<string, { checkedAt: number }>;
       }
-    ).snapshots.get("sms::__default__")!;
+    ).snapshots.get("voice::__default__")!;
     cached.checkedAt = Date.now() - REMOTE_TTL_MS - 1;
 
     // Second call should re-run remote checks
@@ -283,7 +283,7 @@ describe("ChannelReadinessService", () => {
 
     expect(snapshots).toHaveLength(2);
     const channels = snapshots.map((s) => s.channel).sort();
-    expect(channels).toEqual(["voice", "telegram"]);
+    expect(channels).toEqual(["telegram", "voice"]);
   });
 
   test("cached remote checks preserve original checkedAt (TTL not reset on reuse)", async () => {
@@ -379,7 +379,7 @@ describe("ChannelReadinessService", () => {
       service as unknown as {
         snapshots: Map<string, { checkedAt: number }>;
       }
-    ).snapshots.get("sms::__default__")!;
+    ).snapshots.get("voice::__default__")!;
     cached.checkedAt = Date.now() - REMOTE_TTL_MS - 1;
 
     // Local-only call should not be blocked by stale remote failure

--- a/assistant/src/__tests__/conversation-attention-telegram.test.ts
+++ b/assistant/src/__tests__/conversation-attention-telegram.test.ts
@@ -384,12 +384,11 @@ describe("duplicate event deduplication", () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe("non-Telegram channel filtering", () => {
-  test("SMS inbound message does not record a Telegram seen signal", async () => {
-    // Override contact store for SMS channel
+  test("email inbound message does not record a Telegram seen signal", async () => {
     const req = makeInboundRequest({
-      sourceChannel: "sms",
-      interface: "sms",
-      content: "sms message",
+      sourceChannel: "email",
+      interface: "email",
+      content: "email message",
     });
 
     const res = await handleChannelInbound(

--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -407,20 +407,20 @@ describe("pairDeliveryWithConversation", () => {
     };
     mockBindings["notification:sms:+15551234567"] = {
       conversationId: "conv-user-owned",
-      sourceChannel: "notification:sms",
-      externalChatId: "+15551234567",
+      sourceChannel: "notification:slack",
+      externalChatId: "C0123ABCDEF",
     };
 
     const signal = makeSignal();
     const copy = makeCopy();
     const bindingContext: DestinationBindingContext = {
-      sourceChannel: "sms" as NotificationChannel,
-      externalChatId: "+15551234567",
+      sourceChannel: "slack" as NotificationChannel,
+      externalChatId: "C0123ABCDEF",
     };
 
     const result = await pairDeliveryWithConversation(
       signal,
-      "sms" as NotificationChannel,
+      "slack" as NotificationChannel,
       copy,
       { bindingContext },
     );
@@ -436,7 +436,7 @@ describe("pairDeliveryWithConversation", () => {
       unknown
     >;
     expect(upsertArgs.conversationId).toBe("conv-001");
-    expect(upsertArgs.sourceChannel).toBe("notification:sms");
+    expect(upsertArgs.sourceChannel).toBe("notification:slack");
   });
 
   test("falls back to new conversation when bound conversation no longer exists", async () => {
@@ -546,13 +546,13 @@ describe("pairDeliveryWithConversation", () => {
       conversationId: "conv-gone",
     };
     const bindingContext: DestinationBindingContext = {
-      sourceChannel: "sms" as NotificationChannel,
-      externalChatId: "+15559876543",
+      sourceChannel: "slack" as NotificationChannel,
+      externalChatId: "C9876ZYXWVU",
     };
 
     const result = await pairDeliveryWithConversation(
       signal,
-      "sms" as NotificationChannel,
+      "slack" as NotificationChannel,
       copy,
       { threadAction, bindingContext },
     );

--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -750,7 +750,7 @@ describe("gateway-only ingress enforcement", () => {
       expect(res.status).toBe(401);
     });
 
-    test("POST /v1/channels/inbound with SMS and actor JWT returns 403", async () => {
+    test("POST /v1/channels/inbound with slack and actor JWT returns 403", async () => {
       const res = await fetch(`http://127.0.0.1:${port}/v1/channels/inbound`, {
         method: "POST",
         headers: {
@@ -758,13 +758,13 @@ describe("gateway-only ingress enforcement", () => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          sourceChannel: "sms",
-          externalChatId: "+15551234567",
-          externalMessageId: "SM-test-gw-1",
-          content: "hello via SMS",
+          sourceChannel: "slack",
+          externalChatId: "C0123ABCDEF",
+          externalMessageId: "slack-test-gw-1",
+          content: "hello via Slack",
         }),
       });
-      // SMS messages also require svc_gateway principal type.
+      // Channel inbound messages require svc_gateway principal type.
       expect(res.status).toBe(403);
       const body = (await res.json()) as {
         error: { code: string; message: string };
@@ -772,7 +772,7 @@ describe("gateway-only ingress enforcement", () => {
       expect(body.error.code).toBe("FORBIDDEN");
     });
 
-    test("POST /v1/channels/inbound with SMS and gateway JWT passes", async () => {
+    test("POST /v1/channels/inbound with slack and gateway JWT passes", async () => {
       const res = await fetch(`http://127.0.0.1:${port}/v1/channels/inbound`, {
         method: "POST",
         headers: {
@@ -780,10 +780,10 @@ describe("gateway-only ingress enforcement", () => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          sourceChannel: "sms",
-          externalChatId: "+15551234567",
-          externalMessageId: "SM-test-gw-2",
-          content: "hello via SMS",
+          sourceChannel: "slack",
+          externalChatId: "C0123ABCDEF",
+          externalMessageId: "slack-test-gw-2",
+          content: "hello via Slack",
         }),
       });
       // Should NOT be 403 — the svc_gateway principal type passes.

--- a/assistant/src/__tests__/notification-broadcaster.test.ts
+++ b/assistant/src/__tests__/notification-broadcaster.test.ts
@@ -417,26 +417,26 @@ describe("notification broadcaster", () => {
 
   // ── Destination binding context ────────────────────────────────────
 
-  test("SMS delivery carries destination binding context into pairing", async () => {
-    const smsAdapter = new MockAdapter("telegram");
-    const broadcaster = new NotificationBroadcaster([smsAdapter]);
+  test("Telegram delivery carries destination binding context into pairing (additional)", async () => {
+    const telegramAdapter2 = new MockAdapter("telegram");
+    const broadcaster = new NotificationBroadcaster([telegramAdapter2]);
 
     const signal = makeSignal();
     const decision = makeDecision({
       selectedChannels: ["telegram"],
       renderedCopy: {
-        telegram: { title: "SMS Alert", body: "Something happened" },
+        telegram: { title: "Telegram Alert", body: "Something happened" },
       },
     });
 
     await broadcaster.broadcastDecision(signal, decision);
 
-    const smsCall = pairingCalls.find((c) => c.channel === "telegram");
-    expect(smsCall).toBeDefined();
-    expect(smsCall!.options?.bindingContext).toEqual({
+    const telegramCall = pairingCalls.find((c) => c.channel === "telegram");
+    expect(telegramCall).toBeDefined();
+    expect(telegramCall!.options?.bindingContext).toEqual({
       sourceChannel: "telegram",
-      externalChatId: "ext-chat-sms",
-      externalUserId: "ext-user-sms",
+      externalChatId: "ext-chat-telegram",
+      externalUserId: "ext-user-telegram",
     });
   });
 

--- a/assistant/src/__tests__/notification-routing-intent.test.ts
+++ b/assistant/src/__tests__/notification-routing-intent.test.ts
@@ -104,13 +104,9 @@ describe("routing intent enforcement", () => {
       expect(enforced.selectedChannels).toEqual(["vellum"]);
     });
 
-    test("includes SMS when SMS is among connected channels", () => {
+    test("includes all connected channels in all_channels mode", () => {
       const decision = makeDecision({ selectedChannels: ["vellum"] });
-      const connected: NotificationChannel[] = [
-        "vellum",
-        "telegram",
-        "telegram",
-      ];
+      const connected: NotificationChannel[] = ["vellum", "telegram", "slack"];
 
       const enforced = enforceRoutingIntent(
         decision,
@@ -121,14 +117,14 @@ describe("routing intent enforcement", () => {
       expect(enforced.selectedChannels).toEqual([
         "vellum",
         "telegram",
-        "telegram",
+        "slack",
       ]);
       expect(enforced.reasoningSummary).toContain(
         "routing_intent=all_channels",
       );
     });
 
-    test("excludes SMS when SMS is not among connected channels", () => {
+    test("excludes disconnected channels from all_channels", () => {
       const decision = makeDecision({ selectedChannels: ["vellum"] });
       const connected: NotificationChannel[] = ["vellum", "telegram"];
 
@@ -139,7 +135,7 @@ describe("routing intent enforcement", () => {
       );
 
       expect(enforced.selectedChannels).toEqual(["vellum", "telegram"]);
-      expect(enforced.selectedChannels).not.toContain("telegram");
+      expect(enforced.selectedChannels).not.toContain("slack");
     });
   });
 

--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -648,7 +648,7 @@ describe("injectInboundActorContext", () => {
     const text = (injected as { type: "text"; text: string }).text;
     expect(text).toContain("<inbound_actor_context>");
     expect(text).toContain("trust_class: guardian");
-    expect(text).toContain("source_channel: sms");
+    expect(text).toContain("source_channel: voice");
     expect(text).toContain("canonical_actor_identity: guardian-user-1");
     expect(text).toContain("actor_display_name: Guardian Name");
     expect(text).toContain("actor_sender_display_name: Guardian Name");

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -2,8 +2,8 @@
  * Tests verifying the trusted contact flow is channel-agnostic.
  *
  * The access request -> guardian notification -> verification -> activation
- * flow should work identically across Telegram, SMS, and voice channels.
- * These tests confirm no Telegram-specific assumptions leaked into the
+ * flow should work identically across all channels.
+ * These tests confirm no channel-specific assumptions leaked into the
  * trusted contact code paths.
  */
 import { mkdtempSync, rmSync } from "node:fs";
@@ -140,9 +140,8 @@ function resetState(): void {
 }
 
 interface ChannelTestConfig {
-  channel: "telegram" | "sms" | "voice";
+  channel: "telegram" | "slack";
   deliverEndpoint: string;
-  /** SMS/voice use phone E.164 as identifiers */
   senderExternalUserId: string;
   externalChatId: string;
   guardianExternalUserId: string;
@@ -159,12 +158,12 @@ const CHANNEL_CONFIGS: ChannelTestConfig[] = [
     guardianChatId: "tg-guardian-chat-789",
   },
   {
-    channel: "sms",
-    deliverEndpoint: "/deliver/sms",
-    senderExternalUserId: "+15551234567",
-    externalChatId: "+15551234567",
-    guardianExternalUserId: "+15559876543",
-    guardianChatId: "+15559876543",
+    channel: "slack",
+    deliverEndpoint: "/deliver/slack",
+    senderExternalUserId: "U0123ABCDEF",
+    externalChatId: "C0123ABCDEF",
+    guardianExternalUserId: "U9876ZYXWVU",
+    guardianChatId: "C9876ZYXWVU",
   },
 ];
 
@@ -318,7 +317,7 @@ for (const config of CHANNEL_CONFIGS) {
       expect(sameChanResult).not.toBeNull();
 
       // Should NOT be found on a different channel
-      const otherChannel = config.channel === "telegram" ? "sms" : "telegram";
+      const otherChannel = config.channel === "telegram" ? "slack" : "telegram";
       const crossChanResult = findContactChannel({
         channelType: otherChannel,
         externalUserId: config.senderExternalUserId,
@@ -329,18 +328,18 @@ for (const config of CHANNEL_CONFIGS) {
 }
 
 // ---------------------------------------------------------------------------
-// SMS-specific: phone E.164 identity binding
+// Voice-specific: phone E.164 identity binding
 // ---------------------------------------------------------------------------
 
-describe("SMS identity binding with E.164 phone numbers", () => {
+describe("voice identity binding with E.164 phone numbers", () => {
   beforeEach(() => {
     resetState();
   });
 
-  test("SMS verification session binds to phone E.164", () => {
+  test("voice verification session binds to phone E.164", () => {
     const phone = "+15551234567";
     const session = createOutboundSession({
-      channel: "sms",
+      channel: "voice",
       expectedExternalUserId: phone,
       expectedPhoneE164: phone,
       expectedChatId: phone,
@@ -351,7 +350,7 @@ describe("SMS identity binding with E.164 phone numbers", () => {
 
     // Verify with matching phone identity
     const result = validateAndConsumeChallenge(
-      "sms",
+      "voice",
       session.secret,
       phone,
       phone,
@@ -362,12 +361,12 @@ describe("SMS identity binding with E.164 phone numbers", () => {
     }
   });
 
-  test("SMS verification rejects mismatched phone identity", () => {
+  test("voice verification rejects mismatched phone identity", () => {
     const expectedPhone = "+15551234567";
     const wrongPhone = "+15559999999";
 
     const session = createOutboundSession({
-      channel: "sms",
+      channel: "voice",
       expectedExternalUserId: expectedPhone,
       expectedPhoneE164: expectedPhone,
       expectedChatId: expectedPhone,
@@ -377,7 +376,7 @@ describe("SMS identity binding with E.164 phone numbers", () => {
 
     // Try to verify with a different phone (anti-oracle: same error message)
     const result = validateAndConsumeChallenge(
-      "sms",
+      "voice",
       session.secret,
       wrongPhone,
       wrongPhone,
@@ -405,30 +404,29 @@ describe("cross-channel isolation", () => {
       destinationAddress: "chat-123",
     });
 
-    const smsSession = createOutboundSession({
-      channel: "sms",
-      expectedExternalUserId: "+15551234567",
-      expectedPhoneE164: "+15551234567",
-      expectedChatId: "+15551234567",
+    const slackSession = createOutboundSession({
+      channel: "slack",
+      expectedExternalUserId: "U0123ABCDEF",
+      expectedChatId: "C0123ABCDEF",
       identityBindingStatus: "bound",
-      destinationAddress: "+15551234567",
+      destinationAddress: "C0123ABCDEF",
     });
 
-    // Telegram code should not work on SMS channel
+    // Telegram code should not work on Slack channel
     const wrongChannelResult = validateAndConsumeChallenge(
-      "sms",
+      "slack",
       telegramSession.secret,
-      "+15551234567",
-      "+15551234567",
+      "U0123ABCDEF",
+      "C0123ABCDEF",
     );
     expect(wrongChannelResult.success).toBe(false);
 
-    // SMS code should work on SMS channel
+    // Slack code should work on Slack channel
     const correctChannelResult = validateAndConsumeChallenge(
-      "sms",
-      smsSession.secret,
-      "+15551234567",
-      "+15551234567",
+      "slack",
+      slackSession.secret,
+      "U0123ABCDEF",
+      "C0123ABCDEF",
     );
     expect(correctChannelResult.success).toBe(true);
   });


### PR DESCRIPTION
## Summary
- Updated 13 test files that still referenced `sms` as a channel ID after PR #13775 removed SMS from shared types
- Replaced SMS channel references with valid channels (telegram, slack, voice) and fixed assertions to match the current channel policy (voice is `not_deliverable`)
- Removed dead SMS client mock, fixed cache key typos, and removed the deleted sms-setup skill from the guard test banlist

## Original prompt
fix this ci failure: https://github.com/vellum-ai/vellum-assistant/actions/runs/22789613937/job/66113609197

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
