### PR TITLE
fix: catch per-message extraction errors in flush

### DIFF
--- a/assistant/src/memory/flush.test.ts
+++ b/assistant/src/memory/flush.test.ts
@@ -123,14 +123,12 @@ describe("flushMemoryForMessages", () => {
   });
 
   it("handles extraction errors without crashing the flush", async () => {
-    // The implementation does NOT catch errors per-message — it will propagate.
-    // Verify that a thrown error actually propagates (the function is not
-    // silently swallowing it). This documents the current behavior.
     extractMock
       .mockImplementationOnce(() => Promise.resolve()) // msg-1 succeeds
       .mockImplementationOnce(() =>
         Promise.reject(new Error("extraction failed")),
-      ); // msg-2 fails
+      ) // msg-2 fails
+      .mockImplementationOnce(() => Promise.resolve()); // msg-3 succeeds
 
     const messages = [
       { id: "msg-1", role: "user" },
@@ -138,12 +136,14 @@ describe("flushMemoryForMessages", () => {
       { id: "msg-3", role: "user" },
     ];
 
-    await expect(
-      flushMemoryForMessages({ ...baseOpts(), messages }),
-    ).rejects.toThrow("extraction failed");
+    const result = await flushMemoryForMessages({
+      ...baseOpts(),
+      messages,
+    });
 
-    // msg-1 was extracted, msg-2 threw
-    expect(extractMock).toHaveBeenCalledTimes(2);
+    // All three messages attempted; msg-2 failed but didn't abort the flush
+    expect(extractMock).toHaveBeenCalledTimes(3);
+    expect(result).toEqual({ flushed: 2, skipped: 0 });
   });
 
   it("filters to user messages only", async () => {

--- a/assistant/src/memory/flush.ts
+++ b/assistant/src/memory/flush.ts
@@ -48,12 +48,19 @@ export async function flushMemoryForMessages(
       continue;
     }
 
-    await extractAndUpsertMemoryItemsForMessage(
-      message.id,
-      scopeId,
-      conversationId,
-    );
-    flushed += 1;
+    try {
+      await extractAndUpsertMemoryItemsForMessage(
+        message.id,
+        scopeId,
+        conversationId,
+      );
+      flushed += 1;
+    } catch (err) {
+      log.error(
+        { conversationId, messageId: message.id, err },
+        "Failed to extract memory items for message, continuing flush",
+      );
+    }
   }
 
   log.info(


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pre-compaction-memory-flush.md.

**Gap:** Individual extraction errors crash the entire flush
**What was expected:** Per-message errors caught and logged, flush continues
**What was found:** No try/catch, single failure aborts entire flush

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
