### PR TITLE
fix: sort imports in channel-verification-service

### DIFF
--- a/assistant/src/runtime/channel-verification-service.ts
+++ b/assistant/src/runtime/channel-verification-service.ts
@@ -15,8 +15,8 @@ import type {
   GuardianBinding,
   IdentityBindingStatus,
   SessionStatus,
-  VerificationSession,
   VerificationPurpose,
+  VerificationSession,
 } from "../memory/channel-guardian-store.js";
 import {
   bindSessionIdentity as storeBindSessionIdentity,
@@ -387,9 +387,7 @@ export function revokePendingSessions(channel: string): void {
  * channel. Used by relay setup to detect whether an active
  * voice verification session exists.
  */
-export function getPendingSession(
-  channel: string,
-): VerificationSession | null {
+export function getPendingSession(channel: string): VerificationSession | null {
   return findPendingSessionForChannel(channel);
 }
 
@@ -470,9 +468,7 @@ export function createOutboundSession(params: {
 /**
  * Find the most recent active outbound session for a given channel.
  */
-export function findActiveSession(
-  channel: string,
-): VerificationSession | null {
+export function findActiveSession(channel: string): VerificationSession | null {
   return storeFindActiveSession(channel);
 }
 


### PR DESCRIPTION
## Summary
- Fix CI lint failure: reorder type imports in channel-verification-service.ts to satisfy simple-import-sort/imports (VerificationPurpose before VerificationSession)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13807" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
