### PR TITLE
refactor: remove cron schedule syntax fallback defaults

### DIFF
--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -52,9 +52,9 @@ afterAll(() => {
   }
 });
 
-// ── Cron backward compatibility ─────────────────────────────────────
+// ── Cron schedules ──────────────────────────────────────────────────
 
-describe("createSchedule (cron, legacy API)", () => {
+describe("createSchedule (cron)", () => {
   beforeEach(() => {
     const db = getDb();
     db.run("DELETE FROM cron_runs");
@@ -66,6 +66,7 @@ describe("createSchedule (cron, legacy API)", () => {
       name: "Morning ping",
       cronExpression: "0 9 * * *",
       message: "good morning",
+      syntax: "cron",
     });
 
     expect(job.syntax).toBe("cron");
@@ -80,6 +81,7 @@ describe("createSchedule (cron, legacy API)", () => {
       name: "Hourly",
       cronExpression: "0 * * * *",
       message: "hourly check",
+      syntax: "cron",
     });
 
     const retrieved = getSchedule(job.id);
@@ -94,6 +96,7 @@ describe("createSchedule (cron, legacy API)", () => {
       name: "Syntax check",
       cronExpression: "*/5 * * * *",
       message: "test",
+      syntax: "cron",
     });
 
     const raw = getRawDb()
@@ -109,6 +112,7 @@ describe("createSchedule (cron, legacy API)", () => {
         name: "Bad cron",
         cronExpression: "not-a-cron",
         message: "fail",
+        syntax: "cron",
       }),
     ).toThrow();
   });
@@ -339,6 +343,7 @@ describe("updateSchedule", () => {
       name: "Update test",
       cronExpression: "0 9 * * *",
       message: "update me",
+      syntax: "cron",
     });
 
     const updated = updateSchedule(job.id, { cronExpression: "0 10 * * *" });
@@ -355,6 +360,7 @@ describe("updateSchedule", () => {
       name: "Switch to RRULE",
       cronExpression: "0 9 * * *",
       message: "switching",
+      syntax: "cron",
     });
 
     const rrule = "DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY;INTERVAL=2";
@@ -381,6 +387,7 @@ describe("updateSchedule", () => {
       name: "Update to set",
       cronExpression: "0 9 * * *",
       message: "update to set",
+      syntax: "cron",
     });
 
     const setExpr = [
@@ -406,6 +413,7 @@ describe("updateSchedule", () => {
       name: "Reject bad update",
       cronExpression: "0 9 * * *",
       message: "nope",
+      syntax: "cron",
     });
 
     expect(() =>
@@ -431,6 +439,7 @@ describe("claimDueSchedules", () => {
       name: "Claim cron",
       cronExpression: "* * * * *",
       message: "cron claim test",
+      syntax: "cron",
     });
 
     // Force the schedule to be due
@@ -486,6 +495,7 @@ describe("claimDueSchedules", () => {
       name: "Not due yet",
       cronExpression: "0 9 * * *",
       message: "future schedule",
+      syntax: "cron",
     });
 
     const claimed = claimDueSchedules(0); // timestamp 0 means nothing is due
@@ -543,6 +553,7 @@ describe("claimDueSchedules", () => {
       name: "Double claim",
       cronExpression: "* * * * *",
       message: "no double",
+      syntax: "cron",
     });
 
     getRawDb().run("UPDATE cron_jobs SET next_run_at = ? WHERE id = ?", [

--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -270,6 +270,7 @@ describe("scheduler RRULE execution", () => {
       name: "Cron Schedule",
       cronExpression: "* * * * *",
       message: "Cron message",
+      syntax: "cron",
     });
 
     // Verify it defaults to cron syntax

--- a/assistant/src/__tests__/task-scheduler.test.ts
+++ b/assistant/src/__tests__/task-scheduler.test.ts
@@ -188,6 +188,7 @@ describe("scheduler run_task detection", () => {
       name: "Regular Schedule",
       cronExpression: "* * * * *",
       message: "Do something normal",
+      syntax: "cron",
     });
 
     forceScheduleDue(schedule.id);
@@ -218,6 +219,7 @@ describe("scheduler run_task detection", () => {
       name: "Bad Task Schedule",
       cronExpression: "* * * * *",
       message: "run_task:nonexistent-task-id",
+      syntax: "cron",
     });
 
     forceScheduleDue(schedule.id);

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -77,16 +77,14 @@ export function createSchedule(params: {
   message: string;
   enabled?: boolean;
   createdBy?: string;
-  syntax?: ScheduleSyntax;
+  syntax: ScheduleSyntax;
   expression?: string;
 }): ScheduleJob {
-  // Resolve syntax and expression: prefer explicit values, fall back to cron default
-  const syntax: ScheduleSyntax = params.syntax ?? "cron";
   const expression = params.expression ?? params.cronExpression;
 
-  const spec = { syntax, expression, timezone: params.timezone };
+  const spec = { syntax: params.syntax, expression, timezone: params.timezone };
   if (!isValidScheduleExpression(spec)) {
-    throw new Error(`Invalid ${syntax} expression: "${expression}"`);
+    throw new Error(`Invalid ${params.syntax} expression: "${expression}"`);
   }
 
   const db = getDb();
@@ -101,7 +99,7 @@ export function createSchedule(params: {
     name: params.name,
     enabled,
     cronExpression: expression,
-    scheduleSyntax: syntax,
+    scheduleSyntax: params.syntax,
     timezone,
     message: params.message,
     nextRunAt,
@@ -178,7 +176,7 @@ export function updateSchedule(
 
   // Resolve the effective syntax and expression after this update
   const newSyntax =
-    updates.syntax ?? (existing.scheduleSyntax as ScheduleSyntax) ?? "cron";
+    updates.syntax ?? (existing.scheduleSyntax as ScheduleSyntax);
   const newExpr =
     updates.expression ?? updates.cronExpression ?? existing.cronExpression;
   const newTimezone =
@@ -262,7 +260,7 @@ export function claimDueSchedules(now: number): ScheduleJob[] {
     let newNextRunAt: number | null;
     let exhausted = false;
     try {
-      const syntax = (row.scheduleSyntax as ScheduleSyntax) ?? "cron";
+      const syntax = row.scheduleSyntax as ScheduleSyntax;
       newNextRunAt = computeNextRunAtEngine({
         syntax,
         expression: row.cronExpression,
@@ -575,7 +573,7 @@ function parseJobRow(row: typeof scheduleJobs.$inferSelect): ScheduleJob {
     id: row.id,
     name: row.name,
     enabled: row.enabled,
-    syntax: (row.scheduleSyntax as ScheduleSyntax) ?? "cron",
+    syntax: row.scheduleSyntax as ScheduleSyntax,
     expression: row.cronExpression,
     cronExpression: row.cronExpression,
     timezone: row.timezone,

--- a/assistant/src/tasks/task-scheduler.ts
+++ b/assistant/src/tasks/task-scheduler.ts
@@ -2,7 +2,6 @@ import { createSchedule } from "../schedule/schedule-store.js";
 
 /**
  * Create a cron schedule that runs a task on a recurring cron expression.
- * RRULE syntax is supported at the store layer but this helper currently defaults to cron.
  * The scheduler detects the `run_task:<taskId>` message format
  * and delegates to runTask() instead of processMessage().
  */
@@ -17,5 +16,6 @@ export function scheduleTask(opts: {
     cronExpression: opts.cronExpression,
     timezone: opts.timezone ?? null,
     message: `run_task:${opts.taskId}`,
+    syntax: "cron",
   });
 }


### PR DESCRIPTION
## Summary
- Remove all `?? "cron"` fallbacks from schedule-store
- Make syntax explicitly required or set at schema level

Part of plan: prelaunch-deprecation-cleanup.md (PR 14 of 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
