### PR TITLE
feat: add memory_recall tool definition schema

### DIFF
--- a/assistant/src/tools/memory/definitions.ts
+++ b/assistant/src/tools/memory/definitions.ts
@@ -26,6 +26,32 @@ export const memorySearchDefinition: ToolDefinition = {
   },
 };
 
+export const memoryRecallDefinition: ToolDefinition = {
+  name: "memory_recall",
+  description:
+    "Deep search across all memory sources (semantic, lexical, entity graph, recency) for specific information. Use this when you need to recall details about past conversations, decisions, preferences, project context, or any prior knowledge. Returns formatted memory context. Prefer this over memory_search for richer, multi-source retrieval.",
+  input_schema: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "The search query — be specific and descriptive",
+      },
+      max_results: {
+        type: "number",
+        description: "Maximum number of memory items to return (default: 10)",
+      },
+      scope: {
+        type: "string",
+        enum: ["default", "conversation"],
+        description:
+          'Scope to search — "default" searches all memory, "conversation" restricts to current thread',
+      },
+    },
+    required: ["query"],
+  },
+};
+
 export const memorySaveDefinition: ToolDefinition = {
   name: "memory_save",
   description:


### PR DESCRIPTION
## Summary
- Add `memoryRecallDefinition` tool schema in `definitions.ts` alongside existing memory tool definitions
- Schema includes query (required), max_results (optional), and scope (optional, enum: default/conversation)
- Description guides the assistant to use this for deep multi-source memory retrieval

Part of plan: on-demand-memory-search-tool.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
