### PR TITLE
test: add integration tests for onBeforeCompact hook

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -711,4 +711,90 @@ describe("ContextWindowManager", () => {
       normalResult.compactedMessages,
     );
   });
+
+  test("onBeforeCompact is called with compactable messages and boundary index", async () => {
+    const provider = createProvider(() => ({
+      content: [{ type: "text", text: "## Goals\n- hook test summary" }],
+      model: "mock-model",
+      usage: { inputTokens: 60, outputTokens: 12 },
+      stopReason: "end_turn",
+    }));
+
+    let hookCalls = 0;
+    let capturedMessages: Message[] = [];
+    let capturedBoundary = -1;
+    let capturedSignal: AbortSignal | undefined;
+
+    const ac = new AbortController();
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({
+        maxInputTokens: 260,
+        targetInputTokens: 140,
+        preserveRecentUserTurns: 1,
+      }),
+      onBeforeCompact: async (messages, boundary, signal) => {
+        hookCalls += 1;
+        capturedMessages = messages;
+        capturedBoundary = boundary;
+        capturedSignal = signal;
+      },
+    });
+
+    const long = "h".repeat(220);
+    const history: Message[] = [
+      message("user", `u1 ${long}`),
+      message("assistant", `a1 ${long}`),
+      message("user", `u2 ${long}`),
+    ];
+
+    const result = await manager.maybeCompact(history, ac.signal);
+
+    expect(result.compacted).toBe(true);
+    expect(hookCalls).toBe(1);
+    // The hook receives the messages that will be compacted (everything before
+    // the keep boundary), not the full history.
+    expect(capturedMessages.length).toBeGreaterThan(0);
+    expect(capturedMessages.length).toBeLessThan(history.length);
+    expect(capturedBoundary).toBeGreaterThan(0);
+    expect(capturedSignal).toBe(ac.signal);
+  });
+
+  test("onBeforeCompact errors do not prevent compaction", async () => {
+    const provider = createProvider(() => ({
+      content: [{ type: "text", text: "## Goals\n- resilient compaction" }],
+      model: "mock-model",
+      usage: { inputTokens: 60, outputTokens: 12 },
+      stopReason: "end_turn",
+    }));
+
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({
+        maxInputTokens: 260,
+        targetInputTokens: 140,
+        preserveRecentUserTurns: 1,
+      }),
+      onBeforeCompact: async () => {
+        throw new Error("hook exploded");
+      },
+    });
+
+    const long = "r".repeat(220);
+    const history: Message[] = [
+      message("user", `u1 ${long}`),
+      message("assistant", `a1 ${long}`),
+      message("user", `u2 ${long}`),
+    ];
+
+    const result = await manager.maybeCompact(history);
+
+    expect(result.compacted).toBe(true);
+    expect(result.summaryCalls).toBeGreaterThan(0);
+    expect(getSummaryFromContextMessage(result.messages[0])).toContain(
+      "resilient compaction",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pre-compaction-memory-flush.md.

**Gap:** No integration test for onBeforeCompact hook
**What was expected:** Tests for hook invocation and error resilience
**What was found:** No test coverage for the hook in context-window-manager.test.ts

- Added test verifying onBeforeCompact is called with the correct arguments (compactable messages, boundary index, abort signal)
- Added test verifying errors thrown by onBeforeCompact do not prevent compaction from completing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
