### PR TITLE
refactor: update Swift client for channel-verification-session API

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -937,33 +937,41 @@ struct ContactDetailView: View {
         telegramBootstrapUrl = nil
         telegramBootstrapChannelId = nil
 
-        Task {
-            do {
-                let result = try await daemonClient.verifyContactChannel(
-                    contactChannelId: channel.id
-                )
-                if result?.ok == true {
-                    // Telegram bootstrap: ok is true but no code was sent yet —
-                    // the user needs to open the bootstrap URL first.
-                    if let bootstrapUrl = result?.telegramBootstrapUrl {
-                        telegramBootstrapUrl = bootstrapUrl
-                        telegramBootstrapChannelId = channel.id
-                    } else {
-                        verificationSuccessChannelId = channel.id
-                        // Auto-clear the success message after 5 seconds
-                        Task {
-                            try? await Task.sleep(nanoseconds: 5_000_000_000)
-                            if verificationSuccessChannelId == channel.id {
-                                verificationSuccessChannelId = nil
-                            }
+        // Stash the previous callback so we can restore it after the one-shot response.
+        let previousCallback = daemonClient.onChannelVerificationSessionResponse
+        daemonClient.onChannelVerificationSessionResponse = { [self] response in
+            // Restore the previous handler after consuming this one-shot response.
+            daemonClient.onChannelVerificationSessionResponse = previousCallback
+            // Also forward to the previous handler so SettingsStore still processes it.
+            previousCallback?(response)
+
+            if response.success {
+                if let bootstrapUrl = response.telegramBootstrapUrl {
+                    telegramBootstrapUrl = bootstrapUrl
+                    telegramBootstrapChannelId = channel.id
+                } else {
+                    verificationSuccessChannelId = channel.id
+                    Task {
+                        try? await Task.sleep(nanoseconds: 5_000_000_000)
+                        if verificationSuccessChannelId == channel.id {
+                            verificationSuccessChannelId = nil
                         }
                     }
-                } else {
-                    errorMessage = result?.error ?? "Failed to send verification"
                 }
-            } catch {
-                errorMessage = "Failed to send verification: \(error.localizedDescription)"
+            } else {
+                errorMessage = response.error ?? "Failed to send verification"
             }
+            verificationInProgress = nil
+        }
+
+        do {
+            try daemonClient.sendChannelVerificationSession(
+                action: "create_session",
+                contactChannelId: channel.id
+            )
+        } catch {
+            daemonClient.onChannelVerificationSessionResponse = previousCallback
+            errorMessage = "Failed to send verification: \(error.localizedDescription)"
             verificationInProgress = nil
         }
     }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1488,7 +1488,7 @@ public final class SettingsStore: ObservableObject {
 
     func refreshChannelGuardianStatus(channel: String) {
         do {
-            try daemonClient?.sendGuardianVerification(action: "status", channel: channel)
+            try daemonClient?.sendChannelVerificationSession(action: "status", channel: channel)
         } catch {
             log.error("Failed to refresh \(channel) guardian status: \(error)")
         }
@@ -1543,7 +1543,7 @@ public final class SettingsStore: ObservableObject {
             }
             pendingGuardianChallengeChannel = channel
             armGuardianChallengeTimeout(for: channel)
-            try daemonClient.sendGuardianVerification(
+            try daemonClient.sendChannelVerificationSession(
                 action: "create_session",
                 channel: channel,
                 rebind: rebind ? true : nil
@@ -1591,7 +1591,7 @@ public final class SettingsStore: ObservableObject {
         }
         // Invalidate the pending challenge token on the backend so it can't be used after cancellation
         do {
-            try daemonClient?.sendGuardianVerification(action: "revoke", channel: channel)
+            try daemonClient?.sendChannelVerificationSession(action: "revoke", channel: channel)
         } catch {
             log.error("Failed to revoke \(channel) guardian challenge on cancel: \(error)")
         }
@@ -1615,7 +1615,7 @@ public final class SettingsStore: ObservableObject {
             break
         }
         do {
-            try daemonClient?.sendGuardianVerification(action: "revoke", channel: channel)
+            try daemonClient?.sendChannelVerificationSession(action: "revoke", channel: channel)
         } catch {
             log.error("Failed to revoke \(channel) guardian: \(error)")
         }
@@ -1832,7 +1832,7 @@ public final class SettingsStore: ObservableObject {
                 }
                 return
             }
-            try daemonClient.sendGuardianVerification(
+            try daemonClient.sendChannelVerificationSession(
                 action: "create_session",
                 channel: channel,
                 destination: destination
@@ -1860,7 +1860,7 @@ public final class SettingsStore: ObservableObject {
 
     func resendOutboundGuardian(channel: String) {
         do {
-            try daemonClient?.sendGuardianVerification(
+            try daemonClient?.sendChannelVerificationSession(
                 action: "resend_session",
                 channel: channel
             )
@@ -1885,7 +1885,7 @@ public final class SettingsStore: ObservableObject {
             break
         }
         do {
-            try daemonClient?.sendGuardianVerification(
+            try daemonClient?.sendChannelVerificationSession(
                 action: "cancel_session",
                 channel: channel
             )

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1445,14 +1445,16 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         try send(VercelApiConfigRequestMessage(action: action, apiToken: apiToken))
     }
 
-    /// Guardian verification session management: "create_session", "status", "cancel_session", "revoke", "resend_session".
-    public func sendGuardianVerification(
+    /// Channel verification session management: "create_session", "status", "cancel_session", "revoke", "resend_session".
+    public func sendChannelVerificationSession(
         action: String,
         channel: String? = nil,
         sessionId: String? = nil,
         rebind: Bool? = nil,
         destination: String? = nil,
-        originConversationId: String? = nil
+        originConversationId: String? = nil,
+        purpose: String? = nil,
+        contactChannelId: String? = nil
     ) throws {
         try send(ChannelVerificationSessionRequestMessage(
             action: action,
@@ -1460,7 +1462,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             sessionId: sessionId,
             rebind: rebind,
             destination: destination,
-            originConversationId: originConversationId
+            originConversationId: originConversationId,
+            purpose: purpose,
+            contactChannelId: contactChannelId
         ))
     }
 
@@ -1829,16 +1833,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     // MARK: - Contacts Management
 
-    /// Response from the channel verification endpoint.
-    public struct ChannelVerificationResult: Decodable {
-        public let ok: Bool
-        public let verificationSessionId: String?
-        public let expiresAt: Int?
-        public let sendCount: Int?
-        public let telegramBootstrapUrl: String?
-        public let error: String?
-    }
-
     /// A channel to attach when creating a new contact.
     public struct NewContactChannel: Codable {
         public let type: String
@@ -2074,32 +2068,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         return result
         #else
         return [:]
-        #endif
-    }
-
-    /// Send a verification code to a contact's channel via the gateway.
-    /// Routes through `HTTPTransport` when available. Falls back to the
-    /// local gateway (port 7830) for socket-based connections.
-    public func verifyContactChannel(
-        contactChannelId: String
-    ) async throws -> ChannelVerificationResult? {
-        if let httpTransport {
-            return try await httpTransport.verifyContactChannel(
-                contactChannelId: contactChannelId
-            )
-        }
-
-        #if os(macOS)
-        let encoded = contactChannelId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? contactChannelId
-        guard var request = buildLocalRequest(target: .gateway, path: "v1/contact-channels/\(encoded)/verify", method: "POST") else { return nil }
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-        guard let http = response as? HTTPURLResponse,
-              (200...299).contains(http.statusCode) else { return nil }
-        return try JSONDecoder().decode(ChannelVerificationResult.self, from: data)
-        #else
-        return nil
         #endif
     }
 

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -183,7 +183,6 @@ public final class HTTPTransport {
         case contactsGet(id: String)
         case contactsDelete(id: String)
         case contactChannelUpdate(contactChannelId: String)
-        case contactChannelVerify(contactChannelId: String)
         case contactsUpsert
         case contactsInvitesCreate
         case channelsReadiness
@@ -284,9 +283,6 @@ public final class HTTPTransport {
         case .contactChannelUpdate(let contactChannelId):
             let encoded = contactChannelId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? contactChannelId
             return ("/v1/contact-channels/\(encoded)", nil)
-        case .contactChannelVerify(let contactChannelId):
-            let encoded = contactChannelId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? contactChannelId
-            return ("/v1/contact-channels/\(encoded)/verify", nil)
         case .contactsUpsert:
             return ("/v1/contacts", nil)
         case .contactsInvitesCreate:
@@ -378,9 +374,6 @@ public final class HTTPTransport {
         case .contactChannelUpdate(let contactChannelId):
             let encoded = contactChannelId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? contactChannelId
             return ("\(prefix)/contact-channels/\(encoded)/", nil)
-        case .contactChannelVerify(let contactChannelId):
-            let encoded = contactChannelId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? contactChannelId
-            return ("\(prefix)/contact-channels/\(encoded)/verify/", nil)
         case .contactsUpsert:
             return ("\(prefix)/contacts/", nil)
         case .contactsInvitesCreate:
@@ -1492,29 +1485,6 @@ public final class HTTPTransport {
             )
         }
         return result
-    }
-
-    // MARK: - Channel Verification
-
-    /// Send a verification code to a contact's channel via the gateway.
-    func verifyContactChannel(contactChannelId: String, isRetry: Bool = false) async throws -> DaemonClient.ChannelVerificationResult? {
-        guard let url = buildURL(for: .contactChannelVerify(contactChannelId: contactChannelId)) else { return nil }
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        applyAuth(&request)
-        let (data, response) = try await URLSession.shared.data(for: request)
-        if let http = response as? HTTPURLResponse {
-            if http.statusCode == 401 && !isRetry {
-                let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
-                if case .success = refreshResult {
-                    return try await verifyContactChannel(contactChannelId: contactChannelId, isRetry: true)
-                }
-                return nil
-            }
-            guard (200...299).contains(http.statusCode) else { return nil }
-        }
-        return try JSONDecoder().decode(DaemonClient.ChannelVerificationResult.self, from: data)
     }
 
     // MARK: - Surface Actions

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1996,10 +1996,6 @@ extension IPCChannelVerificationSessionRequest {
 /// Backed by generated `IPCChannelVerificationSessionResponse`.
 public typealias ChannelVerificationSessionResponseMessage = IPCChannelVerificationSessionResponse
 
-// Legacy aliases for backward compatibility during migration.
-public typealias GuardianVerificationRequestMessage = ChannelVerificationSessionRequestMessage
-public typealias GuardianVerificationResponseMessage = ChannelVerificationSessionResponseMessage
-
 // MARK: - Twitter Integration Config Messages
 
 /// Sent to get/set Twitter integration config.


### PR DESCRIPTION
## Summary
- Rename Swift guardian verification methods, callbacks, and enum cases to channel-verification-session naming
- Update HTTP endpoint paths to /v1/channel-verification-sessions/*
- Remove contactChannelVerify endpoint (absorbed into unified create)
- Update all Swift callers

Part of plan: chan-verify-session-unify.md (PR 9 of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
