### PR TITLE
fix: remove SMS from guardian and action source comments

### DIFF
--- a/assistant/src/calls/guardian-action-sweep.ts
+++ b/assistant/src/calls/guardian-action-sweep.ts
@@ -5,7 +5,7 @@
  * timestamp:
  * 1. Expires the request and all its deliveries in the store
  * 2. Expires the associated pending question so the call-side timeout fires
- * 3. Sends expiry notices to external delivery destinations (telegram, sms)
+ * 3. Sends expiry notices to external delivery destinations (telegram)
  * 4. Adds an expiry message to mac guardian thread conversations
  */
 
@@ -32,7 +32,7 @@ let sweepInProgress = false;
 /**
  * Send expiry notices to all delivery destinations for a guardian action
  * request. Handles both vellum/mac thread messages and external channel
- * replies (telegram, sms).
+ * replies (telegram, slack).
  *
  * Deliveries must be captured *before* their status is changed to 'expired'
  * so the sent/pending filter still matches.

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -2,7 +2,7 @@
  * Store for cross-channel guardian action requests and deliveries.
  *
  * Guardian action requests are created when a voice call's ASK_GUARDIAN
- * marker fires, and deliveries track per-channel dispatch (telegram, sms, mac).
+ * marker fires, and deliveries track per-channel dispatch (telegram, mac).
  * Resolution uses first-response-wins semantics: the first channel to
  * answer resolves the request and all other deliveries are marked answered.
  */
@@ -864,7 +864,7 @@ export function getExpiredDeliveriesByConversation(
 /**
  * Look up deliveries for requests in `awaiting_guardian_choice` follow-up state.
  * Used by inbound message routing to intercept guardian follow-up replies
- * on channel paths (Telegram, SMS).
+ * on channel paths (Telegram, WhatsApp).
  */
 export function getFollowupDeliveriesByDestination(
   channel: string,

--- a/assistant/src/runtime/guardian-action-message-composer.ts
+++ b/assistant/src/runtime/guardian-action-message-composer.ts
@@ -75,7 +75,7 @@ export const GUARDIAN_ACTION_COPY_MAX_TOKENS = 200;
 export const GUARDIAN_ACTION_COPY_SYSTEM_PROMPT =
   "You are an assistant writing one user-facing message about a guardian action in a voice call scenario. " +
   "Keep it concise, natural, and conversational. Preserve factual details exactly. " +
-  "These messages are spoken aloud or sent as SMS, so use a warm, human tone. " +
+  "These messages are spoken aloud, so use a warm, human tone. " +
   "Do not mention internal systems, scenario IDs, or technical details. " +
   "Return plain text only.";
 
@@ -132,7 +132,7 @@ export function buildGuardianActionGenerationPrompt(
       : "";
   return [
     "Rewrite the following guardian action message as a natural, conversational reply.",
-    "These messages are for voice call scenarios and may be spoken aloud or sent as SMS.",
+    "These messages are for voice call scenarios and may be spoken aloud.",
     "Keep the same concrete facts and next-step guidance.",
     keywordClause,
     `Context JSON: ${JSON.stringify(context)}`,
@@ -165,7 +165,7 @@ export function includesRequiredKeywords(
  * Return a scenario-specific deterministic fallback message.
  *
  * Each template produces natural, conversational text suitable for voice
- * or SMS delivery.
+ * delivery.
  */
 export function getGuardianActionFallbackMessage(
   context: GuardianActionMessageContext,
@@ -248,7 +248,7 @@ export function getGuardianActionFallbackMessage(
         : "Got it! Your answer has been applied to the current active request on the call.";
 
     case "outbound_message_copy":
-      // This SMS is sent TO the original caller relaying the guardian's answer.
+      // This message is sent TO the original caller relaying the guardian's answer.
       // When lateAnswerText is available, include it — that's the whole point of message_back.
       if (context.lateAnswerText && context.questionText) {
         return `Hi! You asked "${context.questionText}" earlier. Here's the answer: ${context.lateAnswerText}`;

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -2,7 +2,7 @@
  * Shared guardian reply router for inbound channel messages.
  *
  * Provides a single entry point (`routeGuardianReply`) for all inbound
- * guardian reply processing across Telegram, SMS, and WhatsApp. Routes
+ * guardian reply processing across Telegram and WhatsApp. Routes
  * through a priority-ordered pipeline:
  *
  *   1. Deterministic callback/ref parsing (button presses with `apr:<requestId>:<action>`)
@@ -57,7 +57,7 @@ const log = getLogger("guardian-reply-router");
 export interface GuardianReplyContext {
   /** The raw message text (trimmed). */
   messageText: string;
-  /** Source channel (telegram, sms, whatsapp, etc.). */
+  /** Source channel (telegram, whatsapp, etc.). */
   channel: string;
   /** Actor identity context for the sender. */
   actor: ActorContext;
@@ -260,7 +260,7 @@ function notConsumed(): GuardianReplyResult {
  * Route an inbound guardian reply through the canonical decision pipeline.
  *
  * This is the single entry point for all inbound guardian reply processing.
- * It handles messages from any channel (Telegram, SMS, WhatsApp) and
+ * It handles messages from any channel (Telegram, WhatsApp) and
  * routes through priority-ordered matching:
  *
  *   1. Deterministic callback parsing (button presses)


### PR DESCRIPTION
## Summary
- Update comments in guardian-action-sweep, guardian-action-store, guardian-action-message-composer, and guardian-reply-router to remove SMS references
- Replace SMS examples with telegram/slack/voice alternatives

Part of plan: rm-remaining-sms-mentions.md (PR 3 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
