### PR TITLE
fix: remove SMS from system prompts and LLM text

### DIFF
--- a/assistant/src/config/computer-use-prompt.ts
+++ b/assistant/src/config/computer-use-prompt.ts
@@ -71,7 +71,7 @@ APP-SPECIFIC TIPS:
 - Messages: Click the search bar or use cmd+n for a new message.
 
 VERIFICATION CODES:
-When a signup or login flow requires a verification code (email, SMS, or authenticator):
+When a signup or login flow requires a verification code (email or authenticator):
 1. Use ui_show with surface_type "form" to ask the user:
    ui_show({ surface_type: "form", title: "Verification Code", data: { fields: [{ id: "code", type: "text", label: "Enter the verification code", required: true }] } })
 2. Wait for the user's response

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -403,9 +403,9 @@ export function buildPhoneCallsRoutingSection(): string {
     "### Trigger phrases",
     '- "Set up phone calling" / "enable calls"',
     '- "Make a call to..." / "call [number/business]"',
-    '- "Configure Twilio" (in context of voice calls, not SMS)',
+    '- "Configure Twilio" (in context of voice calls)',
     '- "Can you make phone calls?"',
-    '- "Set up my phone number" (for calling, not SMS)',
+    '- "Set up my phone number" (for calling)',
     "",
     "### What it does",
     "The skill handles the full phone calling lifecycle:",
@@ -909,7 +909,7 @@ function buildDynamicSkillWorkflowSection(
     lines.push(
       "",
       "### Messaging Skill",
-      'When the user asks about email, messaging, inbox management, or wants to read/send/search messages on any platform (Gmail, Slack, Telegram, SMS), load the "messaging" skill using `skill_load`. The messaging skill handles connection setup, credential flows, and all messaging operations — do not improvise setup instructions from general knowledge.',
+      'When the user asks about email, messaging, inbox management, or wants to read/send/search messages on any platform (Gmail, Slack, Telegram), load the "messaging" skill using `skill_load`. The messaging skill handles connection setup, credential flows, and all messaging operations — do not improvise setup instructions from general knowledge.',
     );
   }
 

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -402,7 +402,7 @@ export async function executeBrowserNavigate(
                 "2. Use browser_fill_credential to fill email/password from credential_store",
               );
               lines.push(
-                "3. For SMS/email verification codes, use ui_show with a form to ask the user for the code mid-turn",
+                "3. For email verification codes, use ui_show with a form to ask the user for the code mid-turn",
               );
               lines.push(
                 "4. Do NOT give up or tell the user to sign in manually — handle the login flow yourself",
@@ -433,7 +433,7 @@ export async function executeBrowserNavigate(
             "2. Use browser_fill_credential to fill email/password from credential_store",
           );
           lines.push(
-            "3. For SMS/email verification codes, use ui_show with a form to ask the user for the code mid-turn",
+            "3. For email verification codes, use ui_show with a form to ask the user for the code mid-turn",
           );
           lines.push(
             "4. Do NOT give up or tell the user to sign in manually — handle the login flow yourself",


### PR DESCRIPTION
## Summary
- Remove SMS references from system prompt, computer-use prompt, and browser execution instructions
- Update LLM guidance to no longer mention SMS as a channel option

Part of plan: rm-remaining-sms-mentions.md (PR 6 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
