### PR TITLE
fix: remove SMS from contacts and messaging SKILL.md

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: true
 metadata: { "vellum": { "emoji": "\ud83d\udc65" } }
 ---
 
-Manage the user's contacts, relationship graph, access control (trusted contacts), and invite links. This skill covers contact CRUD with multi-channel tracking, controlling who can message the assistant through external channels (Telegram, SMS, voice), and creating/managing invite links that grant access.
+Manage the user's contacts, relationship graph, access control (trusted contacts), and invite links. This skill covers contact CRUD with multi-channel tracking, controlling who can message the assistant through external channels (Telegram, voice), and creating/managing invite links that grant access.
 
 ## Prerequisites
 
@@ -67,14 +67,14 @@ assistant contacts merge <surviving_contact_id> <donor_contact_id> --json
 
 ## Access Control (Trusted Contacts)
 
-Trusted contacts control who is allowed to send messages to the assistant through external channels like Telegram, SMS, and voice (phone calls).
+Trusted contacts control who is allowed to send messages to the assistant through external channels like Telegram and voice (phone calls).
 
 ### Concepts
 
 - **Contact channel**: A user identity (external user ID or chat ID) on a specific messaging platform, stored as an entry in a contact's `channels` array. Each channel entry has its own `status` and `policy`.
 - **Policy**: Controls what the contact channel can do -- `allow` (can message freely) or `deny` (blocked from messaging).
 - **Status**: The channel's lifecycle state -- `active` (currently effective), `revoked` (access removed), or `blocked` (explicitly denied).
-- **Channel type**: The messaging platform (e.g., `telegram`, `sms`, `voice`).
+- **Channel type**: The messaging platform (e.g., `telegram`, `voice`).
 
 ### List trusted contacts
 
@@ -103,7 +103,7 @@ The response contains `{ ok: true, contacts: [...] }` where each contact has:
 - `displayName` -- human-readable name
 - `channels` -- array of channel entries, each with:
   - `id` -- channel ID (needed for status/policy changes)
-  - `channel` -- the channel type (e.g., `telegram`, `sms`, `voice`)
+  - `channel` -- the channel type (e.g., `telegram`, `voice`)
   - `externalUserId` -- the user's ID on that channel
   - `externalChatId` -- the chat ID on that channel
   - `displayName` -- channel-specific display name
@@ -128,13 +128,13 @@ Required flags:
 
 - `--display-name` -- human-readable name for the contact
 - `--channels` -- at least one channel entry with:
-  - `type` -- the channel type (e.g., `telegram`, `sms`)
+  - `type` -- the channel type (e.g., `telegram`)
   - `address` -- the channel-specific identifier
   - `externalUserId` -- the user's ID on that channel (or `externalChatId` for chat-based channels)
   - `status` -- set to `"active"` for immediate access
   - `policy` -- set to `"allow"` to grant messaging access
 
-If the user provides a name but not an external ID, explain that you need the channel-specific user ID or chat ID to create the contact entry. For Telegram, this is a numeric user ID; for SMS, this is the phone number in E.164 format.
+If the user provides a name but not an external ID, explain that you need the channel-specific user ID or chat ID to create the contact entry. For Telegram, this is a numeric user ID.
 
 ### Revoke a user (remove access)
 
@@ -174,7 +174,7 @@ assistant channels readiness --json
 
 The response contains `{ success: true, snapshots: [...] }` where each snapshot has:
 
-- `channel` -- the channel type (e.g., `telegram`, `email`, `whatsapp`, `sms`, `slack`, `voice`)
+- `channel` -- the channel type (e.g., `telegram`, `email`, `whatsapp`, `slack`, `voice`)
 - `ready` -- boolean indicating whether the channel is fully operational
 - `checkedAt` -- timestamp (ms since epoch) of when readiness was evaluated
 - `stale` -- boolean indicating whether cached remote check data is outdated
@@ -187,7 +187,7 @@ If the target channel's `ready` field is `false`, do **not** create the invite. 
 
 ## Invite Links
 
-Invite links let the guardian share a link or code that automatically grants access when used. Telegram invites use a deep link; voice invites use a phone number + numeric code; email, WhatsApp, SMS, and Slack invites use a 6-digit code that the invitee sends to the assistant on the respective channel.
+Invite links let the guardian share a link or code that automatically grants access when used. Telegram invites use a deep link; voice invites use a phone number + numeric code; email, WhatsApp, and Slack invites use a 6-digit code that the invitee sends to the assistant on the respective channel.
 
 ### Create a Telegram invite link
 
@@ -366,20 +366,6 @@ If `channelHandle` is absent, present the invite code and tell the guardian to s
 
 If the assistant's WhatsApp integration is not configured at all (Meta WhatsApp Business API credentials missing), tell the guardian they need to set up WhatsApp integration first.
 
-### Create an SMS invite
-
-Use this when the guardian wants to invite someone to message the assistant via SMS. SMS invites use a 6-digit code — the invitee texts the code to the assistant's phone number to redeem access.
-
-**Before creating the invite**, check channel readiness (see [Channel Readiness](#channel-readiness)). If the `sms` channel is not ready, tell the guardian what prerequisites are missing instead of creating an unusable invite.
-
-```bash
-assistant contacts invites create --source-channel sms --contact-name "<invitee_name>" --max-uses 1 --note "<optional note, e.g. the person it is for>" --json
-```
-
-The response follows the same shape as email and WhatsApp invites (`inviteCode`, `guardianInstruction`, `channelHandle`).
-
-**Presenting to the guardian**: Give the guardian the invite code and the assistant's phone number, with instructions for the invitee to text the code.
-
 ### Create a Slack invite
 
 Use this when the guardian wants to invite someone to message the assistant on Slack. Slack invites use a 6-digit code -- the invitee sends the code as a direct message to the assistant's Slack bot to redeem access.
@@ -390,7 +376,7 @@ Use this when the guardian wants to invite someone to message the assistant on S
 assistant contacts invites create --source-channel slack --contact-name "<invitee_name>" --max-uses 1 --note "<optional note, e.g. the person it is for>" --json
 ```
 
-The response follows the same shape as email, WhatsApp, and SMS invites (`inviteCode`, `guardianInstruction`, `channelHandle`).
+The response follows the same shape as email and WhatsApp invites (`inviteCode`, `guardianInstruction`, `channelHandle`).
 
 **Presenting to the guardian**: Give the guardian the invite code and instructions for the invitee to send the code as a DM to the assistant's Slack bot.
 
@@ -418,18 +404,17 @@ For voice invites:
 assistant contacts invites list --source-channel voice --json
 ```
 
-For email, WhatsApp, SMS, or Slack invites:
+For email, WhatsApp, or Slack invites:
 
 ```bash
 assistant contacts invites list --source-channel email --json
 assistant contacts invites list --source-channel whatsapp --json
-assistant contacts invites list --source-channel sms --json
 assistant contacts invites list --source-channel slack --json
 ```
 
 Optional query parameters:
 
-- `--source-channel` -- filter by channel (e.g., `telegram`, `voice`, `email`, `whatsapp`, `sms`, `slack`)
+- `--source-channel` -- filter by channel (e.g., `telegram`, `voice`, `email`, `whatsapp`, `slack`)
 - `--status` -- filter by status (`active`, `revoked`, `redeemed`, `expired`)
 
 The response contains `{ ok: true, invites: [...] }` where each invite has:
@@ -484,7 +469,7 @@ Each channel has:
 
 ## Confirmation Requirements
 
-**All mutating actions (allow, revoke, block, revoke invite) require explicit user confirmation before execution.** This is a safety measure -- modifying who can access the assistant should always be a deliberate choice. Creating an invite (Telegram link, voice invite, email invite, WhatsApp invite, SMS invite, or Slack invite) does not require confirmation since it does not grant access until the invitee redeems it.
+**All mutating actions (allow, revoke, block, revoke invite) require explicit user confirmation before execution.** This is a safety measure -- modifying who can access the assistant should always be a deliberate choice. Creating an invite (Telegram link, voice invite, email invite, WhatsApp invite, or Slack invite) does not require confirmation since it does not grant access until the invitee redeems it.
 
 - Clearly state what action you are about to take and who it affects.
 - Wait for the user to confirm before running the command.
@@ -528,8 +513,6 @@ Each channel has:
 **"Invite someone by email"** / **"Send an email invite"** -- Create an invite with `assistant contacts invites create --source-channel email`. Present the 6-digit invite code and the assistant's email address. Tell the guardian to share both with the invitee.
 
 **"Invite someone on WhatsApp"** -- Create an invite with `assistant contacts invites create --source-channel whatsapp`. Present the 6-digit invite code. If `channelHandle` is returned, also present the assistant's WhatsApp number; otherwise, tell the guardian to share the code and instruct the invitee to send it to the assistant on WhatsApp.
-
-**"Invite someone via SMS"** / **"Send a text invite"** -- Create an invite with `assistant contacts invites create --source-channel sms`. Present the 6-digit invite code and the assistant's phone number. Tell the guardian to share both with the invitee.
 
 **"Invite someone on Slack"** -- Create an invite with `assistant contacts invites create --source-channel slack`. Present the 6-digit invite code and tell the guardian to have the invitee DM the code to the assistant's Slack bot.
 

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -75,15 +75,6 @@ The telegram-setup skill handles: verifying the bot token from @BotFather, gener
 
 The telegram-setup skill also includes **guardian verification**, which links your Telegram account as the trusted guardian for the bot.
 
-### SMS (Twilio)
-
-SMS messaging uses Twilio as the telephony provider. Twilio credentials and phone number configuration are shared with the **phone-calls** skill. Load the **sms-setup** skill for complete SMS configuration including compliance and testing:
-
-- Call `skill_load` with `skill: "sms-setup"` to load the dependency skill.
-- Tell the user: _"I've loaded the SMS setup guide. It will walk you through configuring Twilio, handling compliance requirements, and testing SMS delivery."_
-
-The sms-setup skill handles: Twilio credential storage (Account SID + Auth Token), phone number provisioning or assignment, public ingress setup, SMS compliance verification, and end-to-end test sending. Once SMS is set up, messaging is available automatically — no additional feature flag is needed.
-
 ### Guardian Verification (Voice or Telegram)
 
 If the user asks to verify their guardian identity for voice or Telegram, load the **guardian-verify-setup** skill:
@@ -137,24 +128,6 @@ Telegram is supported as a messaging provider with limited capabilities compared
 
 - The bot can only message users or groups that have previously interacted with it (sent `/start` or been added to a group). Bots cannot initiate conversations with arbitrary phone numbers.
 - Future support for MTProto user-account sessions may lift some of these restrictions.
-
-### SMS (Twilio)
-
-SMS is supported as a messaging provider with limited capabilities. The conversation ID is the recipient's phone number in E.164 format (e.g. `+14155551234`):
-
-- **Send**: Send an SMS to a phone number (high risk — requires user approval)
-- **Auth Test**: Verify Twilio credentials and show the configured phone number
-
-**Not available** (SMS limitations):
-
-- List conversations — SMS is stateless; there is no API to enumerate past conversations
-- Read message history — message history is not available through the gateway
-- Search messages — no search API is available for SMS
-
-**SMS limits:**
-
-- Outbound SMS uses the assistant's configured Twilio phone number as the sender. The phone number must be provisioned and assigned via the twilio-setup skill.
-- SMS messages are subject to Twilio's character limits and carrier filtering. Long messages may be split into multiple segments.
 
 ### Slack-specific
 
@@ -247,7 +220,7 @@ Gmail uses a **draft-first workflow**. All compose and reply tools create Gmail 
 
 **Reply-all**: `messaging_reply` for Gmail automatically builds the reply-all recipient list from the thread. You do not need to manually look up recipients.
 
-Non-Gmail platforms (Slack, Telegram, SMS) send directly via `messaging_send` / `messaging_reply`.
+Non-Gmail platforms (Slack, Telegram) send directly via `messaging_send` / `messaging_reply`.
 
 ## Email Threading (Gmail)
 
@@ -267,7 +240,7 @@ Before composing any email that references a date or time:
 ## Notifications vs Messages
 
 - `send_notification` is provided by the **notifications** skill (always active) -- use it when the user asks for an alert/notification (for example "send this as a desktop notification").
-- Use `messaging_send` when the user asks to send a message into a specific chat/email/SMS destination.
+- Use `messaging_send` when the user asks to send a message into a specific chat/email destination.
 - `send_notification` channel routing is LLM-driven; `preferred_channels` are hints, not hard channel forcing.
 
 ## Personalized Drafting


### PR DESCRIPTION
## Summary
- Remove all SMS references from contacts/SKILL.md including channel listings, invite sections, and examples
- Remove SMS setup and capabilities sections from messaging/SKILL.md
- Update documentation to accurately reflect current supported channels

Part of plan: rm-remaining-sms-mentions.md (PR 13 of 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
