### PR TITLE
feat: register memory_recall tool in tool manifest

### DIFF
--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -3,11 +3,13 @@ import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 import {
+  memoryRecallDefinition,
   memorySaveDefinition,
   memorySearchDefinition,
   memoryUpdateDefinition,
 } from "./definitions.js";
 import {
+  handleMemoryRecall,
   handleMemorySave,
   handleMemorySearch,
   handleMemoryUpdate,
@@ -82,8 +84,30 @@ class MemoryUpdateTool implements Tool {
   }
 }
 
+// ── memory_recall ────────────────────────────────────────────────────
+
+class MemoryRecallTool implements Tool {
+  name = "memory_recall";
+  description = memoryRecallDefinition.description;
+  category = "memory";
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return memoryRecallDefinition;
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const config = getConfig();
+    return handleMemoryRecall(input, config, context.memoryScopeId);
+  }
+}
+
 // ── Exported tool instances ──────────────────────────────────────────
 
 export const memorySearchTool = new MemorySearchTool();
 export const memorySaveTool = new MemorySaveTool();
 export const memoryUpdateTool = new MemoryUpdateTool();
+export const memoryRecallTool = new MemoryRecallTool();

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -9,6 +9,7 @@
 import { accountManageTool } from "./credentials/account-registry.js";
 import { credentialStoreTool } from "./credentials/vault.js";
 import {
+  memoryRecallTool,
   memorySaveTool,
   memorySearchTool,
   memoryUpdateTool,
@@ -82,6 +83,7 @@ export const explicitTools: Tool[] = [
   memorySearchTool,
   memorySaveTool,
   memoryUpdateTool,
+  memoryRecallTool,
   credentialStoreTool,
   accountManageTool,
   screenWatchTool,


### PR DESCRIPTION
## Summary
- Add `MemoryRecallTool` class in `register.ts` implementing the Tool interface
- Export singleton `memoryRecallTool` instance
- Register in `tool-manifest.ts` alongside existing memory tools

Part of plan: on-demand-memory-search-tool.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
