### PR TITLE
refactor: move guardian bootstrap/refresh to /v1/guardian/init and /v1/guardian/refresh

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -59,11 +59,11 @@ All HTTP API requests use a single `Authorization: Bearer <jwt>` header for auth
 
 **Identity lifecycle:**
 
-1. **Bootstrap (loopback-only, macOS/CLI)** — On first launch, the client calls `POST /v1/integrations/guardian/vellum/bootstrap` with `{ platform, deviceId }`. The endpoint is loopback-only and mints a JWT access token + refresh token pair. Returns `{ guardianPrincipalId, accessToken, accessTokenExpiresAt, refreshToken, refreshTokenExpiresAt, refreshAfter, isNew }`.
+1. **Bootstrap (loopback-only, macOS/CLI)** — On first launch, the client calls `POST /v1/guardian/init` with `{ platform, deviceId }`. The endpoint is loopback-only and mints a JWT access token + refresh token pair. Returns `{ guardianPrincipalId, accessToken, accessTokenExpiresAt, refreshToken, refreshTokenExpiresAt, refreshAfter, isNew }`.
 
 2. **iOS pairing** — iOS devices obtain JWTs through the QR pairing flow. The pairing response includes `accessToken` and `refreshToken` credentials.
 
-3. **Refresh** — `POST /v1/integrations/guardian/vellum/refresh` accepts `{ refreshToken }` and returns a new access/refresh token pair. Single-use rotation with replay detection and family-based revocation.
+3. **Refresh** — `POST /v1/guardian/refresh` accepts `{ refreshToken }` and returns a new access/refresh token pair. Single-use rotation with replay detection and family-based revocation.
 
 4. **IPC identity** — Local IPC connections use `resolveLocalIpcGuardianContext()` for deterministic identity without tokens.
 
@@ -85,8 +85,8 @@ All HTTP API requests use a single `Authorization: Bearer <jwt>` header for auth
 | `src/runtime/auth/subject.ts`                     | Subject string parser (`parseSub`)                                                            |
 | `src/runtime/auth/middleware.ts`                  | JWT bearer auth middleware (`authenticateRequest`)                                            |
 | `src/runtime/auth/route-policy.ts`                | Route-level scope/principal enforcement                                                       |
-| `src/runtime/routes/guardian-bootstrap-routes.ts` | `POST /v1/integrations/guardian/vellum/bootstrap` (initial JWT issuance)                      |
-| `src/runtime/routes/guardian-refresh-routes.ts`   | `POST /v1/integrations/guardian/vellum/refresh` (token rotation)                              |
+| `src/runtime/routes/guardian-bootstrap-routes.ts` | `POST /v1/guardian/init` (initial JWT issuance)                                               |
+| `src/runtime/routes/guardian-refresh-routes.ts`   | `POST /v1/guardian/refresh` (token rotation)                                                  |
 | `src/runtime/routes/pairing-routes.ts`            | JWT credential issuance in pairing flow                                                       |
 | `src/runtime/local-actor-identity.ts`             | `resolveLocalIpcGuardianContext` — deterministic IPC identity                                 |
 | `src/memory/channel-guardian-store.ts`            | Guardian binding types and re-exports                                                         |

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -278,7 +278,7 @@ The channel guardian service generates verification challenge instructions with 
 
 The vellum channel (macOS, iOS, CLI) uses JWTs to bind guardian identity to HTTP requests. This enables identity-based authentication for the local desktop/mobile channel, paralleling how external channels (Telegram, SMS) use `actorExternalId` for guardian identity.
 
-- **Bootstrap**: After hatch, the macOS client calls `POST /v1/integrations/guardian/vellum/bootstrap` with `{ platform, deviceId }`. Returns `{ guardianPrincipalId, accessToken, accessTokenExpiresAt, refreshToken, refreshTokenExpiresAt, refreshAfter, isNew }`. The endpoint is idempotent -- repeated calls with the same device return the same principal but mint fresh credentials.
+- **Bootstrap**: After hatch, the macOS client calls `POST /v1/guardian/init` with `{ platform, deviceId }`. Returns `{ guardianPrincipalId, accessToken, accessTokenExpiresAt, refreshToken, refreshTokenExpiresAt, refreshAfter, isNew }`. The endpoint is idempotent -- repeated calls with the same device return the same principal but mint fresh credentials.
 - **iOS pairing**: The pairing response includes `accessToken` and `refreshToken` credentials automatically when a vellum guardian binding exists.
 - **IPC fallback**: Local IPC (Unix socket) connections resolve identity server-side via `resolveLocalIpcGuardianContext()` without requiring a JWT.
 - **HTTP enforcement**: All vellum HTTP routes require a valid JWT via the `Authorization: Bearer <jwt>` header. The JWT carries identity claims (`sub` with principal type and ID) and scope permissions. Route-level enforcement in `route-policy.ts` checks scopes and principal types.

--- a/assistant/src/__tests__/actor-token-service.test.ts
+++ b/assistant/src/__tests__/actor-token-service.test.ts
@@ -249,14 +249,11 @@ describe("bootstrap endpoint idempotency", () => {
     const { handleGuardianBootstrap } =
       await import("../runtime/routes/guardian-bootstrap-routes.js");
 
-    const req1 = new Request(
-      "http://localhost/v1/integrations/guardian/vellum/bootstrap",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ platform: "macos", deviceId: "test-device-1" }),
-      },
-    );
+    const req1 = new Request("http://localhost/v1/guardian/init", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ platform: "macos", deviceId: "test-device-1" }),
+    });
 
     const res1 = await handleGuardianBootstrap(req1, loopbackServer);
     expect(res1.status).toBe(200);
@@ -266,14 +263,11 @@ describe("bootstrap endpoint idempotency", () => {
     expect(body1.isNew).toBe(true);
 
     // Second call with same device
-    const req2 = new Request(
-      "http://localhost/v1/integrations/guardian/vellum/bootstrap",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ platform: "macos", deviceId: "test-device-1" }),
-      },
-    );
+    const req2 = new Request("http://localhost/v1/guardian/init", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ platform: "macos", deviceId: "test-device-1" }),
+    });
 
     const res2 = await handleGuardianBootstrap(req2, loopbackServer);
     expect(res2.status).toBe(200);
@@ -289,14 +283,11 @@ describe("bootstrap endpoint idempotency", () => {
     const { handleGuardianBootstrap } =
       await import("../runtime/routes/guardian-bootstrap-routes.js");
 
-    const req = new Request(
-      "http://localhost/v1/integrations/guardian/vellum/bootstrap",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ platform: "macos" }),
-      },
-    );
+    const req = new Request("http://localhost/v1/guardian/init", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ platform: "macos" }),
+    });
 
     const res = await handleGuardianBootstrap(req, loopbackServer);
     expect(res.status).toBe(400);
@@ -306,14 +297,11 @@ describe("bootstrap endpoint idempotency", () => {
     const { handleGuardianBootstrap } =
       await import("../runtime/routes/guardian-bootstrap-routes.js");
 
-    const req = new Request(
-      "http://localhost/v1/integrations/guardian/vellum/bootstrap",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ platform: "android", deviceId: "test-device" }),
-      },
-    );
+    const req = new Request("http://localhost/v1/guardian/init", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ platform: "android", deviceId: "test-device" }),
+    });
 
     const res = await handleGuardianBootstrap(req, loopbackServer);
     expect(res.status).toBe(400);
@@ -323,26 +311,20 @@ describe("bootstrap endpoint idempotency", () => {
     const { handleGuardianBootstrap } =
       await import("../runtime/routes/guardian-bootstrap-routes.js");
 
-    const req1 = new Request(
-      "http://localhost/v1/integrations/guardian/vellum/bootstrap",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ platform: "macos", deviceId: "device-A" }),
-      },
-    );
+    const req1 = new Request("http://localhost/v1/guardian/init", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ platform: "macos", deviceId: "device-A" }),
+    });
 
     const res1 = await handleGuardianBootstrap(req1, loopbackServer);
     const body1 = (await res1.json()) as Record<string, unknown>;
 
-    const req2 = new Request(
-      "http://localhost/v1/integrations/guardian/vellum/bootstrap",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ platform: "macos", deviceId: "device-B" }),
-      },
-    );
+    const req2 = new Request("http://localhost/v1/guardian/init", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ platform: "macos", deviceId: "device-B" }),
+    });
 
     const res2 = await handleGuardianBootstrap(req2, loopbackServer);
     const body2 = (await res2.json()) as Record<string, unknown>;
@@ -356,17 +338,14 @@ describe("bootstrap endpoint idempotency", () => {
     const { handleGuardianBootstrap } =
       await import("../runtime/routes/guardian-bootstrap-routes.js");
 
-    const req = new Request(
-      "http://localhost/v1/integrations/guardian/vellum/bootstrap",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          platform: "macos",
-          deviceId: "test-device-jwt",
-        }),
-      },
-    );
+    const req = new Request("http://localhost/v1/guardian/init", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        platform: "macos",
+        deviceId: "test-device-jwt",
+      }),
+    });
 
     const res = await handleGuardianBootstrap(req, loopbackServer);
     expect(res.status).toBe(200);
@@ -707,17 +686,14 @@ describe("bootstrap loopback guard", () => {
     const { handleGuardianBootstrap } =
       await import("../runtime/routes/guardian-bootstrap-routes.js");
 
-    const req = new Request(
-      "http://localhost/v1/integrations/guardian/vellum/bootstrap",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Forwarded-For": "10.0.0.1",
-        },
-        body: JSON.stringify({ platform: "macos", deviceId: "test-device" }),
+    const req = new Request("http://localhost/v1/guardian/init", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Forwarded-For": "10.0.0.1",
       },
-    );
+      body: JSON.stringify({ platform: "macos", deviceId: "test-device" }),
+    });
 
     const res = await handleGuardianBootstrap(req, loopbackServer);
     expect(res.status).toBe(403);
@@ -729,14 +705,11 @@ describe("bootstrap loopback guard", () => {
     const { handleGuardianBootstrap } =
       await import("../runtime/routes/guardian-bootstrap-routes.js");
 
-    const req = new Request(
-      "http://localhost/v1/integrations/guardian/vellum/bootstrap",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ platform: "macos", deviceId: "test-device" }),
-      },
-    );
+    const req = new Request("http://localhost/v1/guardian/init", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ platform: "macos", deviceId: "test-device" }),
+    });
 
     const res = await handleGuardianBootstrap(req, nonLoopbackServer);
     expect(res.status).toBe(403);
@@ -748,14 +721,11 @@ describe("bootstrap loopback guard", () => {
     const { handleGuardianBootstrap } =
       await import("../runtime/routes/guardian-bootstrap-routes.js");
 
-    const req = new Request(
-      "http://localhost/v1/integrations/guardian/vellum/bootstrap",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ platform: "macos", deviceId: "test-device-ok" }),
-      },
-    );
+    const req = new Request("http://localhost/v1/guardian/init", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ platform: "macos", deviceId: "test-device-ok" }),
+    });
 
     const res = await handleGuardianBootstrap(req, loopbackServer);
     expect(res.status).toBe(200);

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -460,16 +460,10 @@ export class RuntimeHttpServer {
     // needs to work when the access token is expired. Bootstrap has its
     // own loopback IP validation; refresh is secured by the refresh token
     // in the request body (32 random bytes, hash-only storage).
-    if (
-      path === "/v1/integrations/guardian/vellum/bootstrap" &&
-      req.method === "POST"
-    ) {
+    if (path === "/v1/guardian/init" && req.method === "POST") {
       return await handleGuardianBootstrap(req, server);
     }
-    if (
-      path === "/v1/integrations/guardian/vellum/refresh" &&
-      req.method === "POST"
-    ) {
+    if (path === "/v1/guardian/refresh" && req.method === "POST") {
       return await handleGuardianRefresh(req);
     }
 

--- a/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
+++ b/assistant/src/runtime/routes/guardian-bootstrap-routes.ts
@@ -1,5 +1,5 @@
 /**
- * POST /v1/integrations/guardian/vellum/bootstrap
+ * POST /v1/guardian/init
  *
  * Idempotent bootstrap endpoint for the vellum guardian channel.
  * Creates or confirms a guardianPrincipalId and channel='vellum'
@@ -76,7 +76,7 @@ function ensureGuardianPrincipal(assistantId: string): {
 const LOOPBACK_ADDRESSES = new Set(["127.0.0.1", "::1", "::ffff:127.0.0.1"]);
 
 /**
- * Handle POST /v1/integrations/guardian/vellum/bootstrap
+ * Handle POST /v1/guardian/init
  *
  * Body: { platform: 'macos', deviceId: string }
  * Returns: { guardianPrincipalId, accessToken, isNew }
@@ -167,7 +167,7 @@ export async function handleGuardianBootstrap(
 export function guardianBootstrapRouteDefinitions(): RouteDefinition[] {
   return [
     {
-      endpoint: "integrations/guardian/vellum/bootstrap",
+      endpoint: "guardian/init",
       method: "POST",
       handler: async ({ req, server }) => handleGuardianBootstrap(req, server),
     },

--- a/assistant/src/runtime/routes/guardian-refresh-routes.ts
+++ b/assistant/src/runtime/routes/guardian-refresh-routes.ts
@@ -1,5 +1,5 @@
 /**
- * POST /v1/integrations/guardian/vellum/refresh
+ * POST /v1/guardian/refresh
  *
  * Rotates the refresh token and mints a new access token + refresh token pair.
  * This endpoint is the runtime handler proxied through the gateway.
@@ -13,7 +13,7 @@ import type { RouteDefinition } from "../http-router.js";
 const log = getLogger("guardian-refresh");
 
 /**
- * Handle POST /v1/integrations/guardian/vellum/refresh
+ * Handle POST /v1/guardian/refresh
  *
  * Body: { platform: 'ios' | 'macos', deviceId: string, refreshToken: string }
  * Returns: { guardianPrincipalId, accessToken, accessTokenExpiresAt, refreshToken, refreshTokenExpiresAt, refreshAfter }
@@ -86,7 +86,7 @@ export async function handleGuardianRefresh(req: Request): Promise<Response> {
 export function guardianRefreshRouteDefinitions(): RouteDefinition[] {
   return [
     {
-      endpoint: "integrations/guardian/vellum/refresh",
+      endpoint: "guardian/refresh",
       method: "POST",
       handler: async ({ req }) => handleGuardianRefresh(req),
     },

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -214,7 +214,7 @@ async function bootstrapAccessToken(
   }
 
   const deviceId = `vellum-cli:${platform()}:${hostname()}:${userInfo().username}`;
-  const url = `${baseUrl}/v1/integrations/guardian/vellum/bootstrap`;
+  const url = `${baseUrl}/v1/guardian/init`;
 
   const response = await fetch(url, {
     method: "POST",

--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -695,7 +695,7 @@ Both macOS and iOS clients use a single JWT access token for all HTTP authentica
 | Refresh token expiry | Keychain | Absolute expiry timestamp of the current refresh token |
 | `refreshAfter` | Keychain | Timestamp at which the client should proactively refresh (80% of access token TTL) |
 
-**Proactive refresh:** Both macOS and iOS run a periodic check every 5 minutes. If `now >= refreshAfter`, the client calls `POST /v1/integrations/guardian/vellum/refresh` (through the gateway) with the current refresh token and `Authorization: Bearer <jwt>`. On success, the response provides a new `accessToken`, `refreshToken`, `accessTokenExpiresAt`, `refreshTokenExpiresAt`, and `refreshAfter`. All stored credentials are updated atomically.
+**Proactive refresh:** Both macOS and iOS run a periodic check every 5 minutes. If `now >= refreshAfter`, the client calls `POST /v1/guardian/refresh` (through the gateway) with the current refresh token and `Authorization: Bearer <jwt>`. On success, the response provides a new `accessToken`, `refreshToken`, `accessTokenExpiresAt`, `refreshTokenExpiresAt`, and `refreshAfter`. All stored credentials are updated atomically.
 
 **401 recovery:** When an HTTP request receives a 401 response with `{ "code": "refresh_required" }`, the `HTTPTransport` attempts a single refresh before surfacing a "Session expired" error. If the refresh succeeds, the original request is retried with the new JWT. If the 401 contains a different code or the refresh fails (e.g., refresh token expired or revoked), the client surfaces the session-expired error and the user must re-pair (iOS) or re-bootstrap (macOS).
 

--- a/clients/shared/App/Auth/ActorCredentialRefresher.swift
+++ b/clients/shared/App/Auth/ActorCredentialRefresher.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Shared credential refresher. Calls POST /v1/integrations/guardian/vellum/refresh
+/// Shared credential refresher. Calls POST /v1/guardian/refresh
 /// through the gateway, updates Keychain via ActorTokenManager, and handles
 /// terminal errors that require re-pairing.
 public class ActorCredentialRefresher {
@@ -24,7 +24,7 @@ public class ActorCredentialRefresher {
             return .terminalError(reason: "refresh_token_expired")
         }
 
-        guard let url = URL(string: "\(baseURL)/v1/integrations/guardian/vellum/refresh") else {
+        guard let url = URL(string: "\(baseURL)/v1/guardian/refresh") else {
             return .transientError
         }
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -2363,7 +2363,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     // MARK: - Actor Token Bootstrap
 
-    /// Response from `POST /v1/integrations/guardian/vellum/bootstrap`.
+    /// Response from `POST /v1/guardian/init`.
     /// Accepts both `accessToken` (new) and `actorToken` (legacy) field names.
     public struct GuardianBootstrapResponse: Decodable {
         public let guardianPrincipalId: String
@@ -2418,7 +2418,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         var request: URLRequest
 
         if let httpTransport {
-            guard let url = URL(string: "\(httpTransport.baseURL)/v1/integrations/guardian/vellum/bootstrap") else {
+            guard let url = URL(string: "\(httpTransport.baseURL)/v1/guardian/init") else {
                 log.error("Invalid bootstrap URL")
                 return false
             }
@@ -2430,7 +2430,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
                 r.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
             }
             request = r
-        } else if var r = buildLocalRequest(target: .daemon, path: "v1/integrations/guardian/vellum/bootstrap", method: "POST", timeout: 15) {
+        } else if var r = buildLocalRequest(target: .daemon, path: "v1/guardian/init", method: "POST", timeout: 15) {
             r.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request = r
         } else {

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -88,9 +88,9 @@ Guardian verification endpoints are exposed directly by the gateway and forwarde
 | POST   | `/v1/integrations/guardian/sessions/resend` |
 | GET    | `/v1/integrations/guardian/status`          |
 | POST   | `/v1/integrations/guardian/revoke`          |
-| POST   | `/v1/integrations/guardian/vellum/refresh`  |
+| POST   | `/v1/guardian/refresh`                      |
 
-The `/vellum/refresh` endpoint is the only public ingress for rotating JWT access + refresh token credentials. Clients must call this through the gateway; the runtime endpoint is not directly exposed. The gateway validates the caller's JWT and forwards to the runtime, which handles refresh token validation, rotation, and replay detection (see [`assistant/ARCHITECTURE.md`](../assistant/ARCHITECTURE.md) for the JWT auth lifecycle).
+The `/guardian/refresh` endpoint is the only public ingress for rotating JWT access + refresh token credentials. Clients must call this through the gateway; the runtime endpoint is not directly exposed. The gateway validates the caller's JWT and forwards to the runtime, which handles refresh token validation, rotation, and replay detection (see [`assistant/ARCHITECTURE.md`](../assistant/ARCHITECTURE.md) for the JWT auth lifecycle).
 
 **Authentication boundary:**
 

--- a/gateway/src/http/routes/guardian-control-plane-proxy.ts
+++ b/gateway/src/http/routes/guardian-control-plane-proxy.ts
@@ -127,20 +127,12 @@ export function createGuardianControlPlaneProxyHandler(config: GatewayConfig) {
       );
     },
 
-    async handleGuardianVellumBootstrap(req: Request): Promise<Response> {
-      return proxyToRuntime(
-        req,
-        "/v1/integrations/guardian/vellum/bootstrap",
-        "",
-      );
+    async handleGuardianInit(req: Request): Promise<Response> {
+      return proxyToRuntime(req, "/v1/guardian/init", "");
     },
 
     async handleGuardianRefresh(req: Request): Promise<Response> {
-      return proxyToRuntime(
-        req,
-        "/v1/integrations/guardian/vellum/refresh",
-        "",
-      );
+      return proxyToRuntime(req, "/v1/guardian/refresh", "");
     },
   };
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -429,11 +429,10 @@ async function main() {
 
     // ── Guardian control plane ──
     {
-      path: "/v1/integrations/guardian/vellum/bootstrap",
+      path: "/v1/guardian/init",
       method: "POST",
       auth: "edge",
-      handler: (req) =>
-        guardianControlPlaneProxy.handleGuardianVellumBootstrap(req),
+      handler: (req) => guardianControlPlaneProxy.handleGuardianInit(req),
     },
     {
       path: "/v1/integrations/guardian/sessions",
@@ -476,7 +475,7 @@ async function main() {
     // expires. Signature, audience, and policy epoch are still verified
     // — only the expiration check is relaxed.
     {
-      path: "/v1/integrations/guardian/vellum/refresh",
+      path: "/v1/guardian/refresh",
       method: "POST",
       auth: "custom",
       handler: (req, _params, getClientIp) => {

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1339,12 +1339,12 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
-      "/v1/integrations/guardian/vellum/bootstrap": {
+      "/v1/guardian/init": {
         post: {
-          summary: "Bootstrap Vellum guardian",
+          summary: "Initialize guardian",
           description:
-            "Authenticated gateway endpoint that bootstraps the Vellum guardian identity and binds it to the assistant runtime.",
-          operationId: "guardianVellumBootstrap",
+            "Authenticated gateway endpoint that initializes the guardian identity and binds it to the assistant runtime.",
+          operationId: "guardianInit",
           security: [{ BearerAuth: [] }],
           requestBody: {
             required: true,
@@ -1355,7 +1355,7 @@ export function buildSchema(): Record<string, unknown> {
             },
           },
           responses: {
-            "200": { description: "Guardian bootstrapped" },
+            "200": { description: "Guardian initialized" },
             "400": { description: "Invalid request payload" },
             "401": {
               description: "Unauthorized — missing or invalid bearer token",
@@ -1393,12 +1393,12 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
-      "/v1/integrations/guardian/vellum/refresh": {
+      "/v1/guardian/refresh": {
         post: {
           summary: "Refresh guardian access token",
           description:
             "Refreshes an expired guardian access token. Accepts expired JWTs (signature, audience, and policy epoch are still verified — only the expiration check is relaxed).",
-          operationId: "guardianVellumRefresh",
+          operationId: "guardianRefresh",
           security: [{ BearerAuth: [] }],
           requestBody: {
             required: true,


### PR DESCRIPTION
## Summary
- Move guardian bootstrap endpoint from /v1/integrations/guardian/vellum/bootstrap to /v1/guardian/init
- Move guardian refresh endpoint from /v1/integrations/guardian/vellum/refresh to /v1/guardian/refresh
- Update gateway routes, proxy handlers, OpenAPI schema, runtime pre-auth routes, and Swift client

Part of plan: chan-verify-session-unify.md (PR 3 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
