### PR TITLE
refactor: migrate production ipc-contract imports to ipc-protocol

### DIFF
--- a/assistant/src/calls/call-controller.ts
+++ b/assistant/src/calls/call-controller.ts
@@ -9,7 +9,7 @@
  */
 
 import { getGatewayInternalBaseUrl } from "../config/env.js";
-import type { ServerMessage } from "../daemon/ipc-contract.js";
+import type { ServerMessage } from "../daemon/ipc-protocol.js";
 import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import {
   expireCanonicalGuardianRequest,

--- a/assistant/src/daemon/doordash-steps.ts
+++ b/assistant/src/daemon/doordash-steps.ts
@@ -6,7 +6,7 @@
  */
 
 import { isPlainObject } from "../util/object.js";
-import type { CardSurfaceData } from "./ipc-contract.js";
+import type { CardSurfaceData } from "./ipc-protocol.js";
 import type { ToolSetupContext } from "./session-tool-setup.js";
 
 interface DoordashStep {

--- a/assistant/src/daemon/handlers/session-history.ts
+++ b/assistant/src/daemon/handlers/session-history.ts
@@ -8,11 +8,11 @@ import {
 import * as conversationStore from "../../memory/conversation-store.js";
 import { silentlyWithLog } from "../../util/silently.js";
 import { truncate } from "../../util/truncate.js";
-import type { UserMessageAttachment } from "../ipc-contract.js";
 import type {
   ConversationSearchRequest,
   HistoryRequest,
   MessageContentRequest,
+  UserMessageAttachment,
 } from "../ipc-protocol.js";
 import { generateVideoThumbnail } from "../video-thumbnail.js";
 import {

--- a/assistant/src/daemon/handlers/session-user-message.ts
+++ b/assistant/src/daemon/handlers/session-user-message.ts
@@ -32,8 +32,11 @@ import {
 } from "../../security/secret-scanner.js";
 import { createApprovalConversationGenerator } from "../approval-generators.js";
 import { getAssistantName } from "../identity-helpers.js";
-import type { UserMessageAttachment } from "../ipc-contract.js";
-import type { ServerMessage, UserMessage } from "../ipc-protocol.js";
+import type {
+  ServerMessage,
+  UserMessage,
+  UserMessageAttachment,
+} from "../ipc-protocol.js";
 import { executeRecordingIntent } from "../recording-executor.js";
 import { resolveRecordingIntent } from "../recording-intent.js";
 import {

--- a/assistant/src/daemon/ipc-blob-store.ts
+++ b/assistant/src/daemon/ipc-blob-store.ts
@@ -11,7 +11,7 @@ import { join, relative, resolve, sep } from "node:path";
 
 import { getLogger } from "../util/logger.js";
 import { getIpcBlobDir } from "../util/platform.js";
-import type { IpcBlobRef } from "./ipc-contract.js";
+import type { IpcBlobRef } from "./ipc-protocol.js";
 
 const log = getLogger("ipc-blob-store");
 

--- a/assistant/src/daemon/ipc-validate.ts
+++ b/assistant/src/daemon/ipc-validate.ts
@@ -1,6 +1,6 @@
 import { isChannelId, isInterfaceId } from "../channels/types.js";
-import type { ClientMessage } from "./ipc-contract.js";
 import inventory from "./ipc-contract-inventory.json" with { type: "json" };
+import type { ClientMessage } from "./ipc-protocol.js";
 
 /**
  * All known ClientMessage `type` discriminator values, derived from the

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -24,8 +24,11 @@ import { createPreference } from "../notifications/preferences-store.js";
 import type { Message } from "../providers/types.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
 import { getLogger } from "../util/logger.js";
-import type { UsageStats } from "./ipc-contract.js";
-import type { ServerMessage, UserMessageAttachment } from "./ipc-protocol.js";
+import type {
+  ServerMessage,
+  UsageStats,
+  UserMessageAttachment,
+} from "./ipc-protocol.js";
 import type { MessageQueue } from "./session-queue-manager.js";
 import type { QueueDrainReason } from "./session-queue-manager.js";
 import type { TrustContext } from "./session-runtime-assembly.js";

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -1,5 +1,5 @@
 import { getConfig } from "../config/loader.js";
-import type { HeartbeatAlert } from "../daemon/ipc-contract.js";
+import type { HeartbeatAlert } from "../daemon/ipc-protocol.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { readTextFileSync } from "../util/fs.js";
 import { getLogger } from "../util/logger.js";

--- a/assistant/src/notifications/adapters/macos.ts
+++ b/assistant/src/notifications/adapters/macos.ts
@@ -13,7 +13,7 @@
  * does not match their own identity.
  */
 
-import type { ServerMessage } from "../../daemon/ipc-contract.js";
+import type { ServerMessage } from "../../daemon/ipc-protocol.js";
 import { getLogger } from "../../util/logger.js";
 import type {
   ChannelAdapter,

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -33,7 +33,7 @@ import {
   hasUngatedHttpAuthDisabled,
   isHttpAuthDisabled,
 } from "../config/env.js";
-import type { ServerMessage } from "../daemon/ipc-contract.js";
+import type { ServerMessage } from "../daemon/ipc-protocol.js";
 import { PairingStore } from "../daemon/pairing-store.js";
 import {
   type Confidence,

--- a/assistant/src/runtime/routes/pairing-routes.ts
+++ b/assistant/src/runtime/routes/pairing-routes.ts
@@ -7,7 +7,7 @@ import {
   isDeviceApproved,
   refreshDevice,
 } from "../../daemon/approved-devices-store.js";
-import type { ServerMessage } from "../../daemon/ipc-contract.js";
+import type { ServerMessage } from "../../daemon/ipc-protocol.js";
 import { PairingStore } from "../../daemon/pairing-store.js";
 import { getLogger } from "../../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -11,7 +11,7 @@
 import { v4 as uuid } from "uuid";
 
 import { getConfig } from "../config/loader.js";
-import type { ServerMessage } from "../daemon/ipc-contract.js";
+import type { ServerMessage } from "../daemon/ipc-protocol.js";
 import { Session, type SessionMemoryPolicy } from "../daemon/session.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -6,7 +6,7 @@
  * back to the parent's client socket wrapped in `subagent_event` envelopes.
  */
 
-import type { UsageStats } from "../daemon/ipc-contract.js";
+import type { UsageStats } from "../daemon/ipc-protocol.js";
 
 // ── Status ──────────────────────────────────────────────────────────────
 

--- a/assistant/src/tools/browser/browser-screencast.ts
+++ b/assistant/src/tools/browser/browser-screencast.ts
@@ -1,4 +1,4 @@
-import type { ServerMessage } from "../../daemon/ipc-contract.js";
+import type { ServerMessage } from "../../daemon/ipc-protocol.js";
 import { browserManager } from "./browser-manager.js";
 
 // Track which sessions have an active browser page.


### PR DESCRIPTION
## Summary
- Migrate all production file imports from `ipc-contract.js` to `ipc-protocol.js`
- Preparation for inlining ipc-contract into ipc-protocol

Part of plan: prelaunch-deprecation-cleanup.md (PR 26 of 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13963" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
