### PR TITLE
fix: return early when memory_delete targets an already-deleted item

### DIFF
--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -475,6 +475,13 @@ export async function handleMemoryDelete(
       };
     }
 
+    if (existing.status === "deleted") {
+      return {
+        content: `Memory item (ID: ${memoryId}) was already deleted.`,
+        isError: false,
+      };
+    }
+
     db.update(memoryItems)
       .set({
         status: "deleted",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for memory-delete-tool.md.

**Gap:** handleMemoryDelete allows re-deleting already-deleted items without feedback
**What was expected:** The handler should inform the caller if the item was already deleted
**What was found:** Re-deleting silently succeeds without any indication

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
