### PR TITLE
fix: remove stale SMS references and migrate legacy config mappings

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -145,7 +145,6 @@ import {
   validateAndConsumeChallenge,
 } from "../runtime/channel-guardian-service.js";
 import {
-  composeVerificationSms,
   composeVerificationTelegram,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,
 } from "../runtime/guardian-verification-templates.js";
@@ -2837,29 +2836,6 @@ describe("outbound SMS verification", () => {
     }
   });
 
-  test("template composer returns expected SMS format", () => {
-    const challengeSms = composeVerificationSms(
-      GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST,
-      { code: "123456", expiresInMinutes: 10 },
-    );
-    // Code should NOT appear in the message — user sees it in the app
-    expect(challengeSms).not.toContain("123456");
-    expect(challengeSms).toContain("code you were given");
-
-    const resendSms = composeVerificationSms(
-      GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND,
-      { code: "ABCDEF", expiresInMinutes: 5 },
-    );
-    expect(resendSms).not.toContain("ABCDEF");
-    expect(resendSms).toContain("resent");
-
-    const alreadySms = composeVerificationSms(
-      GUARDIAN_VERIFY_TEMPLATE_KEYS.ALREADY_VERIFIED,
-      { code: "unused", expiresInMinutes: 0 },
-    );
-    expect(alreadySms).toContain("already verified");
-  });
-
   test("start_outbound rejects unsupported channels", async () => {
     const { ctx, lastResponse } = createMockCtx();
     await handleGuardianVerification(
@@ -2949,16 +2925,6 @@ describe("outbound SMS verification", () => {
     expect(voiceCallInitCalls.length).toBeGreaterThanOrEqual(1);
     const lastCall = voiceCallInitCalls[voiceCallInitCalls.length - 1];
     expect(lastCall.phoneNumber).toBe("+15551234567");
-  });
-
-  test("template composer includes Vellum assistant prefix", () => {
-    const sms = composeVerificationSms(
-      GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST,
-      { code: "999999", expiresInMinutes: 10, assistantName: "MyBot" },
-    );
-    expect(sms).toContain("Vellum assistant");
-    // Code should NOT appear in the message
-    expect(sms).not.toContain("999999");
   });
 
   test("cancel_session succeeds even when no active session (idempotent)", async () => {

--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -76,7 +76,7 @@ mock.module("../config/loader.js", () => ({
     ingress: {
       publicBaseUrl: "https://test.example.com",
     },
-    sms: {
+    twilio: {
       phoneNumber: "+15550001111",
     },
   }),
@@ -90,7 +90,7 @@ mock.module("../config/loader.js", () => ({
     ingress: {
       publicBaseUrl: "https://test.example.com",
     },
-    sms: {
+    twilio: {
       phoneNumber: "+15550001111",
     },
   }),

--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -31,7 +31,7 @@ describe("integration-status", () => {
         { name: "Gmail", category: "email", connected: false },
         { name: "Twitter", category: "social", connected: false },
         { name: "Slack", category: "messaging", connected: false },
-        { name: "SMS", category: "messaging", connected: false },
+        { name: "Twilio", category: "telephony", connected: false },
         { name: "Telegram", category: "messaging", connected: false },
       ]);
     });
@@ -66,7 +66,7 @@ describe("integration-status", () => {
       );
 
       expect(connected.map((s: { name: string }) => s.name)).toEqual([
-        "SMS",
+        "Twilio",
         "Telegram",
       ]);
       expect(disconnected.map((s: { name: string }) => s.name)).toEqual([
@@ -76,11 +76,11 @@ describe("integration-status", () => {
       ]);
     });
 
-    test("SMS disconnected when only account_sid is set (missing auth_token)", () => {
+    test("Twilio disconnected when only account_sid is set (missing auth_token)", () => {
       mockTwilioAccountSid = "sid";
 
       const summary = getIntegrationSummary();
-      const sms = summary.find((s: { name: string }) => s.name === "SMS");
+      const sms = summary.find((s: { name: string }) => s.name === "Twilio");
       expect(sms?.connected).toBe(false);
     });
 
@@ -104,14 +104,14 @@ describe("integration-status", () => {
 
       const result = formatIntegrationSummary();
       expect(result).toBe(
-        "Gmail \u2717 | Twitter \u2717 | Slack \u2717 | SMS \u2713 | Telegram \u2713",
+        "Gmail \u2717 | Twitter \u2717 | Slack \u2717 | Twilio \u2713 | Telegram \u2713",
       );
     });
 
     test("all disconnected", () => {
       const result = formatIntegrationSummary();
       expect(result).toBe(
-        "Gmail \u2717 | Twitter \u2717 | Slack \u2717 | SMS \u2717 | Telegram \u2717",
+        "Gmail \u2717 | Twitter \u2717 | Slack \u2717 | Twilio \u2717 | Telegram \u2717",
       );
     });
 
@@ -126,7 +126,7 @@ describe("integration-status", () => {
 
       const result = formatIntegrationSummary();
       expect(result).toBe(
-        "Gmail \u2713 | Twitter \u2713 | Slack \u2713 | SMS \u2713 | Telegram \u2713",
+        "Gmail \u2713 | Twitter \u2713 | Slack \u2713 | Twilio \u2713 | Telegram \u2713",
       );
     });
   });

--- a/assistant/src/__tests__/integrations-cli.test.ts
+++ b/assistant/src/__tests__/integrations-cli.test.ts
@@ -324,7 +324,7 @@ describe("assistant integrations CLI", () => {
 
   test("reads twilio config without gateway fetch", async () => {
     rawConfig = {
-      sms: {
+      twilio: {
         phoneNumber: "+15550001111",
       },
     };

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -40,7 +40,6 @@ let updatePhoneNumberWebhookCalls: Array<{
   urls: {
     voiceUrl: string;
     statusCallbackUrl: string;
-    smsUrl: string;
   };
 }> = [];
 let reconcileCalls: Array<{
@@ -67,10 +66,10 @@ function readMockTwilioAuthToken(): string | undefined {
 }
 
 function readMockTwilioPhoneNumber(): string | undefined {
-  const sms = (mockRawConfigStore.sms ?? {}) as Record<string, unknown>;
+  const twilio = (mockRawConfigStore.twilio ?? {}) as Record<string, unknown>;
   return (
     mockSecureKeyStore["credential:twilio:phone_number"] ??
-    (sms.phoneNumber as string | undefined)
+    (twilio.phoneNumber as string | undefined)
   );
 }
 
@@ -283,8 +282,6 @@ mock.module("../inbound/public-ingress-urls.js", () => ({
     `${resolveIngressBaseUrlFromConfig(ingressConfig)}/webhooks/twilio/voice`,
   getTwilioStatusCallbackUrl: (ingressConfig: unknown) =>
     `${resolveIngressBaseUrlFromConfig(ingressConfig)}/webhooks/twilio/status`,
-  getTwilioSmsWebhookUrl: (ingressConfig: unknown) =>
-    `${resolveIngressBaseUrlFromConfig(ingressConfig)}/webhooks/twilio/sms`,
 }));
 
 mock.module("../runtime/auth/token-service.js", () => ({
@@ -426,8 +423,7 @@ describe("twilio webhook routes", () => {
     mockGatewayInternalBaseUrl = "http://gateway.internal:7830";
     mockMintedToken = "test-delivery-token";
     mockRawConfigStore = {
-      twilio: { accountSid: "AC_existing" },
-      sms: { phoneNumber: "+15550001111" },
+      twilio: { accountSid: "AC_existing", phoneNumber: "+15550001111" },
     };
     mockSecureKeyStore = {
       "credential:twilio:account_sid": "AC_existing",
@@ -1169,7 +1165,6 @@ describe("twilio webhook routes", () => {
       mockProvisionedNumber = { phoneNumber: "+15557778888" };
       mockRawConfigStore = {
         twilio: { accountSid: "AC_existing" },
-        sms: {},
       };
 
       const res = await handleProvisionTwilioNumber(
@@ -1197,7 +1192,6 @@ describe("twilio webhook routes", () => {
       expect(updatePhoneNumberWebhookCalls[0]!.urls).toEqual({
         voiceUrl: "https://numbers.example.com/webhooks/twilio/voice",
         statusCallbackUrl: "https://numbers.example.com/webhooks/twilio/status",
-        smsUrl: "https://numbers.example.com/webhooks/twilio/sms",
       });
 
       await flushReconcileWork();

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -110,7 +110,6 @@ export type ResolverResult =
 function resolveDeliverCallbackUrlForChannel(channel: string): string | null {
   switch (channel) {
     case "telegram":
-    case "sms":
     case "whatsapp":
     case "slack":
       return `${getGatewayInternalBaseUrl()}/deliver/${channel}`;

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -1,5 +1,5 @@
 import { getTwilioPhoneNumberEnv } from "../config/env.js";
-import { loadConfig, loadRawConfig } from "../config/loader.js";
+import { loadConfig } from "../config/loader.js";
 import {
   getPublicBaseUrl,
   getTwilioRelayUrl,
@@ -26,9 +26,8 @@ export interface TwilioConfig {
  * Resolution order:
  *   1. TWILIO_PHONE_NUMBER env var
  *   2. config.twilio?.phoneNumber
- *   3. config.sms?.phoneNumber  (legacy)
- *   4. secure store credential:twilio:phone_number  (legacy)
- *   5. ""
+ *   3. secure store credential:twilio:phone_number  (legacy)
+ *   4. ""
  */
 export function resolveTwilioPhoneNumber(): string {
   const fromEnv = getTwilioPhoneNumberEnv();
@@ -37,12 +36,6 @@ export function resolveTwilioPhoneNumber(): string {
   try {
     const config = loadConfig();
     if (config.twilio?.phoneNumber) return config.twilio.phoneNumber;
-    // Legacy: phone number was stored under sms.phoneNumber before SMS removal
-    const raw = loadRawConfig() as Record<string, unknown> | undefined;
-    const smsSection = raw?.sms as Record<string, unknown> | undefined;
-    if (typeof smsSection?.phoneNumber === "string" && smsSection.phoneNumber) {
-      return smsSection.phoneNumber;
-    }
   } catch {
     // Config may not be available yet during early startup
   }

--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -246,15 +246,13 @@ export async function fetchMessageStatus(
 export interface WebhookUrls {
   voiceUrl: string;
   statusCallbackUrl: string;
-  smsUrl: string;
 }
 
 /**
  * Update the webhook URLs on a Twilio IncomingPhoneNumber.
  *
- * Configures voice webhook, voice status callback, and SMS webhook so
- * that Twilio routes inbound calls and messages to the assistant's
- * gateway endpoints.
+ * Configures voice webhook and voice status callback so that Twilio
+ * routes inbound calls to the assistant's gateway endpoints.
  */
 export async function updatePhoneNumberWebhooks(
   accountSid: string,
@@ -304,8 +302,6 @@ export async function updatePhoneNumberWebhooks(
     VoiceMethod: "POST",
     StatusCallback: webhooks.statusCallbackUrl,
     StatusCallbackMethod: "POST",
-    SmsUrl: webhooks.smsUrl,
-    SmsMethod: "POST",
   });
 
   const updateRes = await fetch(

--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -121,9 +121,9 @@ function readTwilioConfig(): {
     ? getTwilioCredentials().accountSid
     : undefined;
   const raw = loadRawConfig();
-  const sms = asRecord(raw.sms);
+  const twilio = asRecord(raw.twilio);
   const phoneNumber =
-    typeof sms.phoneNumber === "string" ? sms.phoneNumber.trim() : "";
+    typeof twilio.phoneNumber === "string" ? twilio.phoneNumber.trim() : "";
 
   return {
     success: true,

--- a/assistant/src/daemon/handlers/config-ingress.ts
+++ b/assistant/src/daemon/handlers/config-ingress.ts
@@ -17,7 +17,6 @@ import {
   shouldUsePlatformCallbacks,
 } from "../../inbound/platform-callback-registration.js";
 import {
-  getTwilioSmsWebhookUrl,
   getTwilioStatusCallbackUrl,
   getTwilioVoiceWebhookUrl,
   type IngressConfig,
@@ -158,7 +157,7 @@ export function triggerGatewayTwilioReconcile(
 /**
  * Best-effort Twilio webhook sync helper.
  *
- * Computes the voice, status-callback, and SMS webhook URLs from the current
+ * Computes the voice and status-callback webhook URLs from the current
  * ingress config and pushes them to the Twilio IncomingPhoneNumber API.
  *
  * Returns `{ success, warning }`. When the update fails, `success` is false
@@ -183,15 +182,9 @@ export async function syncTwilioWebhooks(
       "webhooks/twilio/status",
       "twilio_status",
     );
-    const smsUrl = await resolveCallbackUrl(
-      () => getTwilioSmsWebhookUrl(ingressConfig),
-      "webhooks/twilio/sms",
-      "twilio_sms",
-    );
     await updatePhoneNumberWebhooks(accountSid, authToken, phoneNumber, {
       voiceUrl,
       statusCallbackUrl,
-      smsUrl,
     });
     log.info({ phoneNumber }, "Twilio webhooks configured successfully");
     return { success: true };
@@ -320,15 +313,18 @@ export async function handleIngressConfig(
 
       // Best-effort Twilio webhook reconciliation: when ingress is being
       // enabled/updated and Twilio numbers are assigned with valid credentials,
-      // push the new webhook URLs to Twilio so calls and SMS route correctly.
+      // push the new webhook URLs to Twilio so calls route correctly.
       if (isEnabled && hasTwilioCredentials()) {
         const currentConfig = loadRawConfig();
-        const smsConfig = (currentConfig?.sms ?? {}) as Record<string, unknown>;
+        const twilioConfig = (currentConfig?.twilio ?? {}) as Record<
+          string,
+          unknown
+        >;
         const assignedNumbers = new Set<string>();
-        const legacyNumber = (smsConfig.phoneNumber as string) ?? "";
-        if (legacyNumber) assignedNumbers.add(legacyNumber);
+        const primaryNumber = (twilioConfig.phoneNumber as string) ?? "";
+        if (primaryNumber) assignedNumbers.add(primaryNumber);
 
-        const assistantPhoneNumbers = smsConfig.assistantPhoneNumbers;
+        const assistantPhoneNumbers = twilioConfig.assistantPhoneNumbers;
         if (
           assistantPhoneNumbers &&
           typeof assistantPhoneNumbers === "object" &&

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -25,7 +25,7 @@ import { channelStatusToMemberStatus } from "../runtime/routes/inbound-stages/ac
  * interacting.  Used to gate UI-specific references and permission asks.
  */
 export interface ChannelCapabilities {
-  /** The raw channel identifier (e.g. "vellum", "telegram", "sms"). */
+  /** The raw channel identifier (e.g. "vellum", "telegram"). */
   channel: string;
   /** Whether this channel can render the dashboard UI (apps, dynamic pages). */
   dashboardCapable: boolean;
@@ -362,7 +362,6 @@ export function resolveChannelCapabilities(
       };
     }
     case "telegram":
-    case "sms":
     case "voice":
     case "whatsapp":
     case "slack":

--- a/assistant/src/inbound/public-ingress-urls.ts
+++ b/assistant/src/inbound/public-ingress-urls.ts
@@ -129,14 +129,6 @@ export function getOAuthCallbackUrl(config: IngressConfig): string {
 }
 
 /**
- * Build the Twilio SMS webhook URL.
- */
-export function getTwilioSmsWebhookUrl(config: IngressConfig): string {
-  const base = getPublicBaseUrl(config);
-  return `${base}/webhooks/twilio/sms`;
-}
-
-/**
  * Build the Telegram webhook URL.
  */
 export function getTelegramWebhookUrl(config: IngressConfig): string {

--- a/assistant/src/memory/schema/guardian.ts
+++ b/assistant/src/memory/schema/guardian.ts
@@ -52,7 +52,7 @@ export const guardianActionDeliveries = sqliteTable(
     requestId: text("request_id")
       .notNull()
       .references(() => guardianActionRequests.id, { onDelete: "cascade" }),
-    destinationChannel: text("destination_channel").notNull(), // 'telegram' | 'sms' | 'vellum'
+    destinationChannel: text("destination_channel").notNull(), // 'telegram' | 'vellum'
     destinationConversationId: text("destination_conversation_id"),
     destinationChatId: text("destination_chat_id"),
     destinationExternalUserId: text("destination_external_user_id"),

--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -13,8 +13,6 @@ const MANAGED_CALLBACK_TOKEN_HEADER = "X-Managed-Gateway-Callback-Token";
 const MANAGED_IDEMPOTENCY_HEADER = "X-Idempotency-Key";
 const MANAGED_OUTBOUND_MAX_ATTEMPTS = 3;
 const MANAGED_OUTBOUND_RETRY_BASE_MS = 150;
-const SMS_ATTACHMENTS_FALLBACK_TEXT =
-  "I have a media attachment to share, but SMS currently supports text only.";
 
 export interface ChannelReplyPayload {
   chatId: string;
@@ -51,7 +49,7 @@ interface ManagedOutboundCallbackContext {
   requestUrl: string;
   routeId: string;
   assistantId: string;
-  sourceChannel: "sms" | "voice";
+  sourceChannel: "voice";
   sourceUpdateId?: string;
   callbackToken?: string;
 }
@@ -138,11 +136,7 @@ function parseManagedOutboundCallback(
   const assistantId = parsed.searchParams.get("assistant_id")?.trim();
   const sourceChannel = parsed.searchParams.get("source_channel")?.trim();
 
-  if (
-    !routeId ||
-    !assistantId ||
-    (sourceChannel !== "sms" && sourceChannel !== "voice")
-  ) {
+  if (!routeId || !assistantId || sourceChannel !== "voice") {
     throw new Error(
       "Managed outbound callback URL is missing required route_id, assistant_id, or source_channel.",
     );
@@ -185,11 +179,7 @@ async function deliverManagedOutboundReply(
     Array.isArray(payload.attachments) && payload.attachments.length > 0;
   const text = payload.approval?.plainTextFallback ?? payload.text;
   const normalizedText =
-    typeof text === "string" && text.trim().length > 0
-      ? text
-      : hasAttachments
-        ? SMS_ATTACHMENTS_FALLBACK_TEXT
-        : "";
+    typeof text === "string" && text.trim().length > 0 ? text : "";
   if (!normalizedText) {
     throw new Error(
       "Managed outbound delivery requires text or plainTextFallback.",

--- a/assistant/src/runtime/guardian-action-followup-executor.ts
+++ b/assistant/src/runtime/guardian-action-followup-executor.ts
@@ -2,11 +2,9 @@
  * Guardian action follow-up executor.
  *
  * After the conversation engine classifies the guardian's reply as
- * `call_back` or `message_back` and transitions the follow-up state to
- * `dispatching`, this module executes the actual action:
+ * `call_back` and transitions the follow-up state to `dispatching`,
+ * this module executes the actual action:
  *
- *   - **message_back**: Generates outbound SMS text and sends it to the
- *     counterparty phone number via the gateway's /deliver/sms endpoint.
  *   - **call_back**: Starts an outbound call to the counterparty with
  *     context about the guardian's answer.
  *
@@ -14,13 +12,12 @@
  * dispatches the appropriate action, and returns a result with generated
  * reply text for the guardian's confirmation message.
  *
- * This module is channel-agnostic: both inbound-message-handler (Telegram,
- * SMS channels) and session-process (mac/IPC channel) use it.
+ * This module is channel-agnostic: both inbound-message-handler (Telegram
+ * channels) and session-process (mac/IPC channel) use it.
  */
 
 import { startCall } from "../calls/call-domain.js";
 import { getCallSession } from "../calls/call-store.js";
-import { getGatewayInternalBaseUrl } from "../config/env.js";
 import { getOrCreateConversation } from "../memory/conversation-key-store.js";
 import {
   finalizeFollowup,
@@ -30,8 +27,6 @@ import {
 } from "../memory/guardian-action-store.js";
 import { getLogger } from "../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
-import { mintDaemonDeliveryToken } from "./auth/token-service.js";
-import { deliverChannelReply } from "./gateway-client.js";
 import { composeGuardianActionMessageGenerative } from "./guardian-action-message-composer.js";
 import type { GuardianActionCopyGenerator } from "./http-types.js";
 
@@ -104,62 +99,6 @@ export function resolveCounterparty(
 // ---------------------------------------------------------------------------
 // Action dispatchers
 // ---------------------------------------------------------------------------
-
-/**
- * Send an SMS to the counterparty with the guardian's answer context.
- * Uses the gateway's /deliver/sms endpoint (same path as the SMS notification adapter).
- */
-async function executeMessageBack(
-  request: GuardianActionRequest,
-  counterparty: CounterpartyInfo,
-  generator?: GuardianActionCopyGenerator,
-): Promise<{ ok: true } | { ok: false; error: string }> {
-  try {
-    // Generate the outbound SMS text using the composer
-    const messageText = await composeGuardianActionMessageGenerative(
-      {
-        scenario: "outbound_message_copy",
-        questionText: request.questionText,
-        lateAnswerText: request.lateAnswerText ?? undefined,
-        callerIdentifier: counterparty.displayIdentifier,
-      },
-      {},
-      generator,
-    );
-
-    const gatewayBase = getGatewayInternalBaseUrl();
-    const deliverUrl = `${gatewayBase}/deliver/sms`;
-    const bearerToken = mintDaemonDeliveryToken();
-
-    await deliverChannelReply(
-      deliverUrl,
-      {
-        chatId: counterparty.phoneNumber,
-        text: messageText,
-        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-      },
-      bearerToken,
-    );
-
-    log.info(
-      { requestId: request.id, counterpartyPhone: counterparty.phoneNumber },
-      "Follow-up message_back SMS sent successfully",
-    );
-
-    return { ok: true };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error(
-      {
-        err,
-        requestId: request.id,
-        counterpartyPhone: counterparty.phoneNumber,
-      },
-      "Failed to send follow-up message_back SMS",
-    );
-    return { ok: false, error: message };
-  }
-}
 
 /**
  * Start an outbound call to the counterparty with context about the
@@ -307,12 +246,11 @@ export async function executeFollowupAction(
   // Execute the action
   let actionResult: { ok: true } | { ok: false; error: string };
 
-  if (action === "message_back") {
-    actionResult = await executeMessageBack(request, counterparty, generator);
-  } else if (action === "call_back") {
+  if (action === "call_back") {
     actionResult = await executeCallBack(request, counterparty);
   } else {
-    // decline is already handled in M5 — should not reach the executor
+    // decline is already handled in M5 — should not reach the executor.
+    // message_back (SMS) is no longer supported.
     finalizeFollowup(requestId, "failed");
     const errorText = await composeGuardianActionMessageGenerative(
       {
@@ -333,10 +271,7 @@ export async function executeFollowupAction(
   if (actionResult.ok) {
     finalizeFollowup(requestId, "completed");
 
-    const scenario =
-      action === "message_back"
-        ? ("followup_message_sent" as const)
-        : ("followup_call_started" as const);
+    const scenario = "followup_call_started" as const;
     const confirmText = await composeGuardianActionMessageGenerative(
       {
         scenario,

--- a/assistant/src/runtime/guardian-outbound-actions.ts
+++ b/assistant/src/runtime/guardian-outbound-actions.ts
@@ -37,7 +37,7 @@ const log = getLogger("guardian-outbound-actions");
 // Rate limit constants for outbound verification
 // ---------------------------------------------------------------------------
 
-/** Maximum SMS sends per verification session. */
+/** Maximum sends per verification session. */
 export const MAX_SENDS_PER_SESSION = 5;
 
 /** Cooldown between resends in milliseconds (15 seconds). */

--- a/assistant/src/runtime/guardian-verification-templates.ts
+++ b/assistant/src/runtime/guardian-verification-templates.ts
@@ -1,5 +1,5 @@
 /**
- * Template-only copy for outbound guardian verification messages (SMS, Telegram, and voice).
+ * Template-only copy for outbound guardian verification messages (Telegram, Slack, and voice).
  *
  * All outbound verification messages are composed from these templates
  * to prevent free-form caller/user text injection. Only typed variables
@@ -11,10 +11,6 @@
 // ---------------------------------------------------------------------------
 
 export const GUARDIAN_VERIFY_TEMPLATE_KEYS = {
-  /** Initial outbound SMS with verification code. */
-  CHALLENGE_REQUEST: "guardian_verify.sms.challenge_request",
-  /** Resend SMS with verification code. */
-  RESEND: "guardian_verify.sms.resend",
   /** Response when the user is already verified. */
   ALREADY_VERIFIED: "guardian_verify.already_verified",
   /** Initial outbound Telegram verification prompt (code is not included). */
@@ -49,10 +45,8 @@ export const GUARDIAN_VERIFY_TEMPLATE_KEYS = {
 export type GuardianVerifyTemplateKey =
   (typeof GUARDIAN_VERIFY_TEMPLATE_KEYS)[keyof typeof GUARDIAN_VERIFY_TEMPLATE_KEYS];
 
-/** Template keys for SMS/Telegram/Slack text-based verification messages. */
+/** Template keys for Telegram/Slack text-based verification messages. */
 type TextVerifyTemplateKey =
-  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST
-  | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.ALREADY_VERIFIED
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST
   | typeof GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_RESEND
@@ -97,14 +91,6 @@ const templates: Record<
   TextVerifyTemplateKey,
   (vars: GuardianVerifyTemplateVars) => string
 > = {
-  [GUARDIAN_VERIFY_TEMPLATE_KEYS.CHALLENGE_REQUEST]: (_vars) => {
-    return "Vellum assistant guardian verification requested. Reply with the 6-digit code you were given.";
-  },
-
-  [GUARDIAN_VERIFY_TEMPLATE_KEYS.RESEND]: (_vars) => {
-    return "Vellum assistant guardian verification requested. Reply with the 6-digit code you were given. (resent)";
-  },
-
   [GUARDIAN_VERIFY_TEMPLATE_KEYS.ALREADY_VERIFIED]: (_vars) => {
     return "This channel is already verified. No further action is needed.";
   },
@@ -133,18 +119,6 @@ const templates: Record<
     return `Vellum assistant verification: your code is ${vars.code}. Reply with this code to verify your identity. It expires in ${vars.expiresInMinutes} minutes. (resent)`;
   },
 };
-
-/**
- * Compose an outbound verification SMS body from a template key and typed variables.
- * Returns plain string content suitable for SMS delivery.
- */
-export function composeVerificationSms(
-  templateKey: TextVerifyTemplateKey,
-  vars: GuardianVerifyTemplateVars,
-): string {
-  const composer = templates[templateKey];
-  return composer(vars);
-}
 
 /**
  * Compose an outbound verification Slack DM from a template key and typed variables.

--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -42,11 +42,11 @@ import type { RouteDefinition } from "../http-router.js";
 
 /** Helper to clear stale assistant phone number mappings. */
 function pruneAssistantPhoneNumbers(
-  sms: Record<string, unknown>,
+  twilio: Record<string, unknown>,
   keepNumber: string,
   mode: "keep" | "remove",
 ): void {
-  const mappings = sms.assistantPhoneNumbers as
+  const mappings = twilio.assistantPhoneNumbers as
     | Record<string, string>
     | undefined;
   if (mappings && typeof mappings === "object") {
@@ -58,7 +58,7 @@ function pruneAssistantPhoneNumbers(
       }
     }
     if (Object.keys(mappings).length === 0) {
-      delete sms.assistantPhoneNumbers;
+      delete twilio.assistantPhoneNumbers;
     }
   }
 }
@@ -80,8 +80,8 @@ export function handleGetTwilioConfig(): Response {
     ? getTwilioCredentials().accountSid
     : undefined;
   const raw = loadRawConfig();
-  const sms = (raw?.sms ?? {}) as Record<string, unknown>;
-  const phoneNumber = (sms.phoneNumber as string) ?? "";
+  const twilio = (raw?.twilio ?? {}) as Record<string, unknown>;
+  const phoneNumber = (twilio.phoneNumber as string) ?? "";
 
   return Response.json({
     success: true,
@@ -314,10 +314,10 @@ export async function handleProvisionTwilioNumber(
   }
 
   const raw = loadRawConfig();
-  const sms = (raw?.sms ?? {}) as Record<string, unknown>;
-  sms.phoneNumber = purchased.phoneNumber;
-  pruneAssistantPhoneNumbers(sms, purchased.phoneNumber, "keep");
-  saveRawConfig({ ...raw, sms });
+  const twilio = (raw?.twilio ?? {}) as Record<string, unknown>;
+  twilio.phoneNumber = purchased.phoneNumber;
+  pruneAssistantPhoneNumbers(twilio, purchased.phoneNumber, "keep");
+  saveRawConfig({ ...raw, twilio });
 
   // Best-effort webhook configuration
   const webhookResult = await syncTwilioWebhooks(
@@ -370,10 +370,10 @@ export async function handleAssignTwilioNumber(
   }
 
   const raw = loadRawConfig();
-  const sms = (raw?.sms ?? {}) as Record<string, unknown>;
-  sms.phoneNumber = body.phoneNumber;
-  pruneAssistantPhoneNumbers(sms, body.phoneNumber, "keep");
-  saveRawConfig({ ...raw, sms });
+  const twilio = (raw?.twilio ?? {}) as Record<string, unknown>;
+  twilio.phoneNumber = body.phoneNumber;
+  pruneAssistantPhoneNumbers(twilio, body.phoneNumber, "keep");
+  saveRawConfig({ ...raw, twilio });
 
   // Best-effort webhook configuration when credentials are available
   let webhookWarning: string | undefined;
@@ -416,8 +416,8 @@ export async function handleReleaseTwilioNumber(
 
   const body = (await req.json().catch(() => ({}))) as { phoneNumber?: string };
   const raw = loadRawConfig();
-  const sms = (raw?.sms ?? {}) as Record<string, unknown>;
-  const phoneNumber = body.phoneNumber || (sms.phoneNumber as string) || "";
+  const twilio = (raw?.twilio ?? {}) as Record<string, unknown>;
+  const phoneNumber = body.phoneNumber || (twilio.phoneNumber as string) || "";
 
   if (!phoneNumber) {
     return Response.json({
@@ -432,11 +432,11 @@ export async function handleReleaseTwilioNumber(
 
   await releasePhoneNumber(accountSid, authToken, phoneNumber);
 
-  if (sms.phoneNumber === phoneNumber) {
-    delete sms.phoneNumber;
+  if (twilio.phoneNumber === phoneNumber) {
+    delete twilio.phoneNumber;
   }
-  pruneAssistantPhoneNumbers(sms, phoneNumber, "remove");
-  saveRawConfig({ ...raw, sms });
+  pruneAssistantPhoneNumbers(twilio, phoneNumber, "remove");
+  saveRawConfig({ ...raw, twilio });
 
   const storedPhone = getSecureKey("credential:twilio:phone_number");
   if (storedPhone === phoneNumber) {

--- a/assistant/src/schedule/integration-status.ts
+++ b/assistant/src/schedule/integration-status.ts
@@ -28,8 +28,8 @@ const INTEGRATION_PROBES: IntegrationProbe[] = [
       !!getSecureKey("credential:integration:slack:access_token"),
   },
   {
-    name: "SMS",
-    category: "messaging",
+    name: "Twilio",
+    category: "telephony",
     isConnected: () => hasTwilioCredentials(),
   },
   {

--- a/gateway/src/__tests__/config.test.ts
+++ b/gateway/src/__tests__/config.test.ts
@@ -132,7 +132,7 @@ describe("config: twilio assistant phone number mapping", () => {
       writeFileSync(
         join(workspaceDir, "config.json"),
         JSON.stringify({
-          sms: {
+          twilio: {
             phoneNumber: "+15550001111",
             assistantPhoneNumbers: {
               "asst-alpha": "+15550002222",

--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -194,7 +194,7 @@ describe("GET /v1/feature-flags handler", () => {
   test("returns all declared flags even when config has no persisted values", async () => {
     writeFileSync(
       configPath,
-      JSON.stringify({ sms: { phoneNumber: "+1234" } }),
+      JSON.stringify({ twilio: { phoneNumber: "+1234" } }),
     );
 
     const handler = createFeatureFlagsGetHandler();
@@ -305,7 +305,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     writeFileSync(
       configPath,
       JSON.stringify({
-        sms: { phoneNumber: "+1234567890" },
+        twilio: { phoneNumber: "+1234567890" },
         email: { address: "test@example.com" },
         assistantFeatureFlagValues: { "feature_flags.twitter.enabled": true },
       }),
@@ -325,7 +325,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     );
 
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
-    expect(config.sms).toEqual({ phoneNumber: "+1234567890" });
+    expect(config.twilio).toMatchObject({ phoneNumber: "+1234567890" });
     expect(config.email).toEqual({ address: "test@example.com" });
     // New section should have both old and new values
     expect(
@@ -539,7 +539,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
   test("atomic write does not corrupt config on successful write", async () => {
     // Write initial config
     const initial = {
-      sms: { phoneNumber: "+1234" },
+      twilio: { phoneNumber: "+1234" },
       assistantFeatureFlagValues: { "feature_flags.browser.enabled": true },
     };
     writeFileSync(configPath, JSON.stringify(initial));
@@ -560,7 +560,7 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     // Verify the file is valid JSON and contains all expected data
     const raw = readFileSync(configPath, "utf-8");
     const config = JSON.parse(raw);
-    expect(config.sms).toEqual({ phoneNumber: "+1234" });
+    expect(config.twilio).toMatchObject({ phoneNumber: "+1234" });
     expect(
       config.assistantFeatureFlagValues["feature_flags.browser.enabled"],
     ).toBe(true);

--- a/gateway/src/__tests__/twilio-reconcile-route.test.ts
+++ b/gateway/src/__tests__/twilio-reconcile-route.test.ts
@@ -144,8 +144,6 @@ describe("POST /internal/twilio/reconcile", () => {
     writeWorkspaceConfig({
       twilio: {
         accountSid: "AC-config",
-      },
-      sms: {
         phoneNumber: "+15553334444",
       },
     });

--- a/gateway/src/config-file-mappings.ts
+++ b/gateway/src/config-file-mappings.ts
@@ -21,16 +21,14 @@ type ConfigFileMapping =
     };
 
 export const CONFIG_FILE_MAPPINGS: ConfigFileMapping[] = [
-  // Legacy: phone number config was originally stored under the "sms" config key.
-  // Kept for backward compatibility — the phone number is still used for voice calls.
   {
-    key: "sms",
+    key: "twilio",
     field: "phoneNumber",
     configField: "twilioPhoneNumber",
     type: "string",
   },
   {
-    key: "sms",
+    key: "twilio",
     field: "assistantPhoneNumbers",
     configField: "assistantPhoneNumbers",
     type: "normalized-record",


### PR DESCRIPTION
## Summary
- Migrate config file mappings from legacy `sms` key to `twilio` key for phoneNumber and assistantPhoneNumbers
- Remove dead SMS infrastructure: `getTwilioSmsWebhookUrl`, `composeVerificationSms`, SMS verification templates, `executeMessageBack` followup action, SMS webhook URL registration with Twilio API
- Clean up SMS channel references in gateway client, guardian request resolvers, session runtime assembly, integration status probes, and CLI integrations command
- Update all tests to use `twilio:` config key instead of `sms:`

## Original prompt
clean up all the stale references and remove all legacy mappings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
