### PR TITLE
fix: address PR 13782 review feedback

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -234,7 +234,7 @@ struct UsageDashboardPanel: View {
             Text(entry.group)
                 .font(VFont.captionMedium)
                 .foregroundColor(VColor.textPrimary)
-                .frame(width: 130, alignment: .leading)
+                .frame(minWidth: 130, maxWidth: .infinity, alignment: .leading)
                 .lineLimit(1)
             Text(UsageFormatting.formatBreakdownSummary(entry))
                 .font(VFont.small)


### PR DESCRIPTION
Addresses Devin review comments on merged PR #13782:

1. **iOS UsageFormatting** — Already addressed in PR #13783; iOS UsageDashboardView now uses `UsageFormatting.directInputTokensLabel` and `UsageFormatting.formatBreakdownSummary`.

2. **Fixed-width group column** — Changed from `width: 130` to `minWidth: 130, maxWidth: .infinity` so the group column can grow for long model names (e.g. `claude-sonnet-4-20250514`) instead of truncating.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13822" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
