### PR TITLE
fix(ios): only clear unread override on explicit thread open (PR 13863 feedback)

### DIFF
--- a/clients/ios/App/IOSThreadStore.swift
+++ b/clients/ios/App/IOSThreadStore.swift
@@ -686,14 +686,20 @@ class IOSThreadStore: ObservableObject {
 
     /// Mark a connected conversation as seen when the user explicitly opens it.
     /// If the thread has a pending .unread override (user chose "Mark as unread"),
-    /// opening the thread clears that override so the normal seen flow proceeds.
-    func markConversationSeenIfNeeded(threadId: UUID) {
+    /// only an explicit open (e.g. tapping/selecting the thread) clears that
+    /// override — passive onChange callbacks leave it intact so the user's
+    /// "mark as unread" action isn't immediately undone.
+    func markConversationSeenIfNeeded(threadId: UUID, isExplicitOpen: Bool = false) {
         guard isConnectedMode,
               let idx = threads.firstIndex(where: { $0.id == threadId }),
               let sessionId = threads[idx].sessionId,
               threads[idx].hasUnseenLatestAssistantMessage else { return }
         if case .unread = pendingAttentionOverrides[sessionId] {
-            pendingAttentionOverrides.removeValue(forKey: sessionId)
+            if isExplicitOpen {
+                pendingAttentionOverrides.removeValue(forKey: sessionId)
+            } else {
+                return
+            }
         }
 
         pendingAttentionOverrides[sessionId] = .seen(

--- a/clients/ios/Views/ThreadListView.swift
+++ b/clients/ios/Views/ThreadListView.swift
@@ -208,7 +208,7 @@ struct ThreadListView: View {
             )
             .onAppear {
                 store.loadHistoryIfNeeded(for: threadId)
-                store.markConversationSeenIfNeeded(threadId: threadId)
+                store.markConversationSeenIfNeeded(threadId: threadId, isExplicitOpen: true)
                 store.viewModel(for: threadId).consumeDeepLinkIfNeeded()
             }
             .onChange(of: thread.hasUnseenLatestAssistantMessage) { _, hasUnseen in


### PR DESCRIPTION
Addresses review feedback on #13863. The `.unread` override is now only cleared when the user explicitly opens a thread (`onAppear`), not on passive `.onChange` callbacks that also invoke `markConversationSeenIfNeeded`.

Adds an `isExplicitOpen` parameter (default `false`) to distinguish the two call paths. The `onAppear` call site passes `true`; the `onChange` call site uses the default `false`, which preserves the unread override and early-returns.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
