### PR TITLE
feat: add memory_delete tool

### DIFF
--- a/assistant/src/tools/memory/definitions.ts
+++ b/assistant/src/tools/memory/definitions.ts
@@ -119,3 +119,25 @@ export const memoryUpdateDefinition: ToolDefinition = {
     required: ["memory_id", "statement"],
   },
 };
+
+export const memoryDeleteDefinition: ToolDefinition = {
+  name: "memory_delete",
+  description:
+    "Delete a previously saved memory item. Use this when information is no longer relevant, was saved in error, or the user asks to forget something.",
+  input_schema: {
+    type: "object",
+    properties: {
+      memory_id: {
+        type: "string",
+        description:
+          "ID of the memory item to delete (from memory_search results)",
+      },
+      reason: {
+        type: "string",
+        description:
+          "Brief non-technical explanation of what you are deleting and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
+      },
+    },
+    required: ["memory_id"],
+  },
+};

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -440,6 +440,64 @@ export async function handleMemoryRecall(
   }
 }
 
+// ── memory_delete ────────────────────────────────────────────────────
+
+export async function handleMemoryDelete(
+  args: Record<string, unknown>,
+  _config: AssistantConfig,
+  scopeId: string = "default",
+): Promise<ToolExecutionResult> {
+  const rawMemoryId = args.memory_id;
+  if (typeof rawMemoryId !== "string" || rawMemoryId.trim().length === 0) {
+    return {
+      content: "Error: memory_id is required and must be a non-empty string",
+      isError: true,
+    };
+  }
+
+  const memoryId = stripTypedIdPrefix(rawMemoryId.trim());
+
+  try {
+    const db = getDb();
+
+    const existing = db
+      .select()
+      .from(memoryItems)
+      .where(
+        and(eq(memoryItems.id, memoryId), eq(memoryItems.scopeId, scopeId)),
+      )
+      .get();
+
+    if (!existing) {
+      return {
+        content: `Error: Memory item with ID "${memoryId}" not found`,
+        isError: true,
+      };
+    }
+
+    db.update(memoryItems)
+      .set({
+        status: "deleted",
+        lastSeenAt: Date.now(),
+      })
+      .where(eq(memoryItems.id, existing.id))
+      .run();
+
+    log.debug(
+      { id: existing.id, kind: existing.kind },
+      "Memory item deleted via tool",
+    );
+    return {
+      content: `Deleted memory (ID: ${existing.id}).\nKind: ${existing.kind}\nSubject: ${existing.subject}\nStatement: ${existing.statement}`,
+      isError: false,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error({ err, memoryId }, "memory_delete failed");
+    return { content: `Error: Failed to delete memory: ${msg}`, isError: true };
+  }
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function inferSubjectFromStatement(statement: string): string {

--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -3,11 +3,13 @@ import { RiskLevel } from "../../permissions/types.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import type { Tool, ToolContext, ToolExecutionResult } from "../types.js";
 import {
+  memoryDeleteDefinition,
   memorySaveDefinition,
   memorySearchDefinition,
   memoryUpdateDefinition,
 } from "./definitions.js";
 import {
+  handleMemoryDelete,
   handleMemorySave,
   handleMemorySearch,
   handleMemoryUpdate,
@@ -82,8 +84,30 @@ class MemoryUpdateTool implements Tool {
   }
 }
 
+// ── memory_delete ────────────────────────────────────────────────────
+
+class MemoryDeleteTool implements Tool {
+  name = "memory_delete";
+  description = memoryDeleteDefinition.description;
+  category = "memory";
+  defaultRiskLevel = RiskLevel.Low;
+
+  getDefinition(): ToolDefinition {
+    return memoryDeleteDefinition;
+  }
+
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    const config = getConfig();
+    return handleMemoryDelete(input, config, context.memoryScopeId);
+  }
+}
+
 // ── Exported tool instances ──────────────────────────────────────────
 
 export const memorySearchTool = new MemorySearchTool();
 export const memorySaveTool = new MemorySaveTool();
 export const memoryUpdateTool = new MemoryUpdateTool();
+export const memoryDeleteTool = new MemoryDeleteTool();

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -9,6 +9,7 @@
 import { accountManageTool } from "./credentials/account-registry.js";
 import { credentialStoreTool } from "./credentials/vault.js";
 import {
+  memoryDeleteTool,
   memorySaveTool,
   memorySearchTool,
   memoryUpdateTool,
@@ -82,6 +83,7 @@ export const explicitTools: Tool[] = [
   memorySearchTool,
   memorySaveTool,
   memoryUpdateTool,
+  memoryDeleteTool,
   credentialStoreTool,
   accountManageTool,
   screenWatchTool,


### PR DESCRIPTION
## Summary
- Add memory_delete tool definition, handler, registration, and manifest wiring
- Allows the assistant to soft-delete memory items by setting status to deleted
- Follows existing memory tool patterns (scope isolation, typed ID prefix stripping, error handling)

Part of plan: memory-delete-tool.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
