### PR TITLE
refactor: remove memory_search permission defaults and policy entry

### DIFF
--- a/assistant/src/permissions/defaults.ts
+++ b/assistant/src/permissions/defaults.ts
@@ -278,11 +278,11 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     priority: 100,
   };
 
-  // memory_search is a read-only tool — always allow without prompting.
-  const memorySearchRule: DefaultRuleTemplate = {
-    id: "default:allow-memory_search-global",
-    tool: "memory_search",
-    pattern: "memory_search:*",
+  // memory_recall is a read-only tool — always allow without prompting.
+  const memoryRecallRule: DefaultRuleTemplate = {
+    id: "default:allow-memory_recall-global",
+    tool: "memory_recall",
+    pattern: "memory_recall:*",
     scope: "everywhere",
     decision: "allow",
     priority: 100,
@@ -303,6 +303,6 @@ export function getDefaultRuleTemplates(): DefaultRuleTemplate[] {
     ...browserToolRules,
     ...uiSurfaceRules,
     viewImageRule,
-    memorySearchRule,
+    memoryRecallRule,
   ];
 }

--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -80,7 +80,7 @@ const HOST_TOOLS = new Set([
 const ALWAYS_SCOPED_TOOLS = new Set([
   "skill_load",
   "view_image",
-  "memory_search",
+  "memory_recall",
   "ui_update",
   "ui_dismiss",
 ]);


### PR DESCRIPTION
## Summary
- Remove `memorySearchRule` permission default, add `memoryRecallRule` with same auto-allow behavior
- Replace `memory_search` with `memory_recall` in `ALWAYS_SCOPED_TOOLS`

Part of plan: remove-memory-search-tool.md (PR 6 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
