### PR TITLE
fix: restore loaded-state render assertions (PR #13793 review feedback)

### DIFF
--- a/clients/ios/Tests/UsageDashboardViewTests.swift
+++ b/clients/ios/Tests/UsageDashboardViewTests.swift
@@ -177,22 +177,10 @@ final class UsageDashboardViewTests: XCTestCase {
         let view = UsageDashboardView(store: store)
         let renderedText = Self.renderedText(from: view)
 
-        // LabeledContent inside a SwiftUI List renders lazily; the UILabel
-        // hierarchy may not be fully materialised within the RunLoop window on
-        // CI runners.  Fall back to verifying the body can be created (smoke
-        // test) plus at least one known label appears, rather than asserting
-        // every label — the underlying formatting is already covered by the
-        // unit tests above.
-        let hasAnyExpectedLabel = renderedText.contains(UsageFormatting.directInputTokensLabel)
-            || renderedText.contains("Cache Created")
-            || renderedText.contains("Cache Read")
-            || renderedText.contains("Estimated Cost")
-        if !hasAnyExpectedLabel {
-            // Not a hard failure — SwiftUI lazy rendering on CI may not
-            // produce UILabels.  Log for visibility but don't block the build.
-            print("[UsageDashboardViewTests] Warning: rendered text did not contain expected labels — likely lazy List rendering on CI."
-                + " Rendered text: \(renderedText.prefix(500))")
-        }
+        XCTAssertTrue(renderedText.contains(UsageFormatting.directInputTokensLabel))
+        XCTAssertTrue(renderedText.contains("Cache Created"))
+        XCTAssertTrue(renderedText.contains("Cache Read"))
+        XCTAssertTrue(renderedText.contains("700 direct / 120 cache created / 9,876 cache read / 350 out"))
     }
 
     #endif
@@ -236,7 +224,8 @@ private extension UsageDashboardViewTests {
         hostingController.view.frame = window.bounds
         hostingController.view.setNeedsLayout()
         hostingController.view.layoutIfNeeded()
-        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        // Give SwiftUI List time to materialise LabeledContent UILabels on CI.
+        RunLoop.main.run(until: Date().addingTimeInterval(0.3))
 
         return collectText(from: hostingController.view).joined(separator: "\n")
     }


### PR DESCRIPTION
Addresses Codex and Devin review feedback on #13793.

**Feedback:** The relaxed test (warning-only when labels missing) allowed rendering breakages to merge unnoticed — it effectively became a no-op smoke test.

**Changes:**
- Restore `XCTAssertTrue` for all expected labels in `testViewRendersInLoadedState`
- Increase run loop from 0.1s to 0.3s to give SwiftUI List time to materialise LabeledContent UILabels on CI

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
