### PR TITLE
refactor: remove legacy secure-key credential fallback from twilio-rest

### DIFF
--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -34,13 +34,15 @@ let mockAuthToken: string | undefined = "test-auth-token-secret";
 let mockAccountSid: string | undefined = "AC_test_account";
 
 mock.module("../config/loader.js", () => ({
-  loadConfig: () => ({ twilio: { accountSid: mockAccountSid } }),
+  loadConfig: () => ({
+    twilio: { accountSid: mockAccountSid, authToken: mockAuthToken },
+  }),
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (account: string) => {
-    if (account === "credential:twilio:auth_token") return mockAuthToken;
-    if (account === "credential:twilio:account_sid") return mockAccountSid;
+  getSecureKey: (key: string) => {
+    if (key === "credential:twilio:auth_token") return mockAuthToken;
+    if (key === "credential:twilio:account_sid") return mockAccountSid;
     return undefined;
   },
 }));

--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -7,7 +7,6 @@
  */
 
 import { loadConfig } from "../config/loader.js";
-import { getSecureKey } from "../security/secure-keys.js";
 import { ConfigError, ProviderError } from "../util/errors.js";
 
 export interface TwilioCredentials {
@@ -15,28 +14,25 @@ export interface TwilioCredentials {
   authToken: string;
 }
 
-/**
- * Resolve the Twilio Account SID from config, falling back to the secure
- * key store for backward compatibility with users who configured credentials
- * before the config migration.
- */
+/** Resolve the Twilio Account SID from config. */
 function resolveAccountSid(): string | undefined {
   try {
     const config = loadConfig();
-    if (config.twilio?.accountSid) return config.twilio.accountSid;
+    return config.twilio?.accountSid || undefined;
   } catch {
     // Config may not be available during early startup
+    return undefined;
   }
-  return getSecureKey("credential:twilio:account_sid") || undefined;
 }
 
-/** Resolve Twilio credentials from config and secure key store. Throws if not configured. */
+/** Resolve Twilio credentials from config. Throws if not configured. */
 export function getTwilioCredentials(): TwilioCredentials {
   const accountSid = resolveAccountSid();
-  const authToken = getSecureKey("credential:twilio:auth_token");
+  const config = loadConfig();
+  const authToken = config.twilio?.authToken || undefined;
   if (!accountSid || !authToken) {
     throw new ConfigError(
-      "Twilio credentials not configured. Set twilio.accountSid via config and credential:twilio:auth_token via the credential_store tool.",
+      "Twilio credentials not configured. Set twilio.accountSid and twilio.authToken via config.",
     );
   }
   return { accountSid, authToken };
@@ -44,9 +40,12 @@ export function getTwilioCredentials(): TwilioCredentials {
 
 /** Check whether Twilio credentials are present (non-throwing). */
 export function hasTwilioCredentials(): boolean {
-  return (
-    !!resolveAccountSid() && !!getSecureKey("credential:twilio:auth_token")
-  );
+  try {
+    const config = loadConfig();
+    return !!resolveAccountSid() && !!config.twilio?.authToken;
+  } catch {
+    return false;
+  }
 }
 
 /** Build the HTTP Basic auth header for Twilio API requests. */

--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -236,6 +236,9 @@ export const TwilioConfigSchema = z.object({
   accountSid: z
     .string({ error: "twilio.accountSid must be a string" })
     .default(""),
+  authToken: z
+    .string({ error: "twilio.authToken must be a string" })
+    .default(""),
   phoneNumber: z
     .string({ error: "twilio.phoneNumber must be a string" })
     .default(""),


### PR DESCRIPTION
## Summary
- Remove `getSecureKey()` fallback for Twilio account SID and auth token in `twilio-rest.ts`
- Credentials are now read exclusively from config
- Added `authToken` field to `TwilioConfigSchema` so auth token can be stored in config
- Updated `twilio-provider.test.ts` mock to provide `authToken` via config

Part of plan: prelaunch-deprecation-cleanup.md (PR 9 of 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
