### PR TITLE
fix: sanitize double-quote characters in buildFTSQuery

### DIFF
--- a/assistant/src/memory/search/query-expansion.test.ts
+++ b/assistant/src/memory/search/query-expansion.test.ts
@@ -44,4 +44,9 @@ describe("buildFTSQuery", () => {
     const result = buildFTSQuery(["auth"]);
     expect(result).toBe('"auth"');
   });
+
+  test("strips double-quote characters from keywords", () => {
+    const result = buildFTSQuery(['say "hello"', "world"]);
+    expect(result).toBe('"say hello" OR "world"');
+  });
 });

--- a/assistant/src/memory/search/query-expansion.ts
+++ b/assistant/src/memory/search/query-expansion.ts
@@ -115,5 +115,5 @@ export function buildFTSQuery(keywords: string[]): string {
     return '"*"';
   }
 
-  return keywords.map((kw) => `"${kw}"`).join(" OR ");
+  return keywords.map((kw) => `"${kw.replaceAll('"', "")}"`).join(" OR ");
 }


### PR DESCRIPTION
## Summary
- Strip double-quote characters from keywords in `buildFTSQuery` to prevent malformed FTS5 queries when the function is called directly with unsanitized input.
- Add test coverage for the quote-stripping behavior.

Addresses feedback from PR #13898.

## Test plan
- New test verifies that double-quote characters embedded in keywords are stripped before wrapping in FTS5 quote syntax.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
