### PR TITLE
fix: address PR 13787 review feedback (lease sync + sleep gate)

### DIFF
--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -204,7 +204,14 @@ export function updateCallSession(
     .run();
 
   if (shouldSyncActiveLease) {
-    syncActiveCallLeaseFromSession(getCallSession(id));
+    try {
+      syncActiveCallLeaseFromSession(getCallSession(id));
+    } catch (err) {
+      log.warn(
+        { callSessionId: id, err },
+        "Failed to sync active call lease from session update",
+      );
+    }
   }
 }
 

--- a/cli/src/__tests__/sleep.test.ts
+++ b/cli/src/__tests__/sleep.test.ts
@@ -29,8 +29,10 @@ mock.module("os", () => ({
 }));
 
 const stopProcessByPidFileMock = mock(async () => true);
+const isProcessAliveMock = mock(() => ({ alive: false, pid: null }));
 
 mock.module("../lib/process.js", () => ({
+  isProcessAlive: isProcessAliveMock,
   stopProcessByPidFile: stopProcessByPidFileMock,
 }));
 
@@ -66,8 +68,8 @@ function writeLockfile(): void {
         activeAssistant: "sleep-test",
       },
       null,
-      2,
-    ),
+      2
+    )
   );
 }
 
@@ -85,8 +87,8 @@ function writeLeaseFile(callSessionIds: string[]): void {
         })),
       },
       null,
-      2,
-    ),
+      2
+    )
   );
 }
 
@@ -95,6 +97,8 @@ describe("sleep command", () => {
 
   beforeEach(() => {
     originalArgv = [...process.argv];
+    isProcessAliveMock.mockReset();
+    isProcessAliveMock.mockReturnValue({ alive: false, pid: null });
     stopProcessByPidFileMock.mockReset();
     stopProcessByPidFileMock.mockResolvedValue(true);
     rmSync(assistantRootDir, { recursive: true, force: true });
@@ -108,6 +112,7 @@ describe("sleep command", () => {
   });
 
   test("refuses normal sleep while an active call lease exists", async () => {
+    isProcessAliveMock.mockReturnValue({ alive: true, pid: 12345 });
     writeLeaseFile(["call-active-1", "call-active-2"]);
     process.argv = ["bun", "vellum", "sleep", "sleep-test"];
 
@@ -116,12 +121,12 @@ describe("sleep command", () => {
       throw new Error(`process.exit:${code}`);
     });
     const originalExit = process.exit;
-    process.exit = exitMock as unknown as typeof process.exit;
+    process.exit = (exitMock as unknown) as typeof process.exit;
 
     try {
       await expect(sleep()).rejects.toThrow("process.exit:1");
       expect(consoleError).toHaveBeenCalledWith(
-        expect.stringContaining("vellum sleep --force"),
+        expect.stringContaining("vellum sleep --force")
       );
     } finally {
       process.exit = originalExit;
@@ -129,6 +134,22 @@ describe("sleep command", () => {
     }
 
     expect(stopProcessByPidFileMock).not.toHaveBeenCalled();
+  });
+
+  test("proceeds when assistant is not running even with stale lease file", async () => {
+    isProcessAliveMock.mockReturnValue({ alive: false, pid: null });
+    writeLeaseFile(["call-stale-1"]);
+    process.argv = ["bun", "vellum", "sleep", "sleep-test"];
+
+    const consoleLog = spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      await sleep();
+    } finally {
+      consoleLog.mockRestore();
+    }
+
+    expect(stopProcessByPidFileMock).toHaveBeenCalledTimes(2);
   });
 
   test("force stops the assistant even when an active call lease exists", async () => {
@@ -148,14 +169,14 @@ describe("sleep command", () => {
       1,
       join(assistantRootDir, "vellum.pid"),
       "assistant",
-      [join(assistantRootDir, "vellum.sock")],
+      [join(assistantRootDir, "vellum.sock")]
     );
     expect(stopProcessByPidFileMock).toHaveBeenNthCalledWith(
       2,
       join(assistantRootDir, "gateway.pid"),
       "gateway",
       undefined,
-      7000,
+      7000
     );
   });
 });

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -6,7 +6,7 @@ import {
   resolveTargetAssistant,
 } from "../lib/assistant-config.js";
 import type { AssistantEntry } from "../lib/assistant-config.js";
-import { stopProcessByPidFile } from "../lib/process";
+import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
 
 const ACTIVE_CALL_LEASES_FILE = "active-call-leases.json";
 
@@ -35,8 +35,7 @@ function readActiveCallLeases(vellumDir: string): ActiveCallLease[] {
 
   return raw.leases.filter(
     (lease): lease is ActiveCallLease =>
-      typeof lease?.callSessionId === "string" &&
-      lease.callSessionId.length > 0,
+      typeof lease?.callSessionId === "string" && lease.callSessionId.length > 0
   );
 }
 
@@ -49,12 +48,12 @@ export async function sleep(): Promise<void> {
     console.log("");
     console.log("Arguments:");
     console.log(
-      "  <name>    Name of the assistant to stop (default: active or only local)",
+      "  <name>    Name of the assistant to stop (default: active or only local)"
     );
     console.log("");
     console.log("Options:");
     console.log(
-      "  --force   Stop the assistant even if a phone call keepalive lease is active",
+      "  --force   Stop the assistant even if a phone call keepalive lease is active"
     );
     process.exit(0);
   }
@@ -65,7 +64,7 @@ export async function sleep(): Promise<void> {
 
   if (entry.cloud && entry.cloud !== "local") {
     console.error(
-      `Error: 'vellum sleep' only works with local assistants. '${entry.assistantId}' is a ${entry.cloud} instance.`,
+      `Error: 'vellum sleep' only works with local assistants. '${entry.assistantId}' is a ${entry.cloud} instance.`
     );
     process.exit(1);
   }
@@ -77,31 +76,36 @@ export async function sleep(): Promise<void> {
   const gatewayPidFile = join(vellumDir, "gateway.pid");
 
   if (!force) {
-    try {
-      const activeCallLeases = readActiveCallLeases(vellumDir);
-      if (activeCallLeases.length > 0) {
-        const activeIds = activeCallLeases.map((lease) => lease.callSessionId);
+    const assistantAlive = isProcessAlive(assistantPidFile).alive;
+    if (assistantAlive) {
+      try {
+        const activeCallLeases = readActiveCallLeases(vellumDir);
+        if (activeCallLeases.length > 0) {
+          const activeIds = activeCallLeases.map(
+            (lease) => lease.callSessionId
+          );
+          console.error(
+            `Error: assistant is staying awake for active phone calls (${activeIds.join(
+              ", "
+            )}). Use 'vellum sleep --force' to stop it anyway.`
+          );
+          process.exit(1);
+        }
+      } catch (err) {
         console.error(
-          `Error: assistant is staying awake for active phone calls (${activeIds.join(
-            ", ",
-          )}). Use 'vellum sleep --force' to stop it anyway.`,
+          `Error: ${
+            err instanceof Error ? err.message : String(err)
+          }. Use 'vellum sleep --force' to override if you want to stop the assistant anyway.`
         );
         process.exit(1);
       }
-    } catch (err) {
-      console.error(
-        `Error: ${
-          err instanceof Error ? err.message : String(err)
-        }. Use 'vellum sleep --force' to override if you want to stop the assistant anyway.`,
-      );
-      process.exit(1);
     }
   }
 
   const assistantStopped = await stopProcessByPidFile(
     assistantPidFile,
     "assistant",
-    [socketFile],
+    [socketFile]
   );
   if (!assistantStopped) {
     console.log("Assistant is not running.");
@@ -115,7 +119,7 @@ export async function sleep(): Promise<void> {
     gatewayPidFile,
     "gateway",
     undefined,
-    7000,
+    7000
   );
   if (!gatewayStopped) {
     console.log("Gateway is not running.");


### PR DESCRIPTION
Addresses review feedback on merged PR #13787:

1. **call-store.ts**: Wrap `syncActiveCallLeaseFromSession` in try-catch so lease-sync I/O failures don't crash callers after the DB update has committed. Treats lease sync as best-effort.

2. **sleep.ts**: Gate the lease block on assistant liveness. Only block `vellum sleep` when the assistant is actually running; if the assistant has crashed and left a stale lease file, proceed without requiring `--force`.

3. **sleep.test.ts**: Add `isProcessAlive` mock and new test for stale-lease scenario.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
