### PR TITLE
fix: align Twilio credential write path with config-based read

### DIFF
--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -46,7 +46,7 @@ export function resolveTwilioPhoneNumber(): string {
 export function getTwilioConfig(): TwilioConfig {
   const config = loadConfig();
   const accountSid = config.twilio?.accountSid || "";
-  const authToken = getSecureKey("credential:twilio:auth_token");
+  const authToken = config.twilio?.authToken || "";
   const phoneNumber = resolveTwilioPhoneNumber();
   const webhookBaseUrl = getPublicBaseUrl(config);
 
@@ -59,7 +59,7 @@ export function getTwilioConfig(): TwilioConfig {
 
   if (!accountSid || !authToken) {
     throw new ConfigError(
-      "Twilio credentials not configured. Set twilio.accountSid via config and twilio:auth_token via the credential_store tool.",
+      "Twilio credentials not configured. Set twilio.accountSid and twilio.authToken via config.",
     );
   }
   if (!phoneNumber) {

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -1,6 +1,6 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 
-import { getSecureKey } from "../security/secure-keys.js";
+import { loadConfig } from "../config/loader.js";
 import { ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -16,7 +16,7 @@ const log = getLogger("twilio-provider");
  * Twilio ConversationRelay voice provider.
  *
  * Uses the Twilio REST API directly via fetch() — no twilio npm package.
- * Credentials are resolved lazily from the secure key store on each call.
+ * Credentials are resolved lazily from config on each call.
  */
 export class TwilioConversationRelayProvider implements VoiceProvider {
   readonly name = "twilio";
@@ -275,12 +275,17 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
   // ── Webhook signature verification ──────────────────────────────────
 
   /**
-   * Returns the Twilio auth token from the secure key store, or null if
-   * not configured. Exposed as a static method so callers (e.g. the
-   * HTTP server webhook middleware) can check availability independently.
+   * Returns the Twilio auth token from config, or null if not configured.
+   * Exposed as a static method so callers (e.g. the HTTP server webhook
+   * middleware) can check availability independently.
    */
   static getAuthToken(): string | null {
-    return getSecureKey("credential:twilio:auth_token") ?? null;
+    try {
+      const config = loadConfig();
+      return config.twilio?.authToken || null;
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/assistant/src/runtime/middleware/twilio-validation.ts
+++ b/assistant/src/runtime/middleware/twilio-validation.ts
@@ -73,8 +73,8 @@ export async function validateTwilioWebhook(
 
   if (!authToken) {
     log.error(
-      "Twilio auth token not found in secure key store — cannot verify webhook HMAC signature. " +
-        "Rejecting request. Set credential:twilio:auth_token via the credential_store tool.",
+      "Twilio auth token not found in config — cannot verify webhook HMAC signature. " +
+        "Rejecting request. Set twilio.authToken via config.",
     );
     return httpError("FORBIDDEN", "Forbidden", 403);
   }

--- a/assistant/src/runtime/routes/twilio-routes.ts
+++ b/assistant/src/runtime/routes/twilio-routes.ts
@@ -179,6 +179,7 @@ export async function handleSetTwilioCredentials(
   const raw = loadRawConfig();
   const twilio = (raw?.twilio ?? {}) as Record<string, unknown>;
   twilio.accountSid = body.accountSid;
+  twilio.authToken = body.authToken;
   saveRawConfig({ ...raw, twilio });
 
   upsertCredentialMetadata("twilio", "account_sid", {
@@ -236,6 +237,7 @@ export async function handleClearTwilioCredentials(): Promise<Response> {
   const raw = loadRawConfig();
   const twilio = (raw?.twilio ?? {}) as Record<string, unknown>;
   delete twilio.accountSid;
+  delete twilio.authToken;
   saveRawConfig({ ...raw, twilio });
 
   deleteCredentialMetadata("twilio", "account_sid");


### PR DESCRIPTION
## Summary
- Updates `handleSetTwilioCredentials` to also write `authToken` to config (consistent with read path after #13960)
- Updates `handleClearTwilioCredentials` to also delete `authToken` from config
- Migrates `TwilioConversationRelayProvider.getAuthToken()` from secure key store to config
- Migrates `getTwilioConfig()` auth token read from secure key store to config
- Updates error messages referencing "secure key store" / "credential_store tool" to reference config
- Addresses incomplete migration flagged in PR #13960 review

## Test plan
- [ ] Verify Twilio setup flow writes authToken to config
- [ ] Verify `getTwilioCredentials`, `getTwilioConfig`, and `getAuthToken` all read from config consistently
- [ ] Verify webhook validation uses config-based auth token

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
