### PR TITLE
fix: accurate degradation reason for semantic search failures

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -16,7 +16,10 @@ import {
   logMemoryEmbeddingWarning,
 } from "./embedding-backend.js";
 import { formatRecallText } from "./format-recall.js";
-import { isQdrantBreakerOpen } from "./qdrant-circuit-breaker.js";
+import {
+  isQdrantBreakerOpen,
+  QdrantCircuitOpenError,
+} from "./qdrant-circuit-breaker.js";
 import {
   getCachedRecall,
   getMemoryVersion,
@@ -179,6 +182,7 @@ export async function collectAndMergeCandidates(
   );
 
   let semanticSearchFailed = false;
+  let semanticSearchError: unknown;
 
   // Detect when semantic search won't be available so we can compensate
   // by boosting lexical/recency/direct item limits.
@@ -368,6 +372,7 @@ export async function collectAndMergeCandidates(
           scopeIds,
         ).catch((err): Candidate[] => {
           semanticSearchFailed = true;
+          semanticSearchError = err;
           if (isQdrantConnectionError(err)) {
             log.warn(
               { err },
@@ -451,6 +456,7 @@ export async function collectAndMergeCandidates(
     earlyTerminated: canTerminateEarly,
     semanticSearchFailed,
     semanticUnavailable,
+    semanticSearchError,
     merged,
   };
 }
@@ -565,9 +571,6 @@ async function generateQueryEmbedding(
         latencyMs: Date.now() - start,
       }),
     };
-  } else if (backendStatus.degraded) {
-    // Provider exists but is degraded (e.g. no backend configured)
-    degradation = buildDegradationStatus("embedding_provider_down", config);
   }
 
   return { queryVector, provider, model, degraded, degradation, reason };
@@ -833,10 +836,14 @@ export async function buildMemoryRecall(
         ? "memory.qdrant_circuit_open"
         : "memory.semantic_search_failure");
     if (!embeddingResult.degradation) {
-      embeddingResult.degradation = buildDegradationStatus(
-        "qdrant_unavailable",
-        config,
-      );
+      const isQdrantIssue =
+        collected.semanticUnavailable ||
+        isQdrantConnectionError(collected.semanticSearchError) ||
+        collected.semanticSearchError instanceof QdrantCircuitOpenError;
+      const reason: DegradationReason = isQdrantIssue
+        ? "qdrant_unavailable"
+        : "embedding_generation_failed";
+      embeddingResult.degradation = buildDegradationStatus(reason, config);
     }
   }
 

--- a/assistant/src/memory/search/types.ts
+++ b/assistant/src/memory/search/types.ts
@@ -112,6 +112,8 @@ export interface CollectedCandidates {
   semanticSearchFailed: boolean;
   /** True when semantic search was known to be unavailable before retrieval (no vector or breaker open). */
   semanticUnavailable: boolean;
+  /** The error that caused semantic search to fail, if any. */
+  semanticSearchError?: unknown;
   merged: Candidate[];
 }
 


### PR DESCRIPTION
## Summary
- Propagates the caught semantic search error through `CollectedCandidates.semanticSearchError` so the degradation reason is determined by the actual error type (Qdrant connection error / circuit breaker open → `qdrant_unavailable`, other errors → `embedding_generation_failed`) instead of hardcoding `qdrant_unavailable` for all failures.
- Removes unreachable dead code: the `else if (backendStatus.degraded)` branch in `generateQueryEmbedding` was never reachable because when `provider` is null, `degraded` equals `config.memory.embeddings.required`, which is already handled by the preceding branch.

Addresses review feedback on #13894.

## Test plan
- Existing `degradation status: includes expected fields for qdrant_unavailable` test still passes (circuit breaker errors correctly map to `qdrant_unavailable`)
- Non-Qdrant semantic search failures now correctly get `embedding_generation_failed` instead of `qdrant_unavailable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
