### PR TITLE
fix: remove deprecated ContextWindowManager constructor overload

### DIFF
--- a/assistant/src/__tests__/compaction.benchmark.test.ts
+++ b/assistant/src/__tests__/compaction.benchmark.test.ts
@@ -85,7 +85,11 @@ describe("Compaction benchmark", () => {
     const counter = { calls: 0 };
     const provider = makeSummaryProvider(counter);
     const config = makeConfig();
-    const manager = new ContextWindowManager(provider, "system prompt", config);
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config,
+    });
 
     // 90 turns = 180 messages, well above 60% of 6000 = 3600 threshold
     const messages = makeLongMessages(90);
@@ -108,7 +112,11 @@ describe("Compaction benchmark", () => {
     const counter = { calls: 0 };
     const provider = makeSummaryProvider(counter);
     const config = makeConfig();
-    const manager = new ContextWindowManager(provider, "system prompt", config);
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config,
+    });
 
     // 3 turns = 6 messages, well below threshold
     const messages = makeLongMessages(3);
@@ -127,7 +135,11 @@ describe("Compaction benchmark", () => {
     const counter = { calls: 0 };
     const provider = makeSummaryProvider(counter);
     const config = makeConfig();
-    const manager = new ContextWindowManager(provider, "system prompt", config);
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config,
+    });
 
     const messages = makeLongMessages(90);
     const result = await manager.maybeCompact(messages);
@@ -143,7 +155,11 @@ describe("Compaction benchmark", () => {
     const counter = { calls: 0 };
     const provider = makeSummaryProvider(counter);
     const config = makeConfig();
-    const manager = new ContextWindowManager(provider, "system prompt", config);
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config,
+    });
 
     const messages = makeLongMessages(90);
     const result = await manager.maybeCompact(messages);
@@ -163,7 +179,11 @@ describe("Compaction benchmark", () => {
       maxInputTokens: 4000,
       targetInputTokens: 2000,
     };
-    const manager = new ContextWindowManager(provider, "system prompt", config);
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config,
+    });
 
     const messages = makeLongMessages(90);
     const estimated = estimatePromptTokens(messages, "system prompt", {

--- a/assistant/src/__tests__/context-memory-e2e.test.ts
+++ b/assistant/src/__tests__/context-memory-e2e.test.ts
@@ -424,13 +424,17 @@ describe("Context + Memory E2E regression", () => {
     const provider = makeSummaryProvider(summaryCounter);
     const systemPrompt = "System prompt for context + memory e2e";
     const history = makeLongHistory(60, currentUserText);
-    const manager = new ContextWindowManager(provider, systemPrompt, {
-      ...DEFAULT_CONFIG.contextWindow,
-      maxInputTokens: 5200,
-      targetInputTokens: 2600,
-      compactThreshold: 0.55,
-      preserveRecentUserTurns: 6,
-      chunkTokens: 900,
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt,
+      config: {
+        ...DEFAULT_CONFIG.contextWindow,
+        maxInputTokens: 5200,
+        targetInputTokens: 2600,
+        compactThreshold: 0.55,
+        preserveRecentUserTurns: 6,
+        chunkTokens: 900,
+      },
     });
 
     const compacted = await manager.maybeCompact(history);

--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -56,11 +56,11 @@ describe("ContextWindowManager", () => {
     const provider = createProvider(() => {
       throw new Error("should not be called");
     });
-    const manager = new ContextWindowManager(
+    const manager = new ContextWindowManager({
       provider,
-      "system prompt",
-      makeConfig(),
-    );
+      systemPrompt: "system prompt",
+      config: makeConfig(),
+    });
     const history = [message("user", "hello"), message("assistant", "hi")];
 
     const result = await manager.maybeCompact(history);
@@ -82,11 +82,11 @@ describe("ContextWindowManager", () => {
         stopReason: "end_turn",
       };
     });
-    const manager = new ContextWindowManager(
+    const manager = new ContextWindowManager({
       provider,
-      "system prompt",
-      makeConfig(),
-    );
+      systemPrompt: "system prompt",
+      config: makeConfig(),
+    });
     const long = "x".repeat(240);
     const history: Message[] = [
       message("user", `u1 ${long}`),
@@ -144,15 +144,15 @@ describe("ContextWindowManager", () => {
         stopReason: "end_turn",
       };
     });
-    const manager = new ContextWindowManager(
+    const manager = new ContextWindowManager({
       provider,
-      "system prompt",
-      makeConfig({
+      systemPrompt: "system prompt",
+      config: makeConfig({
         maxInputTokens: 7_000,
         targetInputTokens: 2_500,
         preserveRecentUserTurns: 1,
       }),
-    );
+    });
     const long = "q".repeat(6_000);
     const history: Message[] = [
       message("user", `u1 ${long}`),
@@ -189,15 +189,15 @@ describe("ContextWindowManager", () => {
       usage: { inputTokens: 50, outputTokens: 10 },
       stopReason: "end_turn",
     }));
-    const manager = new ContextWindowManager(
+    const manager = new ContextWindowManager({
       provider,
-      "system prompt",
-      makeConfig({
+      systemPrompt: "system prompt",
+      config: makeConfig({
         maxInputTokens: 300,
         targetInputTokens: 160,
         preserveRecentUserTurns: 1,
       }),
-    );
+    });
     const long = "y".repeat(220);
     const history: Message[] = [
       createContextSummaryMessage("## Goals\n- old summary"),
@@ -229,15 +229,15 @@ describe("ContextWindowManager", () => {
     const provider = createProvider(async () => {
       throw new Error("provider unavailable");
     });
-    const manager = new ContextWindowManager(
+    const manager = new ContextWindowManager({
       provider,
-      "system prompt",
-      makeConfig({
+      systemPrompt: "system prompt",
+      config: makeConfig({
         maxInputTokens: 260,
         targetInputTokens: 140,
         preserveRecentUserTurns: 1,
       }),
-    );
+    });
     const long = "z".repeat(220);
     const history = [
       message("user", `task ${long}`),
@@ -268,15 +268,15 @@ describe("ContextWindowManager", () => {
         stopReason: "end_turn",
       };
     });
-    const manager = new ContextWindowManager(
+    const manager = new ContextWindowManager({
       provider,
-      "system prompt",
-      makeConfig({
+      systemPrompt: "system prompt",
+      config: makeConfig({
         maxInputTokens: 280,
         targetInputTokens: 150,
         preserveRecentUserTurns: 1,
       }),
-    );
+    });
     const long = "f".repeat(220);
     const history: Message[] = [
       {
@@ -317,15 +317,15 @@ describe("ContextWindowManager", () => {
       usage: { inputTokens: 75, outputTokens: 20 },
       stopReason: "end_turn",
     }));
-    const manager = new ContextWindowManager(
+    const manager = new ContextWindowManager({
       provider,
-      "system prompt",
-      makeConfig({
+      systemPrompt: "system prompt",
+      config: makeConfig({
         maxInputTokens: 320,
         targetInputTokens: 170,
         preserveRecentUserTurns: 1,
       }),
-    );
+    });
     const long = "k".repeat(220);
     const history: Message[] = [
       message("user", `u1 ${long}`),
@@ -365,15 +365,15 @@ describe("ContextWindowManager", () => {
       usage: { inputTokens: 75, outputTokens: 20 },
       stopReason: "end_turn",
     }));
-    const manager = new ContextWindowManager(
+    const manager = new ContextWindowManager({
       provider,
-      "system prompt",
-      makeConfig({
+      systemPrompt: "system prompt",
+      config: makeConfig({
         maxInputTokens: 320,
         targetInputTokens: 170,
         preserveRecentUserTurns: 1,
       }),
-    );
+    });
     const long = "k".repeat(220);
     // Simulates a merged user message (repairHistory merges consecutive same-role
     // messages), resulting in a user turn with both tool_result and text blocks.
@@ -426,15 +426,15 @@ describe("ContextWindowManager", () => {
       rawResponse,
       stopReason: "end_turn",
     }));
-    const manager = new ContextWindowManager(
+    const manager = new ContextWindowManager({
       provider,
-      "system prompt",
-      makeConfig({
+      systemPrompt: "system prompt",
+      config: makeConfig({
         maxInputTokens: 2600,
         targetInputTokens: 1500,
         preserveRecentUserTurns: 1,
       }),
-    );
+    });
     const long = "c".repeat(5000);
     const history: Message[] = [
       message("user", `u1 ${long}`),
@@ -481,15 +481,15 @@ describe("ContextWindowManager", () => {
         "summarizer should not be called while cooldown skip is active",
       );
     });
-    const manager = new ContextWindowManager(
+    const manager = new ContextWindowManager({
       provider,
-      "system prompt",
-      makeConfig({
+      systemPrompt: "system prompt",
+      config: makeConfig({
         maxInputTokens: 260,
         targetInputTokens: 180,
         preserveRecentUserTurns: 1,
       }),
-    );
+    });
     const long = "c".repeat(220);
     const history: Message[] = [
       message("user", `u1 ${long}`),
@@ -511,15 +511,15 @@ describe("ContextWindowManager", () => {
       usage: { inputTokens: 60, outputTokens: 12 },
       stopReason: "end_turn",
     }));
-    const manager = new ContextWindowManager(
+    const manager = new ContextWindowManager({
       provider,
-      "system prompt",
-      makeConfig({
+      systemPrompt: "system prompt",
+      config: makeConfig({
         maxInputTokens: 320,
         targetInputTokens: 180,
         preserveRecentUserTurns: 1,
       }),
-    );
+    });
     const long = "p".repeat(340);
     const history: Message[] = [
       message("user", `u1 ${long}`),
@@ -543,15 +543,15 @@ describe("ContextWindowManager", () => {
       usage: { inputTokens: 60, outputTokens: 12 },
       stopReason: "end_turn",
     }));
-    const manager = new ContextWindowManager(
+    const manager = new ContextWindowManager({
       provider,
-      "system prompt",
-      makeConfig({
+      systemPrompt: "system prompt",
+      config: makeConfig({
         maxInputTokens: 260,
         targetInputTokens: 180,
         preserveRecentUserTurns: 1,
       }),
-    );
+    });
     const long = "c".repeat(220);
     const history: Message[] = [
       message("user", `u1 ${long}`),
@@ -577,16 +577,16 @@ describe("ContextWindowManager", () => {
       usage: { inputTokens: 75, outputTokens: 20 },
       stopReason: "end_turn",
     }));
-    const manager = new ContextWindowManager(
+    const manager = new ContextWindowManager({
       provider,
-      "system prompt",
-      makeConfig({
+      systemPrompt: "system prompt",
+      config: makeConfig({
         maxInputTokens: 7000,
         targetInputTokens: 5000,
         compactThreshold: 0.8,
         preserveRecentUserTurns: 1,
       }),
-    );
+    });
 
     const images = Array.from({ length: 5 }, (_, i) => ({
       type: "image" as const,
@@ -629,15 +629,15 @@ describe("ContextWindowManager", () => {
       usage: { inputTokens: 60, outputTokens: 12 },
       stopReason: "end_turn",
     }));
-    const manager = new ContextWindowManager(
+    const manager = new ContextWindowManager({
       provider,
-      "system prompt",
-      makeConfig({
+      systemPrompt: "system prompt",
+      config: makeConfig({
         maxInputTokens: 260,
         targetInputTokens: 60,
         preserveRecentUserTurns: 2,
       }),
-    );
+    });
     const long = "e".repeat(220);
     const history: Message[] = [
       message("user", `u1 ${long}`),
@@ -685,21 +685,21 @@ describe("ContextWindowManager", () => {
     ];
 
     // Without override: normal compaction keeps more turns.
-    const normalManager = new ContextWindowManager(
+    const normalManager = new ContextWindowManager({
       provider,
-      "system prompt",
+      systemPrompt: "system prompt",
       config,
-    );
+    });
     const normalResult = await normalManager.maybeCompact(history, undefined, {
       force: true,
     });
 
     // With a very tight override target: should keep fewer turns.
-    const tightManager = new ContextWindowManager(
+    const tightManager = new ContextWindowManager({
       provider,
-      "system prompt",
+      systemPrompt: "system prompt",
       config,
-    );
+    });
     const tightResult = await tightManager.maybeCompact(history, undefined, {
       force: true,
       targetInputTokensOverride: 80,

--- a/assistant/src/__tests__/memory-context-benchmark.benchmark.test.ts
+++ b/assistant/src/__tests__/memory-context-benchmark.benchmark.test.ts
@@ -193,10 +193,10 @@ describe("Memory context benchmark", () => {
 
     const longMessages = makeLongMessages(90); // 180 messages
     const summaryCounter = { calls: 0 };
-    const manager = new ContextWindowManager(
-      makeSummaryProvider(summaryCounter),
-      "system prompt for compaction benchmark",
-      {
+    const manager = new ContextWindowManager({
+      provider: makeSummaryProvider(summaryCounter),
+      systemPrompt: "system prompt for compaction benchmark",
+      config: {
         ...DEFAULT_CONFIG.contextWindow,
         maxInputTokens: 6000,
         targetInputTokens: 3200,
@@ -204,7 +204,7 @@ describe("Memory context benchmark", () => {
         preserveRecentUserTurns: 8,
         chunkTokens: 1200,
       },
-    );
+    });
 
     const compacted = await manager.maybeCompact(longMessages);
     expect(compacted.compacted).toBe(true);

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -93,32 +93,11 @@ export class ContextWindowManager {
   private readonly config: ContextWindowConfig;
   readonly onBeforeCompact?: ContextWindowManagerOptions["onBeforeCompact"];
 
-  constructor(options: ContextWindowManagerOptions);
-  /** @deprecated Use the options-object constructor instead. */
-  constructor(
-    provider: Provider,
-    systemPrompt: string,
-    config: ContextWindowConfig,
-  );
-  constructor(
-    providerOrOptions: Provider | ContextWindowManagerOptions,
-    systemPrompt?: string,
-    config?: ContextWindowConfig,
-  ) {
-    if (
-      typeof providerOrOptions === "object" &&
-      "provider" in providerOrOptions &&
-      "config" in providerOrOptions
-    ) {
-      this.provider = providerOrOptions.provider;
-      this.systemPrompt = providerOrOptions.systemPrompt;
-      this.config = providerOrOptions.config;
-      this.onBeforeCompact = providerOrOptions.onBeforeCompact;
-    } else {
-      this.provider = providerOrOptions as Provider;
-      this.systemPrompt = systemPrompt!;
-      this.config = config!;
-    }
+  constructor(options: ContextWindowManagerOptions) {
+    this.provider = options.provider;
+    this.systemPrompt = options.systemPrompt;
+    this.config = options.config;
+    this.onBeforeCompact = options.onBeforeCompact;
   }
 
   async maybeCompact(


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pre-compaction-memory-flush.md.

**Gap:** Backwards-compatible constructor overload violates project policy
**What was expected:** No backwards-compatibility shims per CLAUDE.md policy
**What was found:** Deprecated 3-arg overload alongside new options-object form, all test callers using old form

Migrates all callers to the options-object constructor and removes the deprecated overload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
