### PR TITLE
feat: preflight local voice ingress before starting a Twilio call

### DIFF
--- a/assistant/src/__tests__/call-domain.test.ts
+++ b/assistant/src/__tests__/call-domain.test.ts
@@ -4,6 +4,7 @@
  *
  * Validates:
  * - Strict implicit-default policy for caller identity.
+ * - Voice-ingress preflight blocks doomed outbound calls before Twilio dialing.
  * - Pointer messages are written on successful call start and on failure.
  */
 import { mkdtempSync, realpathSync, rmSync } from "node:fs";
@@ -35,6 +36,62 @@ mock.module("../util/logger.js", () => ({
 
 // Track whether the Twilio provider's initiateCall should succeed or throw
 let twilioInitiateCallBehavior: "success" | "error" = "success";
+let twilioInitiateCallCount = 0;
+let twilioInitiateCallArgs: Array<Record<string, unknown>> = [];
+let mockIngressEnabled = true;
+let mockIngressPublicBaseUrl = "https://test.example.com";
+
+interface MockGatewayHealthResult {
+  target: string;
+  healthy: boolean;
+  localDeployment: boolean;
+  error?: string;
+}
+
+interface MockEnsureLocalGatewayReadyResult extends MockGatewayHealthResult {
+  recovered: boolean;
+  recoveryAttempted: boolean;
+  recoverySkipped: boolean;
+}
+
+interface MockGatewayReconcileResult {
+  ok: boolean;
+  status?: number;
+  error?: string;
+}
+
+let probeLocalGatewayHealthResults: MockGatewayHealthResult[] = [];
+let probeLocalGatewayHealthCallCount = 0;
+let ensureLocalGatewayReadyResult: MockEnsureLocalGatewayReadyResult;
+let ensureLocalGatewayReadyCallCount = 0;
+let twilioReconcileResult: MockGatewayReconcileResult = {
+  ok: true,
+  status: 200,
+};
+let twilioReconcileCalls: Array<string | undefined> = [];
+
+function makeGatewayHealthResult(
+  overrides: Partial<MockGatewayHealthResult> = {},
+): MockGatewayHealthResult {
+  return {
+    target: "http://127.0.0.1:7830",
+    healthy: true,
+    localDeployment: true,
+    ...overrides,
+  };
+}
+
+function makeRecoveryResult(
+  overrides: Partial<MockEnsureLocalGatewayReadyResult> = {},
+): MockEnsureLocalGatewayReadyResult {
+  return {
+    ...makeGatewayHealthResult(),
+    recovered: false,
+    recoveryAttempted: false,
+    recoverySkipped: false,
+    ...overrides,
+  };
+}
 
 mock.module("../calls/twilio-config.js", () => ({
   getTwilioConfig: (assistantId?: string) => ({
@@ -55,7 +112,9 @@ mock.module("../calls/twilio-provider.js", () => ({
         reason: `${number} is not eligible as a caller ID`,
       };
     }
-    async initiateCall() {
+    async initiateCall(args: Record<string, unknown>) {
+      twilioInitiateCallCount++;
+      twilioInitiateCallArgs.push(args);
       if (twilioInitiateCallBehavior === "error")
         throw new Error("Twilio unavailable");
       return { callSid: "CA_test_123" };
@@ -74,6 +133,10 @@ mock.module("../config/loader.js", () => ({
       provider: "twilio",
       callerIdentity: { allowPerCallOverride: true },
     },
+    ingress: {
+      enabled: mockIngressEnabled,
+      publicBaseUrl: mockIngressPublicBaseUrl,
+    },
     memory: { enabled: false },
   }),
   getConfig: () => ({
@@ -81,6 +144,10 @@ mock.module("../config/loader.js", () => ({
       enabled: true,
       provider: "twilio",
       callerIdentity: { allowPerCallOverride: true },
+    },
+    ingress: {
+      enabled: mockIngressEnabled,
+      publicBaseUrl: mockIngressPublicBaseUrl,
     },
     memory: { enabled: false },
   }),
@@ -101,6 +168,26 @@ mock.module("../memory/conversation-title-service.js", () => ({
   queueGenerateConversationTitle: () => {},
 }));
 
+mock.module("../runtime/local-gateway-health.js", () => ({
+  probeLocalGatewayHealth: async () => {
+    probeLocalGatewayHealthCallCount++;
+    const next =
+      probeLocalGatewayHealthResults.shift() ?? makeGatewayHealthResult();
+    return next;
+  },
+  ensureLocalGatewayReady: async () => {
+    ensureLocalGatewayReadyCallCount++;
+    return ensureLocalGatewayReadyResult;
+  },
+}));
+
+mock.module("../daemon/handlers/config-ingress.js", () => ({
+  triggerGatewayTwilioReconcile: async (publicBaseUrl: string | undefined) => {
+    twilioReconcileCalls.push(publicBaseUrl);
+    return twilioReconcileResult;
+  },
+}));
+
 import { resolveCallerIdentity, startCall } from "../calls/call-domain.js";
 import type { AssistantConfig } from "../config/types.js";
 import { getMessages } from "../memory/conversation-store.js";
@@ -108,6 +195,24 @@ import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { conversations } from "../memory/schema.js";
 
 initializeDb();
+
+beforeEach(() => {
+  resetTables();
+  twilioInitiateCallBehavior = "success";
+  twilioInitiateCallCount = 0;
+  twilioInitiateCallArgs = [];
+  mockIngressEnabled = true;
+  mockIngressPublicBaseUrl = "https://test.example.com";
+  probeLocalGatewayHealthResults = [
+    makeGatewayHealthResult(),
+    makeGatewayHealthResult(),
+  ];
+  probeLocalGatewayHealthCallCount = 0;
+  ensureLocalGatewayReadyResult = makeRecoveryResult();
+  ensureLocalGatewayReadyCallCount = 0;
+  twilioReconcileResult = { ok: true, status: 200 };
+  twilioReconcileCalls = [];
+});
 
 let ensuredConvIds = new Set<string>();
 function ensureConversation(id: string): void {
@@ -288,11 +393,6 @@ describe("resolveCallerIdentity — strict implicit-default policy", () => {
 // ── Pointer message regression tests ──────────────────────────────
 
 describe("startCall — pointer message regression", () => {
-  beforeEach(() => {
-    resetTables();
-    twilioInitiateCallBehavior = "success";
-  });
-
   test("successful call writes a started pointer to the initiating conversation", async () => {
     const convId = "conv-domain-ptr-start";
     ensureConversation(convId);
@@ -304,6 +404,16 @@ describe("startCall — pointer message regression", () => {
     });
 
     expect(result.ok).toBe(true);
+    expect(twilioInitiateCallCount).toBe(1);
+    expect(twilioInitiateCallArgs).toEqual([
+      {
+        from: "+15550001111",
+        to: "+15559876543",
+        webhookUrl: "https://test.example.com/webhooks/twilio/voice/test",
+        statusCallbackUrl: "https://test.example.com/webhooks/twilio/status",
+      },
+    ]);
+    expect(twilioReconcileCalls).toEqual(["https://test.example.com"]);
     // Allow async pointer write to flush
     await new Promise((r) => setTimeout(r, 50));
 
@@ -311,6 +421,101 @@ describe("startCall — pointer message regression", () => {
     expect(text).not.toBeNull();
     expect(text!).toContain("+15559876543");
     expect(text!).toContain("started");
+  });
+
+  test("fails fast when ingress is disabled and never reaches Twilio dialing", async () => {
+    const convId = "conv-domain-ingress-disabled";
+    ensureConversation(convId);
+    mockIngressEnabled = false;
+
+    const result = await startCall({
+      phoneNumber: "+15559876543",
+      task: "Test call",
+      conversationId: convId,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(503);
+      expect(result.error).toContain("public ingress");
+    }
+    expect(probeLocalGatewayHealthCallCount).toBe(0);
+    expect(ensureLocalGatewayReadyCallCount).toBe(0);
+    expect(twilioReconcileCalls).toHaveLength(0);
+    expect(twilioInitiateCallCount).toBe(0);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const text = getLatestAssistantText(convId);
+    expect(text).not.toBeNull();
+    expect(text!).toContain("+15559876543");
+    expect(text!).toContain("failed");
+  });
+
+  test("never dials Twilio when the local callback gateway stays unhealthy", async () => {
+    const convId = "conv-domain-preflight-unhealthy";
+    ensureConversation(convId);
+    probeLocalGatewayHealthResults = [
+      makeGatewayHealthResult({
+        healthy: false,
+        error: "Gateway health check returned HTTP 503",
+      }),
+      makeGatewayHealthResult({
+        healthy: false,
+        error: "Gateway health check returned HTTP 503",
+      }),
+    ];
+    ensureLocalGatewayReadyResult = makeRecoveryResult({
+      healthy: false,
+      error: "Gateway health check returned HTTP 503",
+      recovered: false,
+      recoveryAttempted: true,
+    });
+
+    const result = await startCall({
+      phoneNumber: "+15559876543",
+      task: "Test call",
+      conversationId: convId,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(503);
+      expect(result.error).toContain("still unhealthy");
+    }
+    expect(probeLocalGatewayHealthCallCount).toBe(2);
+    expect(ensureLocalGatewayReadyCallCount).toBe(1);
+    expect(twilioReconcileCalls).toHaveLength(0);
+    expect(twilioInitiateCallCount).toBe(0);
+  });
+
+  test("can recover a local gateway and then place exactly one outbound Twilio call", async () => {
+    const convId = "conv-domain-preflight-recovery";
+    ensureConversation(convId);
+    probeLocalGatewayHealthResults = [
+      makeGatewayHealthResult({
+        healthy: false,
+        error: "Gateway health check returned HTTP 503",
+      }),
+      makeGatewayHealthResult(),
+    ];
+    ensureLocalGatewayReadyResult = makeRecoveryResult({
+      healthy: true,
+      recovered: true,
+      recoveryAttempted: true,
+    });
+
+    const result = await startCall({
+      phoneNumber: "+15559876543",
+      task: "Test call",
+      conversationId: convId,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(probeLocalGatewayHealthCallCount).toBe(2);
+    expect(ensureLocalGatewayReadyCallCount).toBe(1);
+    expect(twilioReconcileCalls).toEqual(["https://test.example.com"]);
+    expect(twilioInitiateCallCount).toBe(1);
   });
 
   test("failed call writes a failed pointer to the initiating conversation", async () => {
@@ -325,6 +530,7 @@ describe("startCall — pointer message regression", () => {
     });
 
     expect(result.ok).toBe(false);
+    expect(twilioInitiateCallCount).toBe(1);
     // Allow async pointer write to flush
     await new Promise((r) => setTimeout(r, 50));
 

--- a/assistant/src/__tests__/call-routes-http.test.ts
+++ b/assistant/src/__tests__/call-routes-http.test.ts
@@ -109,6 +109,19 @@ mock.module("../security/secure-keys.js", () => ({
   getSecureKey: () => null,
 }));
 
+mock.module("../calls/voice-ingress-preflight.js", () => ({
+  preflightVoiceIngress: async () => ({
+    ok: true,
+    publicBaseUrl: "https://test.example.com",
+    ingressConfig: {
+      ingress: {
+        enabled: true,
+        publicBaseUrl: "https://test.example.com",
+      },
+    },
+  }),
+}));
+
 import {
   createCallSession,
   createPendingQuestion,

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -15,6 +15,7 @@ import {
   getTwilioVoiceWebhookUrl,
 } from "../inbound/public-ingress-urls.js";
 import { getOrCreateConversation } from "../memory/conversation-key-store.js";
+import { getConversation } from "../memory/conversation-store.js";
 import { queueGenerateConversationTitle } from "../memory/conversation-title-service.js";
 import { upsertBinding } from "../memory/external-conversation-store.js";
 import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
@@ -40,10 +41,26 @@ import { activeRelayConnections } from "./relay-server.js";
 import { getTwilioConfig } from "./twilio-config.js";
 import { TwilioConversationRelayProvider } from "./twilio-provider.js";
 import type { CallSession } from "./types.js";
+import { preflightVoiceIngress } from "./voice-ingress-preflight.js";
 
 const log = getLogger("call-domain");
 
 const E164_REGEX = /^\+\d+$/;
+
+function postFailedCallPointer(
+  conversationId: string,
+  phoneNumber: string,
+  reason: string,
+): void {
+  addPointerMessage(conversationId, "failed", phoneNumber, {
+    reason,
+  }).catch((pointerErr) => {
+    log.warn(
+      { conversationId, err: pointerErr },
+      "Failed to post call-failed pointer message",
+    );
+  });
+}
 
 // ── Result types ─────────────────────────────────────────────────────
 
@@ -387,18 +404,34 @@ export async function startCall(
   let sessionId: string | null = null;
 
   try {
-    const ingressConfig = loadConfig();
-    const provider = new TwilioConversationRelayProvider();
+    const config = loadConfig();
 
     // Resolve which phone number to use as caller ID
     const identityResult = await resolveCallerIdentity(
-      ingressConfig,
+      config,
       callerIdentityMode,
     );
     if (!identityResult.ok) {
       return { ok: false, error: identityResult.error, status: 400 };
     }
     const fromNumber = identityResult.fromNumber;
+
+    if (!getConversation(conversationId)) {
+      return {
+        ok: false,
+        error: `Invalid conversationId: no conversation found with ID ${conversationId}`,
+        status: 400,
+      };
+    }
+
+    const preflightResult = await preflightVoiceIngress();
+    if (!preflightResult.ok) {
+      postFailedCallPointer(conversationId, phoneNumber, preflightResult.error);
+      return preflightResult;
+    }
+
+    const ingressConfig = preflightResult.ingressConfig;
+    const provider = new TwilioConversationRelayProvider();
 
     const session = createCallSession({
       conversationId,
@@ -531,15 +564,7 @@ export async function startCall(
       });
     }
 
-    // Post a failure pointer message in the initiating conversation
-    addPointerMessage(conversationId, "failed", phoneNumber, {
-      reason: msg,
-    }).catch((pointerErr) => {
-      log.warn(
-        { conversationId, err: pointerErr },
-        "Failed to post call-failed pointer message",
-      );
-    });
+    postFailedCallPointer(conversationId, phoneNumber, msg);
 
     return { ok: false, error: `Error initiating call: ${msg}`, status: 500 };
   }

--- a/assistant/src/calls/voice-ingress-preflight.ts
+++ b/assistant/src/calls/voice-ingress-preflight.ts
@@ -1,0 +1,118 @@
+import { loadConfig } from "../config/loader.js";
+import type { AssistantConfig } from "../config/types.js";
+
+const SERVICE_UNAVAILABLE_STATUS = 503 as const;
+
+export interface VoiceIngressPreflightSuccess {
+  ok: true;
+  ingressConfig: AssistantConfig;
+  publicBaseUrl: string;
+}
+
+export interface VoiceIngressPreflightFailure {
+  ok: false;
+  error: string;
+  status: typeof SERVICE_UNAVAILABLE_STATUS;
+}
+
+export type VoiceIngressPreflightResult =
+  | VoiceIngressPreflightSuccess
+  | VoiceIngressPreflightFailure;
+
+function fail(error: string): VoiceIngressPreflightFailure {
+  return {
+    ok: false,
+    error,
+    status: SERVICE_UNAVAILABLE_STATUS,
+  };
+}
+
+function normalizePublicBaseUrl(value: unknown): string {
+  return typeof value === "string" ? value.trim().replace(/\/+$/, "") : "";
+}
+
+function buildGatewayUnhealthyMessage(
+  target: string,
+  error: string | undefined,
+  afterRecoveryAttempt: boolean,
+): string {
+  const detail = error ?? "Unknown gateway health check failure";
+  if (afterRecoveryAttempt) {
+    return `Voice callback gateway is still unhealthy at ${target} after a local recovery attempt: ${detail}`;
+  }
+  return `Voice callback gateway is unhealthy at ${target}: ${detail}`;
+}
+
+export async function preflightVoiceIngress(): Promise<VoiceIngressPreflightResult> {
+  const ingressConfig = loadConfig();
+  const publicBaseUrl = normalizePublicBaseUrl(
+    ingressConfig.ingress?.publicBaseUrl,
+  );
+  const ingressEnabled =
+    ingressConfig.ingress?.enabled ?? publicBaseUrl.length > 0;
+
+  if (!ingressEnabled) {
+    return fail(
+      "Outbound voice calls require public ingress to be enabled before Twilio can reach the assistant callbacks.",
+    );
+  }
+
+  if (!publicBaseUrl) {
+    return fail(
+      "Outbound voice calls require ingress.publicBaseUrl so Twilio webhook callbacks can reach the assistant.",
+    );
+  }
+
+  const { ensureLocalGatewayReady, probeLocalGatewayHealth } =
+    await import("../runtime/local-gateway-health.js");
+
+  const initialHealth = await probeLocalGatewayHealth();
+  if (!initialHealth.healthy && !initialHealth.localDeployment) {
+    return fail(
+      buildGatewayUnhealthyMessage(
+        initialHealth.target,
+        initialHealth.error,
+        false,
+      ),
+    );
+  }
+
+  if (initialHealth.localDeployment) {
+    const recovery = await ensureLocalGatewayReady();
+    // Re-probe after the wake flow so the dial path only continues when the
+    // current gateway process is demonstrably serving the callback stack.
+    const confirmedHealth = await probeLocalGatewayHealth();
+    if (!confirmedHealth.healthy) {
+      return fail(
+        buildGatewayUnhealthyMessage(
+          confirmedHealth.target,
+          confirmedHealth.error ?? recovery.error,
+          recovery.recoveryAttempted,
+        ),
+      );
+    }
+  }
+
+  const { triggerGatewayTwilioReconcile } =
+    await import("../daemon/handlers/config-ingress.js");
+  const reconcileResult = await triggerGatewayTwilioReconcile(publicBaseUrl);
+  if (!reconcileResult.ok) {
+    return fail(
+      reconcileResult.error ??
+        `Gateway Twilio state reconcile returned HTTP ${reconcileResult.status ?? "unknown"}`,
+    );
+  }
+
+  return {
+    ok: true,
+    ingressConfig: {
+      ...ingressConfig,
+      ingress: {
+        ...(ingressConfig.ingress ?? {}),
+        enabled: true,
+        publicBaseUrl,
+      },
+    },
+    publicBaseUrl,
+  };
+}

--- a/assistant/src/daemon/handlers/config-ingress.ts
+++ b/assistant/src/daemon/handlers/config-ingress.ts
@@ -49,7 +49,13 @@ export function computeGatewayTarget(): string {
   return getGatewayInternalBaseUrl();
 }
 
-function triggerGatewayInternalReconcile(
+export interface GatewayInternalReconcileResult {
+  ok: boolean;
+  status?: number;
+  error?: string;
+}
+
+async function triggerGatewayInternalReconcile(
   endpointPath: string,
   ingressPublicBaseUrl: string | undefined,
   messages: {
@@ -57,8 +63,9 @@ function triggerGatewayInternalReconcile(
     nonOk: string;
     unavailable: string;
     unavailableLogLevel: "debug" | "warn";
+    unavailableErrorPrefix: string;
   },
-): void {
+): Promise<GatewayInternalReconcileResult> {
   const gatewayBase = computeGatewayTarget();
   const token = mintDaemonDeliveryToken();
 
@@ -67,29 +74,41 @@ function triggerGatewayInternalReconcile(
     ingressPublicBaseUrl: ingressPublicBaseUrl ?? "",
   });
 
-  fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body,
-    signal: AbortSignal.timeout(5_000),
-  })
-    .then((res) => {
-      if (res.ok) {
-        log.info(messages.success);
-      } else {
-        log.warn({ status: res.status }, messages.nonOk);
-      }
-    })
-    .catch((err) => {
-      if (messages.unavailableLogLevel === "warn") {
-        log.warn({ err }, messages.unavailable);
-      } else {
-        log.debug({ err }, messages.unavailable);
-      }
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body,
+      signal: AbortSignal.timeout(5_000),
     });
+
+    if (res.ok) {
+      log.info(messages.success);
+      return { ok: true, status: res.status };
+    }
+
+    log.warn({ status: res.status }, messages.nonOk);
+    return {
+      ok: false,
+      status: res.status,
+      error: `${messages.unavailableErrorPrefix} (HTTP ${res.status})`,
+    };
+  } catch (err) {
+    if (messages.unavailableLogLevel === "warn") {
+      log.warn({ err }, messages.unavailable);
+    } else {
+      log.debug({ err }, messages.unavailable);
+    }
+    return {
+      ok: false,
+      error: `${messages.unavailableErrorPrefix}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
 }
 
 /**
@@ -100,7 +119,7 @@ function triggerGatewayInternalReconcile(
 export function triggerGatewayReconcile(
   ingressPublicBaseUrl: string | undefined,
 ): void {
-  triggerGatewayInternalReconcile(
+  void triggerGatewayInternalReconcile(
     "/internal/telegram/reconcile",
     ingressPublicBaseUrl,
     {
@@ -109,6 +128,7 @@ export function triggerGatewayReconcile(
       unavailable:
         "Gateway Telegram webhook reconcile failed (gateway may not be running)",
       unavailableLogLevel: "debug",
+      unavailableErrorPrefix: "Gateway Telegram webhook reconcile failed",
     },
   );
 }
@@ -120,8 +140,8 @@ export function triggerGatewayReconcile(
  */
 export function triggerGatewayTwilioReconcile(
   ingressPublicBaseUrl: string | undefined,
-): void {
-  triggerGatewayInternalReconcile(
+): Promise<GatewayInternalReconcileResult> {
+  return triggerGatewayInternalReconcile(
     "/internal/twilio/reconcile",
     ingressPublicBaseUrl,
     {
@@ -130,6 +150,7 @@ export function triggerGatewayTwilioReconcile(
       unavailable:
         "Gateway Twilio state reconcile failed (gateway may not be running)",
       unavailableLogLevel: "warn",
+      unavailableErrorPrefix: "Gateway Twilio state reconcile failed",
     },
   );
 }
@@ -295,7 +316,7 @@ export async function handleIngressConfig(
       }
 
       triggerGatewayReconcile(effectiveUrl);
-      triggerGatewayTwilioReconcile(effectiveUrl);
+      void triggerGatewayTwilioReconcile(effectiveUrl);
 
       // Best-effort Twilio webhook reconciliation: when ingress is being
       // enabled/updated and Twilio numbers are assigned with valid credentials,

--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -64,7 +64,7 @@ function pruneAssistantPhoneNumbers(
 }
 
 function refreshGatewayTwilioState(): void {
-  triggerGatewayTwilioReconcile(getIngressPublicBaseUrl());
+  void triggerGatewayTwilioReconcile(getIngressPublicBaseUrl());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a voice ingress preflight that verifies ingress configuration, local gateway health, and gateway Twilio reconcile state before dialing
- update outbound call start tests so unhealthy callback stacks fail fast instead of placing doomed Twilio calls

Part of plan: twilio-voice-call-stability.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
