### PR TITLE
fix: align memory_recall degradation semantics with auto-injection path

### DIFF
--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -3,7 +3,10 @@ import { v4 as uuid } from "uuid";
 
 import type { AssistantConfig } from "../../config/types.js";
 import { getDb } from "../../memory/db.js";
-import { getMemoryBackendStatus } from "../../memory/embedding-backend.js";
+import {
+  getMemoryBackendStatus,
+  logMemoryEmbeddingWarning,
+} from "../../memory/embedding-backend.js";
 import { computeMemoryFingerprint } from "../../memory/fingerprint.js";
 import { formatRecallText } from "../../memory/format-recall.js";
 import { enqueueMemoryJob } from "../../memory/jobs-store.js";
@@ -367,9 +370,9 @@ export async function handleMemoryRecall(
         queryVector = embedded.vectors[0] ?? null;
         provider = embedded.provider;
         model = embedded.model;
-      } catch {
-        // Gracefully degrade to non-semantic retrieval
-        degraded = true;
+      } catch (err) {
+        logMemoryEmbeddingWarning(err, "query");
+        degraded = !!config.memory.embeddings.required;
       }
     } else {
       degraded = backendStatus.degraded;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for on-demand-memory-search-tool.md.

**Gap:** Degradation semantics diverge between handleMemoryRecall and generateQueryEmbedding
**What was expected:** `degraded` should respect `config.memory.embeddings.required` on embed failure
**What was found:** Handler unconditionally sets `degraded = true` and skips the embedding warning log

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
