### PR TITLE
refactor: remove backwards-compat re-exports from headless-browser

### DIFF
--- a/assistant/src/__tests__/browser-fill-credential.test.ts
+++ b/assistant/src/__tests__/browser-fill-credential.test.ts
@@ -76,7 +76,7 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
   _setMetadataPath: () => {},
 }));
 
-import { executeBrowserFillCredential } from "../tools/browser/headless-browser.js";
+import { executeBrowserFillCredential } from "../tools/browser/browser-execution.js";
 import type { ToolContext } from "../tools/types.js";
 
 const ctx: ToolContext = {

--- a/assistant/src/__tests__/headless-browser-interactions.test.ts
+++ b/assistant/src/__tests__/headless-browser-interactions.test.ts
@@ -77,7 +77,7 @@ import {
   executeBrowserSelectOption,
   executeBrowserSnapshot,
   executeBrowserType,
-} from "../tools/browser/headless-browser.js";
+} from "../tools/browser/browser-execution.js";
 import type { ToolContext } from "../tools/types.js";
 
 const ctx: ToolContext = {

--- a/assistant/src/__tests__/headless-browser-navigate.test.ts
+++ b/assistant/src/__tests__/headless-browser-navigate.test.ts
@@ -52,7 +52,7 @@ mock.module("../tools/network/url-safety.js", () => ({
   sanitizeUrlForOutput: (url: URL) => url.href,
 }));
 
-import { executeBrowserNavigate } from "../tools/browser/headless-browser.js";
+import { executeBrowserNavigate } from "../tools/browser/browser-execution.js";
 import type { ToolContext } from "../tools/types.js";
 
 const ctx: ToolContext = {

--- a/assistant/src/__tests__/headless-browser-read-tools.test.ts
+++ b/assistant/src/__tests__/headless-browser-read-tools.test.ts
@@ -61,7 +61,7 @@ import {
   executeBrowserExtract,
   executeBrowserPressKey,
   executeBrowserWaitFor,
-} from "../tools/browser/headless-browser.js";
+} from "../tools/browser/browser-execution.js";
 import type { ToolContext } from "../tools/types.js";
 
 const ctx: ToolContext = {

--- a/assistant/src/__tests__/headless-browser-snapshot.test.ts
+++ b/assistant/src/__tests__/headless-browser-snapshot.test.ts
@@ -60,7 +60,7 @@ mock.module("../tools/network/url-safety.js", () => ({
 import {
   executeBrowserClose,
   executeBrowserSnapshot,
-} from "../tools/browser/headless-browser.js";
+} from "../tools/browser/browser-execution.js";
 import type { ToolContext } from "../tools/types.js";
 
 const ctx: ToolContext = {

--- a/assistant/src/tools/browser/headless-browser.ts
+++ b/assistant/src/tools/browser/headless-browser.ts
@@ -654,20 +654,3 @@ class BrowserFillCredentialTool implements Tool {
 }
 
 registerTool(new BrowserFillCredentialTool());
-
-// Re-export execution functions for backward compatibility
-export {
-  executeBrowserClick,
-  executeBrowserClose,
-  executeBrowserExtract,
-  executeBrowserFillCredential,
-  executeBrowserHover,
-  executeBrowserNavigate,
-  executeBrowserPressKey,
-  executeBrowserScreenshot,
-  executeBrowserScroll,
-  executeBrowserSelectOption,
-  executeBrowserSnapshot,
-  executeBrowserType,
-  executeBrowserWaitFor,
-} from "./browser-execution.js";


### PR DESCRIPTION
## Summary
- Remove re-export block from bottom of `headless-browser.ts`
- Update 5 test files to import `executeBrowser*` from `browser-execution.js` directly

Part of plan: prelaunch-deprecation-cleanup.md (PR 18 of 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13956" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
