### PR TITLE
fix: update integration-status test for config-based Twilio auth token

### DIFF
--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const secureKeyValues = new Map<string, string>();
 let mockTwilioAccountSid: string | undefined;
+let mockTwilioAuthToken: string | undefined;
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (account: string) => secureKeyValues.get(account),
@@ -10,7 +11,7 @@ mock.module("../security/secure-keys.js", () => ({
 mock.module("../config/loader.js", () => ({
   loadConfig: () => ({
     twilio: mockTwilioAccountSid
-      ? { accountSid: mockTwilioAccountSid }
+      ? { accountSid: mockTwilioAccountSid, authToken: mockTwilioAuthToken }
       : undefined,
   }),
 }));
@@ -22,6 +23,7 @@ describe("integration-status", () => {
   beforeEach(() => {
     secureKeyValues.clear();
     mockTwilioAccountSid = undefined;
+    mockTwilioAuthToken = undefined;
   });
 
   describe("getIntegrationSummary", () => {
@@ -41,7 +43,7 @@ describe("integration-status", () => {
       secureKeyValues.set("credential:integration:twitter:access_token", "tok");
       secureKeyValues.set("credential:integration:slack:access_token", "tok");
       mockTwilioAccountSid = "sid";
-      secureKeyValues.set("credential:twilio:auth_token", "auth");
+      mockTwilioAuthToken = "auth";
       secureKeyValues.set("credential:telegram:bot_token", "tok");
       secureKeyValues.set("credential:telegram:webhook_secret", "secret");
 
@@ -53,7 +55,7 @@ describe("integration-status", () => {
 
     test("returns mixed status", () => {
       mockTwilioAccountSid = "sid";
-      secureKeyValues.set("credential:twilio:auth_token", "auth");
+      mockTwilioAuthToken = "auth";
       secureKeyValues.set("credential:telegram:bot_token", "tok");
       secureKeyValues.set("credential:telegram:webhook_secret", "secret");
 
@@ -98,7 +100,7 @@ describe("integration-status", () => {
   describe("formatIntegrationSummary", () => {
     test("shows checkmarks and crosses", () => {
       mockTwilioAccountSid = "sid";
-      secureKeyValues.set("credential:twilio:auth_token", "auth");
+      mockTwilioAuthToken = "auth";
       secureKeyValues.set("credential:telegram:bot_token", "tok");
       secureKeyValues.set("credential:telegram:webhook_secret", "secret");
 
@@ -120,7 +122,7 @@ describe("integration-status", () => {
       secureKeyValues.set("credential:integration:twitter:access_token", "tok");
       secureKeyValues.set("credential:integration:slack:access_token", "tok");
       mockTwilioAccountSid = "sid";
-      secureKeyValues.set("credential:twilio:auth_token", "auth");
+      mockTwilioAuthToken = "auth";
       secureKeyValues.set("credential:telegram:bot_token", "tok");
       secureKeyValues.set("credential:telegram:webhook_secret", "secret");
 


### PR DESCRIPTION
## Summary
- The #13960 refactor moved Twilio \`authToken\` from the secure key store into the config file, but \`integration-status.test.ts\` was not updated and still set \`credential:twilio:auth_token\` as a secure key (which \`hasTwilioCredentials()\` no longer reads).
- Added \`mockTwilioAuthToken\` variable and include it in the \`loadConfig\` mock; replaced all \`secureKeyValues.set("credential:twilio:auth_token", ...)\" calls with \`mockTwilioAuthToken = "auth"\`.

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22796113042/job/66130910276

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
