### PR TITLE
fix: remove dead BASE_DATA_DIR fallback and add trailing-slash test (PR 13814 feedback)

### DIFF
--- a/assistant/src/__tests__/local-gateway-health.test.ts
+++ b/assistant/src/__tests__/local-gateway-health.test.ts
@@ -179,4 +179,31 @@ describe("local gateway health", () => {
     expect(wakeCalled).toBe(true);
     expect(result.recovered).toBe(true);
   });
+
+  test("ensureLocalGatewayReady handles BASE_DATA_DIR with trailing slash", async () => {
+    mockBaseDataDir = "/home/user/.local/share/vellum/assistants/alice/";
+    mockLockfile = null;
+
+    const healthStatuses = [503, 200];
+    const fetchImpl: typeof fetch = (async (): Promise<Response> => {
+      const status = healthStatuses.shift() ?? 200;
+      return new Response(status === 200 ? "ok" : "unavailable", { status });
+    }) as unknown as typeof fetch;
+
+    let wakeCalled = false;
+    const result = await ensureLocalGatewayReady({
+      fetchImpl,
+      timeoutMs: 50,
+      pollTimeoutMs: 100,
+      pollIntervalMs: 0,
+      sleepImpl: async () => {},
+      runWakeCommand: async () => {
+        wakeCalled = true;
+        return { exitCode: 0, stdout: "Wake complete.", stderr: "" };
+      },
+    });
+
+    expect(wakeCalled).toBe(true);
+    expect(result.recovered).toBe(true);
+  });
 });

--- a/assistant/src/runtime/local-gateway-health.ts
+++ b/assistant/src/runtime/local-gateway-health.ts
@@ -111,19 +111,6 @@ function resolveLocalAssistantName(): string | undefined {
     return latestAssistant.assistantId.trim();
   }
 
-  // Fallback for named instances: when BASE_DATA_DIR points to an instance
-  // directory (e.g. ~/.local/share/vellum/assistants/<name>), derive the name
-  // so vellum wake gets the correct target. Without this, vellum wake exits
-  // with "No local assistant found" for named instances when the lockfile
-  // lacks assistantId (e.g. before first hatch or during early startup).
-  const baseDir = getBaseDataDir();
-  if (baseDir) {
-    const match = baseDir.match(/[/]assistants[/]([^/]+)$/);
-    if (match && match[1].trim().length > 0) {
-      return match[1].trim();
-    }
-  }
-
   return undefined;
 }
 


### PR DESCRIPTION
Addresses Devin feedback on PR #13814:

- The duplicate fallback block in resolveLocalAssistantName that used the buggy regex (no trailing slash handling) was dead code — resolveInstanceNameFromBaseDataDir already handles this case with proper normalization. Removed the dead code.
- Added test for BASE_DATA_DIR with trailing slash to confirm the existing normalization works correctly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13860" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
