### PR TITLE
fix: clarify backwards compat policy applies to existing code too

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ We have no external customers or users yet. Move fast and do not preserve backwa
 
 When a change breaks an existing interface, contract, or data format: **flag the break in the PR description** so the reviewer is aware, but proceed with the clean implementation. Only preserve compatibility if the reviewer explicitly requests it.
 
-This policy will change once the project has users. Until then, every backwards-compat shim is dead weight that slows us down.
+This policy will change once the project has users. When you encounter existing backwards-compatibility code while working on a file, remove it — the same policy applies to old code as to new code. Until then, every backwards-compat shim is dead weight that slows us down.
 
 ## Extensibility Principle
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for agents-backcompat-policy.md.

**Gap:** No guidance on existing backwards-compat code
**What was expected:** Policy should guide agents on what to do with existing compat shims they encounter
**What was found:** Policy only addressed new changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13796" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
