### PR TITLE
fix: split punctuation-delimited words and escape quotes in FTS query expansion

### DIFF
--- a/assistant/src/memory/search/query-expansion.test.ts
+++ b/assistant/src/memory/search/query-expansion.test.ts
@@ -32,6 +32,11 @@ describe("expandQueryForFTS", () => {
     const result = expandQueryForFTS("what is the");
     expect(result).toEqual(["what", "is", "the"]);
   });
+
+  test("splits punctuation-delimited words into separate tokens", () => {
+    const result = expandQueryForFTS("error-handling config.yaml");
+    expect(result).toEqual(["error", "handling", "config", "yaml"]);
+  });
 });
 
 describe("buildFTSQuery", () => {
@@ -43,5 +48,10 @@ describe("buildFTSQuery", () => {
   test("wraps single keyword in quotes", () => {
     const result = buildFTSQuery(["auth"]);
     expect(result).toBe('"auth"');
+  });
+
+  test("escapes double quotes in keywords", () => {
+    const result = buildFTSQuery(['say "hello"']);
+    expect(result).toBe('"say ""hello"""');
   });
 });

--- a/assistant/src/memory/search/query-expansion.ts
+++ b/assistant/src/memory/search/query-expansion.ts
@@ -83,10 +83,7 @@ export function expandQueryForFTS(query: string): string[] {
     return ["*"];
   }
 
-  const tokens = trimmed
-    .split(/\s+/)
-    .map((token) => token.replace(/[^\w]/g, ""))
-    .filter((token) => token.length > 0);
+  const tokens = trimmed.split(/[^\w]+/).filter((token) => token.length > 0);
 
   if (tokens.length === 0) {
     return ["*"];
@@ -115,5 +112,5 @@ export function buildFTSQuery(keywords: string[]): string {
     return '"*"';
   }
 
-  return keywords.map((kw) => `"${kw}"`).join(" OR ");
+  return keywords.map((kw) => `"${kw.replace(/"/g, '""')}"`).join(" OR ");
 }


### PR DESCRIPTION
## Summary
- **Punctuation splitting**: `expandQueryForFTS` now splits on all non-word characters (not just whitespace), so inputs like `error-handling` produce `["error", "handling"]` instead of `["errorhandling"]`. This matches how FTS5 tokenizers index terms.
- **Quote escaping**: `buildFTSQuery` now escapes double quotes in keywords (`"` -> `""`) to prevent malformed FTS5 queries, consistent with the existing `buildFtsMatchQuery` in `lexical.ts`.

Addresses review feedback from #13891.

## Test plan
- Added test: punctuation-delimited words are split into separate tokens
- Added test: double quotes in keywords are properly escaped
- Existing tests continue to pass

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
