### PR TITLE
refactor: remove memory_search handler and definition

### DIFF
--- a/assistant/src/tools/memory/definitions.ts
+++ b/assistant/src/tools/memory/definitions.ts
@@ -1,31 +1,5 @@
 import type { ToolDefinition } from "../../providers/types.js";
 
-export const memorySearchDefinition: ToolDefinition = {
-  name: "memory_search",
-  description:
-    "Search your memory for previously saved facts, preferences, decisions, and other information. Use this when you need to recall something from past conversations.",
-  input_schema: {
-    type: "object",
-    properties: {
-      query: {
-        type: "string",
-        description:
-          "Natural language search query describing what you want to recall",
-      },
-      limit: {
-        type: "number",
-        description: "Maximum number of results to return (default: 5)",
-      },
-      reason: {
-        type: "string",
-        description:
-          "Brief non-technical explanation of what you are looking up and why, shown to the user as a status update. Use simple language a non-technical person would understand.",
-      },
-    },
-    required: ["query"],
-  },
-};
-
 export const memoryRecallDefinition: ToolDefinition = {
   name: "memory_recall",
   description:

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -13,8 +13,6 @@ import { enqueueMemoryJob } from "../../memory/jobs-store.js";
 import {
   collectAndMergeCandidates,
   embedWithRetry,
-  formatRelativeTime,
-  searchMemoryItems,
 } from "../../memory/retriever.js";
 import { memoryItems } from "../../memory/schema.js";
 import type { ScopePolicyOverride } from "../../memory/search/types.js";
@@ -23,66 +21,6 @@ import { truncate } from "../../util/truncate.js";
 import type { ToolExecutionResult } from "../types.js";
 
 const log = getLogger("memory-tools");
-
-// ── memory_search ────────────────────────────────────────────────────
-
-export async function handleMemorySearch(
-  args: Record<string, unknown>,
-  config: AssistantConfig,
-  scopeId?: string,
-): Promise<ToolExecutionResult> {
-  const query = args.query;
-  if (typeof query !== "string" || query.trim().length === 0) {
-    return {
-      content: "Error: query is required and must be a non-empty string",
-      isError: true,
-    };
-  }
-
-  const limit =
-    typeof args.limit === "number" && args.limit > 0
-      ? Math.min(args.limit, 20)
-      : 5;
-
-  // Private threads should always fall back to default scope for search
-  const scopePolicyOverride: ScopePolicyOverride | undefined =
-    scopeId && scopeId.startsWith("private:")
-      ? { scopeId, fallbackToDefault: true }
-      : undefined;
-
-  try {
-    const results = await searchMemoryItems(
-      query,
-      limit,
-      config,
-      scopeId,
-      scopePolicyOverride,
-    );
-
-    if (results.length === 0) {
-      return { content: "No matching memories found.", isError: false };
-    }
-
-    const lines: string[] = [`Found ${results.length} memory item(s):\n`];
-    for (const result of results) {
-      const timeAgo = formatRelativeTime(result.createdAt);
-      lines.push(`- **[${result.kind}]** ${result.text}`);
-      lines.push(
-        `  _ID: ${result.id} | source: ${
-          result.type
-        } | ${timeAgo} | confidence: ${result.confidence.toFixed(
-          2,
-        )} | importance: ${result.importance.toFixed(2)}_`,
-      );
-    }
-
-    return { content: lines.join("\n"), isError: false };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log.error({ err, query }, "memory_search failed");
-    return { content: `Error: Memory search failed: ${msg}`, isError: true };
-  }
-}
 
 // ── memory_save ──────────────────────────────────────────────────────
 

--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -6,37 +6,14 @@ import {
   memoryDeleteDefinition,
   memoryRecallDefinition,
   memorySaveDefinition,
-  memorySearchDefinition,
   memoryUpdateDefinition,
 } from "./definitions.js";
 import {
   handleMemoryDelete,
   handleMemoryRecall,
   handleMemorySave,
-  handleMemorySearch,
   handleMemoryUpdate,
 } from "./handlers.js";
-
-// ── memory_search ────────────────────────────────────────────────────
-
-class MemorySearchTool implements Tool {
-  name = "memory_search";
-  description = memorySearchDefinition.description;
-  category = "memory";
-  defaultRiskLevel = RiskLevel.Low;
-
-  getDefinition(): ToolDefinition {
-    return memorySearchDefinition;
-  }
-
-  async execute(
-    input: Record<string, unknown>,
-    context: ToolContext,
-  ): Promise<ToolExecutionResult> {
-    const config = getConfig();
-    return handleMemorySearch(input, config, context.memoryScopeId);
-  }
-}
 
 // ── memory_save ──────────────────────────────────────────────────────
 
@@ -135,7 +112,6 @@ class MemoryRecallTool implements Tool {
 
 // ── Exported tool instances ──────────────────────────────────────────
 
-export const memorySearchTool = new MemorySearchTool();
 export const memorySaveTool = new MemorySaveTool();
 export const memoryUpdateTool = new MemoryUpdateTool();
 export const memoryDeleteTool = new MemoryDeleteTool();

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -12,7 +12,6 @@ import {
   memoryDeleteTool,
   memoryRecallTool,
   memorySaveTool,
-  memorySearchTool,
   memoryUpdateTool,
 } from "./memory/register.js";
 import type { LazyToolDescriptor } from "./registry.js";
@@ -81,7 +80,6 @@ export const eagerModuleToolNames: string[] = [
 // relying on import side effects.
 
 export const explicitTools: Tool[] = [
-  memorySearchTool,
   memorySaveTool,
   memoryUpdateTool,
   memoryDeleteTool,


### PR DESCRIPTION
## Summary
- Delete `memorySearchDefinition` from `definitions.ts`
- Delete `handleMemorySearch()` function from `handlers.ts`
- Remove `MemorySearchTool` class and `memorySearchTool` export from `register.ts`
- Remove `memorySearchTool` from `tool-manifest.ts` explicit tools list
- Clean up unused imports (`searchMemoryItems`, `formatRelativeTime`)

Part of plan: remove-memory-search-tool.md (PR 4 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
