### PR TITLE
fix(ios): fix stale line refs in Case 3 comment (PR 13827 feedback)

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -555,7 +555,7 @@ class IOSThreadStore: ObservableObject {
             } else {
                 // Case 3: User is active (VMs exist or local threads present).
                 // Do not clear locallyEditedSessionIds — title/archive edits persist until
-                // reconnect or rebind (which clears at IOSThreadStore:390 and :408).
+                // rebind (which resets all local-edit tracking).
                 // Deduplicate: only prepend restored threads whose sessionId
                 // doesn't already exist in the current thread list.
                 let existingSessionIds: Set<String> = Set(


### PR DESCRIPTION
Addresses Devin feedback on PR #13827:

- Remove stale line number references (IOSThreadStore:390 and :408) from Case 3 comment, replacing with a description of the behavior. Also corrects "reconnect or rebind" to just "rebind" since only `rebindDaemonClient` clears the tracking sets.
- Case 2 pin-acknowledgment clearing was already addressed by PR #13867 (added `locallyEditedPinSessionIds.removeAll()` in Case 2), so no additional change needed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
