### PR TITLE
fix(macos): avoid unbound variable in build.sh test

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -221,9 +221,10 @@ build_binaries() {
 case "$CMD" in
     test)
         echo "Running tests..."
-        SWIFT_TEST_ARGS=("${CMD_ARGS[@]}")
-        if [ ${#SWIFT_TEST_ARGS[@]} -eq 0 ]; then
+        if [ ${#CMD_ARGS[@]} -eq 0 ]; then
             SWIFT_TEST_ARGS=(--filter vellum_assistantTests)
+        else
+            SWIFT_TEST_ARGS=("${CMD_ARGS[@]}")
         fi
         set +e
         TEST_OUTPUT=$(swift_with_retry swift test "${SWIFT_TEST_ARGS[@]}" 2>&1)


### PR DESCRIPTION
## Summary
- Fix CI failure: `./build.sh test` with no extra args triggered `CMD_ARGS[@]: unbound variable` due to `set -u`
- Reorder logic to check `${#CMD_ARGS[@]}` first; only expand `${CMD_ARGS[@]}` when non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13802" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
