### PR TITLE
fix: remove unreachable address migration check in contact-store

### DIFF
--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -274,9 +274,6 @@ function syncChannels(
 
     if (existing) {
       const updateSet: Record<string, unknown> = {};
-      // Migrate address to canonical form if it changed
-      if (existing.address !== normalizedAddress)
-        updateSet.address = normalizedAddress;
       if (ch.isPrimary !== undefined) updateSet.isPrimary = ch.isPrimary;
       if (ch.externalUserId !== undefined)
         updateSet.externalUserId = ch.externalUserId;


### PR DESCRIPTION
## Summary
- Removes dead code (unreachable address migration check) left behind after legacyAddress removal in #13952

## Test plan
- [ ] Verify the removed code was indeed unreachable
- [ ] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13976" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
