### PR TITLE
refactor: remove dead invalidAttempts/windowStartedAt columns

### DIFF
--- a/assistant/src/memory/guardian-rate-limits.ts
+++ b/assistant/src/memory/guardian-rate-limits.ts
@@ -151,9 +151,6 @@ export function recordInvalidAttempt(
     channel,
     actorExternalUserId,
     actorChatId,
-    // Legacy columns kept for backward compatibility with upgraded databases
-    invalidAttempts: 0,
-    windowStartedAt: 0,
     attemptTimestampsJson: JSON.stringify(timestamps),
     lockedUntil,
     createdAt: now,

--- a/assistant/src/memory/schema/calls.ts
+++ b/assistant/src/memory/schema/calls.ts
@@ -148,10 +148,6 @@ export const channelGuardianRateLimits = sqliteTable(
     channel: text("channel").notNull(),
     actorExternalUserId: text("actor_external_user_id").notNull(),
     actorChatId: text("actor_chat_id").notNull(),
-    // Legacy columns kept with defaults for backward compatibility with upgraded databases
-    // that still have the old NOT NULL columns without DEFAULT. Not read by app logic.
-    invalidAttempts: integer("invalid_attempts").notNull().default(0),
-    windowStartedAt: integer("window_started_at").notNull().default(0),
     attemptTimestampsJson: text("attempt_timestamps_json")
       .notNull()
       .default("[]"),


### PR DESCRIPTION
## Summary
- Remove dead `invalidAttempts` and `windowStartedAt` columns from guardian rate limits schema
- Remove dead column writes in `recordInvalidAttempt()`
- These columns were never read by app logic

Part of plan: prelaunch-deprecation-cleanup.md (PR 2 of 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
