### PR TITLE
fix: remove SMS from gateway enforcement, twilio routes, and readiness tests

### DIFF
--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -217,7 +217,7 @@ describe("ChannelReadinessService", () => {
   });
 
   test("invalidateAll clears all cached snapshots", async () => {
-    const smsProbe = makeProbe(
+    const voiceProbe = makeProbe(
       "voice",
       [{ name: "creds", passed: true, message: "ok" }],
       [{ name: "api", passed: true, message: "ok" }],
@@ -227,17 +227,17 @@ describe("ChannelReadinessService", () => {
       [{ name: "token", passed: true, message: "ok" }],
       [{ name: "webhook", passed: true, message: "ok" }],
     );
-    service.registerProbe(smsProbe);
+    service.registerProbe(voiceProbe);
     service.registerProbe(telegramProbe);
 
     await service.getReadiness(undefined, true);
-    expect(smsProbe.remoteCallCount).toBe(1);
+    expect(voiceProbe.remoteCallCount).toBe(1);
     expect(telegramProbe.remoteCallCount).toBe(1);
 
     service.invalidateAll();
 
     await service.getReadiness(undefined, true);
-    expect(smsProbe.remoteCallCount).toBe(2);
+    expect(voiceProbe.remoteCallCount).toBe(2);
     expect(telegramProbe.remoteCallCount).toBe(2);
   });
 

--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -357,33 +357,6 @@ describe("gateway-only ingress enforcement", () => {
       };
       expect(body.error.code).toBe("GONE");
     });
-
-    test("POST /webhooks/twilio/sms returns 410", async () => {
-      const res = await fetch(`http://127.0.0.1:${port}/webhooks/twilio/sms`, {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: makeFormBody({ MessageSid: "SM123", AccountSid: "AC_test" }),
-      });
-      expect(res.status).toBe(410);
-      const body = (await res.json()) as {
-        error: { code: string; message: string };
-      };
-      expect(body.error.code).toBe("GONE");
-      expect(body.error.message).toContain("Direct webhook access disabled");
-    });
-
-    test("POST /v1/calls/twilio/sms returns 410", async () => {
-      const res = await fetch(`http://127.0.0.1:${port}/v1/calls/twilio/sms`, {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: makeFormBody({ MessageSid: "SM123", AccountSid: "AC_test" }),
-      });
-      expect(res.status).toBe(410);
-      const body = (await res.json()) as {
-        error: { code: string; message: string };
-      };
-      expect(body.error.code).toBe("GONE");
-    });
   });
 
   // ── Internal forwarding routes still work ─────

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -249,7 +249,6 @@ mock.module("../calls/twilio-rest.js", () => ({
     urls: {
       voiceUrl: string;
       statusCallbackUrl: string;
-      smsUrl: string;
     },
   ) => {
     updatePhoneNumberWebhookCalls.push({


### PR DESCRIPTION
## Summary
- Remove SMS webhook route enforcement tests in gateway-only-enforcement.test.ts (routes no longer exist)
- Clean up smsUrl from mock type in twilio-routes.test.ts
- Rename smsProbe to voiceProbe in channel-readiness-service.test.ts

Part of plan: rm-remaining-sms-mentions.md (PR 12 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
