### PR TITLE
fix: remove SMS from runtime source logic

### DIFF
--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -2,7 +2,7 @@
  * Reusable Twilio REST API helpers.
  *
  * Provides low-level building blocks (auth header, base URL, credential
- * resolution) shared across the voice provider, SMS channel, and IPC
+ * resolution) shared across the voice provider and IPC
  * config handler. Uses fetch() directly — no twilio npm package.
  */
 
@@ -67,7 +67,7 @@ export function twilioBaseUrl(accountSid: string): string {
 export interface TwilioPhoneNumber {
   phoneNumber: string;
   friendlyName: string;
-  capabilities: { voice: boolean; sms: boolean };
+  capabilities: { voice: boolean };
 }
 
 /** List incoming phone numbers owned by the account. */
@@ -96,21 +96,21 @@ export async function listIncomingPhoneNumbers(
     incoming_phone_numbers: Array<{
       phone_number: string;
       friendly_name: string;
-      capabilities: { voice: boolean; sms: boolean };
+      capabilities: { voice: boolean };
     }>;
   };
 
   return data.incoming_phone_numbers.map((n) => ({
     phoneNumber: n.phone_number,
     friendlyName: n.friendly_name,
-    capabilities: { voice: n.capabilities.voice, sms: n.capabilities.sms },
+    capabilities: { voice: n.capabilities.voice },
   }));
 }
 
 export interface AvailablePhoneNumber {
   phoneNumber: string;
   friendlyName: string;
-  capabilities: { voice: boolean; sms: boolean };
+  capabilities: { voice: boolean };
 }
 
 /** Search for available phone numbers to purchase. */
@@ -149,14 +149,14 @@ export async function searchAvailableNumbers(
     available_phone_numbers: Array<{
       phone_number: string;
       friendly_name: string;
-      capabilities: { voice: boolean; sms: boolean };
+      capabilities: { voice: boolean };
     }>;
   };
 
   return data.available_phone_numbers.map((n) => ({
     phoneNumber: n.phone_number,
     friendlyName: n.friendly_name,
-    capabilities: { voice: n.capabilities.voice, sms: n.capabilities.sms },
+    capabilities: { voice: n.capabilities.voice },
   }));
 }
 
@@ -192,7 +192,7 @@ export async function provisionPhoneNumber(
   const data = (await res.json()) as {
     phone_number: string;
     friendly_name: string;
-    capabilities: { voice: boolean; sms: boolean };
+    capabilities: { voice: boolean };
   };
 
   return {
@@ -200,7 +200,6 @@ export async function provisionPhoneNumber(
     friendlyName: data.friendly_name,
     capabilities: {
       voice: data.capabilities.voice,
-      sms: data.capabilities.sms,
     },
   };
 }

--- a/assistant/src/daemon/guardian-verification-intent.ts
+++ b/assistant/src/daemon/guardian-verification-intent.ts
@@ -24,7 +24,7 @@ const DIRECT_SETUP_PATTERNS: RegExp[] = [
   /\bguardian\s+verif(?:y|ication)\s*(?:setup|set\s*up)?\b/i,
   /\bset\s*up\s+guardian\s+verif(?:y|ication)\b/i,
   /\b(?:help\s+me\s+)?set\s+(?:myself\s+)?(?:up\s+)?as\s+(?:your\s+)?guardian\s+(?:for|via|by|over|on|through)\s+/i,
-  /\bguardian\s+(?:for|via|by|over|on|through)\s+(?:sms|text|phone|voice|telegram|slack|call)\b/i,
+  /\bguardian\s+(?:for|via|by|over|on|through)\s+(?:text|phone|voice|telegram|slack|call)\b/i,
   /\bbecome\s+(?:your\s+|the\s+)?guardian\b/i,
   /\bregister\s+(?:me\s+)?as\s+(?:your\s+|the\s+)?guardian\b/i,
 ];

--- a/assistant/src/runtime/invite-instruction-generator.ts
+++ b/assistant/src/runtime/invite-instruction-generator.ts
@@ -32,8 +32,6 @@ export function channelDisplayLabel(type: string): string {
   switch (type) {
     case "telegram":
       return "Telegram";
-    case "sms":
-      return "SMS";
     case "email":
       return "Email";
     case "slack":

--- a/assistant/src/runtime/migrations/rebind-secrets-screen.ts
+++ b/assistant/src/runtime/migrations/rebind-secrets-screen.ts
@@ -112,10 +112,10 @@ const TASK_DEFINITIONS: readonly TaskDefinition[] = [
     id: "rebind-channels",
     title: "Re-bind communication channels",
     description:
-      "Communication channel bindings (Slack, Telegram, SMS, etc.) are instance-specific. Re-configure each channel to point to the new instance.",
+      "Communication channel bindings (Slack, Telegram, etc.) are instance-specific. Re-configure each channel to point to the new instance.",
     required: true,
     helpText:
-      "For Slack: re-install the Slack app in your workspace. For Telegram: update the bot webhook URL. For SMS: update the webhook URL in your Twilio/provider dashboard.",
+      "For Slack: re-install the Slack app in your workspace. For Telegram: update the bot webhook URL.",
   },
   {
     id: "reconfigure-auth",


### PR DESCRIPTION
## Summary
- Remove SMS case from invite instruction generator channel label switch
- Remove sms from guardian verification intent regex pattern
- Remove sms capability from all Twilio REST interfaces and mappings
- Remove SMS references from rebind-secrets migration screen text

Part of plan: rm-remaining-sms-mentions.md (PR 2 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
