### PR TITLE
fix: preserve combined input token semantics in usage ledger (PR 13759)

### DIFF
--- a/assistant/src/daemon/session-usage.ts
+++ b/assistant/src/daemon/session-usage.ts
@@ -167,7 +167,7 @@ export function recordUsage(
         actor,
         provider: ctx.providerName,
         model,
-        inputTokens: directInputTokens,
+        inputTokens, // total (direct + cache) for downstream aggregates
         outputTokens,
         cacheCreationInputTokens: normalizedCacheCreationInputTokens,
         cacheReadInputTokens: normalizedCacheReadInputTokens,


### PR DESCRIPTION
Addresses Codex P1 and Devin feedback on #13759:

Store total input tokens (direct + cache creation + cache read) in input_tokens instead of direct-only. Downstream aggregates (getUsageDayBuckets, getUsageGroupBreakdown) sum input_tokens as the full input total and do not add cache columns — storing direct-only caused Anthropic cache-heavy traffic to be underreported in daily/breakdown metrics.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
