### PR TITLE
fix: remove SMS from approval, notification, and memory source comments

### DIFF
--- a/assistant/src/memory/external-conversation-store.ts
+++ b/assistant/src/memory/external-conversation-store.ts
@@ -1,6 +1,6 @@
 /**
  * Store for external conversation bindings — maps internal conversation IDs
- * to external channel identifiers (e.g. Telegram chat ID, SMS thread ID).
+ * to external channel identifiers (e.g. Telegram chat ID, voice session).
  *
  * This enables the system to track which conversations originated from
  * external channels and expose channel metadata in session/conversation

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -42,7 +42,7 @@ const log = getLogger("notification-conversation-pairing");
  * Prefix applied to sourceChannel values in notification bindings so they
  * occupy a separate namespace from messaging adapter bindings in the
  * external_conversation_bindings table.  Without this, notification pairing
- * and messaging adapters (Telegram, SMS, etc.) would destructively overwrite
+ * and messaging adapters (Telegram, Slack, etc.) would destructively overwrite
  * each other's bindings since both use (sourceChannel, externalChatId) as key.
  */
 const NOTIFICATION_CHANNEL_PREFIX = "notification:";

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -95,7 +95,7 @@ function buildSystemPrompt(
     `- \`title\` and \`body\` are for native notification popups (e.g. vellum desktop/mobile) — keep them short and glanceable (title ≤ 8 words, body ≤ 2 sentences).`,
     `- \`deliveryText\` is the channel-native message for chat channels (e.g. telegram). It must read naturally as a standalone message.`,
     `  - Do not prepend mechanical labels like "Thread:".`,
-    `  - Do not mention channel or transport names (e.g. Telegram, SMS, email) unless the event context explicitly requires it.`,
+    `  - Do not mention channel or transport names (e.g. Telegram, Slack, email) unless the event context explicitly requires it.`,
     `  - Do not repeat title/body verbatim unless that repetition is truly necessary.`,
     `  - Avoid meta-send phrasing (e.g. "I'd like to send a notification", "May I go ahead with that?"). Write the recipient-facing message directly.`,
     `  - For telegram: 1-2 concise sentences.`,

--- a/assistant/src/runtime/channel-approval-parser.ts
+++ b/assistant/src/runtime/channel-approval-parser.ts
@@ -3,7 +3,7 @@
  *
  * Parses inbound user text to determine whether it matches an approval,
  * rejection, or "approve always" intent. This module is transport-agnostic
- * and can be used by any channel adapter (Telegram, SMS, etc.).
+ * and can be used by any channel adapter (Telegram, Slack, etc.).
  *
  * Both the standard and guardian approval flows now use the conversational
  * approval engine as the primary classifier. This deterministic parser is

--- a/assistant/src/runtime/channel-approval-types.ts
+++ b/assistant/src/runtime/channel-approval-types.ts
@@ -2,7 +2,7 @@
  * Channel-agnostic approval flow types.
  *
  * These types model the approval prompt/decision lifecycle for tool-use
- * confirmations surfaced through external channels (Telegram, SMS, etc.).
+ * confirmations surfaced through external channels (Telegram, Slack, etc.).
  * They are intentionally decoupled from any specific channel so that the
  * same approval flow can be reused across transports.
  */

--- a/assistant/src/runtime/channel-approvals.ts
+++ b/assistant/src/runtime/channel-approvals.ts
@@ -1,7 +1,7 @@
 /**
  * Channel-agnostic approval orchestration module.
  *
- * Bridges the gap between external channel adapters (Telegram, SMS, etc.)
+ * Bridges the gap between external channel adapters (Telegram, Slack, etc.)
  * and the pending-interactions tracker / permission system:
  *
  *   1. Detect pending confirmations for a conversation

--- a/assistant/src/runtime/channel-verification-service.ts
+++ b/assistant/src/runtime/channel-verification-service.ts
@@ -238,7 +238,7 @@ export function validateAndConsumeVerification(
   if (hasExpectedIdentity && challenge.identityBindingStatus === "bound") {
     let identityMatch = false;
 
-    // For SMS/voice: verify actorExternalUserId matches expectedPhoneE164
+    // For voice: verify actorExternalUserId matches expectedPhoneE164
     // OR actorExternalUserId matches expectedExternalUserId
     if (challenge.expectedPhoneE164 != null) {
       if (
@@ -407,7 +407,7 @@ export interface CreateOutboundSessionResult {
  * Create an outbound verification session with expected identity pre-set.
  * Returns session info including the secret for outbound delivery.
  *
- * Channels where identity is pre-bound (SMS, voice, Telegram with known
+ * Channels where identity is pre-bound (voice, Telegram with known
  * chat ID) use 6-digit numeric codes for ease of entry. Unbound bootstrap
  * sessions (e.g. Telegram handle where identity is not yet known) use
  * high-entropy 32-byte hex secrets to prevent brute-force guessing during
@@ -511,7 +511,7 @@ export function updateSessionDelivery(
 }
 
 /**
- * Count total SMS sends to a destination across all sessions within a
+ * Count total sends to a destination across all sessions within a
  * rolling time window. Prevents circumvention of per-session limits by
  * repeatedly creating new sessions to the same phone number.
  */

--- a/assistant/src/runtime/confirmation-request-guardian-bridge.ts
+++ b/assistant/src/runtime/confirmation-request-guardian-bridge.ts
@@ -3,7 +3,7 @@
  *
  * When a trusted-contact channel session creates a confirmation_request (tool approval),
  * this helper emits a guardian.question notification signal and persists canonical
- * delivery rows to guardian destinations (Telegram/SMS/Vellum), enabling the guardian
+ * delivery rows to guardian destinations (Telegram/Slack/Vellum), enabling the guardian
  * to approve via callback/request-code path.
  *
  * Modeled after the tool-grant-request-helper pattern. Designed to be called from

--- a/assistant/src/util/canonicalize-identity.ts
+++ b/assistant/src/util/canonicalize-identity.ts
@@ -5,7 +5,7 @@
  * trust lookups, member matching, and guardian binding comparisons are
  * immune to formatting variance across channels.
  *
- * Phone-like channels (sms, voice, whatsapp) normalize to E.164 using the
+ * Phone-like channels (voice, whatsapp) normalize to E.164 using the
  * existing phone utilities. Non-phone channels (telegram, slack, etc.)
  * pass through the platform-stable ID as-is after whitespace trimming.
  */


### PR DESCRIPTION
## Summary
- Update comments and JSDoc in 9 files across approvals, notifications, and memory modules to remove SMS references
- Replace SMS examples with Slack/voice/Telegram alternatives

Part of plan: rm-remaining-sms-mentions.md (PR 5 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
