### PR TITLE
refactor: move display-order functions from conversation-store to sub-module

### DIFF
--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -11,7 +11,8 @@ import { getLogger } from "../util/logger.js";
 import { createRowMapper } from "../util/row-mapper.js";
 import { deleteOrphanAttachments } from "./attachments-store.js";
 import { projectAssistantMessage } from "./conversation-attention-store.js";
-import { getDb, rawExec, rawGet } from "./db.js";
+import { ensureDisplayOrderMigration } from "./conversation-display-order-migration.js";
+import { getDb, rawExec, rawGet, rawRun } from "./db.js";
 import { indexMessageNow } from "./indexer.js";
 import {
   channelInboundEvents,
@@ -892,4 +893,55 @@ export function getConversationRecentProvenanceTrustClass(
   } catch {
     return undefined;
   }
+}
+
+// ---------------------------------------------------------------------------
+// CRUD functions for display_order and is_pinned
+// ---------------------------------------------------------------------------
+
+export function batchSetDisplayOrders(
+  updates: Array<{
+    id: string;
+    displayOrder: number | null;
+    isPinned: boolean;
+  }>,
+): void {
+  ensureDisplayOrderMigration();
+  rawExec("BEGIN");
+  try {
+    for (const update of updates) {
+      rawRun(
+        "UPDATE conversations SET display_order = ?, is_pinned = ? WHERE id = ?",
+        update.displayOrder,
+        update.isPinned ? 1 : 0,
+        update.id,
+      );
+    }
+    rawExec("COMMIT");
+  } catch (err) {
+    rawExec("ROLLBACK");
+    throw err;
+  }
+}
+
+export function getDisplayMetaForConversations(
+  conversationIds: string[],
+): Map<string, { displayOrder: number | null; isPinned: boolean }> {
+  ensureDisplayOrderMigration();
+  const result = new Map<
+    string,
+    { displayOrder: number | null; isPinned: boolean }
+  >();
+  if (conversationIds.length === 0) return result;
+  for (const id of conversationIds) {
+    const row = rawGet<{
+      display_order: number | null;
+      is_pinned: number | null;
+    }>("SELECT display_order, is_pinned FROM conversations WHERE id = ?", id);
+    result.set(id, {
+      displayOrder: row?.display_order ?? null,
+      isPinned: (row?.is_pinned ?? 0) === 1,
+    });
+  }
+  return result;
 }

--- a/assistant/src/memory/conversation-store.ts
+++ b/assistant/src/memory/conversation-store.ts
@@ -1,11 +1,9 @@
 // Re-export all conversation store functionality from focused sub-modules.
 // Existing imports from this file continue to work without changes.
 
-import { ensureDisplayOrderMigration } from "./conversation-display-order-migration.js";
-import { rawExec, rawGet, rawRun } from "./db.js";
-
 export {
   addMessage,
+  batchSetDisplayOrders,
   clearAll,
   type ConversationRow,
   createConversation,
@@ -19,6 +17,7 @@ export {
   getConversationOriginInterface,
   getConversationRecentProvenanceTrustClass,
   getConversationThreadType,
+  getDisplayMetaForConversations,
   getMessageById,
   getMessages,
   type MessageMetadata,
@@ -46,57 +45,3 @@ export {
   type PaginatedMessagesResult,
   searchConversations,
 } from "./conversation-queries.js";
-
-// Re-export for backward compat — callers that imported ensureColumns from here
-export { ensureDisplayOrderMigration as ensureColumns } from "./conversation-display-order-migration.js";
-
-// ---------------------------------------------------------------------------
-// CRUD functions for display_order and is_pinned
-// ---------------------------------------------------------------------------
-
-export function batchSetDisplayOrders(
-  updates: Array<{
-    id: string;
-    displayOrder: number | null;
-    isPinned: boolean;
-  }>,
-): void {
-  ensureDisplayOrderMigration();
-  rawExec("BEGIN");
-  try {
-    for (const update of updates) {
-      rawRun(
-        "UPDATE conversations SET display_order = ?, is_pinned = ? WHERE id = ?",
-        update.displayOrder,
-        update.isPinned ? 1 : 0,
-        update.id,
-      );
-    }
-    rawExec("COMMIT");
-  } catch (err) {
-    rawExec("ROLLBACK");
-    throw err;
-  }
-}
-
-export function getDisplayMetaForConversations(
-  conversationIds: string[],
-): Map<string, { displayOrder: number | null; isPinned: boolean }> {
-  ensureDisplayOrderMigration();
-  const result = new Map<
-    string,
-    { displayOrder: number | null; isPinned: boolean }
-  >();
-  if (conversationIds.length === 0) return result;
-  for (const id of conversationIds) {
-    const row = rawGet<{
-      display_order: number | null;
-      is_pinned: number | null;
-    }>("SELECT display_order, is_pinned FROM conversations WHERE id = ?", id);
-    result.set(id, {
-      displayOrder: row?.display_order ?? null,
-      isPinned: (row?.is_pinned ?? 0) === 1,
-    });
-  }
-  return result;
-}


### PR DESCRIPTION
## Summary
- Move `batchSetDisplayOrders()` and `getDisplayMetaForConversations()` to `conversation-crud.ts`
- Replace with re-exports in `conversation-store.ts` (temporary until barrel deletion)
- Remove unused `ensureColumns` compat alias

Part of plan: prelaunch-deprecation-cleanup.md (PR 21 of 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
