### PR TITLE
fix: respect ingress.enabled=false in Twilio URL fallback (PR 13821 feedback)

### DIFF
--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -69,10 +69,8 @@ function refreshGatewayTwilioState(): void {
   const fromConfig = (ingress.publicBaseUrl as string)
     ?.trim()
     ?.replace(/\/+$/, "");
-  const url =
-    ingress.enabled !== false && fromConfig
-      ? fromConfig
-      : getIngressPublicBaseUrl();
+  const isEnabled = ingress.enabled !== false;
+  const url = isEnabled ? fromConfig || getIngressPublicBaseUrl() : undefined;
   void triggerGatewayTwilioReconcile(url || undefined);
 }
 


### PR DESCRIPTION
Addresses Devin feedback on PR #13821: check ingress.enabled before falling back to env-var URL, preventing URL leak when ingress is explicitly disabled.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13868" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
