### PR TITLE
refactor: remove loadLatestAssistant fallback in CLI client command

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -59,11 +59,8 @@ function parseArgs(): ParsedArgs {
     // Explicit env var — skip assistant resolution, will use env values below
     entry = loadLatestAssistant();
   } else {
-    // Respect active assistant when set, otherwise fall back to latest
-    // for backward compatibility with remote-only setups.
     const active = getActiveAssistant();
-    const activeEntry = active ? findAssistantByName(active) : null;
-    entry = activeEntry ?? loadLatestAssistant();
+    entry = active ? findAssistantByName(active) : null;
   }
 
   let runtimeUrl =
@@ -106,7 +103,7 @@ ${ANSI.bold}USAGE:${ANSI.reset}
     vellum client [name] [options]
 
 ${ANSI.bold}ARGUMENTS:${ANSI.reset}
-    [name]                     Instance name (default: latest)
+    [name]                     Instance name (default: active)
 
 ${ANSI.bold}OPTIONS:${ANSI.reset}
     -u, --url <url>            Runtime URL


### PR DESCRIPTION
## Summary
- Remove backward-compat fallback to `loadLatestAssistant()` in `cli/src/commands/client.ts` when no name is provided and no `RUNTIME_URL` is set
- Now uses only the active assistant (via `getActiveAssistant()`) instead of falling back to the latest hatched entry
- Update help text to reflect "active" default instead of "latest"

## Original prompt
Remove this: CLI fallback to latest assistant — cli/src/commands/client.ts:62-63
    - Falls back to loadLatestAssistant() "for backward compatibility with remote-only setups"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
