### PR TITLE
fix: add explicit cache fields to UsageGroupBreakdownEntry in panel tests (PR 13779)

### DIFF
--- a/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardPanelTests.swift
@@ -167,7 +167,15 @@ struct UsageDashboardPanelPopulatedTests {
     func groupByDimensionAffectsBreakdownHeadings() async {
         let client = MockPanelClient()
         client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [
-            UsageGroupBreakdownEntry(group: "anthropic", totalInputTokens: 100, totalOutputTokens: 50, totalEstimatedCostUsd: 0.01, eventCount: 1)
+            UsageGroupBreakdownEntry(
+                group: "anthropic",
+                totalInputTokens: 100,
+                totalOutputTokens: 50,
+                totalCacheCreationTokens: 0,
+                totalCacheReadTokens: 0,
+                totalEstimatedCostUsd: 0.01,
+                eventCount: 1
+            )
         ])
 
         let store = UsageDashboardStore(client: client)
@@ -373,7 +381,15 @@ struct UsageDashboardPanelViewPopulatedTests {
         )
         client.stubbedDaily = UsageDailyResponse(buckets: [])
         client.stubbedBreakdown = UsageBreakdownResponse(breakdown: [
-            UsageGroupBreakdownEntry(group: "anthropic", totalInputTokens: 100, totalOutputTokens: 50, totalEstimatedCostUsd: 0.01, eventCount: 1)
+            UsageGroupBreakdownEntry(
+                group: "anthropic",
+                totalInputTokens: 100,
+                totalOutputTokens: 50,
+                totalCacheCreationTokens: 0,
+                totalCacheReadTokens: 0,
+                totalEstimatedCostUsd: 0.01,
+                eventCount: 1
+            )
         ])
 
         let store = UsageDashboardStore(client: client)


### PR DESCRIPTION
Addresses review feedback on merged PR #13779.

UsageDashboardPanelTests had two call sites using the legacy 5-arg `UsageGroupBreakdownEntry` initializer. Add explicit `totalCacheCreationTokens` and `totalCacheReadTokens` for consistency with PR 13779's cache-aware models.

Fixes #13779

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
