### PR TITLE
fix: use non-tautological locale-safe assertions in usage dashboard tests (PR 13830 feedback)

### DIFF
--- a/clients/ios/Tests/UsageDashboardViewTests.swift
+++ b/clients/ios/Tests/UsageDashboardViewTests.swift
@@ -102,15 +102,7 @@ final class UsageDashboardViewTests: XCTestCase {
             XCTAssertEqual(breakdown.breakdown[0].totalCacheCreationTokens, 120)
             XCTAssertEqual(breakdown.breakdown[0].totalCacheReadTokens, 9_876)
             let entry = breakdown.breakdown[0]
-            let expectedSummary = UsageFormatting.formatBreakdownSummary(UsageGroupBreakdownEntry(
-                group: "claude-sonnet-4-20250514",
-                totalInputTokens: 700,
-                totalOutputTokens: 350,
-                totalCacheCreationTokens: 120,
-                totalCacheReadTokens: 9_876,
-                totalEstimatedCostUsd: 0.003,
-                eventCount: 2
-            ))
+            let expectedSummary = "\(UsageFormatting.formatCount(700)) direct / \(UsageFormatting.formatCount(120)) cache created / \(UsageFormatting.formatCount(9_876)) cache read / \(UsageFormatting.formatCount(350)) out"
             XCTAssertEqual(UsageFormatting.formatBreakdownSummary(entry), expectedSummary)
         } else {
             XCTFail("Expected breakdownState to be .loaded, got \(populatedStore.breakdownState)")

--- a/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
+++ b/clients/macos/vellum-assistantTests/UsageDashboardStoreTests.swift
@@ -587,7 +587,7 @@ struct UsageDashboardStorePresentationTests {
         #expect(UsageFormatting.directInputTokensLabel == "Direct Input Tokens")
         #expect(
             UsageFormatting.formatBreakdownSummary(entry)
-                == "1,234 direct / 78 cache created / 9,876 cache read / 56 out"
+                == "\(UsageFormatting.formatCount(1_234)) direct / \(UsageFormatting.formatCount(78)) cache created / \(UsageFormatting.formatCount(9_876)) cache read / \(UsageFormatting.formatCount(56)) out"
         )
     }
 }


### PR DESCRIPTION
Addresses Codex/Devin feedback on PR #13830: replace self-referential test assertion with independent expected value using formatCount() for locale-safe numeric formatting while keeping hardcoded labels/structure. Also fixes the same locale-sensitivity issue in the macOS test.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
