### PR TITLE
test: add message_back executor error path coverage (PR 13801 review)

### DIFF
--- a/assistant/src/__tests__/guardian-action-followup-executor.test.ts
+++ b/assistant/src/__tests__/guardian-action-followup-executor.test.ts
@@ -285,6 +285,30 @@ describe("guardian-action-followup-executor", () => {
     });
   });
 
+  // ── message_back (unsupported) error path ─────────────────────────────
+
+  describe("message_back", () => {
+    test("returns failure and finalizes as failed when message_back is dispatched", async () => {
+      const { request } = createDispatchingRequest(
+        "exec-msg-1",
+        "message_back",
+      );
+
+      const result = await executeFollowupAction(request.id, "message_back");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain("Unsupported action");
+        expect(result.error).toContain("message_back");
+      }
+      expect(result.guardianReplyText.length).toBeGreaterThan(0);
+
+      const updated = getGuardianActionRequest(request.id);
+      expect(updated!.followupState).toBe("failed");
+      expect(updated!.followupCompletedAt).toBeGreaterThan(0);
+    });
+  });
+
   // ── Error handling ──────────────────────────────────────────────────
 
   describe("error handling", () => {

--- a/cli/src/__tests__/sleep.test.ts
+++ b/cli/src/__tests__/sleep.test.ts
@@ -11,22 +11,13 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-// Create a temp directory that acts as a fake home so the real
-// assistant-config module reads/writes here instead of ~/.vellum.
+// Create a temp directory and set BASE_DATA_DIR so the real assistant-config
+// module reads the lockfile from here instead of ~/.vellum. The lockfile
+// includes full resources, so we never need to mock homedir() — avoiding
+// process-global os mocks that leak into other test files (e.g. multi-local).
 const testDir = mkdtempSync(join(tmpdir(), "sleep-command-test-"));
 const assistantRootDir = join(testDir, ".vellum");
 process.env.BASE_DATA_DIR = testDir;
-
-// Mock homedir() so defaultLocalResources() resolves to testDir.
-const realOs = await import("node:os");
-mock.module("node:os", () => ({
-  ...realOs,
-  homedir: () => testDir,
-}));
-mock.module("os", () => ({
-  ...realOs,
-  homedir: () => testDir,
-}));
 
 const stopProcessByPidFileMock = mock(async () => true);
 


### PR DESCRIPTION
Addresses Devin review feedback on merged PR #13801.

Adds test coverage for the `message_back` executor error path: when `message_back` is dispatched, the executor returns failure, finalizes as failed, and returns a guardian reply. Production code already handles this gracefully; this PR adds the missing test.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
