### PR TITLE
fix: [assistant] close anthropic usage review gaps

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -117,6 +117,71 @@ describe("ContextWindowManager", () => {
     expect(userTexts.some((text) => text.startsWith("u3 "))).toBe(true);
   });
 
+  test("aggregates cache-aware summary usage across compaction chunks", async () => {
+    let summaryCalls = 0;
+    const provider = createProvider(() => {
+      summaryCalls += 1;
+      return {
+        content: [
+          { type: "text", text: `## Goals\n- summary chunk ${summaryCalls}` },
+        ],
+        model: "claude-opus-4-6",
+        usage: {
+          inputTokens: 1_000 + summaryCalls,
+          outputTokens: 20 + summaryCalls,
+          cacheCreationInputTokens: 10 * summaryCalls,
+          cacheReadInputTokens: 100 * summaryCalls,
+        },
+        rawResponse: {
+          usage: {
+            cache_creation: {
+              ephemeral_5m_input_tokens: 10 * summaryCalls,
+              ephemeral_1h_input_tokens: 0,
+            },
+            cache_read_input_tokens: 100 * summaryCalls,
+          },
+        },
+        stopReason: "end_turn",
+      };
+    });
+    const manager = new ContextWindowManager(
+      provider,
+      "system prompt",
+      makeConfig({
+        maxInputTokens: 7_000,
+        targetInputTokens: 2_500,
+        preserveRecentUserTurns: 1,
+      }),
+    );
+    const long = "q".repeat(6_000);
+    const history: Message[] = [
+      message("user", `u1 ${long}`),
+      message("assistant", `a1 ${long}`),
+      message("user", `u2 ${long}`),
+      message("assistant", `a2 ${long}`),
+      message("user", `u3 ${long}`),
+    ];
+
+    const result = await manager.maybeCompact(history);
+
+    expect(result.compacted).toBe(true);
+    expect(result.summaryCalls).toBe(summaryCalls);
+    expect(result.summaryCalls).toBeGreaterThan(1);
+    expect(result.summaryCacheCreationInputTokens).toBe(
+      summaryCalls * (summaryCalls + 1) * 5,
+    );
+    expect(result.summaryCacheReadInputTokens).toBe(
+      summaryCalls * (summaryCalls + 1) * 50,
+    );
+    expect(result.summaryRawResponses).toHaveLength(summaryCalls);
+    expect(result.summaryRawResponses?.[0]).toMatchObject({
+      usage: {
+        cache_creation: { ephemeral_5m_input_tokens: 10 },
+        cache_read_input_tokens: 100,
+      },
+    });
+  });
+
   test("updates an existing summary message instead of nesting summaries", async () => {
     const provider = createProvider(() => ({
       content: [{ type: "text", text: "## Goals\n- updated summary" }],
@@ -340,6 +405,51 @@ describe("ContextWindowManager", () => {
     expect(result.compacted).toBe(true);
     // The mixed user message should be counted as persisted (4 = u1 + mixed + a_tooluse + a1)
     expect(result.compactedPersistedMessages).toBe(4);
+  });
+
+  test("returns cache-aware usage metadata for compaction summaries", async () => {
+    const rawResponse = {
+      usage: {
+        cache_creation: { ephemeral_5m_input_tokens: 120 },
+        cache_read_input_tokens: 340,
+      },
+    };
+    const provider = createProvider(() => ({
+      content: [{ type: "text", text: "## Goals\n- cache-aware summary" }],
+      model: "claude-opus-4-6",
+      usage: {
+        inputTokens: 500,
+        outputTokens: 22,
+        cacheCreationInputTokens: 120,
+        cacheReadInputTokens: 340,
+      },
+      rawResponse,
+      stopReason: "end_turn",
+    }));
+    const manager = new ContextWindowManager(
+      provider,
+      "system prompt",
+      makeConfig({
+        maxInputTokens: 2600,
+        targetInputTokens: 1500,
+        preserveRecentUserTurns: 1,
+      }),
+    );
+    const long = "c".repeat(5000);
+    const history: Message[] = [
+      message("user", `u1 ${long}`),
+      message("assistant", `a1 ${long}`),
+      message("user", `u2 ${long}`),
+    ];
+
+    const result = await manager.maybeCompact(history);
+
+    expect(result.compacted).toBe(true);
+    expect(result.summaryCalls).toBe(2);
+    expect(result.summaryInputTokens).toBe(1000);
+    expect(result.summaryCacheCreationInputTokens).toBe(240);
+    expect(result.summaryCacheReadInputTokens).toBe(680);
+    expect(result.summaryRawResponses).toEqual([rawResponse, rawResponse]);
   });
 
   test("parses legacy assistant-role context summary messages", () => {

--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -224,8 +224,9 @@ mock.module("../daemon/session-history.js", () => ({
   consolidateAssistantMessages: () => {},
 }));
 
+const recordUsageMock = mock(() => {});
 mock.module("../daemon/session-usage.js", () => ({
-  recordUsage: () => {},
+  recordUsage: recordUsageMock,
 }));
 
 mock.module("../daemon/session-attachments.js", () => ({
@@ -451,6 +452,7 @@ beforeEach(() => {
   mockReducerStepFn = null;
   mockOverflowAction = "fail_gracefully";
   mockApprovalResult = { approved: false };
+  recordUsageMock.mockClear();
 });
 
 describe("session-agent-loop", () => {
@@ -591,6 +593,100 @@ describe("session-agent-loop", () => {
   });
 
   describe("context window exhaustion (context-too-large recovery)", () => {
+    test("forwards cache-aware compaction usage to recordUsage", async () => {
+      const events: ServerMessage[] = [];
+      mockEstimateTokens = 120_000;
+
+      mockReducerStepFn = (msgs: Message[]) => ({
+        messages: msgs,
+        tier: "forced_compaction",
+        state: {
+          appliedTiers: ["forced_compaction"],
+          injectionMode: "full",
+          exhausted: false,
+        },
+        estimatedTokens: 5_000,
+        compactionResult: {
+          compacted: true,
+          messages: msgs,
+          compactedPersistedMessages: 5,
+          summaryText: "Summary of prior conversation",
+          previousEstimatedInputTokens: 90_000,
+          estimatedInputTokens: 30_000,
+          maxInputTokens: 100_000,
+          thresholdTokens: 80_000,
+          compactedMessages: 10,
+          summaryCalls: 2,
+          summaryInputTokens: 500,
+          summaryOutputTokens: 200,
+          summaryModel: "claude-opus-4-6",
+          summaryCacheCreationInputTokens: 120,
+          summaryCacheReadInputTokens: 340,
+          summaryRawResponses: [
+            {
+              usage: {
+                cache_creation: { ephemeral_5m_input_tokens: 120 },
+                cache_read_input_tokens: 340,
+              },
+            },
+          ],
+        },
+      });
+
+      const agentLoopRun: AgentLoopRun = async (messages, onEvent) => {
+        onEvent({
+          type: "message_complete",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "recovered" }],
+          },
+        });
+        return [
+          ...messages,
+          {
+            role: "assistant" as const,
+            content: [{ type: "text", text: "recovered" }] as ContentBlock[],
+          },
+        ];
+      };
+
+      const ctx = makeCtx({ agentLoopRun });
+      await runAgentLoopImpl(ctx, "hello", "msg-1", (msg) => events.push(msg));
+
+      const compactorCall = recordUsageMock.mock.calls.find(
+        (call) => (call as unknown[])[5] === "context_compactor",
+      ) as unknown[] | undefined;
+      expect(compactorCall).toBeDefined();
+
+      const [
+        usageCtx,
+        inputTokens,
+        outputTokens,
+        model,
+        _onEvent,
+        actor,
+        reqId,
+        cacheCreationInputTokens,
+        cacheReadInputTokens,
+        rawResponse,
+      ] = compactorCall ?? [];
+
+      expect(usageCtx).toMatchObject({ conversationId: "test-conv" });
+      expect(inputTokens).toBe(500);
+      expect(outputTokens).toBe(200);
+      expect(model).toBe("claude-opus-4-6");
+      expect(actor).toBe("context_compactor");
+      expect(reqId).toBe("test-req");
+      expect(cacheCreationInputTokens).toBe(120);
+      expect(cacheReadInputTokens).toBe(340);
+      expect(rawResponse).toEqual({
+        usage: {
+          cache_creation: { ephemeral_5m_input_tokens: 120 },
+          cache_read_input_tokens: 340,
+        },
+      });
+    });
+
     test("convergence loop applies reducer and retries when context-too-large is detected", async () => {
       const events: ServerMessage[] = [];
       let callCount = 0;

--- a/assistant/src/__tests__/usage-cache-backfill-migration.test.ts
+++ b/assistant/src/__tests__/usage-cache-backfill-migration.test.ts
@@ -4,6 +4,12 @@ import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const testDir = mkdtempSync(join(tmpdir(), "usage-cache-backfill-test-"));
+let mockPricingOverrides: Array<{
+  provider: string;
+  modelPattern: string;
+  inputPer1M: number;
+  outputPer1M: number;
+}> = [];
 
 mock.module("../util/platform.js", () => ({
   getDataDir: () => testDir,
@@ -24,6 +30,12 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    pricingOverrides: mockPricingOverrides,
+  }),
+}));
+
 import {
   getDb,
   getSqlite,
@@ -34,7 +46,10 @@ import {
 } from "../memory/db.js";
 import { migrateBackfillUsageCacheAccounting } from "../memory/migrations/140-backfill-usage-cache-accounting.js";
 import type { PricingUsage } from "../usage/types.js";
-import { estimateCost, resolvePricingForUsage } from "../util/pricing.js";
+import {
+  estimateCost,
+  resolvePricingForUsageWithOverrides,
+} from "../util/pricing.js";
 
 initializeDb();
 
@@ -137,6 +152,15 @@ function anthropicResponsePayload(args: {
   });
 }
 
+function foreignResponsePayload(): string {
+  return JSON.stringify({
+    usage: {
+      prompt_tokens: 321,
+      completion_tokens: 54,
+    },
+  });
+}
+
 afterAll(() => {
   resetDb();
   try {
@@ -151,9 +175,10 @@ describe("migrateBackfillUsageCacheAccounting", () => {
     getSqlite().run(`DELETE FROM llm_request_logs`);
     getSqlite().run(`DELETE FROM llm_usage_events`);
     rawRun(`DELETE FROM memory_checkpoints WHERE key = ?`, CHECKPOINT_KEY);
+    mockPricingOverrides = [];
   });
 
-  test("rewrites historical Anthropic rows from request logs and leaves missing-log rows unchanged", () => {
+  test("rewrites historical Anthropic rows from request logs, ignores foreign logs, and leaves missing-log rows unchanged", () => {
     const model = "claude-opus-4-6";
 
     insertUsageEvent({
@@ -204,6 +229,12 @@ describe("migrateBackfillUsageCacheAccounting", () => {
       }),
     });
     insertRequestLog({
+      id: "log-target-foreign",
+      conversationId: "conv-usage-1",
+      createdAt: 2_000,
+      responsePayload: foreignResponsePayload(),
+    });
+    insertRequestLog({
       id: "log-target-2",
       conversationId: "conv-usage-1",
       createdAt: 2_500,
@@ -238,10 +269,11 @@ describe("migrateBackfillUsageCacheAccounting", () => {
         ephemeral_1h_input_tokens: 200_000,
       },
     };
-    const expectedPricing = resolvePricingForUsage(
+    const expectedPricing = resolvePricingForUsageWithOverrides(
       "anthropic",
       model,
       expectedUsage,
+      mockPricingOverrides,
     );
 
     const targetRow = rawGet<UsageEventRow>(
@@ -295,5 +327,80 @@ describe("migrateBackfillUsageCacheAccounting", () => {
       CHECKPOINT_KEY,
     );
     expect(checkpoint?.value).toBe("1");
+  });
+
+  test("uses pricing overrides when backfilling Anthropic cache-aware usage rows", () => {
+    const model = "claude-opus-4-6";
+    mockPricingOverrides = [
+      {
+        provider: "anthropic",
+        modelPattern: "claude-opus-4-6",
+        inputPer1M: 1.5,
+        outputPer1M: 7.25,
+      },
+    ];
+
+    insertUsageEvent({
+      id: "usage-target",
+      conversationId: "conv-usage-override",
+      createdAt: 2_000,
+      model,
+      inputTokens: 1_200,
+      outputTokens: 80,
+      estimatedCostUsd: estimateCost(1_200, 80, model, "anthropic"),
+    });
+    insertRequestLog({
+      id: "log-target",
+      conversationId: "conv-usage-override",
+      createdAt: 1_500,
+      responsePayload: anthropicResponsePayload({
+        inputTokens: 200,
+        outputTokens: 80,
+        cacheReadInputTokens: 700,
+        ephemeral5mInputTokens: 300,
+      }),
+    });
+
+    migrateBackfillUsageCacheAccounting(getDb());
+
+    const expectedUsage: PricingUsage = {
+      directInputTokens: 200,
+      outputTokens: 80,
+      cacheCreationInputTokens: 300,
+      cacheReadInputTokens: 700,
+      anthropicCacheCreation: {
+        ephemeral_5m_input_tokens: 300,
+        ephemeral_1h_input_tokens: 0,
+      },
+    };
+    const expectedPricing = resolvePricingForUsageWithOverrides(
+      "anthropic",
+      model,
+      expectedUsage,
+      mockPricingOverrides,
+    );
+
+    const targetRow = rawGet<UsageEventRow>(
+      `SELECT
+         input_tokens,
+         output_tokens,
+         cache_creation_input_tokens,
+         cache_read_input_tokens,
+         estimated_cost_usd,
+         pricing_status
+       FROM llm_usage_events
+       WHERE id = ?`,
+      "usage-target",
+    );
+    expect(targetRow).not.toBeNull();
+    expect(targetRow?.input_tokens).toBe(200);
+    expect(targetRow?.output_tokens).toBe(80);
+    expect(targetRow?.cache_creation_input_tokens).toBe(300);
+    expect(targetRow?.cache_read_input_tokens).toBe(700);
+    expect(targetRow?.pricing_status).toBe("priced");
+    expect(targetRow?.estimated_cost_usd).toBeCloseTo(
+      expectedPricing.estimatedCostUsd ?? 0,
+      12,
+    );
   });
 });

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -45,6 +45,9 @@ export interface ContextWindowResult {
   summaryInputTokens: number;
   summaryOutputTokens: number;
   summaryModel: string;
+  summaryCacheCreationInputTokens?: number;
+  summaryCacheReadInputTokens?: number;
+  summaryRawResponses?: unknown[];
   summaryText: string;
   reason?: string;
 }
@@ -298,6 +301,9 @@ export class ContextWindowManager {
     let summaryInputTokens = 0;
     let summaryOutputTokens = 0;
     let summaryModel = "";
+    let summaryCacheCreationInputTokens = 0;
+    let summaryCacheReadInputTokens = 0;
+    const summaryRawResponses: unknown[] = [];
     let summaryCalls = 0;
 
     for (const chunk of chunks) {
@@ -306,6 +312,13 @@ export class ContextWindowManager {
       summaryInputTokens += summaryUpdate.inputTokens;
       summaryOutputTokens += summaryUpdate.outputTokens;
       summaryModel = summaryUpdate.model || summaryModel;
+      summaryCacheCreationInputTokens += summaryUpdate.cacheCreationInputTokens;
+      summaryCacheReadInputTokens += summaryUpdate.cacheReadInputTokens;
+      if (Array.isArray(summaryUpdate.rawResponse)) {
+        summaryRawResponses.push(...summaryUpdate.rawResponse);
+      } else if (summaryUpdate.rawResponse !== undefined) {
+        summaryRawResponses.push(summaryUpdate.rawResponse);
+      }
       summaryCalls += 1;
     }
 
@@ -387,6 +400,9 @@ export class ContextWindowManager {
       summaryInputTokens,
       summaryOutputTokens,
       summaryModel,
+      summaryCacheCreationInputTokens,
+      summaryCacheReadInputTokens,
+      summaryRawResponses,
       summaryText: summary,
     };
   }
@@ -451,6 +467,9 @@ export class ContextWindowManager {
     inputTokens: number;
     outputTokens: number;
     model: string;
+    cacheCreationInputTokens: number;
+    cacheReadInputTokens: number;
+    rawResponse?: unknown;
   }> {
     const prompt = buildSummaryPrompt(currentSummary, chunk);
     try {
@@ -471,6 +490,10 @@ export class ContextWindowManager {
           inputTokens: response.usage.inputTokens,
           outputTokens: response.usage.outputTokens,
           model: response.model,
+          cacheCreationInputTokens:
+            response.usage.cacheCreationInputTokens ?? 0,
+          cacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
+          rawResponse: response.rawResponse,
         };
       }
     } catch (err) {
@@ -482,6 +505,8 @@ export class ContextWindowManager {
       inputTokens: 0,
       outputTokens: 0,
       model: "",
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
     };
   }
 }

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -461,6 +461,9 @@ export async function runAgentLoopImpl(
         onEvent,
         "context_compactor",
         reqId,
+        compacted.summaryCacheCreationInputTokens ?? 0,
+        compacted.summaryCacheReadInputTokens ?? 0,
+        collapseRawResponses(compacted.summaryRawResponses),
       );
     }
 
@@ -715,6 +718,9 @@ export async function runAgentLoopImpl(
             onEvent,
             "context_compactor",
             reqId,
+            step.compactionResult.summaryCacheCreationInputTokens ?? 0,
+            step.compactionResult.summaryCacheReadInputTokens ?? 0,
+            collapseRawResponses(step.compactionResult.summaryRawResponses),
           );
         }
 
@@ -902,6 +908,9 @@ export async function runAgentLoopImpl(
             onEvent,
             "context_compactor",
             reqId,
+            step.compactionResult.summaryCacheCreationInputTokens ?? 0,
+            step.compactionResult.summaryCacheReadInputTokens ?? 0,
+            collapseRawResponses(step.compactionResult.summaryRawResponses),
           );
         }
 
@@ -979,6 +988,9 @@ export async function runAgentLoopImpl(
                 onEvent,
                 "context_compactor",
                 reqId,
+                emergencyCompact.summaryCacheCreationInputTokens ?? 0,
+                emergencyCompact.summaryCacheReadInputTokens ?? 0,
+                collapseRawResponses(emergencyCompact.summaryRawResponses),
               );
             }
 
@@ -1074,6 +1086,9 @@ export async function runAgentLoopImpl(
               onEvent,
               "context_compactor",
               reqId,
+              emergencyCompact.summaryCacheCreationInputTokens ?? 0,
+              emergencyCompact.summaryCacheReadInputTokens ?? 0,
+              collapseRawResponses(emergencyCompact.summaryRawResponses),
             );
           }
 
@@ -1246,9 +1261,7 @@ export async function runAgentLoopImpl(
       reqId,
       state.exchangeCacheCreationInputTokens,
       state.exchangeCacheReadInputTokens,
-      state.exchangeRawResponses.length <= 1
-        ? state.exchangeRawResponses[0]
-        : state.exchangeRawResponses,
+      collapseRawResponses(state.exchangeRawResponses),
     );
 
     void getHookManager().trigger("post-message", {
@@ -1474,4 +1487,9 @@ function emitUsage(
     cacheReadInputTokens,
     rawResponse,
   );
+}
+
+function collapseRawResponses(rawResponses?: unknown[]): unknown | undefined {
+  if (!rawResponses || rawResponses.length === 0) return undefined;
+  return rawResponses.length === 1 ? rawResponses[0] : rawResponses;
 }

--- a/assistant/src/memory/migrations/140-backfill-usage-cache-accounting.ts
+++ b/assistant/src/memory/migrations/140-backfill-usage-cache-accounting.ts
@@ -1,9 +1,10 @@
+import { getConfig } from "../../config/loader.js";
 import type {
   AnthropicCacheCreationTokenDetails,
   PricingUsage,
 } from "../../usage/types.js";
 import { getLogger } from "../../util/logger.js";
-import { resolvePricingForUsage } from "../../util/pricing.js";
+import { resolvePricingForUsageWithOverrides } from "../../util/pricing.js";
 import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 import { withCrashRecovery } from "./validate-migration-state.js";
 
@@ -182,12 +183,13 @@ export function migrateBackfillUsageCacheAccounting(database: DrizzleDb): void {
     const requestLogsByConversation = buildRequestLogMap(requestLogRows);
     const requestOffsets = new Map<string, number>();
     const previousUsageEventCreatedAt = new Map<string, number>();
+    const pricingOverrides = getConfig().pricingOverrides;
 
     let scannedAnthropicRows = 0;
     let updatedRows = 0;
     let skippedNoConversation = 0;
     let skippedNoLogs = 0;
-    let skippedInvalidLogs = 0;
+    let ignoredUnusableLogs = 0;
     let skippedInconsistentRows = 0;
 
     const updateRow = raw.prepare(/*sql*/ `
@@ -254,16 +256,17 @@ export function migrateBackfillUsageCacheAccounting(database: DrizzleDb): void {
         let cacheCreationInputTokens = 0;
         let cacheCreation5mInputTokens = 0;
         let cacheCreation1hInputTokens = 0;
+        let usableLogCount = 0;
 
-        let invalidLogFound = false;
         for (const requestLog of windowLogs) {
           const reconstructedUsage = parseResponseUsage(
             requestLog.response_payload,
           );
           if (!reconstructedUsage) {
-            invalidLogFound = true;
-            break;
+            ignoredUnusableLogs += 1;
+            continue;
           }
+          usableLogCount += 1;
           directInputTokens += reconstructedUsage.directInputTokens;
           outputTokens += reconstructedUsage.outputTokens;
           cacheReadInputTokens += reconstructedUsage.cacheReadInputTokens;
@@ -277,8 +280,8 @@ export function migrateBackfillUsageCacheAccounting(database: DrizzleDb): void {
               ?.ephemeral_1h_input_tokens ?? 0;
         }
 
-        if (invalidLogFound) {
-          skippedInvalidLogs += 1;
+        if (usableLogCount === 0) {
+          skippedNoLogs += 1;
           continue;
         }
 
@@ -314,10 +317,11 @@ export function migrateBackfillUsageCacheAccounting(database: DrizzleDb): void {
                 }
               : null,
         };
-        const pricing = resolvePricingForUsage(
+        const pricing = resolvePricingForUsageWithOverrides(
           usageRow.provider,
           usageRow.model,
           pricingUsage,
+          pricingOverrides,
         );
 
         updateRow.run(
@@ -344,7 +348,7 @@ export function migrateBackfillUsageCacheAccounting(database: DrizzleDb): void {
         updatedRows,
         skippedNoConversation,
         skippedNoLogs,
-        skippedInvalidLogs,
+        ignoredUnusableLogs,
         skippedInconsistentRows,
       },
       "Backfilled historical Anthropic usage rows from request-log accounting",

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 #   ./build.sh run            Build + launch + watch for changes (auto-rebuild)
 #   ./build.sh release        Build release .app
 #   ./build.sh binaries       Build only Bun binaries (daemon, CLI, gateway)
-#   ./build.sh test           Run tests (no .app needed)
+#   ./build.sh test [args]    Run tests (no .app needed); forwards extra args to `swift test`
 #   ./build.sh clean          Remove build artifacts
 #   ./build.sh lint           Build with strict concurrency (catches CI-only errors locally)
 #   ./build.sh release-application  Build release, package into DMG, install to /Applications
@@ -81,10 +81,19 @@ BUILD_VERSION="${BUILD_VERSION:-1}"
 # Parse arguments: command + optional flags
 UNIVERSAL_BUILD=false
 CMD="build"
+CMD_SET=false
+CMD_ARGS=()
 for arg in "$@"; do
     case "$arg" in
         --universal) UNIVERSAL_BUILD=true ;;
-        *) CMD="$arg" ;;
+        *)
+            if [ "$CMD_SET" = false ]; then
+                CMD="$arg"
+                CMD_SET=true
+            else
+                CMD_ARGS+=("$arg")
+            fi
+            ;;
     esac
 done
 
@@ -212,8 +221,12 @@ build_binaries() {
 case "$CMD" in
     test)
         echo "Running tests..."
+        SWIFT_TEST_ARGS=("${CMD_ARGS[@]}")
+        if [ ${#SWIFT_TEST_ARGS[@]} -eq 0 ]; then
+            SWIFT_TEST_ARGS=(--filter vellum_assistantTests)
+        fi
         set +e
-        TEST_OUTPUT=$(swift_with_retry swift test --filter vellum_assistantTests 2>&1)
+        TEST_OUTPUT=$(swift_with_retry swift test "${SWIFT_TEST_ARGS[@]}" 2>&1)
         TEST_EXIT=$?
         set -e
         echo "$TEST_OUTPUT"


### PR DESCRIPTION
## Summary
- preserve Anthropic cache usage and raw response metadata through context compaction so compactor usage rows price correctly
- make the historical backfill honor pricing overrides and ignore unrelated/unparseable request logs inside the same window
- add regression coverage for the compactor/session path, migration behavior, and macOS build.sh test arg forwarding

## Testing
- cd assistant && export PATH="$HOME/.bun/bin:$PATH" && bun test src/__tests__/context-window-manager.test.ts
- cd assistant && export PATH="$HOME/.bun/bin:$PATH" && bun test src/__tests__/session-agent-loop.test.ts --grep "forwards cache-aware compaction usage to recordUsage"
- cd assistant && export PATH="$HOME/.bun/bin:$PATH" && bun test src/__tests__/usage-cache-backfill-migration.test.ts
- cd assistant && export PATH="$HOME/.bun/bin:$PATH" && bunx tsc --noEmit
- bash -n clients/macos/build.sh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13797" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
