### PR TITLE
fix: rename guardianVerification identifiers in voice relay subsystem

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -1075,7 +1075,7 @@ describe("telegram guardian verify intercept", () => {
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
-    expect(body.guardianVerification).toBe("verified");
+    expect(body.verificationOutcome).toBe("verified");
 
     expect(deliverSpy).toHaveBeenCalled();
     const replyArgs = deliverSpy.mock.calls[0];
@@ -1119,7 +1119,7 @@ describe("telegram guardian verify intercept", () => {
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
-    expect(body.guardianVerification).toBe("failed");
+    expect(body.verificationOutcome).toBe("failed");
 
     expect(deliverSpy).toHaveBeenCalled();
     const replyArgs = deliverSpy.mock.calls[0];
@@ -1171,7 +1171,7 @@ describe("telegram guardian verify intercept", () => {
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
-    expect(body.guardianVerification).toBe("verified");
+    expect(body.verificationOutcome).toBe("verified");
     expect(processMessageCalled).toBe(false);
   });
 });
@@ -1515,7 +1515,7 @@ describe("assistant-scoped guardian verification via handleChannelInbound", () =
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
-    expect(body.guardianVerification).toBe("verified");
+    expect(body.verificationOutcome).toBe("verified");
 
     deliverSpy.mockRestore();
   });
@@ -1547,7 +1547,7 @@ describe("assistant-scoped guardian verification via handleChannelInbound", () =
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
-    expect(body.guardianVerification).toBe("verified");
+    expect(body.verificationOutcome).toBe("verified");
 
     const bindingX = getGuardianBinding("self", "telegram");
     expect(bindingX).not.toBeNull();
@@ -1581,7 +1581,7 @@ describe("assistant-scoped guardian verification via handleChannelInbound", () =
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(body.accepted).toBe(true);
-    expect(body.guardianVerification).toBe("verified");
+    expect(body.verificationOutcome).toBe("verified");
 
     deliverSpy.mockRestore();
   });

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -53,7 +53,7 @@ const voiceCallInitCalls: Array<{
   assistantId?: string;
 }> = [];
 mock.module("../calls/call-domain.js", () => ({
-  startGuardianVerificationCall: async (input: {
+  startVerificationCall: async (input: {
     phoneNumber: string;
     verificationSessionId: string;
     assistantId?: string;

--- a/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
+++ b/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
@@ -302,7 +302,7 @@ describe("Verification control messages are deterministic (guard)", () => {
       const body = (await response.json()) as Record<string, unknown>;
 
       // Verification should have been handled
-      expect(body.guardianVerification).toBeDefined();
+      expect(body.verificationOutcome).toBeDefined();
 
       // processMessage must NOT have been called — this is the guard
       expect(processMessageCalled).toBe(false);
@@ -391,7 +391,7 @@ describe("Verification control messages are deterministic (guard)", () => {
       const body = (await response.json()) as Record<string, unknown>;
 
       // Bootstrap should have been handled deterministically
-      expect(body.guardianVerification).toBe("bootstrap_bound");
+      expect(body.verificationOutcome).toBe("bootstrap_bound");
       expect(body.accepted).toBe(true);
 
       // processMessage must NOT have been called — deterministic handling

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -65,7 +65,7 @@ const voiceCallInitCalls: Array<{
   originConversationId?: string;
 }> = [];
 mock.module("../calls/call-domain.js", () => ({
-  startGuardianVerificationCall: async (input: {
+  startVerificationCall: async (input: {
     phoneNumber: string;
     verificationSessionId: string;
     assistantId?: string;
@@ -289,7 +289,7 @@ describe("startOutbound", () => {
     expect(result.sendCount).toBe(1);
   });
 
-  test("voice: passes originConversationId to startGuardianVerificationCall", async () => {
+  test("voice: passes originConversationId to startVerificationCall", async () => {
     voiceCallInitCalls.length = 0;
     const result = await startOutbound({
       channel: "voice",

--- a/assistant/src/__tests__/guardian-verification-voice-binding.test.ts
+++ b/assistant/src/__tests__/guardian-verification-voice-binding.test.ts
@@ -111,7 +111,7 @@ mock.module("../memory/conversation-title-service.js", () => ({
   queueGenerateConversationTitle: () => {},
 }));
 
-import { startGuardianVerificationCall } from "../calls/call-domain.js";
+import { startVerificationCall } from "../calls/call-domain.js";
 import { getOrCreateConversation } from "../memory/conversation-key-store.js";
 import { initializeDb, resetDb } from "../memory/db.js";
 import { getBindingByConversation } from "../memory/external-conversation-store.js";
@@ -127,7 +127,7 @@ afterAll(() => {
   }
 });
 
-describe("startGuardianVerificationCall — voice binding", () => {
+describe("startVerificationCall — voice binding", () => {
   beforeEach(() => {
     mockPreflightResult = {
       ok: true as const,
@@ -141,7 +141,7 @@ describe("startGuardianVerificationCall — voice binding", () => {
 
   test("creates a voice channel binding for the guardian verification conversation", async () => {
     const sessionId = "gv-session-001";
-    const result = await startGuardianVerificationCall({
+    const result = await startVerificationCall({
       phoneNumber: "+15559999999",
       verificationSessionId: sessionId,
     });
@@ -165,7 +165,7 @@ describe("startGuardianVerificationCall — voice binding", () => {
       status: 503,
     };
 
-    const result = await startGuardianVerificationCall({
+    const result = await startVerificationCall({
       phoneNumber: "+15559999999",
       verificationSessionId: "gv-session-preflight-fail",
     });

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -1355,7 +1355,7 @@ describe("relay-server", () => {
     );
 
     // Should be in verification-pending state
-    expect(relay.isGuardianVerificationActive()).toBe(true);
+    expect(relay.isVerificationSessionActive()).toBe(true);
     expect(relay.getConnectionState()).toBe("verification_pending");
 
     // Verify TTS prompt was sent asking for code
@@ -1374,7 +1374,7 @@ describe("relay-server", () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     // Verification should have succeeded
-    expect(relay.isGuardianVerificationActive()).toBe(false);
+    expect(relay.isVerificationSessionActive()).toBe(false);
     expect(relay.getConnectionState()).toBe("connected");
 
     // Guardian binding should have been created
@@ -1431,7 +1431,7 @@ describe("relay-server", () => {
       }),
     );
 
-    expect(relay.isGuardianVerificationActive()).toBe(true);
+    expect(relay.isVerificationSessionActive()).toBe(true);
 
     // Speak the code as individual digit characters
     const spokenCode = secret.split("").join(" ");
@@ -1447,7 +1447,7 @@ describe("relay-server", () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     // Verification should have succeeded
-    expect(relay.isGuardianVerificationActive()).toBe(false);
+    expect(relay.isVerificationSessionActive()).toBe(false);
     expect(relay.getConnectionState()).toBe("connected");
 
     // Binding created
@@ -1744,7 +1744,7 @@ describe("relay-server", () => {
       }),
     );
 
-    expect(relay.isGuardianVerificationActive()).toBe(true);
+    expect(relay.isVerificationSessionActive()).toBe(true);
 
     // Enter a wrong code via DTMF
     for (const digit of "000000") {
@@ -1752,7 +1752,7 @@ describe("relay-server", () => {
     }
 
     // Should still be in verification-pending state (retry allowed)
-    expect(relay.isGuardianVerificationActive()).toBe(true);
+    expect(relay.isVerificationSessionActive()).toBe(true);
     expect(relay.getConnectionState()).toBe("verification_pending");
 
     // Should have sent a retry prompt
@@ -1788,7 +1788,7 @@ describe("relay-server", () => {
       }),
     );
 
-    expect(relay.isGuardianVerificationActive()).toBe(true);
+    expect(relay.isVerificationSessionActive()).toBe(true);
 
     // Enter wrong codes 3 times (max attempts = 3)
     for (let attempt = 0; attempt < 3; attempt++) {
@@ -1862,7 +1862,7 @@ describe("relay-server", () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     // Should NOT be in guardian verification state
-    expect(relay.isGuardianVerificationActive()).toBe(false);
+    expect(relay.isVerificationSessionActive()).toBe(false);
     expect(relay.getConnectionState()).toBe("connected");
 
     // Should have started normal greeting
@@ -1898,7 +1898,7 @@ describe("relay-server", () => {
       }),
     );
 
-    expect(relay.isGuardianVerificationActive()).toBe(true);
+    expect(relay.isVerificationSessionActive()).toBe(true);
 
     // Speak only 3 digits
     await relay.handleMessage(
@@ -1911,7 +1911,7 @@ describe("relay-server", () => {
     );
 
     // Should still be in verification state
-    expect(relay.isGuardianVerificationActive()).toBe(true);
+    expect(relay.isVerificationSessionActive()).toBe(true);
 
     // Should have prompted for more digits
     const textMessages = ws.sentMessages
@@ -1961,7 +1961,7 @@ describe("relay-server", () => {
       }),
     );
 
-    expect(relay.isGuardianVerificationActive()).toBe(true);
+    expect(relay.isVerificationSessionActive()).toBe(true);
 
     // Enter the correct code via DTMF
     for (const digit of secret) {
@@ -1969,7 +1969,7 @@ describe("relay-server", () => {
     }
 
     // Verification should have succeeded
-    expect(relay.isGuardianVerificationActive()).toBe(false);
+    expect(relay.isVerificationSessionActive()).toBe(false);
 
     // Origin conversation should have a pointer message
     const originText = getLatestAssistantText("conv-gv-pointer-success-origin");
@@ -2013,7 +2013,7 @@ describe("relay-server", () => {
       }),
     );
 
-    expect(relay.isGuardianVerificationActive()).toBe(true);
+    expect(relay.isVerificationSessionActive()).toBe(true);
 
     // Enter wrong codes 3 times (max attempts = 3)
     for (let attempt = 0; attempt < 3; attempt++) {
@@ -3906,7 +3906,7 @@ describe("relay-server", () => {
     );
 
     // Should be in verification-pending state
-    expect(relay.isGuardianVerificationActive()).toBe(true);
+    expect(relay.isVerificationSessionActive()).toBe(true);
     expect(relay.getConnectionState()).toBe("verification_pending");
 
     // Enter the correct code via DTMF
@@ -3917,7 +3917,7 @@ describe("relay-server", () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     // Verification should have succeeded — call remains connected
-    expect(relay.isGuardianVerificationActive()).toBe(false);
+    expect(relay.isVerificationSessionActive()).toBe(false);
     expect(relay.getConnectionState()).toBe("connected");
 
     // Deterministic handoff copy should have been sent (not a fresh greeting)
@@ -3975,7 +3975,7 @@ describe("relay-server", () => {
       }),
     );
 
-    expect(relay.isGuardianVerificationActive()).toBe(true);
+    expect(relay.isVerificationSessionActive()).toBe(true);
 
     // Enter the correct code
     for (const digit of secret) {
@@ -3985,7 +3985,7 @@ describe("relay-server", () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     // Should have transitioned to connected with normal greeting (not handoff copy)
-    expect(relay.isGuardianVerificationActive()).toBe(false);
+    expect(relay.isVerificationSessionActive()).toBe(false);
     expect(relay.getConnectionState()).toBe("connected");
 
     // Guardian binding should have been created

--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -338,6 +338,6 @@ describe("Slack inbound trusted contact verification", () => {
     const verifyJson = (await verifyResp.json()) as Record<string, unknown>;
 
     expect(verifyJson.accepted).toBe(true);
-    expect(verifyJson.guardianVerification).toBe("verified");
+    expect(verifyJson.verificationOutcome).toBe("verified");
   });
 });

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -885,9 +885,9 @@ export async function relayInstruction(
   return { ok: true };
 }
 
-// ── Guardian verification call ───────────────────────────────────────
+// ── Verification call ─────────────────────────────────────────────────
 
-export type StartGuardianVerificationCallInput = {
+export type StartVerificationCallInput = {
   phoneNumber: string;
   verificationSessionId: string;
   assistantId?: string;
@@ -895,7 +895,7 @@ export type StartGuardianVerificationCallInput = {
   originConversationId?: string;
 };
 
-export type StartGuardianVerificationCallResult =
+export type StartVerificationCallResult =
   | { ok: true; callSessionId: string; callSid: string }
   | CallError;
 
@@ -906,9 +906,9 @@ export type StartGuardianVerificationCallResult =
  * passes `verificationSessionId` as a custom parameter so the
  * relay server can detect this is a guardian verification call.
  */
-export async function startGuardianVerificationCall(
-  input: StartGuardianVerificationCallInput,
-): Promise<StartGuardianVerificationCallResult> {
+export async function startVerificationCall(
+  input: StartVerificationCallInput,
+): Promise<StartVerificationCallResult> {
   const { phoneNumber, verificationSessionId, originConversationId } = input;
 
   if (!phoneNumber || !E164_REGEX.test(phoneNumber)) {

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -58,8 +58,8 @@ import {
 } from "./relay-access-wait.js";
 import { routeSetup } from "./relay-setup-router.js";
 import {
-  attemptGuardianCodeVerification,
   attemptInviteCodeRedemption,
+  attemptVerificationCode,
   parseDigitsFromSpeech,
 } from "./relay-verification.js";
 import {
@@ -196,9 +196,9 @@ export class RelayConnection {
   private dtmfBuffer = "";
 
   // Inbound voice guardian verification state
-  private guardianVerificationActive = false;
+  private verificationSessionActive = false;
   private guardianChallengeAssistantId: string | null = null;
-  private guardianVerificationFromNumber: string | null = null;
+  private verificationFromNumber: string | null = null;
 
   // Outbound guardian verification state (system calls the guardian)
   private outboundVerificationSessionId: string | null = null;
@@ -257,8 +257,8 @@ export class RelayConnection {
   /**
    * Whether inbound guardian voice verification is currently active.
    */
-  isGuardianVerificationActive(): boolean {
-    return this.guardianVerificationActive;
+  isVerificationSessionActive(): boolean {
+    return this.verificationSessionActive;
   }
 
   /**
@@ -557,7 +557,7 @@ export class RelayConnection {
 
     switch (outcome.action) {
       case "outbound_guardian_verification":
-        this.startOutboundGuardianVerification(
+        this.startOutboundVerification(
           outcome.assistantId,
           outcome.sessionId,
           outcome.toNumber,
@@ -601,10 +601,7 @@ export class RelayConnection {
             toTrustContext(resolved.actorTrust, msg.from),
           );
         }
-        this.startInboundGuardianVerification(
-          outcome.assistantId,
-          outcome.fromNumber,
-        );
+        this.startInboundVerification(outcome.assistantId, outcome.fromNumber);
         return;
       case "normal_call":
         if (outcome.isInbound) {
@@ -842,13 +839,13 @@ export class RelayConnection {
    * voice guardian challenge. Prompts the caller to enter their six-digit
    * verification code via DTMF or by speaking it.
    */
-  private startInboundGuardianVerification(
+  private startInboundVerification(
     assistantId: string,
     fromNumber: string,
   ): void {
-    this.guardianVerificationActive = true;
+    this.verificationSessionActive = true;
     this.guardianChallengeAssistantId = assistantId;
-    this.guardianVerificationFromNumber = fromNumber;
+    this.verificationFromNumber = fromNumber;
     this.connectionState = "verification_pending";
     this.verificationAttempts = 0;
     this.verificationMaxAttempts = 3;
@@ -876,16 +873,16 @@ export class RelayConnection {
    * call. The system called the guardian's phone; prompt them to enter the
    * verification code via DTMF or speech.
    */
-  private startOutboundGuardianVerification(
+  private startOutboundVerification(
     assistantId: string,
     verificationSessionId: string,
     toNumber: string,
   ): void {
-    this.guardianVerificationActive = true;
+    this.verificationSessionActive = true;
     this.outboundVerificationSessionId = verificationSessionId;
     this.guardianChallengeAssistantId = assistantId;
     // For outbound guardian calls, the "to" number is the guardian's phone
-    this.guardianVerificationFromNumber = toNumber;
+    this.verificationFromNumber = toNumber;
     this.connectionState = "verification_pending";
     this.verificationAttempts = 0;
     this.verificationMaxAttempts = 3;
@@ -920,24 +917,21 @@ export class RelayConnection {
 
   /**
    * Validate an entered code against the pending voice guardian challenge.
-   * Delegates to the extracted attemptGuardianCodeVerification() and
+   * Delegates to the extracted attemptVerificationCode() and
    * interprets the structured result to drive side-effects.
    */
   private handleGuardianCodeVerificationResult(enteredCode: string): void {
-    if (
-      !this.guardianChallengeAssistantId ||
-      !this.guardianVerificationFromNumber
-    ) {
+    if (!this.guardianChallengeAssistantId || !this.verificationFromNumber) {
       return;
     }
 
     const isOutbound = this.outboundVerificationSessionId != null;
     const assistantId = this.guardianChallengeAssistantId;
-    const fromNumber = this.guardianVerificationFromNumber;
+    const fromNumber = this.verificationFromNumber;
 
-    const result = attemptGuardianCodeVerification({
+    const result = attemptVerificationCode({
       guardianChallengeAssistantId: assistantId,
-      guardianVerificationFromNumber: fromNumber,
+      verificationFromNumber: fromNumber,
       enteredCode,
       isOutbound,
       codeDigits: this.verificationCodeLength,
@@ -947,7 +941,7 @@ export class RelayConnection {
 
     if (result.outcome === "success") {
       this.connectionState = "connected";
-      this.guardianVerificationActive = false;
+      this.verificationSessionActive = false;
       this.verificationAttempts = 0;
       this.dtmfBuffer = "";
 
@@ -1033,7 +1027,7 @@ export class RelayConnection {
         }
       }
     } else if (result.outcome === "failure") {
-      this.guardianVerificationActive = false;
+      this.verificationSessionActive = false;
       this.verificationAttempts = result.attempts;
 
       recordCallEvent(this.callSessionId, result.eventName, {
@@ -1809,7 +1803,7 @@ export class RelayConnection {
     // spoken digits from the transcript and validate them.
     if (
       this.connectionState === "verification_pending" &&
-      this.guardianVerificationActive
+      this.verificationSessionActive
     ) {
       const spokenDigits = parseDigitsFromSpeech(msg.voicePrompt);
       log.info(
@@ -1997,7 +1991,7 @@ export class RelayConnection {
     // digits and validate against the challenge via the guardian service.
     if (
       this.connectionState === "verification_pending" &&
-      this.guardianVerificationActive
+      this.verificationSessionActive
     ) {
       this.dtmfBuffer += msg.digit;
 

--- a/assistant/src/calls/relay-verification.ts
+++ b/assistant/src/calls/relay-verification.ts
@@ -68,9 +68,9 @@ export function parseDigitsFromSpeech(transcript: string): string {
 
 // ── Guardian code verification ─────────────────────────────────────────
 
-export interface GuardianVerificationParams {
+export interface VerificationCallParams {
   guardianChallengeAssistantId: string;
-  guardianVerificationFromNumber: string;
+  verificationFromNumber: string;
   enteredCode: string;
   isOutbound: boolean;
   codeDigits: number;
@@ -78,7 +78,7 @@ export interface GuardianVerificationParams {
   verificationMaxAttempts: number;
 }
 
-export type GuardianVerificationResult =
+export type VerificationCallResult =
   | {
       outcome: "success";
       verificationType: "guardian" | "trusted_contact";
@@ -112,12 +112,12 @@ export type GuardianVerificationResult =
  * so the caller can apply side-effects (state mutations, TTS, session
  * updates) without this function needing access to the relay connection.
  */
-export function attemptGuardianCodeVerification(
-  params: GuardianVerificationParams,
-): GuardianVerificationResult {
+export function attemptVerificationCode(
+  params: VerificationCallParams,
+): VerificationCallResult {
   const {
     guardianChallengeAssistantId,
-    guardianVerificationFromNumber,
+    verificationFromNumber,
     enteredCode,
     isOutbound,
     codeDigits,
@@ -128,8 +128,8 @@ export function attemptGuardianCodeVerification(
   const result = validateAndConsumeVerification(
     "voice",
     enteredCode,
-    guardianVerificationFromNumber,
-    guardianVerificationFromNumber,
+    verificationFromNumber,
+    verificationFromNumber,
   );
 
   if (result.success) {
@@ -148,8 +148,7 @@ export function attemptGuardianCodeVerification(
       );
       if (
         existingBinding &&
-        existingBinding.guardianExternalUserId !==
-          guardianVerificationFromNumber
+        existingBinding.guardianExternalUserId !== verificationFromNumber
       ) {
         bindingConflict = {
           existingGuardian: existingBinding.guardianExternalUserId,
@@ -161,7 +160,7 @@ export function attemptGuardianCodeVerification(
           "vellum",
         );
         canonicalPrincipal =
-          vellumBinding?.guardianPrincipalId ?? guardianVerificationFromNumber;
+          vellumBinding?.guardianPrincipalId ?? verificationFromNumber;
       }
     }
 

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -170,7 +170,7 @@ export function buildSystemPrompt(): string {
       config,
     )
   ) {
-    parts.push(buildVerificationSessionRoutingSection());
+    parts.push(buildVerificationRoutingSection());
   }
   parts.push(buildAttachmentSection());
   parts.push(buildInChatConfigurationSection());
@@ -227,7 +227,7 @@ function buildTaskScheduleReminderRoutingSection(): string {
   ].join("\n");
 }
 
-export function buildVerificationSessionRoutingSection(): string {
+export function buildVerificationRoutingSection(): string {
   return [
     "## Routing: Guardian Verification",
     "",

--- a/assistant/src/runtime/routes/inbound-stages/bootstrap-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/bootstrap-intercept.ts
@@ -123,7 +123,7 @@ export async function handleBootstrapIntercept(
     accepted: true,
     duplicate: false,
     eventId,
-    guardianVerification: "bootstrap_bound",
+    verificationOutcome: "bootstrap_bound",
   });
 }
 

--- a/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/verification-intercept.ts
@@ -321,7 +321,7 @@ export async function handleVerificationIntercept(
         accepted: true,
         duplicate: false,
         eventId,
-        guardianVerification: guardianVerifyOutcome,
+        verificationOutcome: guardianVerifyOutcome,
         deliveryPending: true,
       });
     }
@@ -331,6 +331,6 @@ export async function handleVerificationIntercept(
     accepted: true,
     duplicate: false,
     eventId,
-    guardianVerification: guardianVerifyOutcome,
+    verificationOutcome: guardianVerifyOutcome,
   });
 }

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -50,7 +50,7 @@ import {
   resendOutbound,
   startOutbound,
 } from "../verification-outbound-actions.js";
-import { guardianVerificationLimiter } from "../verification-rate-limiter.js";
+import { verificationRateLimiter } from "../verification-rate-limiter.js";
 
 /**
  * GET /v1/integrations/telegram/config
@@ -209,7 +209,7 @@ export async function handleCreateVerificationSession(
       }
     }
 
-    if (rateLimitKey && guardianVerificationLimiter.isBlocked(rateLimitKey)) {
+    if (rateLimitKey && verificationRateLimiter.isBlocked(rateLimitKey)) {
       return httpError(
         "RATE_LIMITED",
         "Too many verification attempts for this identity. Please try again later.",
@@ -225,7 +225,7 @@ export async function handleCreateVerificationSession(
     });
 
     if (!result.success && rateLimitKey) {
-      guardianVerificationLimiter.recordFailure(rateLimitKey);
+      verificationRateLimiter.recordFailure(rateLimitKey);
     }
 
     const status = result.success

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -9,7 +9,7 @@
 
 import { createHash, randomBytes } from "node:crypto";
 
-import { startGuardianVerificationCall } from "../calls/call-domain.js";
+import { startVerificationCall } from "../calls/call-domain.js";
 import type { ChannelId } from "../channels/types.js";
 import { getGatewayInternalBaseUrl } from "../config/env.js";
 import { getCredentialMetadata } from "../tools/credentials/metadata-store.js";
@@ -197,7 +197,7 @@ function initiateGuardianVoiceCall(
 ): void {
   (async () => {
     try {
-      const result = await startGuardianVerificationCall({
+      const result = await startVerificationCall({
         phoneNumber,
         verificationSessionId,
         assistantId,

--- a/assistant/src/runtime/verification-rate-limiter.ts
+++ b/assistant/src/runtime/verification-rate-limiter.ts
@@ -79,5 +79,5 @@ export class VerificationRateLimiter {
   }
 }
 
-/** Singleton rate limiter for guardian verification endpoint failures. */
-export const guardianVerificationLimiter = new VerificationRateLimiter();
+/** Singleton rate limiter for verification endpoint failures. */
+export const verificationRateLimiter = new VerificationRateLimiter();


### PR DESCRIPTION
## Summary
Renames ~66 occurrences of guardianVerification-prefixed types, functions, and variables
in the voice call relay subsystem to use verificationSession/verificationCall naming.

- `GuardianVerificationParams` -> `VerificationCallParams`
- `GuardianVerificationResult` -> `VerificationCallResult`
- `attemptGuardianCodeVerification()` -> `attemptVerificationCode()`
- `startGuardianVerificationCall()` -> `startVerificationCall()`
- `StartGuardianVerificationCallInput` -> `StartVerificationCallInput`
- `StartGuardianVerificationCallResult` -> `StartVerificationCallResult`
- `isGuardianVerificationActive()` -> `isVerificationSessionActive()`
- `outboundGuardianVerificationSessionId` -> `outboundVerificationSessionId`
- `guardianVerificationActive` -> `verificationSessionActive`
- `guardianVerificationFromNumber` -> `verificationFromNumber`
- `startInboundGuardianVerification()` -> `startInboundVerification()`
- `startOutboundGuardianVerification()` -> `startOutboundVerification()`
- `guardianVerificationSessionId` -> `verificationSessionId` (types, call-store, twilio-routes, etc.)
- `guardianVerificationLimiter` -> `verificationRateLimiter`
- `resolveGuardianVerificationIntent()` -> `resolveVerificationIntent()`
- `GuardianVerificationIntentResult` -> `VerificationIntentResult`
- `buildGuardianVerificationRoutingSection()` -> `buildVerificationRoutingSection()`
- Response JSON key `guardianVerification` -> `verificationOutcome`

DB column names preserved (only drizzle alias renamed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
