### PR TITLE
fix: correct execution channel value in scoped grant security matrix test

### DIFF
--- a/assistant/src/__tests__/scoped-grant-security-matrix.test.ts
+++ b/assistant/src/__tests__/scoped-grant-security-matrix.test.ts
@@ -360,7 +360,7 @@ describe("security matrix: cross-scope invariants", () => {
         toolName: "bash",
         inputDigest: digest,
         consumingRequestId: "c-chan",
-        executionChannel: "voice",
+        executionChannel: "telegram",
         conversationId: "conv-123",
         callSessionId: "call-456",
         requesterExternalUserId: "user-alice",


### PR DESCRIPTION
## Summary
- Fixed the "all scope fields must match simultaneously" test in `scoped-grant-security-matrix.test.ts` — the "wrong execution channel" case was passing `"voice"` (matching the grant) instead of a mismatched value like `"telegram"`, causing the test to incorrectly succeed

## Original prompt
Fix tests: https://github.com/vellum-ai/vellum-assistant/actions/runs/22791206294/job/66117968351

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
