### PR TITLE
fix(ios): clear locallyEditedPinSessionIds when server acknowledges pin sync

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -171,6 +171,14 @@ class IOSThreadStore: ObservableObject {
         if !hasLocalPinEdit {
             thread.isPinned = restored.isPinned
             thread.displayOrder = restored.displayOrder
+        } else if restored.isPinned == thread.isPinned {
+            // Server has acknowledged our pin change — stop suppressing updates so
+            // pin/order changes from other clients are reflected on the next refresh.
+            if let sid = thread.sessionId {
+                locallyEditedPinSessionIds.remove(sid)
+            }
+            thread.isPinned = restored.isPinned
+            thread.displayOrder = restored.displayOrder
         }
         thread.hasUnseenLatestAssistantMessage = restored.hasUnseenLatestAssistantMessage
         thread.latestAssistantMessageAt = restored.latestAssistantMessageAt
@@ -545,6 +553,8 @@ class IOSThreadStore: ObservableObject {
                 locallyEditedSessionIds.removeAll()
             } else {
                 // Case 3: User is active (VMs exist or local threads present).
+                // Do not clear locallyEditedSessionIds — title/archive edits persist until
+                // reconnect or rebind (which clears at IOSThreadStore:390 and :408).
                 // Deduplicate: only prepend restored threads whose sessionId
                 // doesn't already exist in the current thread list.
                 let existingSessionIds: Set<String> = Set(


### PR DESCRIPTION
Addresses review feedback on #13785:

**Codex**: Stop suppressing server pin updates indefinitely. When the daemon returns `isPinned` matching our local state, remove the session from `locallyEditedPinSessionIds` so pin/order changes from other clients are reflected on the next refresh.

**Devin**: Documents Case 3 intent — `locallyEditedSessionIds` is not cleared because title/archive edits persist until reconnect/rebind.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
