### PR TITLE
fix: remove SMS from approval, grant, and dispatch test files

### DIFF
--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -509,8 +509,8 @@ describe("channelSupportsRichApprovalUI", () => {
     expect(channelSupportsRichApprovalUI("vellum")).toBe(false);
   });
 
-  test("returns false for sms", () => {
-    expect(channelSupportsRichApprovalUI("sms")).toBe(false);
+  test("returns false for voice", () => {
+    expect(channelSupportsRichApprovalUI("voice")).toBe(false);
   });
 
   test("returns true for slack", () => {

--- a/assistant/src/__tests__/guardian-dispatch.test.ts
+++ b/assistant/src/__tests__/guardian-dispatch.test.ts
@@ -28,13 +28,13 @@ mock.module("../util/logger.js", () => ({
 }));
 
 let mockTelegramBinding: unknown = null;
-let mockSmsBinding: unknown = null;
+let mockVoiceBinding: unknown = null;
 let mockVellumBinding: unknown = null;
 
 mock.module("../memory/channel-guardian-store.js", () => ({
   getActiveBinding: (_assistantId: string, channel: string) => {
     if (channel === "telegram") return mockTelegramBinding;
-    if (channel === "sms") return mockSmsBinding;
+    if (channel === "voice") return mockVoiceBinding;
     if (channel === "vellum") return mockVellumBinding;
     return null;
   },
@@ -139,7 +139,7 @@ function resetTables(): void {
   db.run("DELETE FROM conversations");
 
   mockTelegramBinding = null;
-  mockSmsBinding = null;
+  mockVoiceBinding = null;
   // Pre-seed vellum binding so the self-healing path in dispatchGuardianQuestion
   // never triggers (avoids UNIQUE constraint violations on repeated dispatches).
   mockVellumBinding = {

--- a/assistant/src/__tests__/guardian-verification-intent-routing.test.ts
+++ b/assistant/src/__tests__/guardian-verification-intent-routing.test.ts
@@ -139,14 +139,14 @@ describe("slash commands are never intercepted", () => {
 // =====================================================================
 
 describe("channel hint extraction", () => {
-  test("SMS phrases still trigger setup but without SMS channel hint", () => {
+  test("unsupported channel keyword triggers setup but yields no channel hint", () => {
     const result = resolveGuardianVerificationIntent(
-      "set me as guardian for SMS",
+      "set me as guardian for text",
     );
     expect(result.kind).toBe("direct_setup");
     if (result.kind === "direct_setup") {
-      // SMS is no longer a supported channel; the intent still matches on
-      // the guardian setup pattern but no channel hint is extracted.
+      // "text" matches the guardian setup pattern but is not a supported
+      // channel, so no channel hint is extracted.
       expect(result.channelHint).toBeUndefined();
     }
   });

--- a/assistant/src/__tests__/scoped-approval-grants.test.ts
+++ b/assistant/src/__tests__/scoped-approval-grants.test.ts
@@ -246,7 +246,7 @@ describe("scoped-approval-grants / tool_signature scope", () => {
       toolName: "bash",
       inputDigest: digest,
       consumingRequestId: "c1",
-      executionChannel: "sms",
+      executionChannel: "voice",
     });
     expect(wrong.ok).toBe(false);
 
@@ -275,7 +275,7 @@ describe("scoped-approval-grants / tool_signature scope", () => {
       toolName: "bash",
       inputDigest: digest,
       consumingRequestId: "c1",
-      executionChannel: "sms",
+      executionChannel: "voice",
     });
     expect(result.ok).toBe(true);
   });
@@ -367,7 +367,7 @@ describe("scoped-approval-grants / tool_signature scope", () => {
       toolName: "bash",
       inputDigest: digest,
       consumingRequestId: "c2",
-      executionChannel: "sms",
+      executionChannel: "voice",
     });
     expect(second.ok).toBe(true);
     expect(second.grant!.id).toBe(wildcardGrant.id);

--- a/assistant/src/__tests__/scoped-grant-security-matrix.test.ts
+++ b/assistant/src/__tests__/scoped-grant-security-matrix.test.ts
@@ -360,7 +360,7 @@ describe("security matrix: cross-scope invariants", () => {
         toolName: "bash",
         inputDigest: digest,
         consumingRequestId: "c-chan",
-        executionChannel: "sms",
+        executionChannel: "voice",
         conversationId: "conv-123",
         callSessionId: "call-456",
         requesterExternalUserId: "user-alice",


### PR DESCRIPTION
## Summary
- Replace SMS channel references in scoped-approval-grants, scoped-grant-security-matrix, channel-approvals, guardian-dispatch, guardian-verification-intent-routing tests
- Update test names, variables, and assertions to use voice/telegram alternatives
- Note: guardian-control-plane-policy.test.ts does not exist in this repo

Part of plan: rm-remaining-sms-mentions.md (PR 10 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
