### PR TITLE
fix: derive wake target from BASE_DATA_DIR when lockfile lacks assistants

### DIFF
--- a/assistant/src/__tests__/local-gateway-health.test.ts
+++ b/assistant/src/__tests__/local-gateway-health.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 let mockGatewayInternalBaseUrl = "http://127.0.0.1:7830";
 let mockIsContainerized = false;
 let mockLockfile: Record<string, unknown> | null = null;
+let mockBaseDataDir: string | undefined;
 
 mock.module("../config/env.js", () => ({
   getGatewayInternalBaseUrl: () => mockGatewayInternalBaseUrl,
@@ -10,6 +11,7 @@ mock.module("../config/env.js", () => ({
 
 mock.module("../config/env-registry.js", () => ({
   getIsContainerized: () => mockIsContainerized,
+  getBaseDataDir: () => mockBaseDataDir,
 }));
 
 mock.module("../util/platform.js", () => ({
@@ -25,6 +27,7 @@ describe("local gateway health", () => {
   beforeEach(() => {
     mockGatewayInternalBaseUrl = "http://127.0.0.1:7830";
     mockIsContainerized = false;
+    mockBaseDataDir = undefined;
     mockLockfile = {
       assistants: [
         {
@@ -148,5 +151,32 @@ describe("local gateway health", () => {
       recoveryAttempted: false,
       recoverySkipped: true,
     });
+  });
+
+  test("ensureLocalGatewayReady derives assistant name from BASE_DATA_DIR when lockfile lacks assistants", async () => {
+    mockBaseDataDir = "/home/user/.local/share/vellum/assistants/alice";
+    mockLockfile = null;
+
+    const healthStatuses = [503, 200];
+    const fetchImpl: typeof fetch = (async (): Promise<Response> => {
+      const status = healthStatuses.shift() ?? 200;
+      return new Response(status === 200 ? "ok" : "unavailable", { status });
+    }) as unknown as typeof fetch;
+
+    let wakeCalled = false;
+    const result = await ensureLocalGatewayReady({
+      fetchImpl,
+      timeoutMs: 50,
+      pollTimeoutMs: 100,
+      pollIntervalMs: 0,
+      sleepImpl: async () => {},
+      runWakeCommand: async () => {
+        wakeCalled = true;
+        return { exitCode: 0, stdout: "Wake complete.", stderr: "" };
+      },
+    });
+
+    expect(wakeCalled).toBe(true);
+    expect(result.recovered).toBe(true);
   });
 });

--- a/assistant/src/runtime/local-gateway-health.ts
+++ b/assistant/src/runtime/local-gateway-health.ts
@@ -1,8 +1,7 @@
 import { getGatewayInternalBaseUrl } from "../config/env.js";
-import { getIsContainerized } from "../config/env-registry.js";
+import { getBaseDataDir, getIsContainerized } from "../config/env-registry.js";
 import { readLockfile } from "../util/platform.js";
 import { sleep } from "../util/retry.js";
-import { spawnWithTimeout } from "../util/spawn.js";
 
 const DEFAULT_PROBE_TIMEOUT_MS = 2_000;
 const DEFAULT_RECOVERY_POLL_TIMEOUT_MS = 30_000;
@@ -84,7 +83,25 @@ function resolveLocalDeployment(): boolean {
   return true;
 }
 
+/**
+ * Derive instance name from BASE_DATA_DIR when it matches the multi-instance
+ * path pattern (~/.local/share/vellum/assistants/<name>/). Returns undefined
+ * for the legacy single-instance layout (BASE_DATA_DIR = homedir).
+ */
+function resolveInstanceNameFromBaseDataDir(): string | undefined {
+  const base = getBaseDataDir();
+  if (!base || typeof base !== "string") return undefined;
+
+  const normalized = base.replace(/\\/g, "/").replace(/\/+$/, "");
+  const match = normalized.match(/\/assistants\/([^/]+)$/);
+  if (match) return match[1];
+  return undefined;
+}
+
 function resolveLocalAssistantName(): string | undefined {
+  const fromPath = resolveInstanceNameFromBaseDataDir();
+  if (fromPath) return fromPath;
+
   const latestAssistant = getLatestAssistantEntry();
   if (
     latestAssistant &&
@@ -108,7 +125,40 @@ async function runDefaultWakeCommand(
   const command = assistantName
     ? ["vellum", "wake", assistantName]
     : ["vellum", "wake"];
-  return spawnWithTimeout(command, timeoutMs);
+
+  // When we have an explicit assistant name (e.g. from instance path), unset
+  // BASE_DATA_DIR so the spawned CLI reads the global lockfile and targets
+  // the correct instance. Otherwise the CLI would read the instance-scoped
+  // lockfile which may lack assistant metadata.
+  const env =
+    assistantName && getBaseDataDir()
+      ? { ...process.env, BASE_DATA_DIR: undefined }
+      : process.env;
+
+  return new Promise((resolve, reject) => {
+    const proc = Bun.spawn(command, {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...env,
+        PATH: [env.PATH, "/opt/homebrew/bin", "/usr/local/bin"]
+          .filter(Boolean)
+          .join(":"),
+      },
+    });
+    const timer = setTimeout(() => {
+      proc.kill();
+      reject(
+        new Error(`Process timed out after ${timeoutMs}ms: ${command[0]}`),
+      );
+    }, timeoutMs);
+    proc.exited.then(async (exitCode) => {
+      clearTimeout(timer);
+      const stdout = await new Response(proc.stdout).text();
+      const stderr = await new Response(proc.stderr).text();
+      resolve({ exitCode, stdout, stderr });
+    });
+  });
 }
 
 export async function probeLocalGatewayHealth(

--- a/assistant/src/runtime/local-gateway-health.ts
+++ b/assistant/src/runtime/local-gateway-health.ts
@@ -126,12 +126,15 @@ async function runDefaultWakeCommand(
     ? ["vellum", "wake", assistantName]
     : ["vellum", "wake"];
 
-  // When we have an explicit assistant name (e.g. from instance path), unset
-  // BASE_DATA_DIR so the spawned CLI reads the global lockfile and targets
-  // the correct instance. Otherwise the CLI would read the instance-scoped
-  // lockfile which may lack assistant metadata.
+  // Only when the assistant name came from the instance path (e.g.
+  // ~/.local/share/vellum/assistants/<name>/), unset BASE_DATA_DIR so the
+  // spawned CLI reads the global lockfile. When the name came from the
+  // lockfile, keep BASE_DATA_DIR — vellum wake resolves names through the
+  // lockfile rooted at BASE_DATA_DIR, so clearing it would read the wrong
+  // lockfile (e.g. $HOME) and fail or wake the wrong assistant.
+  const fromInstancePath = resolveInstanceNameFromBaseDataDir();
   const env =
-    assistantName && getBaseDataDir()
+    fromInstancePath && getBaseDataDir()
       ? { ...process.env, BASE_DATA_DIR: undefined }
       : process.env;
 


### PR DESCRIPTION
## Summary
Addresses P2 feedback on twilio-voice-call-stability: `ensureLocalGatewayReady()` fell back to bare `vellum wake` when the instance-scoped lockfile had no assistants array, causing multi-instance local deployments to fail recovery or target the wrong assistant.

## Changes
- Derive instance name from BASE_DATA_DIR when it matches .../assistants/<name> path pattern
- Prefer path-derived name over lockfile when both available
- Unset BASE_DATA_DIR when spawning vellum wake with explicit assistant name so CLI reads global lockfile
- Add test for recovery when lockfile lacks assistants but BASE_DATA_DIR is instance path

## Verification
`cd assistant && bun test src/__tests__/local-gateway-health.test.ts`

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13806" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
