### PR TITLE
fix: rename guardian-verification-intent, system-prompt function, and CLAUDE.md reference

### DIFF
--- a/assistant/src/__tests__/verification-session-intent-routing.test.ts
+++ b/assistant/src/__tests__/verification-session-intent-routing.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { resolveGuardianVerificationIntent } from "../daemon/guardian-verification-intent.js";
+import { resolveVerificationSessionIntent } from "../daemon/verification-session-intent.js";
 
 // =====================================================================
 // 1. Direct guardian setup phrases => forced skill flow
@@ -30,7 +30,7 @@ describe("direct guardian setup phrases trigger forced routing", () => {
 
   for (const phrase of directSetupPhrases) {
     test(`"${phrase}" => direct_setup`, () => {
-      const result = resolveGuardianVerificationIntent(phrase);
+      const result = resolveVerificationSessionIntent(phrase);
       expect(result.kind).toBe("direct_setup");
       if (result.kind === "direct_setup") {
         expect(result.rewrittenContent).toContain("guardian-verify-setup");
@@ -62,7 +62,7 @@ describe("conceptual questions do NOT trigger forced routing", () => {
 
   for (const phrase of conceptualPhrases) {
     test(`"${phrase}" => none`, () => {
-      const result = resolveGuardianVerificationIntent(phrase);
+      const result = resolveVerificationSessionIntent(phrase);
       expect(result.kind).toBe("none");
     });
   }
@@ -88,7 +88,7 @@ describe("non-guardian messages are not intercepted", () => {
 
   for (const phrase of unrelatedPhrases) {
     test(`"${phrase}" => none`, () => {
-      const result = resolveGuardianVerificationIntent(phrase);
+      const result = resolveVerificationSessionIntent(phrase);
       expect(result.kind).toBe("none");
     });
   }
@@ -108,7 +108,7 @@ describe("ambiguous verify phrases without guardian context do NOT trigger force
 
   for (const phrase of ambiguousPhrases) {
     test(`"${phrase}" => none`, () => {
-      const result = resolveGuardianVerificationIntent(phrase);
+      const result = resolveVerificationSessionIntent(phrase);
       expect(result.kind).toBe("none");
     });
   }
@@ -128,7 +128,7 @@ describe("slash commands are never intercepted", () => {
 
   for (const cmd of slashCommands) {
     test(`"${cmd}" => none`, () => {
-      const result = resolveGuardianVerificationIntent(cmd);
+      const result = resolveVerificationSessionIntent(cmd);
       expect(result.kind).toBe("none");
     });
   }
@@ -140,7 +140,7 @@ describe("slash commands are never intercepted", () => {
 
 describe("channel hint extraction", () => {
   test("unsupported channel keyword triggers setup but yields no channel hint", () => {
-    const result = resolveGuardianVerificationIntent(
+    const result = resolveVerificationSessionIntent(
       "set me as guardian for text",
     );
     expect(result.kind).toBe("direct_setup");
@@ -152,7 +152,7 @@ describe("channel hint extraction", () => {
   });
 
   test("detects voice channel hint", () => {
-    const result = resolveGuardianVerificationIntent(
+    const result = resolveVerificationSessionIntent(
       "set me as guardian for voice",
     );
     expect(result.kind).toBe("direct_setup");
@@ -163,7 +163,7 @@ describe("channel hint extraction", () => {
   });
 
   test("detects Telegram channel hint", () => {
-    const result = resolveGuardianVerificationIntent(
+    const result = resolveVerificationSessionIntent(
       "set me as guardian for telegram",
     );
     expect(result.kind).toBe("direct_setup");
@@ -174,7 +174,7 @@ describe("channel hint extraction", () => {
   });
 
   test("no channel hint when unspecified", () => {
-    const result = resolveGuardianVerificationIntent("verify me as guardian");
+    const result = resolveVerificationSessionIntent("verify me as guardian");
     expect(result.kind).toBe("direct_setup");
     if (result.kind === "direct_setup") {
       expect(result.channelHint).toBeUndefined();

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -170,7 +170,7 @@ export function buildSystemPrompt(): string {
       config,
     )
   ) {
-    parts.push(buildGuardianVerificationRoutingSection());
+    parts.push(buildVerificationSessionRoutingSection());
   }
   parts.push(buildAttachmentSection());
   parts.push(buildInChatConfigurationSection());
@@ -227,7 +227,7 @@ function buildTaskScheduleReminderRoutingSection(): string {
   ].join("\n");
 }
 
-export function buildGuardianVerificationRoutingSection(): string {
+export function buildVerificationSessionRoutingSection(): string {
   return [
     "## Routing: Guardian Verification",
     "",

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -24,7 +24,6 @@ import { createPreference } from "../notifications/preferences-store.js";
 import type { Message } from "../providers/types.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
 import { getLogger } from "../util/logger.js";
-import { resolveGuardianVerificationIntent } from "./guardian-verification-intent.js";
 import type { UsageStats } from "./ipc-contract.js";
 import type { ServerMessage, UserMessageAttachment } from "./ipc-protocol.js";
 import type { MessageQueue } from "./session-queue-manager.js";
@@ -32,6 +31,7 @@ import type { QueueDrainReason } from "./session-queue-manager.js";
 import type { TrustContext } from "./session-runtime-assembly.js";
 import { resolveSlash, type SlashContext } from "./session-slash.js";
 import type { TraceEmitter } from "./trace-emitter.js";
+import { resolveVerificationSessionIntent } from "./verification-session-intent.js";
 
 const log = getLogger("session-process");
 
@@ -373,16 +373,17 @@ export async function drainQueue(
   // loop receives the rewritten instruction.
   let agentLoopContent = resolvedContent;
   if (slashResult.kind === "passthrough") {
-    const guardianIntent = resolveGuardianVerificationIntent(resolvedContent);
-    if (guardianIntent.kind === "direct_setup") {
+    const verificationIntent =
+      resolveVerificationSessionIntent(resolvedContent);
+    if (verificationIntent.kind === "direct_setup") {
       log.info(
         {
           conversationId: session.conversationId,
-          channelHint: guardianIntent.channelHint,
+          channelHint: verificationIntent.channelHint,
         },
-        "Guardian verification intent intercepted in queue — forcing skill flow",
+        "Verification session intent intercepted in queue — forcing skill flow",
       );
-      agentLoopContent = guardianIntent.rewrittenContent;
+      agentLoopContent = verificationIntent.rewrittenContent;
       session.preactivatedSkillIds = ["guardian-verify-setup"];
     }
   }
@@ -698,16 +699,17 @@ export async function processMessage(
   // rewritten content only for the agent loop instruction.
   let agentLoopContent = resolvedContent;
   if (slashResult.kind === "passthrough") {
-    const guardianIntent = resolveGuardianVerificationIntent(resolvedContent);
-    if (guardianIntent.kind === "direct_setup") {
+    const verificationIntent =
+      resolveVerificationSessionIntent(resolvedContent);
+    if (verificationIntent.kind === "direct_setup") {
       log.info(
         {
           conversationId: session.conversationId,
-          channelHint: guardianIntent.channelHint,
+          channelHint: verificationIntent.channelHint,
         },
-        "Guardian verification intent intercepted — forcing skill flow",
+        "Verification session intent intercepted — forcing skill flow",
       );
-      agentLoopContent = guardianIntent.rewrittenContent;
+      agentLoopContent = verificationIntent.rewrittenContent;
       session.preactivatedSkillIds = ["guardian-verify-setup"];
     }
   }

--- a/assistant/src/daemon/verification-session-intent.ts
+++ b/assistant/src/daemon/verification-session-intent.ts
@@ -1,11 +1,11 @@
-// Guardian verification intent resolution for deterministic first-turn routing.
-// Exports `resolveGuardianVerificationIntent` as the single public entry point.
+// Verification session intent resolution for deterministic first-turn routing.
+// Exports `resolveVerificationSessionIntent` as the single public entry point.
 // When a direct guardian setup request is detected, the session pipeline
 // rewrites the message to force immediate entry into the guardian-verify-setup
 // skill flow, bypassing the normal agent loop's tendency to produce conceptual
 // preambles before loading the skill.
 
-export type GuardianVerificationIntentResult =
+export type VerificationSessionIntentResult =
   | { kind: "none" }
   | {
       kind: "direct_setup";
@@ -13,7 +13,7 @@ export type GuardianVerificationIntentResult =
       channelHint?: "voice" | "telegram" | "slack";
     };
 
-// ── Direct setup patterns ────────────────────────────────────────────────
+// -- Direct setup patterns ----------------------------------------------------
 // These capture imperative requests to start guardian verification.
 
 const DIRECT_SETUP_PATTERNS: RegExp[] = [
@@ -29,7 +29,7 @@ const DIRECT_SETUP_PATTERNS: RegExp[] = [
   /\bregister\s+(?:me\s+)?as\s+(?:your\s+|the\s+)?guardian\b/i,
 ];
 
-// ── Conceptual / security question patterns ──────────────────────────────
+// -- Conceptual / security question patterns ----------------------------------
 // These indicate the user is asking *about* guardian verification
 // rather than requesting to start it. Return passthrough for these.
 
@@ -44,7 +44,7 @@ const CONCEPTUAL_PATTERNS: RegExp[] = [
   /\bcan\s+(?:you\s+)?(?:tell|explain|describe)\b/i,
 ];
 
-// ── Channel hint extraction ──────────────────────────────────────────────
+// -- Channel hint extraction --------------------------------------------------
 
 const CHANNEL_HINT_PATTERNS: Array<{
   pattern: RegExp;
@@ -59,7 +59,7 @@ const CHANNEL_HINT_PATTERNS: Array<{
 const FILLER_PATTERN =
   /\b(please|pls|plz|can\s+you|could\s+you|would\s+you|now|right\s+now|thanks|thank\s+you|thx|ty|for\s+me|ok(ay)?|hey|hi|hello|just|i\s+want\s+to|i'd\s+like\s+to|i\s+need\s+to|let's|let\s+me)\b/gi;
 
-// ── Internal helpers ─────────────────────────────────────────────────────
+// -- Internal helpers ---------------------------------------------------------
 
 function isConceptualQuestion(text: string): boolean {
   const cleaned = text.replace(/^\s*(hey|hi|hello|please|pls|plz)[,\s]+/i, "");
@@ -79,10 +79,10 @@ function extractChannelHint(
   return undefined;
 }
 
-// ── Structured intent resolver ───────────────────────────────────────────
+// -- Structured intent resolver -----------------------------------------------
 
 /**
- * Resolves guardian verification intent from user text.
+ * Resolves verification session intent from user text.
  *
  * Pipeline:
  * 1. Skip slash commands entirely
@@ -90,9 +90,9 @@ function extractChannelHint(
  * 3. Detect direct setup patterns
  * 4. On match, build a deterministic model instruction to load guardian-verify-setup
  */
-export function resolveGuardianVerificationIntent(
+export function resolveVerificationSessionIntent(
   text: string,
-): GuardianVerificationIntentResult {
+): VerificationSessionIntentResult {
   const trimmed = text.trim();
 
   // Never intercept slash commands

--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -54,7 +54,7 @@ All UI and feature code lives in `Features/`, organized by domain:
 | `Chat/` | ChatView, ChatViewModel (multi-turn messaging), ChatMessage model |
 | `CommandPalette/` | Command palette (search, actions) |
 | `Contacts/` | Contact management |
-| `GuardianVerification/` | Guardian verification flow |
+| `ChannelVerification/` | Channel verification flow |
 | `MainWindow/` | MainWindowView shell, ThreadTabBar, NavigationToolbar, ThreadManager, side panels |
 | `MainWindow/Panels/` | Side panels including DebugPanel (real-time trace viewer with metrics + timeline) |
 | `Onboarding/` | Multi-step first-launch flow (OnboardingFlowView → OnboardingState) |


### PR DESCRIPTION
## Summary
Fixes naming gaps from verification API consolidation review (round 2).

- Rename guardian-verification-intent.ts → verification-session-intent.ts with export renames
- Rename buildGuardianVerificationRoutingSection → buildVerificationSessionRoutingSection
- Update macOS CLAUDE.md GuardianVerification/ → ChannelVerification/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
