### PR TITLE
fix: remove cross-file os module mock from sleep test (PR 13791)

### DIFF
--- a/cli/src/__tests__/sleep.test.ts
+++ b/cli/src/__tests__/sleep.test.ts
@@ -11,22 +11,13 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-// Create a temp directory that acts as a fake home so the real
-// assistant-config module reads/writes here instead of ~/.vellum.
+// Create a temp directory and set BASE_DATA_DIR so the real assistant-config
+// module reads the lockfile from here instead of ~/.vellum. The lockfile
+// includes full resources, so we never need to mock homedir() — avoiding
+// process-global os mocks that leak into other test files (e.g. multi-local).
 const testDir = mkdtempSync(join(tmpdir(), "sleep-command-test-"));
 const assistantRootDir = join(testDir, ".vellum");
 process.env.BASE_DATA_DIR = testDir;
-
-// Mock homedir() so defaultLocalResources() resolves to testDir.
-const realOs = await import("node:os");
-mock.module("node:os", () => ({
-  ...realOs,
-  homedir: () => testDir,
-}));
-mock.module("os", () => ({
-  ...realOs,
-  homedir: () => testDir,
-}));
 
 const stopProcessByPidFileMock = mock(async () => true);
 


### PR DESCRIPTION
Addresses Codex review on #13791.

**Review feedback:** `mock.module("os", ...)` is process-global in Bun and persists across test files, so the top-level mock can leak into later imports (e.g. multi-local.test.ts) and break assertions.

**Fix:** Remove the os/node:os mocks entirely. The sleep test only needs `BASE_DATA_DIR` and lockfile setup — the lockfile includes full resources, so `homedir()` is never needed.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
