### PR TITLE
refactor: remove deprecated baseDataDir from CLI assistant-config

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -724,8 +724,6 @@ async function hatchLocal(
     resources = await allocateLocalResources(instanceName);
   }
 
-  const baseDataDir = join(resources.instanceDir, ".vellum");
-
   console.log(`🥚 Hatching local assistant: ${instanceName}`);
   console.log(`   Species: ${species}`);
   console.log("");
@@ -761,7 +759,6 @@ async function hatchLocal(
     assistantId: instanceName,
     runtimeUrl,
     localUrl: `http://127.0.0.1:${resources.gatewayPort}`,
-    baseDataDir,
     bearerToken,
     cloud: "local",
     species,

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -45,11 +45,8 @@ function extractHostFromUrl(url: string): string {
 async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   console.log("\u{1F5D1}\ufe0f  Stopping local assistant...\n");
 
-  // Use entry resources when available; for legacy entries, derive paths
-  // from baseDataDir (which may differ from homedir if BASE_DATA_DIR was set).
   const resources = entry.resources ?? defaultLocalResources();
-  const legacyDir = entry.baseDataDir;
-  const vellumDir = legacyDir ?? join(resources.instanceDir, ".vellum");
+  const vellumDir = join(resources.instanceDir, ".vellum");
 
   // Check whether another local assistant shares the same data directory.
   // Legacy entries without `resources` all resolve to ~/.vellum/ — if we
@@ -58,9 +55,10 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   const otherSharesDir = loadAllAssistants().some((other) => {
     if (other.cloud !== "local") return false;
     if (other.assistantId === name) return false;
-    const otherVellumDir =
-      other.baseDataDir ??
-      join((other.resources ?? defaultLocalResources()).instanceDir, ".vellum");
+    const otherVellumDir = join(
+      (other.resources ?? defaultLocalResources()).instanceDir,
+      ".vellum",
+    );
     return otherVellumDir === vellumDir;
   });
 
@@ -72,14 +70,8 @@ async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
     return;
   }
 
-  // Stop daemon via PID file — prefer resources paths, but for legacy entries
-  // with a custom baseDataDir, derive from that directory instead.
-  const daemonPidFile = legacyDir
-    ? join(legacyDir, "vellum.pid")
-    : resources.pidFile;
-  const socketFile = legacyDir
-    ? join(legacyDir, "vellum.sock")
-    : resources.socketPath;
+  const daemonPidFile = resources.pidFile;
+  const socketFile = resources.socketPath;
   const daemonStopped = await stopProcessByPidFile(daemonPidFile, "daemon", [
     socketFile,
   ]);

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -16,7 +16,7 @@ type ActiveCallLease = {
 
 function getAssistantRootDir(entry: AssistantEntry): string {
   const resources = entry.resources ?? defaultLocalResources();
-  return entry.baseDataDir ?? join(resources.instanceDir, ".vellum");
+  return join(resources.instanceDir, ".vellum");
 }
 
 function readActiveCallLeases(vellumDir: string): ActiveCallLease[] {
@@ -35,7 +35,8 @@ function readActiveCallLeases(vellumDir: string): ActiveCallLease[] {
 
   return raw.leases.filter(
     (lease): lease is ActiveCallLease =>
-      typeof lease?.callSessionId === "string" && lease.callSessionId.length > 0
+      typeof lease?.callSessionId === "string" &&
+      lease.callSessionId.length > 0,
   );
 }
 
@@ -48,12 +49,12 @@ export async function sleep(): Promise<void> {
     console.log("");
     console.log("Arguments:");
     console.log(
-      "  <name>    Name of the assistant to stop (default: active or only local)"
+      "  <name>    Name of the assistant to stop (default: active or only local)",
     );
     console.log("");
     console.log("Options:");
     console.log(
-      "  --force   Stop the assistant even if a phone call keepalive lease is active"
+      "  --force   Stop the assistant even if a phone call keepalive lease is active",
     );
     process.exit(0);
   }
@@ -64,7 +65,7 @@ export async function sleep(): Promise<void> {
 
   if (entry.cloud && entry.cloud !== "local") {
     console.error(
-      `Error: 'vellum sleep' only works with local assistants. '${entry.assistantId}' is a ${entry.cloud} instance.`
+      `Error: 'vellum sleep' only works with local assistants. '${entry.assistantId}' is a ${entry.cloud} instance.`,
     );
     process.exit(1);
   }
@@ -82,12 +83,12 @@ export async function sleep(): Promise<void> {
         const activeCallLeases = readActiveCallLeases(vellumDir);
         if (activeCallLeases.length > 0) {
           const activeIds = activeCallLeases.map(
-            (lease) => lease.callSessionId
+            (lease) => lease.callSessionId,
           );
           console.error(
             `Error: assistant is staying awake for active phone calls (${activeIds.join(
-              ", "
-            )}). Use 'vellum sleep --force' to stop it anyway.`
+              ", ",
+            )}). Use 'vellum sleep --force' to stop it anyway.`,
           );
           process.exit(1);
         }
@@ -95,7 +96,7 @@ export async function sleep(): Promise<void> {
         console.error(
           `Error: ${
             err instanceof Error ? err.message : String(err)
-          }. Use 'vellum sleep --force' to override if you want to stop the assistant anyway.`
+          }. Use 'vellum sleep --force' to override if you want to stop the assistant anyway.`,
         );
         process.exit(1);
       }
@@ -105,7 +106,7 @@ export async function sleep(): Promise<void> {
   const assistantStopped = await stopProcessByPidFile(
     assistantPidFile,
     "assistant",
-    [socketFile]
+    [socketFile],
   );
   if (!assistantStopped) {
     console.log("Assistant is not running.");
@@ -119,7 +120,7 @@ export async function sleep(): Promise<void> {
     gatewayPidFile,
     "gateway",
     undefined,
-    7000
+    7000,
   );
   if (!gatewayStopped) {
     console.log("Gateway is not running.");

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -21,8 +21,7 @@ export interface LocalInstanceResources {
    * `~/.local/share/vellum/assistants/<name>/` (workspace at
    * `~/.local/share/vellum/assistants/<name>/.vellum`).
    * The daemon's `.vellum/` directory lives inside it. Equivalent to
-   * `AssistantEntry.baseDataDir` minus the trailing `/.vellum` suffix —
-   * `baseDataDir` is kept on the flat entry for legacy lockfile compat.
+   * The daemon's `.vellum/` directory lives inside it.
    */
   instanceDir: string;
   /** HTTP port for the daemon runtime server */
@@ -43,8 +42,6 @@ export interface AssistantEntry {
   /** Loopback URL for same-machine health checks (e.g. `http://127.0.0.1:7831`).
    *  Avoids mDNS resolution issues when the machine checks its own gateway. */
   localUrl?: string;
-  /** @deprecated Use `resources.instanceDir` for multi-instance entries. Legacy equivalent of `join(instanceDir, ".vellum")`. */
-  baseDataDir?: string;
   bearerToken?: string;
   cloud: string;
   instanceId?: string;


### PR DESCRIPTION
## Summary
- Remove `baseDataDir` field from `AssistantEntry` interface
- Update hatch, sleep, and retire commands to always derive from `resources.instanceDir`

Part of plan: prelaunch-deprecation-cleanup.md (PR 15 of 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
