### PR TITLE
test: update tests for memory_search removal

### DIFF
--- a/assistant/src/__tests__/registry.test.ts
+++ b/assistant/src/__tests__/registry.test.ts
@@ -193,7 +193,7 @@ describe("tool manifest", () => {
 
   test("explicit tools list includes memory, credential, and watch tools", () => {
     const names = explicitTools.map((t) => t.name);
-    expect(names).toContain("memory_search");
+    expect(names).toContain("memory_recall");
     expect(names).toContain("memory_save");
     expect(names).toContain("memory_update");
     expect(names).toContain("credential_store");

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -1166,7 +1166,7 @@ describe("isSideEffectTool", () => {
   describe("returns false for non-side-effect tools", () => {
     const readOnlyTools = [
       "file_read",
-      "memory_search",
+      "memory_recall",
       "memory_save",
       "web_search",
       "browser_snapshot",

--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -892,7 +892,7 @@ describe("Trust Store", () => {
         "host_file_edit",
         "host_file_read",
         "host_file_write",
-        "memory_search",
+        "memory_recall",
         "scaffold_managed_skill",
         "skill_load",
         "ui_dismiss",

--- a/assistant/src/__tests__/workspace-policy.test.ts
+++ b/assistant/src/__tests__/workspace-policy.test.ts
@@ -258,7 +258,7 @@ describe("isWorkspaceScopedInvocation", () => {
     const safeTools = [
       "skill_load",
       "view_image",
-      "memory_search",
+      "memory_recall",
       "ui_update",
       "ui_dismiss",
     ];


### PR DESCRIPTION
## Summary
- Replace all `memory_search` references with `memory_recall` in test files
- Updated assertions in registry.test.ts, workspace-policy.test.ts, tool-executor.test.ts, and trust-store.test.ts

Part of plan: remove-memory-search-tool.md (PR 8 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
