### PR TITLE
refactor: remove legacy featureFlags config section

### DIFF
--- a/assistant/src/__tests__/skill-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags-integration.test.ts
@@ -24,7 +24,6 @@ const TEST_DIR = join(
 
 let currentConfig: Record<string, unknown> = {
   sandbox: { enabled: false, backend: "native" },
-  featureFlags: {},
 };
 
 const DECLARED_SKILL_ID = "hatch-new-assistant";
@@ -118,7 +117,6 @@ beforeEach(() => {
   // Reset config to defaults before each test
   currentConfig = {
     sandbox: { enabled: false, backend: "native" },
-    featureFlags: {},
   };
 });
 
@@ -179,7 +177,7 @@ describe("buildSystemPrompt feature flag filtering", () => {
     expect(result).not.toContain(`id="${DECLARED_SKILL_ID}"`);
   });
 
-  test("declared skills hidden when featureFlags is empty (registry defaults to false)", () => {
+  test("declared skills hidden when no overrides set (registry defaults to false)", () => {
     createSkillOnDisk(
       DECLARED_SKILL_ID,
       "Hatch New Assistant",

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -12,9 +12,7 @@ const TEST_DIR = join(
   `vellum-skill-load-flag-test-${crypto.randomUUID()}`,
 );
 
-let currentConfig: Record<string, unknown> = {
-  featureFlags: {},
-};
+let currentConfig: Record<string, unknown> = {};
 
 const DECLARED_SKILL_ID = "hatch-new-assistant";
 const DECLARED_FLAG_KEY = "feature_flags.hatch-new-assistant.enabled";
@@ -121,7 +119,7 @@ async function executeSkillLoad(
 describe("skill_load feature flag enforcement", () => {
   beforeEach(() => {
     mkdirSync(join(TEST_DIR, "skills"), { recursive: true });
-    currentConfig = { featureFlags: {} };
+    currentConfig = {};
   });
 
   afterEach(() => {

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -20,9 +20,9 @@ let mockRegisteredTools: Map<string, Tool[]> = new Map();
 let mockUnregisteredSkillIds: string[] = [];
 let mockSkillRefCount: Map<string, number> = new Map();
 
-let currentConfig: Record<string, unknown> = { featureFlags: {} };
+let currentConfig: Record<string, unknown> = {};
 const DECLARED_SKILL_ID = "hatch-new-assistant";
-const DECLARED_LEGACY_KEY = "skills.hatch-new-assistant.enabled";
+const DECLARED_FLAG_KEY = "feature_flags.hatch-new-assistant.enabled";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -50,10 +50,6 @@ mock.module("../config/assistant-feature-flags.js", () => ({
       }
     ).assistantFeatureFlagValues;
     if (vals && typeof vals[key] === "boolean") return vals[key];
-    // Check legacy featureFlags too
-    const legacy = (config as { featureFlags?: Record<string, boolean> })
-      .featureFlags;
-    if (legacy && typeof legacy[key] === "boolean") return legacy[key];
     return true; // default enabled
   },
   loadDefaultsRegistry: () => ({}),
@@ -62,7 +58,7 @@ mock.module("../config/assistant-feature-flags.js", () => ({
 }));
 
 mock.module("../config/skill-state.js", () => ({
-  skillFlagKey: (skillId: string) => `skills.${skillId}.enabled`,
+  skillFlagKey: (skillId: string) => `feature_flags.${skillId}.enabled`,
 }));
 
 mock.module("../skills/active-skill-tools.js", () => {
@@ -293,7 +289,7 @@ describe("projectSkillTools feature flag enforcement", () => {
     mockRegisteredTools = new Map();
     mockUnregisteredSkillIds = [];
     mockSkillRefCount = new Map();
-    currentConfig = { featureFlags: {} };
+    currentConfig = {};
     resetSkillToolProjection();
   });
 
@@ -308,7 +304,9 @@ describe("projectSkillTools feature flag enforcement", () => {
     const prevActive = new Map<string, string>();
 
     // Feature flag is OFF
-    currentConfig = { featureFlags: { [DECLARED_LEGACY_KEY]: false } };
+    currentConfig = {
+      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: false },
+    };
 
     const result = projectSkillTools(history, {
       previouslyActiveSkillIds: prevActive,
@@ -329,7 +327,9 @@ describe("projectSkillTools feature flag enforcement", () => {
     const prevActive = new Map<string, string>();
 
     // Feature flag is ON
-    currentConfig = { featureFlags: { [DECLARED_LEGACY_KEY]: true } };
+    currentConfig = {
+      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: true },
+    };
 
     const result = projectSkillTools(history, {
       previouslyActiveSkillIds: prevActive,
@@ -347,8 +347,8 @@ describe("projectSkillTools feature flag enforcement", () => {
     const history = buildHistoryWithMarker(DECLARED_SKILL_ID);
     const prevActive = new Map<string, string>();
 
-    // featureFlags is empty — should default to enabled
-    currentConfig = { featureFlags: {} };
+    // No overrides — should default to enabled
+    currentConfig = {};
 
     const result = projectSkillTools(history, {
       previouslyActiveSkillIds: prevActive,
@@ -414,7 +414,7 @@ describe("projectSkillTools feature flag enforcement", () => {
 
     // Declared skill is OFF, twitter is undeclared with no persisted override so remains ON.
     currentConfig = {
-      featureFlags: { [DECLARED_LEGACY_KEY]: false },
+      assistantFeatureFlagValues: { [DECLARED_FLAG_KEY]: false },
     };
 
     const result = projectSkillTools(history, {

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -127,13 +127,9 @@ export function isAssistantFeatureFlagEnabled(
   const defaults = loadDefaultsRegistry();
   const declared = defaults[key];
 
-  // 1. Check canonical section
-  const newValues = (config as AssistantConfigWithFeatureFlags)
-    .assistantFeatureFlagValues;
-  if (newValues) {
-    const explicit = newValues[key];
-    if (typeof explicit === "boolean") return explicit;
-  }
+  // 1. Check config overrides
+  const explicit = config.assistantFeatureFlagValues?.[key];
+  if (typeof explicit === "boolean") return explicit;
 
   // 2. For declared keys, use the registry default
   if (declared) {
@@ -156,12 +152,4 @@ export function getAssistantFeatureFlagDefaults(): FeatureFlagDefaultsRegistry {
  */
 export function _resetDefaultsCache(): void {
   cachedDefaults = undefined;
-}
-
-// ---------------------------------------------------------------------------
-// Internal type augmentation for the new config field
-// ---------------------------------------------------------------------------
-
-interface AssistantConfigWithFeatureFlags extends AssistantConfig {
-  assistantFeatureFlagValues?: Record<string, boolean>;
 }

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -276,12 +276,6 @@ export const AssistantConfigSchema = z
     ),
     avatar: AvatarConfigSchema.default(AvatarConfigSchema.parse({})),
     ui: UiConfigSchema.default(UiConfigSchema.parse({})),
-    featureFlags: z
-      .record(
-        z.string(),
-        z.boolean({ error: "featureFlags values must be booleans" }),
-      )
-      .default({} as Record<string, boolean>),
     assistantFeatureFlagValues: z
       .record(
         z.string(),

--- a/assistant/src/config/types.ts
+++ b/assistant/src/config/types.ts
@@ -40,22 +40,3 @@ export type {
   UiConfig,
   WorkspaceGitConfig,
 } from "./schema.js";
-
-/**
- * Legacy feature flags section (Record<string, boolean>).
- * Uses the key format `skills.<skillId>.enabled`.
- * Missing key defaults to `true` (enabled); explicit `false` only applies when
- * the corresponding canonical key is declared in the defaults registry.
- *
- * @deprecated Prefer `assistantFeatureFlagValues` with canonical key format
- * `feature_flags.<id>.enabled`. This section is kept for backward compatibility
- * and is still consulted by the resolver as a fallback.
- */
-export type FeatureFlags = Record<string, boolean>;
-
-/**
- * Assistant feature flag values using the canonical key format
- * `feature_flags.<id>.enabled`. Takes priority over the legacy
- * `featureFlags` section during resolution, for declared keys.
- */
-export type AssistantFeatureFlagValues = Record<string, boolean>;


### PR DESCRIPTION
## Summary
- Remove deprecated `featureFlags` config field and `FeatureFlags` type — the legacy `skills.<id>.enabled` key format fallback alongside canonical `feature_flags.<id>.enabled`
- Simplify `isAssistantFeatureFlagEnabled()` to access `config.assistantFeatureFlagValues` directly instead of casting through an internal type augmentation
- Update all test configs from legacy `featureFlags` to canonical `assistantFeatureFlagValues`

## Original prompt
Remove this: Legacy featureFlags config section — assistant/src/config/types.ts:45-53, assistant/src/config/schema.ts:279-284, assistant/src/config/assistant-feature-flags.ts:130-136
    - Old skills.<skillId>.enabled format kept as fallback alongside canonical feature_flags.<id>.enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
