### PR TITLE
fix: address Twilio webhook validation feedback from PR 13751

### DIFF
--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -50,7 +50,11 @@ function inferWebhookKind(reqUrl: string): TwilioWebhookKind {
 }
 
 function normalizeUrlForLog(url: string): string {
-  return new URL(url).toString();
+  try {
+    return new URL(url).toString();
+  } catch {
+    return "[malformed-url]";
+  }
 }
 
 function buildSignatureUrlCandidateDetails(
@@ -131,31 +135,6 @@ function buildValidationDiagnostics(
     logContext,
     signatureUrlCandidates,
   };
-}
-
-/**
- * Build URL candidates Twilio may have used when computing the webhook signature.
- *
- * Precedence:
- * 1) Canonical configured ingress URL (when present)
- * 2) Forwarded public URL headers from tunnel/proxy
- * 3) Raw request URL (last-resort fallback)
- *
- * When `ingressPublicBaseUrl` is configured, the canonical ingress URL is the
- * highest-priority candidate. The raw request URL is still included as a
- * fallback to preserve local-dev operability (e.g., when Twilio is configured
- * to call the local server directly). However, a warning is logged when the
- * raw fallback is the only candidate that validates, as this indicates a
- * potential configuration drift between the ingress URL and the actual
- * webhook registration.
- */
-function buildSignatureUrlCandidates(
-  req: Request,
-  config: GatewayConfig,
-): string[] {
-  return buildSignatureUrlCandidateDetails(req, config).map(
-    (candidate) => candidate.url,
-  );
 }
 
 /**
@@ -256,7 +235,7 @@ export async function validateTwilioWebhookRequest(
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const signatureCandidateUrls = buildSignatureUrlCandidates(req, config);
+  const signatureCandidateUrls = signatureUrlCandidates.map((c) => c.url);
   const validatingIndex = findValidatingCandidateIndex(
     signatureCandidateUrls,
     params,


### PR DESCRIPTION
Addresses Codex and Devin feedback on #13751:

- **Codex (P1)**: Make normalizeUrlForLog safe — wrap URL parsing in try/catch to avoid throwing on malformed candidate URLs (ingressPublicBaseUrl, forwarded headers). Previously malformed URLs could abort validation and turn 403/413 into 500s.
- **Devin**: Derive signatureCandidateUrls from signatureUrlCandidates directly instead of a redundant second call to buildSignatureUrlCandidateDetails. Eliminates fragile cross-indexing between two independently-built arrays.
- Remove dead buildSignatureUrlCandidates function.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
