### PR TITLE
feat: implement memory_recall tool handler

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -91,7 +91,7 @@ const EMBED_BASE_DELAY_MS = 500;
  * Wrap embedWithBackend with retry + exponential backoff for transient failures
  * (network errors, 429s, 5xx). Aborts immediately if the caller's signal fires.
  */
-async function embedWithRetry(
+export async function embedWithRetry(
   config: AssistantConfig,
   texts: string[],
   opts?: { signal?: AbortSignal },
@@ -156,7 +156,7 @@ function buildScopeFilter(
  * using RRF. Used by both `buildMemoryRecall()` (auto recall) and
  * `searchMemoryItems()` (memory_search tool) for consistent behavior.
  */
-async function collectAndMergeCandidates(
+export async function collectAndMergeCandidates(
   query: string,
   config: AssistantConfig,
   opts?: {

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -3,9 +3,13 @@ import { v4 as uuid } from "uuid";
 
 import type { AssistantConfig } from "../../config/types.js";
 import { getDb } from "../../memory/db.js";
+import { getMemoryBackendStatus } from "../../memory/embedding-backend.js";
 import { computeMemoryFingerprint } from "../../memory/fingerprint.js";
+import { formatRecallText } from "../../memory/format-recall.js";
 import { enqueueMemoryJob } from "../../memory/jobs-store.js";
 import {
+  collectAndMergeCandidates,
+  embedWithRetry,
   formatRelativeTime,
   searchMemoryItems,
 } from "../../memory/retriever.js";
@@ -298,6 +302,141 @@ export async function handleMemoryUpdate(
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, memoryId }, "memory_update failed");
     return { content: `Error: Failed to update memory: ${msg}`, isError: true };
+  }
+}
+
+// ── memory_recall ────────────────────────────────────────────────────
+
+export interface MemoryRecallToolResult {
+  text: string;
+  resultCount: number;
+  degraded: boolean;
+  sources: {
+    lexical: number;
+    semantic: number;
+    recency: number;
+    entity: number;
+  };
+}
+
+export async function handleMemoryRecall(
+  args: Record<string, unknown>,
+  config: AssistantConfig,
+  scopeId?: string,
+): Promise<ToolExecutionResult> {
+  const query = args.query;
+  if (typeof query !== "string" || query.trim().length === 0) {
+    return {
+      content: "Error: query is required and must be a non-empty string",
+      isError: true,
+    };
+  }
+
+  const maxResults =
+    typeof args.max_results === "number" && args.max_results > 0
+      ? Math.min(args.max_results, 50)
+      : 10;
+
+  const scope =
+    typeof args.scope === "string" && args.scope.trim().length > 0
+      ? args.scope.trim()
+      : "default";
+
+  // Scope policy: "conversation" means strict (only that scope),
+  // anything else allows fallback to the default scope.
+  const scopePolicyOverride: ScopePolicyOverride | undefined = scopeId
+    ? {
+        scopeId,
+        fallbackToDefault: scope !== "conversation",
+      }
+    : undefined;
+
+  try {
+    const trimmedQuery = query.trim();
+
+    // Generate embedding vector (graceful degradation if unavailable)
+    let queryVector: number[] | null = null;
+    let provider: string | undefined;
+    let model: string | undefined;
+    let degraded = false;
+
+    const backendStatus = getMemoryBackendStatus(config);
+    if (backendStatus.provider) {
+      try {
+        const embedded = await embedWithRetry(config, [trimmedQuery]);
+        queryVector = embedded.vectors[0] ?? null;
+        provider = embedded.provider;
+        model = embedded.model;
+      } catch {
+        // Gracefully degrade to non-semantic retrieval
+        degraded = true;
+      }
+    } else {
+      degraded = backendStatus.degraded;
+    }
+
+    // Run the full retrieval pipeline with all sources enabled
+    const collected = await collectAndMergeCandidates(trimmedQuery, config, {
+      queryVector,
+      provider,
+      model,
+      scopeId,
+      scopePolicyOverride,
+    });
+
+    if (collected.semanticSearchFailed) {
+      degraded = true;
+    }
+
+    const candidates = collected.merged.slice(0, maxResults);
+
+    if (candidates.length === 0) {
+      const result: MemoryRecallToolResult = {
+        text: "No matching memories found.",
+        resultCount: 0,
+        degraded,
+        sources: {
+          lexical: 0,
+          semantic: 0,
+          recency: 0,
+          entity: 0,
+        },
+      };
+      return {
+        content: JSON.stringify(result),
+        isError: false,
+      };
+    }
+
+    // Format candidates into readable text using the shared formatter
+    const formatted = formatRecallText(candidates, {
+      format: config.memory.retrieval.injectionFormat,
+      maxTokens: config.memory.retrieval.maxInjectTokens,
+    });
+
+    const result: MemoryRecallToolResult = {
+      text: formatted.text,
+      resultCount: formatted.selected.length,
+      degraded,
+      sources: {
+        lexical: collected.lexical.length,
+        semantic: collected.semantic.length,
+        recency: collected.recency.length,
+        entity: collected.entity.length,
+      },
+    };
+
+    return {
+      content: JSON.stringify(result),
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err, query }, "memory_recall failed");
+    return {
+      content: `Error: Memory recall failed: ${msg}`,
+      isError: true,
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `handleMemoryRecall()` async function in `handlers.ts` for on-demand deep memory retrieval
- Reuses the full retrieval pipeline (lexical, semantic, entity, recency) with user-supplied query
- Graceful degradation when embeddings/Qdrant unavailable
- Scope parameter controls retrieval scope (default vs conversation)
- Export `collectAndMergeCandidates` and `embedWithRetry` from `retriever.ts` for reuse

Part of plan: on-demand-memory-search-tool.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
