### PR TITLE
fix: split punctuation-delimited words in FTS query expansion

### DIFF
--- a/assistant/src/memory/search/query-expansion.test.ts
+++ b/assistant/src/memory/search/query-expansion.test.ts
@@ -32,6 +32,11 @@ describe("expandQueryForFTS", () => {
     const result = expandQueryForFTS("what is the");
     expect(result).toEqual(["what", "is", "the"]);
   });
+
+  test("splits punctuation-delimited words into separate tokens", () => {
+    const result = expandQueryForFTS("error-handling config.yaml");
+    expect(result).toEqual(["error", "handling", "config", "yaml"]);
+  });
 });
 
 describe("buildFTSQuery", () => {

--- a/assistant/src/memory/search/query-expansion.ts
+++ b/assistant/src/memory/search/query-expansion.ts
@@ -83,10 +83,7 @@ export function expandQueryForFTS(query: string): string[] {
     return ["*"];
   }
 
-  const tokens = trimmed
-    .split(/\s+/)
-    .map((token) => token.replace(/[^\w]/g, ""))
-    .filter((token) => token.length > 0);
+  const tokens = trimmed.split(/[^\w]+/).filter((token) => token.length > 0);
 
   if (tokens.length === 0) {
     return ["*"];


### PR DESCRIPTION
## Summary
- **Punctuation splitting**: `expandQueryForFTS` now splits on all non-word characters (not just whitespace), so inputs like `error-handling` produce `["error", "handling"]` instead of `["errorhandling"]`. This matches how FTS5 tokenizers index terms and improves lexical recall.

Addresses review feedback from #13891.

## Test plan
- Added test: punctuation-delimited words are split into separate tokens
- Existing tests continue to pass

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
