### PR TITLE
fix: remove SMS from CLI help text and channel listings

### DIFF
--- a/assistant/src/cli/channels.ts
+++ b/assistant/src/cli/channels.ts
@@ -12,7 +12,7 @@ export function registerChannelsCommand(program: Command): void {
     "after",
     `
 Queries channel readiness and configuration status through the gateway API.
-Channels are the communication interfaces (telegram, voice, sms, email, etc.)
+Channels are the communication interfaces (telegram, voice, email, etc.)
 that the assistant uses to send and receive messages.
 
 The assistant must be running — channel status is read from the live gateway.
@@ -36,7 +36,7 @@ it can deliver messages to the user.
 
 The --channel flag filters results to a single channel type. Without it, all
 configured channels are returned. Common channel types include: telegram,
-voice, sms, email, slack, vellum.
+voice, email, slack, vellum.
 
 Examples:
   $ assistant channels readiness

--- a/assistant/src/cli/contacts.ts
+++ b/assistant/src/cli/contacts.ts
@@ -61,7 +61,7 @@ Examples:
     )
     .option(
       "--channel-type <channelType>",
-      "Filter by channel type (email, telegram, sms, voice, whatsapp, slack)",
+      "Filter by channel type (email, telegram, voice, whatsapp, slack)",
     )
     .addHelpText(
       "after",
@@ -225,7 +225,7 @@ matches an existing contact, that contact is updated. When --id is omitted,
 a new contact is created with a generated UUID.
 
 The --channels flag accepts a JSON array of channel objects. Each object must
-have "type" (e.g. telegram, sms, voice, email, whatsapp) and "address" fields.
+have "type" (e.g. telegram, voice, email, whatsapp) and "address" fields.
 Optional channel fields: isPrimary (boolean), externalUserId, externalChatId,
 status (active, revoked, blocked), policy (allow, deny).
 
@@ -421,7 +421,7 @@ Examples:
     "after",
     `
 Invites are tokens that grant channel access when redeemed. Each invite is
-tied to a source channel (telegram, voice, sms, email, whatsapp) and can
+tied to a source channel (telegram, voice, email, whatsapp) and can
 optionally have usage limits, expiration, and notes. When redeemed, the
 invite creates a channel membership linking a contact to an external
 identifier on the source channel.
@@ -479,7 +479,7 @@ Examples:
     .description("Create a new invite")
     .requiredOption(
       "--source-channel <channel>",
-      "Source channel (e.g. telegram, voice, sms, email, whatsapp)",
+      "Source channel (e.g. telegram, voice, email, whatsapp)",
     )
     .option("--note <note>", "Optional note")
     .option("--max-uses <n>", "Max redemptions")
@@ -501,7 +501,7 @@ Examples:
       "after",
       `
 Creates a new invite token for the specified source channel. The --source-channel
-flag is required and must be one of: telegram, voice, sms, email, whatsapp.
+flag is required and must be one of: telegram, voice, email, whatsapp.
 
 Optional fields:
   --note                        Free-text note attached to the invite

--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -256,7 +256,7 @@ Some subcommands query the running assistant gateway (\`telegram\`, \`guardian\`
 others read local config or call the underlying provider directly (\`twilio\`, \`ingress\`, \`voice\`).
 
 Integration categories:
-  twilio       Twilio SMS/voice credential and phone number status
+  twilio       Twilio voice credential and phone number status
   telegram     Telegram bot configuration and webhook status
   guardian     Guardian trust verification system for contacts
   ingress      Public ingress URL and local gateway target (config-only)
@@ -266,12 +266,12 @@ Examples:
   $ assistant integrations twilio config
   $ assistant integrations twilio numbers --json
   $ assistant integrations telegram config
-  $ assistant integrations guardian status --channel sms`,
+  $ assistant integrations guardian status --channel telegram`,
   );
 
   const twilio = integrations
     .command("twilio")
-    .description("Twilio SMS/voice integration status");
+    .description("Twilio voice integration status");
 
   twilio.addHelpText(
     "after",
@@ -296,7 +296,7 @@ Arguments:
   (none)
 
 Returns whether Twilio credentials are configured and whether a phone number is
-assigned in the assistant SMS config. Reads local assistant state only; it
+assigned in the assistant config. Reads local assistant state only; it
 does not call the gateway or Twilio.
 
 Examples:
@@ -384,14 +384,14 @@ Examples:
   guardian
     .command("status")
     .description("Get guardian status for a channel")
-    .option("--channel <channel>", "Channel: telegram|voice|sms", "telegram")
+    .option("--channel <channel>", "Channel: telegram|voice", "telegram")
     .addHelpText(
       "after",
       `
 Returns the guardian verification state for the specified channel. Requires
 the assistant to be running.
 
-The --channel flag accepts: telegram, voice, sms. Defaults to telegram if
+The --channel flag accepts: telegram, voice. Defaults to telegram if
 not specified. The response includes whether guardian verification is active
 and the current verification state for that channel.
 
@@ -399,7 +399,7 @@ Examples:
   $ assistant integrations guardian status
   $ assistant integrations guardian status --channel telegram
   $ assistant integrations guardian status --channel voice
-  $ assistant integrations guardian status --channel sms --json`,
+  $ assistant integrations guardian status --channel telegram --json`,
     )
     .action(async (opts: { channel?: GuardianChannel }, cmd: Command) => {
       const channel = opts.channel ?? "telegram";


### PR DESCRIPTION
## Summary
- Remove SMS from CLI help text, channel listings, examples, and validation messages in integrations.ts, channels.ts, and contacts.ts
- Replace SMS examples with telegram or voice alternatives

Part of plan: rm-remaining-sms-mentions.md (PR 1 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13844" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
