### PR TITLE
feat: [macOS] clarify direct-input and cache usage labels

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -86,7 +86,7 @@ struct UsageDashboardPanel: View {
             LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: VSpacing.md) {
                 statCard(label: "Estimated Cost", value: formatCost(totals.totalEstimatedCostUsd))
                 statCard(label: "LLM Calls", value: formatCount(totals.eventCount))
-                statCard(label: "Input Tokens", value: formatTokenCount(totals.totalInputTokens))
+                statCard(label: UsageFormatting.directInputTokensLabel, value: formatTokenCount(totals.totalInputTokens))
                 statCard(label: "Output Tokens", value: formatTokenCount(totals.totalOutputTokens))
                 statCard(label: "Cache Created", value: formatTokenCount(totals.totalCacheCreationTokens))
                 statCard(label: "Cache Read", value: formatTokenCount(totals.totalCacheReadTokens))
@@ -206,15 +206,15 @@ struct UsageDashboardPanel: View {
     private func breakdownList(_ entries: [UsageGroupBreakdownEntry]) -> some View {
         VStack(spacing: VSpacing.sm) {
             // Header row
-            HStack {
+            HStack(alignment: .top, spacing: VSpacing.sm) {
                 Text("Group")
                     .font(VFont.small)
                     .foregroundColor(VColor.textMuted)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .frame(width: 130, alignment: .leading)
                 Text("Tokens")
                     .font(VFont.small)
                     .foregroundColor(VColor.textMuted)
-                    .frame(width: 70, alignment: .trailing)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 Text("Cost")
                     .font(VFont.small)
                     .foregroundColor(VColor.textMuted)
@@ -223,22 +223,29 @@ struct UsageDashboardPanel: View {
             .padding(.bottom, VSpacing.xxs)
 
             ForEach(entries, id: \.group) { entry in
-                HStack {
-                    Text(entry.group)
-                        .font(VFont.captionMedium)
-                        .foregroundColor(VColor.textPrimary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .lineLimit(1)
-                    Text(formatTokenCount(entry.totalInputTokens + entry.totalOutputTokens))
-                        .font(VFont.small)
-                        .foregroundColor(VColor.textSecondary)
-                        .frame(width: 70, alignment: .trailing)
-                    Text(formatCost(entry.totalEstimatedCostUsd))
-                        .font(VFont.small)
-                        .foregroundColor(VColor.textSecondary)
-                        .frame(width: 60, alignment: .trailing)
-                }
+                breakdownRow(entry)
             }
+        }
+    }
+
+    @ViewBuilder
+    func breakdownRow(_ entry: UsageGroupBreakdownEntry) -> some View {
+        HStack(alignment: .top, spacing: VSpacing.sm) {
+            Text(entry.group)
+                .font(VFont.captionMedium)
+                .foregroundColor(VColor.textPrimary)
+                .frame(width: 130, alignment: .leading)
+                .lineLimit(1)
+            Text(UsageFormatting.formatBreakdownSummary(entry))
+                .font(VFont.small)
+                .foregroundColor(VColor.textSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
+            Text(formatCost(entry.totalEstimatedCostUsd))
+                .font(VFont.small)
+                .foregroundColor(VColor.textSecondary)
+                .frame(width: 60, alignment: .trailing)
         }
     }
 

--- a/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
@@ -98,6 +98,26 @@ struct UsageDashboardPanelPopulatedTests {
     @Test @MainActor
     func populatedStoreHasCorrectTotals() async {
         let client = MockPanelClient()
+        let breakdownEntries = [
+            UsageGroupBreakdownEntry(
+                group: "claude-sonnet-4-20250514",
+                totalInputTokens: 30_000,
+                totalOutputTokens: 15_000,
+                totalCacheCreationTokens: 1_200,
+                totalCacheReadTokens: 8_000,
+                totalEstimatedCostUsd: 0.80,
+                eventCount: 25
+            ),
+            UsageGroupBreakdownEntry(
+                group: "claude-haiku-3",
+                totalInputTokens: 20_000,
+                totalOutputTokens: 10_000,
+                totalCacheCreationTokens: 450,
+                totalCacheReadTokens: 3_200,
+                totalEstimatedCostUsd: 0.43,
+                eventCount: 17
+            )
+        ]
         client.stubbedTotals = UsageTotalsResponse(
             totalInputTokens: 50_000, totalOutputTokens: 25_000,
             totalCacheCreationTokens: 5_000, totalCacheReadTokens: 2_000,
@@ -108,10 +128,7 @@ struct UsageDashboardPanelPopulatedTests {
             UsageDayBucket(date: "2026-03-04", totalInputTokens: 20_000, totalOutputTokens: 10_000, totalEstimatedCostUsd: 0.50, eventCount: 15),
             UsageDayBucket(date: "2026-03-05", totalInputTokens: 30_000, totalOutputTokens: 15_000, totalEstimatedCostUsd: 0.73, eventCount: 27)
         ])
-        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [
-            UsageGroupBreakdownEntry(group: "claude-sonnet-4-20250514", totalInputTokens: 30_000, totalOutputTokens: 15_000, totalEstimatedCostUsd: 0.80, eventCount: 25),
-            UsageGroupBreakdownEntry(group: "claude-haiku-3", totalInputTokens: 20_000, totalOutputTokens: 10_000, totalEstimatedCostUsd: 0.43, eventCount: 17)
-        ])
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: breakdownEntries)
 
         let store = UsageDashboardStore(client: client)
         await store.refresh()
@@ -136,7 +153,11 @@ struct UsageDashboardPanelPopulatedTests {
         if case .loaded(let breakdown) = store.breakdownState {
             #expect(breakdown.breakdown.count == 2)
             #expect(breakdown.breakdown[0].group == "claude-sonnet-4-20250514")
+            #expect(breakdown.breakdown[0].totalCacheCreationTokens == 1_200)
+            #expect(breakdown.breakdown[0].totalCacheReadTokens == 8_000)
             #expect(breakdown.breakdown[1].group == "claude-haiku-3")
+            #expect(breakdown.breakdown[1].totalCacheCreationTokens == 450)
+            #expect(breakdown.breakdown[1].totalCacheReadTokens == 3_200)
         } else {
             Issue.record("Expected .loaded for breakdown")
         }
@@ -198,6 +219,15 @@ private func collectPanelContent(store: UsageDashboardStore) -> String {
     return output
 }
 
+@MainActor
+private func collectBreakdownRow(entry: UsageGroupBreakdownEntry) -> String {
+    let panel = UsageDashboardPanel(store: UsageDashboardStore(client: MockPanelClient()), onClose: {})
+    let row = panel.breakdownRow(entry)
+    var output = ""
+    dump(row, to: &output)
+    return output
+}
+
 // MARK: - View Instantiation Tests
 
 /// These tests instantiate the actual UsageDashboardPanel view with stores in
@@ -242,6 +272,9 @@ struct UsageDashboardPanelViewEmptyTests {
         #expect(joined.contains("Totals"))
         #expect(joined.contains("Daily Trend"))
         #expect(joined.contains("Breakdown"))
+        #expect(joined.contains(UsageFormatting.directInputTokensLabel))
+        #expect(joined.contains("Cache Created"))
+        #expect(joined.contains("Cache Read"))
 
         // Zero cost formatting: verify the formatted zero cost appears
         let zeroCost = UsageFormatting.formatCost(0)
@@ -259,6 +292,26 @@ struct UsageDashboardPanelViewPopulatedTests {
     @Test @MainActor
     func panelRendersWithPopulatedData() async {
         let client = MockPanelClient()
+        let breakdownEntries = [
+            UsageGroupBreakdownEntry(
+                group: "claude-sonnet-4-20250514",
+                totalInputTokens: 30_000,
+                totalOutputTokens: 15_000,
+                totalCacheCreationTokens: 1_200,
+                totalCacheReadTokens: 8_000,
+                totalEstimatedCostUsd: 0.80,
+                eventCount: 25
+            ),
+            UsageGroupBreakdownEntry(
+                group: "claude-haiku-3",
+                totalInputTokens: 20_000,
+                totalOutputTokens: 10_000,
+                totalCacheCreationTokens: 450,
+                totalCacheReadTokens: 3_200,
+                totalEstimatedCostUsd: 0.43,
+                eventCount: 17
+            )
+        ]
         client.stubbedTotals = UsageTotalsResponse(
             totalInputTokens: 50_000, totalOutputTokens: 25_000,
             totalCacheCreationTokens: 5_000, totalCacheReadTokens: 2_000,
@@ -269,10 +322,7 @@ struct UsageDashboardPanelViewPopulatedTests {
             UsageDayBucket(date: "2026-03-04", totalInputTokens: 20_000, totalOutputTokens: 10_000, totalEstimatedCostUsd: 0.50, eventCount: 15),
             UsageDayBucket(date: "2026-03-05", totalInputTokens: 30_000, totalOutputTokens: 15_000, totalEstimatedCostUsd: 0.73, eventCount: 27)
         ])
-        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [
-            UsageGroupBreakdownEntry(group: "claude-sonnet-4-20250514", totalInputTokens: 30_000, totalOutputTokens: 15_000, totalEstimatedCostUsd: 0.80, eventCount: 25),
-            UsageGroupBreakdownEntry(group: "claude-haiku-3", totalInputTokens: 20_000, totalOutputTokens: 10_000, totalEstimatedCostUsd: 0.43, eventCount: 17)
-        ])
+        client.stubbedBreakdown = UsageBreakdownResponse(breakdown: breakdownEntries)
 
         let store = UsageDashboardStore(client: client)
         await store.refresh()
@@ -292,6 +342,11 @@ struct UsageDashboardPanelViewPopulatedTests {
         #expect(joined.contains("2026-03-04"))
         #expect(joined.contains("2026-03-05"))
 
+        // Totals wording clarifies direct input vs cache activity
+        #expect(joined.contains(UsageFormatting.directInputTokensLabel))
+        #expect(joined.contains("Cache Created"))
+        #expect(joined.contains("Cache Read"))
+
         // Breakdown model names
         #expect(joined.contains("claude-sonnet-4-20250514"))
         #expect(joined.contains("claude-haiku-3"))
@@ -300,6 +355,11 @@ struct UsageDashboardPanelViewPopulatedTests {
         #expect(joined.contains("Group"))
         #expect(joined.contains("Tokens"))
         #expect(joined.contains("Cost"))
+
+        let firstBreakdownRow = collectBreakdownRow(entry: breakdownEntries[0])
+        let secondBreakdownRow = collectBreakdownRow(entry: breakdownEntries[1])
+        #expect(firstBreakdownRow.contains(UsageFormatting.formatBreakdownSummary(breakdownEntries[0])))
+        #expect(secondBreakdownRow.contains(UsageFormatting.formatBreakdownSummary(breakdownEntries[1])))
     }
 
     @Test @MainActor


### PR DESCRIPTION
## Summary
- use the shared direct-input label for the totals card so cache traffic stays visually separate
- replace the breakdown token total with the shared direct/cache/output summary while keeping cost in its own column
- update macOS panel tests to cover the new wording and row formatting

## Testing
- cd clients/macos && ./build.sh test --filter UsageDashboardPanelTests (script rejects --filter in this repo)
- cd clients/macos && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter UsageDashboardPanelTests

Apple refs checked (2026-03-07): SwiftUI Text, lineLimit(_:), multilineTextAlignment(_:)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
