### PR TITLE
refactor: remove legacyAddress dedup fallback from contact-store

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -91,8 +91,6 @@ interface SyncChannelData {
   isPrimary?: boolean;
   externalUserId?: string | null;
   externalChatId?: string | null;
-  /** Raw (pre-canonicalization) address used for dedup fallback when matching contacts created before address normalization. */
-  legacyAddress?: string;
   status?: ChannelStatus;
   policy?: ChannelPolicy;
   verifiedAt?: number | null;
@@ -185,7 +183,7 @@ export function upsertContact(params: {
   if (!contactId && params.channels && params.channels.length > 0) {
     for (const ch of params.channels) {
       // Primary lookup: match by (type, address)
-      let existingChannel = db
+      const existingChannel = db
         .select()
         .from(contactChannels)
         .where(
@@ -195,27 +193,6 @@ export function upsertContact(params: {
           ),
         )
         .get();
-
-      // Fallback: if the address was canonicalized, the old record may still
-      // have the raw (non-canonical) address stored. Try matching by
-      // legacyAddress so we update the existing contact instead of creating
-      // a duplicate.
-      if (
-        !existingChannel &&
-        ch.legacyAddress &&
-        ch.legacyAddress.toLowerCase() !== ch.address.toLowerCase()
-      ) {
-        existingChannel = db
-          .select()
-          .from(contactChannels)
-          .where(
-            and(
-              eq(contactChannels.type, ch.type),
-              eq(contactChannels.address, ch.legacyAddress.toLowerCase()),
-            ),
-          )
-          .get();
-      }
 
       if (existingChannel) {
         contactId = existingChannel.contactId;
@@ -283,7 +260,7 @@ function syncChannels(
     const normalizedAddress = ch.address.toLowerCase();
 
     // Check if this channel already exists for this contact
-    let existing = db
+    const existing = db
       .select()
       .from(contactChannels)
       .where(
@@ -294,26 +271,6 @@ function syncChannels(
         ),
       )
       .get();
-
-    // Fallback: the channel may have been stored with a pre-canonicalization
-    // address. Try matching by legacyAddress to find it.
-    if (
-      !existing &&
-      ch.legacyAddress &&
-      ch.legacyAddress.toLowerCase() !== normalizedAddress
-    ) {
-      existing = db
-        .select()
-        .from(contactChannels)
-        .where(
-          and(
-            eq(contactChannels.contactId, contactId),
-            eq(contactChannels.type, ch.type),
-            eq(contactChannels.address, ch.legacyAddress.toLowerCase()),
-          ),
-        )
-        .get();
-    }
 
     if (existing) {
       const updateSet: Record<string, unknown> = {};

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -180,10 +180,6 @@ export function upsertContactChannel(params: {
         address,
         externalUserId: canonicalId,
         externalChatId: params.externalChatId ?? null,
-        legacyAddress:
-          params.externalUserId && params.externalUserId !== address
-            ? params.externalUserId
-            : undefined,
         status: (params.status as ChannelStatus) ?? undefined,
         policy: (params.policy as ChannelPolicy) ?? undefined,
         inviteId: params.inviteId ?? null,


### PR DESCRIPTION
## Summary
- Remove `legacyAddress` field from `SyncChannelData` interface
- Remove both fallback lookup blocks in `upsertContact()` and `syncChannels()`
- Remove `legacyAddress` usage from the caller in `contacts-write.ts`

Part of plan: prelaunch-deprecation-cleanup.md (PR 4 of 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
