### PR TITLE
fix: update stale memory_search comment to memory_recall

### DIFF
--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -467,7 +467,7 @@ function inferSubjectFromStatement(statement: string): string {
 
 /**
  * Strip a typed ID prefix (e.g. "item:abc-123" -> "abc-123") so that IDs
- * copied from memory_search output work in memory_update.
+ * copied from memory_recall output work in memory_update.
  */
 function stripTypedIdPrefix(id: string): string {
   const match = id.match(/^(?:item|segment|summary):(.+)$/);


### PR DESCRIPTION
## Summary
Fixes stale comment referencing `memory_search` in `stripTypedIdPrefix` JSDoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
