### PR TITLE
fix: preserve callback claim when lease sync fails after event persistence (PR 13837 feedback)

### DIFF
--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -348,6 +348,7 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
     return new Response(null, { status: 200 });
   }
 
+  let eventPersisted = false;
   try {
     const wasTerminal = isTerminalState(session.status);
 
@@ -379,11 +380,13 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
     // lease is only released after persistence so vellum sleep doesn't proceed
     // before the call is fully recorded.
     updateCallSession(session.id, updates, {
-      beforeLeaseSync: () =>
+      beforeLeaseSync: () => {
         recordCallEvent(session.id, eventType, {
           twilioStatus: callStatus,
           callSid,
-        }),
+        });
+        eventPersisted = true;
+      },
     });
 
     // Expire pending questions on terminal status
@@ -420,8 +423,19 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
       );
     }
   } catch (err) {
-    // Release claim so Twilio retries can reprocess
-    releaseCallbackClaim(dedupeKey, claimId);
+    if (eventPersisted) {
+      // Event already written — releasing the claim would let Twilio
+      // retries insert a duplicate event. Finalize instead so the
+      // dedupe guard blocks subsequent attempts.
+      finalizeCallbackClaim(dedupeKey, claimId);
+      log.warn(
+        { dedupeKey, claimId, callSid, callStatus, err },
+        "Post-persistence error — claim finalized to prevent duplicate events on retry",
+      );
+    } else {
+      // Nothing persisted yet — safe to release so retries can reprocess
+      releaseCallbackClaim(dedupeKey, claimId);
+    }
     throw err;
   }
 


### PR DESCRIPTION
Addresses Codex feedback on PR #13837: don't release callback claim if the event was already persisted but lease sync failed. Tracks whether the event was persisted via a flag; if so, finalizes the claim (preventing duplicate events on retry) instead of releasing it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
