### PR TITLE
feat: emit activity status text before context compaction

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -427,6 +427,13 @@ export async function runAgentLoopImpl(
 
     const isFirstMessage = ctx.messages.length === 1;
 
+    ctx.emitActivityState(
+      "thinking",
+      "thinking_delta",
+      "assistant_turn",
+      reqId,
+      "Compacting context...",
+    );
     const compacted = await ctx.contextWindowManager.maybeCompact(
       ctx.messages,
       abortController.signal,
@@ -670,6 +677,13 @@ export async function runAgentLoopImpl(
         !reducerState.exhausted
       ) {
         preflightAttempts++;
+        ctx.emitActivityState(
+          "thinking",
+          "thinking_delta",
+          "assistant_turn",
+          reqId,
+          "Compacting context...",
+        );
         const step = await reduceContextOverflow(
           ctx.messages,
           {
@@ -860,6 +874,13 @@ export async function runAgentLoopImpl(
           "Context too large — applying next reducer tier",
         );
 
+        ctx.emitActivityState(
+          "thinking",
+          "thinking_delta",
+          "assistant_turn",
+          reqId,
+          "Compacting context...",
+        );
         const step = await reduceContextOverflow(
           ctx.messages,
           {
@@ -1045,6 +1066,13 @@ export async function runAgentLoopImpl(
           }
         } else if (action === "auto_compress_latest_turn") {
           // Non-interactive — auto-compress without asking
+          ctx.emitActivityState(
+            "thinking",
+            "thinking_delta",
+            "assistant_turn",
+            reqId,
+            "Compacting context...",
+          );
           const emergencyCompact = await ctx.contextWindowManager.maybeCompact(
             ctx.messages,
             abortController.signal,


### PR DESCRIPTION
## Summary
- Emit 'Compacting context...' status text via AssistantActivityState at all 4 compaction call sites in session-agent-loop.ts
- Uses existing activity state mechanism — no new event types needed
- Status is naturally overridden by subsequent LLM events

Part of plan: compaction-status-indicator.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
