### PR TITLE
refactor: remove deprecated tryRecordProcessedCallback()

### DIFF
--- a/assistant/src/__tests__/session-init.benchmark.test.ts
+++ b/assistant/src/__tests__/session-init.benchmark.test.ts
@@ -261,7 +261,6 @@ mock.module("../calls/call-store.js", () => ({
   buildCallbackDedupeKey: () => "",
   isCallbackProcessed: () => false,
   recordProcessedCallback: () => {},
-  tryRecordProcessedCallback: () => true,
   claimCallback: () => true,
   releaseCallbackClaim: () => {},
 }));

--- a/assistant/src/calls/call-store.ts
+++ b/assistant/src/calls/call-store.ts
@@ -399,31 +399,6 @@ export function recordProcessedCallback(
 }
 
 /**
- * Try to record a processed callback. Returns true if this is a new callback
- * (inserted successfully). Returns false if the callback was already processed
- * (dedupe key already exists), indicating a replay.
- *
- * Uses INSERT ... ON CONFLICT DO NOTHING pattern for atomicity.
- *
- * @deprecated Use claimCallback + releaseCallbackClaim instead to
- * atomically claim a callback and release on failure.
- */
-export function tryRecordProcessedCallback(
-  dedupeKey: string,
-  callSessionId: string,
-): boolean {
-  return (
-    rawRun(
-      `INSERT OR IGNORE INTO processed_callbacks (id, dedupe_key, call_session_id, created_at) VALUES (?, ?, ?, ?)`,
-      uuid(),
-      dedupeKey,
-      callSessionId,
-      Date.now(),
-    ) > 0
-  );
-}
-
-/**
  * Atomically claim a callback for processing. Returns a unique claim ID
  * (string) if this caller won the claim, or null if another caller already
  * claimed it (dedupe_key conflict).


### PR DESCRIPTION
## Summary
- Remove `tryRecordProcessedCallback()` from `call-store.ts` — deprecated in favor of `claimCallback` + `releaseCallbackClaim`
- Remove corresponding mock in `session-init.benchmark.test.ts`

## Original prompt
Remove this: tryRecordProcessedCallback() — assistant/src/calls/call-store.ts:408-410
    - Deprecated in favor of claimCallback + releaseCallbackClaim

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
