### PR TITLE
test: add tests for FTS query expansion utility

### DIFF
--- a/assistant/src/memory/search/query-expansion.test.ts
+++ b/assistant/src/memory/search/query-expansion.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildFTSQuery, expandQueryForFTS } from "./query-expansion.js";
+
+describe("expandQueryForFTS", () => {
+  test("extracts meaningful keywords from conversational input", () => {
+    const result = expandQueryForFTS(
+      "what did we discuss about the API design?",
+    );
+    expect(result).toEqual(["discuss", "API", "design"]);
+  });
+
+  test("extracts all tokens from technical input (no stop words)", () => {
+    const result = expandQueryForFTS("React component lifecycle hooks");
+    expect(result).toEqual(["React", "component", "lifecycle", "hooks"]);
+  });
+
+  test("returns single keyword as-is", () => {
+    const result = expandQueryForFTS("authentication");
+    expect(result).toEqual(["authentication"]);
+  });
+
+  test("returns wildcard for empty input", () => {
+    expect(expandQueryForFTS("")).toEqual(["*"]);
+  });
+
+  test("returns wildcard for whitespace-only input", () => {
+    expect(expandQueryForFTS("   ")).toEqual(["*"]);
+  });
+
+  test("returns original tokens when all are stop words", () => {
+    const result = expandQueryForFTS("what is the");
+    expect(result).toEqual(["what", "is", "the"]);
+  });
+});
+
+describe("buildFTSQuery", () => {
+  test("joins multiple keywords with OR", () => {
+    const result = buildFTSQuery(["API", "design"]);
+    expect(result).toBe('"API" OR "design"');
+  });
+
+  test("wraps single keyword in quotes", () => {
+    const result = buildFTSQuery(["auth"]);
+    expect(result).toBe('"auth"');
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for `expandQueryForFTS()` covering conversational, technical, single-word, empty, and all-stop-words inputs
- Add unit tests for `buildFTSQuery()` covering single and multiple keywords

Part of plan: graceful-embedding-degradation.md (PR 2 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
