### PR TITLE
refactor: migrate test ipc-contract imports to ipc-protocol

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -103,7 +103,7 @@ import type { HandlerContext } from "../daemon/handlers/shared.js";
 import type {
   ChannelVerificationSessionRequest,
   ChannelVerificationSessionResponse,
-} from "../daemon/ipc-contract.js";
+} from "../daemon/ipc-protocol.js";
 import {
   bindSessionIdentity as _storeBindSessionIdentity,
   consumeSession,

--- a/assistant/src/__tests__/handlers-add-trust-rule-metadata.test.ts
+++ b/assistant/src/__tests__/handlers-add-trust-rule-metadata.test.ts
@@ -67,8 +67,8 @@ mock.module("../config/loader.js", () => ({
 
 import type { HandlerContext } from "../daemon/handlers.js";
 import { handleAddTrustRule } from "../daemon/handlers/config.js";
-import type { AddTrustRule } from "../daemon/ipc-contract.js";
-import type { ServerMessage } from "../daemon/ipc-contract.js";
+import type { AddTrustRule } from "../daemon/ipc-protocol.js";
+import type { ServerMessage } from "../daemon/ipc-protocol.js";
 import {
   clearAllRules,
   clearCache,

--- a/assistant/src/__tests__/handlers-cu-observation-blob.test.ts
+++ b/assistant/src/__tests__/handlers-cu-observation-blob.test.ts
@@ -54,7 +54,7 @@ import type {
   CuObservation,
   IpcBlobRef,
   ServerMessage,
-} from "../daemon/ipc-contract.js";
+} from "../daemon/ipc-protocol.js";
 import { DebouncerMap } from "../util/debounce.js";
 
 /** Poll until a predicate is true or timeout (default 2s). */

--- a/assistant/src/__tests__/handlers-ipc-blob-probe.test.ts
+++ b/assistant/src/__tests__/handlers-ipc-blob-probe.test.ts
@@ -43,7 +43,7 @@ mock.module("../util/logger.js", () => ({
 }));
 
 import { handleMessage, type HandlerContext } from "../daemon/handlers.js";
-import type { IpcBlobProbe, ServerMessage } from "../daemon/ipc-contract.js";
+import type { IpcBlobProbe, ServerMessage } from "../daemon/ipc-protocol.js";
 import { DebouncerMap } from "../util/debounce.js";
 
 /** Write a probe file to the test blob directory. */

--- a/assistant/src/__tests__/handlers-slack-config.test.ts
+++ b/assistant/src/__tests__/handlers-slack-config.test.ts
@@ -59,7 +59,7 @@ import { handleMessage, type HandlerContext } from "../daemon/handlers.js";
 import type {
   ServerMessage,
   SlackWebhookConfigRequest,
-} from "../daemon/ipc-contract.js";
+} from "../daemon/ipc-protocol.js";
 import { DebouncerMap } from "../util/debounce.js";
 
 function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {

--- a/assistant/src/__tests__/handlers-telegram-config.test.ts
+++ b/assistant/src/__tests__/handlers-telegram-config.test.ts
@@ -154,7 +154,7 @@ import { handleTelegramConfig } from "../daemon/handlers/config.js";
 import type {
   ServerMessage,
   TelegramConfigRequest,
-} from "../daemon/ipc-contract.js";
+} from "../daemon/ipc-protocol.js";
 import { initializeDb, resetDb } from "../memory/db.js";
 import { DebouncerMap } from "../util/debounce.js";
 
@@ -1243,7 +1243,7 @@ describe("Telegram config handler", () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 import { handleChannelVerificationSession } from "../daemon/handlers/config.js";
-import type { ChannelVerificationSessionRequest } from "../daemon/ipc-contract.js";
+import type { ChannelVerificationSessionRequest } from "../daemon/ipc-protocol.js";
 describe("Guardian verification IPC actions", () => {
   beforeEach(() => {
     secureKeyStore = {};

--- a/assistant/src/__tests__/handlers-twitter-config.test.ts
+++ b/assistant/src/__tests__/handlers-twitter-config.test.ts
@@ -175,7 +175,7 @@ import type {
   ClientMessage,
   ServerMessage,
   TwitterIntegrationConfigRequest,
-} from "../daemon/ipc-contract.js";
+} from "../daemon/ipc-protocol.js";
 import { DebouncerMap } from "../util/debounce.js";
 
 /**

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -7,7 +7,7 @@ import type { HandlerContext } from "../daemon/handlers.js";
 import type {
   ConfirmationResponse,
   UserMessage,
-} from "../daemon/ipc-contract.js";
+} from "../daemon/ipc-protocol.js";
 import type { ServerMessage } from "../daemon/ipc-protocol.js";
 import { DebouncerMap } from "../util/debounce.js";
 

--- a/assistant/src/__tests__/ingress-reconcile.test.ts
+++ b/assistant/src/__tests__/ingress-reconcile.test.ts
@@ -77,7 +77,7 @@ import type { HandlerContext } from "../daemon/handlers/shared.js";
 import type {
   IngressConfigRequest,
   ServerMessage,
-} from "../daemon/ipc-contract.js";
+} from "../daemon/ipc-protocol.js";
 import { DebouncerMap } from "../util/debounce.js";
 
 // Capture fetch calls for reconcile trigger verification

--- a/assistant/src/__tests__/ipc-blob-store.test.ts
+++ b/assistant/src/__tests__/ipc-blob-store.test.ts
@@ -55,7 +55,7 @@ import {
   resolveBlobPath,
   sweepStaleBlobs,
 } from "../daemon/ipc-blob-store.js";
-import type { IpcBlobRef } from "../daemon/ipc-contract.js";
+import type { IpcBlobRef } from "../daemon/ipc-protocol.js";
 
 /** Write a blob file to the test blob directory and return its path. */
 function writeBlobFile(id: string, content: Buffer): string {

--- a/assistant/src/__tests__/ipc-contract.test.ts
+++ b/assistant/src/__tests__/ipc-contract.test.ts
@@ -4,7 +4,7 @@ import type {
   ClientMessage as ContractClient,
   IPCContractSchema,
   ServerMessage as ContractServer,
-} from "../daemon/ipc-contract.js";
+} from "../daemon/ipc-protocol.js";
 import type {
   ClientMessage as ProtocolClient,
   ServerMessage as ProtocolServer,

--- a/assistant/src/__tests__/ipc-roundtrip.benchmark.test.ts
+++ b/assistant/src/__tests__/ipc-roundtrip.benchmark.test.ts
@@ -21,7 +21,7 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import type { ClientMessage, ServerMessage } from "../daemon/ipc-contract.js";
+import type { ClientMessage, ServerMessage } from "../daemon/ipc-protocol.js";
 import { createMessageParser, serialize } from "../daemon/ipc-protocol.js";
 
 function percentile(values: number[], p: number): number {

--- a/assistant/src/__tests__/notification-deep-link.test.ts
+++ b/assistant/src/__tests__/notification-deep-link.test.ts
@@ -67,7 +67,7 @@ mock.module("../notifications/conversation-pairing.js", () => ({
   },
 }));
 
-import type { ServerMessage } from "../daemon/ipc-contract.js";
+import type { ServerMessage } from "../daemon/ipc-protocol.js";
 import { VellumAdapter } from "../notifications/adapters/macos.js";
 import { NotificationBroadcaster } from "../notifications/broadcaster.js";
 import type { NotificationSignal } from "../notifications/signal.js";

--- a/assistant/src/__tests__/oauth-connect-handler.test.ts
+++ b/assistant/src/__tests__/oauth-connect-handler.test.ts
@@ -119,7 +119,7 @@ import { handleMessage, type HandlerContext } from "../daemon/handlers.js";
 import type {
   OAuthConnectStartRequest,
   ServerMessage,
-} from "../daemon/ipc-contract.js";
+} from "../daemon/ipc-protocol.js";
 import { DebouncerMap } from "../util/debounce.js";
 
 function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {

--- a/assistant/src/__tests__/secret-prompt-log-hygiene.test.ts
+++ b/assistant/src/__tests__/secret-prompt-log-hygiene.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { SecretRequest, ServerMessage } from "../daemon/ipc-contract.js";
+import type { SecretRequest, ServerMessage } from "../daemon/ipc-protocol.js";
 
 // Capture all logger calls so we can verify secret values never appear
 const logCalls: Array<{ level: string; args: unknown[] }> = [];

--- a/assistant/src/__tests__/secret-response-routing.test.ts
+++ b/assistant/src/__tests__/secret-response-routing.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
-import type { SecretRequest, ServerMessage } from "../daemon/ipc-contract.js";
+import type { SecretRequest, ServerMessage } from "../daemon/ipc-protocol.js";
 import type { SecretPromptResult } from "../permissions/secret-prompter.js";
 import { SecretPrompter } from "../permissions/secret-prompter.js";
 

--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import type { ServerMessage } from "../daemon/ipc-contract.js";
+import type { ServerMessage } from "../daemon/ipc-protocol.js";
 import { SubagentManager } from "../subagent/manager.js";
 import type { SubagentState } from "../subagent/types.js";
 

--- a/assistant/src/__tests__/tool-permission-simulate-handler.test.ts
+++ b/assistant/src/__tests__/tool-permission-simulate-handler.test.ts
@@ -67,7 +67,7 @@ import type {
   ServerMessage,
   ToolPermissionSimulateRequest,
   ToolPermissionSimulateResponse,
-} from "../daemon/ipc-contract.js";
+} from "../daemon/ipc-protocol.js";
 import {
   addRule,
   clearAllRules,

--- a/assistant/src/__tests__/twitter-auth-handler.test.ts
+++ b/assistant/src/__tests__/twitter-auth-handler.test.ts
@@ -177,7 +177,7 @@ import type {
   ServerMessage,
   TwitterAuthStartRequest,
   TwitterAuthStatusRequest,
-} from "../daemon/ipc-contract.js";
+} from "../daemon/ipc-protocol.js";
 import { DebouncerMap } from "../util/debounce.js";
 
 function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {


### PR DESCRIPTION
## Summary
- Migrate all test file imports from `ipc-contract.js` to `ipc-protocol.js`
- Preparation for inlining ipc-contract into ipc-protocol

Part of plan: prelaunch-deprecation-cleanup.md (PR 27 of 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
