### PR TITLE
feat: add system prompt guidance for on-demand memory recall

### DIFF
--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -186,6 +186,7 @@ export function buildSystemPrompt(): string {
   parts.push(buildAccessPreferenceSection());
   parts.push(buildIntegrationSection());
   parts.push(buildMemoryPersistenceSection());
+  parts.push(buildMemoryRecallSection());
   parts.push(buildWorkspaceReflectionSection());
   parts.push(buildLearningMemorySection());
 
@@ -656,6 +657,21 @@ function buildMemoryPersistenceSection(): string {
     "- When you make a mistake, save the lesson so future-you doesn't repeat it.",
     "",
     "Saved > unsaved. Always.",
+  ].join("\n");
+}
+
+function buildMemoryRecallSection(): string {
+  return [
+    "## Memory Recall",
+    "",
+    "You have access to a `memory_recall` tool for deep memory retrieval. Use it when:",
+    "",
+    "- The user asks about past conversations, decisions, or context you don't have in the current window",
+    "- You need to recall specific facts, preferences, or project details",
+    "- The auto-injected memory context doesn't contain what you need",
+    "- The user references something from a previous session",
+    "",
+    "The tool searches across semantic, lexical, entity graph, and recency sources. Be specific in your query for best results.",
   ].join("\n");
 }
 


### PR DESCRIPTION
## Summary
- Add memory recall guidance to the system prompt template
- Instructs the assistant when to use the `memory_recall` tool for deep retrieval
- Concise and actionable guidance covering key use cases

Part of plan: on-demand-memory-search-tool.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
