### PR TITLE
refactor: rename channelGuardianVerificationChallenges → channelVerificationSessions

### DIFF
--- a/assistant/docs/runbook-trusted-contacts.md
+++ b/assistant/docs/runbook-trusted-contacts.md
@@ -117,14 +117,14 @@ sqlite3 ~/.vellum/workspace/data/db/assistant.db \
 
 ## 3. Inspect Pending Verification Sessions
 
-Verification challenges are stored in `channel_guardian_verification_challenges`. Active sessions have `status = 'awaiting_response'` and `expires_at > now`.
+Verification challenges are stored in `channel_verification_sessions`. Active sessions have `status = 'awaiting_response'` and `expires_at > now`.
 
 ```bash
 sqlite3 ~/.vellum/workspace/data/db/assistant.db \
   "SELECT id, channel, status, identity_binding_status, \
    expected_external_user_id, expected_chat_id, expected_phone_e164, \
    expires_at, created_at \
-   FROM channel_guardian_verification_challenges \
+   FROM channel_verification_sessions \
    WHERE status IN ('awaiting_response', 'pending_bootstrap') \
    AND expires_at > $(date +%s)000 \
    ORDER BY created_at DESC;"
@@ -200,7 +200,7 @@ sqlite3 ~/.vellum/workspace/data/db/assistant.db \
   "SELECT id, channel, status, identity_binding_status, \
    expected_external_user_id, expected_chat_id, expected_phone_e164, \
    expires_at, consumed_by_external_user_id \
-   FROM channel_guardian_verification_challenges \
+   FROM channel_verification_sessions \
    WHERE expected_external_user_id = 'TARGET_USER_ID' \
    OR expected_chat_id = 'TARGET_CHAT_ID' \
    ORDER BY created_at DESC LIMIT 5;"
@@ -302,7 +302,7 @@ Expired sessions are already invisible to the verification flow (filtered by `ex
 
 ```bash
 sqlite3 ~/.vellum/workspace/data/db/assistant.db \
-  "DELETE FROM channel_guardian_verification_challenges \
+  "DELETE FROM channel_verification_sessions \
    WHERE expires_at < $(date +%s)000 \
    AND status IN ('awaiting_response', 'pending_bootstrap');"
 ```

--- a/assistant/docs/trusted-contact-access.md
+++ b/assistant/docs/trusted-contact-access.md
@@ -44,18 +44,18 @@ Design doc defining how unknown users gain access to a Vellum assistant via chan
 requested -> pending_guardian -> verification_pending -> active | denied | expired
 ```
 
-| State                  | Description                                                                                                        | Store representation                                                                                                                                                                                        |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `requested`            | Unknown user messaged the assistant and was rejected. The system records the access attempt.                       | No member record exists. The rejection is logged in `channel_inbound_events`. A notification signal is emitted via `emitNotificationSignal()`.                                                              |
-| `pending_guardian`     | The guardian has been notified and a decision is pending.                                                          | A `channel_guardian_approval_requests` record exists with `status: 'pending'`, `toolName: 'ingress_access_request'`.                                                                                        |
-| `verification_pending` | The guardian approved. A verification session is active with a 6-digit code waiting for the requester to enter.    | `channel_guardian_verification_challenges` record with `status: 'awaiting_response'`, identity-bound to the requester's expected channel identity. The approval request is updated to `status: 'approved'`. |
-| `active`               | The requester entered the correct code. They are now a trusted contact.                                            | `contact_channels` record with `status: 'active'`, `policy: 'allow'`. The verification session is `status: 'consumed'`.                                                                                     |
-| `denied`               | The guardian explicitly denied the request.                                                                        | The approval request has `status: 'denied'`. No member record is created (or if one existed, it remains unchanged).                                                                                         |
-| `expired`              | The guardian never responded (approval TTL elapsed) or the requester never entered the code (session TTL elapsed). | Approval request: `status: 'expired'` (set by `sweepExpiredGuardianApprovals()`). Verification session: expires naturally when `expiresAt < Date.now()`.                                                    |
+| State                  | Description                                                                                                        | Store representation                                                                                                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `requested`            | Unknown user messaged the assistant and was rejected. The system records the access attempt.                       | No member record exists. The rejection is logged in `channel_inbound_events`. A notification signal is emitted via `emitNotificationSignal()`.                                                   |
+| `pending_guardian`     | The guardian has been notified and a decision is pending.                                                          | A `channel_guardian_approval_requests` record exists with `status: 'pending'`, `toolName: 'ingress_access_request'`.                                                                             |
+| `verification_pending` | The guardian approved. A verification session is active with a 6-digit code waiting for the requester to enter.    | `channel_verification_sessions` record with `status: 'awaiting_response'`, identity-bound to the requester's expected channel identity. The approval request is updated to `status: 'approved'`. |
+| `active`               | The requester entered the correct code. They are now a trusted contact.                                            | `contact_channels` record with `status: 'active'`, `policy: 'allow'`. The verification session is `status: 'consumed'`.                                                                          |
+| `denied`               | The guardian explicitly denied the request.                                                                        | The approval request has `status: 'denied'`. No member record is created (or if one existed, it remains unchanged).                                                                              |
+| `expired`              | The guardian never responded (approval TTL elapsed) or the requester never entered the code (session TTL elapsed). | Approval request: `status: 'expired'` (set by `sweepExpiredGuardianApprovals()`). Verification session: expires naturally when `expiresAt < Date.now()`.                                         |
 
 ## Identity Binding Rules
 
-Identity binding ensures the verification code can only be consumed by the intended recipient on the intended channel. The binding fields are set on the `channel_guardian_verification_challenges` record when the session is created.
+Identity binding ensures the verification code can only be consumed by the intended recipient on the intended channel. The binding fields are set on the `channel_verification_sessions` record when the session is created.
 
 | Channel  | Identity fields                                                                  | Binding behavior                                                                                                                                                                                                                          |
 | -------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -85,18 +85,18 @@ Identity binding ensures the verification code can only be consumed by the inten
 
 ### Stage: `verification_pending` (guardian approved, code issued)
 
-| Store                       | Table                                      | Record                                                                                                                                                                                                                                                                              |
-| --------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `channel-guardian-store.ts` | `channel_guardian_approval_requests`       | Updated to `status: 'approved'`, `decidedByExternalUserId` set.                                                                                                                                                                                                                     |
-| `channel-guardian-store.ts` | `channel_guardian_verification_challenges` | New record: `status: 'awaiting_response'`, `identityBindingStatus: 'bound'`, `expectedExternalUserId`/`expectedChatId`/`expectedPhoneE164` set to the requester's identity, `challengeHash` = SHA-256 of the 6-digit code, `expiresAt` = 10 minutes from creation, `codeDigits: 6`. |
+| Store                       | Table                                | Record                                                                                                                                                                                                                                                                              |
+| --------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `channel-guardian-store.ts` | `channel_guardian_approval_requests` | Updated to `status: 'approved'`, `decidedByExternalUserId` set.                                                                                                                                                                                                                     |
+| `channel-guardian-store.ts` | `channel_verification_sessions`      | New record: `status: 'awaiting_response'`, `identityBindingStatus: 'bound'`, `expectedExternalUserId`/`expectedChatId`/`expectedPhoneE164` set to the requester's identity, `challengeHash` = SHA-256 of the 6-digit code, `expiresAt` = 10 minutes from creation, `codeDigits: 6`. |
 
 ### Stage: `active` (code verified, trusted contact created)
 
-| Store                       | Table                                      | Record                                                                                                                                                                                                      |
-| --------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `contacts-write.ts`         | `contacts` / `contact_channels`            | Upserted via `upsertContactChannel()`: creates a contact record and a `contact_channels` entry with `status: 'active'`, `policy: 'allow'`, channel type, `externalUserId`, `externalChatId`, `displayName`. |
-| `channel-guardian-store.ts` | `channel_guardian_verification_challenges` | Updated to `status: 'consumed'`, `consumedByExternalUserId`, `consumedByChatId` set.                                                                                                                        |
-| `channel-guardian-store.ts` | `channel_guardian_rate_limits`             | Reset via `resetRateLimit()` on successful verification.                                                                                                                                                    |
+| Store                       | Table                           | Record                                                                                                                                                                                                      |
+| --------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `contacts-write.ts`         | `contacts` / `contact_channels` | Upserted via `upsertContactChannel()`: creates a contact record and a `contact_channels` entry with `status: 'active'`, `policy: 'allow'`, channel type, `externalUserId`, `externalChatId`, `displayName`. |
+| `channel-guardian-store.ts` | `channel_verification_sessions` | Updated to `status: 'consumed'`, `consumedByExternalUserId`, `consumedByChatId` set.                                                                                                                        |
+| `channel-guardian-store.ts` | `channel_guardian_rate_limits`  | Reset via `resetRateLimit()` on successful verification.                                                                                                                                                    |
 
 ### Stage: `denied` (guardian rejected)
 
@@ -108,10 +108,10 @@ No member record is created. No verification session is created.
 
 ### Stage: `expired`
 
-| Store                       | Table                                      | Record                                                                                            |
-| --------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `channel-guardian-store.ts` | `channel_guardian_approval_requests`       | Updated to `status: 'expired'` by `sweepExpiredGuardianApprovals()` (runs every 60s).             |
-| `channel-guardian-store.ts` | `channel_guardian_verification_challenges` | Expires naturally: `expiresAt < Date.now()` makes it invisible to `findPendingChallengeByHash()`. |
+| Store                       | Table                                | Record                                                                                            |
+| --------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `channel-guardian-store.ts` | `channel_guardian_approval_requests` | Updated to `status: 'expired'` by `sweepExpiredGuardianApprovals()` (runs every 60s).             |
+| `channel-guardian-store.ts` | `channel_verification_sessions`      | Expires naturally: `expiresAt < Date.now()` makes it invisible to `findPendingChallengeByHash()`. |
 
 ### Invites (alternative path)
 
@@ -250,7 +250,7 @@ sequenceDiagram
 
 ### Code reuse prevention
 
-- Each verification session creates a single `channel_guardian_verification_challenges` record.
+- Each verification session creates a single `channel_verification_sessions` record.
 - `consumeChallenge()` atomically sets `status: 'consumed'`, making the code permanently unusable.
 - `findPendingChallengeByHash()` only matches challenges with `status IN ('pending', 'pending_bootstrap', 'awaiting_response')`, so consumed challenges are invisible.
 

--- a/assistant/src/__tests__/access-request-decision.test.ts
+++ b/assistant/src/__tests__/access-request-decision.test.ts
@@ -91,7 +91,7 @@ const GUARDIAN_APPROVAL_TTL_MS = 5 * 60 * 1000;
 function resetState(): void {
   const db = getDb();
   db.run("DELETE FROM channel_guardian_approval_requests");
-  db.run("DELETE FROM channel_guardian_verification_challenges");
+  db.run("DELETE FROM channel_verification_sessions");
   deliverReplyCalls.length = 0;
 }
 

--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -115,7 +115,7 @@ function resetTables(): void {
     "canonical_guardian_deliveries",
     "canonical_guardian_requests",
     "channel_guardian_approval_requests",
-    "channel_guardian_verification_challenges",
+    "channel_verification_sessions",
     "conversation_keys",
     "message_runs",
     "channel_inbound_events",

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -127,7 +127,7 @@ import {
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { upsertBinding as upsertExternalBinding } from "../memory/external-conversation-store.js";
 import {
-  channelGuardianVerificationChallenges,
+  channelVerificationSessions,
   conversations,
 } from "../memory/schema.js";
 import {
@@ -164,7 +164,7 @@ afterAll(() => {
 
 function resetTables(): void {
   const db = getDb();
-  db.run("DELETE FROM channel_guardian_verification_challenges");
+  db.run("DELETE FROM channel_verification_sessions");
   db.run("DELETE FROM channel_guardian_approval_requests");
   db.run("DELETE FROM channel_guardian_rate_limits");
   db.run("DELETE FROM contact_channels");
@@ -2358,8 +2358,8 @@ describe("outbound verification sessions", () => {
     const db = getDb();
     const firstRow = db
       .select()
-      .from(channelGuardianVerificationChallenges)
-      .where(eq(channelGuardianVerificationChallenges.id, firstId))
+      .from(channelVerificationSessions)
+      .where(eq(channelVerificationSessions.id, firstId))
       .get();
     expect(firstRow).toBeDefined();
     expect(firstRow!.status).toBe("revoked");
@@ -3718,7 +3718,7 @@ describe("outbound voice verification", () => {
     const now = Date.now();
     for (let i = 0; i < 10; i++) {
       // Insert sessions with recent lastSentAt to simulate sends
-      db.insert(channelGuardianVerificationChallenges)
+      db.insert(channelVerificationSessions)
         .values({
           id: `rate-limit-voice-${i}`,
           channel: "voice",

--- a/assistant/src/__tests__/conversation-attention-telegram.test.ts
+++ b/assistant/src/__tests__/conversation-attention-telegram.test.ts
@@ -76,7 +76,7 @@ function resetTables(): void {
     "conversation_attention_events",
     "conversation_assistant_attention_state",
     "channel_guardian_approval_requests",
-    "channel_guardian_verification_challenges",
+    "channel_verification_sessions",
     "conversation_keys",
     "message_runs",
     "channel_inbound_events",

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -156,7 +156,7 @@ afterAll(() => {
 
 function resetTables(): void {
   const db = getDb();
-  db.run("DELETE FROM channel_guardian_verification_challenges");
+  db.run("DELETE FROM channel_verification_sessions");
   try {
     db.run("DELETE FROM channel_guardian_approval_requests");
   } catch {

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -280,7 +280,7 @@ function resetTables() {
     "messages",
     "conversations",
     "assistant_ingress_invites",
-    "channel_guardian_verification_challenges",
+    "channel_verification_sessions",
     "channel_guardian_rate_limits",
     "canonical_guardian_requests",
     "canonical_guardian_deliveries",

--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -102,7 +102,7 @@ const TEST_BEARER_TOKEN = "test-token";
 function resetState(): void {
   const db = getDb();
   db.run("DELETE FROM channel_guardian_approval_requests");
-  db.run("DELETE FROM channel_guardian_verification_challenges");
+  db.run("DELETE FROM channel_verification_sessions");
   db.run("DELETE FROM channel_guardian_rate_limits");
   db.run("DELETE FROM channel_inbound_events");
   db.run("DELETE FROM conversations");

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -119,7 +119,7 @@ const GUARDIAN_APPROVAL_TTL_MS = 5 * 60 * 1000;
 function resetState(): void {
   const db = getDb();
   db.run("DELETE FROM channel_guardian_approval_requests");
-  db.run("DELETE FROM channel_guardian_verification_challenges");
+  db.run("DELETE FROM channel_verification_sessions");
   db.run("DELETE FROM channel_guardian_rate_limits");
   db.run("DELETE FROM channel_inbound_events");
   db.run("DELETE FROM conversations");

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -127,7 +127,7 @@ const TEST_BEARER_TOKEN = "test-token";
 function resetState(): void {
   const db = getDb();
   db.run("DELETE FROM channel_guardian_approval_requests");
-  db.run("DELETE FROM channel_guardian_verification_challenges");
+  db.run("DELETE FROM channel_verification_sessions");
   db.run("DELETE FROM channel_guardian_rate_limits");
   db.run("DELETE FROM channel_inbound_events");
   db.run("DELETE FROM conversations");

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -73,7 +73,7 @@ afterAll(() => {
 
 function resetTables(): void {
   const db = getDb();
-  db.run("DELETE FROM channel_guardian_verification_challenges");
+  db.run("DELETE FROM channel_verification_sessions");
   db.run("DELETE FROM channel_guardian_rate_limits");
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -64,6 +64,7 @@ import {
   migrateNormalizePhoneIdentities,
   migrateNotificationDeliveryThreadDecision,
   migrateReminderRoutingIntent,
+  migrateRenameVerificationTable,
   migrateSchemaIndexesAndColumns,
   migrateUsageDashboardIndexes,
   migrateVoiceInviteColumns,
@@ -307,6 +308,9 @@ export function initializeDb(): void {
 
   // 44. Backfill historical Anthropic usage rows from request-log truth before dashboard reads
   migrateBackfillUsageCacheAccounting(database);
+
+  // 45. Rename channel_guardian_verification_challenges → channel_verification_sessions
+  migrateRenameVerificationTable(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/guardian-verification.ts
+++ b/assistant/src/memory/guardian-verification.ts
@@ -9,7 +9,7 @@
 import { and, count, desc, eq, gt, gte, inArray, or } from "drizzle-orm";
 
 import { getDb } from "./db.js";
-import { channelGuardianVerificationChallenges } from "./schema.js";
+import { channelVerificationSessions } from "./schema.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -63,7 +63,7 @@ export interface VerificationChallenge {
 // ---------------------------------------------------------------------------
 
 function rowToChallenge(
-  row: typeof channelGuardianVerificationChallenges.$inferSelect,
+  row: typeof channelVerificationSessions.$inferSelect,
 ): VerificationChallenge {
   return {
     id: row.id,
@@ -109,12 +109,12 @@ export function createChallenge(params: {
 
   // Revoke any prior pending challenges for the same channel
   // to close the replay window — only the latest challenge should be valid.
-  db.update(channelGuardianVerificationChallenges)
+  db.update(channelVerificationSessions)
     .set({ status: "revoked", updatedAt: now })
     .where(
       and(
-        eq(channelGuardianVerificationChallenges.channel, params.channel),
-        eq(channelGuardianVerificationChallenges.status, "pending"),
+        eq(channelVerificationSessions.channel, params.channel),
+        eq(channelVerificationSessions.status, "pending"),
       ),
     )
     .run();
@@ -144,19 +144,19 @@ export function createChallenge(params: {
     updatedAt: now,
   };
 
-  db.insert(channelGuardianVerificationChallenges).values(row).run();
+  db.insert(channelVerificationSessions).values(row).run();
 
   return rowToChallenge(row);
 }
 
 export function revokePendingChallenges(channel: string): void {
   const db = getDb();
-  db.update(channelGuardianVerificationChallenges)
+  db.update(channelVerificationSessions)
     .set({ status: "revoked", updatedAt: Date.now() })
     .where(
       and(
-        eq(channelGuardianVerificationChallenges.channel, channel),
-        eq(channelGuardianVerificationChallenges.status, "pending"),
+        eq(channelVerificationSessions.channel, channel),
+        eq(channelVerificationSessions.status, "pending"),
       ),
     )
     .run();
@@ -172,17 +172,17 @@ export function findPendingChallengeByHash(
   // Match any consumable status: 'pending' (inbound), 'pending_bootstrap', 'awaiting_response' (outbound)
   const row = db
     .select()
-    .from(channelGuardianVerificationChallenges)
+    .from(channelVerificationSessions)
     .where(
       and(
-        eq(channelGuardianVerificationChallenges.channel, channel),
-        eq(channelGuardianVerificationChallenges.challengeHash, challengeHash),
-        inArray(channelGuardianVerificationChallenges.status, [
+        eq(channelVerificationSessions.channel, channel),
+        eq(channelVerificationSessions.challengeHash, challengeHash),
+        inArray(channelVerificationSessions.status, [
           "pending",
           "pending_bootstrap",
           "awaiting_response",
         ]),
-        gt(channelGuardianVerificationChallenges.expiresAt, now),
+        gt(channelVerificationSessions.expiresAt, now),
       ),
     )
     .get();
@@ -206,12 +206,12 @@ export function findPendingChallengeForChannel(
 
   const row = db
     .select()
-    .from(channelGuardianVerificationChallenges)
+    .from(channelVerificationSessions)
     .where(
       and(
-        eq(channelGuardianVerificationChallenges.channel, channel),
-        eq(channelGuardianVerificationChallenges.status, "pending"),
-        gt(channelGuardianVerificationChallenges.expiresAt, now),
+        eq(channelVerificationSessions.channel, channel),
+        eq(channelVerificationSessions.status, "pending"),
+        gt(channelVerificationSessions.expiresAt, now),
       ),
     )
     .get();
@@ -227,14 +227,14 @@ export function consumeChallenge(
   const db = getDb();
   const now = Date.now();
 
-  db.update(channelGuardianVerificationChallenges)
+  db.update(channelVerificationSessions)
     .set({
       status: "consumed",
       consumedByExternalUserId,
       consumedByChatId,
       updatedAt: now,
     })
-    .where(eq(channelGuardianVerificationChallenges.id, id))
+    .where(eq(channelVerificationSessions.id, id))
     .run();
 }
 
@@ -268,12 +268,12 @@ export function createVerificationSession(params: {
   const now = Date.now();
 
   // Revoke any prior pending/awaiting_response sessions for the same channel
-  db.update(channelGuardianVerificationChallenges)
+  db.update(channelVerificationSessions)
     .set({ status: "revoked", updatedAt: now })
     .where(
       and(
-        eq(channelGuardianVerificationChallenges.channel, params.channel),
-        inArray(channelGuardianVerificationChallenges.status, [
+        eq(channelVerificationSessions.channel, params.channel),
+        inArray(channelVerificationSessions.status, [
           "pending",
           "pending_bootstrap",
           "awaiting_response",
@@ -307,7 +307,7 @@ export function createVerificationSession(params: {
     updatedAt: now,
   };
 
-  db.insert(channelGuardianVerificationChallenges).values(row).run();
+  db.insert(channelVerificationSessions).values(row).run();
 
   return rowToChallenge(row);
 }
@@ -324,18 +324,18 @@ export function findActiveSession(
 
   const row = db
     .select()
-    .from(channelGuardianVerificationChallenges)
+    .from(channelVerificationSessions)
     .where(
       and(
-        eq(channelGuardianVerificationChallenges.channel, channel),
-        inArray(channelGuardianVerificationChallenges.status, [
+        eq(channelVerificationSessions.channel, channel),
+        inArray(channelVerificationSessions.status, [
           "pending_bootstrap",
           "awaiting_response",
         ]),
-        gt(channelGuardianVerificationChallenges.expiresAt, now),
+        gt(channelVerificationSessions.expiresAt, now),
       ),
     )
-    .orderBy(desc(channelGuardianVerificationChallenges.createdAt))
+    .orderBy(desc(channelVerificationSessions.createdAt))
     .get();
 
   return row ? rowToChallenge(row) : null;
@@ -354,13 +354,13 @@ export function findSessionByBootstrapTokenHash(
 
   const row = db
     .select()
-    .from(channelGuardianVerificationChallenges)
+    .from(channelVerificationSessions)
     .where(
       and(
-        eq(channelGuardianVerificationChallenges.channel, channel),
-        eq(channelGuardianVerificationChallenges.bootstrapTokenHash, tokenHash),
-        eq(channelGuardianVerificationChallenges.status, "pending_bootstrap"),
-        gt(channelGuardianVerificationChallenges.expiresAt, now),
+        eq(channelVerificationSessions.channel, channel),
+        eq(channelVerificationSessions.bootstrapTokenHash, tokenHash),
+        eq(channelVerificationSessions.status, "pending_bootstrap"),
+        gt(channelVerificationSessions.expiresAt, now),
       ),
     )
     .get();
@@ -388,32 +388,29 @@ export function findSessionByIdentity(
   const now = Date.now();
 
   const conditions = [
-    eq(channelGuardianVerificationChallenges.channel, channel),
-    inArray(channelGuardianVerificationChallenges.status, [
+    eq(channelVerificationSessions.channel, channel),
+    inArray(channelVerificationSessions.status, [
       "pending_bootstrap",
       "awaiting_response",
     ]),
-    gt(channelGuardianVerificationChallenges.expiresAt, now),
+    gt(channelVerificationSessions.expiresAt, now),
   ];
 
   // Build identity match conditions
   const identityConditions = [];
   if (externalUserId) {
     identityConditions.push(
-      eq(
-        channelGuardianVerificationChallenges.expectedExternalUserId,
-        externalUserId,
-      ),
+      eq(channelVerificationSessions.expectedExternalUserId, externalUserId),
     );
   }
   if (chatId) {
     identityConditions.push(
-      eq(channelGuardianVerificationChallenges.expectedChatId, chatId),
+      eq(channelVerificationSessions.expectedChatId, chatId),
     );
   }
   if (phoneE164) {
     identityConditions.push(
-      eq(channelGuardianVerificationChallenges.expectedPhoneE164, phoneE164),
+      eq(channelVerificationSessions.expectedPhoneE164, phoneE164),
     );
   }
 
@@ -423,9 +420,9 @@ export function findSessionByIdentity(
 
   const row = db
     .select()
-    .from(channelGuardianVerificationChallenges)
+    .from(channelVerificationSessions)
     .where(and(...conditions))
-    .orderBy(desc(channelGuardianVerificationChallenges.createdAt))
+    .orderBy(desc(channelVerificationSessions.createdAt))
     .get();
 
   return row ? rowToChallenge(row) : null;
@@ -445,7 +442,7 @@ export function updateSessionStatus(
   const db = getDb();
   const now = Date.now();
 
-  db.update(channelGuardianVerificationChallenges)
+  db.update(channelVerificationSessions)
     .set({
       status,
       updatedAt: now,
@@ -456,7 +453,7 @@ export function updateSessionStatus(
         ? { consumedByChatId: extraFields.consumedByChatId }
         : {}),
     })
-    .where(eq(channelGuardianVerificationChallenges.id, id))
+    .where(eq(channelVerificationSessions.id, id))
     .run();
 }
 
@@ -472,14 +469,14 @@ export function updateSessionDelivery(
   const db = getDb();
   const now = Date.now();
 
-  db.update(channelGuardianVerificationChallenges)
+  db.update(channelVerificationSessions)
     .set({
       lastSentAt,
       sendCount,
       nextResendAt,
       updatedAt: now,
     })
-    .where(eq(channelGuardianVerificationChallenges.id, id))
+    .where(eq(channelVerificationSessions.id, id))
     .run();
 }
 
@@ -500,15 +497,12 @@ export function countRecentSendsToDestination(
 
   const result = db
     .select({ total: count() })
-    .from(channelGuardianVerificationChallenges)
+    .from(channelVerificationSessions)
     .where(
       and(
-        eq(channelGuardianVerificationChallenges.channel, channel),
-        eq(
-          channelGuardianVerificationChallenges.destinationAddress,
-          destinationAddress,
-        ),
-        gte(channelGuardianVerificationChallenges.lastSentAt, cutoff),
+        eq(channelVerificationSessions.channel, channel),
+        eq(channelVerificationSessions.destinationAddress, destinationAddress),
+        gte(channelVerificationSessions.lastSentAt, cutoff),
       ),
     )
     .get();
@@ -528,13 +522,13 @@ export function bindSessionIdentity(
   const db = getDb();
   const now = Date.now();
 
-  db.update(channelGuardianVerificationChallenges)
+  db.update(channelVerificationSessions)
     .set({
       expectedExternalUserId: externalUserId,
       expectedChatId: chatId,
       identityBindingStatus: "bound",
       updatedAt: now,
     })
-    .where(eq(channelGuardianVerificationChallenges.id, id))
+    .where(eq(channelVerificationSessions.id, id))
     .run();
 }

--- a/assistant/src/memory/migrations/141-rename-verification-table.ts
+++ b/assistant/src/memory/migrations/141-rename-verification-table.ts
@@ -1,0 +1,55 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * One-shot migration: rename channel_guardian_verification_challenges →
+ * channel_verification_sessions, including all indexes that reference the
+ * old table name.
+ */
+export function migrateRenameVerificationTable(database: DrizzleDb): void {
+  withCrashRecovery(database, "migration_rename_verification_table_v1", () => {
+    const raw = getSqliteFrom(database);
+
+    // Check the old table exists before attempting anything
+    const oldTableExists = raw
+      .query(
+        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'channel_guardian_verification_challenges'`,
+      )
+      .get();
+    if (!oldTableExists) return;
+
+    // Rename the physical table
+    raw.exec(
+      /*sql*/ `ALTER TABLE channel_guardian_verification_challenges RENAME TO channel_verification_sessions`,
+    );
+
+    // Drop and recreate indexes that referenced the old table name.
+    // SQLite automatically updates index table references on RENAME, but the
+    // index names still reference the old naming convention — drop and recreate
+    // with consistent names pointing at the new table.
+
+    raw.exec(
+      /*sql*/ `DROP INDEX IF EXISTS idx_channel_guardian_challenges_lookup`,
+    );
+    raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_guardian_sessions_active`);
+    raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_guardian_sessions_identity`);
+    raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_guardian_sessions_destination`);
+    raw.exec(/*sql*/ `DROP INDEX IF EXISTS idx_guardian_sessions_bootstrap`);
+
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_verification_sessions_lookup ON channel_verification_sessions(channel, challenge_hash, status)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_verification_sessions_active ON channel_verification_sessions(channel, status)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_verification_sessions_identity ON channel_verification_sessions(channel, expected_external_user_id, expected_chat_id, status)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_verification_sessions_destination ON channel_verification_sessions(channel, destination_address)`,
+    );
+    raw.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_verification_sessions_bootstrap ON channel_verification_sessions(channel, bootstrap_token_hash, status)`,
+    );
+  });
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -82,6 +82,7 @@ export { migrateDropAssistantIdColumns } from "./136-drop-assistant-id-columns.j
 export { migrateUsageDashboardIndexes } from "./137-usage-dashboard-indexes.js";
 export { migrateDropUsageCompositeIndexes } from "./139-drop-usage-composite-indexes.js";
 export { migrateBackfillUsageCacheAccounting } from "./140-backfill-usage-cache-accounting.js";
+export { migrateRenameVerificationTable } from "./141-rename-verification-table.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -147,6 +147,12 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Backfill historical Anthropic llm_usage_events rows from llm_request_logs with cache-aware pricing",
   },
+  {
+    key: "migration_rename_verification_table_v1",
+    version: 21,
+    description:
+      "Rename channel_guardian_verification_challenges table to channel_verification_sessions and update indexes",
+  },
 ];
 
 export interface MigrationValidationResult {

--- a/assistant/src/memory/schema/calls.ts
+++ b/assistant/src/memory/schema/calls.ts
@@ -85,8 +85,8 @@ export const externalConversationBindings = sqliteTable(
   },
 );
 
-export const channelGuardianVerificationChallenges = sqliteTable(
-  "channel_guardian_verification_challenges",
+export const channelVerificationSessions = sqliteTable(
+  "channel_verification_sessions",
   {
     id: text("id").primaryKey(),
     channel: text("channel").notNull(),


### PR DESCRIPTION
## Summary
- Rename SQLite table from channel_guardian_verification_challenges to channel_verification_sessions via ALTER TABLE migration
- Update drizzle schema definition to use channelVerificationSessions
- Update all codebase references to the renamed table

Part of plan: chan-verify-session-unify.md (PR 1 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
