### PR TITLE
refactor: remove legacy activation_key parameter from voice-config

### DIFF
--- a/assistant/src/tools/system/voice-config.ts
+++ b/assistant/src/tools/system/voice-config.ts
@@ -153,12 +153,6 @@ export class VoiceConfigUpdateTool implements Tool {
             description:
               "The new value for the setting (type depends on setting)",
           },
-          // Backward compat: legacy schema used activation_key directly
-          activation_key: {
-            type: "string",
-            description:
-              'Deprecated — use setting: "activation_key" with value instead',
-          },
           reason: {
             type: "string",
             description:
@@ -173,14 +167,8 @@ export class VoiceConfigUpdateTool implements Tool {
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    // Backward compat: if activation_key is provided without setting/value, treat as setting: "activation_key"
-    let setting = input.setting as string | undefined;
-    let value = input.value;
-
-    if (!setting && typeof input.activation_key === "string") {
-      setting = "activation_key";
-      value = input.activation_key;
-    }
+    const setting = input.setting as string | undefined;
+    const value = input.value;
 
     if (!setting) {
       return {


### PR DESCRIPTION
## Summary
- Remove deprecated `activation_key` parameter from voice-config tool schema
- Remove fallback logic that converted `activation_key` to `setting`/`value`

Part of plan: prelaunch-deprecation-cleanup.md (PR 5 of 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
