### PR TITLE
refactor: migrate daemon/ conversation-store imports to source modules

### DIFF
--- a/assistant/src/daemon/handlers/config-heartbeat.ts
+++ b/assistant/src/daemon/handlers/config-heartbeat.ts
@@ -3,7 +3,8 @@ import * as net from "node:net";
 import { dirname } from "node:path";
 
 import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
-import * as conversationStore from "../../memory/conversation-store.js";
+import { getMessages } from "../../memory/conversation-crud.js";
+import { listConversations } from "../../memory/conversation-queries.js";
 import { readTextFileSync } from "../../util/fs.js";
 import { getWorkspacePromptPath } from "../../util/platform.js";
 import type {
@@ -127,7 +128,7 @@ export function handleHeartbeatRunsList(
   try {
     const limit = msg.limit ?? 20;
     // Get background conversations and filter to heartbeat-origin only
-    const all = conversationStore.listConversations(limit * 20, true);
+    const all = listConversations(limit * 20, true);
     const bgConversations = all
       .filter((c) => c.source === "heartbeat")
       .slice(0, limit);
@@ -137,7 +138,7 @@ export function handleHeartbeatRunsList(
       let result = "unknown";
       let summary = "";
       try {
-        const messages = conversationStore.getMessages(conv.id);
+        const messages = getMessages(conv.id);
         const lastAssistant = [...messages]
           .reverse()
           .find((m) => m.role === "assistant");

--- a/assistant/src/daemon/handlers/config-inbox.ts
+++ b/assistant/src/daemon/handlers/config-inbox.ts
@@ -9,7 +9,7 @@ import {
   listPendingApprovalRequests,
   resolveApprovalRequest,
 } from "../../memory/channel-guardian-store.js";
-import { addMessage, getMessages } from "../../memory/conversation-store.js";
+import { addMessage, getMessages } from "../../memory/conversation-crud.js";
 import { getLatestStoredPayload } from "../../memory/delivery-crud.js";
 import { getBindingByConversation } from "../../memory/external-conversation-store.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -5,7 +5,12 @@ import * as net from "node:net";
 import { v4 as uuid } from "uuid";
 
 import { getConfig } from "../../config/loader.js";
-import * as conversationStore from "../../memory/conversation-store.js";
+import {
+  addMessage,
+  createConversation,
+  deleteConversation,
+  getMessages,
+} from "../../memory/conversation-crud.js";
 import {
   GENERATING_TITLE,
   queueGenerateConversationTitle,
@@ -80,9 +85,7 @@ export async function handleTaskSubmit(
       // Create an ephemeral session so the secret_response lifecycle works
       // end-to-end. The conversation is deleted after the prompt resolves
       // to avoid accumulating placeholder entries in session history.
-      const conversation = conversationStore.createConversation(
-        "(blocked — secret detected)",
-      );
+      const conversation = createConversation("(blocked — secret detected)");
       ctx.socketToSession.set(socket, conversation.id);
       const session = await ctx.getOrCreateSession(
         conversation.id,
@@ -91,7 +94,7 @@ export async function handleTaskSubmit(
       );
       session.redirectToSecurePrompt(taskIngressCheck.detectedTypes, {
         onComplete: () => {
-          conversationStore.deleteConversation(conversation.id);
+          deleteConversation(conversation.id);
           // Clean up in-memory session and socket binding so the ephemeral
           // session doesn't accumulate in the daemon's session map.
           const s = ctx.sessions.get(conversation.id);
@@ -121,9 +124,7 @@ export async function handleTaskSubmit(
         "Recording command intent received",
       );
       if (action === "start") {
-        const conversation = conversationStore.createConversation(
-          msg.task || "Screen Recording",
-        );
+        const conversation = createConversation(msg.task || "Screen Recording");
         ctx.socketToSession.set(socket, conversation.id);
         const recordingId = handleRecordingStart(
           conversation.id,
@@ -148,12 +149,12 @@ export async function handleTaskSubmit(
           type: "message_complete",
           sessionId: conversation.id,
         });
-        await conversationStore.addMessage(
+        await addMessage(
           conversation.id,
           "user",
           JSON.stringify([{ type: "text", text: msg.task || "" }]),
         );
-        await conversationStore.addMessage(
+        await addMessage(
           conversation.id,
           "assistant",
           JSON.stringify([{ type: "text", text: responseText }]),
@@ -175,9 +176,7 @@ export async function handleTaskSubmit(
       } else if (action === "stop") {
         let activeSessionId = ctx.socketToSession.get(socket);
         if (!activeSessionId) {
-          const conversation = conversationStore.createConversation(
-            msg.task || "Stop Recording",
-          );
+          const conversation = createConversation(msg.task || "Stop Recording");
           activeSessionId = conversation.id;
           ctx.socketToSession.set(socket, activeSessionId);
         }
@@ -199,12 +198,12 @@ export async function handleTaskSubmit(
           type: "message_complete",
           sessionId: activeSessionId,
         });
-        await conversationStore.addMessage(
+        await addMessage(
           activeSessionId,
           "user",
           JSON.stringify([{ type: "text", text: msg.task || "" }]),
         );
-        await conversationStore.addMessage(
+        await addMessage(
           activeSessionId,
           "assistant",
           JSON.stringify([{ type: "text", text: responseText }]),
@@ -224,7 +223,7 @@ export async function handleTaskSubmit(
       } else if (action === "restart") {
         let activeSessionId = ctx.socketToSession.get(socket);
         if (!activeSessionId) {
-          const conversation = conversationStore.createConversation(
+          const conversation = createConversation(
             msg.task || "Restart Recording",
           );
           activeSessionId = conversation.id;
@@ -249,12 +248,12 @@ export async function handleTaskSubmit(
           type: "message_complete",
           sessionId: activeSessionId,
         });
-        await conversationStore.addMessage(
+        await addMessage(
           activeSessionId,
           "user",
           JSON.stringify([{ type: "text", text: msg.task || "" }]),
         );
-        await conversationStore.addMessage(
+        await addMessage(
           activeSessionId,
           "assistant",
           JSON.stringify([{ type: "text", text: restartResult.responseText }]),
@@ -274,7 +273,7 @@ export async function handleTaskSubmit(
       } else if (action === "pause") {
         let activeSessionId = ctx.socketToSession.get(socket);
         if (!activeSessionId) {
-          const conversation = conversationStore.createConversation(
+          const conversation = createConversation(
             msg.task || "Pause Recording",
           );
           activeSessionId = conversation.id;
@@ -298,12 +297,12 @@ export async function handleTaskSubmit(
           type: "message_complete",
           sessionId: activeSessionId,
         });
-        await conversationStore.addMessage(
+        await addMessage(
           activeSessionId,
           "user",
           JSON.stringify([{ type: "text", text: msg.task || "" }]),
         );
-        await conversationStore.addMessage(
+        await addMessage(
           activeSessionId,
           "assistant",
           JSON.stringify([{ type: "text", text: responseText }]),
@@ -323,7 +322,7 @@ export async function handleTaskSubmit(
       } else if (action === "resume") {
         let activeSessionId = ctx.socketToSession.get(socket);
         if (!activeSessionId) {
-          const conversation = conversationStore.createConversation(
+          const conversation = createConversation(
             msg.task || "Resume Recording",
           );
           activeSessionId = conversation.id;
@@ -348,12 +347,12 @@ export async function handleTaskSubmit(
           type: "message_complete",
           sessionId: activeSessionId,
         });
-        await conversationStore.addMessage(
+        await addMessage(
           activeSessionId,
           "user",
           JSON.stringify([{ type: "text", text: msg.task || "" }]),
         );
-        await conversationStore.addMessage(
+        await addMessage(
           activeSessionId,
           "assistant",
           JSON.stringify([{ type: "text", text: responseText }]),
@@ -395,7 +394,7 @@ export async function handleTaskSubmit(
 
       if (intentResult.kind === "start_only") {
         // Create a conversation so the recording can be attached later
-        const conversation = conversationStore.createConversation(msg.task);
+        const conversation = createConversation(msg.task);
         ctx.socketToSession.set(socket, conversation.id);
 
         const execResult = executeRecordingIntent(intentResult, {
@@ -418,12 +417,12 @@ export async function handleTaskSubmit(
           type: "message_complete",
           sessionId: conversation.id,
         });
-        await conversationStore.addMessage(
+        await addMessage(
           conversation.id,
           "user",
           JSON.stringify([{ type: "text", text: msg.task || "" }]),
         );
-        await conversationStore.addMessage(
+        await addMessage(
           conversation.id,
           "assistant",
           JSON.stringify([{ type: "text", text: execResult.responseText! }]),
@@ -455,7 +454,7 @@ export async function handleTaskSubmit(
       if (intentResult.kind === "stop_only") {
         let activeSessionId = ctx.socketToSession.get(socket);
         if (!activeSessionId) {
-          const conversation = conversationStore.createConversation(msg.task);
+          const conversation = createConversation(msg.task);
           activeSessionId = conversation.id;
           ctx.socketToSession.set(socket, activeSessionId);
         }
@@ -481,12 +480,12 @@ export async function handleTaskSubmit(
           type: "message_complete",
           sessionId: activeSessionId,
         });
-        await conversationStore.addMessage(
+        await addMessage(
           activeSessionId,
           "user",
           JSON.stringify([{ type: "text", text: msg.task || "" }]),
         );
-        await conversationStore.addMessage(
+        await addMessage(
           activeSessionId,
           "assistant",
           JSON.stringify([{ type: "text", text: execResult.responseText! }]),
@@ -508,7 +507,7 @@ export async function handleTaskSubmit(
       if (intentResult.kind === "start_and_stop_only") {
         let activeSessionId = ctx.socketToSession.get(socket);
         if (!activeSessionId) {
-          const conversation = conversationStore.createConversation(msg.task);
+          const conversation = createConversation(msg.task);
           activeSessionId = conversation.id;
           ctx.socketToSession.set(socket, activeSessionId);
         }
@@ -534,12 +533,12 @@ export async function handleTaskSubmit(
           type: "message_complete",
           sessionId: activeSessionId,
         });
-        await conversationStore.addMessage(
+        await addMessage(
           activeSessionId,
           "user",
           JSON.stringify([{ type: "text", text: msg.task || "" }]),
         );
-        await conversationStore.addMessage(
+        await addMessage(
           activeSessionId,
           "assistant",
           JSON.stringify([{ type: "text", text: execResult.responseText! }]),
@@ -566,7 +565,7 @@ export async function handleTaskSubmit(
       ) {
         let activeSessionId = ctx.socketToSession.get(socket);
         if (!activeSessionId) {
-          const conversation = conversationStore.createConversation(msg.task);
+          const conversation = createConversation(msg.task);
           activeSessionId = conversation.id;
           ctx.socketToSession.set(socket, activeSessionId);
         }
@@ -592,12 +591,12 @@ export async function handleTaskSubmit(
           type: "message_complete",
           sessionId: activeSessionId,
         });
-        await conversationStore.addMessage(
+        await addMessage(
           activeSessionId,
           "user",
           JSON.stringify([{ type: "text", text: msg.task || "" }]),
         );
-        await conversationStore.addMessage(
+        await addMessage(
           activeSessionId,
           "assistant",
           JSON.stringify([{ type: "text", text: execResult.responseText! }]),
@@ -677,9 +676,7 @@ export async function handleTaskSubmit(
           if (mapped) {
             let activeSessionId = ctx.socketToSession.get(socket);
             if (!activeSessionId) {
-              const conversation = conversationStore.createConversation(
-                msg.task,
-              );
+              const conversation = createConversation(msg.task);
               activeSessionId = conversation.id;
               ctx.socketToSession.set(socket, activeSessionId);
             }
@@ -709,12 +706,12 @@ export async function handleTaskSubmit(
                 type: "message_complete",
                 sessionId: activeSessionId,
               });
-              await conversationStore.addMessage(
+              await addMessage(
                 activeSessionId,
                 "user",
                 JSON.stringify([{ type: "text", text: msg.task || "" }]),
               );
-              await conversationStore.addMessage(
+              await addMessage(
                 activeSessionId,
                 "assistant",
                 JSON.stringify([
@@ -781,8 +778,7 @@ export async function handleTaskSubmit(
         pendingRecordingStop ||
         pendingRecordingRestart
       ) {
-        const recConversation =
-          conversationStore.createConversation("Screen Recording");
+        const recConversation = createConversation("Screen Recording");
         if (pendingRecordingStop) handleRecordingStop(recConversation.id, ctx);
         if (pendingRecordingStart)
           handleRecordingStart(
@@ -822,8 +818,7 @@ export async function handleTaskSubmit(
       });
     } else {
       // Create text QA session and immediately start processing
-      const conversation =
-        conversationStore.createConversation(GENERATING_TITLE);
+      const conversation = createConversation(GENERATING_TITLE);
       queueGenerateConversationTitle({
         conversationId: conversation.id,
         context: { origin: "task_submit" },
@@ -938,7 +933,7 @@ export async function handleSuggestionRequest(
     });
   };
 
-  const rawMessages = conversationStore.getMessages(msg.sessionId);
+  const rawMessages = getMessages(msg.sessionId);
   if (rawMessages.length === 0) {
     noSuggestion();
     return;

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -8,7 +8,7 @@ import {
   linkAttachmentToMessage,
   uploadFileBackedAttachment,
 } from "../../memory/attachments-store.js";
-import * as conversationStore from "../../memory/conversation-store.js";
+import { addMessage } from "../../memory/conversation-crud.js";
 import type { RecordingOptions, RecordingStatus } from "../ipc-protocol.js";
 import {
   defineHandlers,
@@ -524,7 +524,7 @@ export async function finalizeAndPublishRecording(params: {
     );
     const errorText = "Recording stopped but no file was produced.";
     try {
-      await conversationStore.addMessage(
+      await addMessage(
         conversationId,
         "assistant",
         JSON.stringify([{ type: "text", text: errorText }]),
@@ -577,7 +577,7 @@ export async function finalizeAndPublishRecording(params: {
     );
     const errorText = "Recording file is unavailable or expired.";
     try {
-      await conversationStore.addMessage(
+      await addMessage(
         conversationId,
         "assistant",
         JSON.stringify([{ type: "text", text: errorText }]),
@@ -605,7 +605,7 @@ export async function finalizeAndPublishRecording(params: {
       log.error({ recordingId, filePath }, "Recording file does not exist");
       const errorText = "Recording failed to save.";
       try {
-        await conversationStore.addMessage(
+        await addMessage(
           conversationId,
           "assistant",
           JSON.stringify([{ type: "text", text: errorText }]),
@@ -638,7 +638,7 @@ export async function finalizeAndPublishRecording(params: {
       );
       const errorText = "Recording failed to save.";
       try {
-        await conversationStore.addMessage(
+        await addMessage(
           conversationId,
           "assistant",
           JSON.stringify([{ type: "text", text: errorText }]),
@@ -688,7 +688,7 @@ export async function finalizeAndPublishRecording(params: {
     // Reusing the last assistant message would attach the recording to an
     // unrelated older message after reload.
     const msgText = "Screen recording complete. Your recording has been saved.";
-    const newMsg = await conversationStore.addMessage(
+    const newMsg = await addMessage(
       conversationId,
       "assistant",
       JSON.stringify([{ type: "text", text: msgText }]),
@@ -740,7 +740,7 @@ export async function finalizeAndPublishRecording(params: {
     );
     const errorText = "Recording saved but failed to attach to conversation.";
     try {
-      await conversationStore.addMessage(
+      await addMessage(
         conversationId,
         "assistant",
         JSON.stringify([{ type: "text", text: errorText }]),

--- a/assistant/src/daemon/handlers/session-history.ts
+++ b/assistant/src/daemon/handlers/session-history.ts
@@ -5,7 +5,12 @@ import {
   getFilePathForAttachment,
   setAttachmentThumbnail,
 } from "../../memory/attachments-store.js";
-import * as conversationStore from "../../memory/conversation-store.js";
+import { getMessageById } from "../../memory/conversation-crud.js";
+import {
+  getMessagesPaginated,
+  getNextMessage,
+  searchConversations,
+} from "../../memory/conversation-queries.js";
 import { silentlyWithLog } from "../../util/silently.js";
 import { truncate } from "../../util/truncate.js";
 import type {
@@ -41,13 +46,12 @@ export function handleHistoryRequest(
   const includeToolImages = msg.includeToolImages ?? isFullMode;
   const includeSurfaceData = msg.includeSurfaceData ?? isFullMode;
 
-  const { messages: dbMessages, hasMore } =
-    conversationStore.getMessagesPaginated(
-      msg.sessionId,
-      limit,
-      msg.beforeTimestamp,
-      msg.beforeMessageId,
-    );
+  const { messages: dbMessages, hasMore } = getMessagesPaginated(
+    msg.sessionId,
+    limit,
+    msg.beforeTimestamp,
+    msg.beforeMessageId,
+  );
 
   const parsed: ParsedHistoryMessage[] = dbMessages.map((m) => {
     let text = "";
@@ -299,7 +303,7 @@ export function handleConversationSearch(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  const results = conversationStore.searchConversations(msg.query, {
+  const results = searchConversations(msg.query, {
     limit: msg.limit,
     maxMessagesPerConversation: msg.maxMessagesPerConversation,
   });
@@ -315,10 +319,7 @@ export function handleMessageContentRequest(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  const dbMessage = conversationStore.getMessageById(
-    msg.messageId,
-    msg.sessionId,
-  );
+  const dbMessage = getMessageById(msg.messageId, msg.sessionId);
   if (!dbMessage) {
     ctx.send(socket, {
       type: "error",
@@ -345,7 +346,7 @@ export function handleMessageContentRequest(
       dbMessage.role === "assistant" &&
       mergedToolCalls.some((tc) => tc.result === undefined)
     ) {
-      const nextMsg = conversationStore.getNextMessage(
+      const nextMsg = getNextMessage(
         msg.sessionId,
         dbMessage.createdAt,
         dbMessage.id,

--- a/assistant/src/daemon/handlers/session-user-message.ts
+++ b/assistant/src/daemon/handlers/session-user-message.ts
@@ -17,7 +17,7 @@ import {
   listCanonicalGuardianRequests,
   listPendingCanonicalGuardianRequestsByDestinationConversation,
 } from "../../memory/canonical-guardian-store.js";
-import * as conversationStore from "../../memory/conversation-store.js";
+import { addMessage } from "../../memory/conversation-crud.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
 import { routeGuardianReply } from "../../runtime/guardian-reply-router.js";
 import {
@@ -86,12 +86,12 @@ async function persistRecordingExchange(
     type: "message_complete",
     sessionId,
   });
-  await conversationStore.addMessage(
+  await addMessage(
     sessionId,
     "user",
     JSON.stringify([{ type: "text", text: messageText }]),
   );
-  await conversationStore.addMessage(
+  await addMessage(
     sessionId,
     "assistant",
     JSON.stringify([{ type: "text", text: responseText }]),
@@ -561,7 +561,7 @@ async function handlePendingConfirmationReply(
         messageText,
         msg.attachments ?? [],
       );
-      await conversationStore.addMessage(
+      await addMessage(
         msg.sessionId,
         "user",
         JSON.stringify(consumedUserMessage.content),
@@ -574,7 +574,7 @@ async function handlePendingConfirmationReply(
           ? "Decision applied."
           : "Request already resolved.");
       const consumedAssistantMessage = createAssistantMessage(replyText);
-      await conversationStore.addMessage(
+      await addMessage(
         msg.sessionId,
         "assistant",
         JSON.stringify(consumedAssistantMessage.content),

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -15,7 +15,20 @@ import {
   resolveCanonicalGuardianRequest,
 } from "../../memory/canonical-guardian-store.js";
 import { getAttentionStateByConversationIds } from "../../memory/conversation-attention-store.js";
-import * as conversationStore from "../../memory/conversation-store.js";
+import {
+  clearAll,
+  createConversation,
+  getConversation,
+  updateConversationTitle,
+} from "../../memory/conversation-crud.js";
+import {
+  countConversations,
+  listConversations,
+} from "../../memory/conversation-queries.js";
+import {
+  batchSetDisplayOrders,
+  getDisplayMetaForConversations,
+} from "../../memory/conversation-store.js";
 import {
   GENERATING_TITLE,
   queueGenerateConversationTitle,
@@ -252,18 +265,13 @@ export function handleSessionList(
   offset = 0,
   limit = 50,
 ): void {
-  const conversations = conversationStore.listConversations(
-    limit,
-    false,
-    offset,
-  );
-  const totalCount = conversationStore.countConversations();
+  const conversations = listConversations(limit, false, offset);
+  const totalCount = countConversations();
   const conversationIds = conversations.map((c) => c.id);
   const bindings =
     externalConversationStore.getBindingsForConversations(conversationIds);
   const attentionStates = getAttentionStateByConversationIds(conversationIds);
-  const displayMetas =
-    conversationStore.getDisplayMetaForConversations(conversationIds);
+  const displayMetas = getDisplayMetaForConversations(conversationIds);
   ctx.send(socket, {
     type: "session_list_response",
     sessions: conversations.map((c) => {
@@ -338,7 +346,7 @@ export function handleSessionsClear(
   // sendInitialSession, it auto-creates a conversation if none exist.
   // Without this DB clear, that auto-created row survives, contradicting
   // the "clear all conversations" intent.
-  conversationStore.clearAll();
+  clearAll();
   ctx.send(socket, { type: "sessions_clear_response", cleared });
 }
 
@@ -350,7 +358,7 @@ export async function handleSessionCreate(
   const threadType = normalizeThreadType(msg.threadType);
   const title =
     msg.title ?? (msg.initialMessage ? GENERATING_TITLE : "New Conversation");
-  const conversation = conversationStore.createConversation({
+  const conversation = createConversation({
     title,
     threadType,
   });
@@ -435,13 +443,10 @@ export async function handleSessionCreate(
         // Replace stuck loading placeholder with a stable fallback title
         // if title generation hasn't already completed or been renamed.
         try {
-          const current = conversationStore.getConversation(conversation.id);
+          const current = getConversation(conversation.id);
           if (current && current.title === GENERATING_TITLE) {
             const fallback = UNTITLED_FALLBACK;
-            conversationStore.updateConversationTitle(
-              conversation.id,
-              fallback,
-            );
+            updateConversationTitle(conversation.id, fallback);
             ctx.send(socket, {
               type: "session_title_updated",
               sessionId: conversation.id,
@@ -460,7 +465,7 @@ export async function handleSessionSwitch(
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
-  const conversation = conversationStore.getConversation(msg.sessionId);
+  const conversation = getConversation(msg.sessionId);
   if (!conversation) {
     ctx.send(socket, {
       type: "error",
@@ -502,7 +507,7 @@ export function handleSessionRename(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  const conversation = conversationStore.getConversation(msg.sessionId);
+  const conversation = getConversation(msg.sessionId);
   if (!conversation) {
     ctx.send(socket, {
       type: "error",
@@ -510,7 +515,7 @@ export function handleSessionRename(
     });
     return;
   }
-  conversationStore.updateConversationTitle(msg.sessionId, msg.title, 0);
+  updateConversationTitle(msg.sessionId, msg.title, 0);
   ctx.send(socket, {
     type: "session_title_updated",
     sessionId: msg.sessionId,
@@ -613,7 +618,7 @@ export function handleUsageRequest(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  const conversation = conversationStore.getConversation(msg.sessionId);
+  const conversation = getConversation(msg.sessionId);
   if (!conversation) {
     ctx.send(socket, { type: "error", message: "No active session" });
     return;
@@ -664,7 +669,7 @@ export function handleReorderThreads(
   if (!Array.isArray(msg.updates)) {
     return;
   }
-  conversationStore.batchSetDisplayOrders(
+  batchSetDisplayOrders(
     msg.updates.map((u) => ({
       id: u.sessionId,
       displayOrder: u.displayOrder ?? null,

--- a/assistant/src/daemon/handlers/subagents.ts
+++ b/assistant/src/daemon/handlers/subagents.ts
@@ -4,7 +4,7 @@
 
 import * as net from "node:net";
 
-import * as conversationStore from "../../memory/conversation-store.js";
+import { getMessages } from "../../memory/conversation-crud.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import type {
   SubagentAbortRequest,
@@ -192,7 +192,7 @@ export function handleSubagentDetailRequest(
     return;
   }
 
-  const subagentMsgs = conversationStore.getMessages(msg.conversationId);
+  const subagentMsgs = getMessages(msg.conversationId);
 
   // Extract objective from the first user message
   let objective: string | undefined;

--- a/assistant/src/daemon/handlers/work-items.ts
+++ b/assistant/src/daemon/handlers/work-items.ts
@@ -1,6 +1,6 @@
 import * as net from "node:net";
 
-import { getMessages } from "../../memory/conversation-store.js";
+import { getMessages } from "../../memory/conversation-crud.js";
 import { check, classifyRisk } from "../../permissions/checker.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { runTask } from "../../tasks/task-runner.js";

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -26,7 +26,11 @@ import { closeSentry, initSentry } from "../instrument.js";
 import { initLogfire } from "../logfire.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import * as attachmentsStore from "../memory/attachments-store.js";
-import * as conversationStore from "../memory/conversation-store.js";
+import {
+  deleteMessageById,
+  getConversationThreadType,
+  getMessages,
+} from "../memory/conversation-crud.js";
 import { initializeDb } from "../memory/db.js";
 import { startMemoryJobsWorker } from "../memory/jobs-worker.js";
 import { initQdrantClient } from "../memory/qdrant-client.js";
@@ -445,8 +449,7 @@ export async function runDaemon(): Promise<void> {
           data: a.dataBase64,
         })),
       deriveDefaultStrictSideEffects: (conversationId) => {
-        const threadType =
-          conversationStore.getConversationThreadType(conversationId);
+        const threadType = getConversationThreadType(conversationId);
         return threadType === "private";
       },
     });
@@ -483,13 +486,13 @@ export async function runDaemon(): Promise<void> {
             // messages array during runAgentLoop.
             const rollback = async (extraMessageIds?: string[]) => {
               try {
-                conversationStore.deleteMessageById(messageId);
+                deleteMessageById(messageId);
               } catch {
                 /* best effort */
               }
               for (const id of extraMessageIds ?? []) {
                 try {
-                  conversationStore.deleteMessageById(id);
+                  deleteMessageById(id);
                 } catch {
                   /* best effort */
                 }
@@ -516,7 +519,7 @@ export async function runDaemon(): Promise<void> {
             // improvement could tag messages with a per-run correlation
             // ID so rollback only targets its own output.
             const preRunMessageIds = new Set(
-              conversationStore.getMessages(conversationId).map((m) => m.id),
+              getMessages(conversationId).map((m) => m.id),
             );
 
             let agentLoopError: string | undefined;
@@ -546,8 +549,7 @@ export async function runDaemon(): Promise<void> {
             // the pre-run snapshot. This captures all messages added to the
             // conversation during the loop window, which may include messages
             // from concurrent pointer events (see over-capture caveat above).
-            const postRunMessages =
-              conversationStore.getMessages(conversationId);
+            const postRunMessages = getMessages(conversationId);
             const createdMessageIds = postRunMessages
               .filter((m) => !preRunMessageIds.has(m.id) && m.id !== messageId)
               .map((m) => m.id);

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -23,8 +23,15 @@ import {
   createCanonicalGuardianRequest,
   generateCanonicalRequestCode,
 } from "../memory/canonical-guardian-store.js";
-import * as conversationStore from "../memory/conversation-store.js";
-import { provenanceFromTrustContext } from "../memory/conversation-store.js";
+import {
+  addMessage,
+  getConversationMemoryScopeId,
+  getConversationThreadType,
+  provenanceFromTrustContext,
+  setConversationOriginChannelIfUnset,
+  setConversationOriginInterfaceIfUnset,
+} from "../memory/conversation-crud.js";
+import { getLatestConversation } from "../memory/conversation-queries.js";
 import { RateLimitProvider } from "../providers/ratelimit.js";
 import {
   getFailoverProvider,
@@ -254,11 +261,10 @@ export class DaemonServer {
   }
 
   private deriveMemoryPolicy(conversationId: string): SessionMemoryPolicy {
-    const threadType =
-      conversationStore.getConversationThreadType(conversationId);
+    const threadType = getConversationThreadType(conversationId);
     if (threadType === "private") {
       return {
-        scopeId: conversationStore.getConversationMemoryScopeId(conversationId),
+        scopeId: getConversationMemoryScopeId(conversationId),
         includeDefaultFallback: true,
         strictSideEffects: true,
       };
@@ -842,7 +848,7 @@ export class DaemonServer {
   }
 
   private async sendInitialSession(socket: net.Socket): Promise<void> {
-    const conversation = conversationStore.getLatestConversation();
+    const conversation = getLatestConversation();
     if (!conversation) {
       this.send(socket, {
         type: "daemon_status",
@@ -1192,7 +1198,7 @@ export class DaemonServer {
           : {}),
       };
       const userMsg = createUserMessage(content, attachments);
-      const persisted = await conversationStore.addMessage(
+      const persisted = await addMessage(
         conversationId,
         "user",
         JSON.stringify(userMsg.content),
@@ -1202,7 +1208,7 @@ export class DaemonServer {
 
       if (serverTurnCtx) {
         try {
-          conversationStore.setConversationOriginChannelIfUnset(
+          setConversationOriginChannelIfUnset(
             conversationId,
             serverTurnCtx.userMessageChannel,
           );
@@ -1215,7 +1221,7 @@ export class DaemonServer {
       }
       if (serverInterfaceCtx) {
         try {
-          conversationStore.setConversationOriginInterfaceIfUnset(
+          setConversationOriginInterfaceIfUnset(
             conversationId,
             serverInterfaceCtx.userMessageInterface,
           );
@@ -1228,7 +1234,7 @@ export class DaemonServer {
       }
 
       const assistantMsg = createAssistantMessage(slashResult.message);
-      await conversationStore.addMessage(
+      await addMessage(
         conversationId,
         "assistant",
         JSON.stringify(assistantMsg.content),

--- a/assistant/src/daemon/session-agent-loop-handlers.ts
+++ b/assistant/src/daemon/session-agent-loop-handlers.ts
@@ -13,8 +13,12 @@ import type {
   TurnChannelContext,
   TurnInterfaceContext,
 } from "../channels/types.js";
-import * as conversationStore from "../memory/conversation-store.js";
-import { provenanceFromTrustContext } from "../memory/conversation-store.js";
+import {
+  addMessage,
+  getMessageById,
+  provenanceFromTrustContext,
+  updateMessageContent,
+} from "../memory/conversation-crud.js";
 import { recordRequestLog } from "../memory/llm-request-log-store.js";
 import type { ContentBlock, ImageContent } from "../providers/types.js";
 import type { DirectiveRequest } from "./assistant-attachments.js";
@@ -491,7 +495,7 @@ function annotatePersistedAssistantMessage(state: EventHandlerState): void {
   const messageId = state.lastAssistantMessageId;
   if (!messageId) return;
 
-  const row = conversationStore.getMessageById(messageId);
+  const row = getMessageById(messageId);
   if (!row) return;
 
   let content: ContentBlock[];
@@ -526,7 +530,7 @@ function annotatePersistedAssistantMessage(state: EventHandlerState): void {
   }
 
   if (modified) {
-    conversationStore.updateMessageContent(messageId, JSON.stringify(content));
+    updateMessageContent(messageId, JSON.stringify(content));
   }
 
   // Clear for the next turn
@@ -599,7 +603,7 @@ export async function handleMessageComplete(
       assistantMessageInterface:
         deps.turnInterfaceContext.assistantMessageInterface,
     };
-    await conversationStore.addMessage(
+    await addMessage(
       deps.ctx.conversationId,
       "user",
       JSON.stringify(toolResultBlocks),
@@ -661,7 +665,7 @@ export async function handleMessageComplete(
     assistantMessageInterface:
       deps.turnInterfaceContext.assistantMessageInterface,
   };
-  const assistantMsg = await conversationStore.addMessage(
+  const assistantMsg = await addMessage(
     deps.ctx.conversationId,
     "assistant",
     JSON.stringify(contentWithSurfaces),

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -28,12 +28,16 @@ import type { ToolProfiler } from "../events/tool-profiling-listener.js";
 import { getHookManager } from "../hooks/manager.js";
 import { commitAppTurnChanges } from "../memory/app-git-service.js";
 import { getApp, listAppFiles } from "../memory/app-store.js";
-import * as conversationStore from "../memory/conversation-store.js";
 import {
+  addMessage,
+  deleteMessageById,
+  getConversation,
   getConversationOriginChannel,
   getConversationOriginInterface,
   provenanceFromTrustContext,
-} from "../memory/conversation-store.js";
+  updateConversationContextWindow,
+  updateConversationTitle,
+} from "../memory/conversation-crud.js";
 import {
   isReplaceableTitle,
   queueGenerateConversationTitle,
@@ -371,18 +375,15 @@ export async function runAgentLoopImpl(
     if (preMessageResult.blocked) {
       if (!options?.skipPreMessageRollback) {
         ctx.messages.pop();
-        conversationStore.deleteMessageById(userMessageId);
+        deleteMessageById(userMessageId);
       }
       // Replace loading placeholder so the thread isn't stuck as "Generating title..."
-      const currentConv = conversationStore.getConversation(ctx.conversationId);
+      const currentConv = getConversation(ctx.conversationId);
       if (
         isReplaceableTitle(currentConv?.title ?? null) &&
         currentConv?.title !== UNTITLED_FALLBACK
       ) {
-        conversationStore.updateConversationTitle(
-          ctx.conversationId,
-          UNTITLED_FALLBACK,
-        );
+        updateConversationTitle(ctx.conversationId, UNTITLED_FALLBACK);
         onEvent({
           type: "session_title_updated",
           sessionId: ctx.conversationId,
@@ -405,9 +406,7 @@ export async function runAgentLoopImpl(
     // Deferred via setTimeout so the main agent loop LLM call enqueues
     // first, avoiding rate-limit slot contention on strict configs.
     if (
-      isReplaceableTitle(
-        conversationStore.getConversation(ctx.conversationId)?.title ?? null,
-      )
+      isReplaceableTitle(getConversation(ctx.conversationId)?.title ?? null)
     ) {
       setTimeout(() => {
         queueGenerateConversationTitle({
@@ -443,7 +442,7 @@ export async function runAgentLoopImpl(
       ctx.messages = compacted.messages;
       ctx.contextCompactedMessageCount += compacted.compactedPersistedMessages;
       ctx.contextCompactedAt = Date.now();
-      conversationStore.updateConversationContextWindow(
+      updateConversationContextWindow(
         ctx.conversationId,
         compacted.summaryText,
         ctx.contextCompactedMessageCount,
@@ -706,7 +705,7 @@ export async function runAgentLoopImpl(
           ctx.contextCompactedMessageCount +=
             step.compactionResult.compactedPersistedMessages;
           ctx.contextCompactedAt = Date.now();
-          conversationStore.updateConversationContextWindow(
+          updateConversationContextWindow(
             ctx.conversationId,
             step.compactionResult.summaryText,
             ctx.contextCompactedMessageCount,
@@ -767,7 +766,7 @@ export async function runAgentLoopImpl(
     let preRunHistoryLength = runMessages.length;
 
     const shouldGenerateTitle = isReplaceableTitle(
-      conversationStore.getConversation(ctx.conversationId)?.title ?? null,
+      getConversation(ctx.conversationId)?.title ?? null,
     );
 
     const deps: EventHandlerDeps = {
@@ -903,7 +902,7 @@ export async function runAgentLoopImpl(
           ctx.contextCompactedMessageCount +=
             step.compactionResult.compactedPersistedMessages;
           ctx.contextCompactedAt = Date.now();
-          conversationStore.updateConversationContextWindow(
+          updateConversationContextWindow(
             ctx.conversationId,
             step.compactionResult.summaryText,
             ctx.contextCompactedMessageCount,
@@ -983,7 +982,7 @@ export async function runAgentLoopImpl(
               ctx.contextCompactedMessageCount +=
                 emergencyCompact.compactedPersistedMessages;
               ctx.contextCompactedAt = Date.now();
-              conversationStore.updateConversationContextWindow(
+              updateConversationContextWindow(
                 ctx.conversationId,
                 emergencyCompact.summaryText,
                 ctx.contextCompactedMessageCount,
@@ -1049,7 +1048,7 @@ export async function runAgentLoopImpl(
                 capturedTurnInterfaceContext.assistantMessageInterface,
             };
             const denyMessage = createAssistantMessage(denyText);
-            await conversationStore.addMessage(
+            await addMessage(
               ctx.conversationId,
               "assistant",
               JSON.stringify(denyMessage.content),
@@ -1088,7 +1087,7 @@ export async function runAgentLoopImpl(
             ctx.contextCompactedMessageCount +=
               emergencyCompact.compactedPersistedMessages;
             ctx.contextCompactedAt = Date.now();
-            conversationStore.updateConversationContextWindow(
+            updateConversationContextWindow(
               ctx.conversationId,
               emergencyCompact.summaryText,
               ctx.contextCompactedMessageCount,
@@ -1211,7 +1210,7 @@ export async function runAgentLoopImpl(
         assistantMessageInterface:
           capturedTurnInterfaceContext.assistantMessageInterface,
       };
-      await conversationStore.addMessage(
+      await addMessage(
         ctx.conversationId,
         "user",
         JSON.stringify(toolResultBlocks),
@@ -1253,7 +1252,7 @@ export async function runAgentLoopImpl(
       const errorAssistantMessage = createAssistantMessage(
         state.providerErrorUserMessage,
       );
-      await conversationStore.addMessage(
+      await addMessage(
         ctx.conversationId,
         "assistant",
         JSON.stringify(errorAssistantMessage.content),

--- a/assistant/src/daemon/session-history.ts
+++ b/assistant/src/daemon/session-history.ts
@@ -1,7 +1,14 @@
 import { v4 as uuid } from "uuid";
 
 import { getSummaryFromContextMessage } from "../context/window-manager.js";
-import * as conversationStore from "../memory/conversation-store.js";
+import {
+  deleteLastExchange,
+  deleteMessageById,
+  getMessages,
+  relinkAttachments,
+  updateMessageContent,
+} from "../memory/conversation-crud.js";
+import { isLastUserMessageToolResult } from "../memory/conversation-queries.js";
 import { enqueueMemoryJob } from "../memory/jobs-store.js";
 import { withQdrantBreaker } from "../memory/qdrant-circuit-breaker.js";
 import { getQdrantClient } from "../memory/qdrant-client.js";
@@ -117,7 +124,7 @@ export function consolidateAssistantMessages(
   conversationId: string,
   userMessageId: string,
 ): void {
-  const allMessages = conversationStore.getMessages(conversationId);
+  const allMessages = getMessages(conversationId);
   const userMsgIndex = allMessages.findIndex((m) => m.id === userMessageId);
   if (userMsgIndex === -1) return;
 
@@ -159,7 +166,7 @@ export function consolidateAssistantMessages(
     const allSegmentIds: string[] = [];
     const allOrphanedItemIds: string[] = [];
     for (const id of messagesToDelete) {
-      const deleted = conversationStore.deleteMessageById(id);
+      const deleted = deleteMessageById(id);
       allSegmentIds.push(...deleted.segmentIds);
       allOrphanedItemIds.push(...deleted.orphanedItemIds);
     }
@@ -260,7 +267,7 @@ export function consolidateAssistantMessages(
 
   // Update the first assistant message with all content
   const firstAssistantMsg = messagesToConsolidate[0];
-  conversationStore.updateMessageContent(
+  updateMessageContent(
     firstAssistantMsg.id,
     JSON.stringify(consolidatedContent),
   );
@@ -273,7 +280,7 @@ export function consolidateAssistantMessages(
     ...messagesToDelete,
   ];
   if (messageIdsToDelete.length > 0) {
-    const relinked = conversationStore.relinkAttachments(
+    const relinked = relinkAttachments(
       messageIdsToDelete,
       firstAssistantMsg.id,
     );
@@ -290,14 +297,12 @@ export function consolidateAssistantMessages(
   const allSegmentIds: string[] = [];
   const allOrphanedItemIds: string[] = [];
   for (let i = 1; i < messagesToConsolidate.length; i++) {
-    const deleted = conversationStore.deleteMessageById(
-      messagesToConsolidate[i].id,
-    );
+    const deleted = deleteMessageById(messagesToConsolidate[i].id);
     allSegmentIds.push(...deleted.segmentIds);
     allOrphanedItemIds.push(...deleted.orphanedItemIds);
   }
   for (const id of messagesToDelete) {
-    const deleted = conversationStore.deleteMessageById(id);
+    const deleted = deleteMessageById(id);
     allSegmentIds.push(...deleted.segmentIds);
     allOrphanedItemIds.push(...deleted.orphanedItemIds);
   }
@@ -376,15 +381,15 @@ export function undo(session: HistorySessionContext): number {
   // deleteLastExchange when the loop peeled back tool_result messages.
   let hadToolResult = false;
   do {
-    conversationStore.deleteLastExchange(session.conversationId);
-    if (conversationStore.isLastUserMessageToolResult(session.conversationId)) {
+    deleteLastExchange(session.conversationId);
+    if (isLastUserMessageToolResult(session.conversationId)) {
       hadToolResult = true;
     } else {
       break;
     }
   } while (true);
   if (hadToolResult) {
-    conversationStore.deleteLastExchange(session.conversationId);
+    deleteLastExchange(session.conversationId);
   }
 
   return removed;
@@ -455,7 +460,7 @@ export async function regenerate(
 
   // Find DB message IDs to delete: get all messages from the DB, then
   // identify the ones that come after the last user message.
-  const dbMessages = conversationStore.getMessages(session.conversationId);
+  const dbMessages = getMessages(session.conversationId);
 
   // Walk backwards to find the last real (non-tool_result) user message in the DB.
   let dbUserMsgIdx = -1;
@@ -504,7 +509,7 @@ export async function regenerate(
   const allSegmentIds: string[] = [];
   const allOrphanedItemIds: string[] = [];
   for (const msg of messagesToDelete) {
-    const deleted = conversationStore.deleteMessageById(msg.id);
+    const deleted = deleteMessageById(msg.id);
     allSegmentIds.push(...deleted.segmentIds);
     allOrphanedItemIds.push(...deleted.orphanedItemIds);
   }

--- a/assistant/src/daemon/session-lifecycle.ts
+++ b/assistant/src/daemon/session-lifecycle.ts
@@ -9,7 +9,11 @@ import type { EventBus } from "../events/bus.js";
 import type { AssistantDomainEvents } from "../events/domain-events.js";
 import type { ToolProfiler } from "../events/tool-profiling-listener.js";
 import { getHookManager } from "../hooks/manager.js";
-import * as conversationStore from "../memory/conversation-store.js";
+import {
+  getConversation,
+  getMessages,
+  type MessageRow,
+} from "../memory/conversation-crud.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import type { ContentBlock, Message } from "../providers/types.js";
@@ -50,9 +54,7 @@ function parseProvenanceTrustClass(
   return undefined;
 }
 
-function filterMessagesForUntrustedActor(
-  messages: conversationStore.MessageRow[],
-): conversationStore.MessageRow[] {
+function filterMessagesForUntrustedActor(messages: MessageRow[]): MessageRow[] {
   return messages.filter((m) => {
     const provenanceTrustClass = parseProvenanceTrustClass(m.metadata);
     return (
@@ -105,12 +107,12 @@ export interface DisposeContext extends AbortContext {
 
 export async function loadFromDb(ctx: LoadFromDbContext): Promise<void> {
   const trustClass = ctx.trustContext?.trustClass;
-  const allDbMessages = conversationStore.getMessages(ctx.conversationId);
+  const allDbMessages = getMessages(ctx.conversationId);
   const dbMessages = isUntrustedTrustClass(trustClass)
     ? filterMessagesForUntrustedActor(allDbMessages)
     : allDbMessages;
 
-  const conv = conversationStore.getConversation(ctx.conversationId);
+  const conv = getConversation(ctx.conversationId);
   const contextSummary = !isUntrustedTrustClass(trustClass)
     ? conv?.contextSummary?.trim() || null
     : null;

--- a/assistant/src/daemon/session-messaging.ts
+++ b/assistant/src/daemon/session-messaging.ts
@@ -19,8 +19,12 @@ import {
   uploadAttachment,
   validateAttachmentUpload,
 } from "../memory/attachments-store.js";
-import * as conversationStore from "../memory/conversation-store.js";
-import { provenanceFromTrustContext } from "../memory/conversation-store.js";
+import {
+  addMessage,
+  provenanceFromTrustContext,
+  setConversationOriginChannelIfUnset,
+  setConversationOriginInterfaceIfUnset,
+} from "../memory/conversation-crud.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import type { Message } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
@@ -317,7 +321,7 @@ export async function persistUserMessage(
           ).content,
         )
       : JSON.stringify(userMessage.content);
-    const persistedUserMessage = await conversationStore.addMessage(
+    const persistedUserMessage = await addMessage(
       ctx.conversationId,
       "user",
       contentToPersist,
@@ -325,13 +329,13 @@ export async function persistUserMessage(
     );
 
     if (turnCtx) {
-      conversationStore.setConversationOriginChannelIfUnset(
+      setConversationOriginChannelIfUnset(
         ctx.conversationId,
         turnCtx.userMessageChannel,
       );
     }
     if (turnIfCtx) {
-      conversationStore.setConversationOriginInterfaceIfUnset(
+      setConversationOriginInterfaceIfUnset(
         ctx.conversationId,
         turnIfCtx.userMessageInterface,
       );

--- a/assistant/src/daemon/session-notifiers.ts
+++ b/assistant/src/daemon/session-notifiers.ts
@@ -18,8 +18,10 @@ import {
   unregisterCallTranscriptNotifier,
 } from "../calls/call-state.js";
 import { getCallSession } from "../calls/call-store.js";
-import * as conversationStore from "../memory/conversation-store.js";
-import { provenanceFromTrustContext } from "../memory/conversation-store.js";
+import {
+  addMessage,
+  provenanceFromTrustContext,
+} from "../memory/conversation-crud.js";
 import type { Message } from "../providers/types.js";
 import type { WatchSession } from "../tools/watch/watch-state.js";
 import {
@@ -106,7 +108,7 @@ export function registerSessionNotifiers(
       const callee = callSession?.toNumber ?? "the caller";
       const questionText = `**Live call question** (to ${callee}):\n\n${question}\n\n_Use the call answer API to respond._`;
 
-      await conversationStore.addMessage(
+      await addMessage(
         conversationId,
         "assistant",
         JSON.stringify([{ type: "text", text: questionText }]),

--- a/assistant/src/daemon/session-process.ts
+++ b/assistant/src/daemon/session-process.ts
@@ -17,8 +17,12 @@ import type {
 import { parseChannelId, parseInterfaceId } from "../channels/types.js";
 import { getConfig } from "../config/loader.js";
 import { listPendingRequestsByConversationScope } from "../memory/canonical-guardian-store.js";
-import * as conversationStore from "../memory/conversation-store.js";
-import { provenanceFromTrustContext } from "../memory/conversation-store.js";
+import {
+  addMessage,
+  provenanceFromTrustContext,
+  setConversationOriginChannelIfUnset,
+  setConversationOriginInterfaceIfUnset,
+} from "../memory/conversation-crud.js";
 import { extractPreferences } from "../notifications/preference-extractor.js";
 import { createPreference } from "../notifications/preferences-store.js";
 import type { Message } from "../providers/types.js";
@@ -290,7 +294,7 @@ export async function drainQueue(
             createUserMessage(next.displayContent, next.attachments).content,
           )
         : JSON.stringify(userMsg.content);
-      await conversationStore.addMessage(
+      await addMessage(
         session.conversationId,
         "user",
         contentToPersist,
@@ -299,7 +303,7 @@ export async function drainQueue(
       session.messages.push(userMsg);
 
       const assistantMsg = createAssistantMessage(slashResult.message);
-      await conversationStore.addMessage(
+      await addMessage(
         session.conversationId,
         "assistant",
         JSON.stringify(assistantMsg.content),
@@ -308,13 +312,13 @@ export async function drainQueue(
       session.messages.push(assistantMsg);
 
       if (queuedTurnCtx) {
-        conversationStore.setConversationOriginChannelIfUnset(
+        setConversationOriginChannelIfUnset(
           session.conversationId,
           queuedTurnCtx.userMessageChannel,
         );
       }
       if (queuedInterfaceCtx) {
-        conversationStore.setConversationOriginInterfaceIfUnset(
+        setConversationOriginInterfaceIfUnset(
           session.conversationId,
           queuedInterfaceCtx.userMessageInterface,
         );
@@ -570,7 +574,7 @@ export async function processMessage(
       };
 
       const userMsg = createUserMessage(content, attachments);
-      const persisted = await conversationStore.addMessage(
+      const persisted = await addMessage(
         session.conversationId,
         "user",
         JSON.stringify(userMsg.content),
@@ -584,7 +588,7 @@ export async function processMessage(
           ? "Decision applied."
           : "Request already resolved.");
       const assistantMsg = createAssistantMessage(replyText);
-      await conversationStore.addMessage(
+      await addMessage(
         session.conversationId,
         "assistant",
         JSON.stringify(assistantMsg.content),
@@ -640,7 +644,7 @@ export async function processMessage(
     const contentToPersist = displayContent
       ? JSON.stringify(createUserMessage(displayContent, attachments).content)
       : JSON.stringify(userMsg.content);
-    const persisted = await conversationStore.addMessage(
+    const persisted = await addMessage(
       session.conversationId,
       "user",
       contentToPersist,
@@ -649,7 +653,7 @@ export async function processMessage(
     session.messages.push(userMsg);
 
     const assistantMsg = createAssistantMessage(slashResult.message);
-    await conversationStore.addMessage(
+    await addMessage(
       session.conversationId,
       "assistant",
       JSON.stringify(assistantMsg.content),
@@ -658,13 +662,13 @@ export async function processMessage(
     session.messages.push(assistantMsg);
 
     if (pmTurnCtx) {
-      conversationStore.setConversationOriginChannelIfUnset(
+      setConversationOriginChannelIfUnset(
         session.conversationId,
         pmTurnCtx.userMessageChannel,
       );
     }
     if (pmInterfaceCtx) {
-      conversationStore.setConversationOriginInterfaceIfUnset(
+      setConversationOriginInterfaceIfUnset(
         session.conversationId,
         pmInterfaceCtx.userMessageInterface,
       );

--- a/assistant/src/daemon/session-usage.ts
+++ b/assistant/src/daemon/session-usage.ts
@@ -1,5 +1,5 @@
 import { getConfig } from "../config/loader.js";
-import * as conversationStore from "../memory/conversation-store.js";
+import { updateConversationUsage } from "../memory/conversation-crud.js";
 import { recordUsageEvent } from "../memory/llm-usage-store.js";
 import type { UsageActor } from "../usage/actors.js";
 import type {
@@ -144,7 +144,7 @@ export function recordUsage(
   ctx.usageStats.outputTokens += outputTokens;
   ctx.usageStats.estimatedCost += estimatedCost;
 
-  conversationStore.updateConversationUsage(
+  updateConversationUsage(
     ctx.conversationId,
     ctx.usageStats.inputTokens,
     ctx.usageStats.outputTokens,


### PR DESCRIPTION
## Summary

- Replaces all namespace imports (`import * as conversationStore`) from `conversation-store.js` across 19 daemon/ files with named imports from the actual source modules (`conversation-crud.js` and `conversation-queries.js`)
- Removes unused imports surfaced by the migration (5 functions in `server.ts` that upstream changes made dead)
- Two functions (`batchSetDisplayOrders`, `getDisplayMetaForConversations`) remain imported from `conversation-store.js` in `handlers/sessions.ts` since they are defined directly in that barrel module

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] Prettier formatting passes
- [x] ESLint passes
- [x] Grep confirms no remaining `import * as conversationStore` in daemon/

Part of prelaunch-deprecation-cleanup plan (PR 22/28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
