### PR TITLE
fix: pass conversationId to memory_recall for recency search

### DIFF
--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -323,6 +323,7 @@ export async function handleMemoryRecall(
   args: Record<string, unknown>,
   config: AssistantConfig,
   scopeId?: string,
+  conversationId?: string,
 ): Promise<ToolExecutionResult> {
   const query = args.query;
   if (typeof query !== "string" || query.trim().length === 0) {
@@ -380,6 +381,7 @@ export async function handleMemoryRecall(
       queryVector,
       provider,
       model,
+      conversationId,
       scopeId,
       scopePolicyOverride,
     });

--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -124,7 +124,12 @@ class MemoryRecallTool implements Tool {
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
     const config = getConfig();
-    return handleMemoryRecall(input, config, context.memoryScopeId);
+    return handleMemoryRecall(
+      input,
+      config,
+      context.memoryScopeId,
+      context.conversationId,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for on-demand-memory-search-tool.md.

**Gap:** Missing conversationId — recency search always skipped
**What was expected:** `handleMemoryRecall` should forward `conversationId` so recency-based retrieval works
**What was found:** `conversationId` was never passed to `collectAndMergeCandidates`, silently disabling recency search

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
