### PR TITLE
fix: flush all uncompacted DB messages to prevent data loss

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -385,12 +385,15 @@ export class Session {
 
         try {
           // Resolve DB message rows so flush has real message IDs for
-          // deduplication and extraction. The compactable messages correspond
-          // to DB rows starting after the already-compacted count.
+          // deduplication and extraction. Flush all uncompacted rows rather
+          // than slicing by in-memory count, because repairHistory() can merge
+          // consecutive same-role messages making the in-memory count smaller
+          // than the DB row count. Over-fetching is safe — isAlreadyExtracted
+          // deduplicates.
           const dbMessages = conversationStore.getMessages(this.conversationId);
           const compactedCount = this.contextCompactedMessageCount;
           let flushMessages = dbMessages
-            .slice(compactedCount, compactedCount + messages.length)
+            .slice(compactedCount)
             .map((row) => ({ id: row.id, role: row.role }));
 
           // Take the most recent N messages — older messages are more likely


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pre-compaction-memory-flush.md.

**Gap:** DB-to-in-memory message count misalignment causes flush to miss messages
**What was wrong:** History repair merges consecutive same-role messages, making in-memory count < DB count
**Fix:** Flush all uncompacted DB messages instead of slicing by in-memory count. Over-fetching is safe because isAlreadyExtracted deduplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
