### PR TITLE
refactor: remove legacy lockfile fallback path

### DIFF
--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -51,27 +51,21 @@ export function getClipboardCommand(): string | null {
 }
 
 /**
- * Read and parse the lockfile, trying the primary path (~/.vellum.lock.json)
- * first, then falling back to the legacy path (~/.vellum.lockfile.json).
+ * Read and parse the lockfile (~/.vellum.lock.json).
  * Respects BASE_DATA_DIR for non-standard home directories.
- * Returns null if neither file exists or both are malformed.
+ * Returns null if the file doesn't exist or is malformed.
  */
 export function readLockfile(): Record<string, unknown> | null {
   const base = getBaseDataDir() || homedir();
-  const candidates = [
-    join(base, ".vellum.lock.json"),
-    join(base, ".vellum.lockfile.json"),
-  ];
-  for (const lockPath of candidates) {
-    if (!existsSync(lockPath)) continue;
-    try {
-      const raw = JSON.parse(readFileSync(lockPath, "utf-8"));
-      if (raw && typeof raw === "object" && !Array.isArray(raw)) {
-        return raw as Record<string, unknown>;
-      }
-    } catch {
-      // malformed JSON — try next
+  const lockPath = join(base, ".vellum.lock.json");
+  if (!existsSync(lockPath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(lockPath, "utf-8"));
+    if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+      return raw as Record<string, unknown>;
     }
+  } catch {
+    // malformed JSON
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- Remove backwards-compatibility fallback in `readLockfile()` that checked the legacy `~/.vellum.lockfile.json` path after the primary `~/.vellum.lock.json`
- Pre-launch product with no users on the old path; per backwards compatibility policy, remove the shim

## Test plan
- [ ] Verify `readLockfile()` still reads from `~/.vellum.lock.json`
- [ ] Confirm no other references to `.vellum.lockfile.json` exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
