### PR TITLE
fix: exclude deleted memories from fingerprint collision checks

### DIFF
--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import type { AssistantConfig } from "../../config/types.js";
@@ -87,6 +87,7 @@ export async function handleMemorySave(
         and(
           eq(memoryItems.fingerprint, fingerprint),
           eq(memoryItems.scopeId, scopeId),
+          ne(memoryItems.status, "deleted"),
         ),
       )
       .get();
@@ -208,6 +209,7 @@ export async function handleMemoryUpdate(
         and(
           eq(memoryItems.fingerprint, fingerprint),
           eq(memoryItems.scopeId, scopeId),
+          ne(memoryItems.status, "deleted"),
         ),
       )
       .get();


### PR DESCRIPTION
## Summary

- Add `ne(memoryItems.status, "deleted")` filter to fingerprint collision queries in `handleMemorySave` and `handleMemoryUpdate`
- Previously, soft-deleted memory items could still block saving a new identical statement or cause false "already contains this statement" errors during updates

## Test plan

- Verify that saving a memory with the same content as a previously deleted memory succeeds
- Verify that updating a memory to match a previously deleted memory's fingerprint does not trigger a collision error
- `bunx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
