### PR TITLE
chore: remove deprecated call constants

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -82,9 +82,6 @@ mock.module("../calls/call-constants.js", () => ({
   getMaxCallDurationMs: () => 12 * 60 * 1000,
   getUserConsultationTimeoutMs: () => mockConsultationTimeoutMs,
   getSilenceTimeoutMs: () => mockSilenceTimeoutMs,
-  SILENCE_TIMEOUT_MS: 30_000,
-  MAX_CALL_DURATION_MS: 3600 * 1000,
-  USER_CONSULTATION_TIMEOUT_MS: 120 * 1000,
 }));
 
 // ── Voice session bridge mock ────────────────────────────────────────

--- a/assistant/src/calls/call-constants.ts
+++ b/assistant/src/calls/call-constants.ts
@@ -75,10 +75,3 @@ export function getGuardianWaitUpdateSteadyMaxIntervalMs(): number {
 export function getSilenceTimeoutMs(): number {
   return 30 * 1000; // 30 seconds
 }
-
-/** @deprecated Use getSilenceTimeoutMs() for mockability in tests. */
-export const SILENCE_TIMEOUT_MS = 30 * 1000; // 30 seconds
-
-// Legacy named exports for backward compatibility (use functions above for config-backed values)
-export const MAX_CALL_DURATION_MS = 3600 * 1000; // fallback default; prefer getMaxCallDurationMs()
-export const USER_CONSULTATION_TIMEOUT_MS = 120 * 1000; // fallback default; prefer getUserConsultationTimeoutMs()


### PR DESCRIPTION
## Summary
- Remove unused deprecated constants `SILENCE_TIMEOUT_MS`, `MAX_CALL_DURATION_MS`, and `USER_CONSULTATION_TIMEOUT_MS` from `call-constants.ts`
- Clean up corresponding dead mock entries in `call-controller.test.ts`
- Config-backed function accessors (`getSilenceTimeoutMs()`, `getMaxCallDurationMs()`, `getUserConsultationTimeoutMs()`) remain as the sole API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
