### PR TITLE
refactor: make guardian action expiry reason required

### DIFF
--- a/assistant/src/__tests__/guardian-action-followup-store.test.ts
+++ b/assistant/src/__tests__/guardian-action-followup-store.test.ts
@@ -375,18 +375,8 @@ describe("guardian-action-followup-store", () => {
     expect(resolved!.expiredReason).toBeNull();
   });
 
-  test("expireGuardianActionRequest defaults to sweep_timeout reason", () => {
+  test("expireGuardianActionRequest sets explicit reason", () => {
     const request = createTestRequest("conv-followup-19");
-
-    expireGuardianActionRequest(request.id);
-
-    const reloaded = getGuardianActionRequest(request.id);
-    expect(reloaded!.status).toBe("expired");
-    expect(reloaded!.expiredReason).toBe("sweep_timeout");
-  });
-
-  test("expireGuardianActionRequest accepts explicit reason", () => {
-    const request = createTestRequest("conv-followup-20");
 
     expireGuardianActionRequest(request.id, "call_timeout");
 

--- a/assistant/src/memory/guardian-action-store.ts
+++ b/assistant/src/memory/guardian-action-store.ts
@@ -301,11 +301,10 @@ export function resolveGuardianActionRequest(
 
 /**
  * Expire a guardian action request and all its deliveries.
- * When reason is not provided, defaults to 'sweep_timeout' for backward compatibility.
  */
 export function expireGuardianActionRequest(
   id: string,
-  reason?: ExpiredReason,
+  reason: ExpiredReason,
 ): void {
   const db = getDb();
   const now = Date.now();
@@ -313,7 +312,7 @@ export function expireGuardianActionRequest(
   db.update(guardianActionRequests)
     .set({
       status: "expired",
-      expiredReason: reason ?? "sweep_timeout",
+      expiredReason: reason,
       updatedAt: now,
     })
     .where(


### PR DESCRIPTION
## Summary
- Make `reason` parameter required in `expireGuardianActionRequest()`
- Remove `?? "sweep_timeout"` default fallback
- Remove test for default reason behavior, consolidate into explicit reason test

Part of plan: prelaunch-deprecation-cleanup.md (PR 7 of 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
