### PR TITLE
fix: wrap releaseCallbackClaim in try-catch and condition finalization log (PR 13877 feedback)

### DIFF
--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -439,19 +439,26 @@ export async function handleStatusCallback(req: Request): Promise<Response> {
       // dedupe guard blocks subsequent attempts.
       try {
         finalizeCallbackClaim(dedupeKey, claimId);
+        log.warn(
+          { dedupeKey, claimId, callSid, callStatus, err },
+          "Post-persistence error — claim finalized to prevent duplicate events on retry",
+        );
       } catch (finalizeErr) {
         log.error(
           { dedupeKey, claimId, callSid, callStatus, finalizeErr },
           "Failed to finalize claim after event persistence — original error will still be re-thrown",
         );
       }
-      log.warn(
-        { dedupeKey, claimId, callSid, callStatus, err },
-        "Post-persistence error — claim finalized to prevent duplicate events on retry",
-      );
     } else {
       // Nothing persisted yet — safe to release so retries can reprocess
-      releaseCallbackClaim(dedupeKey, claimId);
+      try {
+        releaseCallbackClaim(dedupeKey, claimId);
+      } catch (releaseErr) {
+        log.error(
+          { dedupeKey, claimId, callSid, callStatus, releaseErr },
+          "Failed to release claim — original error will still be re-thrown",
+        );
+      }
     }
     throw err;
   }


### PR DESCRIPTION
Addresses Devin review feedback on PR #13877: (1) wraps releaseCallbackClaim in try-catch to prevent masking original error, (2) makes the finalization log conditional on success.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
