### PR TITLE
fix: remove stale SMS references from 5 failing test files

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -217,9 +217,9 @@ function ensureTestContact(): void {
         policy: "allow",
       },
       {
-        type: "sms",
-        address: "sms-user-default",
-        externalUserId: "sms-user-default",
+        type: "slack",
+        address: "slack-user-default",
+        externalUserId: "slack-user-default",
         status: "active",
         policy: "allow",
       },
@@ -887,27 +887,27 @@ describe("stale callback handling", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// 15. SMS channel approval decisions
+// 15. Plain-text channel approval decisions (telegram)
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe("SMS channel approval decisions", () => {
+describe("plain-text channel approval decisions", () => {
   beforeEach(() => {
     createGuardianBinding({
-      channel: "sms",
-      guardianExternalUserId: "sms-user-default",
-      guardianDeliveryChatId: "sms-chat-123",
-      guardianPrincipalId: "sms-user-default",
+      channel: "telegram",
+      guardianExternalUserId: "telegram-user-default",
+      guardianDeliveryChatId: "chat-123",
+      guardianPrincipalId: "telegram-user-default",
     });
   });
 
-  function makeSmsInboundRequest(
+  function makePlainTextInboundRequest(
     overrides: Record<string, unknown> = {},
   ): Request {
     const body = {
-      sourceChannel: "sms",
-      interface: "sms",
-      conversationExternalId: "sms-chat-123",
-      actorExternalId: "sms-user-default",
+      sourceChannel: "telegram",
+      interface: "telegram",
+      conversationExternalId: "chat-123",
+      actorExternalId: "telegram-user-default",
       externalMessageId: `msg-${Date.now()}-${Math.random()}`,
       content: "hello",
       replyCallbackUrl: "https://gateway.test/deliver",
@@ -922,14 +922,14 @@ describe("SMS channel approval decisions", () => {
     });
   }
 
-  test('plain-text "yes" via SMS triggers approve_once decision', async () => {
+  test('plain-text "yes" triggers approve_once decision', async () => {
     const deliverSpy = spyOn(
       gatewayClient,
       "deliverChannelReply",
     ).mockResolvedValue({ ok: true });
 
-    // Establish the conversation via SMS
-    const initReq = makeSmsInboundRequest({ content: "init" });
+    // Establish the conversation
+    const initReq = makePlainTextInboundRequest({ content: "init" });
     await handleChannelInbound(initReq, noopProcessMessage);
 
     const db = getDb();
@@ -940,29 +940,29 @@ describe("SMS channel approval decisions", () => {
     ensureConversation(conversationId!);
 
     const sessionMock = registerPendingInteraction(
-      "req-sms-1",
+      "req-pt-1",
       conversationId!,
       "shell",
     );
 
-    const req = makeSmsInboundRequest({ content: "yes" });
+    const req = makePlainTextInboundRequest({ content: "yes" });
     const res = await handleChannelInbound(req, noopProcessMessage);
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
     expect(body.approval).toBe("decision_applied");
-    expect(sessionMock).toHaveBeenCalledWith("req-sms-1", "allow");
+    expect(sessionMock).toHaveBeenCalledWith("req-pt-1", "allow");
 
     deliverSpy.mockRestore();
   });
 
-  test('plain-text "no" via SMS triggers reject decision', async () => {
+  test('plain-text "no" triggers reject decision', async () => {
     const deliverSpy = spyOn(
       gatewayClient,
       "deliverChannelReply",
     ).mockResolvedValue({ ok: true });
 
-    const initReq = makeSmsInboundRequest({ content: "init" });
+    const initReq = makePlainTextInboundRequest({ content: "init" });
     await handleChannelInbound(initReq, noopProcessMessage);
 
     const db = getDb();
@@ -973,23 +973,23 @@ describe("SMS channel approval decisions", () => {
     ensureConversation(conversationId!);
 
     const sessionMock = registerPendingInteraction(
-      "req-sms-2",
+      "req-pt-2",
       conversationId!,
       "shell",
     );
 
-    const req = makeSmsInboundRequest({ content: "no" });
+    const req = makePlainTextInboundRequest({ content: "no" });
     const res = await handleChannelInbound(req, noopProcessMessage);
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
     expect(body.approval).toBe("decision_applied");
-    expect(sessionMock).toHaveBeenCalledWith("req-sms-2", "deny");
+    expect(sessionMock).toHaveBeenCalledWith("req-pt-2", "deny");
 
     deliverSpy.mockRestore();
   });
 
-  test("non-decision SMS message during pending approval sends status reply", async () => {
+  test("non-decision message during pending approval sends status reply", async () => {
     const deliverSpy = spyOn(
       gatewayClient,
       "deliverChannelReply",
@@ -999,7 +999,7 @@ describe("SMS channel approval decisions", () => {
       "deliverApprovalPrompt",
     ).mockResolvedValue(undefined);
 
-    const initReq = makeSmsInboundRequest({ content: "init" });
+    const initReq = makePlainTextInboundRequest({ content: "init" });
     await handleChannelInbound(initReq, noopProcessMessage);
 
     const db = getDb();
@@ -1009,22 +1009,22 @@ describe("SMS channel approval decisions", () => {
     const conversationId = events[events.length - 1]?.conversation_id;
     ensureConversation(conversationId!);
 
-    registerPendingInteraction("req-sms-3", conversationId!, "shell");
+    registerPendingInteraction("req-pt-3", conversationId!, "shell");
 
-    const req = makeSmsInboundRequest({ content: "what is happening?" });
+    const req = makePlainTextInboundRequest({ content: "what is happening?" });
     const res = await handleChannelInbound(req, noopProcessMessage);
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
     expect(body.approval).toBe("assistant_turn");
 
-    // SMS non-decision: status reply delivered via plain text
+    // Non-decision: status reply delivered via plain text
     expect(deliverSpy).toHaveBeenCalled();
     expect(approvalSpy).not.toHaveBeenCalled();
     const statusCall = deliverSpy.mock.calls.find(
       (call) =>
         typeof call[1] === "object" &&
-        (call[1] as { chatId?: string }).chatId === "sms-chat-123",
+        (call[1] as { chatId?: string }).chatId === "chat-123",
     );
     expect(statusCall).toBeDefined();
     const statusPayload = statusCall![1] as {
@@ -2784,23 +2784,23 @@ describe("non-decision status reply for different channels", () => {
       guardianPrincipalId: "telegram-user-default",
     });
     createGuardianBinding({
-      channel: "sms",
+      channel: "slack",
       guardianExternalUserId: "telegram-user-default",
       guardianDeliveryChatId: "chat-123",
       guardianPrincipalId: "telegram-user-default",
     });
   });
 
-  test("non-decision message on non-rich channel (sms) sends status reply", async () => {
+  test("non-decision message on slack sends status reply", async () => {
     const deliverSpy = spyOn(
       gatewayClient,
       "deliverChannelReply",
     ).mockResolvedValue({ ok: true });
 
-    // Establish the conversation using sms (non-rich channel)
+    // Establish the conversation using slack
     const initReq = makeInboundRequest({
       content: "init",
-      sourceChannel: "sms",
+      sourceChannel: "slack",
     });
     await handleChannelInbound(initReq, noopProcessMessage);
 
@@ -2811,12 +2811,12 @@ describe("non-decision status reply for different channels", () => {
     const conversationId = events[0]?.conversation_id;
     ensureConversation(conversationId!);
 
-    registerPendingInteraction("req-status-sms", conversationId!, "shell");
+    registerPendingInteraction("req-status-slack", conversationId!, "shell");
 
     // Send a non-decision message
     const req = makeInboundRequest({
       content: "what is happening?",
-      sourceChannel: "sms",
+      sourceChannel: "slack",
     });
     const res = await handleChannelInbound(req, noopProcessMessage);
     const body = (await res.json()) as Record<string, unknown>;

--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -567,8 +567,8 @@ describe("pairDeliveryWithConversation", () => {
       unknown
     >;
     expect(upsertArgs.conversationId).toBe("conv-001");
-    expect(upsertArgs.sourceChannel).toBe("notification:sms");
-    expect(upsertArgs.externalChatId).toBe("+15559876543");
+    expect(upsertArgs.sourceChannel).toBe("notification:slack");
+    expect(upsertArgs.externalChatId).toBe("C9876ZYXWVU");
   });
 
   test("explicit reuse_existing takes precedence over binding-key reuse", async () => {

--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -359,67 +359,6 @@ describe("gateway-only ingress enforcement", () => {
     });
   });
 
-  // ── SMS-specific direct webhook routes blocked ──────────────────────
-
-  describe("SMS webhook routes are blocked at the runtime (gateway-only)", () => {
-    test("POST /webhooks/twilio/sms returns 410 (cannot bypass gateway)", async () => {
-      const res = await fetch(`http://127.0.0.1:${port}/webhooks/twilio/sms`, {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: makeFormBody({
-          Body: "hello",
-          From: "+15551234567",
-          To: "+15559876543",
-          MessageSid: "SM123",
-        }),
-      });
-      expect(res.status).toBe(410);
-      const body = (await res.json()) as {
-        error: { code: string; message: string };
-      };
-      expect(body.error.code).toBe("GONE");
-      expect(body.error.message).toContain("Direct webhook access disabled");
-    });
-
-    test("POST /v1/calls/twilio/sms returns 410 (legacy path also blocked)", async () => {
-      const res = await fetch(`http://127.0.0.1:${port}/v1/calls/twilio/sms`, {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: makeFormBody({
-          Body: "hello",
-          From: "+15551234567",
-          MessageSid: "SM456",
-        }),
-      });
-      expect(res.status).toBe(410);
-      const body = (await res.json()) as {
-        error: { code: string; message: string };
-      };
-      expect(body.error.code).toBe("GONE");
-    });
-
-    test("POST /webhooks/twilio/sms with valid auth still returns 410 (auth does not bypass gateway-only)", async () => {
-      const res = await fetch(`http://127.0.0.1:${port}/webhooks/twilio/sms`, {
-        method: "POST",
-        headers: {
-          ...AUTH_HEADERS,
-          "Content-Type": "application/x-www-form-urlencoded",
-        },
-        body: makeFormBody({
-          Body: "sneaky",
-          From: "+15551234567",
-          MessageSid: "SM789",
-        }),
-      });
-      // The gateway-only guard runs before auth for Twilio webhook paths
-      expect(res.status).toBe(410);
-      const body = (await res.json()) as {
-        error: { code: string; message: string };
-      };
-      expect(body.error.code).toBe("GONE");
-    });
-  });
-
   // ── Internal forwarding routes still work ─────
 
   describe("internal forwarding routes are not blocked", () => {

--- a/assistant/src/__tests__/notification-routing-intent.test.ts
+++ b/assistant/src/__tests__/notification-routing-intent.test.ts
@@ -158,11 +158,7 @@ describe("routing intent enforcement", () => {
 
     test("does not expand to all channels when 3+ are connected", () => {
       const decision = makeDecision({ selectedChannels: ["telegram"] });
-      const connected: NotificationChannel[] = [
-        "vellum",
-        "telegram",
-        "telegram",
-      ];
+      const connected: NotificationChannel[] = ["vellum", "telegram", "slack"];
 
       const enforced = enforceRoutingIntent(
         decision,
@@ -171,7 +167,7 @@ describe("routing intent enforcement", () => {
       );
 
       expect(enforced.selectedChannels).toEqual(["telegram", "vellum"]);
-      expect(enforced.selectedChannels).not.toContain("telegram");
+      expect(enforced.selectedChannels).not.toContain("slack");
     });
 
     test("does not override when LLM already picked 2+ channels", () => {

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -216,15 +216,24 @@ for (const config of CHANNEL_CONFIGS) {
       const json = (await resp.json()) as Record<string, unknown>;
 
       expect(json.denied).toBe(true);
-      expect(json.reason).toBe("not_a_member");
+      // Slack sends a verification challenge instead of a flat rejection
+      if (config.channel === "slack") {
+        expect(json.reason).toBe("verification_challenge_sent");
+      } else {
+        expect(json.reason).toBe("not_a_member");
+      }
       expect(deliverReplyCalls.length).toBe(1);
       const replyText = (
         deliverReplyCalls[0].payload as Record<string, unknown>
       ).text as string;
-      expect(
-        replyText.includes("you haven't been approved") ||
-          replyText.includes("you don't have access"),
-      ).toBe(true);
+      if (config.channel === "slack") {
+        expect(replyText).toContain("verification code");
+      } else {
+        expect(
+          replyText.includes("you haven't been approved") ||
+            replyText.includes("you don't have access"),
+        ).toBe(true);
+      }
     });
 
     test("guardian is notified when a non-member messages", async () => {


### PR DESCRIPTION
## Summary
- Fix 5 test files that still referenced `sms` as a channel after SMS removal (#13775/#13781), causing CI failures
- Replace SMS channel references with valid channels (telegram, slack) in test setup, assertions, and expectations
- Remove dead Twilio SMS webhook tests from gateway-only-enforcement since the route was already removed
- Update trusted-contact-multichannel test to expect Slack's verification challenge flow instead of flat rejection

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22789815476

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
