### PR TITLE
fix(ios): clear locallyEditedPinSessionIds in Case 2 merge path (PR 13824 feedback)

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -551,6 +551,7 @@ class IOSThreadStore: ObservableObject {
 
                 threads = merged + privateThreads
                 locallyEditedSessionIds.removeAll()
+                locallyEditedPinSessionIds.removeAll()
             } else {
                 // Case 3: User is active (VMs exist or local threads present).
                 // Do not clear locallyEditedSessionIds — title/archive edits persist until


### PR DESCRIPTION
Addresses Codex/Devin feedback on PR #13824: clear locallyEditedPinSessionIds alongside locallyEditedSessionIds in Case 2 of handleSessionListResponse.

Without this, after Case 2 reconciles cached threads, stale entries in locallyEditedPinSessionIds would cause subsequent Case 3 merges to preserve stale local pin/displayOrder values, blocking cross-device pin sync.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
