### PR TITLE
fix: rename remaining guardian_verification identifiers in calls subsystem

### DIFF
--- a/assistant/src/__tests__/call-pointer-message-composer.test.ts
+++ b/assistant/src/__tests__/call-pointer-message-composer.test.ts
@@ -74,36 +74,36 @@ describe("getPointerFallbackMessage", () => {
     expect(msg).toContain("failed: no answer");
   });
 
-  test("guardian_verification_succeeded defaults to voice channel", () => {
+  test("verification_succeeded defaults to voice channel", () => {
     const msg = getPointerFallbackMessage({
-      scenario: "guardian_verification_succeeded",
+      scenario: "verification_succeeded",
       phoneNumber: "+15559876543",
     });
     expect(msg).toContain("Guardian verification (voice)");
     expect(msg).toContain("succeeded");
   });
 
-  test("guardian_verification_succeeded with custom channel", () => {
+  test("verification_succeeded with custom channel", () => {
     const msg = getPointerFallbackMessage({
-      scenario: "guardian_verification_succeeded",
+      scenario: "verification_succeeded",
       phoneNumber: "+15559876543",
       channel: "voice",
     });
     expect(msg).toContain("Guardian verification (voice)");
   });
 
-  test("guardian_verification_failed without reason", () => {
+  test("verification_failed without reason", () => {
     const msg = getPointerFallbackMessage({
-      scenario: "guardian_verification_failed",
+      scenario: "verification_failed",
       phoneNumber: "+15559876543",
     });
     expect(msg).toContain("Guardian verification");
     expect(msg).toContain("failed");
   });
 
-  test("guardian_verification_failed with reason", () => {
+  test("verification_failed with reason", () => {
     const msg = getPointerFallbackMessage({
-      scenario: "guardian_verification_failed",
+      scenario: "verification_failed",
       phoneNumber: "+15559876543",
       reason: "Max attempts exceeded",
     });
@@ -159,7 +159,7 @@ describe("buildPointerInstruction", () => {
 
   test("includes channel when provided", () => {
     const ctx: CallPointerMessageContext = {
-      scenario: "guardian_verification_succeeded",
+      scenario: "verification_succeeded",
       phoneNumber: "+15559876543",
       channel: "voice",
     };

--- a/assistant/src/__tests__/call-pointer-messages.test.ts
+++ b/assistant/src/__tests__/call-pointer-messages.test.ts
@@ -201,34 +201,30 @@ describe("addPointerMessage", () => {
     expect(text).toContain("failed: no answer");
   });
 
-  test("adds a guardian_verification_succeeded pointer message", () => {
+  test("adds a verification_succeeded pointer message", () => {
     const convId = "conv-ptr-gv-success";
     ensureConversation(convId);
-    addPointerMessage(
-      convId,
-      "guardian_verification_succeeded",
-      "+15559876543",
-    );
+    addPointerMessage(convId, "verification_succeeded", "+15559876543");
     const text = getLatestAssistantText(convId);
     expect(text).toContain("Guardian verification");
     expect(text).toContain("+15559876543");
     expect(text).toContain("succeeded");
   });
 
-  test("adds a guardian_verification_failed pointer message without reason", () => {
+  test("adds a verification_failed pointer message without reason", () => {
     const convId = "conv-ptr-gv-fail";
     ensureConversation(convId);
-    addPointerMessage(convId, "guardian_verification_failed", "+15559876543");
+    addPointerMessage(convId, "verification_failed", "+15559876543");
     const text = getLatestAssistantText(convId);
     expect(text).toContain("Guardian verification");
     expect(text).toContain("+15559876543");
     expect(text).toContain("failed");
   });
 
-  test("adds a guardian_verification_failed pointer message with reason", () => {
+  test("adds a verification_failed pointer message with reason", () => {
     const convId = "conv-ptr-gv-fail-r";
     ensureConversation(convId);
-    addPointerMessage(convId, "guardian_verification_failed", "+15559876543", {
+    addPointerMessage(convId, "verification_failed", "+15559876543", {
       reason: "Max attempts exceeded",
     });
     const text = getLatestAssistantText(convId);

--- a/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
+++ b/assistant/src/__tests__/deterministic-verification-control-plane.test.ts
@@ -186,17 +186,17 @@ describe("Call session mode metadata", () => {
       provider: "twilio",
       fromNumber: "+15551234567",
       toNumber: "+15559876543",
-      callMode: "guardian_verification",
+      callMode: "verification",
       verificationSessionId: "gv-session-test",
     });
 
-    expect(session.callMode).toBe("guardian_verification");
+    expect(session.callMode).toBe("verification");
     expect(session.verificationSessionId).toBe("gv-session-test");
 
     // Verify it persists to DB
     const loaded = getCallSession(session.id);
     expect(loaded).not.toBeNull();
-    expect(loaded!.callMode).toBe("guardian_verification");
+    expect(loaded!.callMode).toBe("verification");
     expect(loaded!.verificationSessionId).toBe("gv-session-test");
   });
 

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -1392,13 +1392,11 @@ describe("relay-server", () => {
     // Verify events recorded
     const guardianEvents = getCallEvents(session.id);
     expect(
-      guardianEvents.some(
-        (e) => e.eventType === "guardian_voice_verification_started",
-      ),
+      guardianEvents.some((e) => e.eventType === "voice_verification_started"),
     ).toBe(true);
     expect(
       guardianEvents.some(
-        (e) => e.eventType === "guardian_voice_verification_succeeded",
+        (e) => e.eventType === "voice_verification_succeeded",
       ),
     ).toBe(true);
 
@@ -1816,7 +1814,7 @@ describe("relay-server", () => {
     // Verify events
     const events = getCallEvents(session.id);
     expect(
-      events.some((e) => e.eventType === "guardian_voice_verification_failed"),
+      events.some((e) => e.eventType === "voice_verification_failed"),
     ).toBe(true);
 
     // Let the delayed endSession callback flush
@@ -1937,7 +1935,7 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15551111111",
       toNumber: "+15559999999",
-      callMode: "guardian_verification",
+      callMode: "verification",
       verificationSessionId: "gv-session-ptr-success",
       initiatedFromConversationId: "conv-gv-pointer-success-origin",
     });
@@ -1992,7 +1990,7 @@ describe("relay-server", () => {
       provider: "twilio",
       fromNumber: "+15551111111",
       toNumber: "+15559999999",
-      callMode: "guardian_verification",
+      callMode: "verification",
       verificationSessionId: "gv-session-ptr-fail",
       initiatedFromConversationId: "conv-gv-pointer-fail-origin",
     });

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -954,7 +954,7 @@ export async function startVerificationCall(
       provider: "twilio",
       fromNumber: identityResult.fromNumber,
       toNumber: phoneNumber,
-      callMode: "guardian_verification",
+      callMode: "verification",
       verificationSessionId,
       initiatedFromConversationId: originConversationId,
     });

--- a/assistant/src/calls/call-pointer-message-composer.ts
+++ b/assistant/src/calls/call-pointer-message-composer.ts
@@ -14,8 +14,8 @@ export type CallPointerMessageScenario =
   | "started"
   | "completed"
   | "failed"
-  | "guardian_verification_succeeded"
-  | "guardian_verification_failed";
+  | "verification_succeeded"
+  | "verification_failed";
 
 export interface CallPointerMessageContext {
   scenario: CallPointerMessageScenario;
@@ -83,11 +83,11 @@ export function getPointerFallbackMessage(
       return context.reason
         ? `\u{1F4DE} Call to ${context.phoneNumber} failed: ${context.reason}.`
         : `\u{1F4DE} Call to ${context.phoneNumber} failed.`;
-    case "guardian_verification_succeeded": {
+    case "verification_succeeded": {
       const ch = context.channel ?? "voice";
       return `\u{2705} Guardian verification (${ch}) for ${context.phoneNumber} succeeded.`;
     }
-    case "guardian_verification_failed": {
+    case "verification_failed": {
       const ch = context.channel ?? "voice";
       return context.reason
         ? `\u{274C} Guardian verification (${ch}) for ${context.phoneNumber} failed: ${context.reason}.`

--- a/assistant/src/calls/call-pointer-messages.ts
+++ b/assistant/src/calls/call-pointer-messages.ts
@@ -23,8 +23,8 @@ export type PointerEvent =
   | "started"
   | "completed"
   | "failed"
-  | "guardian_verification_succeeded"
-  | "guardian_verification_failed";
+  | "verification_succeeded"
+  | "verification_failed";
 
 export type PointerAudienceMode = "auto" | "trusted" | "untrusted";
 
@@ -145,8 +145,8 @@ export async function addPointerMessage(
     started: "started",
     completed: "completed",
     failed: "failed",
-    guardian_verification_succeeded: "succeeded",
-    guardian_verification_failed: "failed",
+    verification_succeeded: "succeeded",
+    verification_failed: "failed",
   };
   const outcomeKeyword = eventOutcomeKeywords[event];
   if (outcomeKeyword) requiredFacts.push(outcomeKeyword);

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -197,7 +197,7 @@ export class RelayConnection {
 
   // Inbound voice guardian verification state
   private verificationSessionActive = false;
-  private guardianChallengeAssistantId: string | null = null;
+  private verificationAssistantId: string | null = null;
   private verificationFromNumber: string | null = null;
 
   // Outbound guardian verification state (system calls the guardian)
@@ -556,7 +556,7 @@ export class RelayConnection {
     this.setController(controller);
 
     switch (outcome.action) {
-      case "outbound_guardian_verification":
+      case "outbound_verification":
         this.startOutboundVerification(
           outcome.assistantId,
           outcome.sessionId,
@@ -588,7 +588,7 @@ export class RelayConnection {
         );
         this.startNameCapture(outcome.assistantId, outcome.fromNumber);
         return;
-      case "guardian_verification":
+      case "verification":
         if (
           resolved.actorTrust.memberRecord &&
           (resolved.actorTrust.trustClass === "guardian" ||
@@ -844,7 +844,7 @@ export class RelayConnection {
     fromNumber: string,
   ): void {
     this.verificationSessionActive = true;
-    this.guardianChallengeAssistantId = assistantId;
+    this.verificationAssistantId = assistantId;
     this.verificationFromNumber = fromNumber;
     this.connectionState = "verification_pending";
     this.verificationAttempts = 0;
@@ -852,7 +852,7 @@ export class RelayConnection {
     this.verificationCodeLength = 6;
     this.dtmfBuffer = "";
 
-    recordCallEvent(this.callSessionId, "guardian_voice_verification_started", {
+    recordCallEvent(this.callSessionId, "voice_verification_started", {
       assistantId,
       maxAttempts: this.verificationMaxAttempts,
     });
@@ -880,7 +880,7 @@ export class RelayConnection {
   ): void {
     this.verificationSessionActive = true;
     this.outboundVerificationSessionId = verificationSessionId;
-    this.guardianChallengeAssistantId = assistantId;
+    this.verificationAssistantId = assistantId;
     // For outbound guardian calls, the "to" number is the guardian's phone
     this.verificationFromNumber = toNumber;
     this.connectionState = "verification_pending";
@@ -889,15 +889,11 @@ export class RelayConnection {
     this.verificationCodeLength = 6;
     this.dtmfBuffer = "";
 
-    recordCallEvent(
-      this.callSessionId,
-      "outbound_guardian_voice_verification_started",
-      {
-        assistantId,
-        verificationSessionId,
-        maxAttempts: this.verificationMaxAttempts,
-      },
-    );
+    recordCallEvent(this.callSessionId, "outbound_voice_verification_started", {
+      assistantId,
+      verificationSessionId,
+      maxAttempts: this.verificationMaxAttempts,
+    });
 
     const introText = composeVerificationVoice(
       GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_CALL_INTRO,
@@ -920,17 +916,17 @@ export class RelayConnection {
    * Delegates to the extracted attemptVerificationCode() and
    * interprets the structured result to drive side-effects.
    */
-  private handleGuardianCodeVerificationResult(enteredCode: string): void {
-    if (!this.guardianChallengeAssistantId || !this.verificationFromNumber) {
+  private handleVerificationCodeResult(enteredCode: string): void {
+    if (!this.verificationAssistantId || !this.verificationFromNumber) {
       return;
     }
 
     const isOutbound = this.outboundVerificationSessionId != null;
-    const assistantId = this.guardianChallengeAssistantId;
+    const assistantId = this.verificationAssistantId;
     const fromNumber = this.verificationFromNumber;
 
     const result = attemptVerificationCode({
-      guardianChallengeAssistantId: assistantId,
+      verificationAssistantId: assistantId,
       verificationFromNumber: fromNumber,
       enteredCode,
       isOutbound,
@@ -988,7 +984,7 @@ export class RelayConnection {
         if (successSession?.initiatedFromConversationId) {
           addPointerMessage(
             successSession.initiatedFromConversationId,
-            "guardian_verification_succeeded",
+            "verification_succeeded",
             successSession.toNumber,
             { channel: "voice" },
           ).catch((err) => {
@@ -1057,7 +1053,7 @@ export class RelayConnection {
         if (isOutbound && failSession.initiatedFromConversationId) {
           addPointerMessage(
             failSession.initiatedFromConversationId,
-            "guardian_verification_failed",
+            "verification_failed",
             failSession.toNumber,
             {
               channel: "voice",
@@ -1816,7 +1812,7 @@ export class RelayConnection {
       );
       if (spokenDigits.length >= this.verificationCodeLength) {
         const enteredCode = spokenDigits.slice(0, this.verificationCodeLength);
-        this.handleGuardianCodeVerificationResult(enteredCode);
+        this.handleVerificationCodeResult(enteredCode);
       } else if (spokenDigits.length > 0) {
         this.sendTextToken(
           `I heard ${spokenDigits.length} digits. Please enter all ${this.verificationCodeLength} digits of your code.`,
@@ -2001,7 +1997,7 @@ export class RelayConnection {
           this.verificationCodeLength,
         );
         this.dtmfBuffer = "";
-        this.handleGuardianCodeVerificationResult(enteredCode);
+        this.handleVerificationCodeResult(enteredCode);
       }
       return;
     }

--- a/assistant/src/calls/relay-setup-router.ts
+++ b/assistant/src/calls/relay-setup-router.ts
@@ -34,12 +34,12 @@ export interface SetupContext {
 export type SetupOutcome =
   | { action: "normal_call"; isInbound: boolean }
   | {
-      action: "guardian_verification";
+      action: "verification";
       assistantId: string;
       fromNumber: string;
     }
   | {
-      action: "outbound_guardian_verification";
+      action: "outbound_verification";
       assistantId: string;
       sessionId: string;
       toNumber: string;
@@ -105,10 +105,10 @@ export function routeSetup(ctx: SetupContext): {
   const customParamVsId = ctx.customParameters?.verificationSessionId;
   const verificationSessionId = persistedVsId ?? customParamVsId;
 
-  if (persistedMode === "guardian_verification" && verificationSessionId) {
+  if (persistedMode === "verification" && verificationSessionId) {
     return {
       outcome: {
-        action: "outbound_guardian_verification",
+        action: "outbound_verification",
         assistantId,
         sessionId: verificationSessionId,
         toNumber: ctx.to,
@@ -128,7 +128,7 @@ export function routeSetup(ctx: SetupContext): {
     );
     return {
       outcome: {
-        action: "outbound_guardian_verification",
+        action: "outbound_verification",
         assistantId,
         sessionId: customParamVsId,
         toNumber: ctx.to,
@@ -285,7 +285,7 @@ export function routeSetup(ctx: SetupContext): {
   if (pendingChallenge) {
     return {
       outcome: {
-        action: "guardian_verification",
+        action: "verification",
         assistantId,
         fromNumber: ctx.from,
       },

--- a/assistant/src/calls/relay-verification.ts
+++ b/assistant/src/calls/relay-verification.ts
@@ -69,7 +69,7 @@ export function parseDigitsFromSpeech(transcript: string): string {
 // ── Guardian code verification ─────────────────────────────────────────
 
 export interface VerificationCallParams {
-  guardianChallengeAssistantId: string;
+  verificationAssistantId: string;
   verificationFromNumber: string;
   enteredCode: string;
   isOutbound: boolean;
@@ -116,7 +116,7 @@ export function attemptVerificationCode(
   params: VerificationCallParams,
 ): VerificationCallResult {
   const {
-    guardianChallengeAssistantId,
+    verificationAssistantId,
     verificationFromNumber,
     enteredCode,
     isOutbound,
@@ -134,8 +134,8 @@ export function attemptVerificationCode(
 
   if (result.success) {
     const eventName = isOutbound
-      ? "outbound_guardian_voice_verification_succeeded"
-      : "guardian_voice_verification_succeeded";
+      ? "outbound_voice_verification_succeeded"
+      : "voice_verification_succeeded";
 
     // Resolve binding conflict and canonical principal for guardian type
     let bindingConflict: { existingGuardian: string } | undefined;
@@ -143,7 +143,7 @@ export function attemptVerificationCode(
 
     if (result.verificationType === "guardian") {
       const existingBinding = getGuardianBinding(
-        guardianChallengeAssistantId,
+        verificationAssistantId,
         "voice",
       );
       if (
@@ -156,7 +156,7 @@ export function attemptVerificationCode(
       } else {
         // Resolve canonical principal from the vellum channel binding
         const vellumBinding = getGuardianBinding(
-          guardianChallengeAssistantId,
+          verificationAssistantId,
           "vellum",
         );
         canonicalPrincipal =
@@ -187,8 +187,8 @@ export function attemptVerificationCode(
 
   if (newAttempts >= verificationMaxAttempts) {
     const failEventName = isOutbound
-      ? "outbound_guardian_voice_verification_failed"
-      : "guardian_voice_verification_failed";
+      ? "outbound_voice_verification_failed"
+      : "voice_verification_failed";
 
     const failureText = isOutbound
       ? composeVerificationVoice(GUARDIAN_VERIFY_TEMPLATE_KEYS.VOICE_FAILURE, {

--- a/assistant/src/calls/types.ts
+++ b/assistant/src/calls/types.ts
@@ -19,12 +19,12 @@ export type CallEventType =
   | "callee_verification_started"
   | "callee_verification_succeeded"
   | "callee_verification_failed"
-  | "guardian_voice_verification_started"
-  | "guardian_voice_verification_succeeded"
-  | "guardian_voice_verification_failed"
-  | "outbound_guardian_voice_verification_started"
-  | "outbound_guardian_voice_verification_succeeded"
-  | "outbound_guardian_voice_verification_failed"
+  | "voice_verification_started"
+  | "voice_verification_succeeded"
+  | "voice_verification_failed"
+  | "outbound_voice_verification_started"
+  | "outbound_voice_verification_succeeded"
+  | "outbound_voice_verification_failed"
   | "guardian_consultation_timed_out"
   | "guardian_unavailable_skipped"
   | "guardian_consult_deferred"
@@ -58,7 +58,7 @@ export type PendingQuestionStatus =
  * uses this as the primary signal for deterministic flow selection,
  * with Twilio setup custom parameters as a secondary/observability signal.
  */
-export type CallMode = "normal" | "guardian_verification";
+export type CallMode = "normal" | "verification";
 
 export interface CallSession {
   id: string;

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -64,6 +64,7 @@ import {
   migrateNormalizePhoneIdentities,
   migrateNotificationDeliveryThreadDecision,
   migrateReminderRoutingIntent,
+  migrateRenameGuardianVerificationValues,
   migrateRenameVerificationSessionIdColumn,
   migrateRenameVerificationTable,
   migrateSchemaIndexesAndColumns,
@@ -315,6 +316,9 @@ export function initializeDb(): void {
 
   // 46. Rename guardian_verification_session_id → verification_session_id in call_sessions
   migrateRenameVerificationSessionIdColumn(database);
+
+  // 47. Rename persisted guardian_verification call_mode and event_type values
+  migrateRenameGuardianVerificationValues(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/143-rename-guardian-verification-values.ts
+++ b/assistant/src/memory/migrations/143-rename-guardian-verification-values.ts
@@ -1,0 +1,48 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * One-shot migration: rename persisted `guardian_verification` and
+ * `guardian_voice_verification_*` / `outbound_guardian_voice_verification_*`
+ * values in the call_sessions and call_events tables to drop the "guardian_"
+ * prefix, aligning with the broader verification vocabulary.
+ *
+ * - call_sessions.call_mode: "guardian_verification" -> "verification"
+ * - call_events.event_type: six guardian_voice_verification_* values renamed
+ */
+export function migrateRenameGuardianVerificationValues(
+  database: DrizzleDb,
+): void {
+  withCrashRecovery(
+    database,
+    "migration_rename_guardian_verification_values_v1",
+    () => {
+      const raw = getSqliteFrom(database);
+
+      // Rename call_mode values
+      raw.exec(
+        /*sql*/ `UPDATE call_sessions SET call_mode = 'verification' WHERE call_mode = 'guardian_verification'`,
+      );
+
+      // Rename event_type values
+      raw.exec(
+        /*sql*/ `UPDATE call_events SET event_type = 'voice_verification_started' WHERE event_type = 'guardian_voice_verification_started'`,
+      );
+      raw.exec(
+        /*sql*/ `UPDATE call_events SET event_type = 'voice_verification_succeeded' WHERE event_type = 'guardian_voice_verification_succeeded'`,
+      );
+      raw.exec(
+        /*sql*/ `UPDATE call_events SET event_type = 'voice_verification_failed' WHERE event_type = 'guardian_voice_verification_failed'`,
+      );
+      raw.exec(
+        /*sql*/ `UPDATE call_events SET event_type = 'outbound_voice_verification_started' WHERE event_type = 'outbound_guardian_voice_verification_started'`,
+      );
+      raw.exec(
+        /*sql*/ `UPDATE call_events SET event_type = 'outbound_voice_verification_succeeded' WHERE event_type = 'outbound_guardian_voice_verification_succeeded'`,
+      );
+      raw.exec(
+        /*sql*/ `UPDATE call_events SET event_type = 'outbound_voice_verification_failed' WHERE event_type = 'outbound_guardian_voice_verification_failed'`,
+      );
+    },
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -84,6 +84,7 @@ export { migrateDropUsageCompositeIndexes } from "./139-drop-usage-composite-ind
 export { migrateBackfillUsageCacheAccounting } from "./140-backfill-usage-cache-accounting.js";
 export { migrateRenameVerificationTable } from "./141-rename-verification-table.js";
 export { migrateRenameVerificationSessionIdColumn } from "./142-rename-verification-session-id-column.js";
+export { migrateRenameGuardianVerificationValues } from "./143-rename-guardian-verification-values.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -159,6 +159,12 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Rename guardian_verification_session_id column in call_sessions to verification_session_id",
   },
+  {
+    key: "migration_rename_guardian_verification_values_v1",
+    version: 23,
+    description:
+      "Rename persisted guardian_verification call_mode and guardian_voice_verification_* event_type values to drop the guardian_ prefix",
+  },
 ];
 
 export interface MigrationValidationResult {


### PR DESCRIPTION
## Summary
Renames all remaining `guardian_verification` string literals and identifiers in the calls/relay subsystem to match the channel-verification-session unification:

- `CallMode`: `"guardian_verification"` → `"verification"` (with SQLite migration)
- `SetupOutcome` discriminants: `"guardian_verification"` / `"outbound_guardian_verification"` → `"verification"` / `"outbound_verification"`
- `PointerEvent`/`CallPointerMessageScenario`: `"guardian_verification_succeeded/failed"` → `"verification_succeeded/failed"`
- Method/field renames: `handleGuardianCodeVerificationResult` → `handleVerificationCodeResult`, `guardianChallengeAssistantId` → `verificationAssistantId`
- `CallEventType`: `guardian_voice_verification_*` → `voice_verification_*` (with SQLite migration)

Part of plan: chan-verify-session-unify.md (fix round 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13886" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
