### PR TITLE
fix: remove stale smsUrl from twilio-routes test mock

### DIFF
--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -301,7 +301,6 @@ mock.module("../daemon/handlers/config-ingress.js", () => ({
       urls: {
         voiceUrl: `${baseUrl}/webhooks/twilio/voice`,
         statusCallbackUrl: `${baseUrl}/webhooks/twilio/status`,
-        smsUrl: `${baseUrl}/webhooks/twilio/sms`,
       },
     });
     return { success: true };


### PR DESCRIPTION
## Summary
- Remove `smsUrl` from the `updatePhoneNumberWebhookCalls` mock in twilio-routes.test.ts
- The Twilio webhook URL type was updated to only include `voiceUrl` and `statusCallbackUrl` (SMS support removed), but the test mock still had the obsolete `smsUrl` property causing TS2353

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
