### PR TITLE
fix: allow explicit open to clear unread override and add macOS guard (PR 13819 feedback)

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -684,14 +684,16 @@ class IOSThreadStore: ObservableObject {
     }
 
     /// Mark a connected conversation as seen when the user explicitly opens it.
-    /// Skips when the thread has a pending .unread override (user chose "Mark as unread")
-    /// so we don't immediately revert the user's explicit unread action.
+    /// If the thread has a pending .unread override (user chose "Mark as unread"),
+    /// opening the thread clears that override so the normal seen flow proceeds.
     func markConversationSeenIfNeeded(threadId: UUID) {
         guard isConnectedMode,
               let idx = threads.firstIndex(where: { $0.id == threadId }),
               let sessionId = threads[idx].sessionId,
               threads[idx].hasUnseenLatestAssistantMessage else { return }
-        if case .unread = pendingAttentionOverrides[sessionId] { return }
+        if case .unread = pendingAttentionOverrides[sessionId] {
+            pendingAttentionOverrides.removeValue(forKey: sessionId)
+        }
 
         pendingAttentionOverrides[sessionId] = .seen(
             latestAssistantMessageAt: threads[idx].latestAssistantMessageAt

--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1108,6 +1108,12 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
     /// guard would skip the signal.
     internal func markConversationSeen(threadId: UUID) {
         guard let idx = threads.firstIndex(where: { $0.id == threadId }) else { return }
+        // If the thread has a pending .unread override, opening the thread clears it
+        // so the normal seen flow proceeds rather than leaving the thread stuck as unread.
+        if let sessionId = threads[idx].sessionId,
+           case .unread = pendingAttentionOverrides[sessionId] {
+            pendingAttentionOverrides.removeValue(forKey: sessionId)
+        }
         threads[idx].hasUnseenLatestAssistantMessage = false
         if let sessionId = threads[idx].sessionId {
             pendingAttentionOverrides[sessionId] = .seen(


### PR DESCRIPTION
Addresses Codex/Devin feedback on PR #13819: let explicit thread open clear user-forced unread state, and add matching guard to macOS markConversationSeen.

## Changes

**iOS (`IOSThreadStore.swift`)**: Changed the `.unread` override guard in `markConversationSeenIfNeeded` from an early return to clearing the override. Previously, if a user marked a thread as unread, reopening it would not clear the unread state because the guard blocked all seen updates. Now, explicitly opening the thread removes the `.unread` override and proceeds with the normal seen flow.

**macOS (`ThreadManager.swift`)**: Added the same `.unread` override clearing logic to `markConversationSeen`. This was missing entirely on macOS, meaning `selectThread`, `activateThread`, and `markActiveThreadSeenIfNeeded` would unconditionally overwrite a user's unread action with `.seen`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
