### PR TITLE
fix: flush assistant messages when extractFromAssistant is enabled

### DIFF
--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -403,6 +403,8 @@ export class Session {
             messages: flushMessages,
             conversationId: this.conversationId,
             scopeId: this.memoryPolicy.scopeId,
+            extractFromAssistant:
+              getConfig().memory.extraction.extractFromAssistant,
             abortSignal: flushController.signal,
           });
 

--- a/assistant/src/memory/flush.test.ts
+++ b/assistant/src/memory/flush.test.ts
@@ -145,7 +145,7 @@ describe("flushMemoryForMessages", () => {
     expect(result).toEqual({ flushed: 2, skipped: 0 });
   });
 
-  it("filters to user messages only", async () => {
+  it("filters to user messages only when extractFromAssistant is false", async () => {
     const messages = [
       { id: "msg-1", role: "user" },
       { id: "msg-2", role: "assistant" },
@@ -155,6 +155,7 @@ describe("flushMemoryForMessages", () => {
 
     const result = await flushMemoryForMessages({
       ...baseOpts(),
+      extractFromAssistant: false,
       messages,
     });
 
@@ -162,6 +163,27 @@ describe("flushMemoryForMessages", () => {
     expect(extractMock).toHaveBeenCalledWith("msg-1", "scope-1", "conv-1");
     expect(extractMock).toHaveBeenCalledWith("msg-4", "scope-1", "conv-1");
     expect(result).toEqual({ flushed: 2, skipped: 0 });
+  });
+
+  it("includes assistant messages when extractFromAssistant is true", async () => {
+    const messages = [
+      { id: "msg-1", role: "user" },
+      { id: "msg-2", role: "assistant" },
+      { id: "msg-3", role: "system" },
+      { id: "msg-4", role: "user" },
+    ];
+
+    const result = await flushMemoryForMessages({
+      ...baseOpts(),
+      extractFromAssistant: true,
+      messages,
+    });
+
+    expect(extractMock).toHaveBeenCalledTimes(3);
+    expect(extractMock).toHaveBeenCalledWith("msg-1", "scope-1", "conv-1");
+    expect(extractMock).toHaveBeenCalledWith("msg-2", "scope-1", "conv-1");
+    expect(extractMock).toHaveBeenCalledWith("msg-4", "scope-1", "conv-1");
+    expect(result).toEqual({ flushed: 3, skipped: 0 });
   });
 
   it("returns zeroes for empty message list", async () => {

--- a/assistant/src/memory/flush.ts
+++ b/assistant/src/memory/flush.ts
@@ -13,6 +13,7 @@ export interface FlushMemoryOptions {
   messages: FlushMessage[];
   conversationId: string;
   scopeId: string;
+  extractFromAssistant?: boolean;
   abortSignal?: AbortSignal;
 }
 
@@ -24,15 +25,23 @@ export interface FlushMemoryOptions {
 export async function flushMemoryForMessages(
   opts: FlushMemoryOptions,
 ): Promise<{ flushed: number; skipped: number }> {
-  const { messages, conversationId, scopeId, abortSignal } = opts;
+  const {
+    messages,
+    conversationId,
+    scopeId,
+    extractFromAssistant,
+    abortSignal,
+  } = opts;
 
-  // Only user messages are extracted per current policy
-  const userMessages = messages.filter((m) => m.role === "user");
+  const extractableMessages = messages.filter(
+    (m) =>
+      m.role === "user" || (m.role === "assistant" && extractFromAssistant),
+  );
 
   let flushed = 0;
   let skipped = 0;
 
-  for (const message of userMessages) {
+  for (const message of extractableMessages) {
     if (abortSignal?.aborted) {
       log.info(
         { conversationId, flushed, skipped },
@@ -62,7 +71,7 @@ export async function flushMemoryForMessages(
   }
 
   log.info(
-    { conversationId, total: userMessages.length, flushed, skipped },
+    { conversationId, total: extractableMessages.length, flushed, skipped },
     "Pre-compaction memory flush complete",
   );
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pre-compaction-memory-flush.

**Gap:** Flush skips assistant messages despite extractFromAssistant config defaulting to true
**What was wrong:** Hard-filtered to user messages only, ignoring config
**Fix:** Respects extractFromAssistant config, includes assistant messages when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13921" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
