### PR TITLE
feat: add FTS query expansion utility for degraded retrieval

### DIFF
--- a/assistant/src/memory/search/query-expansion.ts
+++ b/assistant/src/memory/search/query-expansion.ts
@@ -1,0 +1,119 @@
+// Stop words filtered out during query expansion to focus on meaningful keywords.
+const STOP_WORDS = new Set([
+  "a",
+  "an",
+  "the",
+  "is",
+  "are",
+  "was",
+  "were",
+  "be",
+  "been",
+  "being",
+  "do",
+  "does",
+  "did",
+  "have",
+  "has",
+  "had",
+  "will",
+  "would",
+  "could",
+  "should",
+  "can",
+  "may",
+  "might",
+  "shall",
+  "that",
+  "this",
+  "these",
+  "those",
+  "which",
+  "what",
+  "how",
+  "who",
+  "whom",
+  "where",
+  "when",
+  "why",
+  "it",
+  "its",
+  "i",
+  "me",
+  "my",
+  "we",
+  "us",
+  "our",
+  "you",
+  "your",
+  "he",
+  "she",
+  "they",
+  "them",
+  "his",
+  "her",
+  "of",
+  "in",
+  "on",
+  "at",
+  "to",
+  "for",
+  "with",
+  "by",
+  "from",
+  "about",
+  "and",
+  "or",
+  "but",
+  "not",
+  "so",
+  "if",
+  "then",
+]);
+
+/**
+ * Extract meaningful keywords from a conversational query by tokenizing,
+ * stripping punctuation, and removing stop words.
+ *
+ * Returns `["*"]` for empty input (match-all fallback).
+ */
+export function expandQueryForFTS(query: string): string[] {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) {
+    return ["*"];
+  }
+
+  const tokens = trimmed
+    .split(/\s+/)
+    .map((token) => token.replace(/[^\w]/g, ""))
+    .filter((token) => token.length > 0);
+
+  if (tokens.length === 0) {
+    return ["*"];
+  }
+
+  const keywords = tokens.filter(
+    (token) => !STOP_WORDS.has(token.toLowerCase()),
+  );
+
+  // If every token was a stop word, return the original tokens rather than
+  // discarding the entire query.
+  if (keywords.length === 0) {
+    return tokens;
+  }
+
+  return keywords;
+}
+
+/**
+ * Build an FTS5 query string from keywords using OR operators.
+ *
+ * Example: `["discuss", "API", "design"]` -> `"discuss" OR "API" OR "design"`
+ */
+export function buildFTSQuery(keywords: string[]): string {
+  if (keywords.length === 0) {
+    return '"*"';
+  }
+
+  return keywords.map((kw) => `"${kw}"`).join(" OR ");
+}


### PR DESCRIPTION
## Summary
- Add `expandQueryForFTS()` to extract meaningful keywords from conversational queries by tokenizing, stripping punctuation, and removing stop words
- Add `buildFTSQuery()` to compose FTS5 query strings with OR operators
- Handle edge cases: empty input returns match-all, single words returned as-is

Part of plan: graceful-embedding-degradation.md (PR 1 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
