### PR TITLE
fix: regenerate IPC Swift types after SMS removal

### DIFF
--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -685,7 +685,7 @@ public struct IPCChannelVerificationSessionRequest: Codable, Sendable {
     public let channel: String?
     public let sessionId: String?
     public let rebind: Bool?
-    /// E.164 phone number for SMS/voice, Telegram handle/chat-id. Used by outbound actions.
+    /// E.164 phone number for voice, Telegram handle/chat-id. Used by outbound actions.
     public let destination: String?
     /// Origin conversation ID so completion/failure pointers can route back.
     public let originConversationId: String?
@@ -715,7 +715,7 @@ public struct IPCChannelVerificationSessionResponse: Codable, Sendable {
     /// Present when action is 'status'.
     public let bound: Bool?
     public let guardianExternalUserId: String?
-    /// The channel this status pertains to (e.g. "telegram", "sms"). Present when action is 'status'.
+    /// The channel this status pertains to (e.g. "telegram", "voice"). Present when action is 'status'.
     public let channel: String?
     /// The assistant ID scoped to this status. Present when action is 'status'.
     public let assistantId: String?
@@ -736,7 +736,7 @@ public struct IPCChannelVerificationSessionResponse: Codable, Sendable {
     public let expiresAt: Int?
     /// Epoch ms after which a resend is allowed.
     public let nextResendAt: Int?
-    /// Number of SMS sends for this session.
+    /// Number of sends for this session.
     public let sendCount: Int?
     /// Telegram deep-link URL for bootstrap (M3 placeholder).
     public let telegramBootstrapUrl: String?


### PR DESCRIPTION
## Summary
- Regenerate `IPCContractGenerated.swift` to pick up comment changes from the SMS removal PRs
- Only doc comment updates (no behavioral changes)

## Original prompt
Fix type checking: https://github.com/vellum-ai/vellum-assistant/actions/runs/22791206294/job/66117968349

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
