### PR TITLE
fix: isolate sleep test from multi-local test

### DIFF
--- a/cli/src/__tests__/sleep.test.ts
+++ b/cli/src/__tests__/sleep.test.ts
@@ -11,35 +11,65 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+// Create a temp directory that acts as a fake home so the real
+// assistant-config module reads/writes here instead of ~/.vellum.
 const testDir = mkdtempSync(join(tmpdir(), "sleep-command-test-"));
 const assistantRootDir = join(testDir, ".vellum");
+process.env.BASE_DATA_DIR = testDir;
+
+// Mock homedir() so defaultLocalResources() resolves to testDir.
+const realOs = await import("node:os");
+mock.module("node:os", () => ({
+  ...realOs,
+  homedir: () => testDir,
+}));
+mock.module("os", () => ({
+  ...realOs,
+  homedir: () => testDir,
+}));
 
 const stopProcessByPidFileMock = mock(async () => true);
-
-const mockEntry = {
-  assistantId: "sleep-test",
-  runtimeUrl: "http://127.0.0.1:7777",
-  cloud: "local",
-  resources: {
-    instanceDir: testDir,
-    daemonPort: 7777,
-    gatewayPort: 7830,
-    qdrantPort: 6333,
-    socketPath: join(assistantRootDir, "vellum.sock"),
-    pidFile: join(assistantRootDir, "vellum.pid"),
-  },
-};
-
-mock.module("../lib/assistant-config.js", () => ({
-  defaultLocalResources: () => mockEntry.resources,
-  resolveTargetAssistant: () => mockEntry,
-}));
 
 mock.module("../lib/process.js", () => ({
   stopProcessByPidFile: stopProcessByPidFileMock,
 }));
 
 import { sleep } from "../commands/sleep.js";
+import {
+  DEFAULT_DAEMON_PORT,
+  DEFAULT_GATEWAY_PORT,
+  DEFAULT_QDRANT_PORT,
+} from "../lib/constants.js";
+
+// Write a lockfile entry so the real resolveTargetAssistant() finds our test
+// assistant without needing to mock the entire assistant-config module.
+function writeLockfile(): void {
+  writeFileSync(
+    join(testDir, ".vellum.lock.json"),
+    JSON.stringify(
+      {
+        assistants: [
+          {
+            assistantId: "sleep-test",
+            runtimeUrl: `http://127.0.0.1:${DEFAULT_DAEMON_PORT}`,
+            cloud: "local",
+            resources: {
+              instanceDir: testDir,
+              daemonPort: DEFAULT_DAEMON_PORT,
+              gatewayPort: DEFAULT_GATEWAY_PORT,
+              qdrantPort: DEFAULT_QDRANT_PORT,
+              socketPath: join(assistantRootDir, "vellum.sock"),
+              pidFile: join(assistantRootDir, "vellum.pid"),
+            },
+          },
+        ],
+        activeAssistant: "sleep-test",
+      },
+      null,
+      2,
+    ),
+  );
+}
 
 function writeLeaseFile(callSessionIds: string[]): void {
   mkdirSync(assistantRootDir, { recursive: true });
@@ -68,11 +98,13 @@ describe("sleep command", () => {
     stopProcessByPidFileMock.mockReset();
     stopProcessByPidFileMock.mockResolvedValue(true);
     rmSync(assistantRootDir, { recursive: true, force: true });
+    writeLockfile();
   });
 
   afterAll(() => {
     process.argv = originalArgv;
     rmSync(testDir, { recursive: true, force: true });
+    delete process.env.BASE_DATA_DIR;
   });
 
   test("refuses normal sleep while an active call lease exists", async () => {


### PR DESCRIPTION
## Summary
- `sleep.test.ts` was using `mock.module("../lib/assistant-config.js", ...)` which globally replaced the module, causing `multi-local.test.ts` to receive mocked values instead of real ones
- Replaced the global mock with proper test setup: write a lockfile entry and set `BASE_DATA_DIR` + mock `homedir()` so the real `assistant-config.js` module works correctly in both tests

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22790135679/job/66115011346

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
