### PR TITLE
fix: restore prettier formatting in sleep.test.ts (PR 13808 feedback)

### DIFF
--- a/cli/src/__tests__/sleep.test.ts
+++ b/cli/src/__tests__/sleep.test.ts
@@ -62,8 +62,8 @@ function writeLockfile(): void {
         activeAssistant: "sleep-test",
       },
       null,
-      2
-    )
+      2,
+    ),
   );
 }
 
@@ -81,8 +81,8 @@ function writeLeaseFile(callSessionIds: string[]): void {
         })),
       },
       null,
-      2
-    )
+      2,
+    ),
   );
 }
 
@@ -115,12 +115,12 @@ describe("sleep command", () => {
       throw new Error(`process.exit:${code}`);
     });
     const originalExit = process.exit;
-    process.exit = (exitMock as unknown) as typeof process.exit;
+    process.exit = exitMock as unknown as typeof process.exit;
 
     try {
       await expect(sleep()).rejects.toThrow("process.exit:1");
       expect(consoleError).toHaveBeenCalledWith(
-        expect.stringContaining("vellum sleep --force")
+        expect.stringContaining("vellum sleep --force"),
       );
     } finally {
       process.exit = originalExit;
@@ -163,14 +163,14 @@ describe("sleep command", () => {
       1,
       join(assistantRootDir, "vellum.pid"),
       "assistant",
-      [join(assistantRootDir, "vellum.sock")]
+      [join(assistantRootDir, "vellum.sock")],
     );
     expect(stopProcessByPidFileMock).toHaveBeenNthCalledWith(
       2,
       join(assistantRootDir, "gateway.pid"),
       "gateway",
       undefined,
-      7000
+      7000,
     );
   });
 });


### PR DESCRIPTION
Addresses Devin review feedback on PR #13808: restores trailing commas and cast formatting to match Prettier v3 defaults. The Codex feedback about duplicate callback events was already addressed in the merged PR via the beforeLeaseSync callback pattern.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
