### PR TITLE
fix: remove SMS from non-member, ingress, and gateway client tests

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -161,7 +161,7 @@ describe("channel-reply-delivery", () => {
 
   it("falls back to rendered.text when no non-empty textSegments exist", async () => {
     await deliverRenderedReplyViaCallback({
-      callbackUrl: "http://gateway/deliver/sms",
+      callbackUrl: "http://gateway/deliver/telegram",
       chatId: "chat-2",
       textSegments: [" ", ""],
       fallbackText: "Fallback text",

--- a/assistant/src/__tests__/gateway-client-managed-outbound.test.ts
+++ b/assistant/src/__tests__/gateway-client-managed-outbound.test.ts
@@ -138,7 +138,7 @@ describe("gateway-client managed outbound lane", () => {
 
   test("falls back to standard callback delivery for non-managed callback URL", async () => {
     await deliverChannelReply(
-      "https://gateway.test/deliver/sms",
+      "https://gateway.test/deliver/voice",
       {
         chatId: "+15550001111",
         text: "standard gateway callback",
@@ -148,7 +148,7 @@ describe("gateway-client managed outbound lane", () => {
 
     expect(calls).toHaveLength(1);
     const call = calls[0];
-    expect(call.url).toBe("https://gateway.test/deliver/sms");
+    expect(call.url).toBe("https://gateway.test/deliver/voice");
 
     const headers = call.init.headers as Record<string, string>;
     expect(headers["Content-Type"]).toBe("application/json");

--- a/assistant/src/__tests__/ingress-url-consistency.test.ts
+++ b/assistant/src/__tests__/ingress-url-consistency.test.ts
@@ -259,65 +259,6 @@ describe("Ingress URL consistency between assistant and gateway", () => {
     expect(gatewayCanonical).toBe(callbackUrl);
   });
 
-  // ── SMS-specific URL consistency ──────────────────────────────────
-
-  test("SMS webhook URL consistency: gateway signature URL matches configured ingress", () => {
-    const publicBase = "https://sms-gateway.example.com";
-    const authToken = "test-sms-auth-token";
-
-    // The gateway registers /webhooks/twilio/sms with Twilio. Twilio signs
-    // inbound SMS requests against the full public URL.
-    const smsWebhookUrl = `${publicBase}/webhooks/twilio/sms`;
-
-    const params = {
-      Body: "hello",
-      From: "+15551234567",
-      To: "+15559876543",
-      MessageSid: "SM123",
-    };
-    const twilioSignature = computeTwilioSignature(
-      smsWebhookUrl,
-      params,
-      authToken,
-    );
-
-    // Gateway receives the request on its local address and reconstructs
-    // the canonical URL using the configured ingress base.
-    const localUrl = "http://127.0.0.1:7830/webhooks/twilio/sms";
-    const canonicalUrl = reconstructGatewayCanonicalUrl(publicBase, localUrl);
-
-    expect(canonicalUrl).toBe(smsWebhookUrl);
-
-    const recomputed = computeTwilioSignature(canonicalUrl, params, authToken);
-    expect(recomputed).toBe(twilioSignature);
-  });
-
-  test("SMS webhook signature fails when ingress URL is not configured (fail-visible)", () => {
-    const publicBase = "https://sms-gateway.example.com";
-    const authToken = "test-sms-auth-token";
-
-    const smsWebhookUrl = `${publicBase}/webhooks/twilio/sms`;
-    const params = { Body: "test", From: "+15550001111", MessageSid: "SM456" };
-    const twilioSignature = computeTwilioSignature(
-      smsWebhookUrl,
-      params,
-      authToken,
-    );
-
-    // Without ingress config, the gateway uses the local URL — signature mismatch.
-    const localUrl = "http://127.0.0.1:7830/webhooks/twilio/sms";
-    const canonicalWithout = reconstructGatewayCanonicalUrl(
-      undefined,
-      localUrl,
-    );
-    const recomputedWithout = computeTwilioSignature(
-      canonicalWithout,
-      params,
-      authToken,
-    );
-    expect(recomputedWithout).not.toBe(twilioSignature);
-  });
-
   test("all Twilio webhook paths share the /webhooks/twilio/ prefix consistently", () => {
     const config: IngressConfig = {
       ingress: { publicBaseUrl: "https://consistent.example.com" },
@@ -331,10 +272,5 @@ describe("Ingress URL consistency between assistant and gateway", () => {
     // Verify they all share the same base and prefix
     expect(voiceUrl).toStartWith(`${base}/webhooks/twilio/`);
     expect(statusUrl).toStartWith(`${base}/webhooks/twilio/`);
-
-    // SMS is currently handled at the gateway level (/webhooks/twilio/sms)
-    // but the path pattern is the same
-    const smsUrl = `${base}/webhooks/twilio/sms`;
-    expect(smsUrl).toStartWith(`${base}/webhooks/twilio/`);
   });
 });

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -301,12 +301,12 @@ describe("non-member access request notification", () => {
     expect(pending[0].guardianPrincipalId).toBeDefined();
   });
 
-  test("cross-channel fallback: SMS guardian binding resolves for Telegram access request", async () => {
-    // Only an SMS guardian binding exists — no Telegram binding
+  test("cross-channel fallback: voice guardian binding resolves for Telegram access request", async () => {
+    // Only a voice guardian binding exists — no Telegram binding
     createGuardianBinding({
-      channel: "sms",
-      guardianExternalUserId: "guardian-sms-user",
-      guardianDeliveryChatId: "guardian-sms-chat",
+      channel: "voice",
+      guardianExternalUserId: "guardian-voice-user",
+      guardianDeliveryChatId: "guardian-voice-chat",
       guardianPrincipalId: "test-principal-id",
       verifiedVia: "test",
     });
@@ -324,9 +324,9 @@ describe("non-member access request notification", () => {
       string,
       unknown
     >;
-    expect(payload.guardianBindingChannel).toBe("sms");
+    expect(payload.guardianBindingChannel).toBe("voice");
 
-    // Canonical request has the SMS guardian's external user ID
+    // Canonical request has the voice guardian's external user ID
     const pending = listCanonicalGuardianRequests({
       status: "pending",
       requesterExternalUserId: "user-unknown-456",
@@ -334,7 +334,7 @@ describe("non-member access request notification", () => {
       kind: "access_request",
     });
     expect(pending.length).toBe(1);
-    expect(pending[0].guardianExternalUserId).toBe("guardian-sms-user");
+    expect(pending[0].guardianExternalUserId).toBe("guardian-voice-user");
   });
 
   test("no notification when actorExternalId is absent", async () => {
@@ -413,11 +413,11 @@ describe("access-request-helper unit tests", () => {
   });
 
   test("notifyGuardianOfAccessRequest uses cross-channel binding when source-channel binding is missing", () => {
-    // Only SMS binding exists
+    // Only voice binding exists
     createGuardianBinding({
-      channel: "sms",
-      guardianExternalUserId: "guardian-sms",
-      guardianDeliveryChatId: "sms-chat",
+      channel: "voice",
+      guardianExternalUserId: "guardian-voice",
+      guardianDeliveryChatId: "voice-chat",
       guardianPrincipalId: "test-principal-id",
       verifiedVia: "test",
     });
@@ -437,18 +437,18 @@ describe("access-request-helper unit tests", () => {
       kind: "access_request",
     });
     expect(pending.length).toBe(1);
-    expect(pending[0].guardianExternalUserId).toBe("guardian-sms");
+    expect(pending[0].guardianExternalUserId).toBe("guardian-voice");
 
     // Signal payload includes fallback channel
     const payload = emitSignalCalls[0].contextPayload as Record<
       string,
       unknown
     >;
-    expect(payload.guardianBindingChannel).toBe("sms");
+    expect(payload.guardianBindingChannel).toBe("voice");
   });
 
   test("notifyGuardianOfAccessRequest prefers source-channel binding over cross-channel fallback", () => {
-    // Both Telegram and SMS bindings exist
+    // Both Telegram and voice bindings exist
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "guardian-tg",
@@ -457,10 +457,10 @@ describe("access-request-helper unit tests", () => {
       verifiedVia: "test",
     });
     createGuardianBinding({
-      channel: "sms",
-      guardianExternalUserId: "guardian-sms",
-      guardianDeliveryChatId: "sms-chat",
-      guardianPrincipalId: "test-principal-sms",
+      channel: "voice",
+      guardianExternalUserId: "guardian-voice",
+      guardianDeliveryChatId: "voice-chat",
+      guardianPrincipalId: "test-principal-voice",
       verifiedVia: "test",
     });
 
@@ -479,7 +479,7 @@ describe("access-request-helper unit tests", () => {
       kind: "access_request",
     });
     expect(pending.length).toBe(1);
-    // Should use the Telegram binding, not SMS fallback
+    // Should use the Telegram binding, not voice fallback
     expect(pending[0].guardianExternalUserId).toBe("guardian-tg");
 
     const payload = emitSignalCalls[0].contextPayload as Record<

--- a/assistant/src/__tests__/slack-block-formatting.test.ts
+++ b/assistant/src/__tests__/slack-block-formatting.test.ts
@@ -93,7 +93,7 @@ describe("isSlackCallbackUrl", () => {
   test("returns false for managed outbound URLs", () => {
     expect(
       isSlackCallbackUrl(
-        "http://localhost:7830/v1/internal/managed-gateway/outbound-send/?route_id=r1&assistant_id=a1&source_channel=sms",
+        "http://localhost:7830/v1/internal/managed-gateway/outbound-send/?route_id=r1&assistant_id=a1&source_channel=voice",
       ),
     ).toBe(false);
   });


### PR DESCRIPTION
## Summary
- Replace SMS channel references in non-member-access-request, ingress-url-consistency, gateway-client-managed-outbound, channel-reply-delivery, and slack-block-formatting tests
- Remove or rewrite SMS webhook URL consistency tests
- Replace SMS string fixtures with voice/telegram alternatives

Part of plan: rm-remaining-sms-mentions.md (PR 9 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
