### PR TITLE
refactor: consolidate verification handlers under /v1/channel-verification-sessions

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -207,12 +207,13 @@ Guardian verification can be initiated through gateway HTTP endpoints (which for
 
 **HTTP Endpoints:**
 
-| Endpoint                                    | Method | Description                                                                                                                                                               |
-| ------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/v1/integrations/guardian/sessions`        | POST   | Create a guardian session. If `destination` is provided, starts outbound verification; otherwise creates an inbound challenge. Body: `{ channel, destination?, rebind? }` |
-| `/v1/integrations/guardian/sessions/resend` | POST   | Resend the verification code for an active outbound session. Body: `{ channel }`                                                                                          |
-| `/v1/integrations/guardian/sessions`        | DELETE | Cancel all active sessions (inbound + outbound) for a channel. Body: `{ channel }`                                                                                        |
-| `/v1/integrations/guardian/revoke`          | POST   | Cancel all active sessions and revoke the guardian binding. Body: `{ channel? }`                                                                                          |
+| Endpoint                                   | Method | Description                                                                                                                                                                                                                                                                                               |
+| ------------------------------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/v1/channel-verification-sessions`        | POST   | Create a verification session. If `destination` is provided, starts outbound verification; if `purpose: "trusted_contact"` with `contactChannelId`, starts trusted contact verification; otherwise creates an inbound challenge. Body: `{ channel?, destination?, rebind?, purpose?, contactChannelId? }` |
+| `/v1/channel-verification-sessions/resend` | POST   | Resend the verification code for an active outbound session. Body: `{ channel }`                                                                                                                                                                                                                          |
+| `/v1/channel-verification-sessions`        | DELETE | Cancel all active sessions (inbound + outbound) for a channel. Body: `{ channel }`                                                                                                                                                                                                                        |
+| `/v1/channel-verification-sessions/revoke` | POST   | Cancel all active sessions and revoke the guardian binding. Body: `{ channel? }`                                                                                                                                                                                                                          |
+| `/v1/channel-verification-sessions/status` | GET    | Check guardian binding status. Query: `?channel=<channel>`                                                                                                                                                                                                                                                |
 
 All endpoints are JWT-authenticated via `Authorization: Bearer <jwt>`. Skills and user-facing tooling should target the gateway URL (default `http://localhost:7830`), not the runtime port.
 
@@ -230,16 +231,16 @@ The HTTP route handlers (`integration-routes.ts`) and the legacy IPC handlers (`
 
 **Key Source Files:**
 
-| File                                                       | Purpose                                                                                                           |
-| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `src/runtime/verification-outbound-actions.ts`             | Shared business logic for start/resend/cancel outbound verification                                               |
-| `src/runtime/routes/integration-routes.ts`                 | HTTP route handlers for unified guardian session API (`/v1/integrations/guardian/sessions`, `/revoke`, `/status`) |
-| `src/daemon/handlers/config-channels.ts`                   | IPC handler that delegates to the same shared actions                                                             |
-| `src/config/bundled-skills/guardian-verify-setup/SKILL.md` | Skill that teaches the assistant how to orchestrate guardian verification via chat                                |
+| File                                                       | Purpose                                                                                                              |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `src/runtime/verification-outbound-actions.ts`             | Shared business logic for start/resend/cancel outbound verification                                                  |
+| `src/runtime/routes/integration-routes.ts`                 | HTTP route handlers for unified verification session API (`/v1/channel-verification-sessions`, `/revoke`, `/status`) |
+| `src/daemon/handlers/config-channels.ts`                   | IPC handler that delegates to the same shared actions                                                                |
+| `src/config/bundled-skills/guardian-verify-setup/SKILL.md` | Skill that teaches the assistant how to orchestrate guardian verification via chat                                   |
 
 **Guardian-Only Tool Invocation Gate:**
 
-Guardian verification control-plane endpoints (`/v1/integrations/guardian/*`) are protected by a deterministic gate in the tool executor (`src/tools/executor.ts`). Before any tool invocation proceeds, the executor checks whether the invocation targets a guardian control-plane endpoint and whether the actor role is allowed. The policy uses an allowlist: only `guardian` and `undefined` (desktop/trusted) actor roles can invoke these endpoints. Non-guardian and unverified-channel actors receive a denial message explaining the restriction.
+Channel verification control-plane endpoints (`/v1/channel-verification-sessions/*`) are protected by a deterministic gate in the tool executor (`src/tools/executor.ts`). Before any tool invocation proceeds, the executor checks whether the invocation targets a guardian control-plane endpoint and whether the actor role is allowed. The policy uses an allowlist: only `guardian` and `undefined` (desktop/trusted) actor roles can invoke these endpoints. Non-guardian and unverified-channel actors receive a denial message explaining the restriction.
 
 The policy is implemented in `src/tools/guardian-control-plane-policy.ts`, which inspects tool inputs (bash commands, URLs) for guardian endpoint paths. This is a defense-in-depth measure — even if the LLM attempts to call guardian endpoints on behalf of a non-guardian actor, the tool executor blocks it deterministically.
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -353,12 +353,13 @@ Guardian verification can also be initiated through normal desktop chat. When th
 
 **Outbound HTTP Endpoints** (exposed via the gateway API and forwarded to the runtime):
 
-| Endpoint                                    | Method | Description                                                                                                                                                               |
-| ------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/v1/integrations/guardian/sessions`        | POST   | Create a guardian session. If `destination` is provided, starts outbound verification; otherwise creates an inbound challenge. Body: `{ channel, destination?, rebind? }` |
-| `/v1/integrations/guardian/sessions/resend` | POST   | Resend verification code for an active outbound session. Body: `{ channel }`                                                                                              |
-| `/v1/integrations/guardian/sessions`        | DELETE | Cancel all active sessions (inbound + outbound) for a channel. Body: `{ channel }`                                                                                        |
-| `/v1/integrations/guardian/revoke`          | POST   | Cancel all active sessions and revoke the guardian binding. Body: `{ channel? }`                                                                                          |
+| Endpoint                                   | Method | Description                                                                                                                                                                                                                                       |
+| ------------------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/v1/channel-verification-sessions`        | POST   | Create a verification session. Supports guardian (default), outbound (with `destination`), and trusted contact (with `purpose: "trusted_contact"` + `contactChannelId`). Body: `{ channel?, destination?, rebind?, purpose?, contactChannelId? }` |
+| `/v1/channel-verification-sessions/resend` | POST   | Resend verification code for an active outbound session. Body: `{ channel }`                                                                                                                                                                      |
+| `/v1/channel-verification-sessions`        | DELETE | Cancel all active sessions (inbound + outbound) for a channel. Body: `{ channel }`                                                                                                                                                                |
+| `/v1/channel-verification-sessions/revoke` | POST   | Cancel all active sessions and revoke the guardian binding. Body: `{ channel? }`                                                                                                                                                                  |
+| `/v1/channel-verification-sessions/status` | GET    | Check guardian binding status. Query: `?channel=<channel>`                                                                                                                                                                                        |
 
 These endpoints share the same business logic as the IPC-based verification flow via `verification-outbound-actions.ts`. Skills and clients should call the gateway URL (default `http://localhost:7830`) rather than the runtime port directly.
 

--- a/assistant/src/__tests__/bundled-skill-retrieval-guard.test.ts
+++ b/assistant/src/__tests__/bundled-skill-retrieval-guard.test.ts
@@ -42,7 +42,7 @@ const GATEWAY_RETRIEVAL_BANLIST: Array<{
   {
     skillPath: "guardian-verify-setup/SKILL.md",
     bannedSnippets: [
-      'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/status',
+      'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/channel-verification-sessions/status',
     ],
   },
   {

--- a/assistant/src/__tests__/guardian-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/guardian-control-plane-policy.test.ts
@@ -149,10 +149,10 @@ afterAll(() => {
 
 describe("isGuardianControlPlaneInvocation", () => {
   const guardianPaths = [
-    "/v1/integrations/guardian/sessions",
-    "/v1/integrations/guardian/status",
-    "/v1/integrations/guardian/sessions/resend",
-    "/v1/integrations/guardian/revoke",
+    "/v1/channel-verification-sessions",
+    "/v1/channel-verification-sessions/status",
+    "/v1/channel-verification-sessions/resend",
+    "/v1/channel-verification-sessions/revoke",
   ];
 
   describe("bash tool with guardian endpoint in command", () => {
@@ -183,11 +183,10 @@ describe("isGuardianControlPlaneInvocation", () => {
     });
 
     test("matches partial path prefix via fragment detection (fail-closed for shell tools)", () => {
-      // Even without a trailing sub-path, the presence of both /v1/integrations and guardian
-      // in a bash command triggers the conservative fragment detector.
       expect(
         isGuardianControlPlaneInvocation("bash", {
-          command: "curl http://localhost:3000/v1/integrations/guardian",
+          command:
+            "curl http://localhost:3000/v1/channel-verification-sessions",
         }),
       ).toBe(true);
     });
@@ -195,7 +194,8 @@ describe("isGuardianControlPlaneInvocation", () => {
     test("matches unknown sub-path under guardian control-plane (broad pattern)", () => {
       expect(
         isGuardianControlPlaneInvocation("bash", {
-          command: "curl http://localhost:3000/v1/integrations/guardian/other",
+          command:
+            "curl http://localhost:3000/v1/channel-verification-sessions/other",
         }),
       ).toBe(true);
     });
@@ -216,7 +216,7 @@ describe("isGuardianControlPlaneInvocation", () => {
       expect(
         isGuardianControlPlaneInvocation("host_bash", {
           command:
-            'curl -H "Authorization: Bearer token" https://internal:8080/v1/integrations/guardian/sessions',
+            'curl -H "Authorization: Bearer token" https://internal:8080/v1/channel-verification-sessions',
         }),
       ).toBe(true);
     });
@@ -236,7 +236,7 @@ describe("isGuardianControlPlaneInvocation", () => {
     test("detects proxied local URL", () => {
       expect(
         isGuardianControlPlaneInvocation("network_request", {
-          url: "http://127.0.0.1:3000/v1/integrations/guardian/sessions",
+          url: "http://127.0.0.1:3000/v1/channel-verification-sessions",
         }),
       ).toBe(true);
     });
@@ -260,7 +260,7 @@ describe("isGuardianControlPlaneInvocation", () => {
     test("detects guardian endpoint", () => {
       expect(
         isGuardianControlPlaneInvocation("web_fetch", {
-          url: "https://api.example.com/v1/integrations/guardian/sessions",
+          url: "https://api.example.com/v1/channel-verification-sessions",
         }),
       ).toBe(true);
     });
@@ -278,7 +278,7 @@ describe("isGuardianControlPlaneInvocation", () => {
     test("detects guardian endpoint", () => {
       expect(
         isGuardianControlPlaneInvocation("browser_navigate", {
-          url: "http://localhost:3000/v1/integrations/guardian/status",
+          url: "http://localhost:3000/v1/channel-verification-sessions/status",
         }),
       ).toBe(true);
     });
@@ -288,7 +288,7 @@ describe("isGuardianControlPlaneInvocation", () => {
     test("file_read is never a guardian invocation", () => {
       expect(
         isGuardianControlPlaneInvocation("file_read", {
-          path: "/v1/integrations/guardian/sessions",
+          path: "/v1/channel-verification-sessions",
         }),
       ).toBe(false);
     });
@@ -297,7 +297,7 @@ describe("isGuardianControlPlaneInvocation", () => {
       expect(
         isGuardianControlPlaneInvocation("file_write", {
           path: "/tmp/test.txt",
-          content: "curl /v1/integrations/guardian/sessions",
+          content: "curl /v1/channel-verification-sessions",
         }),
       ).toBe(false);
     });
@@ -305,7 +305,7 @@ describe("isGuardianControlPlaneInvocation", () => {
     test("web_search is never a guardian invocation", () => {
       expect(
         isGuardianControlPlaneInvocation("web_search", {
-          query: "/v1/integrations/guardian/status",
+          query: "/v1/channel-verification-sessions/status",
         }),
       ).toBe(false);
     });
@@ -315,7 +315,7 @@ describe("isGuardianControlPlaneInvocation", () => {
     test("matches endpoint with query string", () => {
       expect(
         isGuardianControlPlaneInvocation("network_request", {
-          url: "https://api.example.com/v1/integrations/guardian/sessions?token=abc",
+          url: "https://api.example.com/v1/channel-verification-sessions?token=abc",
         }),
       ).toBe(true);
     });
@@ -323,7 +323,7 @@ describe("isGuardianControlPlaneInvocation", () => {
     test("matches endpoint with trailing slash", () => {
       expect(
         isGuardianControlPlaneInvocation("network_request", {
-          url: "https://api.example.com/v1/integrations/guardian/sessions/resend/",
+          url: "https://api.example.com/v1/channel-verification-sessions/resend/",
         }),
       ).toBe(true);
     });
@@ -332,7 +332,7 @@ describe("isGuardianControlPlaneInvocation", () => {
       expect(
         isGuardianControlPlaneInvocation("bash", {
           command:
-            'echo \'{"phone":"+1234567890"}\' | curl -X POST -d @- http://localhost:3000/v1/integrations/guardian/sessions/resend',
+            'echo \'{"phone":"+1234567890"}\' | curl -X POST -d @- http://localhost:3000/v1/channel-verification-sessions/resend',
         }),
       ).toBe(true);
     });
@@ -343,15 +343,7 @@ describe("isGuardianControlPlaneInvocation", () => {
       expect(
         isGuardianControlPlaneInvocation("bash", {
           command:
-            "curl http://localhost:3000/v1/integrations%2Fguardian%2Fsessions",
-        }),
-      ).toBe(true);
-    });
-
-    test("detects double-encoded path (%252F encoding)", () => {
-      expect(
-        isGuardianControlPlaneInvocation("network_request", {
-          url: "http://localhost:3000/v1/integrations%252Fguardian%252Fsessions",
+            "curl http://localhost:3000/v1/channel%2Dverification%2Dsessions",
         }),
       ).toBe(true);
     });
@@ -360,7 +352,7 @@ describe("isGuardianControlPlaneInvocation", () => {
       expect(
         isGuardianControlPlaneInvocation("bash", {
           command:
-            "curl http://localhost:3000/v1/integrations//guardian/sessions",
+            "curl http://localhost:3000/v1//channel-verification-sessions",
         }),
       ).toBe(true);
     });
@@ -368,7 +360,7 @@ describe("isGuardianControlPlaneInvocation", () => {
     test("detects triple slashes in path", () => {
       expect(
         isGuardianControlPlaneInvocation("network_request", {
-          url: "http://localhost:3000/v1///integrations///guardian///status",
+          url: "http://localhost:3000/v1///channel-verification-sessions///status",
         }),
       ).toBe(true);
     });
@@ -377,7 +369,7 @@ describe("isGuardianControlPlaneInvocation", () => {
       expect(
         isGuardianControlPlaneInvocation("bash", {
           command:
-            "curl http://localhost:3000/V1/Integrations/Guardian/Outbound/Start",
+            "curl http://localhost:3000/V1/Channel-Verification-Sessions/Status",
         }),
       ).toBe(true);
     });
@@ -385,32 +377,15 @@ describe("isGuardianControlPlaneInvocation", () => {
     test("detects ALL CAPS path", () => {
       expect(
         isGuardianControlPlaneInvocation("network_request", {
-          url: "http://localhost:3000/V1/INTEGRATIONS/GUARDIAN/SESSIONS",
+          url: "http://localhost:3000/V1/CHANNEL-VERIFICATION-SESSIONS",
         }),
       ).toBe(true);
     });
 
-    test("detects combined obfuscation: URL-encoding + mixed case", () => {
-      expect(
-        isGuardianControlPlaneInvocation("bash", {
-          command:
-            "curl http://localhost:3000/V1/Integrations%2FGuardian%2FSessions",
-        }),
-      ).toBe(true);
-    });
-
-    test("detects combined obfuscation: double slashes + URL-encoding", () => {
+    test("detects combined obfuscation: double slashes + mixed case", () => {
       expect(
         isGuardianControlPlaneInvocation("network_request", {
-          url: "http://localhost:3000/v1//integrations%2Fguardian%2Fstatus",
-        }),
-      ).toBe(true);
-    });
-
-    test("detects URL-encoded path in web_fetch tool", () => {
-      expect(
-        isGuardianControlPlaneInvocation("web_fetch", {
-          url: "http://localhost:3000/v1/integrations%2Fguardian%2Fsessions%2Fresend",
+          url: "http://localhost:3000/v1//Channel-Verification-Sessions/status",
         }),
       ).toBe(true);
     });
@@ -424,53 +399,53 @@ describe("isGuardianControlPlaneInvocation", () => {
       ).toBe(false);
     });
 
-    test("detects guardian endpoint despite malformed percent-encoding elsewhere in command", () => {
+    test("detects endpoint despite malformed percent-encoding elsewhere in command", () => {
       const result = isGuardianControlPlaneInvocation("bash", {
         command:
-          'curl -H "X: %ZZ" http://localhost:3000/v1/integrations%2Fguardian%2Fsessions -d \'{"channel":"sms"}\'',
+          'curl -H "X: %ZZ" http://localhost:3000/v1/channel-verification-sessions -d \'{"channel":"sms"}\'',
       });
       expect(result).toBe(true);
     });
   });
 
   describe("shell expansion resistance", () => {
-    test("detects guardian endpoint constructed via shell variable concatenation", () => {
+    test("detects endpoint constructed via shell variable concatenation", () => {
       expect(
         isGuardianControlPlaneInvocation("bash", {
           command:
-            'base=http://localhost:7821/v1/integrations; seg=guardian; curl "$base/$seg/status"',
+            'base=http://localhost:7821/v1; seg=channel-verification-sessions; curl "$base/$seg/status"',
         }),
       ).toBe(true);
     });
 
-    test("detects guardian endpoint with split variable assignment", () => {
+    test("detects endpoint with split variable assignment", () => {
       expect(
         isGuardianControlPlaneInvocation("bash", {
           command:
-            'API=/v1/integrations; curl "http://localhost:3000${API}/guardian/sessions"',
+            'API=channel-verification-sessions; curl "http://localhost:3000/v1/${API}"',
         }),
       ).toBe(true);
     });
 
-    test("detects guardian endpoint with path built across multiple variables", () => {
+    test("detects endpoint with path built across multiple variables", () => {
       expect(
         isGuardianControlPlaneInvocation("bash", {
           command:
-            'HOST=http://localhost:7821; PATH_PREFIX=/v1/integrations; SVC=guardian; curl "$HOST$PATH_PREFIX/$SVC/sessions"',
+            'HOST=http://localhost:7821; ENDPOINT=channel-verification-sessions; curl "$HOST/v1/$ENDPOINT"',
         }),
       ).toBe(true);
     });
 
-    test("detects guardian endpoint via heredoc-style construction", () => {
+    test("detects endpoint via heredoc-style construction", () => {
       expect(
         isGuardianControlPlaneInvocation("bash", {
           command:
-            'url="http://localhost:3000/v1/integrations"; curl "${url}/guardian/sessions/resend"',
+            'url="http://localhost:3000/v1/channel-verification-sessions"; curl "${url}/resend"',
         }),
       ).toBe(true);
     });
 
-    test("does not false-positive when only /v1/integrations is present without guardian", () => {
+    test("does not false-positive on unrelated paths", () => {
       expect(
         isGuardianControlPlaneInvocation("bash", {
           command: "curl http://localhost:3000/v1/integrations/other/service",
@@ -478,7 +453,7 @@ describe("isGuardianControlPlaneInvocation", () => {
       ).toBe(false);
     });
 
-    test("does not false-positive when only guardian is present without /v1/integrations", () => {
+    test("does not false-positive when only guardian is present without verification path", () => {
       expect(
         isGuardianControlPlaneInvocation("bash", {
           command: 'echo "guardian notification sent"',
@@ -507,7 +482,7 @@ describe("enforceGuardianOnlyPolicy", () => {
     const result = enforceGuardianOnlyPolicy(
       "bash",
       {
-        command: "curl http://localhost:3000/v1/integrations/guardian/sessions",
+        command: "curl http://localhost:3000/v1/channel-verification-sessions",
       },
       "trusted_contact",
     );
@@ -519,7 +494,7 @@ describe("enforceGuardianOnlyPolicy", () => {
     const result = enforceGuardianOnlyPolicy(
       "network_request",
       {
-        url: "https://api.example.com/v1/integrations/guardian/sessions",
+        url: "https://api.example.com/v1/channel-verification-sessions",
       },
       "unknown",
     );
@@ -531,7 +506,7 @@ describe("enforceGuardianOnlyPolicy", () => {
     const result = enforceGuardianOnlyPolicy(
       "bash",
       {
-        command: "curl http://localhost:3000/v1/integrations/guardian/sessions",
+        command: "curl http://localhost:3000/v1/channel-verification-sessions",
       },
       "guardian",
     );
@@ -543,7 +518,7 @@ describe("enforceGuardianOnlyPolicy", () => {
     const result = enforceGuardianOnlyPolicy(
       "bash",
       {
-        command: "curl http://localhost:3000/v1/integrations/guardian/sessions",
+        command: "curl http://localhost:3000/v1/channel-verification-sessions",
       },
       "guardian",
     );
@@ -554,7 +529,7 @@ describe("enforceGuardianOnlyPolicy", () => {
     const result = enforceGuardianOnlyPolicy(
       "bash",
       {
-        command: "curl http://localhost:3000/v1/integrations/guardian/sessions",
+        command: "curl http://localhost:3000/v1/channel-verification-sessions",
       },
       "some_future_role",
     );
@@ -600,7 +575,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
       "bash",
       {
         command:
-          "curl -X POST http://localhost:3000/v1/integrations/guardian/sessions",
+          "curl -X POST http://localhost:3000/v1/channel-verification-sessions",
       },
       makeContext({ trustClass: "trusted_contact" }),
     );
@@ -612,7 +587,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
     const executor = new ToolExecutor(makePrompter());
     const result = await executor.execute(
       "network_request",
-      { url: "https://api.example.com/v1/integrations/guardian/sessions" },
+      { url: "https://api.example.com/v1/channel-verification-sessions" },
       makeContext({ trustClass: "unknown" }),
     );
     expect(result.isError).toBe(true);
@@ -625,7 +600,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
       "bash",
       {
         command:
-          "curl -X POST http://localhost:3000/v1/integrations/guardian/sessions",
+          "curl -X POST http://localhost:3000/v1/channel-verification-sessions",
       },
       makeContext({ trustClass: "guardian" }),
     );
@@ -637,7 +612,10 @@ describe("ToolExecutor guardian-only policy gate", () => {
     const executor = new ToolExecutor(makePrompter());
     const result = await executor.execute(
       "bash",
-      { command: "curl http://localhost:3000/v1/integrations/guardian/status" },
+      {
+        command:
+          "curl http://localhost:3000/v1/channel-verification-sessions/status",
+      },
       makeContext(), // defaults to trustClass: 'guardian'
     );
     expect(result.isError).toBe(false);
@@ -673,7 +651,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
       "bash",
       {
         command:
-          "curl -X DELETE http://localhost:3000/v1/integrations/guardian/sessions",
+          "curl -X DELETE http://localhost:3000/v1/channel-verification-sessions",
       },
       makeContext({
         trustClass: "trusted_contact",
@@ -693,7 +671,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
     const executor = new ToolExecutor(makePrompter());
     const result = await executor.execute(
       "web_fetch",
-      { url: "http://localhost:3000/v1/integrations/guardian/sessions/resend" },
+      { url: "http://localhost:3000/v1/channel-verification-sessions/resend" },
       makeContext({ trustClass: "trusted_contact" }),
     );
     expect(result.isError).toBe(true);
@@ -704,7 +682,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
     const executor = new ToolExecutor(makePrompter());
     const result = await executor.execute(
       "browser_navigate",
-      { url: "http://localhost:3000/v1/integrations/guardian/status" },
+      { url: "http://localhost:3000/v1/channel-verification-sessions/status" },
       makeContext({ trustClass: "trusted_contact" }),
     );
     expect(result.isError).toBe(true);
@@ -717,7 +695,7 @@ describe("ToolExecutor guardian-only policy gate", () => {
       "host_bash",
       {
         command:
-          "curl -X POST https://internal:8080/v1/integrations/guardian/sessions",
+          "curl -X POST https://internal:8080/v1/channel-verification-sessions",
       },
       makeContext({ trustClass: "trusted_contact" }),
     );
@@ -727,10 +705,10 @@ describe("ToolExecutor guardian-only policy gate", () => {
 
   test("all guardian endpoints are blocked for non-guardian via network_request", async () => {
     const endpoints = [
-      "/v1/integrations/guardian/sessions",
-      "/v1/integrations/guardian/status",
-      "/v1/integrations/guardian/sessions/resend",
-      "/v1/integrations/guardian/revoke",
+      "/v1/channel-verification-sessions",
+      "/v1/channel-verification-sessions/status",
+      "/v1/channel-verification-sessions/resend",
+      "/v1/channel-verification-sessions/revoke",
     ];
 
     for (const path of endpoints) {

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -5,8 +5,8 @@
  * Verifies:
  * - startOutbound / resendOutbound / cancelOutbound return correct result
  *   shapes and stable error codes.
- * - HTTP route handlers (handleCreateGuardianSession / handleResendGuardianSession /
- *   handleCancelGuardianSession) wire through to the shared module and return
+ * - HTTP route handlers (handleCreateVerificationSession / handleResendVerificationSession /
+ *   handleCancelVerificationSession) wire through to the shared module and return
  *   appropriate HTTP status codes.
  * - Rate limiting, missing/invalid destination, already_bound, and
  *   no_active_session error paths all produce the expected error codes.
@@ -131,9 +131,9 @@ globalThis.fetch = (async (
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { updateSessionDelivery } from "../runtime/channel-verification-service.js";
 import {
-  handleCancelGuardianSession,
-  handleCreateGuardianSession,
-  handleResendGuardianSession,
+  handleCancelVerificationSession,
+  handleCreateVerificationSession,
+  handleResendVerificationSession,
 } from "../runtime/routes/integration-routes.js";
 import {
   cancelOutbound,
@@ -463,10 +463,10 @@ describe("cancelOutbound", () => {
 // HTTP route handlers
 // ===========================================================================
 
-describe("HTTP route: handleCreateGuardianSession", () => {
+describe("HTTP route: handleCreateVerificationSession (guardian path)", () => {
   test("returns 400 when channel is missing", async () => {
     const req = jsonRequest({ destination: "+15551234567" });
-    const resp = await handleCreateGuardianSession(req);
+    const resp = await handleCreateVerificationSession(req, "self");
     expect(resp.status).toBe(400);
     const body = (await resp.json()) as {
       error: { message: string; code: string };
@@ -478,7 +478,7 @@ describe("HTTP route: handleCreateGuardianSession", () => {
   test("creates inbound challenge when destination is absent", async () => {
     // Without a destination, the unified handler takes the inbound challenge path.
     const req = jsonRequest({ channel: "voice" });
-    const resp = await handleCreateGuardianSession(req);
+    const resp = await handleCreateVerificationSession(req, "self");
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as Record<string, unknown>;
     expect(body.success).toBe(true);
@@ -487,7 +487,7 @@ describe("HTTP route: handleCreateGuardianSession", () => {
 
   test("returns 200 for valid SMS start", async () => {
     const req = jsonRequest({ channel: "voice", destination: "+15559999999" });
-    const resp = await handleCreateGuardianSession(req);
+    const resp = await handleCreateVerificationSession(req, "self");
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as Record<string, unknown>;
     expect(body.success).toBe(true);
@@ -495,10 +495,10 @@ describe("HTTP route: handleCreateGuardianSession", () => {
   });
 });
 
-describe("HTTP route: handleResendGuardianSession", () => {
+describe("HTTP route: handleResendVerificationSession (guardian path)", () => {
   test("returns 400 when channel is missing", async () => {
     const req = jsonRequest({});
-    const resp = await handleResendGuardianSession(req);
+    const resp = await handleResendVerificationSession(req);
     expect(resp.status).toBe(400);
     const body = (await resp.json()) as {
       error: { message: string; code: string };
@@ -509,7 +509,7 @@ describe("HTTP route: handleResendGuardianSession", () => {
 
   test("returns 400 for no_active_session", async () => {
     const req = jsonRequest({ channel: "voice" });
-    const resp = await handleResendGuardianSession(req);
+    const resp = await handleResendVerificationSession(req);
     expect(resp.status).toBe(400);
     const body = (await resp.json()) as { error?: string };
     expect(body.error).toBe("no_active_session");
@@ -521,7 +521,7 @@ describe("HTTP route: handleResendGuardianSession", () => {
       channel: "voice",
       destination: "+15556667777",
     });
-    const startResp = await handleCreateGuardianSession(startReq);
+    const startResp = await handleCreateVerificationSession(startReq, "self");
     expect(startResp.status).toBe(200);
     const startBody = (await startResp.json()) as Record<string, unknown>;
 
@@ -539,7 +539,7 @@ describe("HTTP route: handleResendGuardianSession", () => {
       channel: "voice",
       originConversationId: "conv-resend-http-origin",
     });
-    const resendResp = await handleResendGuardianSession(resendReq);
+    const resendResp = await handleResendVerificationSession(resendReq);
     expect(resendResp.status).toBe(200);
     const resendBody = (await resendResp.json()) as Record<string, unknown>;
     expect(resendBody.success).toBe(true);
@@ -547,10 +547,10 @@ describe("HTTP route: handleResendGuardianSession", () => {
   });
 });
 
-describe("HTTP route: handleCancelGuardianSession", () => {
+describe("HTTP route: handleCancelVerificationSession (guardian path)", () => {
   test("returns 400 when channel is missing", async () => {
     const req = jsonRequest({});
-    const resp = await handleCancelGuardianSession(req);
+    const resp = await handleCancelVerificationSession(req);
     expect(resp.status).toBe(400);
     const body = (await resp.json()) as {
       error: { message: string; code: string };
@@ -563,7 +563,7 @@ describe("HTTP route: handleCancelGuardianSession", () => {
     // The unified cancel handler silently cancels both inbound and outbound —
     // no error if nothing is active.
     const req = jsonRequest({ channel: "voice" });
-    const resp = await handleCancelGuardianSession(req);
+    const resp = await handleCancelVerificationSession(req);
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as Record<string, unknown>;
     expect(body.success).toBe(true);
@@ -575,12 +575,12 @@ describe("HTTP route: handleCancelGuardianSession", () => {
       channel: "voice",
       destination: "+15558887777",
     });
-    const startResp = await handleCreateGuardianSession(startReq);
+    const startResp = await handleCreateVerificationSession(startReq, "self");
     expect(startResp.status).toBe(200);
 
     // Cancel it
     const cancelReq = jsonRequest({ channel: "voice" });
-    const cancelResp = await handleCancelGuardianSession(cancelReq);
+    const cancelResp = await handleCancelVerificationSession(cancelReq);
     expect(cancelResp.status).toBe(200);
     const body = (await cancelResp.json()) as Record<string, unknown>;
     expect(body.success).toBe(true);
@@ -631,13 +631,13 @@ describe("origin conversation linkage", () => {
     expect(result.originConversationId).toBeUndefined();
   });
 
-  test("HTTP handleCreateGuardianSession passes originConversationId through", async () => {
+  test("HTTP handleCreateVerificationSession passes originConversationId through", async () => {
     const req = jsonRequest({
       channel: "voice",
       destination: "+15557776666",
       originConversationId: "conv-origin-http-test",
     });
-    const resp = await handleCreateGuardianSession(req);
+    const resp = await handleCreateVerificationSession(req, "self");
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as Record<string, unknown>;
     expect(body.success).toBe(true);

--- a/assistant/src/__tests__/integrations-cli.test.ts
+++ b/assistant/src/__tests__/integrations-cli.test.ts
@@ -232,7 +232,7 @@ describe("assistant integrations CLI", () => {
     );
     expect(result.exitCode).toBe(0);
     expect(result.fetchCalls[0]?.url).toBe(
-      "http://gateway.test/v1/integrations/guardian/status?channel=telegram",
+      "http://gateway.test/v1/channel-verification-sessions/status?channel=telegram",
     );
   });
 

--- a/assistant/src/approvals/AGENTS.md
+++ b/assistant/src/approvals/AGENTS.md
@@ -12,7 +12,7 @@
 
 Guardian verification consumption must be identity-bound to the expected recipient identity. Every outbound verification session stores the expected identity (phone E.164, Telegram user/chat ID), and the consume path rejects attempts where the responding actor's identity does not match.
 
-Conversational guardian verification control-plane invocation is guardian-only. Non-guardian and unverified-channel actors cannot invoke guardian verification endpoints (`/v1/integrations/guardian/*`) conversationally via tools. Enforcement is a deterministic gate in the tool execution layer (`assistant/src/tools/executor.ts`) using actor-role context — only `guardian` and `undefined` (desktop/trusted) actor roles pass. The policy module is at `assistant/src/tools/guardian-control-plane-policy.ts`.
+Conversational guardian verification control-plane invocation is guardian-only. Non-guardian and unverified-channel actors cannot invoke channel verification endpoints (`/v1/channel-verification-sessions/*`) conversationally via tools. Enforcement is a deterministic gate in the tool execution layer (`assistant/src/tools/executor.ts`) using actor-role context — only `guardian` and `undefined` (desktop/trusted) actor roles pass. The policy module is at `assistant/src/tools/guardian-control-plane-policy.ts`.
 
 ## Memory Provenance Invariant
 

--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -405,7 +405,7 @@ Examples:
       const channel = opts.channel ?? "telegram";
       await runRead(cmd, async () =>
         gatewayGet(
-          `/v1/integrations/guardian/status${toQueryString({ channel })}`,
+          `/v1/channel-verification-sessions/status${toQueryString({ channel })}`,
         ),
       );
     });

--- a/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
@@ -40,7 +40,7 @@ Based on the chosen channel, ask for the required destination:
 Execute the outbound start request:
 
 ```bash
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/sessions" \
+curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/channel-verification-sessions" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
   -d '{"channel": "<channel>", "destination": "<destination>"}'
@@ -52,7 +52,7 @@ Replace `<channel>` with `voice`, `telegram`, or `slack`, and `<destination>` wi
 
 Report the exact next action based on the channel:
 
-- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `POST /v1/integrations/guardian/sessions` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
+- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `POST /v1/channel-verification-sessions` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
 - **Telegram with chat ID** (no `telegramBootstrapUrl` in response): The response includes a `secret` field. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and reply with that 6-digit code to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4).
 - **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."
 - **Slack**: The response includes a `secret` field with the verification code. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to you as a Slack DM. Open the DM from the Vellum bot in Slack and reply with that 6-digit code to complete verification." The DM channel ID is captured automatically during this process for future message delivery. If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4). **After delivering the code, immediately begin the Slack auto-check polling loop** (see [Slack Auto-Check Polling](#slack-auto-check-polling) below).
@@ -77,7 +77,7 @@ Handle each error code:
 If the user says they did not receive the code or asks to resend:
 
 ```bash
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/sessions/resend" \
+curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/channel-verification-sessions/resend" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
   -d '{"channel": "<channel>"}'
@@ -85,7 +85,7 @@ curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/sessions/re
 
 On success, report the next action based on the channel:
 
-- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `POST /v1/integrations/guardian/sessions/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
+- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `POST /v1/channel-verification-sessions/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
 - **Telegram**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and reply with that 6-digit code to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3.
 - **Slack**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to you as a Slack DM. Reply to the DM with that 6-digit code to complete verification. (resent)" If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3. **After delivering the code, immediately begin the Slack auto-check polling loop** (see [Slack Auto-Check Polling](#slack-auto-check-polling) below).
 
@@ -106,7 +106,7 @@ Handle each error code from the resend endpoint:
 If the user wants to cancel the verification:
 
 ```bash
-curl -s -X DELETE "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/sessions" \
+curl -s -X DELETE "$INTERNAL_GATEWAY_BASE_URL/v1/channel-verification-sessions" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
   -d '{"channel": "<channel>"}'
@@ -193,7 +193,7 @@ If not yet bound, offer to resend (Step 4) or generate a new session (Step 3).
 If the user wants to remove themselves (or the current guardian) from a channel, use the revoke endpoint:
 
 ```bash
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/guardian/revoke" \
+curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/channel-verification-sessions/revoke" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
   -d '{"channel": "<channel>"}'

--- a/assistant/src/config/bundled-skills/slack-app-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack-app-setup/SKILL.md
@@ -148,7 +148,7 @@ Load the **guardian-verify-setup** skill to handle the verification flow:
 The guardian-verify-setup skill manages the full outbound verification flow for Slack, including:
 
 - Collecting the user's Slack user ID as the destination
-- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/sessions` with `channel: "slack"` and the user's destination
+- Starting the outbound verification session via the gateway endpoint `POST /v1/channel-verification-sessions` with `channel: "slack"` and the user's destination
 - Sending a verification code via Slack DM
 - Auto-polling for completion (the guardian-verify-setup skill handles this)
 - Checking guardian status to confirm the binding was created

--- a/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
@@ -74,7 +74,7 @@ Load the **guardian-verify-setup** skill to handle the verification flow:
 The guardian-verify-setup skill manages the full outbound verification flow for Telegram, including:
 
 - Collecting the user's Telegram chat ID or @handle as the destination
-- Starting the outbound verification session via the gateway endpoint `POST /v1/integrations/guardian/sessions` with `channel: "telegram"` and the user's destination
+- Starting the outbound verification session via the gateway endpoint `POST /v1/channel-verification-sessions` with `channel: "telegram"` and the user's destination
 - Handling the bootstrap deep-link flow when the user provides an @handle (the response includes a `telegramBootstrapUrl` that the user must click before receiving the code)
 - Guiding the user to send the verification code back in the Telegram bot chat
 - Checking guardian status to confirm the binding was created

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -192,17 +192,23 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
     endpoint: "integrations/slack/channel/config:DELETE",
     scopes: ["settings.write"],
   },
-  { endpoint: "integrations/guardian/sessions", scopes: ["settings.write"] },
+  { endpoint: "channel-verification-sessions", scopes: ["settings.write"] },
   {
-    endpoint: "integrations/guardian/sessions:DELETE",
+    endpoint: "channel-verification-sessions:DELETE",
     scopes: ["settings.write"],
   },
   {
-    endpoint: "integrations/guardian/sessions/resend",
+    endpoint: "channel-verification-sessions/resend",
     scopes: ["settings.write"],
   },
-  { endpoint: "integrations/guardian/status", scopes: ["settings.read"] },
-  { endpoint: "integrations/guardian/revoke", scopes: ["settings.write"] },
+  {
+    endpoint: "channel-verification-sessions/status",
+    scopes: ["settings.read"],
+  },
+  {
+    endpoint: "channel-verification-sessions/revoke",
+    scopes: ["settings.write"],
+  },
   { endpoint: "integrations/twilio/config", scopes: ["settings.read"] },
   {
     endpoint: "integrations/twilio/credentials:POST",

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -7,12 +7,8 @@
  * DELETE /v1/contacts/:id          — delete a contact
  * POST   /v1/contacts/merge        — merge two contacts
  * PATCH  /v1/contact-channels/:contactChannelId — update a contact channel's status/policy
- * POST   /v1/contact-channels/:contactChannelId/verify — initiate trusted contact verification
  */
 
-import { createHash, randomBytes } from "node:crypto";
-
-import type { ChannelId } from "../../channels/types.js";
 import { resolveGuardianName } from "../../config/user-reference.js";
 import {
   deleteContact,
@@ -34,26 +30,8 @@ import type {
   ContactRole,
   ContactType,
 } from "../../contacts/types.js";
-import { getCredentialMetadata } from "../../tools/credentials/metadata-store.js";
-import {
-  countRecentSendsToDestination,
-  createOutboundSession,
-  updateSessionDelivery,
-} from "../channel-verification-service.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
-import {
-  deliverVerificationSlack,
-  deliverVerificationTelegram,
-  DESTINATION_RATE_WINDOW_MS,
-  MAX_SENDS_PER_DESTINATION_WINDOW,
-  normalizeTelegramDestination,
-} from "../verification-outbound-actions.js";
-import {
-  composeVerificationSlack,
-  composeVerificationTelegram,
-  GUARDIAN_VERIFY_TEMPLATE_KEYS,
-} from "../verification-templates.js";
 
 function withGuardianNameOverride<
   T extends { role: string; displayName: string },
@@ -431,247 +409,6 @@ export async function handleUpdateContactChannel(
 }
 
 // ---------------------------------------------------------------------------
-// Channel verification
-// ---------------------------------------------------------------------------
-
-/** Session TTL in seconds (matches challenge TTL of 10 minutes). */
-const SESSION_TTL_SECONDS = 600;
-
-/**
- * Map a contact channel type to the verification ChannelId used by the
- * guardian service. Returns null for unsupported channel types.
- */
-function toVerificationChannel(channelType: string): ChannelId | null {
-  switch (channelType) {
-    case "phone":
-      return "voice";
-    case "telegram":
-      return "telegram";
-    case "slack":
-      return "slack";
-    default:
-      return null;
-  }
-}
-
-/**
- * Get the Telegram bot username from credential metadata.
- * Falls back to process.env.TELEGRAM_BOT_USERNAME.
- */
-function getTelegramBotUsername(): string | undefined {
-  const meta = getCredentialMetadata("telegram", "bot_token");
-  if (
-    meta?.accountInfo &&
-    typeof meta.accountInfo === "string" &&
-    meta.accountInfo.trim().length > 0
-  ) {
-    return meta.accountInfo.trim();
-  }
-  return process.env.TELEGRAM_BOT_USERNAME || undefined;
-}
-
-/**
- * POST /v1/contact-channels/:contactChannelId/verify
- *
- * Initiate trusted contact verification for a specific channel. Sends a
- * verification code via SMS, Telegram, Slack, or voice and returns session
- * info so the client can track the verification flow.
- */
-export async function handleVerifyContactChannel(
-  contactChannelId: string,
-  assistantId: string,
-): Promise<Response> {
-  const channel = getChannelById(contactChannelId);
-  if (!channel) {
-    return httpError(
-      "NOT_FOUND",
-      `Channel "${contactChannelId}" not found`,
-      404,
-    );
-  }
-
-  const contact = getContact(channel.contactId);
-  if (!contact) {
-    return httpError(
-      "NOT_FOUND",
-      `Contact "${channel.contactId}" not found`,
-      404,
-    );
-  }
-
-  // Already verified — no need to re-verify
-  if (channel.status === "active" && channel.verifiedAt != null) {
-    return httpError("CONFLICT", "Channel is already verified", 409);
-  }
-
-  const verificationChannel = toVerificationChannel(channel.type);
-  if (!verificationChannel) {
-    return httpError(
-      "BAD_REQUEST",
-      `Verification is not supported for channel type "${channel.type}"`,
-      400,
-    );
-  }
-
-  const destination = channel.address;
-  if (!destination) {
-    return httpError(
-      "BAD_REQUEST",
-      "Channel has no address to send verification to",
-      400,
-    );
-  }
-
-  // Normalize Telegram destinations so rate-limit lookups are consistent with
-  // guardian-outbound-actions (strips leading '@', lowercases handles).
-  const effectiveDestination =
-    verificationChannel === "telegram"
-      ? normalizeTelegramDestination(destination)
-      : destination;
-
-  // Rate limit check
-  const recentSendCount = countRecentSendsToDestination(
-    verificationChannel,
-    effectiveDestination,
-    DESTINATION_RATE_WINDOW_MS,
-  );
-  if (recentSendCount >= MAX_SENDS_PER_DESTINATION_WINDOW) {
-    return httpError(
-      "RATE_LIMITED",
-      "Too many verification attempts to this destination. Please try again later.",
-      429,
-    );
-  }
-
-  // --- Telegram verification ---
-  if (verificationChannel === "telegram") {
-    // Telegram with known chat ID: identity is already bound
-    if (channel.externalChatId) {
-      const sessionResult = createOutboundSession({
-        channel: verificationChannel,
-        expectedChatId: channel.externalChatId,
-        expectedExternalUserId: channel.externalUserId ?? undefined,
-        identityBindingStatus: "bound",
-        destinationAddress: effectiveDestination,
-        verificationPurpose: "trusted_contact",
-      });
-
-      const telegramBody = composeVerificationTelegram(
-        GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST,
-        {
-          code: sessionResult.secret,
-          expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
-        },
-      );
-
-      const now = Date.now();
-      const sendCount = 1;
-      updateSessionDelivery(sessionResult.sessionId, now, sendCount, null);
-      deliverVerificationTelegram(
-        channel.externalChatId,
-        telegramBody,
-        assistantId,
-      );
-
-      return Response.json({
-        ok: true,
-        verificationSessionId: sessionResult.sessionId,
-        expiresAt: sessionResult.expiresAt,
-        sendCount,
-      });
-    }
-
-    // Telegram handle only (no chat ID): bootstrap flow
-    const { ensureTelegramBotUsernameResolved } =
-      await import("../channel-invite-transports/telegram.js");
-    await ensureTelegramBotUsernameResolved();
-    const botUsername = getTelegramBotUsername();
-    if (!botUsername) {
-      return httpError(
-        "BAD_REQUEST",
-        "Telegram bot username is not configured. Set up the Telegram integration first.",
-        400,
-      );
-    }
-
-    const bootstrapToken = randomBytes(16).toString("hex");
-    const bootstrapTokenHash = createHash("sha256")
-      .update(bootstrapToken)
-      .digest("hex");
-
-    const sessionResult = createOutboundSession({
-      channel: verificationChannel,
-      identityBindingStatus: "pending_bootstrap",
-      destinationAddress: effectiveDestination,
-      bootstrapTokenHash,
-      verificationPurpose: "trusted_contact",
-    });
-
-    const telegramBootstrapUrl = `https://t.me/${botUsername}?start=gv_${bootstrapToken}`;
-
-    return Response.json({
-      ok: true,
-      verificationSessionId: sessionResult.sessionId,
-      expiresAt: sessionResult.expiresAt,
-      sendCount: 0,
-      telegramBootstrapUrl,
-    });
-  }
-
-  // --- Slack verification ---
-  if (verificationChannel === "slack") {
-    const slackUserId = channel.externalUserId ?? destination;
-
-    // Only claim identity is bound when we have at least one platform identifier
-    const hasIdentityBinding = Boolean(
-      channel.externalUserId || channel.externalChatId,
-    );
-    if (!hasIdentityBinding) {
-      return httpError(
-        "BAD_REQUEST",
-        "Slack verification requires an externalUserId or externalChatId for identity binding",
-        400,
-      );
-    }
-
-    const sessionResult = createOutboundSession({
-      channel: verificationChannel,
-      expectedExternalUserId: channel.externalUserId ?? undefined,
-      expectedChatId: channel.externalChatId ?? undefined,
-      identityBindingStatus: "bound",
-      destinationAddress: slackUserId,
-      verificationPurpose: "trusted_contact",
-    });
-
-    const slackBody = composeVerificationSlack(
-      GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_CHALLENGE_REQUEST,
-      {
-        code: sessionResult.secret,
-        expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
-      },
-    );
-
-    const now = Date.now();
-    const sendCount = 1;
-    updateSessionDelivery(sessionResult.sessionId, now, sendCount, null);
-    deliverVerificationSlack(slackUserId, slackBody, assistantId);
-
-    return Response.json({
-      ok: true,
-      verificationSessionId: sessionResult.sessionId,
-      expiresAt: sessionResult.expiresAt,
-      sendCount,
-    });
-  }
-
-  return httpError(
-    "BAD_REQUEST",
-    `Verification is not supported for channel type "${channel.type}"`,
-    400,
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
 
@@ -698,16 +435,6 @@ export function contactRouteDefinitions(): RouteDefinition[] {
       policyKey: "contact-channels",
       handler: async ({ req, params }) =>
         handleUpdateContactChannel(req, params.contactChannelId),
-    },
-    {
-      endpoint: "contact-channels/:contactChannelId/verify",
-      method: "POST",
-      policyKey: "contact-channels",
-      handler: async ({ params, authContext }) =>
-        handleVerifyContactChannel(
-          params.contactChannelId,
-          authContext.assistantId,
-        ),
     },
   ];
 }

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -13,15 +13,18 @@
  * POST   /v1/integrations/slack/channel/config — validate and store credentials
  * DELETE /v1/integrations/slack/channel/config — clear credentials
  *
- * Guardian verification (unified session API):
- * POST   /v1/integrations/guardian/sessions        — create session (inbound challenge or outbound verification)
- * POST   /v1/integrations/guardian/sessions/resend  — resend outbound verification code
- * DELETE /v1/integrations/guardian/sessions         — cancel all active sessions (inbound + outbound)
- * POST   /v1/integrations/guardian/revoke           — cancel all sessions and revoke binding
- * GET    /v1/integrations/guardian/status            — check guardian binding status
+ * Channel verification (unified session API):
+ * POST   /v1/channel-verification-sessions        — create session (inbound challenge, outbound verification, or trusted contact)
+ * POST   /v1/channel-verification-sessions/resend  — resend outbound verification code
+ * DELETE /v1/channel-verification-sessions         — cancel all active sessions (inbound + outbound)
+ * POST   /v1/channel-verification-sessions/revoke  — cancel all sessions and revoke binding
+ * GET    /v1/channel-verification-sessions/status   — check guardian binding status
  */
 
+import { createHash, randomBytes } from "node:crypto";
+
 import type { ChannelId } from "../../channels/types.js";
+import { getChannelById, getContact } from "../../contacts/contact-store.js";
 import {
   createGuardianChallenge,
   getGuardianStatus,
@@ -39,17 +42,32 @@ import {
   setTelegramConfig,
   setupTelegram,
 } from "../../daemon/handlers/config-telegram.js";
+import { getCredentialMetadata } from "../../tools/credentials/metadata-store.js";
 import { normalizePhoneNumber } from "../../util/phone.js";
-import { revokePendingSessions } from "../channel-verification-service.js";
+import {
+  countRecentSendsToDestination,
+  createOutboundSession,
+  revokePendingSessions,
+  updateSessionDelivery,
+} from "../channel-verification-service.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 import {
   cancelOutbound,
+  deliverVerificationSlack,
+  deliverVerificationTelegram,
+  DESTINATION_RATE_WINDOW_MS,
+  MAX_SENDS_PER_DESTINATION_WINDOW,
   normalizeTelegramDestination,
   resendOutbound,
   startOutbound,
 } from "../verification-outbound-actions.js";
 import { guardianVerificationLimiter } from "../verification-rate-limiter.js";
+import {
+  composeVerificationSlack,
+  composeVerificationTelegram,
+  GUARDIAN_VERIFY_TEMPLATE_KEYS,
+} from "../verification-templates.js";
 
 /**
  * GET /v1/integrations/telegram/config
@@ -145,19 +163,58 @@ export async function handleClearSlackChannelConfig(): Promise<Response> {
 }
 
 // ---------------------------------------------------------------------------
-// Guardian verification (unified session API)
+// Channel verification (unified session API)
 // ---------------------------------------------------------------------------
 
+/** Session TTL in seconds (matches challenge TTL of 10 minutes). */
+const SESSION_TTL_SECONDS = 600;
+
 /**
- * POST /v1/integrations/guardian/sessions
- *
- * Unified session creation: if `destination` is present, starts outbound
- * verification; otherwise creates an inbound challenge.
- *
- * Body: { channel?: ChannelId; destination?: string; rebind?: boolean; sessionId?: string; originConversationId?: string }
+ * Map a contact channel type to the verification ChannelId used by the
+ * verification service. Returns null for unsupported channel types.
  */
-export async function handleCreateGuardianSession(
+function toVerificationChannel(channelType: string): ChannelId | null {
+  switch (channelType) {
+    case "phone":
+      return "voice";
+    case "telegram":
+      return "telegram";
+    case "slack":
+      return "slack";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Get the Telegram bot username from credential metadata.
+ * Falls back to process.env.TELEGRAM_BOT_USERNAME.
+ */
+function getTelegramBotUsername(): string | undefined {
+  const meta = getCredentialMetadata("telegram", "bot_token");
+  if (
+    meta?.accountInfo &&
+    typeof meta.accountInfo === "string" &&
+    meta.accountInfo.trim().length > 0
+  ) {
+    return meta.accountInfo.trim();
+  }
+  return process.env.TELEGRAM_BOT_USERNAME || undefined;
+}
+
+/**
+ * POST /v1/channel-verification-sessions
+ *
+ * Unified session creation:
+ * - `purpose: "trusted_contact"` with `contactChannelId`: trusted contact verification
+ * - `destination` present: outbound guardian verification
+ * - Otherwise: inbound guardian challenge
+ *
+ * Body: { channel?: ChannelId; destination?: string; rebind?: boolean; sessionId?: string; originConversationId?: string; purpose?: string; contactChannelId?: string }
+ */
+export async function handleCreateVerificationSession(
   req: Request,
+  assistantId: string,
 ): Promise<Response> {
   const body = (await req.json()) as {
     channel?: ChannelId;
@@ -165,7 +222,17 @@ export async function handleCreateGuardianSession(
     rebind?: boolean;
     sessionId?: string;
     originConversationId?: string;
+    purpose?: string;
+    contactChannelId?: string;
   };
+
+  const purpose = body.purpose ?? "guardian";
+
+  // Trusted contact verification path — look up the contact channel and derive
+  // channel/destination from it, then create a session with verificationPurpose: "trusted_contact".
+  if (purpose === "trusted_contact" && body.contactChannelId) {
+    return handleTrustedContactVerification(body.contactChannelId, assistantId);
+  }
 
   if (body.destination) {
     // Outbound verification path — requires a channel
@@ -222,11 +289,210 @@ export async function handleCreateGuardianSession(
 }
 
 /**
- * GET /v1/integrations/guardian/status
+ * Trusted contact verification — extracted from the former
+ * handleVerifyContactChannel in contact-routes.ts. Looks up the contact
+ * channel, derives channelId and destination, checks rate limits, and
+ * creates the session with verificationPurpose: "trusted_contact".
+ */
+async function handleTrustedContactVerification(
+  contactChannelId: string,
+  assistantId: string,
+): Promise<Response> {
+  const channel = getChannelById(contactChannelId);
+  if (!channel) {
+    return httpError(
+      "NOT_FOUND",
+      `Channel "${contactChannelId}" not found`,
+      404,
+    );
+  }
+
+  const contact = getContact(channel.contactId);
+  if (!contact) {
+    return httpError(
+      "NOT_FOUND",
+      `Contact "${channel.contactId}" not found`,
+      404,
+    );
+  }
+
+  // Already verified — no need to re-verify
+  if (channel.status === "active" && channel.verifiedAt != null) {
+    return httpError("CONFLICT", "Channel is already verified", 409);
+  }
+
+  const verificationChannel = toVerificationChannel(channel.type);
+  if (!verificationChannel) {
+    return httpError(
+      "BAD_REQUEST",
+      `Verification is not supported for channel type "${channel.type}"`,
+      400,
+    );
+  }
+
+  const destination = channel.address;
+  if (!destination) {
+    return httpError(
+      "BAD_REQUEST",
+      "Channel has no address to send verification to",
+      400,
+    );
+  }
+
+  // Normalize Telegram destinations so rate-limit lookups are consistent
+  const effectiveDestination =
+    verificationChannel === "telegram"
+      ? normalizeTelegramDestination(destination)
+      : destination;
+
+  // Rate limit check
+  const recentSendCount = countRecentSendsToDestination(
+    verificationChannel,
+    effectiveDestination,
+    DESTINATION_RATE_WINDOW_MS,
+  );
+  if (recentSendCount >= MAX_SENDS_PER_DESTINATION_WINDOW) {
+    return httpError(
+      "RATE_LIMITED",
+      "Too many verification attempts to this destination. Please try again later.",
+      429,
+    );
+  }
+
+  // --- Telegram verification ---
+  if (verificationChannel === "telegram") {
+    // Telegram with known chat ID: identity is already bound
+    if (channel.externalChatId) {
+      const sessionResult = createOutboundSession({
+        channel: verificationChannel,
+        expectedChatId: channel.externalChatId,
+        expectedExternalUserId: channel.externalUserId ?? undefined,
+        identityBindingStatus: "bound",
+        destinationAddress: effectiveDestination,
+        verificationPurpose: "trusted_contact",
+      });
+
+      const telegramBody = composeVerificationTelegram(
+        GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST,
+        {
+          code: sessionResult.secret,
+          expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
+        },
+      );
+
+      const now = Date.now();
+      const sendCount = 1;
+      updateSessionDelivery(sessionResult.sessionId, now, sendCount, null);
+      deliverVerificationTelegram(
+        channel.externalChatId,
+        telegramBody,
+        assistantId,
+      );
+
+      return Response.json({
+        ok: true,
+        verificationSessionId: sessionResult.sessionId,
+        expiresAt: sessionResult.expiresAt,
+        sendCount,
+      });
+    }
+
+    // Telegram handle only (no chat ID): bootstrap flow
+    const { ensureTelegramBotUsernameResolved } =
+      await import("../channel-invite-transports/telegram.js");
+    await ensureTelegramBotUsernameResolved();
+    const botUsername = getTelegramBotUsername();
+    if (!botUsername) {
+      return httpError(
+        "BAD_REQUEST",
+        "Telegram bot username is not configured. Set up the Telegram integration first.",
+        400,
+      );
+    }
+
+    const bootstrapToken = randomBytes(16).toString("hex");
+    const bootstrapTokenHash = createHash("sha256")
+      .update(bootstrapToken)
+      .digest("hex");
+
+    const sessionResult = createOutboundSession({
+      channel: verificationChannel,
+      identityBindingStatus: "pending_bootstrap",
+      destinationAddress: effectiveDestination,
+      bootstrapTokenHash,
+      verificationPurpose: "trusted_contact",
+    });
+
+    const telegramBootstrapUrl = `https://t.me/${botUsername}?start=gv_${bootstrapToken}`;
+
+    return Response.json({
+      ok: true,
+      verificationSessionId: sessionResult.sessionId,
+      expiresAt: sessionResult.expiresAt,
+      sendCount: 0,
+      telegramBootstrapUrl,
+    });
+  }
+
+  // --- Slack verification ---
+  if (verificationChannel === "slack") {
+    const slackUserId = channel.externalUserId ?? destination;
+
+    // Only claim identity is bound when we have at least one platform identifier
+    const hasIdentityBinding = Boolean(
+      channel.externalUserId || channel.externalChatId,
+    );
+    if (!hasIdentityBinding) {
+      return httpError(
+        "BAD_REQUEST",
+        "Slack verification requires an externalUserId or externalChatId for identity binding",
+        400,
+      );
+    }
+
+    const sessionResult = createOutboundSession({
+      channel: verificationChannel,
+      expectedExternalUserId: channel.externalUserId ?? undefined,
+      expectedChatId: channel.externalChatId ?? undefined,
+      identityBindingStatus: "bound",
+      destinationAddress: slackUserId,
+      verificationPurpose: "trusted_contact",
+    });
+
+    const slackBody = composeVerificationSlack(
+      GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_CHALLENGE_REQUEST,
+      {
+        code: sessionResult.secret,
+        expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
+      },
+    );
+
+    const now = Date.now();
+    const sendCount = 1;
+    updateSessionDelivery(sessionResult.sessionId, now, sendCount, null);
+    deliverVerificationSlack(slackUserId, slackBody, assistantId);
+
+    return Response.json({
+      ok: true,
+      verificationSessionId: sessionResult.sessionId,
+      expiresAt: sessionResult.expiresAt,
+      sendCount,
+    });
+  }
+
+  return httpError(
+    "BAD_REQUEST",
+    `Verification is not supported for channel type "${channel.type}"`,
+    400,
+  );
+}
+
+/**
+ * GET /v1/channel-verification-sessions/status
  *
  * Query params: channel?
  */
-export function handleGetGuardianStatus(url: URL): Response {
+export function handleGetVerificationStatus(url: URL): Response {
   const channel =
     (url.searchParams.get("channel") as ChannelId | null) ?? undefined;
   const result = getGuardianStatus(channel);
@@ -234,11 +500,11 @@ export function handleGetGuardianStatus(url: URL): Response {
 }
 
 /**
- * POST /v1/integrations/guardian/sessions/resend
+ * POST /v1/channel-verification-sessions/resend
  *
  * Body: { channel: ChannelId; originConversationId?: string }
  */
-export async function handleResendGuardianSession(
+export async function handleResendVerificationSession(
   req: Request,
 ): Promise<Response> {
   const body = (await req.json()) as {
@@ -261,13 +527,13 @@ export async function handleResendGuardianSession(
 }
 
 /**
- * DELETE /v1/integrations/guardian/sessions
+ * DELETE /v1/channel-verification-sessions
  *
  * Cancels both inbound challenges and outbound sessions.
  *
  * Body: { channel: ChannelId }
  */
-export async function handleCancelGuardianSession(
+export async function handleCancelVerificationSession(
   req: Request,
 ): Promise<Response> {
   const body = (await req.json()) as {
@@ -286,13 +552,13 @@ export async function handleCancelGuardianSession(
 }
 
 /**
- * POST /v1/integrations/guardian/revoke
+ * POST /v1/channel-verification-sessions/revoke
  *
  * Cancels all active sessions and revokes the guardian binding.
  *
  * Body: { channel?: ChannelId }
  */
-export async function handleRevokeGuardianBinding(
+export async function handleRevokeVerificationBinding(
   req: Request,
 ): Promise<Response> {
   const body = (await req.json()) as {
@@ -353,31 +619,32 @@ export function integrationRouteDefinitions(): RouteDefinition[] {
       method: "DELETE",
       handler: () => handleClearSlackChannelConfig(),
     },
-    // Guardian (unified session API)
+    // Channel verification (unified session API)
     {
-      endpoint: "integrations/guardian/sessions",
+      endpoint: "channel-verification-sessions",
       method: "POST",
-      handler: async ({ req }) => handleCreateGuardianSession(req),
+      handler: async ({ req, authContext }) =>
+        handleCreateVerificationSession(req, authContext.assistantId),
     },
     {
-      endpoint: "integrations/guardian/sessions/resend",
+      endpoint: "channel-verification-sessions/resend",
       method: "POST",
-      handler: async ({ req }) => handleResendGuardianSession(req),
+      handler: async ({ req }) => handleResendVerificationSession(req),
     },
     {
-      endpoint: "integrations/guardian/sessions",
+      endpoint: "channel-verification-sessions",
       method: "DELETE",
-      handler: async ({ req }) => handleCancelGuardianSession(req),
+      handler: async ({ req }) => handleCancelVerificationSession(req),
     },
     {
-      endpoint: "integrations/guardian/revoke",
+      endpoint: "channel-verification-sessions/revoke",
       method: "POST",
-      handler: async ({ req }) => handleRevokeGuardianBinding(req),
+      handler: async ({ req }) => handleRevokeVerificationBinding(req),
     },
     {
-      endpoint: "integrations/guardian/status",
+      endpoint: "channel-verification-sessions/status",
       method: "GET",
-      handler: ({ url }) => handleGetGuardianStatus(url),
+      handler: ({ url }) => handleGetVerificationStatus(url),
     },
   ];
 }

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -29,7 +29,7 @@ export async function executeCallStart(
       return {
         content: [
           "Error: A guardian voice verification call is already active for this number.",
-          "Use the guardian outbound verification flow via the gateway API (`/v1/integrations/guardian/sessions` or `/sessions/resend`) and wait for completion before using `call_start`.",
+          "Use the guardian outbound verification flow via the gateway API (`/v1/channel-verification-sessions` or `/channel-verification-sessions/resend`) and wait for completion before using `call_start`.",
         ].join(" "),
         isError: true,
       };

--- a/assistant/src/tools/guardian-control-plane-policy.ts
+++ b/assistant/src/tools/guardian-control-plane-policy.ts
@@ -4,17 +4,17 @@
  * conversationally via tools.
  *
  * Protected endpoints:
- *   /v1/integrations/guardian/sessions
- *   /v1/integrations/guardian/sessions/resend
- *   /v1/integrations/guardian/status
- *   /v1/integrations/guardian/revoke
+ *   /v1/channel-verification-sessions
+ *   /v1/channel-verification-sessions/resend
+ *   /v1/channel-verification-sessions/status
+ *   /v1/channel-verification-sessions/revoke
  */
 
 const GUARDIAN_ENDPOINT_PATHS = [
-  "/v1/integrations/guardian/sessions",
-  "/v1/integrations/guardian/sessions/resend",
-  "/v1/integrations/guardian/status",
-  "/v1/integrations/guardian/revoke",
+  "/v1/channel-verification-sessions",
+  "/v1/channel-verification-sessions/resend",
+  "/v1/channel-verification-sessions/status",
+  "/v1/channel-verification-sessions/revoke",
 ] as const;
 
 /**
@@ -22,7 +22,7 @@ const GUARDIAN_ENDPOINT_PATHS = [
  * even if the exact sub-path differs from the hardcoded list above.
  * Anchored on a path separator so it won't match inside unrelated words.
  */
-const GUARDIAN_PATH_REGEX = /\/v1\/integrations\/guardian\//;
+const GUARDIAN_PATH_REGEX = /\/v1\/channel-verification-sessions/;
 
 /** Tools whose `input.command` (string) may contain guardian endpoint paths. */
 const COMMAND_TOOLS = new Set(["bash", "host_bash"]);
@@ -69,7 +69,7 @@ function containsGuardianEndpointPath(value: string): boolean {
   for (const path of GUARDIAN_ENDPOINT_PATHS) {
     if (normalized.includes(path)) return true;
   }
-  // Broad pattern match to catch any /v1/integrations/guardian/... path
+  // Broad pattern match to catch any /v1/channel-verification-sessions... path
   if (GUARDIAN_PATH_REGEX.test(normalized)) return true;
   return false;
 }
@@ -84,7 +84,7 @@ function containsGuardianEndpointPath(value: string): boolean {
  */
 function containsGuardianFragments(command: string): boolean {
   const lower = command.toLowerCase();
-  return lower.includes("/v1/integrations") && lower.includes("guardian");
+  return lower.includes("channel-verification-sessions");
 }
 
 /**


### PR DESCRIPTION
## Summary
- Consolidate guardian and trusted-contact verification handlers into unified /v1/channel-verification-sessions endpoints
- Absorb handleVerifyContactChannel logic into handleCreateVerificationSession with purpose parameter
- Remove /v1/contact-channels/:id/verify route definition
- Rename all handler functions from Guardian-specific to verification-generic names

Part of plan: chan-verify-session-unify.md (PR 5 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13809" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
