### PR TITLE
fix(ios): restore usage dashboard test assertions with locale-safe values (PR 13872 feedback)

### DIFF
--- a/clients/ios/Tests/UsageDashboardViewTests.swift
+++ b/clients/ios/Tests/UsageDashboardViewTests.swift
@@ -169,12 +169,12 @@ final class UsageDashboardViewTests: XCTestCase {
         let view = UsageDashboardView(store: store)
         let renderedText = Self.renderedText(from: view)
 
-        // SwiftUI List renders LabeledContent lazily — UILabel hierarchy may
-        // not fully materialise within the RunLoop window on CI runners.
-        // Use soft checks so CI isn't blocked by non-deterministic rendering.
-        let hasExpectedLabels = renderedText.contains(UsageFormatting.directInputTokensLabel)
-            && renderedText.contains("Cache Created")
-            && renderedText.contains("Cache Read")
+        XCTAssertTrue(renderedText.contains(UsageFormatting.directInputTokensLabel),
+                      "Expected rendered text to contain direct input tokens label")
+        XCTAssertTrue(renderedText.contains("Cache Created"),
+                      "Expected rendered text to contain 'Cache Created'")
+        XCTAssertTrue(renderedText.contains("Cache Read"),
+                      "Expected rendered text to contain 'Cache Read'")
 
         let expectedSummary = UsageFormatting.formatBreakdownSummary(UsageGroupBreakdownEntry(
             group: "claude-sonnet-4-20250514",
@@ -185,14 +185,8 @@ final class UsageDashboardViewTests: XCTestCase {
             totalEstimatedCostUsd: 0.003,
             eventCount: 2
         ))
-        let hasExpectedSummary = renderedText.contains(expectedSummary)
-
-        if !hasExpectedLabels || !hasExpectedSummary {
-            print("[UsageDashboardViewTests] Warning: rendered text missing expected content"
-                + " (labels=\(hasExpectedLabels), summary=\(hasExpectedSummary))"
-                + " — likely lazy List rendering on CI."
-                + " Rendered text: \(renderedText.prefix(500))")
-        }
+        XCTAssertTrue(renderedText.contains(expectedSummary),
+                      "Expected rendered text to contain breakdown summary")
     }
 
     #endif


### PR DESCRIPTION
Addresses review feedback on #13872. Restores XCTAssertTrue assertions for the loaded-state usage view test, using locale-safe expected values via UsageFormatting helpers.

The soft print-only checks have been replaced with proper `XCTAssertTrue` calls that will fail CI if the view doesn't render the expected content.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
