### PR TITLE
fix: keep BASE_DATA_DIR when wake target comes from lockfile

### DIFF
--- a/assistant/src/runtime/local-gateway-health.ts
+++ b/assistant/src/runtime/local-gateway-health.ts
@@ -126,12 +126,15 @@ async function runDefaultWakeCommand(
     ? ["vellum", "wake", assistantName]
     : ["vellum", "wake"];
 
-  // When we have an explicit assistant name (e.g. from instance path), unset
-  // BASE_DATA_DIR so the spawned CLI reads the global lockfile and targets
-  // the correct instance. Otherwise the CLI would read the instance-scoped
-  // lockfile which may lack assistant metadata.
+  // Only when the assistant name came from the instance path (e.g.
+  // ~/.local/share/vellum/assistants/<name>/), unset BASE_DATA_DIR so the
+  // spawned CLI reads the global lockfile. When the name came from the
+  // lockfile, keep BASE_DATA_DIR — vellum wake resolves names through the
+  // lockfile rooted at BASE_DATA_DIR, so clearing it would read the wrong
+  // lockfile (e.g. $HOME) and fail or wake the wrong assistant.
+  const fromInstancePath = resolveInstanceNameFromBaseDataDir();
   const env =
-    assistantName && getBaseDataDir()
+    fromInstancePath && getBaseDataDir()
       ? { ...process.env, BASE_DATA_DIR: undefined }
       : process.env;
 


### PR DESCRIPTION
Addresses review feedback on #13806.

Only clear BASE_DATA_DIR when the assistant name is derived from the instance path (`~/.local/share/vellum/assistants/<name>/`). When the name comes from the lockfile, keep BASE_DATA_DIR so `vellum wake` resolves through the correct lockfile — clearing it would read the wrong lockfile (e.g. $HOME) and fail or wake the wrong assistant (e.g. in `assistant dev`).

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
