### PR TITLE
refactor: remove legacy unscoped channel keys from delivery-crud

### DIFF
--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -164,22 +164,12 @@ describe("channel-delivery-store", () => {
     expect(r1.conversationId).not.toBe(r2.conversationId);
   });
 
-  test("self assistant reuses legacy key and creates scoped alias", () => {
-    // Create a conversation via the legacy (no assistantId) path
-    const legacy = recordInbound("telegram", "chat-1", "msg-1");
-
-    // Now use assistantId='self' — should reuse the legacy conversation
-    const scoped = recordInbound("telegram", "chat-1", "msg-2", {
+  test("no assistantId defaults to self-scoped key", () => {
+    const r1 = recordInbound("telegram", "chat-1", "msg-1");
+    const r2 = recordInbound("telegram", "chat-1", "msg-2", {
       assistantId: "self",
     });
-    expect(scoped.conversationId).toBe(legacy.conversationId);
-
-    // The scoped alias key should exist, so subsequent calls with 'self'
-    // resolve directly without falling back to the legacy key
-    const again = recordInbound("telegram", "chat-1", "msg-3", {
-      assistantId: "self",
-    });
-    expect(again.conversationId).toBe(legacy.conversationId);
+    expect(r1.conversationId).toBe(r2.conversationId);
   });
 
   // ── Deduplication ─────────────────────────────────────────────────

--- a/assistant/src/memory/delivery-crud.ts
+++ b/assistant/src/memory/delivery-crud.ts
@@ -9,11 +9,7 @@ import { and, desc, eq, isNotNull } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
-import {
-  getConversationByKey,
-  getOrCreateConversation,
-  setConversationKeyIfAbsent,
-} from "./conversation-key-store.js";
+import { getOrCreateConversation } from "./conversation-key-store.js";
 import { getDb } from "./db.js";
 import { channelInboundEvents, conversations } from "./schema.js";
 
@@ -65,35 +61,9 @@ export function recordInbound(
     };
   }
 
-  const assistantId = options?.assistantId;
-  const legacyKey = `${sourceChannel}:${externalChatId}`;
-  const scopedKey = assistantId
-    ? `asst:${assistantId}:${sourceChannel}:${externalChatId}`
-    : legacyKey;
-
-  // Resolve conversation mapping with assistant-scoped keying:
-  // 1. If scoped key exists, use it directly.
-  // 2. If assistantId is "self" and legacy key exists, reuse the legacy
-  //    conversation and create a scoped alias to prevent future bleed.
-  // 3. Otherwise, create/get conversation from the scoped key.
-  let mapping: { conversationId: string; created: boolean };
-  const scopedMapping = assistantId ? getConversationByKey(scopedKey) : null;
-  if (scopedMapping) {
-    mapping = { conversationId: scopedMapping.conversationId, created: false };
-  } else if (assistantId === DAEMON_INTERNAL_ASSISTANT_ID) {
-    const legacyMapping = getConversationByKey(legacyKey);
-    if (legacyMapping) {
-      mapping = {
-        conversationId: legacyMapping.conversationId,
-        created: false,
-      };
-      setConversationKeyIfAbsent(scopedKey, legacyMapping.conversationId);
-    } else {
-      mapping = getOrCreateConversation(scopedKey);
-    }
-  } else {
-    mapping = getOrCreateConversation(scopedKey);
-  }
+  const assistantId = options?.assistantId ?? DAEMON_INTERNAL_ASSISTANT_ID;
+  const scopedKey = `asst:${assistantId}:${sourceChannel}:${externalChatId}`;
+  const mapping = getOrCreateConversation(scopedKey);
   const now = Date.now();
   const eventId = uuid();
 


### PR DESCRIPTION
## Summary
- Remove legacy unscoped channel key fallback path
- All channel keys now always use `asst:` prefix scoping

Part of plan: prelaunch-deprecation-cleanup.md (PR 11 of 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
