### PR TITLE
fix: rename guardian_verification_session_id column to verification_session_id

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -49,13 +49,13 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 // Call domain mock — outbound voice verification calls are fire-and-forget.
 const voiceCallInitCalls: Array<{
   phoneNumber: string;
-  guardianVerificationSessionId: string;
+  verificationSessionId: string;
   assistantId?: string;
 }> = [];
 mock.module("../calls/call-domain.js", () => ({
   startGuardianVerificationCall: async (input: {
     phoneNumber: string;
-    guardianVerificationSessionId: string;
+    verificationSessionId: string;
     assistantId?: string;
   }) => {
     voiceCallInitCalls.push(input);
@@ -3530,9 +3530,7 @@ describe("outbound voice verification", () => {
     expect(voiceCallInitCalls.length).toBeGreaterThanOrEqual(1);
     const lastCall = voiceCallInitCalls[voiceCallInitCalls.length - 1];
     expect(lastCall.phoneNumber).toBe("+15551234567");
-    expect(lastCall.guardianVerificationSessionId).toBe(
-      resp!.verificationSessionId!,
-    );
+    expect(lastCall.verificationSessionId).toBe(resp!.verificationSessionId!);
   });
 
   test("start_outbound for voice rejects unparseable phone number", async () => {

--- a/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
+++ b/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
@@ -131,16 +131,16 @@ describe("TwiML parameter propagation", () => {
     voice: "en-US-Standard-A",
   };
 
-  test("includes guardianVerificationSessionId as Parameter when provided", () => {
+  test("includes verificationSessionId as Parameter when provided", () => {
     const twiml = generateTwiML(
       "session-123",
       "wss://example.com/v1/calls/relay",
       null,
       defaultProfile,
       undefined,
-      { guardianVerificationSessionId: "gv-session-456" },
+      { verificationSessionId: "gv-session-456" },
     );
-    expect(twiml).toContain('name="guardianVerificationSessionId"');
+    expect(twiml).toContain('name="verificationSessionId"');
     expect(twiml).toContain('value="gv-session-456"');
     expect(twiml).toContain("<Parameter");
   });
@@ -173,7 +173,7 @@ describe("TwiML parameter propagation", () => {
 // ---------------------------------------------------------------------------
 
 describe("Call session mode metadata", () => {
-  test("createCallSession persists callMode and guardianVerificationSessionId", async () => {
+  test("createCallSession persists callMode and verificationSessionId", async () => {
     // Dynamic import to avoid circular dependency issues
     const { createCallSession, getCallSession } =
       await import("../calls/call-store.js");
@@ -187,17 +187,17 @@ describe("Call session mode metadata", () => {
       fromNumber: "+15551234567",
       toNumber: "+15559876543",
       callMode: "guardian_verification",
-      guardianVerificationSessionId: "gv-session-test",
+      verificationSessionId: "gv-session-test",
     });
 
     expect(session.callMode).toBe("guardian_verification");
-    expect(session.guardianVerificationSessionId).toBe("gv-session-test");
+    expect(session.verificationSessionId).toBe("gv-session-test");
 
     // Verify it persists to DB
     const loaded = getCallSession(session.id);
     expect(loaded).not.toBeNull();
     expect(loaded!.callMode).toBe("guardian_verification");
-    expect(loaded!.guardianVerificationSessionId).toBe("gv-session-test");
+    expect(loaded!.verificationSessionId).toBe("gv-session-test");
   });
 
   test("createCallSession defaults callMode to null when not provided", async () => {
@@ -217,12 +217,12 @@ describe("Call session mode metadata", () => {
     });
 
     expect(session.callMode).toBeNull();
-    expect(session.guardianVerificationSessionId).toBeNull();
+    expect(session.verificationSessionId).toBeNull();
 
     const loaded = getCallSession(session.id);
     expect(loaded).not.toBeNull();
     expect(loaded!.callMode).toBeNull();
-    expect(loaded!.guardianVerificationSessionId).toBeNull();
+    expect(loaded!.verificationSessionId).toBeNull();
   });
 });
 

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -60,14 +60,14 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 // Voice call mock
 const voiceCallInitCalls: Array<{
   phoneNumber: string;
-  guardianVerificationSessionId: string;
+  verificationSessionId: string;
   assistantId?: string;
   originConversationId?: string;
 }> = [];
 mock.module("../calls/call-domain.js", () => ({
   startGuardianVerificationCall: async (input: {
     phoneNumber: string;
-    guardianVerificationSessionId: string;
+    verificationSessionId: string;
     assistantId?: string;
     originConversationId?: string;
   }) => {

--- a/assistant/src/__tests__/guardian-verification-voice-binding.test.ts
+++ b/assistant/src/__tests__/guardian-verification-voice-binding.test.ts
@@ -143,7 +143,7 @@ describe("startGuardianVerificationCall — voice binding", () => {
     const sessionId = "gv-session-001";
     const result = await startGuardianVerificationCall({
       phoneNumber: "+15559999999",
-      guardianVerificationSessionId: sessionId,
+      verificationSessionId: sessionId,
     });
 
     expect(result.ok).toBe(true);
@@ -167,7 +167,7 @@ describe("startGuardianVerificationCall — voice binding", () => {
 
     const result = await startGuardianVerificationCall({
       phoneNumber: "+15559999999",
-      guardianVerificationSessionId: "gv-session-preflight-fail",
+      verificationSessionId: "gv-session-preflight-fail",
     });
 
     expect(result.ok).toBe(false);

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -1938,7 +1938,7 @@ describe("relay-server", () => {
       fromNumber: "+15551111111",
       toNumber: "+15559999999",
       callMode: "guardian_verification",
-      guardianVerificationSessionId: "gv-session-ptr-success",
+      verificationSessionId: "gv-session-ptr-success",
       initiatedFromConversationId: "conv-gv-pointer-success-origin",
     });
 
@@ -1956,7 +1956,7 @@ describe("relay-server", () => {
         from: "+15551111111",
         to: "+15559999999",
         customParameters: {
-          guardianVerificationSessionId: "gv-session-ptr-success",
+          verificationSessionId: "gv-session-ptr-success",
         },
       }),
     );
@@ -1993,7 +1993,7 @@ describe("relay-server", () => {
       fromNumber: "+15551111111",
       toNumber: "+15559999999",
       callMode: "guardian_verification",
-      guardianVerificationSessionId: "gv-session-ptr-fail",
+      verificationSessionId: "gv-session-ptr-fail",
       initiatedFromConversationId: "conv-gv-pointer-fail-origin",
     });
 
@@ -2008,7 +2008,7 @@ describe("relay-server", () => {
         from: "+15551111111",
         to: "+15559999999",
         customParameters: {
-          guardianVerificationSessionId: "gv-session-ptr-fail",
+          verificationSessionId: "gv-session-ptr-fail",
         },
       }),
     );

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -889,7 +889,7 @@ export async function relayInstruction(
 
 export type StartGuardianVerificationCallInput = {
   phoneNumber: string;
-  guardianVerificationSessionId: string;
+  verificationSessionId: string;
   assistantId?: string;
   /** Origin conversation ID so completion/failure pointers can route back. */
   originConversationId?: string;
@@ -903,14 +903,13 @@ export type StartGuardianVerificationCallResult =
  * Initiate an outbound call to the guardian's phone for verification.
  *
  * Creates a minimal call session with a voice channel binding and
- * passes `guardianVerificationSessionId` as a custom parameter so the
+ * passes `verificationSessionId` as a custom parameter so the
  * relay server can detect this is a guardian verification call.
  */
 export async function startGuardianVerificationCall(
   input: StartGuardianVerificationCallInput,
 ): Promise<StartGuardianVerificationCallResult> {
-  const { phoneNumber, guardianVerificationSessionId, originConversationId } =
-    input;
+  const { phoneNumber, verificationSessionId, originConversationId } = input;
 
   if (!phoneNumber || !E164_REGEX.test(phoneNumber)) {
     return {
@@ -941,13 +940,13 @@ export async function startGuardianVerificationCall(
     // Create a minimal conversation so the call session has a valid FK,
     // and bind it to the voice channel so it never appears as an unbound
     // desktop thread.
-    const convKey = `guardian-verify:${guardianVerificationSessionId}`;
+    const convKey = `guardian-verify:${verificationSessionId}`;
     const { conversationId } = getOrCreateConversation(convKey);
 
     upsertBinding({
       conversationId,
       sourceChannel: "voice",
-      externalChatId: `guardian-verify:${guardianVerificationSessionId}`,
+      externalChatId: `guardian-verify:${verificationSessionId}`,
     });
 
     const session = createCallSession({
@@ -956,7 +955,7 @@ export async function startGuardianVerificationCall(
       fromNumber: identityResult.fromNumber,
       toNumber: phoneNumber,
       callMode: "guardian_verification",
-      guardianVerificationSessionId,
+      verificationSessionId,
       initiatedFromConversationId: originConversationId,
     });
     sessionId = session.id;
@@ -981,7 +980,7 @@ export async function startGuardianVerificationCall(
       webhookUrl,
       statusCallbackUrl,
       customParams: {
-        guardianVerificationSessionId,
+        verificationSessionId,
       },
     });
 
@@ -991,7 +990,7 @@ export async function startGuardianVerificationCall(
       {
         callSessionId: session.id,
         callSid,
-        guardianVerificationSessionId,
+        verificationSessionId,
         to: phoneNumber,
       },
       "Guardian verification call initiated",
@@ -1001,7 +1000,7 @@ export async function startGuardianVerificationCall(
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log.error(
-      { err, phoneNumber, guardianVerificationSessionId },
+      { err, phoneNumber, verificationSessionId },
       "Failed to initiate guardian verification call",
     );
 

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -36,7 +36,7 @@ const parseCallSession = createRowMapper<
   task: "task",
   status: { from: "status", transform: cast<CallSession["status"]>() },
   callMode: { from: "callMode", transform: cast<CallSession["callMode"]>() },
-  guardianVerificationSessionId: "guardianVerificationSessionId",
+  verificationSessionId: "verificationSessionId",
   callerIdentityMode: "callerIdentityMode",
   callerIdentitySource: "callerIdentitySource",
   initiatedFromConversationId: "initiatedFromConversationId",
@@ -80,7 +80,7 @@ export function createCallSession(opts: {
   toNumber: string;
   task?: string;
   callMode?: string;
-  guardianVerificationSessionId?: string;
+  verificationSessionId?: string;
   callerIdentityMode?: string;
   callerIdentitySource?: string;
   initiatedFromConversationId?: string;
@@ -97,7 +97,7 @@ export function createCallSession(opts: {
     task: opts.task ?? null,
     status: "initiated" as const,
     callMode: (opts.callMode ?? null) as CallSession["callMode"],
-    guardianVerificationSessionId: opts.guardianVerificationSessionId ?? null,
+    verificationSessionId: opts.verificationSessionId ?? null,
     callerIdentityMode: opts.callerIdentityMode ?? null,
     callerIdentitySource: opts.callerIdentitySource ?? null,
     initiatedFromConversationId: opts.initiatedFromConversationId ?? null,

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -201,7 +201,7 @@ export class RelayConnection {
   private guardianVerificationFromNumber: string | null = null;
 
   // Outbound guardian verification state (system calls the guardian)
-  private outboundGuardianVerificationSessionId: string | null = null;
+  private outboundVerificationSessionId: string | null = null;
 
   // Inbound voice invite redemption state
   private inviteRedemptionActive = false;
@@ -878,11 +878,11 @@ export class RelayConnection {
    */
   private startOutboundGuardianVerification(
     assistantId: string,
-    guardianVerificationSessionId: string,
+    verificationSessionId: string,
     toNumber: string,
   ): void {
     this.guardianVerificationActive = true;
-    this.outboundGuardianVerificationSessionId = guardianVerificationSessionId;
+    this.outboundVerificationSessionId = verificationSessionId;
     this.guardianChallengeAssistantId = assistantId;
     // For outbound guardian calls, the "to" number is the guardian's phone
     this.guardianVerificationFromNumber = toNumber;
@@ -897,7 +897,7 @@ export class RelayConnection {
       "outbound_guardian_voice_verification_started",
       {
         assistantId,
-        guardianVerificationSessionId,
+        verificationSessionId,
         maxAttempts: this.verificationMaxAttempts,
       },
     );
@@ -912,7 +912,7 @@ export class RelayConnection {
       {
         callSessionId: this.callSessionId,
         assistantId,
-        guardianVerificationSessionId,
+        verificationSessionId,
       },
       "Outbound guardian voice verification started",
     );
@@ -931,7 +931,7 @@ export class RelayConnection {
       return;
     }
 
-    const isOutbound = this.outboundGuardianVerificationSessionId != null;
+    const isOutbound = this.outboundVerificationSessionId != null;
     const assistantId = this.guardianChallengeAssistantId;
     const fromNumber = this.guardianVerificationFromNumber;
 

--- a/assistant/src/calls/relay-setup-router.ts
+++ b/assistant/src/calls/relay-setup-router.ts
@@ -101,21 +101,16 @@ export function routeSetup(ctx: SetupContext): {
 
   // ── Outbound guardian verification (persisted mode) ──────────────
   const persistedMode = ctx.session?.callMode;
-  const persistedGvSessionId = ctx.session?.guardianVerificationSessionId;
-  const customParamGvSessionId =
-    ctx.customParameters?.guardianVerificationSessionId;
-  const guardianVerificationSessionId =
-    persistedGvSessionId ?? customParamGvSessionId;
+  const persistedVsId = ctx.session?.verificationSessionId;
+  const customParamVsId = ctx.customParameters?.verificationSessionId;
+  const verificationSessionId = persistedVsId ?? customParamVsId;
 
-  if (
-    persistedMode === "guardian_verification" &&
-    guardianVerificationSessionId
-  ) {
+  if (persistedMode === "guardian_verification" && verificationSessionId) {
     return {
       outcome: {
         action: "outbound_guardian_verification",
         assistantId,
-        sessionId: guardianVerificationSessionId,
+        sessionId: verificationSessionId,
         toNumber: ctx.to,
       },
       resolved,
@@ -123,11 +118,11 @@ export function routeSetup(ctx: SetupContext): {
   }
 
   // Secondary signal: custom parameter without persisted mode (pre-migration)
-  if (!persistedMode && customParamGvSessionId) {
+  if (!persistedMode && customParamVsId) {
     log.warn(
       {
         callSessionId: ctx.callSessionId,
-        guardianVerificationSessionId: customParamGvSessionId,
+        verificationSessionId: customParamVsId,
       },
       "Guardian verification detected via setup custom parameter (no persisted call_mode) — entering verification path",
     );
@@ -135,7 +130,7 @@ export function routeSetup(ctx: SetupContext): {
       outcome: {
         action: "outbound_guardian_verification",
         assistantId,
-        sessionId: customParamGvSessionId,
+        sessionId: customParamVsId,
         toNumber: ctx.to,
       },
       resolved,

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -198,7 +198,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
     return buildVoiceWebhookTwiml(
       session.id,
       session.task,
-      session.guardianVerificationSessionId,
+      session.verificationSessionId,
     );
   }
 
@@ -226,7 +226,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
   return buildVoiceWebhookTwiml(
     callSessionId,
     session.task,
-    session.guardianVerificationSessionId,
+    session.verificationSessionId,
   );
 }
 
@@ -235,7 +235,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
  * Resolves voice quality profile, relay URL, and welcome greeting,
  * then returns a Response with the generated TwiML.
  *
- * When `guardianVerificationSessionId` is provided, it is included as a
+ * When `verificationSessionId` is provided, it is included as a
  * `<Parameter>` in the TwiML for observability and compatibility with
  * the Twilio setup payload. The persisted call session mode is the
  * primary signal for deterministic flow selection in the relay server.
@@ -243,7 +243,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
 function buildVoiceWebhookTwiml(
   callSessionId: string,
   task: string | null,
-  guardianVerificationSessionId?: string | null,
+  verificationSessionId?: string | null,
 ): Response {
   const profile = resolveVoiceQualityProfile(loadConfig());
 
@@ -267,13 +267,11 @@ function buildVoiceWebhookTwiml(
 
   const relayToken = mintEdgeRelayToken();
 
-  // Propagate guardianVerificationSessionId as a TwiML <Parameter> for
+  // Propagate verificationSessionId as a TwiML <Parameter> for
   // observability. This is not the sole source of truth; the relay
   // server reads the persisted call_mode from the call session first.
   const customParameters: Record<string, string> | undefined =
-    guardianVerificationSessionId
-      ? { guardianVerificationSessionId }
-      : undefined;
+    verificationSessionId ? { verificationSessionId } : undefined;
 
   const twiml = generateTwiML(
     callSessionId,

--- a/assistant/src/calls/types.ts
+++ b/assistant/src/calls/types.ts
@@ -70,7 +70,7 @@ export interface CallSession {
   task: string | null;
   status: CallStatus;
   callMode: CallMode | null;
-  guardianVerificationSessionId: string | null;
+  verificationSessionId: string | null;
   callerIdentityMode: string | null;
   callerIdentitySource: string | null;
   initiatedFromConversationId?: string | null;

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -64,6 +64,7 @@ import {
   migrateNormalizePhoneIdentities,
   migrateNotificationDeliveryThreadDecision,
   migrateReminderRoutingIntent,
+  migrateRenameVerificationSessionIdColumn,
   migrateRenameVerificationTable,
   migrateSchemaIndexesAndColumns,
   migrateUsageDashboardIndexes,
@@ -311,6 +312,9 @@ export function initializeDb(): void {
 
   // 45. Rename channel_guardian_verification_challenges → channel_verification_sessions
   migrateRenameVerificationTable(database);
+
+  // 46. Rename guardian_verification_session_id → verification_session_id in call_sessions
+  migrateRenameVerificationSessionIdColumn(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/142-rename-verification-session-id-column.ts
+++ b/assistant/src/memory/migrations/142-rename-verification-session-id-column.ts
@@ -1,0 +1,32 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * One-shot migration: rename the guardian_verification_session_id column
+ * in call_sessions to verification_session_id, dropping the "guardian_"
+ * prefix to align with the broader verification vocabulary.
+ */
+export function migrateRenameVerificationSessionIdColumn(
+  database: DrizzleDb,
+): void {
+  withCrashRecovery(
+    database,
+    "migration_rename_verification_session_id_column_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+
+      // Check the old column exists before attempting the rename
+      const columns = raw
+        .query(`PRAGMA table_info(call_sessions)`)
+        .all() as Array<{ name: string }>;
+      const hasOldColumn = columns.some(
+        (c) => c.name === "guardian_verification_session_id",
+      );
+      if (!hasOldColumn) return;
+
+      raw.exec(
+        /*sql*/ `ALTER TABLE call_sessions RENAME COLUMN guardian_verification_session_id TO verification_session_id`,
+      );
+    },
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -83,6 +83,7 @@ export { migrateUsageDashboardIndexes } from "./137-usage-dashboard-indexes.js";
 export { migrateDropUsageCompositeIndexes } from "./139-drop-usage-composite-indexes.js";
 export { migrateBackfillUsageCacheAccounting } from "./140-backfill-usage-cache-accounting.js";
 export { migrateRenameVerificationTable } from "./141-rename-verification-table.js";
+export { migrateRenameVerificationSessionIdColumn } from "./142-rename-verification-session-id-column.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -153,6 +153,12 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Rename channel_guardian_verification_challenges table to channel_verification_sessions and update indexes",
   },
+  {
+    key: "migration_rename_verification_session_id_column_v1",
+    version: 22,
+    description:
+      "Rename guardian_verification_session_id column in call_sessions to verification_session_id",
+  },
 ];
 
 export interface MigrationValidationResult {

--- a/assistant/src/memory/schema/calls.ts
+++ b/assistant/src/memory/schema/calls.ts
@@ -22,7 +22,7 @@ export const callSessions = sqliteTable(
     task: text("task"),
     status: text("status").notNull().default("initiated"),
     callMode: text("call_mode"),
-    guardianVerificationSessionId: text("guardian_verification_session_id"),
+    verificationSessionId: text("verification_session_id"),
     callerIdentityMode: text("caller_identity_mode"),
     callerIdentitySource: text("caller_identity_source"),
     initiatedFromConversationId: text("initiated_from_conversation_id"),

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -191,7 +191,7 @@ export function deliverVerificationTelegram(
  */
 function initiateGuardianVoiceCall(
   phoneNumber: string,
-  guardianVerificationSessionId: string,
+  verificationSessionId: string,
   assistantId: string,
   originConversationId?: string,
 ): void {
@@ -199,7 +199,7 @@ function initiateGuardianVoiceCall(
     try {
       const result = await startGuardianVerificationCall({
         phoneNumber,
-        guardianVerificationSessionId,
+        verificationSessionId,
         assistantId,
         originConversationId,
       });
@@ -207,20 +207,20 @@ function initiateGuardianVoiceCall(
         log.info(
           {
             phoneNumber,
-            guardianVerificationSessionId,
+            verificationSessionId,
             callSid: result.callSid,
           },
           "Guardian verification call initiated",
         );
       } else {
         log.error(
-          { phoneNumber, guardianVerificationSessionId, error: result.error },
+          { phoneNumber, verificationSessionId, error: result.error },
           "Failed to initiate guardian verification call",
         );
       }
     } catch (err) {
       log.error(
-        { err, phoneNumber, guardianVerificationSessionId },
+        { err, phoneNumber, verificationSessionId },
         "Failed to initiate guardian verification call",
       );
     }


### PR DESCRIPTION
## Summary
Renames the guardian_verification_session_id column in call_sessions to verification_session_id,
with a SQLite migration and all codebase reference updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
