### PR TITLE
fix: insert space when stripping inline directives

### DIFF
--- a/assistant/src/__tests__/assistant-attachments.test.ts
+++ b/assistant/src/__tests__/assistant-attachments.test.ts
@@ -278,6 +278,29 @@ describe("drainDirectiveDisplayBuffer", () => {
     expect(result.bufferedRemainder).toBe("");
   });
 
+  test("inserts space when inline directive is stripped with no surrounding whitespace", () => {
+    const input = 'sentence.<vellum-attachment path="out.png" />Next sentence.';
+    const result = drainDirectiveDisplayBuffer(input);
+    expect(result.emitText).toBe("sentence. Next sentence.");
+    expect(result.bufferedRemainder).toBe("");
+  });
+
+  test("does not insert space when stripped directive already has trailing whitespace", () => {
+    const input =
+      'sentence. <vellum-attachment path="out.png" />Next sentence.';
+    const result = drainDirectiveDisplayBuffer(input);
+    expect(result.emitText).toBe("sentence. Next sentence.");
+    expect(result.bufferedRemainder).toBe("");
+  });
+
+  test("does not insert space when stripped directive already has leading whitespace on next char", () => {
+    const input =
+      'sentence.<vellum-attachment path="out.png" /> Next sentence.';
+    const result = drainDirectiveDisplayBuffer(input);
+    expect(result.emitText).toBe("sentence. Next sentence.");
+    expect(result.bufferedRemainder).toBe("");
+  });
+
   test("preserves invalid directives as plain text", () => {
     const input = 'Bad <vellum-attachment source="bad" path="x.txt" /> tag';
     const result = drainDirectiveDisplayBuffer(input);

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -340,6 +340,15 @@ export function drainDirectiveDisplayBuffer(
         (nextChar === "\n" || nextChar === "\r")
       ) {
         emitText = emitText.slice(0, -1); // trim \n
+      } else if (
+        nextChar !== undefined &&
+        !/\s/.test(emitText[emitText.length - 1] ?? "") &&
+        !/\s/.test(nextChar)
+      ) {
+        // Inline directive with no surrounding whitespace — insert a space
+        // so the text on either side doesn't get smashed together (e.g.
+        // "down.Let" → "down. Let").
+        emitText += " ";
       }
     }
 


### PR DESCRIPTION
## Summary
- When the LLM outputs a `<vellum-attachment />` directive inline without surrounding whitespace, the directive stripping logic in `drainDirectiveDisplayBuffer()` would concatenate adjacent text with no separator (e.g. `"down.Let"`)
- Added a space insertion branch: after stripping a valid directive, if neither the preceding nor following character is whitespace, insert a space
- Added 3 test cases covering the inline-no-whitespace, trailing-whitespace, and leading-whitespace scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
