### PR TITLE
fix(macos): preserve pre-session renames in thread creation (PR 13712 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -217,7 +217,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         let threadId = thread.id
         viewModel.onFirstUserMessage = { [weak self] _ in
             self?.completedConversationCount += 1
-            self?.updateThreadTitle(id: threadId, title: "Untitled")
+            // Only set "Untitled" if the user hasn't already renamed this thread.
+            if self?.pendingRenames[threadId] == nil {
+                self?.updateThreadTitle(id: threadId, title: "Untitled")
+            }
             self?.updateLastInteracted(threadId: threadId)
         }
         threads.insert(thread, at: 0)
@@ -303,7 +306,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         if !fromUserSend {
             viewModel.onFirstUserMessage = { [weak self] _ in
                 self?.completedConversationCount += 1
-                self?.updateThreadTitle(id: threadId, title: "Untitled")
+                // Only set "Untitled" if the user hasn't already renamed this thread.
+                if self?.pendingRenames[threadId] == nil {
+                    self?.updateThreadTitle(id: threadId, title: "Untitled")
+                }
                 self?.updateLastInteracted(threadId: threadId)
             }
         }
@@ -323,7 +329,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         let threadId = thread.id
         viewModel.onFirstUserMessage = { [weak self] _ in
             self?.completedConversationCount += 1
-            self?.updateThreadTitle(id: threadId, title: "Untitled")
+            // Only set "Untitled" if the user hasn't already renamed this thread.
+            if self?.pendingRenames[threadId] == nil {
+                self?.updateThreadTitle(id: threadId, title: "Untitled")
+            }
             self?.updateLastInteracted(threadId: threadId)
         }
         threads.insert(thread, at: 0)


### PR DESCRIPTION
## Summary
- Addresses Codex feedback on PR #13712: prevent pre-session thread renames from being silently overwritten
- When a user renames a thread before a session is assigned, the title is queued in `pendingRenames`. Previously, `onFirstUserMessage` would unconditionally set the title to "Untitled", overwriting the user's rename
- Now checks `pendingRenames` before setting "Untitled" — if a rename is pending, the user's title is preserved

## Test plan
- [ ] Rename a thread before sending any message, then send a message — title should be preserved
- [ ] Create a new thread and send a message without renaming — title should still default to "Untitled"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13858" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
