### PR TITLE
fix: address PR 13784 review feedback

### DIFF
--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -932,6 +932,12 @@ export async function startGuardianVerificationCall(
       return { ok: false, error: identityResult.error, status: 400 };
     }
 
+    const preflightResult = await preflightVoiceIngress();
+    if (!preflightResult.ok) {
+      return preflightResult;
+    }
+    const ingressConfig = preflightResult.ingressConfig;
+
     // Create a minimal conversation so the call session has a valid FK,
     // and bind it to the voice channel so it never appears as an unbound
     // desktop thread.
@@ -956,13 +962,13 @@ export async function startGuardianVerificationCall(
     sessionId = session.id;
 
     const webhookUrl = await resolveCallbackUrl(
-      () => getTwilioVoiceWebhookUrl(config, session.id),
+      () => getTwilioVoiceWebhookUrl(ingressConfig, session.id),
       "webhooks/twilio/voice",
       "twilio_voice",
       { callSessionId: session.id },
     );
     const statusCallbackUrl = await resolveCallbackUrl(
-      () => getTwilioStatusCallbackUrl(config),
+      () => getTwilioStatusCallbackUrl(ingressConfig),
       "webhooks/twilio/status",
       "twilio_status",
     );

--- a/assistant/src/calls/voice-ingress-preflight.ts
+++ b/assistant/src/calls/voice-ingress-preflight.ts
@@ -1,5 +1,6 @@
 import { loadConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/types.js";
+import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
 
 const SERVICE_UNAVAILABLE_STATUS = 503 as const;
 
@@ -27,10 +28,6 @@ function fail(error: string): VoiceIngressPreflightFailure {
   };
 }
 
-function normalizePublicBaseUrl(value: unknown): string {
-  return typeof value === "string" ? value.trim().replace(/\/+$/, "") : "";
-}
-
 function buildGatewayUnhealthyMessage(
   target: string,
   error: string | undefined,
@@ -45,21 +42,14 @@ function buildGatewayUnhealthyMessage(
 
 export async function preflightVoiceIngress(): Promise<VoiceIngressPreflightResult> {
   const ingressConfig = loadConfig();
-  const publicBaseUrl = normalizePublicBaseUrl(
-    ingressConfig.ingress?.publicBaseUrl,
-  );
-  const ingressEnabled =
-    ingressConfig.ingress?.enabled ?? publicBaseUrl.length > 0;
-
-  if (!ingressEnabled) {
+  let publicBaseUrl: string;
+  try {
+    publicBaseUrl = getPublicBaseUrl(ingressConfig);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
     return fail(
-      "Outbound voice calls require public ingress to be enabled before Twilio can reach the assistant callbacks.",
-    );
-  }
-
-  if (!publicBaseUrl) {
-    return fail(
-      "Outbound voice calls require ingress.publicBaseUrl so Twilio webhook callbacks can reach the assistant.",
+      msg ||
+        "Outbound voice calls require public ingress to be enabled and a public base URL (ingress.publicBaseUrl or INGRESS_PUBLIC_BASE_URL).",
     );
   }
 


### PR DESCRIPTION
Addresses post-merge review feedback on #13784:

1. **Honor INGRESS_PUBLIC_BASE_URL** (Codex P1): Voice ingress preflight now uses `getPublicBaseUrl()` instead of reading only from `config.ingress`, so env-only ingress setups (e.g. `INGRESS_PUBLIC_BASE_URL`) are no longer rejected with 503 before dialing.

2. **Preflight for guardian verification** (Devin): `startGuardianVerificationCall()` now runs `preflightVoiceIngress()` before dialing, so guardian verification calls get the same gateway health/ingress checks as regular outbound calls.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13829" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
