### PR TITLE
fix: rename Swift guardian verification methods and directory to channel-verification

### DIFF
--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -466,7 +466,7 @@ Features/
   Chat/               Chat interface (ChatView, ChatViewModel, ChatMessage)
   CommandPalette/     Command palette (search, actions)
   Contacts/           Contact management
-  GuardianVerification/ Guardian verification flow
+  ChannelVerification/ Channel verification flow
   MainWindow/         Main window shell, ThreadTabBar, PanelCoordinator, side panels
   Onboarding/         First-launch setup flow (permissions, naming, Fn key)
   QuickInput/         Quick task input popover and screen selection

--- a/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationFlowView.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 import VellumAssistantShared
 
-/// Reusable SwiftUI view that renders the full guardian verification flow for a single channel.
+/// Reusable SwiftUI view that renders the full channel verification flow for a single channel.
 /// Supports all 5 states: destination input, sending, outbound pending (code/countdown/resend),
 /// instruction pending (code/copy), and verified (identity/revoke).
 ///
 /// Decoupled from SettingsStore — accepts state + action closures so it can be reused
-/// in both the Channels preferences tab and the Contacts page guardian card.
-struct GuardianVerificationFlowView: View {
-    let state: GuardianChannelState
+/// in both the Channels preferences tab and the Contacts page verification card.
+struct ChannelVerificationFlowView: View {
+    let state: ChannelVerificationState
     @Binding var countdownNow: Date
     @Binding var destinationText: String
 
@@ -74,7 +74,7 @@ struct GuardianVerificationFlowView: View {
         return VStack(alignment: .leading, spacing: VSpacing.sm) {
             HStack(spacing: VSpacing.sm) {
                 if showLabel {
-                    guardianLabel
+                    verificationLabel
                 }
                 VStack(alignment: .leading, spacing: 2) {
                     if let telegramProfileURL {
@@ -119,7 +119,7 @@ struct GuardianVerificationFlowView: View {
     private var sendingView: some View {
         HStack(spacing: VSpacing.sm) {
             if showLabel {
-                guardianLabel
+                verificationLabel
             }
             ProgressView()
                 .controlSize(.small)
@@ -148,7 +148,7 @@ struct GuardianVerificationFlowView: View {
         return VStack(alignment: .leading, spacing: VSpacing.sm) {
             HStack(spacing: VSpacing.sm) {
                 if showLabel {
-                    guardianLabel
+                    verificationLabel
                 }
                 Spacer()
             }
@@ -276,15 +276,15 @@ struct GuardianVerificationFlowView: View {
 
     @ViewBuilder
     private func instructionView(instruction: String) -> some View {
-        // All channels now use code-only verification. extractGuardianCommand
+        // All channels now use code-only verification. extractVerificationCommand
         // handles both "six-digit code: 123456" and "the code: <hex>" formats.
-        let command: String? = extractGuardianCommand(from: instruction)
+        let command: String? = extractVerificationCommand(from: instruction)
         let leadingPadding: CGFloat = showLabel ? labelColumnWidth + VSpacing.sm : 0
 
         VStack(alignment: .leading, spacing: VSpacing.sm) {
             HStack(spacing: VSpacing.sm) {
                 if showLabel {
-                    guardianLabel
+                    verificationLabel
                 }
                 Text("Verification pending")
                     .font(VFont.body)
@@ -293,7 +293,7 @@ struct GuardianVerificationFlowView: View {
             }
 
             if let command {
-                Text(guardianInstructionSubtext(
+                Text(verificationInstructionSubtext(
                     channel: state.channel,
                     botUsername: botUsername,
                     phoneNumber: phoneNumber
@@ -371,11 +371,11 @@ struct GuardianVerificationFlowView: View {
 
     private var destinationInputView: some View {
         let destination = destinationText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let placeholder = guardianDestinationPlaceholder(for: state.channel)
+        let placeholder = verificationDestinationPlaceholder(for: state.channel)
 
         return VStack(alignment: .leading, spacing: VSpacing.md) {
             if showLabel {
-                guardianLabel
+                verificationLabel
             }
 
             TextField(placeholder, text: $destinationText)
@@ -436,9 +436,9 @@ struct GuardianVerificationFlowView: View {
         .padding(.leading, leadingPadding)
     }
 
-    // MARK: - Guardian Label
+    // MARK: - Verification Label
 
-    private var guardianLabel: some View {
+    private var verificationLabel: some View {
         HStack(spacing: VSpacing.xs) {
             Text("Guardian Verification")
             VInfoTooltip("Guardian verification links your account identity for this channel.")
@@ -452,12 +452,12 @@ struct GuardianVerificationFlowView: View {
 // MARK: - Preview
 
 #if DEBUG
-struct GuardianVerificationFlowView_Previews: PreviewProvider {
+struct ChannelVerificationFlowView_Previews: PreviewProvider {
     struct PreviewWrapper: View {
         @State private var countdownNow = Date()
         @State private var destinationText = ""
 
-        let state: GuardianChannelState
+        let state: ChannelVerificationState
         let title: String
 
         var body: some View {
@@ -465,7 +465,7 @@ struct GuardianVerificationFlowView_Previews: PreviewProvider {
                 Text(title)
                     .font(VFont.captionMedium)
                     .foregroundColor(VColor.textMuted)
-                GuardianVerificationFlowView(
+                ChannelVerificationFlowView(
                     state: state,
                     countdownNow: $countdownNow,
                     destinationText: $destinationText,
@@ -485,7 +485,7 @@ struct GuardianVerificationFlowView_Previews: PreviewProvider {
             VColor.background.ignoresSafeArea()
             VStack(alignment: .leading, spacing: VSpacing.xl) {
                 PreviewWrapper(
-                    state: GuardianChannelState(
+                    state: ChannelVerificationState(
                         channel: "telegram",
                         identity: "123456789",
                         username: "guardian_user",
@@ -506,7 +506,7 @@ struct GuardianVerificationFlowView_Previews: PreviewProvider {
                 )
 
                 PreviewWrapper(
-                    state: GuardianChannelState(
+                    state: ChannelVerificationState(
                         channel: "telegram",
                         identity: nil,
                         username: nil,
@@ -527,7 +527,7 @@ struct GuardianVerificationFlowView_Previews: PreviewProvider {
                 )
 
                 PreviewWrapper(
-                    state: GuardianChannelState(
+                    state: ChannelVerificationState(
                         channel: "telegram",
                         identity: nil,
                         username: nil,
@@ -548,7 +548,7 @@ struct GuardianVerificationFlowView_Previews: PreviewProvider {
                 )
 
                 PreviewWrapper(
-                    state: GuardianChannelState(
+                    state: ChannelVerificationState(
                         channel: "telegram",
                         identity: nil,
                         username: nil,
@@ -571,7 +571,7 @@ struct GuardianVerificationFlowView_Previews: PreviewProvider {
             .padding(VSpacing.xl)
         }
         .frame(width: 500, height: 800)
-        .previewDisplayName("GuardianVerificationFlowView")
+        .previewDisplayName("ChannelVerificationFlowView")
     }
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationModels.swift
+++ b/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationModels.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-// MARK: - Guardian Channel State
+// MARK: - Channel Verification State
 
-/// Bundles all per-channel guardian verification state into a single value type,
-/// built from SettingsStore's @Published properties for use in guardian verification UI.
-struct GuardianChannelState {
+/// Bundles all per-channel verification state into a single value type,
+/// built from SettingsStore's @Published properties for use in channel verification UI.
+struct ChannelVerificationState {
     let channel: String
     let identity: String?
     let username: String?
@@ -21,7 +21,7 @@ struct GuardianChannelState {
     let outboundCode: String?
     let bootstrapUrl: String?
 
-    /// The most user-friendly display name for this guardian.
+    /// The most user-friendly display name for the verified identity.
     /// For telegram/slack: prefers @username, falls back to display name, then raw identity.
     /// For sms/voice: prefers display name, falls back to identity.
     var primaryIdentity: String? {
@@ -64,20 +64,20 @@ struct GuardianChannelState {
 
 @MainActor
 extension SettingsStore {
-    /// Reads all per-channel @Published guardian properties and returns them as a single struct.
-    func guardianChannelState(for channel: String) -> GuardianChannelState {
+    /// Reads all per-channel @Published verification properties and returns them as a single struct.
+    func channelVerificationState(for channel: String) -> ChannelVerificationState {
         switch channel {
         case "telegram":
-            return GuardianChannelState(
+            return ChannelVerificationState(
                 channel: channel,
-                identity: telegramGuardianIdentity,
-                username: telegramGuardianUsername,
-                displayName: telegramGuardianDisplayName,
-                verified: telegramGuardianVerified,
-                inProgress: telegramGuardianVerificationInProgress,
-                instruction: telegramGuardianInstruction,
-                error: telegramGuardianError,
-                alreadyBound: telegramGuardianAlreadyBound,
+                identity: telegramVerificationIdentity,
+                username: telegramVerificationUsername,
+                displayName: telegramVerificationDisplayName,
+                verified: telegramVerificationVerified,
+                inProgress: telegramVerificationInProgress,
+                instruction: telegramVerificationInstruction,
+                error: telegramVerificationError,
+                alreadyBound: telegramVerificationAlreadyBound,
                 outboundSessionId: telegramOutboundSessionId,
                 outboundExpiresAt: telegramOutboundExpiresAt,
                 outboundNextResendAt: telegramOutboundNextResendAt,
@@ -86,16 +86,16 @@ extension SettingsStore {
                 bootstrapUrl: telegramBootstrapUrl
             )
         case "sms":
-            return GuardianChannelState(
+            return ChannelVerificationState(
                 channel: channel,
-                identity: smsGuardianIdentity,
-                username: smsGuardianUsername,
-                displayName: smsGuardianDisplayName,
-                verified: smsGuardianVerified,
-                inProgress: smsGuardianVerificationInProgress,
-                instruction: smsGuardianInstruction,
-                error: smsGuardianError,
-                alreadyBound: smsGuardianAlreadyBound,
+                identity: smsVerificationIdentity,
+                username: smsVerificationUsername,
+                displayName: smsVerificationDisplayName,
+                verified: smsVerificationVerified,
+                inProgress: smsVerificationInProgress,
+                instruction: smsVerificationInstruction,
+                error: smsVerificationError,
+                alreadyBound: smsVerificationAlreadyBound,
                 outboundSessionId: smsOutboundSessionId,
                 outboundExpiresAt: smsOutboundExpiresAt,
                 outboundNextResendAt: smsOutboundNextResendAt,
@@ -104,16 +104,16 @@ extension SettingsStore {
                 bootstrapUrl: nil
             )
         case "voice":
-            return GuardianChannelState(
+            return ChannelVerificationState(
                 channel: channel,
-                identity: voiceGuardianIdentity,
-                username: voiceGuardianUsername,
-                displayName: voiceGuardianDisplayName,
-                verified: voiceGuardianVerified,
-                inProgress: voiceGuardianVerificationInProgress,
-                instruction: voiceGuardianInstruction,
-                error: voiceGuardianError,
-                alreadyBound: voiceGuardianAlreadyBound,
+                identity: voiceVerificationIdentity,
+                username: voiceVerificationUsername,
+                displayName: voiceVerificationDisplayName,
+                verified: voiceVerificationVerified,
+                inProgress: voiceVerificationInProgress,
+                instruction: voiceVerificationInstruction,
+                error: voiceVerificationError,
+                alreadyBound: voiceVerificationAlreadyBound,
                 outboundSessionId: voiceOutboundSessionId,
                 outboundExpiresAt: voiceOutboundExpiresAt,
                 outboundNextResendAt: voiceOutboundNextResendAt,
@@ -122,16 +122,16 @@ extension SettingsStore {
                 bootstrapUrl: nil
             )
         case "slack":
-            return GuardianChannelState(
+            return ChannelVerificationState(
                 channel: channel,
-                identity: slackGuardianIdentity,
-                username: slackGuardianUsername,
-                displayName: slackGuardianDisplayName,
-                verified: slackGuardianVerified,
-                inProgress: slackGuardianVerificationInProgress,
-                instruction: slackGuardianInstruction,
-                error: slackGuardianError,
-                alreadyBound: slackGuardianAlreadyBound,
+                identity: slackVerificationIdentity,
+                username: slackVerificationUsername,
+                displayName: slackVerificationDisplayName,
+                verified: slackVerificationVerified,
+                inProgress: slackVerificationInProgress,
+                instruction: slackVerificationInstruction,
+                error: slackVerificationError,
+                alreadyBound: slackVerificationAlreadyBound,
                 outboundSessionId: slackOutboundSessionId,
                 outboundExpiresAt: slackOutboundExpiresAt,
                 outboundNextResendAt: slackOutboundNextResendAt,
@@ -140,7 +140,7 @@ extension SettingsStore {
                 bootstrapUrl: nil
             )
         default:
-            return GuardianChannelState(
+            return ChannelVerificationState(
                 channel: channel,
                 identity: nil,
                 username: nil,
@@ -163,11 +163,11 @@ extension SettingsStore {
 
 // MARK: - Pure Helper Functions
 
-/// Extracts a guardian verification code from a raw instruction string.
+/// Extracts a verification code from a raw instruction string.
 /// Supports two formats:
 ///   1. "N-digit code: <digits>" (numeric codes, e.g. "6-digit code: 123456")
 ///   2. "the code: <hex>" (high-entropy hex codes for inbound challenges)
-func extractGuardianCommand(from instruction: String) -> String? {
+func extractVerificationCommand(from instruction: String) -> String? {
     if let code = extractNumericCode(from: instruction) {
         return code
     }
@@ -193,9 +193,9 @@ func extractNumericCode(from instruction: String) -> String? {
     return String(match[colonRange.upperBound...])
 }
 
-/// Human-readable instruction text for the guardian verification flow.
+/// Human-readable instruction text for the channel verification flow.
 /// Tells the user how to send the verification code for the given channel.
-func guardianInstructionSubtext(channel: String, botUsername: String?, phoneNumber: String?) -> String {
+func verificationInstructionSubtext(channel: String, botUsername: String?, phoneNumber: String?) -> String {
     if channel == "telegram" {
         let handle = botUsername.map { "@\($0)" } ?? "your bot"
         return "Message \(handle) with the below code within the next 10 minutes"
@@ -208,8 +208,8 @@ func guardianInstructionSubtext(channel: String, botUsername: String?, phoneNumb
     }
 }
 
-/// Placeholder text for the guardian destination input field, varying by channel.
-func guardianDestinationPlaceholder(for channel: String) -> String {
+/// Placeholder text for the verification destination input field, varying by channel.
+func verificationDestinationPlaceholder(for channel: String) -> String {
     switch channel {
     case "telegram": return "@username or chat ID"
     case "sms", "voice": return "+1234567890"

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -8,7 +8,7 @@ import VellumAssistantShared
 struct ContactDetailView: View {
     private static let allChannelTypes = ["telegram", "sms", "email", "whatsapp", "voice", "slack"]
 
-    private static let guardianSupportedChannels: Set<String> = ["telegram", "sms", "voice", "slack"]
+    private static let verificationSupportedChannels: Set<String> = ["telegram", "sms", "voice", "slack"]
 
     /// Channels that support 6-digit code invites from this view. Voice invites
     /// require additional fields not available here, so they are excluded.
@@ -46,22 +46,22 @@ struct ContactDetailView: View {
     @State private var inviteCopiedType: String?
     @State private var channelReadiness: [String: DaemonClient.ChannelReadinessInfo] = [:]
     @State private var readinessFetchFailed = false
-    @State private var guardianDestinationTexts: [String: String] = [:]
-    @State private var guardianCountdownNow: Date = Date()
-    @State private var guardianCountdownTimer: Timer?
+    @State private var verificationDestinationTexts: [String: String] = [:]
+    @State private var verificationCountdownNow: Date = Date()
+    @State private var verificationCountdownTimer: Timer?
     /// Incremented whenever SettingsStore publishes a change, forcing SwiftUI to
-    /// re-evaluate guardian verification state derived from the store.
-    @State private var guardianStoreRevision: Int = 0
+    /// re-evaluate channel verification state derived from the store.
+    @State private var verificationStoreRevision: Int = 0
 
     var displayContact: ContactPayload {
         currentContact ?? contact
     }
 
     var body: some View {
-        // Read guardianStoreRevision so SwiftUI tracks it; the .onReceive
+        // Read verificationStoreRevision so SwiftUI tracks it; the .onReceive
         // below increments it whenever SettingsStore publishes, forcing
-        // re-evaluation of guardian verification state.
-        let _ = guardianStoreRevision
+        // re-evaluation of channel verification state.
+        let _ = verificationStoreRevision
 
         ScrollView {
             VStack(alignment: .leading, spacing: VSpacing.lg) {
@@ -86,20 +86,20 @@ struct ContactDetailView: View {
         .onAppear {
             currentContact = contact
             if contact.role == "guardian" {
-                startGuardianCountdownTimer()
-                // Refresh guardian verification state for all supported channels
+                startVerificationCountdownTimer()
+                // Refresh channel verification state for all supported channels
                 // so the view shows current status even if the user hasn't visited
                 // the Channels settings tab yet.
-                for channel in Self.guardianSupportedChannels {
-                    store?.refreshChannelGuardianStatus(channel: channel)
+                for channel in Self.verificationSupportedChannels {
+                    store?.refreshChannelVerificationStatus(channel: channel)
                 }
             }
         }
         .onDisappear {
-            stopGuardianCountdownTimer()
+            stopVerificationCountdownTimer()
         }
         .onReceive(store?.objectWillChange.map { _ in () }.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
-            guardianStoreRevision += 1
+            verificationStoreRevision += 1
         }
     }
 
@@ -397,9 +397,9 @@ struct ContactDetailView: View {
                 Spacer()
             }
 
-            // Guardian contacts get the full verification flow; others get standard actions
+            // Guardian contacts get the full channel verification flow; others get standard actions
             if displayContact.role == "guardian" {
-                guardianVerificationActions(for: channel)
+                channelVerificationActions(for: channel)
             } else {
                 channelActions(for: channel)
             }
@@ -432,24 +432,24 @@ struct ContactDetailView: View {
                     .foregroundColor(VColor.textMuted)
             }
 
-            // Guardian contacts get the full verification flow; others get invite button
+            // Guardian contacts get the full channel verification flow; others get invite button
             if displayContact.role == "guardian" {
-                if Self.guardianSupportedChannels.contains(type), let store {
-                    let state = store.guardianChannelState(for: type)
+                if Self.verificationSupportedChannels.contains(type), let store {
+                    let state = store.channelVerificationState(for: type)
                     let destinationBinding = Binding<String>(
-                        get: { guardianDestinationTexts[type] ?? "" },
-                        set: { guardianDestinationTexts[type] = $0 }
+                        get: { verificationDestinationTexts[type] ?? "" },
+                        set: { verificationDestinationTexts[type] = $0 }
                     )
-                    GuardianVerificationFlowView(
+                    ChannelVerificationFlowView(
                         state: state,
-                        countdownNow: $guardianCountdownNow,
+                        countdownNow: $verificationCountdownNow,
                         destinationText: destinationBinding,
-                        onStartOutbound: { dest in store.startOutboundGuardianVerification(channel: type, destination: dest) },
-                        onResend: { store.resendOutboundGuardian(channel: type) },
-                        onCancelOutbound: { store.cancelOutboundGuardian(channel: type) },
-                        onRevoke: { store.revokeChannelGuardian(channel: type) },
-                        onStartChallenge: { rebind in store.startChannelGuardianVerification(channel: type, rebind: rebind) },
-                        onCancelChallenge: { store.cancelGuardianChallenge(channel: type) },
+                        onStartOutbound: { dest in store.startOutboundVerification(channel: type, destination: dest) },
+                        onResend: { store.resendOutboundVerification(channel: type) },
+                        onCancelOutbound: { store.cancelOutboundVerification(channel: type) },
+                        onRevoke: { store.revokeChannelVerification(channel: type) },
+                        onStartChallenge: { rebind in store.startChannelVerification(channel: type, rebind: rebind) },
+                        onCancelChallenge: { store.cancelVerificationChallenge(channel: type) },
                         botUsername: store.telegramBotUsername,
                         phoneNumber: store.twilioPhoneNumber,
                         showLabel: false
@@ -760,27 +760,27 @@ struct ContactDetailView: View {
         }
     }
 
-    // MARK: - Guardian Verification Actions
+    // MARK: - Channel Verification Actions
 
     @ViewBuilder
-    private func guardianVerificationActions(for channel: ContactChannelPayload) -> some View {
-        if Self.guardianSupportedChannels.contains(channel.type), let store {
-            let state = store.guardianChannelState(for: channel.type)
+    private func channelVerificationActions(for channel: ContactChannelPayload) -> some View {
+        if Self.verificationSupportedChannels.contains(channel.type), let store {
+            let state = store.channelVerificationState(for: channel.type)
             let destinationBinding = Binding<String>(
-                get: { guardianDestinationTexts[channel.type] ?? "" },
-                set: { guardianDestinationTexts[channel.type] = $0 }
+                get: { verificationDestinationTexts[channel.type] ?? "" },
+                set: { verificationDestinationTexts[channel.type] = $0 }
             )
 
-            GuardianVerificationFlowView(
+            ChannelVerificationFlowView(
                 state: state,
-                countdownNow: $guardianCountdownNow,
+                countdownNow: $verificationCountdownNow,
                 destinationText: destinationBinding,
-                onStartOutbound: { dest in store.startOutboundGuardianVerification(channel: channel.type, destination: dest) },
-                onResend: { store.resendOutboundGuardian(channel: channel.type) },
-                onCancelOutbound: { store.cancelOutboundGuardian(channel: channel.type) },
-                onRevoke: { store.revokeChannelGuardian(channel: channel.type) },
-                onStartChallenge: { rebind in store.startChannelGuardianVerification(channel: channel.type, rebind: rebind) },
-                onCancelChallenge: { store.cancelGuardianChallenge(channel: channel.type) },
+                onStartOutbound: { dest in store.startOutboundVerification(channel: channel.type, destination: dest) },
+                onResend: { store.resendOutboundVerification(channel: channel.type) },
+                onCancelOutbound: { store.cancelOutboundVerification(channel: channel.type) },
+                onRevoke: { store.revokeChannelVerification(channel: channel.type) },
+                onStartChallenge: { rebind in store.startChannelVerification(channel: channel.type, rebind: rebind) },
+                onCancelChallenge: { store.cancelVerificationChallenge(channel: channel.type) },
                 botUsername: store.telegramBotUsername,
                 phoneNumber: store.twilioPhoneNumber,
                 showLabel: false
@@ -789,21 +789,21 @@ struct ContactDetailView: View {
         // Email and other unsupported channel types: show nothing (display-only)
     }
 
-    // MARK: - Guardian Countdown Timer
+    // MARK: - Verification Countdown Timer
 
-    private func startGuardianCountdownTimer() {
-        guard guardianCountdownTimer == nil else { return }
-        guardianCountdownNow = Date()
-        guardianCountdownTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+    private func startVerificationCountdownTimer() {
+        guard verificationCountdownTimer == nil else { return }
+        verificationCountdownNow = Date()
+        verificationCountdownTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
             Task { @MainActor in
-                guardianCountdownNow = Date()
+                verificationCountdownNow = Date()
             }
         }
     }
 
-    private func stopGuardianCountdownTimer() {
-        guardianCountdownTimer?.invalidate()
-        guardianCountdownTimer = nil
+    private func stopVerificationCountdownTimer() {
+        verificationCountdownTimer?.invalidate()
+        verificationCountdownTimer = nil
     }
 
     // MARK: - Status Badge

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -37,18 +37,18 @@ struct SettingsChannelsTab: View {
     // Email copy state
     @State private var emailCopied: Bool = false
 
-    // Outbound guardian verification destination input (keyed by channel)
-    @State private var guardianDestinationText: [String: String] = [:]
+    // Outbound verification destination input (keyed by channel)
+    @State private var verificationDestinationText: [String: String] = [:]
 
     // Countdown timer for outbound verification expiry — only active when
     // at least one channel has an outbound verification session pending
     @State private var countdownNow: Date = Date()
     @State private var countdownTimer: Timer?
 
-    // Shared label column width for channelStatusRow and guardian verification alignment
+    // Shared label column width for channelStatusRow and channel verification alignment
     private let labelColumnWidth: CGFloat = 140
 
-    /// True when at least one channel has an active outbound guardian verification session
+    /// True when at least one channel has an active outbound verification session
     /// that needs the 1-second countdown timer for expiry/resend cooldown display.
     private var hasAnyOutboundSession: Bool {
         store.telegramOutboundSessionId != nil ||
@@ -64,9 +64,9 @@ struct SettingsChannelsTab: View {
         .onAppear {
             store.refreshAssistantEmail()
             store.refreshApprovedDevices()
-            store.refreshChannelGuardianStatus(channel: "telegram")
-            store.refreshChannelGuardianStatus(channel: "voice")
-            store.refreshChannelGuardianStatus(channel: "slack")
+            store.refreshChannelVerificationStatus(channel: "telegram")
+            store.refreshChannelVerificationStatus(channel: "voice")
+            store.refreshChannelVerificationStatus(channel: "slack")
             store.refreshTelegramApprovedMembers()
             store.refreshSlackApprovedMembers()
             store.fetchSlackChannelConfig()
@@ -76,7 +76,7 @@ struct SettingsChannelsTab: View {
             Task {
                 await loadSmsFeatureFlag()
                 if isSmsFeatureEnabled {
-                    store.refreshChannelGuardianStatus(channel: "sms")
+                    store.refreshChannelVerificationStatus(channel: "sms")
                 }
             }
             if hasAnyOutboundSession {
@@ -217,14 +217,14 @@ struct SettingsChannelsTab: View {
                     .foregroundColor(VColor.error)
             }
 
-            // Guardian row (only when credentials exist)
+            // Verification row (only when credentials exist)
             if store.telegramHasBotToken {
                 Divider().background(VColor.surfaceBorder)
-                guardianVerificationView(channel: "telegram")
+                channelVerificationView(channel: "telegram")
             }
 
-            // Approved users (only when bot token exists and guardian is verified)
-            if store.telegramHasBotToken && store.telegramGuardianVerified {
+            // Approved users (only when bot token exists and verification is complete)
+            if store.telegramHasBotToken && store.telegramVerificationVerified {
                 Divider().background(VColor.surfaceBorder)
                 telegramApprovedUsersSection
             }
@@ -369,10 +369,10 @@ struct SettingsChannelsTab: View {
                     .foregroundColor(VColor.error)
             }
 
-            // Guardian row (only when bot token and app token are configured)
+            // Verification row (only when bot token and app token are configured)
             if store.slackChannelHasBotToken && store.slackChannelHasAppToken {
                 Divider().background(VColor.surfaceBorder)
-                guardianVerificationView(channel: "slack")
+                channelVerificationView(channel: "slack")
 
                 Divider().background(VColor.surfaceBorder)
                 slackApprovedUsersSection
@@ -557,10 +557,10 @@ struct SettingsChannelsTab: View {
                     .foregroundColor(VColor.error)
             }
 
-            // Guardian row (only when credentials exist)
+            // Verification row (only when credentials exist)
             if store.twilioHasCredentials {
                 Divider().background(VColor.surfaceBorder)
-                guardianVerificationView(channel: "sms")
+                channelVerificationView(channel: "sms")
             }
         }
         .padding(VSpacing.lg)
@@ -632,11 +632,11 @@ struct SettingsChannelsTab: View {
                     .foregroundColor(VColor.error)
             }
 
-            // Guardian row (only when credentials and a phone number are assigned —
+            // Verification row (only when credentials and a phone number are assigned —
             // voice verification initiates an outbound call which requires a valid caller number)
             if store.twilioHasCredentials && store.twilioPhoneNumber != nil {
                 Divider().background(VColor.surfaceBorder)
-                guardianVerificationView(channel: "voice")
+                channelVerificationView(channel: "voice")
             }
         }
         .padding(VSpacing.lg)
@@ -801,23 +801,23 @@ struct SettingsChannelsTab: View {
         }
     }
 
-    // MARK: - Guardian Verification Row
+    // MARK: - Channel Verification Row
 
     @ViewBuilder
-    private func guardianVerificationView(channel: String) -> some View {
-        GuardianVerificationFlowView(
-            state: store.guardianChannelState(for: channel),
+    private func channelVerificationView(channel: String) -> some View {
+        ChannelVerificationFlowView(
+            state: store.channelVerificationState(for: channel),
             countdownNow: $countdownNow,
             destinationText: Binding<String>(
-                get: { guardianDestinationText[channel] ?? "" },
-                set: { guardianDestinationText[channel] = $0 }
+                get: { verificationDestinationText[channel] ?? "" },
+                set: { verificationDestinationText[channel] = $0 }
             ),
-            onStartOutbound: { dest in store.startOutboundGuardianVerification(channel: channel, destination: dest) },
-            onResend: { store.resendOutboundGuardian(channel: channel) },
-            onCancelOutbound: { store.cancelOutboundGuardian(channel: channel) },
-            onRevoke: { store.revokeChannelGuardian(channel: channel) },
-            onStartChallenge: { rebind in store.startChannelGuardianVerification(channel: channel, rebind: rebind) },
-            onCancelChallenge: { store.cancelGuardianChallenge(channel: channel) },
+            onStartOutbound: { dest in store.startOutboundVerification(channel: channel, destination: dest) },
+            onResend: { store.resendOutboundVerification(channel: channel) },
+            onCancelOutbound: { store.cancelOutboundVerification(channel: channel) },
+            onRevoke: { store.revokeChannelVerification(channel: channel) },
+            onStartChallenge: { rebind in store.startChannelVerification(channel: channel, rebind: rebind) },
+            onCancelChallenge: { store.cancelVerificationChallenge(channel: channel) },
             botUsername: store.telegramBotUsername,
             phoneNumber: store.twilioPhoneNumber,
             showLabel: true,
@@ -887,7 +887,7 @@ struct SettingsChannelsTab: View {
                 }
             }
 
-            // Device pairing row — mirrors Guardian Verification row layout
+            // Device pairing row — mirrors Channel Verification row layout
             mobilePairingRow
         }
         .padding(VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -108,40 +108,40 @@ public final class SettingsStore: ObservableObject {
     @Published var twilioWarning: String?
     @Published var twilioError: String?
 
-    // MARK: - Channel Guardian State (Telegram)
+    // MARK: - Channel Verification State (Telegram)
 
-    @Published var telegramGuardianIdentity: String?
-    @Published var telegramGuardianUsername: String?
-    @Published var telegramGuardianDisplayName: String?
-    @Published var telegramGuardianVerified: Bool = false
-    @Published var telegramGuardianVerificationInProgress: Bool = false
-    @Published var telegramGuardianInstruction: String?
-    @Published var telegramGuardianError: String?
-    @Published var telegramGuardianAlreadyBound: Bool = false
+    @Published var telegramVerificationIdentity: String?
+    @Published var telegramVerificationUsername: String?
+    @Published var telegramVerificationDisplayName: String?
+    @Published var telegramVerificationVerified: Bool = false
+    @Published var telegramVerificationInProgress: Bool = false
+    @Published var telegramVerificationInstruction: String?
+    @Published var telegramVerificationError: String?
+    @Published var telegramVerificationAlreadyBound: Bool = false
 
-    // MARK: - Channel Guardian State (SMS)
+    // MARK: - Channel Verification State (SMS)
 
-    @Published var smsGuardianIdentity: String?
-    @Published var smsGuardianUsername: String?
-    @Published var smsGuardianDisplayName: String?
-    @Published var smsGuardianVerified: Bool = false
-    @Published var smsGuardianVerificationInProgress: Bool = false
-    @Published var smsGuardianInstruction: String?
-    @Published var smsGuardianError: String?
-    @Published var smsGuardianAlreadyBound: Bool = false
+    @Published var smsVerificationIdentity: String?
+    @Published var smsVerificationUsername: String?
+    @Published var smsVerificationDisplayName: String?
+    @Published var smsVerificationVerified: Bool = false
+    @Published var smsVerificationInProgress: Bool = false
+    @Published var smsVerificationInstruction: String?
+    @Published var smsVerificationError: String?
+    @Published var smsVerificationAlreadyBound: Bool = false
 
-    // MARK: - Channel Guardian State (Voice)
+    // MARK: - Channel Verification State (Voice)
 
-    @Published var voiceGuardianIdentity: String?
-    @Published var voiceGuardianUsername: String?
-    @Published var voiceGuardianDisplayName: String?
-    @Published var voiceGuardianVerified: Bool = false
-    @Published var voiceGuardianVerificationInProgress: Bool = false
-    @Published var voiceGuardianInstruction: String?
-    @Published var voiceGuardianError: String?
-    @Published var voiceGuardianAlreadyBound: Bool = false
+    @Published var voiceVerificationIdentity: String?
+    @Published var voiceVerificationUsername: String?
+    @Published var voiceVerificationDisplayName: String?
+    @Published var voiceVerificationVerified: Bool = false
+    @Published var voiceVerificationInProgress: Bool = false
+    @Published var voiceVerificationInstruction: String?
+    @Published var voiceVerificationError: String?
+    @Published var voiceVerificationAlreadyBound: Bool = false
 
-    // MARK: - Outbound Guardian Session State (Telegram)
+    // MARK: - Outbound Verification Session State (Telegram)
 
     @Published var telegramOutboundSessionId: String?
     @Published var telegramOutboundExpiresAt: Date?
@@ -150,7 +150,7 @@ public final class SettingsStore: ObservableObject {
     @Published var telegramBootstrapUrl: String?
     @Published var telegramOutboundCode: String?
 
-    // MARK: - Outbound Guardian Session State (SMS)
+    // MARK: - Outbound Verification Session State (SMS)
 
     @Published var smsOutboundSessionId: String?
     @Published var smsOutboundExpiresAt: Date?
@@ -158,7 +158,7 @@ public final class SettingsStore: ObservableObject {
     @Published var smsOutboundSendCount: Int = 0
     @Published var smsOutboundCode: String?
 
-    // MARK: - Outbound Guardian Session State (Voice)
+    // MARK: - Outbound Verification Session State (Voice)
 
     @Published var voiceOutboundSessionId: String?
     @Published var voiceOutboundExpiresAt: Date?
@@ -190,16 +190,16 @@ public final class SettingsStore: ObservableObject {
     @Published var slackChannelSaveInProgress: Bool = false
     @Published var slackChannelError: String?
 
-    // MARK: - Channel Guardian State (Slack)
+    // MARK: - Channel Verification State (Slack)
 
-    @Published var slackGuardianIdentity: String?
-    @Published var slackGuardianUsername: String?
-    @Published var slackGuardianDisplayName: String?
-    @Published var slackGuardianVerified: Bool = false
-    @Published var slackGuardianVerificationInProgress: Bool = false
-    @Published var slackGuardianInstruction: String?
-    @Published var slackGuardianError: String?
-    @Published var slackGuardianAlreadyBound: Bool = false
+    @Published var slackVerificationIdentity: String?
+    @Published var slackVerificationUsername: String?
+    @Published var slackVerificationDisplayName: String?
+    @Published var slackVerificationVerified: Bool = false
+    @Published var slackVerificationInProgress: Bool = false
+    @Published var slackVerificationInstruction: String?
+    @Published var slackVerificationError: String?
+    @Published var slackVerificationAlreadyBound: Bool = false
 
     // MARK: - Approved Ingress Contacts (Slack)
 
@@ -208,7 +208,7 @@ public final class SettingsStore: ObservableObject {
     @Published var slackApprovedMembersError: String?
     @Published var slackRevokingMemberIds: Set<String> = []
 
-    // MARK: - Outbound Guardian Session State (Slack)
+    // MARK: - Outbound Verification Session State (Slack)
 
     @Published var slackOutboundSessionId: String?
     @Published var slackOutboundExpiresAt: Date?
@@ -279,13 +279,13 @@ public final class SettingsStore: ObservableObject {
     /// Last model reported by the daemon — used to skip redundant model_set calls
     /// that would otherwise reinitialize providers and evict idle sessions.
     private var lastDaemonModel: String?
-    private var pendingGuardianChallengeChannel: String?
-    private var guardianChallengeTimeoutWorkItem: DispatchWorkItem?
-    private var guardianStatusPollingWorkItems: [String: DispatchWorkItem] = [:]
-    private var guardianStatusPollingDeadlines: [String: Date] = [:]
-    private let guardianChallengeTimeoutDuration: TimeInterval
-    private let guardianStatusPollInterval: TimeInterval
-    private let guardianStatusPollWindow: TimeInterval
+    private var pendingVerificationChallengeChannel: String?
+    private var verificationChallengeTimeoutWorkItem: DispatchWorkItem?
+    private var verificationStatusPollingWorkItems: [String: DispatchWorkItem] = [:]
+    private var verificationStatusPollingDeadlines: [String: Date] = [:]
+    private let verificationChallengeTimeoutDuration: TimeInterval
+    private let verificationStatusPollInterval: TimeInterval
+    private let verificationStatusPollWindow: TimeInterval
     private static func reflectedString(_ value: Any, key: String) -> String? {
         for child in Mirror(reflecting: value).children {
             guard child.label == key else { continue }
@@ -305,15 +305,15 @@ public final class SettingsStore: ObservableObject {
     init(
         daemonClient: DaemonClient? = nil,
         configPath: String? = nil,
-        guardianChallengeTimeoutDuration: TimeInterval = 12,
-        guardianStatusPollInterval: TimeInterval = 2,
-        guardianStatusPollWindow: TimeInterval = 600
+        verificationChallengeTimeoutDuration: TimeInterval = 12,
+        verificationStatusPollInterval: TimeInterval = 2,
+        verificationStatusPollWindow: TimeInterval = 600
     ) {
         self.daemonClient = daemonClient
         self.configPath = configPath
-        self.guardianChallengeTimeoutDuration = max(0.05, guardianChallengeTimeoutDuration)
-        self.guardianStatusPollInterval = max(0.05, guardianStatusPollInterval)
-        self.guardianStatusPollWindow = max(self.guardianStatusPollInterval, guardianStatusPollWindow)
+        self.verificationChallengeTimeoutDuration = max(0.05, verificationChallengeTimeoutDuration)
+        self.verificationStatusPollInterval = max(0.05, verificationStatusPollInterval)
+        self.verificationStatusPollWindow = max(self.verificationStatusPollInterval, verificationStatusPollWindow)
 
         // Seed from UserDefaults / Keychain
         let anthropicKey = APIKeyManager.getKey()
@@ -553,101 +553,101 @@ public final class SettingsStore: ObservableObject {
 
         // Twilio config is now handled via HTTP — no IPC callback wiring needed.
 
-        // Wire up guardian verification IPC response
+        // Wire up channel verification IPC response
         daemonClient?.onChannelVerificationSessionResponse = { [weak self] response in
             guard let self else { return }
-            guard let channel = self.resolveGuardianResponseChannel(response.channel) else { return }
+            guard let channel = self.resolveVerificationResponseChannel(response.channel) else { return }
             let isStatusPoll = response.success && response.secret == nil && response.instruction == nil && response.bound != true
             if !isStatusPoll {
-                self.clearGuardianChallengePending(for: channel)
+                self.clearVerificationChallengePending(for: channel)
             }
 
             switch channel {
             case "telegram":
-                self.telegramGuardianVerificationInProgress = false
+                self.telegramVerificationInProgress = false
                 if response.success {
-                    self.telegramGuardianIdentity = response.guardianExternalUserId
-                    self.telegramGuardianUsername = Self.reflectedString(response, key: "guardianUsername")
-                    self.telegramGuardianDisplayName = Self.reflectedString(response, key: "guardianDisplayName")
+                    self.telegramVerificationIdentity = response.guardianExternalUserId
+                    self.telegramVerificationUsername = Self.reflectedString(response, key: "guardianUsername")
+                    self.telegramVerificationDisplayName = Self.reflectedString(response, key: "guardianDisplayName")
                     let isVerified = response.bound ?? false
-                    self.telegramGuardianVerified = isVerified
+                    self.telegramVerificationVerified = isVerified
                     if isVerified {
-                        self.telegramGuardianInstruction = nil
+                        self.telegramVerificationInstruction = nil
                     } else if let instruction = response.instruction {
-                        self.telegramGuardianInstruction = instruction
+                        self.telegramVerificationInstruction = instruction
                     }
-                    self.telegramGuardianError = nil
-                    self.telegramGuardianAlreadyBound = false
+                    self.telegramVerificationError = nil
+                    self.telegramVerificationAlreadyBound = false
                 } else {
                     let isAlreadyBound = response.error == "already_bound"
-                    self.telegramGuardianAlreadyBound = isAlreadyBound
-                    self.telegramGuardianError = isAlreadyBound
+                    self.telegramVerificationAlreadyBound = isAlreadyBound
+                    self.telegramVerificationError = isAlreadyBound
                         ? "A guardian is already bound. Revoke it first or replace it."
                         : response.error
                 }
             case "sms":
-                self.smsGuardianVerificationInProgress = false
+                self.smsVerificationInProgress = false
                 if response.success {
-                    self.smsGuardianIdentity = response.guardianExternalUserId
-                    self.smsGuardianUsername = Self.reflectedString(response, key: "guardianUsername")
-                    self.smsGuardianDisplayName = Self.reflectedString(response, key: "guardianDisplayName")
+                    self.smsVerificationIdentity = response.guardianExternalUserId
+                    self.smsVerificationUsername = Self.reflectedString(response, key: "guardianUsername")
+                    self.smsVerificationDisplayName = Self.reflectedString(response, key: "guardianDisplayName")
                     let isVerified = response.bound ?? false
-                    self.smsGuardianVerified = isVerified
+                    self.smsVerificationVerified = isVerified
                     if isVerified {
-                        self.smsGuardianInstruction = nil
+                        self.smsVerificationInstruction = nil
                     } else if let instruction = response.instruction {
-                        self.smsGuardianInstruction = instruction
+                        self.smsVerificationInstruction = instruction
                     }
-                    self.smsGuardianError = nil
-                    self.smsGuardianAlreadyBound = false
+                    self.smsVerificationError = nil
+                    self.smsVerificationAlreadyBound = false
                 } else {
                     let isAlreadyBound = response.error == "already_bound"
-                    self.smsGuardianAlreadyBound = isAlreadyBound
-                    self.smsGuardianError = isAlreadyBound
+                    self.smsVerificationAlreadyBound = isAlreadyBound
+                    self.smsVerificationError = isAlreadyBound
                         ? "A guardian is already bound. Revoke it first or replace it."
                         : response.error
                 }
             case "voice":
-                self.voiceGuardianVerificationInProgress = false
+                self.voiceVerificationInProgress = false
                 if response.success {
-                    self.voiceGuardianIdentity = response.guardianExternalUserId
-                    self.voiceGuardianUsername = Self.reflectedString(response, key: "guardianUsername")
-                    self.voiceGuardianDisplayName = Self.reflectedString(response, key: "guardianDisplayName")
+                    self.voiceVerificationIdentity = response.guardianExternalUserId
+                    self.voiceVerificationUsername = Self.reflectedString(response, key: "guardianUsername")
+                    self.voiceVerificationDisplayName = Self.reflectedString(response, key: "guardianDisplayName")
                     let isVerified = response.bound ?? false
-                    self.voiceGuardianVerified = isVerified
+                    self.voiceVerificationVerified = isVerified
                     if isVerified {
-                        self.voiceGuardianInstruction = nil
+                        self.voiceVerificationInstruction = nil
                     } else if let instruction = response.instruction {
-                        self.voiceGuardianInstruction = instruction
+                        self.voiceVerificationInstruction = instruction
                     }
-                    self.voiceGuardianError = nil
-                    self.voiceGuardianAlreadyBound = false
+                    self.voiceVerificationError = nil
+                    self.voiceVerificationAlreadyBound = false
                 } else {
                     let isAlreadyBound = response.error == "already_bound"
-                    self.voiceGuardianAlreadyBound = isAlreadyBound
-                    self.voiceGuardianError = isAlreadyBound
+                    self.voiceVerificationAlreadyBound = isAlreadyBound
+                    self.voiceVerificationError = isAlreadyBound
                         ? "A guardian is already bound. Revoke it first or replace it."
                         : response.error
                 }
             case "slack":
-                self.slackGuardianVerificationInProgress = false
+                self.slackVerificationInProgress = false
                 if response.success {
-                    self.slackGuardianIdentity = response.guardianExternalUserId
-                    self.slackGuardianUsername = Self.reflectedString(response, key: "guardianUsername")
-                    self.slackGuardianDisplayName = Self.reflectedString(response, key: "guardianDisplayName")
+                    self.slackVerificationIdentity = response.guardianExternalUserId
+                    self.slackVerificationUsername = Self.reflectedString(response, key: "guardianUsername")
+                    self.slackVerificationDisplayName = Self.reflectedString(response, key: "guardianDisplayName")
                     let isVerified = response.bound ?? false
-                    self.slackGuardianVerified = isVerified
+                    self.slackVerificationVerified = isVerified
                     if isVerified {
-                        self.slackGuardianInstruction = nil
+                        self.slackVerificationInstruction = nil
                     } else if let instruction = response.instruction {
-                        self.slackGuardianInstruction = instruction
+                        self.slackVerificationInstruction = instruction
                     }
-                    self.slackGuardianError = nil
-                    self.slackGuardianAlreadyBound = false
+                    self.slackVerificationError = nil
+                    self.slackVerificationAlreadyBound = false
                 } else {
                     let isAlreadyBound = response.error == "already_bound"
-                    self.slackGuardianAlreadyBound = isAlreadyBound
-                    self.slackGuardianError = isAlreadyBound
+                    self.slackVerificationAlreadyBound = isAlreadyBound
+                    self.slackVerificationError = isAlreadyBound
                         ? "A guardian is already bound. Revoke it first or replace it."
                         : response.error
                 }
@@ -659,12 +659,12 @@ public final class SettingsStore: ObservableObject {
             if response.success {
                 if response.verificationSessionId != nil {
                     self.applyOutboundResponseState(channel: channel, response: response)
-                    self.startGuardianStatusPolling(for: channel)
+                    self.startVerificationStatusPolling(for: channel)
                 } else if response.secret != nil || response.instruction != nil {
-                    self.startGuardianStatusPolling(for: channel)
+                    self.startVerificationStatusPolling(for: channel)
                 } else if response.bound == true {
                     self.clearOutboundState(for: channel)
-                    self.stopGuardianStatusPolling(for: channel)
+                    self.stopVerificationStatusPolling(for: channel)
                 }
             } else {
                 // Errors that indicate the outbound session is no longer valid
@@ -674,7 +674,7 @@ public final class SettingsStore: ObservableObject {
                 if let error = response.error, terminalErrors.contains(error) {
                     self.clearOutboundState(for: channel)
                 }
-                self.stopGuardianStatusPolling(for: channel)
+                self.stopVerificationStatusPolling(for: channel)
             }
         }
 
@@ -697,11 +697,11 @@ public final class SettingsStore: ObservableObject {
         // Refresh Twilio integration status on init
         refreshTwilioStatus()
 
-        // Refresh channel guardian status on init
-        refreshChannelGuardianStatus(channel: "telegram")
-        refreshChannelGuardianStatus(channel: "sms")
-        refreshChannelGuardianStatus(channel: "voice")
-        refreshChannelGuardianStatus(channel: "slack")
+        // Refresh channel verification status on init
+        refreshChannelVerificationStatus(channel: "telegram")
+        refreshChannelVerificationStatus(channel: "sms")
+        refreshChannelVerificationStatus(channel: "voice")
+        refreshChannelVerificationStatus(channel: "slack")
 
         // Ingress config is refreshed by onAppear in SettingsPanel,
         // not here, to avoid duplicate get requests whose
@@ -1484,108 +1484,108 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    // MARK: - Channel Guardian Actions
+    // MARK: - Channel Verification Actions
 
-    func refreshChannelGuardianStatus(channel: String) {
+    func refreshChannelVerificationStatus(channel: String) {
         do {
             try daemonClient?.sendChannelVerificationSession(action: "status", channel: channel)
         } catch {
-            log.error("Failed to refresh \(channel) guardian status: \(error)")
+            log.error("Failed to refresh \(channel) verification status: \(error)")
         }
     }
 
-    func startChannelGuardianVerification(channel: String, rebind: Bool = false) {
-        stopGuardianStatusPolling(for: channel)
+    func startChannelVerification(channel: String, rebind: Bool = false) {
+        stopVerificationStatusPolling(for: channel)
         switch channel {
         case "telegram":
-            telegramGuardianVerificationInProgress = true
-            telegramGuardianError = nil
-            telegramGuardianAlreadyBound = false
-            telegramGuardianInstruction = nil
+            telegramVerificationInProgress = true
+            telegramVerificationError = nil
+            telegramVerificationAlreadyBound = false
+            telegramVerificationInstruction = nil
         case "sms":
-            smsGuardianVerificationInProgress = true
-            smsGuardianError = nil
-            smsGuardianAlreadyBound = false
-            smsGuardianInstruction = nil
+            smsVerificationInProgress = true
+            smsVerificationError = nil
+            smsVerificationAlreadyBound = false
+            smsVerificationInstruction = nil
         case "voice":
-            voiceGuardianVerificationInProgress = true
-            voiceGuardianError = nil
-            voiceGuardianAlreadyBound = false
-            voiceGuardianInstruction = nil
+            voiceVerificationInProgress = true
+            voiceVerificationError = nil
+            voiceVerificationAlreadyBound = false
+            voiceVerificationInstruction = nil
         case "slack":
-            slackGuardianVerificationInProgress = true
-            slackGuardianError = nil
-            slackGuardianAlreadyBound = false
-            slackGuardianInstruction = nil
+            slackVerificationInProgress = true
+            slackVerificationError = nil
+            slackVerificationAlreadyBound = false
+            slackVerificationInstruction = nil
         default:
             return
         }
         do {
             guard let daemonClient else {
-                clearGuardianChallengePending(for: channel)
+                clearVerificationChallengePending(for: channel)
                 switch channel {
                 case "telegram":
-                    telegramGuardianVerificationInProgress = false
-                    telegramGuardianError = "Daemon is not connected. Reconnect and try again."
+                    telegramVerificationInProgress = false
+                    telegramVerificationError = "Daemon is not connected. Reconnect and try again."
                 case "sms":
-                    smsGuardianVerificationInProgress = false
-                    smsGuardianError = "Daemon is not connected. Reconnect and try again."
+                    smsVerificationInProgress = false
+                    smsVerificationError = "Daemon is not connected. Reconnect and try again."
                 case "voice":
-                    voiceGuardianVerificationInProgress = false
-                    voiceGuardianError = "Daemon is not connected. Reconnect and try again."
+                    voiceVerificationInProgress = false
+                    voiceVerificationError = "Daemon is not connected. Reconnect and try again."
                 case "slack":
-                    slackGuardianVerificationInProgress = false
-                    slackGuardianError = "Daemon is not connected. Reconnect and try again."
+                    slackVerificationInProgress = false
+                    slackVerificationError = "Daemon is not connected. Reconnect and try again."
                 default:
                     break
                 }
                 return
             }
-            pendingGuardianChallengeChannel = channel
-            armGuardianChallengeTimeout(for: channel)
+            pendingVerificationChallengeChannel = channel
+            armVerificationChallengeTimeout(for: channel)
             try daemonClient.sendChannelVerificationSession(
                 action: "create_session",
                 channel: channel,
                 rebind: rebind ? true : nil
             )
         } catch {
-            log.error("Failed to start \(channel) guardian verification: \(error)")
-            clearGuardianChallengePending(for: channel)
+            log.error("Failed to start \(channel) channel verification: \(error)")
+            clearVerificationChallengePending(for: channel)
             switch channel {
             case "telegram":
-                telegramGuardianVerificationInProgress = false
-                telegramGuardianError = "Failed to start verification. Try again."
+                telegramVerificationInProgress = false
+                telegramVerificationError = "Failed to start verification. Try again."
             case "sms":
-                smsGuardianVerificationInProgress = false
-                smsGuardianError = "Failed to start verification. Try again."
+                smsVerificationInProgress = false
+                smsVerificationError = "Failed to start verification. Try again."
             case "voice":
-                voiceGuardianVerificationInProgress = false
-                voiceGuardianError = "Failed to start verification. Try again."
+                voiceVerificationInProgress = false
+                voiceVerificationError = "Failed to start verification. Try again."
             case "slack":
-                slackGuardianVerificationInProgress = false
-                slackGuardianError = "Failed to start verification. Try again."
+                slackVerificationInProgress = false
+                slackVerificationError = "Failed to start verification. Try again."
             default:
                 break
             }
         }
     }
 
-    func cancelGuardianChallenge(channel: String) {
-        stopGuardianStatusPolling(for: channel)
-        clearGuardianChallengePending(for: channel)
+    func cancelVerificationChallenge(channel: String) {
+        stopVerificationStatusPolling(for: channel)
+        clearVerificationChallengePending(for: channel)
         switch channel {
         case "telegram":
-            telegramGuardianVerificationInProgress = false
-            telegramGuardianInstruction = nil
+            telegramVerificationInProgress = false
+            telegramVerificationInstruction = nil
         case "sms":
-            smsGuardianVerificationInProgress = false
-            smsGuardianInstruction = nil
+            smsVerificationInProgress = false
+            smsVerificationInstruction = nil
         case "voice":
-            voiceGuardianVerificationInProgress = false
-            voiceGuardianInstruction = nil
+            voiceVerificationInProgress = false
+            voiceVerificationInstruction = nil
         case "slack":
-            slackGuardianVerificationInProgress = false
-            slackGuardianInstruction = nil
+            slackVerificationInProgress = false
+            slackVerificationInstruction = nil
         default:
             break
         }
@@ -1593,31 +1593,31 @@ public final class SettingsStore: ObservableObject {
         do {
             try daemonClient?.sendChannelVerificationSession(action: "revoke", channel: channel)
         } catch {
-            log.error("Failed to revoke \(channel) guardian challenge on cancel: \(error)")
+            log.error("Failed to revoke \(channel) verification challenge on cancel: \(error)")
         }
     }
 
-    func revokeChannelGuardian(channel: String) {
-        stopGuardianStatusPolling(for: channel)
-        // Eagerly clear instruction so the "Verify Guardian" button reappears
+    func revokeChannelVerification(channel: String) {
+        stopVerificationStatusPolling(for: channel)
+        // Eagerly clear instruction so the "Verify" button reappears
         // immediately instead of waiting for the daemon's response (which
         // looks identical to a status poll and won't clear it).
         switch channel {
         case "telegram":
-            telegramGuardianInstruction = nil
+            telegramVerificationInstruction = nil
         case "sms":
-            smsGuardianInstruction = nil
+            smsVerificationInstruction = nil
         case "voice":
-            voiceGuardianInstruction = nil
+            voiceVerificationInstruction = nil
         case "slack":
-            slackGuardianInstruction = nil
+            slackVerificationInstruction = nil
         default:
             break
         }
         do {
             try daemonClient?.sendChannelVerificationSession(action: "revoke", channel: channel)
         } catch {
-            log.error("Failed to revoke \(channel) guardian: \(error)")
+            log.error("Failed to revoke \(channel) verification: \(error)")
         }
     }
 
@@ -1643,7 +1643,7 @@ public final class SettingsStore: ObservableObject {
                 if httpResp.statusCode == 200 {
                     if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                        let contactsList = json["contacts"] as? [[String: Any]] {
-                        let guardianId = self.telegramGuardianIdentity
+                        let verifiedIdentityId = self.telegramVerificationIdentity
                         var approvedMembers: [ApprovedMember] = []
                         for contact in contactsList {
                             let displayName = contact["displayName"] as? String
@@ -1655,8 +1655,8 @@ public final class SettingsStore: ObservableObject {
                                       status == "active",
                                       let channelId = channel["id"] as? String else { continue }
                                 let externalUserId = channel["externalUserId"] as? String
-                                // Skip the guardian — they're already shown in the Guardian Verification row
-                                if let guardianId, let externalUserId, externalUserId == guardianId {
+                                // Skip the verified identity — they're already shown in the Channel Verification row
+                                if let verifiedIdentityId, let externalUserId, externalUserId == verifiedIdentityId {
                                     continue
                                 }
                                 approvedMembers.append(ApprovedMember(
@@ -1725,7 +1725,7 @@ public final class SettingsStore: ObservableObject {
                 if httpResp.statusCode == 200 {
                     if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                        let contactsList = json["contacts"] as? [[String: Any]] {
-                        let guardianId = self.slackGuardianIdentity
+                        let verifiedIdentityId = self.slackVerificationIdentity
                         var approvedMembers: [ApprovedMember] = []
                         for contact in contactsList {
                             let displayName = contact["displayName"] as? String
@@ -1737,8 +1737,8 @@ public final class SettingsStore: ObservableObject {
                                       status == "active",
                                       let channelId = channel["id"] as? String else { continue }
                                 let externalUserId = channel["externalUserId"] as? String
-                                // Skip the guardian — they're already shown in the Guardian Verification row
-                                if let guardianId, let externalUserId, externalUserId == guardianId {
+                                // Skip the verified identity — they're already shown in the Channel Verification row
+                                if let verifiedIdentityId, let externalUserId, externalUserId == verifiedIdentityId {
                                     continue
                                 }
                                 approvedMembers.append(ApprovedMember(
@@ -1787,28 +1787,28 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    // MARK: - Outbound Guardian Actions
+    // MARK: - Outbound Verification Actions
 
-    func startOutboundGuardianVerification(channel: String, destination: String) {
+    func startOutboundVerification(channel: String, destination: String) {
         clearOutboundState(for: channel)
-        stopGuardianStatusPolling(for: channel)
+        stopVerificationStatusPolling(for: channel)
         switch channel {
         case "telegram":
-            telegramGuardianVerificationInProgress = true
-            telegramGuardianError = nil
-            telegramGuardianAlreadyBound = false
+            telegramVerificationInProgress = true
+            telegramVerificationError = nil
+            telegramVerificationAlreadyBound = false
         case "sms":
-            smsGuardianVerificationInProgress = true
-            smsGuardianError = nil
-            smsGuardianAlreadyBound = false
+            smsVerificationInProgress = true
+            smsVerificationError = nil
+            smsVerificationAlreadyBound = false
         case "voice":
-            voiceGuardianVerificationInProgress = true
-            voiceGuardianError = nil
-            voiceGuardianAlreadyBound = false
+            voiceVerificationInProgress = true
+            voiceVerificationError = nil
+            voiceVerificationAlreadyBound = false
         case "slack":
-            slackGuardianVerificationInProgress = true
-            slackGuardianError = nil
-            slackGuardianAlreadyBound = false
+            slackVerificationInProgress = true
+            slackVerificationError = nil
+            slackVerificationAlreadyBound = false
         default:
             return
         }
@@ -1816,17 +1816,17 @@ public final class SettingsStore: ObservableObject {
             guard let daemonClient else {
                 switch channel {
                 case "telegram":
-                    telegramGuardianVerificationInProgress = false
-                    telegramGuardianError = "Daemon is not connected. Reconnect and try again."
+                    telegramVerificationInProgress = false
+                    telegramVerificationError = "Daemon is not connected. Reconnect and try again."
                 case "sms":
-                    smsGuardianVerificationInProgress = false
-                    smsGuardianError = "Daemon is not connected. Reconnect and try again."
+                    smsVerificationInProgress = false
+                    smsVerificationError = "Daemon is not connected. Reconnect and try again."
                 case "voice":
-                    voiceGuardianVerificationInProgress = false
-                    voiceGuardianError = "Daemon is not connected. Reconnect and try again."
+                    voiceVerificationInProgress = false
+                    voiceVerificationError = "Daemon is not connected. Reconnect and try again."
                 case "slack":
-                    slackGuardianVerificationInProgress = false
-                    slackGuardianError = "Daemon is not connected. Reconnect and try again."
+                    slackVerificationInProgress = false
+                    slackVerificationError = "Daemon is not connected. Reconnect and try again."
                 default:
                     break
                 }
@@ -1838,49 +1838,49 @@ public final class SettingsStore: ObservableObject {
                 destination: destination
             )
         } catch {
-            log.error("Failed to start outbound \(channel) guardian verification: \(error)")
+            log.error("Failed to start outbound \(channel) channel verification: \(error)")
             switch channel {
             case "telegram":
-                telegramGuardianVerificationInProgress = false
-                telegramGuardianError = "Failed to start verification. Try again."
+                telegramVerificationInProgress = false
+                telegramVerificationError = "Failed to start verification. Try again."
             case "sms":
-                smsGuardianVerificationInProgress = false
-                smsGuardianError = "Failed to start verification. Try again."
+                smsVerificationInProgress = false
+                smsVerificationError = "Failed to start verification. Try again."
             case "voice":
-                voiceGuardianVerificationInProgress = false
-                voiceGuardianError = "Failed to start verification. Try again."
+                voiceVerificationInProgress = false
+                voiceVerificationError = "Failed to start verification. Try again."
             case "slack":
-                slackGuardianVerificationInProgress = false
-                slackGuardianError = "Failed to start verification. Try again."
+                slackVerificationInProgress = false
+                slackVerificationError = "Failed to start verification. Try again."
             default:
                 break
             }
         }
     }
 
-    func resendOutboundGuardian(channel: String) {
+    func resendOutboundVerification(channel: String) {
         do {
             try daemonClient?.sendChannelVerificationSession(
                 action: "resend_session",
                 channel: channel
             )
         } catch {
-            log.error("Failed to resend outbound \(channel) guardian verification: \(error)")
+            log.error("Failed to resend outbound \(channel) channel verification: \(error)")
         }
     }
 
-    func cancelOutboundGuardian(channel: String) {
-        stopGuardianStatusPolling(for: channel)
+    func cancelOutboundVerification(channel: String) {
+        stopVerificationStatusPolling(for: channel)
         clearOutboundState(for: channel)
         switch channel {
         case "telegram":
-            telegramGuardianVerificationInProgress = false
+            telegramVerificationInProgress = false
         case "sms":
-            smsGuardianVerificationInProgress = false
+            smsVerificationInProgress = false
         case "voice":
-            voiceGuardianVerificationInProgress = false
+            voiceVerificationInProgress = false
         case "slack":
-            slackGuardianVerificationInProgress = false
+            slackVerificationInProgress = false
         default:
             break
         }
@@ -1890,7 +1890,7 @@ public final class SettingsStore: ObservableObject {
                 channel: channel
             )
         } catch {
-            log.error("Failed to cancel outbound \(channel) guardian verification: \(error)")
+            log.error("Failed to cancel outbound \(channel) channel verification: \(error)")
         }
     }
 
@@ -2002,19 +2002,19 @@ public final class SettingsStore: ObservableObject {
         }
     }
 
-    private func resolveGuardianResponseChannel(_ channel: String?) -> String? {
+    private func resolveVerificationResponseChannel(_ channel: String?) -> String? {
         if let channel {
             return channel
         }
-        if let pendingGuardianChallengeChannel {
-            return pendingGuardianChallengeChannel
+        if let pendingVerificationChallengeChannel {
+            return pendingVerificationChallengeChannel
         }
         // Disambiguate when exactly one channel has verification in progress
         let inProgressChannels = [
-            ("telegram", telegramGuardianVerificationInProgress),
-            ("sms", smsGuardianVerificationInProgress),
-            ("voice", voiceGuardianVerificationInProgress),
-            ("slack", slackGuardianVerificationInProgress),
+            ("telegram", telegramVerificationInProgress),
+            ("sms", smsVerificationInProgress),
+            ("voice", voiceVerificationInProgress),
+            ("slack", slackVerificationInProgress),
         ].filter(\.1)
         if inProgressChannels.count == 1 {
             return inProgressChannels.first?.0
@@ -2022,93 +2022,93 @@ public final class SettingsStore: ObservableObject {
         return nil
     }
 
-    private func clearGuardianChallengePending(for channel: String) {
-        if pendingGuardianChallengeChannel == channel {
-            pendingGuardianChallengeChannel = nil
-            guardianChallengeTimeoutWorkItem?.cancel()
-            guardianChallengeTimeoutWorkItem = nil
+    private func clearVerificationChallengePending(for channel: String) {
+        if pendingVerificationChallengeChannel == channel {
+            pendingVerificationChallengeChannel = nil
+            verificationChallengeTimeoutWorkItem?.cancel()
+            verificationChallengeTimeoutWorkItem = nil
         }
-        // Clear stale instruction so the "Verify Guardian" button reappears
+        // Clear stale instruction so the "Verify" button reappears
         // when a challenge is no longer active (timeout, revoke, or error).
         switch channel {
         case "telegram":
-            telegramGuardianInstruction = nil
+            telegramVerificationInstruction = nil
         case "sms":
-            smsGuardianInstruction = nil
+            smsVerificationInstruction = nil
         case "voice":
-            voiceGuardianInstruction = nil
+            voiceVerificationInstruction = nil
         case "slack":
-            slackGuardianInstruction = nil
+            slackVerificationInstruction = nil
         default:
             break
         }
     }
 
-    private func armGuardianChallengeTimeout(for channel: String) {
-        guardianChallengeTimeoutWorkItem?.cancel()
+    private func armVerificationChallengeTimeout(for channel: String) {
+        verificationChallengeTimeoutWorkItem?.cancel()
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
-            guard self.pendingGuardianChallengeChannel == channel else { return }
-            self.pendingGuardianChallengeChannel = nil
+            guard self.pendingVerificationChallengeChannel == channel else { return }
+            self.pendingVerificationChallengeChannel = nil
             switch channel {
             case "telegram":
-                self.telegramGuardianVerificationInProgress = false
-                self.telegramGuardianInstruction = nil
-                if self.telegramGuardianError == nil {
-                    self.telegramGuardianError = "Timed out waiting for verification instructions. Try again."
+                self.telegramVerificationInProgress = false
+                self.telegramVerificationInstruction = nil
+                if self.telegramVerificationError == nil {
+                    self.telegramVerificationError = "Timed out waiting for verification instructions. Try again."
                 }
             case "sms":
-                self.smsGuardianVerificationInProgress = false
-                self.smsGuardianInstruction = nil
-                if self.smsGuardianError == nil {
-                    self.smsGuardianError = "Timed out waiting for verification instructions. Try again."
+                self.smsVerificationInProgress = false
+                self.smsVerificationInstruction = nil
+                if self.smsVerificationError == nil {
+                    self.smsVerificationError = "Timed out waiting for verification instructions. Try again."
                 }
             case "voice":
-                self.voiceGuardianVerificationInProgress = false
-                self.voiceGuardianInstruction = nil
-                if self.voiceGuardianError == nil {
-                    self.voiceGuardianError = "Timed out waiting for verification instructions. Try again."
+                self.voiceVerificationInProgress = false
+                self.voiceVerificationInstruction = nil
+                if self.voiceVerificationError == nil {
+                    self.voiceVerificationError = "Timed out waiting for verification instructions. Try again."
                 }
             case "slack":
-                self.slackGuardianVerificationInProgress = false
-                self.slackGuardianInstruction = nil
-                if self.slackGuardianError == nil {
-                    self.slackGuardianError = "Timed out waiting for verification instructions. Try again."
+                self.slackVerificationInProgress = false
+                self.slackVerificationInstruction = nil
+                if self.slackVerificationError == nil {
+                    self.slackVerificationError = "Timed out waiting for verification instructions. Try again."
                 }
             default:
                 break
             }
         }
-        guardianChallengeTimeoutWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + guardianChallengeTimeoutDuration, execute: workItem)
+        verificationChallengeTimeoutWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + verificationChallengeTimeoutDuration, execute: workItem)
     }
 
-    private func startGuardianStatusPolling(for channel: String) {
+    private func startVerificationStatusPolling(for channel: String) {
         guard channel == "telegram" || channel == "sms" || channel == "voice" || channel == "slack" else { return }
-        stopGuardianStatusPolling(for: channel)
-        guardianStatusPollingDeadlines[channel] = Date().addingTimeInterval(guardianStatusPollWindow)
-        scheduleGuardianStatusPoll(for: channel, delay: guardianStatusPollInterval)
+        stopVerificationStatusPolling(for: channel)
+        verificationStatusPollingDeadlines[channel] = Date().addingTimeInterval(verificationStatusPollWindow)
+        scheduleVerificationStatusPoll(for: channel, delay: verificationStatusPollInterval)
     }
 
-    private func stopGuardianStatusPolling(for channel: String) {
-        guardianStatusPollingWorkItems[channel]?.cancel()
-        guardianStatusPollingWorkItems[channel] = nil
-        guardianStatusPollingDeadlines[channel] = nil
+    private func stopVerificationStatusPolling(for channel: String) {
+        verificationStatusPollingWorkItems[channel]?.cancel()
+        verificationStatusPollingWorkItems[channel] = nil
+        verificationStatusPollingDeadlines[channel] = nil
     }
 
-    private func scheduleGuardianStatusPoll(for channel: String, delay: TimeInterval) {
+    private func scheduleVerificationStatusPoll(for channel: String, delay: TimeInterval) {
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
-            guard let deadline = self.guardianStatusPollingDeadlines[channel] else { return }
+            guard let deadline = self.verificationStatusPollingDeadlines[channel] else { return }
             if Date() >= deadline {
-                self.stopGuardianStatusPolling(for: channel)
+                self.stopVerificationStatusPolling(for: channel)
                 return
             }
-            self.refreshChannelGuardianStatus(channel: channel)
-            self.scheduleGuardianStatusPoll(for: channel, delay: self.guardianStatusPollInterval)
+            self.refreshChannelVerificationStatus(channel: channel)
+            self.scheduleVerificationStatusPoll(for: channel, delay: self.verificationStatusPollInterval)
         }
-        guardianStatusPollingWorkItems[channel]?.cancel()
-        guardianStatusPollingWorkItems[channel] = workItem
+        verificationStatusPollingWorkItems[channel]?.cancel()
+        verificationStatusPollingWorkItems[channel] = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
 

--- a/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
@@ -40,72 +40,72 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
 
     // MARK: - Initial State
 
-    func testInitialGuardianStateIsNilOrFalse() {
-        XCTAssertNil(store.telegramGuardianIdentity)
-        XCTAssertFalse(store.telegramGuardianVerified)
-        XCTAssertFalse(store.telegramGuardianVerificationInProgress)
-        XCTAssertNil(store.telegramGuardianInstruction)
-        XCTAssertNil(store.telegramGuardianError)
+    func testInitialVerificationStateIsNilOrFalse() {
+        XCTAssertNil(store.telegramVerificationIdentity)
+        XCTAssertFalse(store.telegramVerificationVerified)
+        XCTAssertFalse(store.telegramVerificationInProgress)
+        XCTAssertNil(store.telegramVerificationInstruction)
+        XCTAssertNil(store.telegramVerificationError)
 
-        XCTAssertNil(store.smsGuardianIdentity)
-        XCTAssertFalse(store.smsGuardianVerified)
-        XCTAssertFalse(store.smsGuardianVerificationInProgress)
-        XCTAssertNil(store.smsGuardianInstruction)
-        XCTAssertNil(store.smsGuardianError)
+        XCTAssertNil(store.smsVerificationIdentity)
+        XCTAssertFalse(store.smsVerificationVerified)
+        XCTAssertFalse(store.smsVerificationInProgress)
+        XCTAssertNil(store.smsVerificationInstruction)
+        XCTAssertNil(store.smsVerificationError)
 
-        XCTAssertNil(store.voiceGuardianIdentity)
-        XCTAssertFalse(store.voiceGuardianVerified)
-        XCTAssertFalse(store.voiceGuardianVerificationInProgress)
-        XCTAssertNil(store.voiceGuardianInstruction)
-        XCTAssertNil(store.voiceGuardianError)
+        XCTAssertNil(store.voiceVerificationIdentity)
+        XCTAssertFalse(store.voiceVerificationVerified)
+        XCTAssertFalse(store.voiceVerificationInProgress)
+        XCTAssertNil(store.voiceVerificationInstruction)
+        XCTAssertNil(store.voiceVerificationError)
     }
 
-    // MARK: - refreshChannelGuardianStatus
+    // MARK: - refreshChannelVerificationStatus
 
-    func testRefreshChannelGuardianStatusSendsStatusRequest() {
+    func testRefreshChannelVerificationStatusSendsStatusRequest() {
         // Init already sends status requests, count those first
-        let guardianMessagesBefore = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let statusCountBefore = guardianMessagesBefore.filter { $0.action == "status" }.count
+        let verificationMessagesBefore = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
+        let statusCountBefore = verificationMessagesBefore.filter { $0.action == "status" }.count
 
-        store.refreshChannelGuardianStatus(channel: "telegram")
+        store.refreshChannelVerificationStatus(channel: "telegram")
 
-        let guardianMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let statusMessages = guardianMessages.filter { $0.action == "status" && $0.channel == "telegram" }
+        let verificationMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
+        let statusMessages = verificationMessages.filter { $0.action == "status" && $0.channel == "telegram" }
         XCTAssertGreaterThan(statusMessages.count, 0)
 
-        let statusCountAfter = guardianMessages.filter { $0.action == "status" }.count
+        let statusCountAfter = verificationMessages.filter { $0.action == "status" }.count
         XCTAssertEqual(statusCountAfter, statusCountBefore + 1)
     }
 
-    // MARK: - startChannelGuardianVerification (Telegram)
+    // MARK: - startChannelVerification (Telegram)
 
     func testStartTelegramVerificationSetsInProgressAndSendsChallenge() {
-        store.startChannelGuardianVerification(channel: "telegram")
+        store.startChannelVerification(channel: "telegram")
 
-        XCTAssertTrue(store.telegramGuardianVerificationInProgress)
-        XCTAssertNil(store.telegramGuardianError)
+        XCTAssertTrue(store.telegramVerificationInProgress)
+        XCTAssertNil(store.telegramVerificationError)
 
-        let guardianMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let challengeMessages = guardianMessages.filter { $0.action == "create_session" && $0.channel == "telegram" }
+        let verificationMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
+        let challengeMessages = verificationMessages.filter { $0.action == "create_session" && $0.channel == "telegram" }
         XCTAssertEqual(challengeMessages.count, 1)
     }
 
-    // MARK: - startChannelGuardianVerification (SMS)
+    // MARK: - startChannelVerification (SMS)
 
     func testStartSmsVerificationSetsInProgressAndSendsChallenge() {
-        store.startChannelGuardianVerification(channel: "sms")
+        store.startChannelVerification(channel: "sms")
 
-        XCTAssertTrue(store.smsGuardianVerificationInProgress)
-        XCTAssertNil(store.smsGuardianError)
+        XCTAssertTrue(store.smsVerificationInProgress)
+        XCTAssertNil(store.smsVerificationError)
 
-        let guardianMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let challengeMessages = guardianMessages.filter { $0.action == "create_session" && $0.channel == "sms" }
+        let verificationMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
+        let challengeMessages = verificationMessages.filter { $0.action == "create_session" && $0.channel == "sms" }
         XCTAssertEqual(challengeMessages.count, 1)
     }
 
     // MARK: - Successful status response
 
-    func testSuccessfulStatusResponseUpdatesTelegramGuardianState() {
+    func testSuccessfulStatusResponseUpdatesTelegramVerificationState() {
         daemonClient.onChannelVerificationSessionResponse?(ChannelVerificationSessionResponseMessage(
             type: "channel_verification_session_response",
             success: true,
@@ -119,17 +119,17 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             error: nil
         ))
 
-        let predicate = NSPredicate { _, _ in self.store.telegramGuardianVerified }
+        let predicate = NSPredicate { _, _ in self.store.telegramVerificationVerified }
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
         wait(for: [expectation], timeout: 2.0)
 
-        XCTAssertEqual(store.telegramGuardianIdentity, "tg_user_123")
-        XCTAssertTrue(store.telegramGuardianVerified)
-        XCTAssertFalse(store.telegramGuardianVerificationInProgress)
-        XCTAssertNil(store.telegramGuardianError)
+        XCTAssertEqual(store.telegramVerificationIdentity, "tg_user_123")
+        XCTAssertTrue(store.telegramVerificationVerified)
+        XCTAssertFalse(store.telegramVerificationInProgress)
+        XCTAssertNil(store.telegramVerificationError)
     }
 
-    func testSuccessfulStatusResponseUpdatesSmsGuardianState() {
+    func testSuccessfulStatusResponseUpdatesSmsVerificationState() {
         daemonClient.onChannelVerificationSessionResponse?(ChannelVerificationSessionResponseMessage(
             type: "channel_verification_session_response",
             success: true,
@@ -143,20 +143,20 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             error: nil
         ))
 
-        let predicate = NSPredicate { _, _ in self.store.smsGuardianVerified }
+        let predicate = NSPredicate { _, _ in self.store.smsVerificationVerified }
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
         wait(for: [expectation], timeout: 2.0)
 
-        XCTAssertEqual(store.smsGuardianIdentity, "+15551234567")
-        XCTAssertTrue(store.smsGuardianVerified)
-        XCTAssertFalse(store.smsGuardianVerificationInProgress)
-        XCTAssertNil(store.smsGuardianError)
+        XCTAssertEqual(store.smsVerificationIdentity, "+15551234567")
+        XCTAssertTrue(store.smsVerificationVerified)
+        XCTAssertFalse(store.smsVerificationInProgress)
+        XCTAssertNil(store.smsVerificationError)
     }
 
     // MARK: - Successful create_session response provides instruction
 
     func testSuccessfulChallengeResponseProvidesInstruction() {
-        store.telegramGuardianVerificationInProgress = true
+        store.telegramVerificationInProgress = true
 
         daemonClient.onChannelVerificationSessionResponse?(ChannelVerificationSessionResponseMessage(
             type: "channel_verification_session_response",
@@ -171,18 +171,18 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             error: nil
         ))
 
-        let predicate = NSPredicate { _, _ in !self.store.telegramGuardianVerificationInProgress }
+        let predicate = NSPredicate { _, _ in !self.store.telegramVerificationInProgress }
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
         wait(for: [expectation], timeout: 2.0)
 
-        XCTAssertEqual(store.telegramGuardianInstruction, "Send /verify abc123 to @MyBot on Telegram")
-        XCTAssertFalse(store.telegramGuardianVerified)
-        XCTAssertFalse(store.telegramGuardianVerificationInProgress)
-        XCTAssertNil(store.telegramGuardianError)
+        XCTAssertEqual(store.telegramVerificationInstruction, "Send /verify abc123 to @MyBot on Telegram")
+        XCTAssertFalse(store.telegramVerificationVerified)
+        XCTAssertFalse(store.telegramVerificationInProgress)
+        XCTAssertNil(store.telegramVerificationError)
     }
 
     func testUnverifiedStatusResponseDoesNotClearExistingTelegramInstruction() {
-        store.telegramGuardianInstruction = "Send code abc123 on Telegram"
+        store.telegramVerificationInstruction = "Send code abc123 on Telegram"
 
         daemonClient.onChannelVerificationSessionResponse?(ChannelVerificationSessionResponseMessage(
             type: "channel_verification_session_response",
@@ -197,12 +197,12 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             error: nil
         ))
 
-        XCTAssertEqual(store.telegramGuardianInstruction, "Send code abc123 on Telegram")
-        XCTAssertFalse(store.telegramGuardianVerified)
+        XCTAssertEqual(store.telegramVerificationInstruction, "Send code abc123 on Telegram")
+        XCTAssertFalse(store.telegramVerificationVerified)
     }
 
     func testVerifiedStatusResponseClearsExistingTelegramInstruction() {
-        store.telegramGuardianInstruction = "Send code abc123 on Telegram"
+        store.telegramVerificationInstruction = "Send code abc123 on Telegram"
 
         daemonClient.onChannelVerificationSessionResponse?(ChannelVerificationSessionResponseMessage(
             type: "channel_verification_session_response",
@@ -217,14 +217,14 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             error: nil
         ))
 
-        XCTAssertNil(store.telegramGuardianInstruction)
-        XCTAssertTrue(store.telegramGuardianVerified)
+        XCTAssertNil(store.telegramVerificationInstruction)
+        XCTAssertTrue(store.telegramVerificationVerified)
     }
 
     // MARK: - Failed response sets error
 
     func testFailedResponseSetsTelegramError() {
-        store.telegramGuardianVerificationInProgress = true
+        store.telegramVerificationInProgress = true
 
         daemonClient.onChannelVerificationSessionResponse?(ChannelVerificationSessionResponseMessage(
             type: "channel_verification_session_response",
@@ -239,16 +239,16 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             error: "Telegram bot not configured"
         ))
 
-        let predicate = NSPredicate { _, _ in !self.store.telegramGuardianVerificationInProgress }
+        let predicate = NSPredicate { _, _ in !self.store.telegramVerificationInProgress }
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
         wait(for: [expectation], timeout: 2.0)
 
-        XCTAssertFalse(store.telegramGuardianVerificationInProgress)
-        XCTAssertEqual(store.telegramGuardianError, "Telegram bot not configured")
+        XCTAssertFalse(store.telegramVerificationInProgress)
+        XCTAssertEqual(store.telegramVerificationError, "Telegram bot not configured")
     }
 
     func testFailedResponseSetsSmsError() {
-        store.smsGuardianVerificationInProgress = true
+        store.smsVerificationInProgress = true
 
         daemonClient.onChannelVerificationSessionResponse?(ChannelVerificationSessionResponseMessage(
             type: "channel_verification_session_response",
@@ -263,12 +263,12 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             error: "Twilio credentials missing"
         ))
 
-        let predicate = NSPredicate { _, _ in !self.store.smsGuardianVerificationInProgress }
+        let predicate = NSPredicate { _, _ in !self.store.smsVerificationInProgress }
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
         wait(for: [expectation], timeout: 2.0)
 
-        XCTAssertFalse(store.smsGuardianVerificationInProgress)
-        XCTAssertEqual(store.smsGuardianError, "Twilio credentials missing")
+        XCTAssertFalse(store.smsVerificationInProgress)
+        XCTAssertEqual(store.smsVerificationError, "Twilio credentials missing")
     }
 
     // MARK: - Unknown channel is silently ignored
@@ -288,10 +288,10 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         ))
 
         // Neither telegram nor sms state should change
-        XCTAssertNil(store.telegramGuardianIdentity)
-        XCTAssertFalse(store.telegramGuardianVerified)
-        XCTAssertNil(store.smsGuardianIdentity)
-        XCTAssertFalse(store.smsGuardianVerified)
+        XCTAssertNil(store.telegramVerificationIdentity)
+        XCTAssertFalse(store.telegramVerificationVerified)
+        XCTAssertNil(store.smsVerificationIdentity)
+        XCTAssertFalse(store.smsVerificationVerified)
     }
 
     func testResponseWithNilChannelAndNoPendingStateIsIgnored() {
@@ -308,15 +308,15 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             error: nil
         ))
 
-        XCTAssertNil(store.telegramGuardianIdentity)
-        XCTAssertFalse(store.telegramGuardianVerified)
-        XCTAssertNil(store.smsGuardianIdentity)
-        XCTAssertFalse(store.smsGuardianVerified)
+        XCTAssertNil(store.telegramVerificationIdentity)
+        XCTAssertFalse(store.telegramVerificationVerified)
+        XCTAssertNil(store.smsVerificationIdentity)
+        XCTAssertFalse(store.smsVerificationVerified)
     }
 
     func testResponseWithNilChannelUsesPendingVerificationChannel() {
-        store.startChannelGuardianVerification(channel: "telegram")
-        XCTAssertTrue(store.telegramGuardianVerificationInProgress)
+        store.startChannelVerification(channel: "telegram")
+        XCTAssertTrue(store.telegramVerificationInProgress)
 
         daemonClient.onChannelVerificationSessionResponse?(ChannelVerificationSessionResponseMessage(
             type: "channel_verification_session_response",
@@ -331,23 +331,23 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             error: nil
         ))
 
-        let predicate = NSPredicate { _, _ in !self.store.telegramGuardianVerificationInProgress }
+        let predicate = NSPredicate { _, _ in !self.store.telegramVerificationInProgress }
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
         wait(for: [expectation], timeout: 2.0)
 
-        XCTAssertEqual(store.telegramGuardianInstruction, "Send code abc123 on Telegram")
-        XCTAssertFalse(store.telegramGuardianVerificationInProgress)
-        XCTAssertNil(store.telegramGuardianError)
+        XCTAssertEqual(store.telegramVerificationInstruction, "Send code abc123 on Telegram")
+        XCTAssertFalse(store.telegramVerificationInProgress)
+        XCTAssertNil(store.telegramVerificationError)
     }
 
-    func testChallengeResponseStartsGuardianStatusPolling() {
+    func testChallengeResponseStartsVerificationStatusPolling() {
         sentMessages.removeAll()
         let pollingStore = SettingsStore(
             daemonClient: daemonClient,
-            guardianStatusPollInterval: 0.05,
-            guardianStatusPollWindow: 2.0
+            verificationStatusPollInterval: 0.05,
+            verificationStatusPollWindow: 2.0
         )
-        pollingStore.startChannelGuardianVerification(channel: "telegram")
+        pollingStore.startChannelVerification(channel: "telegram")
 
         let statusCountBefore = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
             .filter { $0.action == "status" && $0.channel == "telegram" }
@@ -376,14 +376,14 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         wait(for: [expectation], timeout: 2.0)
     }
 
-    func testVerifiedResponseStopsGuardianStatusPolling() {
+    func testVerifiedResponseStopsVerificationStatusPolling() {
         sentMessages.removeAll()
         let pollingStore = SettingsStore(
             daemonClient: daemonClient,
-            guardianStatusPollInterval: 0.05,
-            guardianStatusPollWindow: 2.0
+            verificationStatusPollInterval: 0.05,
+            verificationStatusPollWindow: 2.0
         )
-        pollingStore.startChannelGuardianVerification(channel: "telegram")
+        pollingStore.startChannelVerification(channel: "telegram")
 
         daemonClient.onChannelVerificationSessionResponse?(ChannelVerificationSessionResponseMessage(
             type: "channel_verification_session_response",
@@ -439,25 +439,25 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         XCTAssertEqual(statusCountFinal, statusCountAfterVerification)
     }
 
-    // MARK: - revokeChannelGuardian
+    // MARK: - revokeChannelVerification
 
-    func testRevokeChannelGuardianSendsRevokeAction() {
-        let guardianMessagesBefore = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let revokeCountBefore = guardianMessagesBefore.filter { $0.action == "revoke" }.count
+    func testRevokeChannelVerificationSendsRevokeAction() {
+        let verificationMessagesBefore = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
+        let revokeCountBefore = verificationMessagesBefore.filter { $0.action == "revoke" }.count
         XCTAssertEqual(revokeCountBefore, 0)
 
-        store.revokeChannelGuardian(channel: "telegram")
+        store.revokeChannelVerification(channel: "telegram")
 
-        let guardianMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let revokeMessages = guardianMessages.filter { $0.action == "revoke" && $0.channel == "telegram" }
+        let verificationMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
+        let revokeMessages = verificationMessages.filter { $0.action == "revoke" && $0.channel == "telegram" }
         XCTAssertEqual(revokeMessages.count, 1)
     }
 
-    func testRevokeSmsGuardianSendsRevokeAction() {
-        store.revokeChannelGuardian(channel: "sms")
+    func testRevokeSmsVerificationSendsRevokeAction() {
+        store.revokeChannelVerification(channel: "sms")
 
-        let guardianMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let revokeMessages = guardianMessages.filter { $0.action == "revoke" && $0.channel == "sms" }
+        let verificationMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
+        let revokeMessages = verificationMessages.filter { $0.action == "revoke" && $0.channel == "sms" }
         XCTAssertEqual(revokeMessages.count, 1)
     }
 
@@ -467,21 +467,21 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         let orphanStore = SettingsStore()
 
         // None of these should crash
-        orphanStore.refreshChannelGuardianStatus(channel: "telegram")
-        orphanStore.refreshChannelGuardianStatus(channel: "sms")
-        orphanStore.refreshChannelGuardianStatus(channel: "voice")
-        orphanStore.startChannelGuardianVerification(channel: "telegram")
-        orphanStore.startChannelGuardianVerification(channel: "sms")
-        orphanStore.startChannelGuardianVerification(channel: "voice")
-        orphanStore.revokeChannelGuardian(channel: "telegram")
-        orphanStore.revokeChannelGuardian(channel: "sms")
-        orphanStore.revokeChannelGuardian(channel: "voice")
+        orphanStore.refreshChannelVerificationStatus(channel: "telegram")
+        orphanStore.refreshChannelVerificationStatus(channel: "sms")
+        orphanStore.refreshChannelVerificationStatus(channel: "voice")
+        orphanStore.startChannelVerification(channel: "telegram")
+        orphanStore.startChannelVerification(channel: "sms")
+        orphanStore.startChannelVerification(channel: "voice")
+        orphanStore.revokeChannelVerification(channel: "telegram")
+        orphanStore.revokeChannelVerification(channel: "sms")
+        orphanStore.revokeChannelVerification(channel: "voice")
     }
 
     // MARK: - Successful response clears previous error
 
     func testSuccessfulResponseClearsPreviousError() {
-        store.telegramGuardianError = "old error"
+        store.telegramVerificationError = "old error"
 
         daemonClient.onChannelVerificationSessionResponse?(ChannelVerificationSessionResponseMessage(
             type: "channel_verification_session_response",
@@ -496,31 +496,31 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             error: nil
         ))
 
-        let predicate = NSPredicate { _, _ in self.store.telegramGuardianVerified }
+        let predicate = NSPredicate { _, _ in self.store.telegramVerificationVerified }
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
         wait(for: [expectation], timeout: 2.0)
 
-        XCTAssertNil(store.telegramGuardianError)
+        XCTAssertNil(store.telegramVerificationError)
     }
 
     // MARK: - Start verification clears previous error
 
     func testStartVerificationClearsPreviousError() {
-        store.telegramGuardianError = "previous error"
+        store.telegramVerificationError = "previous error"
 
-        store.startChannelGuardianVerification(channel: "telegram")
+        store.startChannelVerification(channel: "telegram")
 
-        XCTAssertNil(store.telegramGuardianError)
-        XCTAssertTrue(store.telegramGuardianVerificationInProgress)
+        XCTAssertNil(store.telegramVerificationError)
+        XCTAssertTrue(store.telegramVerificationInProgress)
     }
 
-    // MARK: - Unknown channel in startChannelGuardianVerification is no-op
+    // MARK: - Unknown channel in startChannelVerification is no-op
 
     func testStartVerificationWithUnknownChannelIsNoOp() {
         let messageCountBefore = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
             .filter { $0.action == "create_session" }.count
 
-        store.startChannelGuardianVerification(channel: "discord")
+        store.startChannelVerification(channel: "discord")
 
         let messageCountAfter = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
             .filter { $0.action == "create_session" }.count
@@ -529,9 +529,9 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
 
     // MARK: - Init sends status requests for both channels
 
-    func testInitSendsGuardianStatusRequestsForAllChannels() {
-        let guardianMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let statusMessages = guardianMessages.filter { $0.action == "status" }
+    func testInitSendsVerificationStatusRequestsForAllChannels() {
+        let verificationMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
+        let statusMessages = verificationMessages.filter { $0.action == "status" }
 
         let telegramStatus = statusMessages.filter { $0.channel == "telegram" }
         let smsStatus = statusMessages.filter { $0.channel == "sms" }
@@ -542,9 +542,9 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         XCTAssertEqual(voiceStatus.count, 1)
     }
 
-    func testStatusPollResponseDoesNotClearGuardianChallengePending() {
-        store.startChannelGuardianVerification(channel: "telegram")
-        XCTAssertTrue(store.telegramGuardianVerificationInProgress)
+    func testStatusPollResponseDoesNotClearVerificationChallengePending() {
+        store.startChannelVerification(channel: "telegram")
+        XCTAssertTrue(store.telegramVerificationInProgress)
 
         // Simulate a status poll response (no secret, no instruction, not bound)
         daemonClient.onChannelVerificationSessionResponse?(ChannelVerificationSessionResponseMessage(
@@ -574,26 +574,26 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             error: nil
         ))
 
-        XCTAssertEqual(store.telegramGuardianInstruction, "Send code abc123 on Telegram")
-        XCTAssertFalse(store.telegramGuardianVerificationInProgress)
+        XCTAssertEqual(store.telegramVerificationInstruction, "Send code abc123 on Telegram")
+        XCTAssertFalse(store.telegramVerificationInProgress)
     }
 
     // MARK: - Revoke clears instruction
 
-    func testRevokeTelegramGuardianClearsInstruction() {
-        store.telegramGuardianInstruction = "Send code abc123 on Telegram"
+    func testRevokeTelegramVerificationClearsInstruction() {
+        store.telegramVerificationInstruction = "Send code abc123 on Telegram"
 
-        store.revokeChannelGuardian(channel: "telegram")
+        store.revokeChannelVerification(channel: "telegram")
 
-        XCTAssertNil(store.telegramGuardianInstruction)
+        XCTAssertNil(store.telegramVerificationInstruction)
     }
 
-    func testRevokeSmsGuardianClearsInstruction() {
-        store.smsGuardianInstruction = "Send code abc123 via SMS"
+    func testRevokeSmsVerificationClearsInstruction() {
+        store.smsVerificationInstruction = "Send code abc123 via SMS"
 
-        store.revokeChannelGuardian(channel: "sms")
+        store.revokeChannelVerification(channel: "sms")
 
-        XCTAssertNil(store.smsGuardianInstruction)
+        XCTAssertNil(store.smsVerificationInstruction)
     }
 
     // MARK: - Timeout clears instruction
@@ -602,51 +602,51 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         sentMessages.removeAll()
         let shortTimeoutStore = SettingsStore(
             daemonClient: daemonClient,
-            guardianChallengeTimeoutDuration: 0.15,
-            guardianStatusPollInterval: 0.05,
-            guardianStatusPollWindow: 2.0
+            verificationChallengeTimeoutDuration: 0.15,
+            verificationStatusPollInterval: 0.05,
+            verificationStatusPollWindow: 2.0
         )
 
-        shortTimeoutStore.startChannelGuardianVerification(channel: "telegram")
+        shortTimeoutStore.startChannelVerification(channel: "telegram")
 
         // Manually set instruction to simulate a previous challenge's stale text
         // that persists when a new challenge times out before the daemon responds.
-        shortTimeoutStore.telegramGuardianInstruction = "Send code stale on Telegram"
+        shortTimeoutStore.telegramVerificationInstruction = "Send code stale on Telegram"
 
         // Wait for the timeout to fire
         let predicate = NSPredicate { _, _ in
-            shortTimeoutStore.telegramGuardianError != nil
+            shortTimeoutStore.telegramVerificationError != nil
         }
         let timeoutExpectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
         wait(for: [timeoutExpectation], timeout: 2.0)
 
-        XCTAssertNil(shortTimeoutStore.telegramGuardianInstruction)
-        XCTAssertFalse(shortTimeoutStore.telegramGuardianVerificationInProgress)
+        XCTAssertNil(shortTimeoutStore.telegramVerificationInstruction)
+        XCTAssertFalse(shortTimeoutStore.telegramVerificationInProgress)
     }
 
     func testTimeoutClearsSmsInstruction() {
         sentMessages.removeAll()
         let shortTimeoutStore = SettingsStore(
             daemonClient: daemonClient,
-            guardianChallengeTimeoutDuration: 0.15,
-            guardianStatusPollInterval: 0.05,
-            guardianStatusPollWindow: 2.0
+            verificationChallengeTimeoutDuration: 0.15,
+            verificationStatusPollInterval: 0.05,
+            verificationStatusPollWindow: 2.0
         )
 
-        shortTimeoutStore.startChannelGuardianVerification(channel: "sms")
+        shortTimeoutStore.startChannelVerification(channel: "sms")
 
         // Manually set instruction to simulate a previous challenge's stale text
-        shortTimeoutStore.smsGuardianInstruction = "Send code stale via SMS"
+        shortTimeoutStore.smsVerificationInstruction = "Send code stale via SMS"
 
         // Wait for the timeout to fire
         let predicate = NSPredicate { _, _ in
-            shortTimeoutStore.smsGuardianError != nil
+            shortTimeoutStore.smsVerificationError != nil
         }
         let timeoutExpectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
         wait(for: [timeoutExpectation], timeout: 2.0)
 
-        XCTAssertNil(shortTimeoutStore.smsGuardianInstruction)
-        XCTAssertFalse(shortTimeoutStore.smsGuardianVerificationInProgress)
+        XCTAssertNil(shortTimeoutStore.smsVerificationInstruction)
+        XCTAssertFalse(shortTimeoutStore.smsVerificationInProgress)
     }
 
     // MARK: - Cross-channel timeout isolation
@@ -656,14 +656,14 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         sentMessages.removeAll()
         let shortTimeoutStore = SettingsStore(
             daemonClient: daemonClient,
-            guardianChallengeTimeoutDuration: 0.3,
-            guardianStatusPollInterval: 0.05,
-            guardianStatusPollWindow: 2.0
+            verificationChallengeTimeoutDuration: 0.3,
+            verificationStatusPollInterval: 0.05,
+            verificationStatusPollWindow: 2.0
         )
 
         // Start SMS verification — this arms the timeout for SMS
-        shortTimeoutStore.startChannelGuardianVerification(channel: "sms")
-        XCTAssertTrue(shortTimeoutStore.smsGuardianVerificationInProgress)
+        shortTimeoutStore.startChannelVerification(channel: "sms")
+        XCTAssertTrue(shortTimeoutStore.smsVerificationInProgress)
 
         // A telegram response arrives — this must NOT cancel the SMS timeout
         daemonClient.onChannelVerificationSessionResponse?(ChannelVerificationSessionResponseMessage(
@@ -680,33 +680,33 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         ))
 
         // SMS should still be in progress right after the telegram response
-        XCTAssertTrue(shortTimeoutStore.smsGuardianVerificationInProgress)
-        XCTAssertNil(shortTimeoutStore.smsGuardianError)
+        XCTAssertTrue(shortTimeoutStore.smsVerificationInProgress)
+        XCTAssertNil(shortTimeoutStore.smsVerificationError)
 
         // Wait for the SMS timeout to fire (0.3s + buffer)
-        let predicate = NSPredicate { _, _ in !shortTimeoutStore.smsGuardianVerificationInProgress }
+        let predicate = NSPredicate { _, _ in !shortTimeoutStore.smsVerificationInProgress }
         let timeoutExpectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
         wait(for: [timeoutExpectation], timeout: 2.0)
 
         // The SMS timeout should have fired, clearing the spinner and setting an error
-        XCTAssertFalse(shortTimeoutStore.smsGuardianVerificationInProgress)
-        XCTAssertEqual(shortTimeoutStore.smsGuardianError, "Timed out waiting for verification instructions. Try again.")
+        XCTAssertFalse(shortTimeoutStore.smsVerificationInProgress)
+        XCTAssertEqual(shortTimeoutStore.smsVerificationError, "Timed out waiting for verification instructions. Try again.")
     }
 
-    // MARK: - Voice Guardian Verification
+    // MARK: - Voice Channel Verification
 
     func testStartVoiceVerificationSetsInProgressAndSendsChallenge() {
-        store.startChannelGuardianVerification(channel: "voice")
+        store.startChannelVerification(channel: "voice")
 
-        XCTAssertTrue(store.voiceGuardianVerificationInProgress)
-        XCTAssertNil(store.voiceGuardianError)
+        XCTAssertTrue(store.voiceVerificationInProgress)
+        XCTAssertNil(store.voiceVerificationError)
 
-        let guardianMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let challengeMessages = guardianMessages.filter { $0.action == "create_session" && $0.channel == "voice" }
+        let verificationMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
+        let challengeMessages = verificationMessages.filter { $0.action == "create_session" && $0.channel == "voice" }
         XCTAssertEqual(challengeMessages.count, 1)
     }
 
-    func testSuccessfulStatusResponseUpdatesVoiceGuardianState() {
+    func testSuccessfulStatusResponseUpdatesVoiceVerificationState() {
         daemonClient.onChannelVerificationSessionResponse?(ChannelVerificationSessionResponseMessage(
             type: "channel_verification_session_response",
             success: true,
@@ -720,18 +720,18 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             error: nil
         ))
 
-        let predicate = NSPredicate { _, _ in self.store.voiceGuardianVerified }
+        let predicate = NSPredicate { _, _ in self.store.voiceVerificationVerified }
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
         wait(for: [expectation], timeout: 2.0)
 
-        XCTAssertEqual(store.voiceGuardianIdentity, "+15559876543")
-        XCTAssertTrue(store.voiceGuardianVerified)
-        XCTAssertFalse(store.voiceGuardianVerificationInProgress)
-        XCTAssertNil(store.voiceGuardianError)
+        XCTAssertEqual(store.voiceVerificationIdentity, "+15559876543")
+        XCTAssertTrue(store.voiceVerificationVerified)
+        XCTAssertFalse(store.voiceVerificationInProgress)
+        XCTAssertNil(store.voiceVerificationError)
     }
 
     func testFailedResponseSetsVoiceError() {
-        store.voiceGuardianVerificationInProgress = true
+        store.voiceVerificationInProgress = true
 
         daemonClient.onChannelVerificationSessionResponse?(ChannelVerificationSessionResponseMessage(
             type: "channel_verification_session_response",
@@ -746,51 +746,51 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             error: "Voice channel not configured"
         ))
 
-        let predicate = NSPredicate { _, _ in !self.store.voiceGuardianVerificationInProgress }
+        let predicate = NSPredicate { _, _ in !self.store.voiceVerificationInProgress }
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
         wait(for: [expectation], timeout: 2.0)
 
-        XCTAssertFalse(store.voiceGuardianVerificationInProgress)
-        XCTAssertEqual(store.voiceGuardianError, "Voice channel not configured")
+        XCTAssertFalse(store.voiceVerificationInProgress)
+        XCTAssertEqual(store.voiceVerificationError, "Voice channel not configured")
     }
 
-    func testRevokeVoiceGuardianSendsRevokeAction() {
-        store.revokeChannelGuardian(channel: "voice")
+    func testRevokeVoiceVerificationSendsRevokeAction() {
+        store.revokeChannelVerification(channel: "voice")
 
-        let guardianMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let revokeMessages = guardianMessages.filter { $0.action == "revoke" && $0.channel == "voice" }
+        let verificationMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
+        let revokeMessages = verificationMessages.filter { $0.action == "revoke" && $0.channel == "voice" }
         XCTAssertEqual(revokeMessages.count, 1)
     }
 
-    func testRevokeVoiceGuardianClearsInstruction() {
-        store.voiceGuardianInstruction = "Call and say 123456"
+    func testRevokeVoiceVerificationClearsInstruction() {
+        store.voiceVerificationInstruction = "Call and say 123456"
 
-        store.revokeChannelGuardian(channel: "voice")
+        store.revokeChannelVerification(channel: "voice")
 
-        XCTAssertNil(store.voiceGuardianInstruction)
+        XCTAssertNil(store.voiceVerificationInstruction)
     }
 
     func testTimeoutClearsVoiceInstruction() {
         sentMessages.removeAll()
         let shortTimeoutStore = SettingsStore(
             daemonClient: daemonClient,
-            guardianChallengeTimeoutDuration: 0.15,
-            guardianStatusPollInterval: 0.05,
-            guardianStatusPollWindow: 2.0
+            verificationChallengeTimeoutDuration: 0.15,
+            verificationStatusPollInterval: 0.05,
+            verificationStatusPollWindow: 2.0
         )
 
-        shortTimeoutStore.startChannelGuardianVerification(channel: "voice")
+        shortTimeoutStore.startChannelVerification(channel: "voice")
 
-        shortTimeoutStore.voiceGuardianInstruction = "Call and say 123456"
+        shortTimeoutStore.voiceVerificationInstruction = "Call and say 123456"
 
         let predicate = NSPredicate { _, _ in
-            shortTimeoutStore.voiceGuardianError != nil
+            shortTimeoutStore.voiceVerificationError != nil
         }
         let timeoutExpectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
         wait(for: [timeoutExpectation], timeout: 2.0)
 
-        XCTAssertNil(shortTimeoutStore.voiceGuardianInstruction)
-        XCTAssertFalse(shortTimeoutStore.voiceGuardianVerificationInProgress)
+        XCTAssertNil(shortTimeoutStore.voiceVerificationInstruction)
+        XCTAssertFalse(shortTimeoutStore.voiceVerificationInProgress)
     }
 
     func testVoiceResponseDoesNotAffectTelegramOrSmsState() {
@@ -807,27 +807,27 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             error: nil
         ))
 
-        let predicate = NSPredicate { _, _ in self.store.voiceGuardianVerified }
+        let predicate = NSPredicate { _, _ in self.store.voiceVerificationVerified }
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
         wait(for: [expectation], timeout: 2.0)
 
         // Telegram and SMS should be unaffected
-        XCTAssertNil(store.telegramGuardianIdentity)
-        XCTAssertFalse(store.telegramGuardianVerified)
-        XCTAssertNil(store.smsGuardianIdentity)
-        XCTAssertFalse(store.smsGuardianVerified)
+        XCTAssertNil(store.telegramVerificationIdentity)
+        XCTAssertFalse(store.telegramVerificationVerified)
+        XCTAssertNil(store.smsVerificationIdentity)
+        XCTAssertFalse(store.smsVerificationVerified)
     }
 
-    // MARK: - Outbound Verification: startOutboundGuardianVerification
+    // MARK: - Outbound Verification: startOutboundVerification
 
     func testStartOutboundVerificationSendsCorrectIPCMessage() {
-        store.startOutboundGuardianVerification(channel: "sms", destination: "+15551234567")
+        store.startOutboundVerification(channel: "sms", destination: "+15551234567")
 
-        let guardianMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let outboundMessages = guardianMessages.filter { $0.action == "create_session" && $0.channel == "sms" }
+        let verificationMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
+        let outboundMessages = verificationMessages.filter { $0.action == "create_session" && $0.channel == "sms" }
         XCTAssertEqual(outboundMessages.count, 1)
         XCTAssertEqual(outboundMessages.first?.destination, "+15551234567")
-        XCTAssertTrue(store.smsGuardianVerificationInProgress)
+        XCTAssertTrue(store.smsVerificationInProgress)
     }
 
     func testStartOutboundVerificationClearsExistingOutboundState() {
@@ -835,7 +835,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         store.smsOutboundExpiresAt = Date()
         store.smsOutboundSendCount = 3
 
-        store.startOutboundGuardianVerification(channel: "sms", destination: "+15551234567")
+        store.startOutboundVerification(channel: "sms", destination: "+15551234567")
 
         XCTAssertNil(store.smsOutboundSessionId)
         XCTAssertNil(store.smsOutboundExpiresAt)
@@ -843,19 +843,19 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
     }
 
     func testStartOutboundTelegramVerificationSendsCorrectMessage() {
-        store.startOutboundGuardianVerification(channel: "telegram", destination: "@guardian_user")
+        store.startOutboundVerification(channel: "telegram", destination: "@guardian_user")
 
-        let guardianMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let outboundMessages = guardianMessages.filter { $0.action == "create_session" && $0.channel == "telegram" }
+        let verificationMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
+        let outboundMessages = verificationMessages.filter { $0.action == "create_session" && $0.channel == "telegram" }
         XCTAssertEqual(outboundMessages.count, 1)
         XCTAssertEqual(outboundMessages.first?.destination, "@guardian_user")
-        XCTAssertTrue(store.telegramGuardianVerificationInProgress)
+        XCTAssertTrue(store.telegramVerificationInProgress)
     }
 
     // MARK: - Outbound Verification: response populates session state
 
     func testOutboundResponsePopulatesSessionState() {
-        store.smsGuardianVerificationInProgress = true
+        store.smsVerificationInProgress = true
 
         let expiresMs = Int(Date().addingTimeInterval(600).timeIntervalSince1970 * 1000)
         let nextResendMs = Int(Date().addingTimeInterval(30).timeIntervalSince1970 * 1000)
@@ -883,7 +883,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
     // MARK: - Outbound Verification: Telegram bootstrap URL
 
     func testTelegramBootstrapUrlIsStored() {
-        store.telegramGuardianVerificationInProgress = true
+        store.telegramVerificationInProgress = true
 
         let expiresMs = Int(Date().addingTimeInterval(600).timeIntervalSince1970 * 1000)
 
@@ -908,13 +908,13 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
     // MARK: - Outbound Verification: resend sends correct message
 
     func testResendOutboundSendsCorrectIPCMessage() {
-        let guardianMessagesBefore = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let resendCountBefore = guardianMessagesBefore.filter { $0.action == "resend_session" }.count
+        let verificationMessagesBefore = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
+        let resendCountBefore = verificationMessagesBefore.filter { $0.action == "resend_session" }.count
 
-        store.resendOutboundGuardian(channel: "sms")
+        store.resendOutboundVerification(channel: "sms")
 
-        let guardianMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let resendMessages = guardianMessages.filter { $0.action == "resend_session" && $0.channel == "sms" }
+        let verificationMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
+        let resendMessages = verificationMessages.filter { $0.action == "resend_session" && $0.channel == "sms" }
         XCTAssertEqual(resendMessages.count, resendCountBefore + 1)
     }
 
@@ -924,18 +924,18 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         store.smsOutboundSessionId = "sess-to-cancel"
         store.smsOutboundExpiresAt = Date().addingTimeInterval(300)
         store.smsOutboundSendCount = 2
-        store.smsGuardianVerificationInProgress = true
+        store.smsVerificationInProgress = true
 
-        store.cancelOutboundGuardian(channel: "sms")
+        store.cancelOutboundVerification(channel: "sms")
 
         XCTAssertNil(store.smsOutboundSessionId)
         XCTAssertNil(store.smsOutboundExpiresAt)
         XCTAssertNil(store.smsOutboundNextResendAt)
         XCTAssertEqual(store.smsOutboundSendCount, 0)
-        XCTAssertFalse(store.smsGuardianVerificationInProgress)
+        XCTAssertFalse(store.smsVerificationInProgress)
 
-        let guardianMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let cancelMessages = guardianMessages.filter { $0.action == "cancel_session" && $0.channel == "sms" }
+        let verificationMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
+        let cancelMessages = verificationMessages.filter { $0.action == "cancel_session" && $0.channel == "sms" }
         XCTAssertEqual(cancelMessages.count, 1)
     }
 
@@ -943,7 +943,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         store.telegramOutboundSessionId = "tg-sess-cancel"
         store.telegramBootstrapUrl = "https://t.me/MyBot?start=verify_abc"
 
-        store.cancelOutboundGuardian(channel: "telegram")
+        store.cancelOutboundVerification(channel: "telegram")
 
         XCTAssertNil(store.telegramOutboundSessionId)
         XCTAssertNil(store.telegramBootstrapUrl)
@@ -965,14 +965,14 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             assistantId: "self"
         ))
 
-        let predicate = NSPredicate { _, _ in self.store.smsGuardianVerified }
+        let predicate = NSPredicate { _, _ in self.store.smsVerificationVerified }
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
         wait(for: [expectation], timeout: 2.0)
 
         XCTAssertNil(store.smsOutboundSessionId)
         XCTAssertNil(store.smsOutboundExpiresAt)
         XCTAssertEqual(store.smsOutboundSendCount, 0)
-        XCTAssertTrue(store.smsGuardianVerified)
+        XCTAssertTrue(store.smsVerificationVerified)
     }
 
     // MARK: - Outbound Verification: initial state is nil


### PR DESCRIPTION
## Summary
Fixes gaps 4 and 5 identified during plan review for chan-verify-session-unify.md.

**Gap 4:** Renamed all SettingsStore methods, published properties, and private variables from Guardian-centric naming to verification-centric naming (e.g. `refreshChannelGuardianStatus` -> `refreshChannelVerificationStatus`, `telegramGuardianVerified` -> `telegramVerificationVerified`).

**Gap 5:** Renamed `GuardianVerification/` directory and files to `ChannelVerification/`, updated all types/structs/enums inside (`GuardianChannelState` -> `ChannelVerificationState`, `GuardianVerificationFlowView` -> `ChannelVerificationFlowView`).

Wire protocol field names (e.g. `guardianExternalUserId`, `guardianDeliveryChatId`) and domain-concept Guardian references (role name in UI) are intentionally preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
