### PR TITLE
fix: record terminal callback event before releasing keepalive lease

### DIFF
--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: iOS Build
     runs-on: macos-15
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,8 +25,21 @@ jobs:
       - name: Install XcodeGen
         run: brew install xcodegen
 
-      - name: Clear stale SPM artifact cache
-        run: rm -rf ~/Library/Caches/org.swift.swiftpm/artifacts
+      - name: Cache SPM artifacts
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: ios-spm-${{ hashFiles('clients/Package.resolved') }}
+          restore-keys: ios-spm-
+
+      - name: Cache Xcode DerivedData
+        uses: actions/cache@v4
+        with:
+          path: clients/ios/dist/DerivedData
+          key: ios-deriveddata-${{ hashFiles('clients/Package.resolved') }}-${{ hashFiles('clients/ios/project.yml', 'clients/shared/**/*.swift', 'clients/ios/**/*.swift') }}
+          restore-keys: |
+            ios-deriveddata-${{ hashFiles('clients/Package.resolved') }}-
+            ios-deriveddata-
 
       - name: Build for simulator
         working-directory: clients/ios

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -761,6 +761,53 @@ describe("twilio webhook routes", () => {
       unregisterCallCompletionNotifier("conv-status-complete-1");
     });
 
+    test("terminal callback preserves lease when recordCallEvent throws", async () => {
+      const session = createTestSession(
+        "conv-status-lease-fail",
+        "CA_status_lease_fail",
+      );
+      upsertActiveCallLease({
+        callSessionId: session.id,
+        providerCallSid: "CA_status_lease_fail",
+      });
+      updateCallSession(session.id, {
+        status: "in_progress",
+        startedAt: Date.now() - 20_000,
+      });
+
+      const spy = spyOn(callStore, "recordCallEvent").mockImplementation(
+        (..._args: Parameters<typeof callStore.recordCallEvent>) => {
+          spy.mockRestore();
+          throw new Error("Simulated recordCallEvent failure");
+        },
+      );
+
+      const params = new URLSearchParams({
+        CallSid: "CA_status_lease_fail",
+        CallStatus: "completed",
+        Timestamp: "2025-01-21T10:12:00Z",
+      });
+      const req = new Request("http://127.0.0.1/v1/calls/twilio/status", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: params.toString(),
+      });
+
+      await expect(handleStatusCallback(req)).rejects.toThrow(
+        "Simulated recordCallEvent failure",
+      );
+
+      // Lease must still be present because updateCallSession was never reached
+      const leases = listActiveCallLeases();
+      expect(leases.length).toBe(1);
+      expect(leases[0].callSessionId).toBe(session.id);
+
+      // Session must not be terminal; recordCallEvent threw before updateCallSession
+      const updated = getCallSession(session.id);
+      expect(updated).not.toBeNull();
+      expect(updated!.status).toBe("in_progress");
+    });
+
     test("completed callback does not re-fire completion notifier for already terminal call", async () => {
       const session = createTestSession(
         "conv-status-complete-2",

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -366,9 +366,6 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
       updates.endedAt = Date.now();
     }
 
-    updateCallSession(session.id, updates);
-
-    // Record event
     const eventType = isTerminal
       ? mappedStatus === "completed"
         ? "call_ended"
@@ -377,10 +374,16 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
         ? "call_connected"
         : "call_started";
 
+    // Record terminal event before updating the session so the lease is only
+    // released (via updateCallSession → syncActiveCallLeaseFromSession) after
+    // terminal callback persistence completes. Prevents vellum sleep from
+    // proceeding before the call is fully recorded.
     recordCallEvent(session.id, eventType, {
       twilioStatus: callStatus,
       callSid,
     });
+
+    updateCallSession(session.id, updates);
 
     // Expire pending questions on terminal status
     if (isTerminal) {


### PR DESCRIPTION
## Summary
- Record terminal event before updating the session so the keepalive lease is only released (via updateCallSession → syncActiveCallLeaseFromSession) after recordCallEvent succeeds. Prevents vellum sleep from proceeding before terminal callback persistence completes.
- Add test that verifies lease and session stay non-terminal when recordCallEvent throws on a completed callback.
- iOS CI: add SPM artifacts and Xcode DerivedData caching, increase build timeout to 25min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
