### PR TITLE
fix: remove SMS from route, daemon, and inbound source comments

### DIFF
--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -321,7 +321,7 @@ async function executeApprove(
   // The guardian already approved this escalation via the inbox, so we
   // directly set guardian trust. Going through resolveLocalIpcTrustContext
   // would look up the vellum binding's guardian ID and compare it against
-  // a different channel's binding (e.g. telegram/sms), misclassifying the
+  // a different channel's binding (e.g. telegram/voice), misclassifying the
   // actor as 'unknown'.
   session.setTrustContext({
     sourceChannel: sourceChannel ?? "vellum",

--- a/assistant/src/daemon/ipc-contract/integrations.ts
+++ b/assistant/src/daemon/ipc-contract/integrations.ts
@@ -63,7 +63,7 @@ export interface ChannelVerificationSessionRequest {
   channel?: ChannelId; // Defaults to 'telegram'
   sessionId?: string;
   rebind?: boolean; // When true, allows creating a challenge even if a binding already exists
-  /** E.164 phone number for SMS/voice, Telegram handle/chat-id. Used by outbound actions. */
+  /** E.164 phone number for voice, Telegram handle/chat-id. Used by outbound actions. */
   destination?: string;
   /** Origin conversation ID so completion/failure pointers can route back. */
   originConversationId?: string;
@@ -177,7 +177,7 @@ export interface ChannelVerificationSessionResponse {
   /** Present when action is 'status'. */
   bound?: boolean;
   guardianExternalUserId?: string;
-  /** The channel this status pertains to (e.g. "telegram", "sms"). Present when action is 'status'. */
+  /** The channel this status pertains to (e.g. "telegram", "voice"). Present when action is 'status'. */
   channel?: ChannelId;
   /** The assistant ID scoped to this status. Present when action is 'status'. */
   assistantId?: string;
@@ -198,7 +198,7 @@ export interface ChannelVerificationSessionResponse {
   expiresAt?: number;
   /** Epoch ms after which a resend is allowed. */
   nextResendAt?: number;
-  /** Number of SMS sends for this session. */
+  /** Number of sends for this session. */
   sendCount?: number;
   /** Telegram deep-link URL for bootstrap (M3 placeholder). */
   telegramBootstrapUrl?: string;

--- a/assistant/src/inbound/platform-callback-registration.ts
+++ b/assistant/src/inbound/platform-callback-registration.ts
@@ -52,7 +52,7 @@ interface RegisterCallbackRouteResponse {
  * @param callbackPath - The path portion after the ingress base URL
  *   (e.g. "webhooks/twilio/voice"). Leading/trailing slashes are stripped
  *   by the platform.
- * @param type - The route type identifier (e.g. "twilio_voice", "twilio_sms",
+ * @param type - The route type identifier (e.g. "twilio_voice",
  *   "twilio_status", "oauth", "telegram").
  * @returns The platform-provided callback URL that external services should use.
  * @throws If the platform request fails.

--- a/assistant/src/runtime/routes/guardian-expiry-sweep.ts
+++ b/assistant/src/runtime/routes/guardian-expiry-sweep.ts
@@ -31,7 +31,7 @@ let expirySweepTimer: ReturnType<typeof setInterval> | null = null;
  *
  * Accepts a `gatewayBaseUrl` rather than a fixed delivery URL so that
  * each approval's notification is routed to the correct channel-specific
- * endpoint (e.g. `/deliver/telegram`, `/deliver/sms`).
+ * endpoint (e.g. `/deliver/telegram`, `/deliver/voice`).
  */
 export function sweepExpiredGuardianApprovals(
   gatewayBaseUrl: string,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -182,7 +182,7 @@ export async function handleChannelInbound(
 
   // Canonicalize the sender identity so all trust lookups, member matching,
   // and guardian binding comparisons use a normalized form. Phone-like
-  // channels (sms, voice, whatsapp) are normalized to E.164; non-phone
+  // channels (voice, whatsapp) are normalized to E.164; non-phone
   // channels pass through the platform-stable ID unchanged.
   const canonicalSenderId = rawSenderId
     ? canonicalizeInboundIdentity(sourceChannel, rawSenderId)


### PR DESCRIPTION
## Summary
- Update comments in guardian-expiry-sweep, inbound-message-handler, platform-callback-registration, config-inbox, and ipc-contract/integrations to remove SMS references
- Replace SMS examples with voice/telegram alternatives

Part of plan: rm-remaining-sms-mentions.md (PR 4 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13843" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
