### PR TITLE
refactor: remove deprecated tool parameter shims

### DIFF
--- a/assistant/src/followups/followup-store.ts
+++ b/assistant/src/followups/followup-store.ts
@@ -18,7 +18,6 @@ function parseFollowUp(row: typeof followups.$inferSelect): FollowUp {
     expectedResponseBy: row.expectedResponseBy,
     status: row.status as FollowUpStatus,
     reminderScheduleId: scheduleId,
-    reminderCronId: scheduleId,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -40,7 +39,7 @@ export function createFollowUp(input: FollowUpCreateInput): FollowUp {
       sentAt: input.sentAt ?? now,
       expectedResponseBy: input.expectedResponseBy ?? null,
       status: "pending",
-      reminderCronId: input.reminderScheduleId ?? input.reminderCronId ?? null,
+      reminderCronId: input.reminderScheduleId ?? null,
       createdAt: now,
       updatedAt: now,
     })

--- a/assistant/src/followups/types.ts
+++ b/assistant/src/followups/types.ts
@@ -8,10 +8,7 @@ export interface FollowUp {
   sentAt: number;
   expectedResponseBy: number | null;
   status: FollowUpStatus;
-  /** Canonical field — the recurrence schedule ID linked to this follow-up. */
   reminderScheduleId: string | null;
-  /** @deprecated Use {@link reminderScheduleId}. Kept for migration compatibility. */
-  reminderCronId: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -22,8 +19,5 @@ export interface FollowUpCreateInput {
   contactId?: string | null;
   sentAt?: number;
   expectedResponseBy?: number | null;
-  /** Canonical field — the recurrence schedule ID to link. */
   reminderScheduleId?: string | null;
-  /** @deprecated Use {@link reminderScheduleId}. Kept for migration compatibility. */
-  reminderCronId?: string | null;
 }

--- a/assistant/src/tools/followups/followup_create.ts
+++ b/assistant/src/tools/followups/followup_create.ts
@@ -46,14 +46,6 @@ export async function executeFollowupCreate(
     };
   }
 
-  if (input.reminder_cron_id !== undefined) {
-    return {
-      content:
-        'Error: "reminder_cron_id" is deprecated. Use "reminder_schedule_id" instead.',
-      isError: true,
-    };
-  }
-
   const contactId = input.contact_id as string | undefined;
   const expectedResponseHours = input.expected_response_hours as
     | number

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -20,14 +20,6 @@ export async function executeScheduleUpdate(
     return { content: "Error: job_id is required", isError: true };
   }
 
-  if (input.cron_expression !== undefined) {
-    return {
-      content:
-        'Error: "cron_expression" is deprecated. Use "expression" instead.',
-      isError: true,
-    };
-  }
-
   const updates: Record<string, unknown> = {};
   if (input.name !== undefined) updates.name = input.name;
   if (input.timezone !== undefined) updates.timezone = input.timezone;


### PR DESCRIPTION
## Summary
- Remove deprecated `cron_expression` parameter guard from `schedule_update` tool — callers must use `expression`
- Remove deprecated `reminder_cron_id` parameter guard from `followup_create` tool — callers must use `reminder_schedule_id`
- Remove deprecated `reminderCronId` alias from `FollowUp` type and store layer
- Pre-launch product with no users, so no migration path needed per backwards compatibility policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13929" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
