### PR TITLE
fix(ios): use tall window and longer timeout for usage dashboard render test

### DIFF
--- a/clients/ios/Tests/UsageDashboardViewTests.swift
+++ b/clients/ios/Tests/UsageDashboardViewTests.swift
@@ -236,12 +236,14 @@ private extension UsageDashboardViewTests {
     /// rather than resetting each time.
     static func pollRenderedText(
         from view: UsageDashboardView,
-        timeout: TimeInterval = 3.0,
+        timeout: TimeInterval = 10.0,
         interval: TimeInterval = 0.1,
         until condition: (String) -> Bool
     ) -> String {
         let hostingController = UIHostingController(rootView: view)
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 393, height: 852))
+        // Use an extra-tall window so the lazy List materialises every cell,
+        // including sections that would normally be off-screen on a real device.
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 393, height: 5000))
         window.rootViewController = hostingController
         window.isHidden = false
         hostingController.view.frame = window.bounds


### PR DESCRIPTION
## Summary
- Use a 5000px tall window (instead of 852px) so SwiftUI's lazy List materialises all cells including off-screen sections like the breakdown
- Increase polling timeout from 3s to 10s for CI timing resilience

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22791723069

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
