### PR TITLE
fix(ios): preserve daemon pin metadata for non-pin local edits (PR 13778)

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -123,6 +123,10 @@ class IOSThreadStore: ObservableObject {
     /// since the cache was loaded. Only these threads preserve local overrides
     /// when the daemon response arrives; all others accept daemon data.
     private var locallyEditedSessionIds: Set<String> = []
+    /// SessionIds where the user explicitly pinned or unpinned. Used to preserve
+    /// local pin/displayOrder when merging daemon data; title/archive-only edits
+    /// must not overwrite daemon pin updates from other devices.
+    private var locallyEditedPinSessionIds: Set<String> = []
     /// Local seen/unread mutations must survive a stale session-list replay until
     /// the daemon acknowledges them or returns a newer assistant reply.
     private var pendingAttentionOverrides: [String: PendingAttentionOverride] = [:]
@@ -163,8 +167,8 @@ class IOSThreadStore: ObservableObject {
     private func mergeThreadMetadata(from restored: IOSThread, into thread: inout IOSThread) {
         thread.sessionId = restored.sessionId ?? thread.sessionId
         thread.scheduleJobId = restored.scheduleJobId ?? thread.scheduleJobId
-        let isLocallyEdited = thread.sessionId.map { locallyEditedSessionIds.contains($0) } ?? false
-        if !isLocallyEdited {
+        let hasLocalPinEdit = thread.sessionId.map { locallyEditedPinSessionIds.contains($0) } ?? false
+        if !hasLocalPinEdit {
             thread.isPinned = restored.isPinned
             thread.displayOrder = restored.displayOrder
         }
@@ -388,6 +392,7 @@ class IOSThreadStore: ObservableObject {
             // Connected mode — show cached threads instantly or spinner on first launch.
             isConnectedMode = true
             locallyEditedSessionIds.removeAll()
+            locallyEditedPinSessionIds.removeAll()
             let cached = Self.loadConnectedCache()
             if cached.isEmpty {
                 isLoadingInitialThreads = true
@@ -406,6 +411,7 @@ class IOSThreadStore: ObservableObject {
             isConnectedMode = false
             isLoadingInitialThreads = false
             locallyEditedSessionIds.removeAll()
+            locallyEditedPinSessionIds.removeAll()
             pendingAttentionOverrides.removeAll()
             clearConnectedCache()
             let loaded = Self.load()
@@ -448,6 +454,7 @@ class IOSThreadStore: ObservableObject {
             hasMoreThreads = response.hasMore ?? false
             clearConnectedCache()
             locallyEditedSessionIds.removeAll()
+            locallyEditedPinSessionIds.removeAll()
             pendingAttentionOverrides.removeAll()
             return
         }
@@ -513,6 +520,8 @@ class IOSThreadStore: ObservableObject {
                 var merged: [IOSThread] = []
                 for var restored in restoredThreads {
                     if let local = localOverrides[restored.sessionId ?? ""] {
+                        let sid = restored.sessionId ?? ""
+                        let useLocalPin = locallyEditedPinSessionIds.contains(sid)
                         restored = IOSThread(
                             id: restored.id,
                             title: local.title,
@@ -520,8 +529,8 @@ class IOSThreadStore: ObservableObject {
                             lastActivityAt: restored.lastActivityAt,
                             sessionId: restored.sessionId,
                             isArchived: local.isArchived,
-                            isPinned: local.isPinned,
-                            displayOrder: local.displayOrder,
+                            isPinned: useLocalPin ? local.isPinned : restored.isPinned,
+                            displayOrder: useLocalPin ? local.displayOrder : restored.displayOrder,
                             scheduleJobId: restored.scheduleJobId,
                             hasUnseenLatestAssistantMessage: restored.hasUnseenLatestAssistantMessage,
                             latestAssistantMessageAt: restored.latestAssistantMessageAt,
@@ -838,6 +847,7 @@ class IOSThreadStore: ObservableObject {
         viewModels.removeValue(forKey: thread.id)
         if let sid = thread.sessionId {
             locallyEditedSessionIds.remove(sid)
+            locallyEditedPinSessionIds.remove(sid)
             pendingAttentionOverrides.removeValue(forKey: sid)
         }
         threads.removeAll { $0.id == thread.id }
@@ -876,7 +886,10 @@ class IOSThreadStore: ObservableObject {
 
         threads[idx].isPinned = true
         threads[idx].displayOrder = Int.max
-        if let sid = threads[idx].sessionId { locallyEditedSessionIds.insert(sid) }
+        if let sid = threads[idx].sessionId {
+            locallyEditedSessionIds.insert(sid)
+            locallyEditedPinSessionIds.insert(sid)
+        }
         recompactPinnedDisplayOrders()
         sendReorderThreads()
         saveConnectedCache()
@@ -890,7 +903,10 @@ class IOSThreadStore: ObservableObject {
 
         threads[idx].isPinned = false
         threads[idx].displayOrder = nil
-        if let sid = threads[idx].sessionId { locallyEditedSessionIds.insert(sid) }
+        if let sid = threads[idx].sessionId {
+            locallyEditedSessionIds.insert(sid)
+            locallyEditedPinSessionIds.insert(sid)
+        }
         recompactPinnedDisplayOrders()
         sendReorderThreads()
         saveConnectedCache()


### PR DESCRIPTION
Addresses review feedback on merged PR #13778:

- **Preserve daemon pin metadata for non-pin local edits**: `locallyEditedSessionIds` was used for title/archive edits too, so Case 2 overwrote `isPinned`/`displayOrder` with cached local values even when the user only edited title. Cross-device pin updates could be lost. Now we use `locallyEditedPinSessionIds` for pin-specific tracking.

- **BUG (lines 166-167)**: `mergeThreadMetadata` now checks `locallyEditedPinSessionIds` (not `locallyEditedSessionIds`) to preserve local pin/displayOrder only when the user actually pinned/unpinned. Stale session-list refresh no longer overwrites local pin state.

- Case 2: use daemon `isPinned`/`displayOrder` when user only edited title/archive; preserve local only when `locallyEditedPinSessionIds` contains the session.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
