### PR TITLE
feat: add flushMemoryForMessages for bulk extraction

### DIFF
--- a/assistant/src/memory/flush.ts
+++ b/assistant/src/memory/flush.ts
@@ -1,0 +1,81 @@
+import { getLogger } from "../util/logger.js";
+import type { DrizzleDb } from "./db.js";
+import { extractAndUpsertMemoryItemsForMessage } from "./items-extractor.js";
+import { rawGet } from "./raw-query.js";
+
+const log = getLogger("memory-flush");
+
+export interface FlushMessage {
+  id: string;
+  role: string;
+}
+
+export interface FlushMemoryOptions {
+  messages: FlushMessage[];
+  conversationId: string;
+  scopeId: string;
+  db: DrizzleDb;
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * Synchronously extract memory items from messages that haven't been processed
+ * yet. Intended for use before compaction discards the raw messages, ensuring
+ * no memory-worthy content is lost.
+ */
+export async function flushMemoryForMessages(
+  opts: FlushMemoryOptions,
+): Promise<{ flushed: number; skipped: number }> {
+  const { messages, conversationId, scopeId, abortSignal } = opts;
+
+  // Only user messages are extracted per current policy
+  const userMessages = messages.filter((m) => m.role === "user");
+
+  let flushed = 0;
+  let skipped = 0;
+
+  for (const message of userMessages) {
+    if (abortSignal?.aborted) {
+      log.info(
+        { conversationId, flushed, skipped },
+        "Memory flush aborted by signal",
+      );
+      break;
+    }
+
+    if (isAlreadyExtracted(message.id)) {
+      skipped += 1;
+      continue;
+    }
+
+    await extractAndUpsertMemoryItemsForMessage(
+      message.id,
+      scopeId,
+      conversationId,
+    );
+    flushed += 1;
+  }
+
+  log.info(
+    { conversationId, total: userMessages.length, flushed, skipped },
+    "Pre-compaction memory flush complete",
+  );
+
+  return { flushed, skipped };
+}
+
+/**
+ * Check whether a completed `extract_items` job already exists for this
+ * message, meaning its memory items have already been extracted.
+ */
+function isAlreadyExtracted(messageId: string): boolean {
+  const row = rawGet<{ id: string }>(
+    `SELECT id FROM memory_jobs
+     WHERE type = 'extract_items'
+       AND status = 'completed'
+       AND json_extract(payload, '$.messageId') = ?
+     LIMIT 1`,
+    messageId,
+  );
+  return row != null;
+}


### PR DESCRIPTION
## Summary
- Adds a new `flushMemoryForMessages()` function for synchronous bulk memory extraction
- Filters to user messages, skips already-extracted ones, respects abort signals
- Designed for pre-compaction memory flush pipeline

Part of plan: pre-compaction-memory-flush.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
