### PR TITLE
fix(macos): clear pendingAttentionOverrides on mark-all-seen undo (PR 13817 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1241,6 +1241,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         for id in threadIds {
             if let idx = threads.firstIndex(where: { $0.id == id }) {
                 threads[idx].hasUnseenLatestAssistantMessage = true
+                threads[idx].lastSeenAssistantMessageAt = nil
+                if let sessionId = threads[idx].sessionId {
+                    pendingAttentionOverrides.removeValue(forKey: sessionId)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- `restoreUnseen()` now rolls back `pendingAttentionOverrides` and `lastSeenAssistantMessageAt` set by `markAllThreadsSeen()`
- Prevents stale `.seen` overrides from silently re-applying seen state after the user clicks Undo

Addresses Codex/Devin feedback on PR #13817.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
