### PR TITLE
fix: skip auto-seen when unread is user-forced (PR 13760)

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -665,11 +665,14 @@ class IOSThreadStore: ObservableObject {
     }
 
     /// Mark a connected conversation as seen when the user explicitly opens it.
+    /// Skips when the thread has a pending .unread override (user chose "Mark as unread")
+    /// so we don't immediately revert the user's explicit unread action.
     func markConversationSeenIfNeeded(threadId: UUID) {
         guard isConnectedMode,
               let idx = threads.firstIndex(where: { $0.id == threadId }),
               let sessionId = threads[idx].sessionId,
               threads[idx].hasUnseenLatestAssistantMessage else { return }
+        if case .unread = pendingAttentionOverrides[sessionId] { return }
 
         pendingAttentionOverrides[sessionId] = .seen(
             latestAssistantMessageAt: threads[idx].latestAssistantMessageAt


### PR DESCRIPTION
Addresses Codex P2 feedback on #13760:

The onChange(of: thread.hasUnseenLatestAssistantMessage) handler was calling markConversationSeenIfNeeded whenever the flag flipped to true. That also happens when the user explicitly chooses "Mark as unread" — markThreadUnread sets the flag to true. The handler would immediately revert the unread state.

Fix: markConversationSeenIfNeeded now returns early when there is a pending .unread override for the session (set by markThreadUnread). This preserves the user's explicit unread action.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
