### PR TITLE
refactor: remove legacy relay URL resolution fallback from twilio-routes

### DIFF
--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -9,7 +9,6 @@
  * - Duplicate callback replay (idempotency)
  * - Unknown status and malformed payload handling
  * - Status mapping and completion notifications
- * - resolveRelayUrl unit behavior
  * - Voice webhook TwiML relay URL generation
  * - Handler-level idempotency concurrency (concurrent duplicates, failure-retry)
  */
@@ -190,17 +189,13 @@ mock.module("../calls/twilio-provider.js", () => ({
   },
 }));
 
-// Configurable mock Twilio config — tests can override wssBaseUrl
-let mockWssBaseUrl: string = "wss://test.example.com";
-let mockWebhookBaseUrl: string = "https://test.example.com";
-
 mock.module("../calls/twilio-config.js", () => ({
   getTwilioConfig: () => ({
     accountSid: "AC_test",
     authToken: "test-auth-token-for-webhooks",
     phoneNumber: "+15550001111",
-    webhookBaseUrl: mockWebhookBaseUrl,
-    wssBaseUrl: mockWssBaseUrl,
+    webhookBaseUrl: "https://test.example.com",
+    wssBaseUrl: "wss://test.example.com",
   }),
   resolveTwilioPhoneNumber: () => readMockTwilioPhoneNumber(),
 }));
@@ -320,8 +315,10 @@ mock.module("../inbound/platform-callback-registration.js", () => ({
 }));
 
 mock.module("../inbound/public-ingress-urls.js", () => ({
-  getTwilioRelayUrl: () => {
-    throw new Error("ingress unavailable in call-route tests");
+  getTwilioRelayUrl: (ingressConfig: unknown) => {
+    const base = resolveIngressBaseUrlFromConfig(ingressConfig);
+    const wsBase = base.replace(/^http(s?)/, "ws$1");
+    return `${wsBase}/webhooks/twilio/relay`;
   },
   getTwilioVoiceWebhookUrl: (ingressConfig: unknown) =>
     `${resolveIngressBaseUrlFromConfig(ingressConfig)}/webhooks/twilio/voice`,
@@ -363,7 +360,6 @@ import {
   buildWelcomeGreeting,
   handleStatusCallback,
   handleVoiceWebhook,
-  resolveRelayUrl,
 } from "../calls/twilio-routes.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { conversations } from "../memory/schema.js";
@@ -468,8 +464,6 @@ describe("twilio webhook routes", () => {
   beforeEach(() => {
     resetTables();
     clearActiveCallLeases();
-    mockWssBaseUrl = "wss://test.example.com";
-    mockWebhookBaseUrl = "https://test.example.com";
     mockIngressPublicBaseUrl = "https://ingress.example.com";
     mockGatewayInternalBaseUrl = "http://gateway.internal:7830";
     mockMintedToken = "test-delivery-token";
@@ -844,59 +838,6 @@ describe("twilio webhook routes", () => {
     });
   });
 
-  // ── resolveRelayUrl unit tests ──────────────────────────────────────
-
-  describe("resolveRelayUrl", () => {
-    test("uses wssBaseUrl when explicitly set", () => {
-      const url = resolveRelayUrl(
-        "wss://ws.example.com",
-        "https://web.example.com",
-      );
-      expect(url).toBe("wss://ws.example.com/v1/calls/relay");
-    });
-
-    test("falls back to webhookBaseUrl when wssBaseUrl is empty", () => {
-      const url = resolveRelayUrl("", "https://web.example.com");
-      expect(url).toBe("wss://web.example.com/v1/calls/relay");
-    });
-
-    test("falls back to webhookBaseUrl when wssBaseUrl is whitespace-only", () => {
-      const url = resolveRelayUrl("   ", "https://web.example.com");
-      expect(url).toBe("wss://web.example.com/v1/calls/relay");
-    });
-
-    test("normalizes http to ws in webhookBaseUrl fallback", () => {
-      const url = resolveRelayUrl("", "http://localhost:3000");
-      expect(url).toBe("ws://localhost:3000/v1/calls/relay");
-    });
-
-    test("normalizes https to wss in webhookBaseUrl fallback", () => {
-      const url = resolveRelayUrl("", "https://gateway.example.com");
-      expect(url).toBe("wss://gateway.example.com/v1/calls/relay");
-    });
-
-    test("strips trailing slash from wssBaseUrl", () => {
-      const url = resolveRelayUrl(
-        "wss://ws.example.com/",
-        "https://web.example.com",
-      );
-      expect(url).toBe("wss://ws.example.com/v1/calls/relay");
-    });
-
-    test("strips trailing slash from webhookBaseUrl fallback", () => {
-      const url = resolveRelayUrl("", "https://web.example.com/");
-      expect(url).toBe("wss://web.example.com/v1/calls/relay");
-    });
-
-    test("preserves wss scheme in explicitly set wssBaseUrl", () => {
-      const url = resolveRelayUrl(
-        "wss://custom-relay.example.com",
-        "https://web.example.com",
-      );
-      expect(url).toBe("wss://custom-relay.example.com/v1/calls/relay");
-    });
-  });
-
   describe("buildWelcomeGreeting", () => {
     test("returns empty by default so orchestrator drives first opener", () => {
       const greeting = buildWelcomeGreeting("check store hours for tomorrow");
@@ -916,9 +857,7 @@ describe("twilio webhook routes", () => {
   // Call handleVoiceWebhook directly since direct routes are blocked.
 
   describe("voice webhook TwiML relay URL", () => {
-    test("TwiML uses explicit wssBaseUrl when set", async () => {
-      mockWssBaseUrl = "wss://explicit-ws.example.com";
-
+    test("TwiML relay URL is sourced from getTwilioRelayUrl", async () => {
       const session = createTestSession("conv-twiml-1", "CA_twiml_1");
       const req = makeVoiceRequest(session.id, { CallSid: "CA_twiml_1" });
 
@@ -926,21 +865,9 @@ describe("twilio webhook routes", () => {
 
       expect(res.status).toBe(200);
       const twiml = await res.text();
-      expect(twiml).toContain("wss://explicit-ws.example.com/v1/calls/relay");
-    });
-
-    test("TwiML falls back to webhookBaseUrl when wssBaseUrl is empty", async () => {
-      mockWssBaseUrl = "";
-      mockWebhookBaseUrl = "https://gateway.example.com";
-
-      const session = createTestSession("conv-twiml-2", "CA_twiml_2");
-      const req = makeVoiceRequest(session.id, { CallSid: "CA_twiml_2" });
-
-      const res = await handleVoiceWebhook(req);
-
-      expect(res.status).toBe(200);
-      const twiml = await res.text();
-      expect(twiml).toContain("wss://gateway.example.com/v1/calls/relay");
+      expect(twiml).toContain(
+        "wss://ingress.example.com/webhooks/twilio/relay",
+      );
     });
 
     test("TwiML omits welcome greeting by default so call opener is model-driven", async () => {

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -27,7 +27,6 @@ import {
   releaseCallbackClaim,
   updateCallSession,
 } from "./call-store.js";
-import { getTwilioConfig } from "./twilio-config.js";
 import type { CallStatus } from "./types.js";
 import { resolveVoiceQualityProfile } from "./voice-quality.js";
 
@@ -113,22 +112,6 @@ export function buildWelcomeGreeting(
   // initial LLM turn via the session pipeline. Keep Twilio's relay-level
   // greeting empty by default so we don't speak a deterministic static line first.
   return "";
-}
-
-/**
- * Resolve the WebSocket relay URL from Twilio config.
- *
- * Treats wssBaseUrl as present only when it is non-empty after trimming.
- * Falls back to webhookBaseUrl, normalizing the scheme from http(s) to ws(s)
- * and stripping any trailing slash.
- */
-export function resolveRelayUrl(
-  wssBaseUrl: string,
-  webhookBaseUrl: string,
-): string {
-  const base = wssBaseUrl.trim() || webhookBaseUrl;
-  const normalized = base.replace(/\/$/, "").replace(/^http(s?)/, "ws$1");
-  return `${normalized}/v1/calls/relay`;
 }
 
 /**
@@ -252,17 +235,7 @@ function buildVoiceWebhookTwiml(
     "Voice quality profile resolved",
   );
 
-  const twilioConfig = getTwilioConfig();
-  let relayUrl: string;
-  try {
-    relayUrl = getTwilioRelayUrl(loadConfig());
-  } catch {
-    // Fallback to legacy resolution when ingress is not configured
-    relayUrl = resolveRelayUrl(
-      twilioConfig.wssBaseUrl,
-      twilioConfig.webhookBaseUrl,
-    );
-  }
+  const relayUrl = getTwilioRelayUrl(loadConfig());
   const welcomeGreeting = buildWelcomeGreeting(task, getCallWelcomeGreeting());
 
   const relayToken = mintEdgeRelayToken();


### PR DESCRIPTION
## Summary
- Remove try-catch fallback in `buildVoiceWebhookTwiml()`
- Delete `resolveRelayUrl()` function
- `getTwilioRelayUrl()` is now the sole source for relay URLs
- Remove unused `getTwilioConfig` import
- Update tests: remove `resolveRelayUrl` unit tests, fix mock to return URL instead of throwing

Part of plan: prelaunch-deprecation-cleanup.md (PR 10 of 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
