### PR TITLE
refactor: update memory_update/memory_delete to reference memory_recall

### DIFF
--- a/assistant/src/tools/memory/definitions.ts
+++ b/assistant/src/tools/memory/definitions.ts
@@ -29,7 +29,7 @@ export const memorySearchDefinition: ToolDefinition = {
 export const memoryRecallDefinition: ToolDefinition = {
   name: "memory_recall",
   description:
-    "Deep search across all memory sources (semantic, lexical, entity graph, recency) for specific information. Use this when you need to recall details about past conversations, decisions, preferences, project context, or any prior knowledge. Returns formatted memory context. Prefer this over memory_search for richer, multi-source retrieval.",
+    "Deep search across all memory sources (semantic, lexical, entity graph, recency) for specific information. Use this when you need to recall details about past conversations, decisions, preferences, project context, or any prior knowledge. Returns formatted memory context with item IDs for use with memory_update/memory_delete.",
   input_schema: {
     type: "object",
     properties: {
@@ -104,7 +104,7 @@ export const memoryUpdateDefinition: ToolDefinition = {
       memory_id: {
         type: "string",
         description:
-          "ID of the memory item to update (from memory_search results)",
+          "ID of the memory item to update (from memory_recall results)",
       },
       statement: {
         type: "string",
@@ -130,7 +130,7 @@ export const memoryDeleteDefinition: ToolDefinition = {
       memory_id: {
         type: "string",
         description:
-          "ID of the memory item to delete (from memory_search results)",
+          "ID of the memory item to delete (from memory_recall results)",
       },
       reason: {
         type: "string",


### PR DESCRIPTION
## Summary
- Update `memory_update` and `memory_delete` descriptions to reference `memory_recall` instead of `memory_search`
- Make `memory_recall` description standalone (no reference to `memory_search`)

Part of plan: remove-memory-search-tool.md (PR 2 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13922" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
