### PR TITLE
feat: use query expansion for lexical search in degraded mode

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -29,6 +29,7 @@ import {
   lexicalSearch,
   recencySearch,
 } from "./search/lexical.js";
+import { buildFTSQuery, expandQueryForFTS } from "./search/query-expansion.js";
 import {
   applySourceCaps,
   markItemUsage,
@@ -194,11 +195,20 @@ async function collectAndMergeCandidates(
   const lexicalTopK = semanticUnavailable
     ? config.memory.retrieval.lexicalTopK * 2
     : config.memory.retrieval.lexicalTopK;
+
+  // When semantic search is unavailable, expand the conversational query
+  // into meaningful keywords for better FTS recall. This compensates for
+  // the lack of vector-based semantic matching.
+  const expandedFtsQuery = semanticUnavailable
+    ? buildFTSQuery(expandQueryForFTS(query))
+    : undefined;
+
   const lexical = lexicalSearch(
     query,
     lexicalTopK,
     excludeMessageIds,
     scopeIds,
+    expandedFtsQuery,
   );
 
   const baseRecencyLimit = Math.max(

--- a/assistant/src/memory/search/lexical.ts
+++ b/assistant/src/memory/search/lexical.ts
@@ -42,10 +42,13 @@ export function lexicalSearch(
   limit: number,
   excludedMessageIds: string[] = [],
   scopeIds?: string[],
+  expandedQuery?: string,
 ): Candidate[] {
   const trimmed = query.trim();
   if (trimmed.length === 0 || limit <= 0) return [];
-  const matchQuery = buildFtsMatchQuery(trimmed);
+  // When an expanded query is provided (e.g. from query expansion in degraded
+  // mode), use it instead of building one from the raw conversational query.
+  const matchQuery = expandedQuery ?? buildFtsMatchQuery(trimmed);
   if (!matchQuery) return [];
   const excluded = new Set(excludedMessageIds);
   const scopeClause = scopeIds


### PR DESCRIPTION
## Summary
- Add optional `expandedQuery` parameter to lexical search function
- When semantic search is unavailable, expand query into keywords using `expandQueryForFTS` and `buildFTSQuery`
- Pass expanded query to lexical search for better FTS recall in degraded mode
- Non-degraded mode behavior unchanged

Part of plan: graceful-embedding-degradation.md (PR 4 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
