### PR TITLE
fix: store direct input tokens in llm_usage_events

### DIFF
--- a/assistant/src/daemon/session-usage.ts
+++ b/assistant/src/daemon/session-usage.ts
@@ -167,7 +167,7 @@ export function recordUsage(
         actor,
         provider: ctx.providerName,
         model,
-        inputTokens, // total (direct + cache) for downstream aggregates
+        inputTokens: directInputTokens,
         outputTokens,
         cacheCreationInputTokens: normalizedCacheCreationInputTokens,
         cacheReadInputTokens: normalizedCacheReadInputTokens,


### PR DESCRIPTION
## Summary
- Store direct input tokens (not total) in llm_usage_events.input_tokens to match schema convention and aggregation expectations
- Fixes session-usage.test.ts CI failure (expected 138, received 3420218)

## Original prompt
Fix this CI failure: https://github.com/vellum-ai/vellum-assistant/actions/runs/22790877086/job/66117121875

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
