### PR TITLE
feat: keep local voice callbacks alive during active calls

### DIFF
--- a/assistant/src/__tests__/call-domain.test.ts
+++ b/assistant/src/__tests__/call-domain.test.ts
@@ -119,6 +119,9 @@ mock.module("../calls/twilio-provider.js", () => ({
         throw new Error("Twilio unavailable");
       return { callSid: "CA_test_123" };
     }
+    async endCall() {
+      return;
+    }
   },
 }));
 
@@ -186,9 +189,19 @@ mock.module("../daemon/handlers/config-ingress.js", () => ({
     twilioReconcileCalls.push(publicBaseUrl);
     return twilioReconcileResult;
   },
+  syncTwilioWebhooks: async () => ({ success: true }),
 }));
 
-import { resolveCallerIdentity, startCall } from "../calls/call-domain.js";
+import {
+  clearActiveCallLeases,
+  getActiveCallLease,
+  listActiveCallLeases,
+} from "../calls/active-call-lease.js";
+import {
+  cancelCall,
+  resolveCallerIdentity,
+  startCall,
+} from "../calls/call-domain.js";
 import type { AssistantConfig } from "../config/types.js";
 import { getMessages } from "../memory/conversation-store.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
@@ -198,6 +211,7 @@ initializeDb();
 
 beforeEach(() => {
   resetTables();
+  clearActiveCallLeases();
   twilioInitiateCallBehavior = "success";
   twilioInitiateCallCount = 0;
   twilioInitiateCallArgs = [];
@@ -414,6 +428,13 @@ describe("startCall — pointer message regression", () => {
       },
     ]);
     expect(twilioReconcileCalls).toEqual(["https://test.example.com"]);
+    if (result.ok) {
+      expect(getActiveCallLease(result.session.id)).toEqual({
+        callSessionId: result.session.id,
+        providerCallSid: "CA_test_123",
+        updatedAt: expect.any(Number),
+      });
+    }
     // Allow async pointer write to flush
     await new Promise((r) => setTimeout(r, 50));
 
@@ -531,6 +552,7 @@ describe("startCall — pointer message regression", () => {
 
     expect(result.ok).toBe(false);
     expect(twilioInitiateCallCount).toBe(1);
+    expect(listActiveCallLeases()).toHaveLength(0);
     // Allow async pointer write to flush
     await new Promise((r) => setTimeout(r, 50));
 
@@ -538,5 +560,31 @@ describe("startCall — pointer message regression", () => {
     expect(text).not.toBeNull();
     expect(text!).toContain("+15559876543");
     expect(text!).toContain("failed");
+  });
+
+  test("canceling an active call releases its persisted keepalive lease", async () => {
+    const convId = "conv-domain-cancel-releases-lease";
+    ensureConversation(convId);
+
+    const startResult = await startCall({
+      phoneNumber: "+15559876543",
+      task: "Test call",
+      conversationId: convId,
+    });
+
+    expect(startResult.ok).toBe(true);
+    if (!startResult.ok) {
+      return;
+    }
+
+    expect(getActiveCallLease(startResult.session.id)).not.toBeNull();
+
+    const cancelResult = await cancelCall({
+      callSessionId: startResult.session.id,
+      reason: "User requested",
+    });
+
+    expect(cancelResult.ok).toBe(true);
+    expect(getActiveCallLease(startResult.session.id)).toBeNull();
   });
 });

--- a/assistant/src/__tests__/call-recovery.test.ts
+++ b/assistant/src/__tests__/call-recovery.test.ts
@@ -6,6 +6,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 const testDir = mkdtempSync(join(tmpdir(), "call-recovery-test-"));
 
 mock.module("../util/platform.js", () => ({
+  getRootDir: () => testDir,
   getDataDir: () => testDir,
   isMacOS: () => process.platform === "darwin",
   isLinux: () => process.platform === "linux",
@@ -24,6 +25,11 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+import {
+  clearActiveCallLeases,
+  listActiveCallLeases,
+  upsertActiveCallLease,
+} from "../calls/active-call-lease.js";
 import {
   logDeadLetterEvent,
   NO_SID_GRACE_PERIOD_MS,
@@ -213,6 +219,7 @@ describe("listRecoverableCalls", () => {
 describe("reconcileCallsOnStartup", () => {
   beforeEach(() => {
     resetTables();
+    clearActiveCallLeases();
   });
 
   test("does nothing when no recoverable calls exist", async () => {
@@ -228,6 +235,7 @@ describe("reconcileCallsOnStartup", () => {
       fromNumber: "+15551111111",
       toNumber: "+15552222222",
     });
+    upsertActiveCallLease({ callSessionId: session.id });
     // Backdate session so it exceeds the grace period
     backdateSession(session.id, NO_SID_GRACE_PERIOD_MS + 10_000);
 
@@ -240,6 +248,45 @@ describe("reconcileCallsOnStartup", () => {
     expect(updated!.status).toBe("failed");
     expect(updated!.endedAt).not.toBeNull();
     expect(updated!.lastError).toContain("grace period expired");
+    expect(listActiveCallLeases()).toHaveLength(0);
+  });
+
+  test("clears orphaned leases when startup finds no recoverable calls", async () => {
+    upsertActiveCallLease({
+      callSessionId: "call-orphaned-lease",
+      providerCallSid: "CA_orphaned_lease",
+    });
+
+    expect(listActiveCallLeases()).toHaveLength(1);
+
+    const provider = createMockProvider();
+    await reconcileCallsOnStartup(provider, silentLog);
+
+    expect(listActiveCallLeases()).toHaveLength(0);
+  });
+
+  test("rebuilds leases for calls that are still active on the provider", async () => {
+    const session = createTestCallSession({
+      conversationId: "conv-active-recovery",
+      provider: "twilio",
+      fromNumber: "+15551111111",
+      toNumber: "+15552222222",
+    });
+    updateCallSession(session.id, { providerCallSid: "CA_active_1" });
+    clearActiveCallLeases();
+
+    const provider = createMockProvider({
+      CA_active_1: "in-progress",
+    });
+    await reconcileCallsOnStartup(provider, silentLog);
+
+    expect(listActiveCallLeases()).toEqual([
+      {
+        callSessionId: session.id,
+        providerCallSid: "CA_active_1",
+        updatedAt: expect.any(Number),
+      },
+    ]);
   });
 
   test("expires pending questions when stale no-SID session is failed", async () => {

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -262,6 +262,53 @@ mock.module("../calls/twilio-rest.js", () => ({
   },
 }));
 
+mock.module("../daemon/handlers/config-ingress.js", () => ({
+  triggerGatewayTwilioReconcile: async (
+    ingressPublicBaseUrl: string | undefined,
+  ) => {
+    reconcileCalls.push({
+      url: `${mockGatewayInternalBaseUrl}/internal/twilio/reconcile`,
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${mockMintedToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        ingressPublicBaseUrl: ingressPublicBaseUrl ?? "",
+      }),
+    });
+
+    if (reconcileShouldFail) {
+      return {
+        ok: false,
+        error:
+          "Gateway Twilio state reconcile failed: ECONNREFUSED: gateway unavailable",
+      };
+    }
+
+    return { ok: true, status: 200 };
+  },
+  syncTwilioWebhooks: async (
+    phoneNumber: string,
+    accountSid: string,
+    authToken: string,
+    ingressConfig: unknown,
+  ) => {
+    const baseUrl = resolveIngressBaseUrlFromConfig(ingressConfig);
+    updatePhoneNumberWebhookCalls.push({
+      accountSid,
+      authToken,
+      phoneNumber,
+      urls: {
+        voiceUrl: `${baseUrl}/webhooks/twilio/voice`,
+        statusCallbackUrl: `${baseUrl}/webhooks/twilio/status`,
+        smsUrl: `${baseUrl}/webhooks/twilio/sms`,
+      },
+    });
+    return { success: true };
+  },
+}));
+
 mock.module("../daemon/handlers/config-channels.js", () => ({
   getReadinessService: () => ({
     getReadiness: async () => [],
@@ -300,6 +347,11 @@ mock.module("../providers/registry.js", () => ({
   initializeProviders: () => {},
 }));
 
+import {
+  clearActiveCallLeases,
+  listActiveCallLeases,
+  upsertActiveCallLease,
+} from "../calls/active-call-lease.js";
 import {
   registerCallCompletionNotifier,
   unregisterCallCompletionNotifier,
@@ -420,6 +472,7 @@ async function flushReconcileWork(): Promise<void> {
 describe("twilio webhook routes", () => {
   beforeEach(() => {
     resetTables();
+    clearActiveCallLeases();
     mockWssBaseUrl = "wss://test.example.com";
     mockWebhookBaseUrl = "https://test.example.com";
     mockIngressPublicBaseUrl = "https://ingress.example.com";
@@ -676,6 +729,10 @@ describe("twilio webhook routes", () => {
         "conv-status-complete-1",
         "CA_status_complete_1",
       );
+      upsertActiveCallLease({
+        callSessionId: session.id,
+        providerCallSid: "CA_status_complete_1",
+      });
       updateCallSession(session.id, {
         status: "in_progress",
         startedAt: Date.now() - 20_000,
@@ -703,6 +760,7 @@ describe("twilio webhook routes", () => {
       expect(updated).not.toBeNull();
       expect(updated!.status).toBe("completed");
       expect(updated!.endedAt).not.toBeNull();
+      expect(listActiveCallLeases()).toHaveLength(0);
       expect(fired).toBe(1);
 
       unregisterCallCompletionNotifier("conv-status-complete-1");

--- a/assistant/src/calls/active-call-lease.ts
+++ b/assistant/src/calls/active-call-lease.ts
@@ -1,0 +1,207 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+import { getLogger } from "../util/logger.js";
+import { getRootDir } from "../util/platform.js";
+import { isTerminalState } from "./call-state-machine.js";
+import type { CallSession } from "./types.js";
+
+const log = getLogger("active-call-lease");
+
+const ACTIVE_CALL_LEASES_VERSION = 1 as const;
+const ACTIVE_CALL_LEASES_FILE = "active-call-leases.json";
+
+interface ActiveCallLeaseFile {
+  version: typeof ACTIVE_CALL_LEASES_VERSION;
+  leases: ActiveCallLease[];
+}
+
+export interface ActiveCallLease {
+  callSessionId: string;
+  providerCallSid: string | null;
+  updatedAt: number;
+}
+
+function getStorePath(): string {
+  return join(getRootDir(), ACTIVE_CALL_LEASES_FILE);
+}
+
+function loadLeaseFile(): ActiveCallLeaseFile {
+  const path = getStorePath();
+  if (!existsSync(path)) {
+    return {
+      version: ACTIVE_CALL_LEASES_VERSION,
+      leases: [],
+    };
+  }
+
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<ActiveCallLeaseFile>;
+    if (
+      parsed.version !== ACTIVE_CALL_LEASES_VERSION ||
+      !Array.isArray(parsed.leases)
+    ) {
+      log.warn(
+        { path },
+        "Invalid active call lease file format; starting fresh",
+      );
+      return {
+        version: ACTIVE_CALL_LEASES_VERSION,
+        leases: [],
+      };
+    }
+
+    return {
+      version: ACTIVE_CALL_LEASES_VERSION,
+      leases: parsed.leases
+        .filter(
+          (lease): lease is ActiveCallLease =>
+            typeof lease?.callSessionId === "string" &&
+            (typeof lease.providerCallSid === "string" ||
+              lease.providerCallSid == null) &&
+            typeof lease.updatedAt === "number",
+        )
+        .sort((a, b) => a.updatedAt - b.updatedAt),
+    };
+  } catch (err) {
+    log.error({ err, path }, "Failed to load active call lease file");
+    return {
+      version: ACTIVE_CALL_LEASES_VERSION,
+      leases: [],
+    };
+  }
+}
+
+function saveLeaseFile(leases: ActiveCallLease[]): void {
+  const path = getStorePath();
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  const payload: ActiveCallLeaseFile = {
+    version: ACTIVE_CALL_LEASES_VERSION,
+    leases: [...leases].sort((a, b) => a.updatedAt - b.updatedAt),
+  };
+  const tmpPath = `${path}.tmp.${process.pid}`;
+  writeFileSync(tmpPath, JSON.stringify(payload, null, 2), { mode: 0o600 });
+  renameSync(tmpPath, path);
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    // chmod is best-effort on platforms that ignore POSIX modes.
+  }
+}
+
+export function clearActiveCallLeases(): void {
+  const path = getStorePath();
+  if (!existsSync(path)) {
+    return;
+  }
+  try {
+    unlinkSync(path);
+  } catch (err) {
+    log.warn({ err, path }, "Failed to clear active call lease file");
+  }
+}
+
+export function listActiveCallLeases(): ActiveCallLease[] {
+  return loadLeaseFile().leases;
+}
+
+export function getActiveCallLease(
+  callSessionId: string,
+): ActiveCallLease | null {
+  return (
+    listActiveCallLeases().find(
+      (lease) => lease.callSessionId === callSessionId,
+    ) ?? null
+  );
+}
+
+export function upsertActiveCallLease(params: {
+  callSessionId: string;
+  providerCallSid?: string | null;
+  updatedAt?: number;
+}): ActiveCallLease {
+  const { callSessionId } = params;
+  const current = loadLeaseFile().leases;
+  const currentById = new Map(
+    current.map((lease) => [lease.callSessionId, lease] as const),
+  );
+  const existing = currentById.get(callSessionId);
+  const nextLease: ActiveCallLease = {
+    callSessionId,
+    providerCallSid:
+      params.providerCallSid ?? existing?.providerCallSid ?? null,
+    updatedAt: params.updatedAt ?? Date.now(),
+  };
+  currentById.set(callSessionId, nextLease);
+  saveLeaseFile(Array.from(currentById.values()));
+  return nextLease;
+}
+
+export function removeActiveCallLease(callSessionId: string): boolean {
+  const current = loadLeaseFile().leases;
+  const next = current.filter((lease) => lease.callSessionId !== callSessionId);
+  if (next.length === current.length) {
+    return false;
+  }
+  if (next.length === 0) {
+    clearActiveCallLeases();
+    return true;
+  }
+  saveLeaseFile(next);
+  return true;
+}
+
+export function syncActiveCallLeaseFromSession(
+  session: Pick<CallSession, "id" | "providerCallSid" | "status"> | null,
+): void {
+  if (!session) {
+    return;
+  }
+
+  if (isTerminalState(session.status)) {
+    removeActiveCallLease(session.id);
+    return;
+  }
+
+  const existing = getActiveCallLease(session.id);
+  if (!existing && session.providerCallSid == null) {
+    return;
+  }
+
+  upsertActiveCallLease({
+    callSessionId: session.id,
+    providerCallSid: session.providerCallSid,
+  });
+}
+
+export function reconcileActiveCallLeases(
+  sessions: Array<Pick<CallSession, "id" | "providerCallSid" | "status">>,
+): void {
+  const nextLeases = sessions
+    .filter((session) => !isTerminalState(session.status))
+    .map((session) => ({
+      callSessionId: session.id,
+      providerCallSid: session.providerCallSid,
+      updatedAt: Date.now(),
+    }));
+
+  if (nextLeases.length === 0) {
+    clearActiveCallLeases();
+    return;
+  }
+
+  saveLeaseFile(nextLeases);
+}

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -23,6 +23,7 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { isGuardian } from "../runtime/channel-guardian-service.js";
 import { getSecureKey } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
+import { upsertActiveCallLease } from "./active-call-lease.js";
 import { isDeniedNumber } from "./call-constants.js";
 import { addPointerMessage } from "./call-pointer-messages.js";
 import { getCallController, unregisterCallController } from "./call-state.js";
@@ -511,6 +512,8 @@ export async function startCall(
       "twilio_status",
     );
 
+    upsertActiveCallLease({ callSessionId: session.id });
+
     const { callSid } = await provider.initiateCall({
       from: fromNumber,
       to: phoneNumber,
@@ -963,6 +966,8 @@ export async function startGuardianVerificationCall(
       "webhooks/twilio/status",
       "twilio_status",
     );
+
+    upsertActiveCallLease({ callSessionId: session.id });
 
     const { callSid } = await provider.initiateCall({
       from: identityResult.fromNumber,

--- a/assistant/src/calls/call-recovery.ts
+++ b/assistant/src/calls/call-recovery.ts
@@ -8,6 +8,7 @@
  */
 
 import { getLogger } from "../util/logger.js";
+import { reconcileActiveCallLeases } from "./active-call-lease.js";
 import { isTerminalState } from "./call-state-machine.js";
 import {
   expirePendingQuestions,
@@ -80,6 +81,7 @@ export async function reconcileCallsOnStartup(
   log: Logger = defaultLog,
 ): Promise<void> {
   const recoverableCalls = listRecoverableCalls();
+  reconcileActiveCallLeases(recoverableCalls);
 
   if (recoverableCalls.length === 0) {
     log.info("No recoverable calls found at startup");

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -9,6 +9,7 @@ import {
 } from "../memory/schema.js";
 import { getLogger } from "../util/logger.js";
 import { cast, createRowMapper } from "../util/row-mapper.js";
+import { syncActiveCallLeaseFromSession } from "./active-call-lease.js";
 import { validateTransition } from "./call-state-machine.js";
 import type {
   CallEvent,
@@ -170,6 +171,9 @@ export function updateCallSession(
   >,
 ): void {
   const db = getDb();
+  const shouldSyncActiveLease =
+    Object.prototype.hasOwnProperty.call(updates, "providerCallSid") ||
+    Object.prototype.hasOwnProperty.call(updates, "status");
 
   // Validate status transition when a new status is provided
   if (updates.status) {
@@ -198,6 +202,10 @@ export function updateCallSession(
     .set({ ...updates, updatedAt: Date.now() })
     .where(eq(callSessions.id, id))
     .run();
+
+  if (shouldSyncActiveLease) {
+    syncActiveCallLeaseFromSession(getCallSession(id));
+  }
 }
 
 // ── Recovery queries ─────────────────────────────────────────────────

--- a/cli/src/__tests__/sleep.test.ts
+++ b/cli/src/__tests__/sleep.test.ts
@@ -1,0 +1,129 @@
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const testDir = mkdtempSync(join(tmpdir(), "sleep-command-test-"));
+const assistantRootDir = join(testDir, ".vellum");
+
+const stopProcessByPidFileMock = mock(async () => true);
+
+const mockEntry = {
+  assistantId: "sleep-test",
+  runtimeUrl: "http://127.0.0.1:7777",
+  cloud: "local",
+  resources: {
+    instanceDir: testDir,
+    daemonPort: 7777,
+    gatewayPort: 7830,
+    qdrantPort: 6333,
+    socketPath: join(assistantRootDir, "vellum.sock"),
+    pidFile: join(assistantRootDir, "vellum.pid"),
+  },
+};
+
+mock.module("../lib/assistant-config.js", () => ({
+  defaultLocalResources: () => mockEntry.resources,
+  resolveTargetAssistant: () => mockEntry,
+}));
+
+mock.module("../lib/process.js", () => ({
+  stopProcessByPidFile: stopProcessByPidFileMock,
+}));
+
+import { sleep } from "../commands/sleep.js";
+
+function writeLeaseFile(callSessionIds: string[]): void {
+  mkdirSync(assistantRootDir, { recursive: true });
+  writeFileSync(
+    join(assistantRootDir, "active-call-leases.json"),
+    JSON.stringify(
+      {
+        version: 1,
+        leases: callSessionIds.map((callSessionId) => ({
+          callSessionId,
+          providerCallSid: null,
+          updatedAt: Date.now(),
+        })),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+describe("sleep command", () => {
+  let originalArgv: string[];
+
+  beforeEach(() => {
+    originalArgv = [...process.argv];
+    stopProcessByPidFileMock.mockReset();
+    stopProcessByPidFileMock.mockResolvedValue(true);
+    rmSync(assistantRootDir, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    process.argv = originalArgv;
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("refuses normal sleep while an active call lease exists", async () => {
+    writeLeaseFile(["call-active-1", "call-active-2"]);
+    process.argv = ["bun", "vellum", "sleep", "sleep-test"];
+
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+    const exitMock = mock((code?: number) => {
+      throw new Error(`process.exit:${code}`);
+    });
+    const originalExit = process.exit;
+    process.exit = exitMock as unknown as typeof process.exit;
+
+    try {
+      await expect(sleep()).rejects.toThrow("process.exit:1");
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining("vellum sleep --force"),
+      );
+    } finally {
+      process.exit = originalExit;
+      consoleError.mockRestore();
+    }
+
+    expect(stopProcessByPidFileMock).not.toHaveBeenCalled();
+  });
+
+  test("force stops the assistant even when an active call lease exists", async () => {
+    writeLeaseFile(["call-active-1"]);
+    process.argv = ["bun", "vellum", "sleep", "sleep-test", "--force"];
+
+    const consoleLog = spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      await sleep();
+    } finally {
+      consoleLog.mockRestore();
+    }
+
+    expect(stopProcessByPidFileMock).toHaveBeenCalledTimes(2);
+    expect(stopProcessByPidFileMock).toHaveBeenNthCalledWith(
+      1,
+      join(assistantRootDir, "vellum.pid"),
+      "assistant",
+      [join(assistantRootDir, "vellum.sock")],
+    );
+    expect(stopProcessByPidFileMock).toHaveBeenNthCalledWith(
+      2,
+      join(assistantRootDir, "gateway.pid"),
+      "gateway",
+      undefined,
+      7000,
+    );
+  });
+});

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -1,15 +1,49 @@
+import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 
 import {
   defaultLocalResources,
   resolveTargetAssistant,
 } from "../lib/assistant-config.js";
+import type { AssistantEntry } from "../lib/assistant-config.js";
 import { stopProcessByPidFile } from "../lib/process";
+
+const ACTIVE_CALL_LEASES_FILE = "active-call-leases.json";
+
+type ActiveCallLease = {
+  callSessionId: string;
+};
+
+function getAssistantRootDir(entry: AssistantEntry): string {
+  const resources = entry.resources ?? defaultLocalResources();
+  return entry.baseDataDir ?? join(resources.instanceDir, ".vellum");
+}
+
+function readActiveCallLeases(vellumDir: string): ActiveCallLease[] {
+  const path = join(vellumDir, ACTIVE_CALL_LEASES_FILE);
+  if (!existsSync(path)) {
+    return [];
+  }
+
+  const raw = JSON.parse(readFileSync(path, "utf-8")) as {
+    version?: number;
+    leases?: Array<{ callSessionId?: unknown }>;
+  };
+  if (raw.version !== 1 || !Array.isArray(raw.leases)) {
+    throw new Error(`Invalid active call lease file at ${path}`);
+  }
+
+  return raw.leases.filter(
+    (lease): lease is ActiveCallLease =>
+      typeof lease?.callSessionId === "string" &&
+      lease.callSessionId.length > 0,
+  );
+}
 
 export async function sleep(): Promise<void> {
   const args = process.argv.slice(3);
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum sleep [<name>]");
+    console.log("Usage: vellum sleep [<name>] [--force]");
     console.log("");
     console.log("Stop the assistant and gateway processes.");
     console.log("");
@@ -17,9 +51,15 @@ export async function sleep(): Promise<void> {
     console.log(
       "  <name>    Name of the assistant to stop (default: active or only local)",
     );
+    console.log("");
+    console.log("Options:");
+    console.log(
+      "  --force   Stop the assistant even if a phone call keepalive lease is active",
+    );
     process.exit(0);
   }
 
+  const force = args.includes("--force");
   const nameArg = args.find((a) => !a.startsWith("-"));
   const entry = resolveTargetAssistant(nameArg);
 
@@ -31,17 +71,39 @@ export async function sleep(): Promise<void> {
   }
 
   const resources = entry.resources ?? defaultLocalResources();
-
-  const daemonPidFile = resources.pidFile;
+  const assistantPidFile = resources.pidFile;
   const socketFile = resources.socketPath;
-  const vellumDir = join(resources.instanceDir, ".vellum");
+  const vellumDir = getAssistantRootDir(entry);
   const gatewayPidFile = join(vellumDir, "gateway.pid");
 
-  // Stop daemon
-  const daemonStopped = await stopProcessByPidFile(daemonPidFile, "daemon", [
-    socketFile,
-  ]);
-  if (!daemonStopped) {
+  if (!force) {
+    try {
+      const activeCallLeases = readActiveCallLeases(vellumDir);
+      if (activeCallLeases.length > 0) {
+        const activeIds = activeCallLeases.map((lease) => lease.callSessionId);
+        console.error(
+          `Error: assistant is staying awake for active phone calls (${activeIds.join(
+            ", ",
+          )}). Use 'vellum sleep --force' to stop it anyway.`,
+        );
+        process.exit(1);
+      }
+    } catch (err) {
+      console.error(
+        `Error: ${
+          err instanceof Error ? err.message : String(err)
+        }. Use 'vellum sleep --force' to override if you want to stop the assistant anyway.`,
+      );
+      process.exit(1);
+    }
+  }
+
+  const assistantStopped = await stopProcessByPidFile(
+    assistantPidFile,
+    "assistant",
+    [socketFile],
+  );
+  if (!assistantStopped) {
     console.log("Assistant is not running.");
   } else {
     console.log("Assistant stopped.");


### PR DESCRIPTION
## Summary
- add a persisted active call lease registry so local voice calls keep the callback stack awake until they terminate
- block normal vellum sleep while an active call lease exists and add --force as the explicit override
- extend call, Twilio, recovery, and CLI tests to cover lease lifecycle and sleep protection

Part of plan: twilio-voice-call-stability.md (PR 6 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
