### PR TITLE
refactor: migrate non-daemon conversation-store imports to source modules

### DIFF
--- a/assistant/src/calls/call-conversation-messages.ts
+++ b/assistant/src/calls/call-conversation-messages.ts
@@ -3,7 +3,7 @@
  * dedicated voice conversation thread.
  */
 
-import * as conversationStore from "../memory/conversation-store.js";
+import { addMessage } from "../memory/conversation-crud.js";
 import { getCallEvents, getCallSession } from "./call-store.js";
 
 export function buildCallCompletionMessage(callSessionId: string): string {
@@ -28,7 +28,7 @@ export async function persistCallCompletionMessage(
   callSessionId: string,
 ): Promise<string> {
   const summaryText = buildCallCompletionMessage(callSessionId);
-  await conversationStore.addMessage(
+  await addMessage(
     conversationId,
     "assistant",
     JSON.stringify([{ type: "text", text: summaryText }]),

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -14,8 +14,8 @@ import {
   getTwilioStatusCallbackUrl,
   getTwilioVoiceWebhookUrl,
 } from "../inbound/public-ingress-urls.js";
+import { getConversation } from "../memory/conversation-crud.js";
 import { getOrCreateConversation } from "../memory/conversation-key-store.js";
-import { getConversation } from "../memory/conversation-store.js";
 import { queueGenerateConversationTitle } from "../memory/conversation-title-service.js";
 import { upsertBinding } from "../memory/external-conversation-store.js";
 import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";

--- a/assistant/src/calls/call-pointer-messages.ts
+++ b/assistant/src/calls/call-pointer-messages.ts
@@ -9,7 +9,12 @@
  * written directly to the conversation store.
  */
 
-import * as conversationStore from "../memory/conversation-store.js";
+import {
+  addMessage,
+  getConversationOriginChannel,
+  getConversationRecentProvenanceTrustClass,
+  getConversationThreadType,
+} from "../memory/conversation-crud.js";
 import { getLogger } from "../util/logger.js";
 import {
   buildPointerInstruction,
@@ -86,18 +91,14 @@ function resolvePointerAudienceTrust(conversationId: string): boolean {
     // trusted contacts who initiate calls from gateway channels (e.g. WhatsApp)
     // where the conversation itself isn't a desktop-origin private thread.
     const provenance =
-      conversationStore.getConversationRecentProvenanceTrustClass(
-        conversationId,
-      );
+      getConversationRecentProvenanceTrustClass(conversationId);
     if (provenance === "guardian" || provenance === "trusted_contact")
       return true;
 
-    const threadType =
-      conversationStore.getConversationThreadType(conversationId);
+    const threadType = getConversationThreadType(conversationId);
     if (threadType === "private") return true;
 
-    const originChannel =
-      conversationStore.getConversationOriginChannel(conversationId);
+    const originChannel = getConversationOriginChannel(conversationId);
     if (originChannel === "vellum") return true;
   } catch {
     // Conversation may not exist or DB may be unavailable — default untrusted.
@@ -185,7 +186,7 @@ export async function addPointerMessage(
   // desktop thread. Do not set userMessageChannel — doing so would mark the
   // conversation's origin channel as voice, causing it to leak into the
   // desktop thread list as a channel-bound session.
-  await conversationStore.addMessage(
+  await addMessage(
     conversationId,
     "assistant",
     JSON.stringify([{ type: "text", text }]),

--- a/assistant/src/calls/guardian-action-sweep.ts
+++ b/assistant/src/calls/guardian-action-sweep.ts
@@ -9,7 +9,7 @@
  * 4. Adds an expiry message to mac guardian thread conversations
  */
 
-import { addMessage } from "../memory/conversation-store.js";
+import { addMessage } from "../memory/conversation-crud.js";
 import {
   expireGuardianActionRequest,
   getDeliveriesByRequestId,

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -23,7 +23,7 @@ import {
 } from "../contacts/contacts-write.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import { getCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
-import * as conversationStore from "../memory/conversation-store.js";
+import { addMessage } from "../memory/conversation-crud.js";
 import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
 import { notifyGuardianOfAccessRequest } from "../runtime/access-request-helper.js";
 import {
@@ -722,7 +722,7 @@ export class RelayConnection {
     // guardian (user) can share it with the callee.
     if (session?.initiatedFromConversationId) {
       const codeMsg = `\u{1F510} Verification code for call to ${session.toNumber}: ${code}`;
-      await conversationStore.addMessage(
+      await addMessage(
         session.initiatedFromConversationId,
         "assistant",
         JSON.stringify([{ type: "text", text: codeMsg }]),
@@ -1918,7 +1918,7 @@ export class RelayConnection {
       // this early-utterance path bypasses it entirely.
       if (session) {
         try {
-          await conversationStore.addMessage(
+          await addMessage(
             session.conversationId,
             "user",
             JSON.stringify([{ type: "text", text: msg.voicePrompt }]),

--- a/assistant/src/cli/memory.ts
+++ b/assistant/src/cli/memory.ts
@@ -9,7 +9,7 @@ import {
   requestMemoryRebuildIndex,
 } from "../memory/admin.js";
 import { listPendingConflictDetails } from "../memory/conflict-store.js";
-import { listConversations } from "../memory/conversation-store.js";
+import { listConversations } from "../memory/conversation-queries.js";
 import { initializeDb, rawGet } from "../memory/db.js";
 import { getCliLogger } from "../util/logger.js";
 

--- a/assistant/src/cli/sessions.ts
+++ b/assistant/src/cli/sessions.ts
@@ -9,8 +9,8 @@ import {
   clearAll as clearAllConversations,
   getConversation,
   getMessages,
-  listConversations,
-} from "../memory/conversation-store.js";
+} from "../memory/conversation-crud.js";
+import { listConversations } from "../memory/conversation-queries.js";
 import { initializeDb } from "../memory/db.js";
 import { initQdrantClient } from "../memory/qdrant-client.js";
 import { getCliLogger } from "../util/logger.js";

--- a/assistant/src/config/bundled-skills/chatgpt-import/tools/chatgpt-import.ts
+++ b/assistant/src/config/bundled-skills/chatgpt-import/tools/chatgpt-import.ts
@@ -8,7 +8,7 @@ import { getConfig } from "../../../../config/loader.js";
 import {
   addMessage,
   createConversation,
-} from "../../../../memory/conversation-store.js";
+} from "../../../../memory/conversation-crud.js";
 import { getDb } from "../../../../memory/db.js";
 import { indexMessageNow } from "../../../../memory/indexer.js";
 import {

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -8,7 +8,7 @@ import {
   mapGeminiError,
 } from "../../../../media/gemini-image-service.js";
 import { getAttachmentsByIds } from "../../../../memory/attachments-store.js";
-import { getConversationThreadType } from "../../../../memory/conversation-store.js";
+import { getConversationThreadType } from "../../../../memory/conversation-crud.js";
 import type { ImageContent } from "../../../../providers/types.js";
 import { getAttachmentSourceConversations } from "../../../../tools/assets/search.js";
 import type {

--- a/assistant/src/memory/conversation-bootstrap.ts
+++ b/assistant/src/memory/conversation-bootstrap.ts
@@ -1,4 +1,4 @@
-import { createConversation } from "./conversation-store.js";
+import { createConversation } from "./conversation-crud.js";
 import {
   GENERATING_TITLE,
   queueGenerateConversationTitle,

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -12,8 +12,12 @@ import { getConfiguredProvider } from "../providers/provider-send-message.js";
 import type { Provider } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 import { truncate } from "../util/truncate.js";
-import type { MessageRow } from "./conversation-store.js";
-import * as conversationStore from "./conversation-store.js";
+import {
+  getConversation,
+  getMessages,
+  type MessageRow,
+  updateConversationTitle,
+} from "./conversation-crud.js";
 
 const log = getLogger("conversation-title-service");
 
@@ -110,7 +114,7 @@ export async function generateAndPersistConversationTitle(
   } = params;
 
   // Check current title is replaceable
-  const conversation = conversationStore.getConversation(conversationId);
+  const conversation = getConversation(conversationId);
   if (conversation && !isReplaceableTitle(conversation.title)) {
     return { title: conversation.title!, updated: false };
   }
@@ -119,7 +123,7 @@ export async function generateAndPersistConversationTitle(
   if (!provider) {
     // No provider available — fall back to context-derived title or untitled
     const fallback = deriveFallbackTitle(context) ?? UNTITLED_FALLBACK;
-    conversationStore.updateConversationTitle(conversationId, fallback, 1);
+    updateConversationTitle(conversationId, fallback, 1);
     onTitleUpdated?.(fallback);
     return { title: fallback, updated: true };
   }
@@ -149,12 +153,12 @@ export async function generateAndPersistConversationTitle(
     }
 
     // Re-check replaceability before persisting (race guard)
-    const current = conversationStore.getConversation(conversationId);
+    const current = getConversation(conversationId);
     if (current && !isReplaceableTitle(current.title)) {
       return { title: current.title!, updated: false };
     }
 
-    conversationStore.updateConversationTitle(conversationId, title, 1);
+    updateConversationTitle(conversationId, title, 1);
     onTitleUpdated?.(title);
     log.info({ conversationId, title }, "Auto-generated conversation title");
     return { title, updated: true };
@@ -165,13 +169,13 @@ export async function generateAndPersistConversationTitle(
   // text-response path above). A concurrent custom rename may have landed
   // while the LLM request was in-flight; writing unconditionally would
   // clobber the user's intent.
-  const currentForFallback = conversationStore.getConversation(conversationId);
+  const currentForFallback = getConversation(conversationId);
   if (currentForFallback && !isReplaceableTitle(currentForFallback.title)) {
     return { title: currentForFallback.title!, updated: false };
   }
 
   const fallback = deriveFallbackTitle(context) ?? UNTITLED_FALLBACK;
-  conversationStore.updateConversationTitle(conversationId, fallback, 1);
+  updateConversationTitle(conversationId, fallback, 1);
   onTitleUpdated?.(fallback);
   return { title: fallback, updated: true };
 }
@@ -191,16 +195,11 @@ export function queueGenerateConversationTitle(
     );
     // Replace loading placeholder with stable fallback
     try {
-      const conversation = conversationStore.getConversation(
-        params.conversationId,
-      );
+      const conversation = getConversation(params.conversationId);
       if (conversation && conversation.title === GENERATING_TITLE) {
         const fallback =
           deriveFallbackTitle(params.context) ?? UNTITLED_FALLBACK;
-        conversationStore.updateConversationTitle(
-          params.conversationId,
-          fallback,
-        );
+        updateConversationTitle(params.conversationId, fallback);
         params.onTitleUpdated?.(fallback);
       }
     } catch {
@@ -228,7 +227,7 @@ export async function regenerateConversationTitle(
 ): Promise<{ title: string; updated: boolean }> {
   const { conversationId, onTitleUpdated, signal } = params;
 
-  const conversation = conversationStore.getConversation(conversationId);
+  const conversation = getConversation(conversationId);
   if (!conversation || !conversation.isAutoTitle) {
     return { title: conversation?.title ?? UNTITLED_FALLBACK, updated: false };
   }
@@ -238,7 +237,7 @@ export async function regenerateConversationTitle(
     return { title: conversation.title ?? UNTITLED_FALLBACK, updated: false };
   }
 
-  const allMessages = conversationStore.getMessages(conversationId);
+  const allMessages = getMessages(conversationId);
   const recentMessages = allMessages.slice(-3);
   if (recentMessages.length === 0) {
     return { title: conversation.title ?? UNTITLED_FALLBACK, updated: false };
@@ -269,12 +268,12 @@ export async function regenerateConversationTitle(
     }
 
     // Re-check isAutoTitle before persisting (race guard against manual rename)
-    const current = conversationStore.getConversation(conversationId);
+    const current = getConversation(conversationId);
     if (!current || !current.isAutoTitle) {
       return { title: current?.title ?? UNTITLED_FALLBACK, updated: false };
     }
 
-    conversationStore.updateConversationTitle(conversationId, title, 1);
+    updateConversationTitle(conversationId, title, 1);
     onTitleUpdated?.(title);
     log.info(
       { conversationId, title },

--- a/assistant/src/memory/job-handlers/backfill.ts
+++ b/assistant/src/memory/job-handlers/backfill.ts
@@ -11,7 +11,7 @@ import {
 import {
   getConversationMemoryScopeId,
   messageMetadataSchema,
-} from "../conversation-store.js";
+} from "../conversation-crud.js";
 import { getDb } from "../db.js";
 import { indexMessageNow } from "../indexer.js";
 import {

--- a/assistant/src/memory/job-handlers/summarization.ts
+++ b/assistant/src/memory/job-handlers/summarization.ts
@@ -10,7 +10,7 @@ import {
   userMessage,
 } from "../../providers/provider-send-message.js";
 import { getLogger } from "../../util/logger.js";
-import { getConversationMemoryScopeId } from "../conversation-store.js";
+import { getConversationMemoryScopeId } from "../conversation-crud.js";
 import { getDb } from "../db.js";
 import {
   asString,

--- a/assistant/src/notifications/conversation-pairing.ts
+++ b/assistant/src/notifications/conversation-pairing.ts
@@ -21,7 +21,7 @@ import {
   addMessage,
   createConversation,
   getConversation,
-} from "../memory/conversation-store.js";
+} from "../memory/conversation-crud.js";
 import {
   getBindingByChannelChat,
   upsertOutboundBinding,

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -1,6 +1,6 @@
 import { renderHistoryContent } from "../daemon/handlers.js";
 import * as attachmentsStore from "../memory/attachments-store.js";
-import * as conversationStore from "../memory/conversation-store.js";
+import { getMessages } from "../memory/conversation-crud.js";
 import type { ChannelDeliveryResult } from "./gateway-client.js";
 import { deliverChannelReply } from "./gateway-client.js";
 import type { RuntimeAttachmentMetadata } from "./http-types.js";
@@ -169,7 +169,7 @@ export async function deliverReplyViaCallback(
   assistantId?: string,
   options?: DeliverReplyOptions,
 ): Promise<void> {
-  const msgs = conversationStore.getMessages(conversationId);
+  const msgs = getMessages(conversationId);
   for (let i = msgs.length - 1; i >= 0; i--) {
     if (msgs[i].role !== "assistant") continue;
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -42,7 +42,10 @@ import {
   recordConversationSeenSignal,
   type SignalType,
 } from "../memory/conversation-attention-store.js";
-import * as conversationStore from "../memory/conversation-store.js";
+import {
+  countConversations,
+  listConversations,
+} from "../memory/conversation-queries.js";
 import * as externalConversationStore from "../memory/external-conversation-store.js";
 import {
   consumeCallback,
@@ -716,12 +719,8 @@ export class RuntimeHttpServer {
         handler: ({ url }) => {
           const limit = Number(url.searchParams.get("limit") ?? 50);
           const offset = Number(url.searchParams.get("offset") ?? 0);
-          const conversations = conversationStore.listConversations(
-            limit,
-            false,
-            offset,
-          );
-          const totalCount = conversationStore.countConversations();
+          const conversations = listConversations(limit, false, offset);
+          const totalCount = countConversations();
           const conversationIds = conversations.map((c) => c.id);
           const bindings =
             externalConversationStore.getBindingsForConversations(

--- a/assistant/src/runtime/routes/conversation-attention-routes.ts
+++ b/assistant/src/runtime/routes/conversation-attention-routes.ts
@@ -8,7 +8,10 @@ import {
   type AttentionFilterState,
   listConversationAttention,
 } from "../../memory/conversation-attention-store.js";
-import * as conversationStore from "../../memory/conversation-store.js";
+import {
+  getConversation,
+  getMessageById,
+} from "../../memory/conversation-crud.js";
 import { truncate } from "../../util/truncate.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
@@ -56,7 +59,7 @@ export function handleListConversationAttention(url: URL): Response {
     { title: string | null; source: string }
   >();
   for (const id of conversationIds) {
-    const conv = conversationStore.getConversation(id);
+    const conv = getConversation(id);
     if (conv) {
       conversationMap.set(id, {
         title: conv.title,
@@ -69,9 +72,7 @@ export function handleListConversationAttention(url: URL): Response {
   const snippetMap = new Map<string, string>();
   for (const attn of pageStates) {
     if (attn.latestAssistantMessageId) {
-      const msg = conversationStore.getMessageById(
-        attn.latestAssistantMessageId,
-      );
+      const msg = getMessageById(attn.latestAssistantMessageId);
       if (msg?.content) {
         snippetMap.set(
           attn.latestAssistantMessageId,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -25,11 +25,12 @@ import {
   generateCanonicalRequestCode,
   listPendingRequestsByConversationScope,
 } from "../../memory/canonical-guardian-store.js";
+import { addMessage, getMessages } from "../../memory/conversation-crud.js";
 import {
   getConversationByKey,
   getOrCreateConversation,
 } from "../../memory/conversation-key-store.js";
-import * as conversationStore from "../../memory/conversation-store.js";
+import { searchConversations } from "../../memory/conversation-queries.js";
 import { getConfiguredProvider } from "../../providers/provider-send-message.js";
 import type { Provider } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
@@ -169,7 +170,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
     };
 
     const userMessage = createUserMessage(content, attachments);
-    const persistedUser = await conversationStore.addMessage(
+    const persistedUser = await addMessage(
       conversationId,
       "user",
       JSON.stringify(userMessage.content),
@@ -183,7 +184,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
         ? "Decision applied."
         : "Request already resolved.");
     const assistantMessage = createAssistantMessage(replyText);
-    await conversationStore.addMessage(
+    await addMessage(
       conversationId,
       "assistant",
       JSON.stringify(assistantMessage.content),
@@ -268,7 +269,7 @@ export function handleListMessages(
   if (!resolvedConversationId) {
     return Response.json({ messages: [] });
   }
-  const rawMessages = conversationStore.getMessages(resolvedConversationId);
+  const rawMessages = getMessages(resolvedConversationId);
 
   // Parse content blocks and extract text + tool calls
   const parsed = rawMessages.map((msg) => {
@@ -748,7 +749,7 @@ export async function handleGetSuggestion(
     });
   }
 
-  const rawMessages = conversationStore.getMessages(mapping.conversationId);
+  const rawMessages = getMessages(mapping.conversationId);
   if (rawMessages.length === 0) {
     return Response.json({
       suggestion: null,
@@ -886,7 +887,7 @@ export function handleSearchConversations(url: URL): Response {
     ? Number(url.searchParams.get("maxMessagesPerConversation"))
     : undefined;
 
-  const results = conversationStore.searchConversations(query, {
+  const results = searchConversations(query, {
     ...(limit !== undefined && !isNaN(limit) ? { limit } : {}),
     ...(maxMessagesPerConversation !== undefined &&
     !isNaN(maxMessagesPerConversation)

--- a/assistant/src/runtime/routes/debug-routes.ts
+++ b/assistant/src/runtime/routes/debug-routes.ts
@@ -5,7 +5,7 @@
 import { statSync } from "node:fs";
 
 import { getConfig } from "../../config/loader.js";
-import { countConversations } from "../../memory/conversation-store.js";
+import { countConversations } from "../../memory/conversation-queries.js";
 import { rawAll } from "../../memory/db.js";
 import { getMemoryJobCounts } from "../../memory/jobs-store.js";
 import { getProviderDebugStatus } from "../../providers/registry.js";

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -13,7 +13,7 @@
 import type { ChannelId } from "../../../channels/types.js";
 import { touchContactInteraction } from "../../../contacts/contacts-write.js";
 import * as channelDeliveryStore from "../../../memory/channel-delivery-store.js";
-import * as conversationStore from "../../../memory/conversation-store.js";
+import { updateMessageContent } from "../../../memory/conversation-crud.js";
 import { getLogger } from "../../../util/logger.js";
 
 const log = getLogger("runtime-http");
@@ -106,7 +106,7 @@ export async function handleEditIntercept(
   }
 
   if (original) {
-    conversationStore.updateMessageContent(original.messageId, content ?? "");
+    updateMessageContent(original.messageId, content ?? "");
     log.info(
       { assistantId, sourceMessageId, messageId: original.messageId },
       "Updated message content from edited_message",

--- a/assistant/src/sequence/engine.ts
+++ b/assistant/src/sequence/engine.ts
@@ -7,7 +7,7 @@
  */
 
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
-import { getMessages } from "../memory/conversation-store.js";
+import { getMessages } from "../memory/conversation-crud.js";
 import type { ScheduleMessageProcessor } from "../schedule/scheduler.js";
 import { getLogger } from "../util/logger.js";
 import { recordEvent } from "./analytics.js";

--- a/assistant/src/tools/assets/materialize.ts
+++ b/assistant/src/tools/assets/materialize.ts
@@ -16,7 +16,7 @@ import {
   type AttachmentContext,
   isAttachmentVisible,
 } from "../../daemon/media-visibility-policy.js";
-import { getConversationThreadType } from "../../memory/conversation-store.js";
+import { getConversationThreadType } from "../../memory/conversation-crud.js";
 import { getDb } from "../../memory/db.js";
 import { attachments } from "../../memory/schema.js";
 import { RiskLevel } from "../../permissions/types.js";

--- a/assistant/src/tools/assets/search.ts
+++ b/assistant/src/tools/assets/search.ts
@@ -14,7 +14,7 @@ import {
   isAttachmentVisible,
 } from "../../daemon/media-visibility-policy.js";
 import type { StoredAttachment } from "../../memory/attachments-store.js";
-import { getConversationThreadType } from "../../memory/conversation-store.js";
+import { getConversationThreadType } from "../../memory/conversation-crud.js";
 import { getDb, rawAll } from "../../memory/db.js";
 import {
   attachments,

--- a/assistant/src/tools/subagent/read.ts
+++ b/assistant/src/tools/subagent/read.ts
@@ -1,4 +1,4 @@
-import { getMessages } from "../../memory/conversation-store.js";
+import { getMessages } from "../../memory/conversation-crud.js";
 import { getSubagentManager, TERMINAL_STATUSES } from "../../subagent/index.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 


### PR DESCRIPTION
## Summary
- Migrate all runtime/, calls/, tools/, and other src files from `import * as conversationStore` to named imports
- Imports now come directly from `conversation-crud.js` and `conversation-queries.js`

Part of plan: prelaunch-deprecation-cleanup.md (PR 23 of 28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
