### PR TITLE
fix: align mock binding key with slack binding context (PR 13781 feedback)

### DIFF
--- a/assistant/src/__tests__/conversation-pairing.test.ts
+++ b/assistant/src/__tests__/conversation-pairing.test.ts
@@ -405,7 +405,7 @@ describe("pairDeliveryWithConversation", () => {
       source: "user",
       title: "User Thread",
     };
-    mockBindings["notification:sms:+15551234567"] = {
+    mockBindings["notification:slack:C0123ABCDEF"] = {
       conversationId: "conv-user-owned",
       sourceChannel: "notification:slack",
       externalChatId: "C0123ABCDEF",


### PR DESCRIPTION
Addresses Devin/Codex review feedback on merged PR #13781.

**Issue:** The test `falls back to new conversation when bound conversation is stale (wrong source)` registered the mock binding with key `notification:sms:+15551234567` but the `bindingContext` uses `sourceChannel: "slack"` and `externalChatId: "C0123ABCDEF"`. `getBindingByChannelChat` constructs the lookup key as `${sourceChannel}:${externalChatId}`, so it looked up `notification:slack:C0123ABCDEF` — which didn't match. The binding was never found, so the test silently passed by creating a new conversation (default behavior) instead of exercising the intended "stale binding with wrong source" code path.

**Fix:** Update the mock binding key to `notification:slack:C0123ABCDEF` to match the binding context.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
