### PR TITLE
feat: include item IDs in memory_recall tool results

### DIFF
--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -314,6 +314,7 @@ export interface MemoryRecallToolResult {
   text: string;
   resultCount: number;
   degraded: boolean;
+  items: Array<{ id: string; type: string; kind: string }>;
   sources: {
     lexical: number;
     semantic: number;
@@ -400,6 +401,7 @@ export async function handleMemoryRecall(
         text: "No matching memories found.",
         resultCount: 0,
         degraded,
+        items: [],
         sources: {
           lexical: 0,
           semantic: 0,
@@ -419,10 +421,17 @@ export async function handleMemoryRecall(
       maxTokens: config.memory.retrieval.maxInjectTokens,
     });
 
+    const items = formatted.selected.map((c) => ({
+      id: c.id,
+      type: c.type,
+      kind: c.kind,
+    }));
+
     const result: MemoryRecallToolResult = {
       text: formatted.text,
       resultCount: formatted.selected.length,
       degraded,
+      items,
       sources: {
         lexical: collected.lexical.length,
         semantic: collected.semantic.length,


### PR DESCRIPTION
## Summary
- Add `items` array to `MemoryRecallToolResult` with `id`, `type`, `kind` per result
- Enables `memory_update`/`memory_delete` to reference specific items from recall results
- Empty results return `items: []`

Part of plan: remove-memory-search-tool.md (PR 1 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
