### PR TITLE
fix: restore SMS webhook gateway-only coverage (PR 13795 review)

### DIFF
--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -357,6 +357,33 @@ describe("gateway-only ingress enforcement", () => {
       };
       expect(body.error.code).toBe("GONE");
     });
+
+    test("POST /webhooks/twilio/sms returns 410", async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/webhooks/twilio/sms`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: makeFormBody({ MessageSid: "SM123", AccountSid: "AC_test" }),
+      });
+      expect(res.status).toBe(410);
+      const body = (await res.json()) as {
+        error: { code: string; message: string };
+      };
+      expect(body.error.code).toBe("GONE");
+      expect(body.error.message).toContain("Direct webhook access disabled");
+    });
+
+    test("POST /v1/calls/twilio/sms returns 410", async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/calls/twilio/sms`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: makeFormBody({ MessageSid: "SM123", AccountSid: "AC_test" }),
+      });
+      expect(res.status).toBe(410);
+      const body = (await res.json()) as {
+        error: { code: string; message: string };
+      };
+      expect(body.error.code).toBe("GONE");
+    });
   });
 
   // ── Internal forwarding routes still work ─────

--- a/assistant/src/runtime/middleware/twilio-validation.ts
+++ b/assistant/src/runtime/middleware/twilio-validation.ts
@@ -29,11 +29,12 @@ export const GATEWAY_SUBPATH_MAP: Record<string, string> = {
   voice: "voice-webhook",
   status: "status",
   "connect-action": "connect-action",
+  sms: "sms",
 };
 
 /**
  * Direct Twilio webhook subpaths that are blocked in gateway_only mode.
- * Includes all public-facing webhook paths (voice, status, connect-action)
+ * Includes all public-facing webhook paths (voice, status, connect-action, sms)
  * because the runtime must never serve as a direct ingress for external webhooks.
  * Internal forwarding endpoints (gateway->runtime) are unaffected.
  */
@@ -41,6 +42,7 @@ export const GATEWAY_ONLY_BLOCKED_SUBPATHS = new Set([
   "voice-webhook",
   "status",
   "connect-action",
+  "sms",
 ]);
 
 /**


### PR DESCRIPTION
Addresses Devin review on #13795:

- Add `sms` to `GATEWAY_ONLY_BLOCKED_SUBPATHS` and `GATEWAY_SUBPATH_MAP` in twilio-validation.ts
- Restore tests for `POST /webhooks/twilio/sms` and `POST /v1/calls/twilio/sms` returning 410

Docs already documented this behavior; runtime now matches.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
