### PR TITLE
fix: provide assistant name to vellum wake fallback (PR 13756 feedback)

### DIFF
--- a/assistant/src/runtime/local-gateway-health.ts
+++ b/assistant/src/runtime/local-gateway-health.ts
@@ -1,5 +1,5 @@
 import { getGatewayInternalBaseUrl } from "../config/env.js";
-import { getIsContainerized } from "../config/env-registry.js";
+import { getBaseDataDir, getIsContainerized } from "../config/env-registry.js";
 import { readLockfile } from "../util/platform.js";
 import { sleep } from "../util/retry.js";
 import { spawnWithTimeout } from "../util/spawn.js";
@@ -92,6 +92,19 @@ function resolveLocalAssistantName(): string | undefined {
     latestAssistant.assistantId.trim().length > 0
   ) {
     return latestAssistant.assistantId.trim();
+  }
+
+  // Fallback for named instances: when BASE_DATA_DIR points to an instance
+  // directory (e.g. ~/.local/share/vellum/assistants/<name>), derive the name
+  // so vellum wake gets the correct target. Without this, vellum wake exits
+  // with "No local assistant found" for named instances when the lockfile
+  // lacks assistantId (e.g. before first hatch or during early startup).
+  const baseDir = getBaseDataDir();
+  if (baseDir) {
+    const match = baseDir.match(/[/]assistants[/]([^/]+)$/);
+    if (match && match[1].trim().length > 0) {
+      return match[1].trim();
+    }
   }
 
   return undefined;


### PR DESCRIPTION
Addresses Codex P1 feedback on #13756:

When resolveLocalAssistantName() cannot read assistantId from the lockfile, runDefaultWakeCommand() previously fell back to `vellum wake` without a name. For named local instances (BASE_DATA_DIR=~/.local/share/vellum/assistants/<name>), vellum wake without a name exits with "No local assistant found" because resolveTargetAssistant() requires a name when multiple instances exist.

Fix: derive the assistant name from BASE_DATA_DIR when it matches the instance path pattern (.../assistants/<name>). This allows gateway auto-recovery to work for named local assistants even when the lockfile lacks assistantId (e.g. during early startup or before first hatch).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
