### PR TITLE
refactor: add pre-compaction callback hook in ContextWindowManager

### DIFF
--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -71,12 +71,55 @@ export interface ContextWindowCompactOptions {
   targetInputTokensOverride?: number;
 }
 
+export interface ContextWindowManagerOptions {
+  provider: Provider;
+  systemPrompt: string;
+  config: ContextWindowConfig;
+  /**
+   * Called just before compaction replaces messages with a summary.
+   * Receives the messages about to be compacted and the boundary index.
+   * Errors are caught and logged — compaction proceeds regardless.
+   */
+  onBeforeCompact?: (
+    messages: Message[],
+    compactionBoundary: number,
+    signal?: AbortSignal,
+  ) => Promise<void>;
+}
+
 export class ContextWindowManager {
+  private readonly provider: Provider;
+  private readonly systemPrompt: string;
+  private readonly config: ContextWindowConfig;
+  readonly onBeforeCompact?: ContextWindowManagerOptions["onBeforeCompact"];
+
+  constructor(options: ContextWindowManagerOptions);
+  /** @deprecated Use the options-object constructor instead. */
   constructor(
-    private readonly provider: Provider,
-    private readonly systemPrompt: string,
-    private readonly config: ContextWindowConfig,
-  ) {}
+    provider: Provider,
+    systemPrompt: string,
+    config: ContextWindowConfig,
+  );
+  constructor(
+    providerOrOptions: Provider | ContextWindowManagerOptions,
+    systemPrompt?: string,
+    config?: ContextWindowConfig,
+  ) {
+    if (
+      typeof providerOrOptions === "object" &&
+      "provider" in providerOrOptions &&
+      "config" in providerOrOptions
+    ) {
+      this.provider = providerOrOptions.provider;
+      this.systemPrompt = providerOrOptions.systemPrompt;
+      this.config = providerOrOptions.config;
+      this.onBeforeCompact = providerOrOptions.onBeforeCompact;
+    } else {
+      this.provider = providerOrOptions as Provider;
+      this.systemPrompt = systemPrompt!;
+      this.config = config!;
+    }
+  }
 
   async maybeCompact(
     messages: Message[],
@@ -291,6 +334,21 @@ export class ContextWindowManager {
         summaryText: existingSummary ?? "",
         reason: "insufficient compactable persisted messages",
       };
+    }
+
+    if (this.onBeforeCompact) {
+      try {
+        await this.onBeforeCompact(
+          compactableMessages,
+          keepPlan.keepFromIndex,
+          signal,
+        );
+      } catch (err) {
+        log.warn(
+          { err },
+          "onBeforeCompact callback failed, proceeding with compaction",
+        );
+      }
     }
 
     const chunks = chunkMessages(


### PR DESCRIPTION
## Summary
- Adds optional `onBeforeCompact` callback to ContextWindowManager via new options-object constructor
- Callback fires before messages are replaced by compaction summary, receiving the messages to compact, boundary index, and abort signal
- Errors are caught and logged — compaction proceeds regardless

Part of plan: pre-compaction-memory-flush.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
