### PR TITLE
refactor: remove unused SKILL_FLAG_KEY_OVERRIDES from skill-state

### DIFF
--- a/assistant/src/config/skill-state.ts
+++ b/assistant/src/config/skill-state.ts
@@ -13,20 +13,14 @@ export interface ResolvedSkill {
   configEntry?: SkillEntryConfig;
 }
 
-// Skill IDs whose feature flag key differs from the default
-// `feature_flags.<skillId>.enabled` derivation.
-const SKILL_FLAG_KEY_OVERRIDES: Record<string, string> = {};
-
 /**
- * Derive the feature flag key for a given skill ID, respecting overrides.
+ * Derive the feature flag key for a given skill ID.
  *
  * Exported so other modules (system-prompt, session-skill-tools, skill loader)
- * can perform the same mapping without duplicating the override table.
+ * can perform the same mapping.
  */
 export function skillFlagKey(skillId: string): string {
-  return (
-    SKILL_FLAG_KEY_OVERRIDES[skillId] ?? `feature_flags.${skillId}.enabled`
-  );
+  return `feature_flags.${skillId}.enabled`;
 }
 
 export function resolveSkillStates(


### PR DESCRIPTION
## Summary
- Remove the empty `SKILL_FLAG_KEY_OVERRIDES` map and its lookup in `skillFlagKey()`
- `skillFlagKey()` now directly returns the canonical `feature_flags.<id>.enabled` key

Part of plan: prelaunch-deprecation-cleanup.md (PR 1 of 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13947" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
