### PR TITLE
fix: circuit breaker degraded-mode correctness improvements

### DIFF
--- a/assistant/src/memory/qdrant-circuit-breaker.ts
+++ b/assistant/src/memory/qdrant-circuit-breaker.ts
@@ -96,9 +96,9 @@ export async function withQdrantBreaker<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
-/** Check whether the circuit breaker is currently open (failing fast). */
+/** Check whether the circuit breaker is currently failing fast (open or half-open with probe in flight). */
 export function isQdrantBreakerOpen(): boolean {
-  return breakerState === "open";
+  return breakerState !== "closed";
 }
 
 /** @internal Test-only: reset circuit breaker state */

--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -334,8 +334,14 @@ export async function collectAndMergeCandidates(
   // not query-match relevance. Common tokens can produce many high-confidence
   // but weakly relevant items that would skip semantic search exactly when
   // it's needed most. Instead, check lexical score (query-match relevance).
+  //
+  // Disable early termination when semantic search is unavailable: boosted
+  // limits inflate cheap candidate counts, making this gate trigger more
+  // easily. Skipping entity retrieval on top of losing semantic search
+  // would reduce recall quality further.
   const canTerminateEarly =
     etConfig.enabled &&
+    !semanticUnavailable &&
     cheapCandidates.length >= etConfig.minCandidates &&
     cheapCandidates.filter((c) => c.lexical >= etConfig.confidenceThreshold)
       .length >= etConfig.minHighConfidence;
@@ -444,6 +450,7 @@ export async function collectAndMergeCandidates(
     relationExpandedItemCount,
     earlyTerminated: canTerminateEarly,
     semanticSearchFailed,
+    semanticUnavailable,
     merged,
   };
 }
@@ -814,11 +821,17 @@ export async function buildMemoryRecall(
     });
   }
 
-  // Propagate semantic search failure into degradation state
-  if (collected.semanticSearchFailed) {
+  // Propagate semantic search failure or breaker-based unavailability into
+  // degradation state. This ensures results computed with boosted limits
+  // are marked degraded and excluded from the recall cache — preventing
+  // stale boosted results from being served after the breaker closes.
+  if (collected.semanticSearchFailed || collected.semanticUnavailable) {
     embeddingResult.degraded = true;
     embeddingResult.reason =
-      embeddingResult.reason ?? "memory.semantic_search_failure";
+      embeddingResult.reason ??
+      (collected.semanticUnavailable
+        ? "memory.qdrant_circuit_open"
+        : "memory.semantic_search_failure");
     if (!embeddingResult.degradation) {
       embeddingResult.degradation = buildDegradationStatus(
         "qdrant_unavailable",

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -110,6 +110,8 @@ export interface CollectedCandidates {
   earlyTerminated: boolean;
   /** True when semantic search was attempted but threw an error. */
   semanticSearchFailed: boolean;
+  /** True when semantic search was known to be unavailable before retrieval (no vector or breaker open). */
+  semanticUnavailable: boolean;
   merged: Candidate[];
 }
 


### PR DESCRIPTION
## Summary

Followup to #13893. Addresses three valid issues raised by automated review:

- **`isQdrantBreakerOpen()` now covers half-open state**: Changed from `breakerState === "open"` to `breakerState !== "closed"` so that non-probe callers rejected during half-open recovery also get boosted lexical limits.
- **Prevent stale cache after breaker closes**: Results computed with boosted limits are now marked as degraded (via `semanticUnavailable` on `CollectedCandidates`), which excludes them from the recall cache. Previously, early-terminated boosted results could be served from cache for up to 60s after the breaker closed.
- **Disable early termination when semantic search is unavailable**: Boosted limits inflate cheap candidate counts, making early termination fire more often. This would skip entity retrieval on top of losing semantic search, compounding recall loss. Early termination is now disabled when `semanticUnavailable` is true.

## Test plan

- Existing circuit breaker tests continue to pass (breaker open state still returns `true`)
- Degradation status propagation tests remain valid
- Manual verification that the three code paths interact correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
