### PR TITLE
fix: preserve iOS pin metadata in Case 3 thread merge

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -163,8 +163,11 @@ class IOSThreadStore: ObservableObject {
     private func mergeThreadMetadata(from restored: IOSThread, into thread: inout IOSThread) {
         thread.sessionId = restored.sessionId ?? thread.sessionId
         thread.scheduleJobId = restored.scheduleJobId
-        thread.isPinned = restored.isPinned
-        thread.displayOrder = restored.displayOrder
+        let isLocallyEdited = thread.sessionId.map { locallyEditedSessionIds.contains($0) } ?? false
+        if !isLocallyEdited {
+            thread.isPinned = restored.isPinned
+            thread.displayOrder = restored.displayOrder
+        }
         thread.hasUnseenLatestAssistantMessage = restored.hasUnseenLatestAssistantMessage
         thread.latestAssistantMessageAt = restored.latestAssistantMessageAt
         thread.lastSeenAssistantMessageAt = restored.lastSeenAssistantMessageAt


### PR DESCRIPTION
## Summary
- `mergeThreadMetadata` was unconditionally overwriting `isPinned` and `displayOrder` with server data, discarding local pin edits when the merge took the Case 3 (active user) path
- Now checks `locallyEditedSessionIds` and preserves local pin/displayOrder for locally edited threads, matching the fix already applied in Case 2

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22789608434

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
