### PR TITLE
refactor: remove preCompactionFlush config schema

### DIFF
--- a/assistant/src/config/memory-schema.ts
+++ b/assistant/src/config/memory-schema.ts
@@ -376,33 +376,6 @@ export const MemoryCleanupConfigSchema = z.object({
     .default(90),
 });
 
-export const MemoryPreCompactionFlushConfigSchema = z.object({
-  enabled: z
-    .boolean({
-      error: "memory.extraction.preCompactionFlush.enabled must be a boolean",
-    })
-    .default(true),
-  maxMessages: z
-    .number({
-      error:
-        "memory.extraction.preCompactionFlush.maxMessages must be a number",
-    })
-    .int("memory.extraction.preCompactionFlush.maxMessages must be an integer")
-    .positive(
-      "memory.extraction.preCompactionFlush.maxMessages must be a positive integer",
-    )
-    .default(50),
-  timeoutMs: z
-    .number({
-      error: "memory.extraction.preCompactionFlush.timeoutMs must be a number",
-    })
-    .int("memory.extraction.preCompactionFlush.timeoutMs must be an integer")
-    .positive(
-      "memory.extraction.preCompactionFlush.timeoutMs must be a positive integer",
-    )
-    .default(30000),
-});
-
 export const MemoryExtractionConfigSchema = z.object({
   useLLM: z
     .boolean({ error: "memory.extraction.useLLM must be a boolean" })
@@ -417,9 +390,6 @@ export const MemoryExtractionConfigSchema = z.object({
       error: "memory.extraction.extractFromAssistant must be a boolean",
     })
     .default(true),
-  preCompactionFlush: MemoryPreCompactionFlushConfigSchema.default(
-    MemoryPreCompactionFlushConfigSchema.parse({}),
-  ),
 });
 
 export const MemoryEntityConfigSchema = z.object({
@@ -636,9 +606,6 @@ export type MemoryRetentionConfig = z.infer<typeof MemoryRetentionConfigSchema>;
 export type MemoryCleanupConfig = z.infer<typeof MemoryCleanupConfigSchema>;
 export type MemoryExtractionConfig = z.infer<
   typeof MemoryExtractionConfigSchema
->;
-export type MemoryPreCompactionFlushConfig = z.infer<
-  typeof MemoryPreCompactionFlushConfigSchema
 >;
 export type MemorySummarizationConfig = z.infer<
   typeof MemorySummarizationConfigSchema


### PR DESCRIPTION
## Summary
- Removes `MemoryPreCompactionFlushConfigSchema` zod object
- Removes `preCompactionFlush` field from extraction config
- Removes `MemoryPreCompactionFlushConfig` type export

Part of plan: remove-precompact-flush.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
