### PR TITLE
fix: remove trailing ellipsis from compaction statusText

### DIFF
--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -432,7 +432,7 @@ export async function runAgentLoopImpl(
       "thinking_delta",
       "assistant_turn",
       reqId,
-      "Compacting context...",
+      "Compacting context",
     );
     const compacted = await ctx.contextWindowManager.maybeCompact(
       ctx.messages,
@@ -682,7 +682,7 @@ export async function runAgentLoopImpl(
           "thinking_delta",
           "assistant_turn",
           reqId,
-          "Compacting context...",
+          "Compacting context",
         );
         const step = await reduceContextOverflow(
           ctx.messages,
@@ -879,7 +879,7 @@ export async function runAgentLoopImpl(
           "thinking_delta",
           "assistant_turn",
           reqId,
-          "Compacting context...",
+          "Compacting context",
         );
         const step = await reduceContextOverflow(
           ctx.messages,
@@ -1071,7 +1071,7 @@ export async function runAgentLoopImpl(
             "thinking_delta",
             "assistant_turn",
             reqId,
-            "Compacting context...",
+            "Compacting context",
           );
           const emergencyCompact = await ctx.contextWindowManager.maybeCompact(
             ctx.messages,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for compaction-status-indicator.md.

**Gap:** Double-ellipsis on macOS ThinkingIndicatorView
**What was expected:** statusText values should omit trailing ellipsis per codebase convention — the macOS client appends '...' automatically
**What was found:** All 4 compaction status emissions used 'Compacting context...' which would render as 'Compacting context......' on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13943" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
