### PR TITLE
fix: update test mocks to reference handlers/shared.js after shim removal

### DIFF
--- a/assistant/src/__tests__/channel-approval-routes.test.ts
+++ b/assistant/src/__tests__/channel-approval-routes.test.ts
@@ -45,7 +45,7 @@ mock.module("../security/secret-ingress.js", () => ({
 }));
 
 // Mock render to return the raw content as text
-mock.module("../daemon/handlers.js", () => ({
+mock.module("../daemon/handlers/shared.js", () => ({
   renderHistoryContent: (content: unknown) => ({
     text: typeof content === "string" ? content : JSON.stringify(content),
   }),

--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -91,7 +91,7 @@ mock.module("../memory/attachments-store.js", () => ({
     attachmentsByMessageId.get(messageId) ?? [],
 }));
 
-mock.module("../daemon/handlers.js", () => ({
+mock.module("../daemon/handlers/shared.js", () => ({
   renderHistoryContent: () => renderedHistoryContent,
 }));
 

--- a/assistant/src/__tests__/conversation-attention-telegram.test.ts
+++ b/assistant/src/__tests__/conversation-attention-telegram.test.ts
@@ -39,7 +39,7 @@ mock.module("../security/secret-ingress.js", () => ({
 }));
 
 // Mock render to return the raw content as text
-mock.module("../daemon/handlers.js", () => ({
+mock.module("../daemon/handlers/shared.js", () => ({
   renderHistoryContent: (content: unknown) => ({
     text: typeof content === "string" ? content : JSON.stringify(content),
   }),


### PR DESCRIPTION
## Summary
- Updates test mock.module paths that referenced deleted daemon/handlers.js shim
- Mocks now point to the actual source module (handlers/shared.js)
- Addresses feedback from PR #13969 review

## Test plan
- [ ] Verify mock paths match actual module locations
- [ ] Tests using these mocks still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
