### PR TITLE
fix(macos): align usage dashboard group column sizing (PR 13822 feedback)

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/UsageDashboardPanel.swift
@@ -234,7 +234,7 @@ struct UsageDashboardPanel: View {
             Text(entry.group)
                 .font(VFont.captionMedium)
                 .foregroundColor(VColor.textPrimary)
-                .frame(minWidth: 130, maxWidth: .infinity, alignment: .leading)
+                .frame(width: 130, alignment: .leading)
                 .lineLimit(1)
             Text(UsageFormatting.formatBreakdownSummary(entry))
                 .font(VFont.small)


### PR DESCRIPTION
Addresses Codex/Devin feedback on PR #13822: fix header/data row column width misalignment in usage dashboard breakdown table by reverting the data row Group column back to fixed `width: 130` to match the header row.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
