### PR TITLE
fix: preserve ingress URL when refreshing Twilio state (PR 13777)

### DIFF
--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -64,7 +64,16 @@ function pruneAssistantPhoneNumbers(
 }
 
 function refreshGatewayTwilioState(): void {
-  void triggerGatewayTwilioReconcile(getIngressPublicBaseUrl());
+  const raw = loadRawConfig();
+  const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
+  const fromConfig = (ingress.publicBaseUrl as string)
+    ?.trim()
+    ?.replace(/\/+$/, "");
+  const url =
+    ingress.enabled !== false && fromConfig
+      ? fromConfig
+      : getIngressPublicBaseUrl();
+  void triggerGatewayTwilioReconcile(url || undefined);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses Codex P1 feedback on #13777: `refreshGatewayTwilioState()` was pulling the URL only from `getIngressPublicBaseUrl()` (env), which could be empty and overwrite the gateway's configured ingress URL. Now uses config (`ingress.publicBaseUrl`) as the canonical source, falling back to env when config has no URL.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13821" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
