### PR TITLE
fix(ios): fix VBadge accessibility and unread dot color consistency (PR 13725 feedback)

### DIFF
--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -569,7 +569,7 @@ struct ThreadListView: View {
                                 .accessibilityLabel("Pinned")
                         }
                         if scheduleGroupHasUnread(group) {
-                            VBadge(style: .dot, color: VColor.accent)
+                            VBadge(style: .dot, color: VColor.warning)
                                 .accessibilityLabel("Unread")
                         }
                         Text("\(group.threads.count)")
@@ -609,7 +609,7 @@ struct ThreadListView: View {
                         .accessibilityLabel("Pinned")
                 }
                 if store.isConnectedMode && thread.hasUnseenLatestAssistantMessage {
-                    VBadge(style: .dot, color: VColor.accent)
+                    VBadge(style: .dot, color: VColor.warning)
                         .accessibilityLabel("Unread")
                 }
                 Spacer()

--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/SidebarThreadItem.swift
@@ -80,9 +80,8 @@ struct SidebarThreadItem: View {
                             .transition(.opacity)
                     case .idle:
                         if thread.hasUnseenLatestAssistantMessage {
-                            Circle()
-                                .fill(Color(hex: 0xE86B40))
-                                .frame(width: 6, height: 6)
+                            VBadge(style: .dot, color: VColor.warning)
+                                .accessibilityLabel("Unread")
                                 .frame(width: 20, height: 20)
                                 .transition(.opacity)
                         } else if thread.isPinned {

--- a/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
+++ b/clients/shared/DesignSystem/Core/Feedback/VBadge.swift
@@ -31,7 +31,6 @@ public struct VBadge: View {
             Circle()
                 .fill(color)
                 .frame(width: 8, height: 8)
-                .accessibilityHidden(true)
 
         case .label(let text):
             Text(text)


### PR DESCRIPTION
Addresses Devin feedback on PR #13725:

- Remove `.accessibilityHidden(true)` from VBadge `.dot` style so callers can attach `.accessibilityLabel`
- Change iOS unread dots from `VColor.accent` (violet) to `VColor.warning` (amber/orange) to match macOS
- Replace macOS raw `Circle()`+hardcoded orange with `VBadge(style: .dot, color: VColor.warning)` for consistency
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
