### PR TITLE
fix: restore guardian-verification and call-domain tests (CI failures)

### DIFF
--- a/assistant/src/__tests__/call-domain.test.ts
+++ b/assistant/src/__tests__/call-domain.test.ts
@@ -458,7 +458,7 @@ describe("startCall — pointer message regression", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.status).toBe(503);
-      expect(result.error).toContain("public ingress");
+      expect(result.error).toContain("Public ingress");
     }
     expect(probeLocalGatewayHealthCallCount).toBe(0);
     expect(ensureLocalGatewayReadyCallCount).toBe(0);

--- a/assistant/src/__tests__/guardian-verification-voice-binding.test.ts
+++ b/assistant/src/__tests__/guardian-verification-voice-binding.test.ts
@@ -66,6 +66,14 @@ mock.module("../inbound/public-ingress-urls.js", () => ({
   getTwilioStatusCallbackUrl: () => "https://test.example.com/status",
 }));
 
+mock.module("../calls/voice-ingress-preflight.js", () => ({
+  preflightVoiceIngress: async () => ({
+    ok: true as const,
+    ingressConfig: {},
+    publicBaseUrl: "https://test.example.com",
+  }),
+}));
+
 mock.module("../config/loader.js", () => ({
   loadConfig: () => ({
     calls: {


### PR DESCRIPTION
## Summary
- **guardian-verification-voice-binding.test.ts**: Mock `preflightVoiceIngress` so the test succeeds in CI. The test was failing because `getPublicBaseUrl` and gateway health checks are not available in the test environment.
- **call-domain.test.ts**: Update assertion from `toContain("public ingress")` to `toContain("Public ingress")` to match the actual error message from `public-ingress-urls.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
