### PR TITLE
fix: remove unused db parameter from flush

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -37,7 +37,6 @@ import {
 import { registerToolTraceListener } from "../events/tool-trace-listener.js";
 import { getHookManager } from "../hooks/manager.js";
 import * as conversationStore from "../memory/conversation-store.js";
-import { getDb } from "../memory/db-connection.js";
 import { flushMemoryForMessages } from "../memory/flush.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
 import { SecretPrompter } from "../permissions/secret-prompter.js";
@@ -395,7 +394,6 @@ export class Session {
             messages: flushMessages,
             conversationId: this.conversationId,
             scopeId: this.memoryPolicy.scopeId,
-            db: getDb(),
             abortSignal: signal,
           });
 

--- a/assistant/src/memory/flush.test.ts
+++ b/assistant/src/memory/flush.test.ts
@@ -31,7 +31,6 @@ const { flushMemoryForMessages } = await import("./flush.js");
 const baseOpts = () => ({
   conversationId: "conv-1",
   scopeId: "scope-1",
-  db: {} as any,
 });
 
 describe("flushMemoryForMessages", () => {

--- a/assistant/src/memory/flush.ts
+++ b/assistant/src/memory/flush.ts
@@ -1,5 +1,4 @@
 import { getLogger } from "../util/logger.js";
-import type { DrizzleDb } from "./db.js";
 import { extractAndUpsertMemoryItemsForMessage } from "./items-extractor.js";
 import { rawGet } from "./raw-query.js";
 
@@ -14,7 +13,6 @@ export interface FlushMemoryOptions {
   messages: FlushMessage[];
   conversationId: string;
   scopeId: string;
-  db: DrizzleDb;
   abortSignal?: AbortSignal;
 }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pre-compaction-memory-flush.md.

**Gap:** `db` parameter accepted but never used (dead code)
**What was expected:** Parameter used or removed
**What was found:** `db` declared in FlushMemoryOptions but never destructured or used

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13914" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
