### PR TITLE
fix: add trusted-contact verification routing to IPC handler

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -1,3 +1,4 @@
+import { createHash, randomBytes } from "node:crypto";
 import * as net from "node:net";
 
 import type { ChannelId } from "../../channels/types.js";
@@ -5,6 +6,8 @@ import { resolveGuardianName } from "../../config/user-reference.js";
 import {
   findContactChannel,
   findGuardianForChannel,
+  getChannelById,
+  getContact,
 } from "../../contacts/contact-store.js";
 import { revokeMember } from "../../contacts/contacts-write.js";
 import type { ChannelStatus } from "../../contacts/types.js";
@@ -15,18 +18,32 @@ import {
   createReadinessService,
 } from "../../runtime/channel-readiness-service.js";
 import {
+  countRecentSendsToDestination,
+  createOutboundSession,
   createVerificationChallenge,
   findActiveSession,
   getGuardianBinding,
   getPendingSession,
   revokeBinding,
   revokePendingSessions,
+  updateSessionDelivery,
 } from "../../runtime/channel-verification-service.js";
 import {
   cancelOutbound,
+  deliverVerificationSlack,
+  deliverVerificationTelegram,
+  DESTINATION_RATE_WINDOW_MS,
+  MAX_SENDS_PER_DESTINATION_WINDOW,
+  normalizeTelegramDestination,
   resendOutbound,
   startOutbound,
 } from "../../runtime/verification-outbound-actions.js";
+import {
+  composeVerificationSlack,
+  composeVerificationTelegram,
+  GUARDIAN_VERIFY_TEMPLATE_KEYS,
+} from "../../runtime/verification-templates.js";
+import { getCredentialMetadata } from "../../tools/credentials/metadata-store.js";
 import type {
   ChannelVerificationSessionRequest,
   ChannelVerificationSessionResponse,
@@ -218,6 +235,242 @@ export function revokeVerificationForChannel(
 }
 
 // ---------------------------------------------------------------------------
+// Trusted-contact verification (shared by IPC + HTTP transports)
+// ---------------------------------------------------------------------------
+
+/** Session TTL in seconds (matches challenge TTL of 10 minutes). */
+const SESSION_TTL_SECONDS = 600;
+
+/**
+ * Map a contact channel type to the verification ChannelId used by the
+ * verification service. Returns null for unsupported channel types.
+ */
+function toVerificationChannel(channelType: string): ChannelId | null {
+  switch (channelType) {
+    case "phone":
+      return "voice";
+    case "telegram":
+      return "telegram";
+    case "slack":
+      return "slack";
+    default:
+      return null;
+  }
+}
+
+function getTelegramBotUsername(): string | undefined {
+  const meta = getCredentialMetadata("telegram", "bot_token");
+  if (
+    meta?.accountInfo &&
+    typeof meta.accountInfo === "string" &&
+    meta.accountInfo.trim().length > 0
+  ) {
+    return meta.accountInfo.trim();
+  }
+  return process.env.TELEGRAM_BOT_USERNAME || undefined;
+}
+
+/**
+ * Transport-agnostic trusted-contact verification. Looks up the contact
+ * channel, derives the verification channel and destination, checks rate
+ * limits, and creates the appropriate outbound session.
+ *
+ * Returns a `ChannelVerificationSessionResult` so both the IPC handler
+ * and the HTTP handler can wrap it in their respective response envelopes.
+ */
+export async function verifyTrustedContact(
+  contactChannelId: string,
+  assistantId: string,
+): Promise<ChannelVerificationSessionResult> {
+  const channel = getChannelById(contactChannelId);
+  if (!channel) {
+    return {
+      success: false,
+      error: `Channel "${contactChannelId}" not found`,
+    };
+  }
+
+  const contact = getContact(channel.contactId);
+  if (!contact) {
+    return {
+      success: false,
+      error: `Contact "${channel.contactId}" not found`,
+    };
+  }
+
+  if (channel.status === "active" && channel.verifiedAt != null) {
+    return {
+      success: false,
+      error: "already_verified",
+      message: "Channel is already verified",
+    };
+  }
+
+  const verificationChannel = toVerificationChannel(channel.type);
+  if (!verificationChannel) {
+    return {
+      success: false,
+      error: `Verification is not supported for channel type "${channel.type}"`,
+    };
+  }
+
+  const destination = channel.address;
+  if (!destination) {
+    return {
+      success: false,
+      error: "Channel has no address to send verification to",
+    };
+  }
+
+  const effectiveDestination =
+    verificationChannel === "telegram"
+      ? normalizeTelegramDestination(destination)
+      : destination;
+
+  const recentSendCount = countRecentSendsToDestination(
+    verificationChannel,
+    effectiveDestination,
+    DESTINATION_RATE_WINDOW_MS,
+  );
+  if (recentSendCount >= MAX_SENDS_PER_DESTINATION_WINDOW) {
+    return {
+      success: false,
+      error: "rate_limited",
+      message:
+        "Too many verification attempts to this destination. Please try again later.",
+    };
+  }
+
+  // --- Telegram verification ---
+  if (verificationChannel === "telegram") {
+    if (channel.externalChatId) {
+      const sessionResult = createOutboundSession({
+        channel: verificationChannel,
+        expectedChatId: channel.externalChatId,
+        expectedExternalUserId: channel.externalUserId ?? undefined,
+        identityBindingStatus: "bound",
+        destinationAddress: effectiveDestination,
+        verificationPurpose: "trusted_contact",
+      });
+
+      const telegramBody = composeVerificationTelegram(
+        GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST,
+        {
+          code: sessionResult.secret,
+          expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
+        },
+      );
+
+      const now = Date.now();
+      const sendCount = 1;
+      updateSessionDelivery(sessionResult.sessionId, now, sendCount, null);
+      deliverVerificationTelegram(
+        channel.externalChatId,
+        telegramBody,
+        assistantId,
+      );
+
+      return {
+        success: true,
+        verificationSessionId: sessionResult.sessionId,
+        expiresAt: sessionResult.expiresAt,
+        sendCount,
+        channel: verificationChannel,
+      };
+    }
+
+    // Telegram handle only (no chat ID): bootstrap flow
+    const { ensureTelegramBotUsernameResolved } =
+      await import("../../runtime/channel-invite-transports/telegram.js");
+    await ensureTelegramBotUsernameResolved();
+    const botUsername = getTelegramBotUsername();
+    if (!botUsername) {
+      return {
+        success: false,
+        error:
+          "Telegram bot username is not configured. Set up the Telegram integration first.",
+      };
+    }
+
+    const bootstrapToken = randomBytes(16).toString("hex");
+    const bootstrapTokenHash = createHash("sha256")
+      .update(bootstrapToken)
+      .digest("hex");
+
+    const sessionResult = createOutboundSession({
+      channel: verificationChannel,
+      identityBindingStatus: "pending_bootstrap",
+      destinationAddress: effectiveDestination,
+      bootstrapTokenHash,
+      verificationPurpose: "trusted_contact",
+    });
+
+    const telegramBootstrapUrl = `https://t.me/${botUsername}?start=gv_${bootstrapToken}`;
+
+    return {
+      success: true,
+      verificationSessionId: sessionResult.sessionId,
+      expiresAt: sessionResult.expiresAt,
+      sendCount: 0,
+      telegramBootstrapUrl,
+      pendingBootstrap: true,
+      channel: verificationChannel,
+    };
+  }
+
+  // --- Slack verification ---
+  if (verificationChannel === "slack") {
+    const slackUserId = channel.externalUserId ?? destination;
+
+    const hasIdentityBinding = Boolean(
+      channel.externalUserId || channel.externalChatId,
+    );
+    if (!hasIdentityBinding) {
+      return {
+        success: false,
+        error:
+          "Slack verification requires an externalUserId or externalChatId for identity binding",
+      };
+    }
+
+    const sessionResult = createOutboundSession({
+      channel: verificationChannel,
+      expectedExternalUserId: channel.externalUserId ?? undefined,
+      expectedChatId: channel.externalChatId ?? undefined,
+      identityBindingStatus: "bound",
+      destinationAddress: slackUserId,
+      verificationPurpose: "trusted_contact",
+    });
+
+    const slackBody = composeVerificationSlack(
+      GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_CHALLENGE_REQUEST,
+      {
+        code: sessionResult.secret,
+        expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
+      },
+    );
+
+    const now = Date.now();
+    const sendCount = 1;
+    updateSessionDelivery(sessionResult.sessionId, now, sendCount, null);
+    deliverVerificationSlack(slackUserId, slackBody, assistantId);
+
+    return {
+      success: true,
+      verificationSessionId: sessionResult.sessionId,
+      expiresAt: sessionResult.expiresAt,
+      sendCount,
+      channel: verificationChannel,
+    };
+  }
+
+  return {
+    success: false,
+    error: `Verification is not supported for channel type "${channel.type}"`,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Channel verification session handler
 // ---------------------------------------------------------------------------
 
@@ -230,7 +483,16 @@ export async function handleChannelVerificationSession(
 
   try {
     if (msg.action === "create_session") {
-      if (msg.destination) {
+      if (msg.purpose === "trusted_contact" && msg.contactChannelId) {
+        const result = await verifyTrustedContact(
+          msg.contactChannelId,
+          DAEMON_INTERNAL_ASSISTANT_ID,
+        );
+        ctx.send(socket, {
+          type: "channel_verification_session_response",
+          ...result,
+        });
+      } else if (msg.destination) {
         const result = await startOutbound({
           channel,
           destination: msg.destination,

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -21,14 +21,12 @@
  * GET    /v1/channel-verification-sessions/status   — check guardian binding status
  */
 
-import { createHash, randomBytes } from "node:crypto";
-
 import type { ChannelId } from "../../channels/types.js";
-import { getChannelById, getContact } from "../../contacts/contact-store.js";
 import {
   createInboundChallenge,
   getVerificationStatus,
   revokeVerificationForChannel,
+  verifyTrustedContact,
 } from "../../daemon/handlers/config-channels.js";
 import {
   clearSlackChannelConfig,
@@ -42,32 +40,17 @@ import {
   setTelegramConfig,
   setupTelegram,
 } from "../../daemon/handlers/config-telegram.js";
-import { getCredentialMetadata } from "../../tools/credentials/metadata-store.js";
 import { normalizePhoneNumber } from "../../util/phone.js";
-import {
-  countRecentSendsToDestination,
-  createOutboundSession,
-  revokePendingSessions,
-  updateSessionDelivery,
-} from "../channel-verification-service.js";
+import { revokePendingSessions } from "../channel-verification-service.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
 import {
   cancelOutbound,
-  deliverVerificationSlack,
-  deliverVerificationTelegram,
-  DESTINATION_RATE_WINDOW_MS,
-  MAX_SENDS_PER_DESTINATION_WINDOW,
   normalizeTelegramDestination,
   resendOutbound,
   startOutbound,
 } from "../verification-outbound-actions.js";
 import { guardianVerificationLimiter } from "../verification-rate-limiter.js";
-import {
-  composeVerificationSlack,
-  composeVerificationTelegram,
-  GUARDIAN_VERIFY_TEMPLATE_KEYS,
-} from "../verification-templates.js";
 
 /**
  * GET /v1/integrations/telegram/config
@@ -166,42 +149,6 @@ export async function handleClearSlackChannelConfig(): Promise<Response> {
 // Channel verification (unified session API)
 // ---------------------------------------------------------------------------
 
-/** Session TTL in seconds (matches challenge TTL of 10 minutes). */
-const SESSION_TTL_SECONDS = 600;
-
-/**
- * Map a contact channel type to the verification ChannelId used by the
- * verification service. Returns null for unsupported channel types.
- */
-function toVerificationChannel(channelType: string): ChannelId | null {
-  switch (channelType) {
-    case "phone":
-      return "voice";
-    case "telegram":
-      return "telegram";
-    case "slack":
-      return "slack";
-    default:
-      return null;
-  }
-}
-
-/**
- * Get the Telegram bot username from credential metadata.
- * Falls back to process.env.TELEGRAM_BOT_USERNAME.
- */
-function getTelegramBotUsername(): string | undefined {
-  const meta = getCredentialMetadata("telegram", "bot_token");
-  if (
-    meta?.accountInfo &&
-    typeof meta.accountInfo === "string" &&
-    meta.accountInfo.trim().length > 0
-  ) {
-    return meta.accountInfo.trim();
-  }
-  return process.env.TELEGRAM_BOT_USERNAME || undefined;
-}
-
 /**
  * POST /v1/channel-verification-sessions
  *
@@ -228,10 +175,21 @@ export async function handleCreateVerificationSession(
 
   const purpose = body.purpose ?? "guardian";
 
-  // Trusted contact verification path — look up the contact channel and derive
-  // channel/destination from it, then create a session with verificationPurpose: "trusted_contact".
+  // Trusted contact verification path — delegates to the shared transport-agnostic
+  // function and wraps the result in an HTTP response.
   if (purpose === "trusted_contact" && body.contactChannelId) {
-    return handleTrustedContactVerification(body.contactChannelId, assistantId);
+    const result = await verifyTrustedContact(
+      body.contactChannelId,
+      assistantId,
+    );
+    const status = result.success
+      ? 200
+      : result.error === "rate_limited"
+        ? 429
+        : result.error === "already_verified"
+          ? 409
+          : 400;
+    return Response.json(result, { status });
   }
 
   if (body.destination) {
@@ -286,205 +244,6 @@ export async function handleCreateVerificationSession(
   );
   const status = result.success ? 200 : 400;
   return Response.json(result, { status });
-}
-
-/**
- * Trusted contact verification — extracted from the former
- * handleVerifyContactChannel in contact-routes.ts. Looks up the contact
- * channel, derives channelId and destination, checks rate limits, and
- * creates the session with verificationPurpose: "trusted_contact".
- */
-async function handleTrustedContactVerification(
-  contactChannelId: string,
-  assistantId: string,
-): Promise<Response> {
-  const channel = getChannelById(contactChannelId);
-  if (!channel) {
-    return httpError(
-      "NOT_FOUND",
-      `Channel "${contactChannelId}" not found`,
-      404,
-    );
-  }
-
-  const contact = getContact(channel.contactId);
-  if (!contact) {
-    return httpError(
-      "NOT_FOUND",
-      `Contact "${channel.contactId}" not found`,
-      404,
-    );
-  }
-
-  // Already verified — no need to re-verify
-  if (channel.status === "active" && channel.verifiedAt != null) {
-    return httpError("CONFLICT", "Channel is already verified", 409);
-  }
-
-  const verificationChannel = toVerificationChannel(channel.type);
-  if (!verificationChannel) {
-    return httpError(
-      "BAD_REQUEST",
-      `Verification is not supported for channel type "${channel.type}"`,
-      400,
-    );
-  }
-
-  const destination = channel.address;
-  if (!destination) {
-    return httpError(
-      "BAD_REQUEST",
-      "Channel has no address to send verification to",
-      400,
-    );
-  }
-
-  // Normalize Telegram destinations so rate-limit lookups are consistent
-  const effectiveDestination =
-    verificationChannel === "telegram"
-      ? normalizeTelegramDestination(destination)
-      : destination;
-
-  // Rate limit check
-  const recentSendCount = countRecentSendsToDestination(
-    verificationChannel,
-    effectiveDestination,
-    DESTINATION_RATE_WINDOW_MS,
-  );
-  if (recentSendCount >= MAX_SENDS_PER_DESTINATION_WINDOW) {
-    return httpError(
-      "RATE_LIMITED",
-      "Too many verification attempts to this destination. Please try again later.",
-      429,
-    );
-  }
-
-  // --- Telegram verification ---
-  if (verificationChannel === "telegram") {
-    // Telegram with known chat ID: identity is already bound
-    if (channel.externalChatId) {
-      const sessionResult = createOutboundSession({
-        channel: verificationChannel,
-        expectedChatId: channel.externalChatId,
-        expectedExternalUserId: channel.externalUserId ?? undefined,
-        identityBindingStatus: "bound",
-        destinationAddress: effectiveDestination,
-        verificationPurpose: "trusted_contact",
-      });
-
-      const telegramBody = composeVerificationTelegram(
-        GUARDIAN_VERIFY_TEMPLATE_KEYS.TELEGRAM_CHALLENGE_REQUEST,
-        {
-          code: sessionResult.secret,
-          expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
-        },
-      );
-
-      const now = Date.now();
-      const sendCount = 1;
-      updateSessionDelivery(sessionResult.sessionId, now, sendCount, null);
-      deliverVerificationTelegram(
-        channel.externalChatId,
-        telegramBody,
-        assistantId,
-      );
-
-      return Response.json({
-        ok: true,
-        verificationSessionId: sessionResult.sessionId,
-        expiresAt: sessionResult.expiresAt,
-        sendCount,
-      });
-    }
-
-    // Telegram handle only (no chat ID): bootstrap flow
-    const { ensureTelegramBotUsernameResolved } =
-      await import("../channel-invite-transports/telegram.js");
-    await ensureTelegramBotUsernameResolved();
-    const botUsername = getTelegramBotUsername();
-    if (!botUsername) {
-      return httpError(
-        "BAD_REQUEST",
-        "Telegram bot username is not configured. Set up the Telegram integration first.",
-        400,
-      );
-    }
-
-    const bootstrapToken = randomBytes(16).toString("hex");
-    const bootstrapTokenHash = createHash("sha256")
-      .update(bootstrapToken)
-      .digest("hex");
-
-    const sessionResult = createOutboundSession({
-      channel: verificationChannel,
-      identityBindingStatus: "pending_bootstrap",
-      destinationAddress: effectiveDestination,
-      bootstrapTokenHash,
-      verificationPurpose: "trusted_contact",
-    });
-
-    const telegramBootstrapUrl = `https://t.me/${botUsername}?start=gv_${bootstrapToken}`;
-
-    return Response.json({
-      ok: true,
-      verificationSessionId: sessionResult.sessionId,
-      expiresAt: sessionResult.expiresAt,
-      sendCount: 0,
-      telegramBootstrapUrl,
-    });
-  }
-
-  // --- Slack verification ---
-  if (verificationChannel === "slack") {
-    const slackUserId = channel.externalUserId ?? destination;
-
-    // Only claim identity is bound when we have at least one platform identifier
-    const hasIdentityBinding = Boolean(
-      channel.externalUserId || channel.externalChatId,
-    );
-    if (!hasIdentityBinding) {
-      return httpError(
-        "BAD_REQUEST",
-        "Slack verification requires an externalUserId or externalChatId for identity binding",
-        400,
-      );
-    }
-
-    const sessionResult = createOutboundSession({
-      channel: verificationChannel,
-      expectedExternalUserId: channel.externalUserId ?? undefined,
-      expectedChatId: channel.externalChatId ?? undefined,
-      identityBindingStatus: "bound",
-      destinationAddress: slackUserId,
-      verificationPurpose: "trusted_contact",
-    });
-
-    const slackBody = composeVerificationSlack(
-      GUARDIAN_VERIFY_TEMPLATE_KEYS.SLACK_CHALLENGE_REQUEST,
-      {
-        code: sessionResult.secret,
-        expiresInMinutes: Math.floor(SESSION_TTL_SECONDS / 60),
-      },
-    );
-
-    const now = Date.now();
-    const sendCount = 1;
-    updateSessionDelivery(sessionResult.sessionId, now, sendCount, null);
-    deliverVerificationSlack(slackUserId, slackBody, assistantId);
-
-    return Response.json({
-      ok: true,
-      verificationSessionId: sessionResult.sessionId,
-      expiresAt: sessionResult.expiresAt,
-      sendCount,
-    });
-  }
-
-  return httpError(
-    "BAD_REQUEST",
-    `Verification is not supported for channel type "${channel.type}"`,
-    400,
-  );
 }
 
 /**

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -967,6 +967,7 @@ struct ContactDetailView: View {
         do {
             try daemonClient.sendChannelVerificationSession(
                 action: "create_session",
+                purpose: "trusted_contact",
                 contactChannelId: channel.id
             )
         } catch {


### PR DESCRIPTION
## Summary
Fixes critical gap identified during plan review for chan-verify-session-unify.md.

**Gap:** IPC handler does not implement trusted-contact verification — ContactDetailView is broken
**What was expected:** IPC handler should route trusted-contact verification requests to the correct business logic
**What was found:** Handler ignores purpose/contactChannelId fields; Swift caller doesn't send purpose

**Changes:**
- Extract `verifyTrustedContact` shared function in `config-channels.ts` so both IPC and HTTP transports use the same business logic
- Add trusted-contact routing to IPC handler's `create_session` action
- Update `ContactDetailView.swift` to pass `purpose: "trusted_contact"` when initiating verification
- Remove duplicated `handleTrustedContactVerification` from `integration-routes.ts` (now calls the shared function)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
