### PR TITLE
fix: re-queue deferred seen signal when unread rollback happens

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1154,6 +1154,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         let previousLastSeenAssistantMessageAt = threads[idx].lastSeenAssistantMessageAt
         let previousOverride = pendingAttentionOverrides[sessionId]
+        let wasPendingSeen = pendingSeenSessionIds.contains(sessionId)
 
         pendingSeenSessionIds.removeAll { $0 == sessionId }
         pendingAttentionOverrides[sessionId] = .unread(
@@ -1171,7 +1172,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
                     sessionId: sessionId,
                     latestAssistantMessageAt: latestAssistantMessageAt,
                     previousLastSeenAssistantMessageAt: previousLastSeenAssistantMessageAt,
-                    previousOverride: previousOverride
+                    previousOverride: previousOverride,
+                    wasPendingSeen: wasPendingSeen
                 )
                 log.warning("Failed to send conversation_unread_signal for \(sessionId): \(error.localizedDescription)")
             }
@@ -1339,7 +1341,8 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         sessionId: String,
         latestAssistantMessageAt: Date?,
         previousLastSeenAssistantMessageAt: Date?,
-        previousOverride: PendingAttentionOverride?
+        previousOverride: PendingAttentionOverride?,
+        wasPendingSeen: Bool = false
     ) {
         guard let idx = threads.firstIndex(where: { $0.id == threadId }),
               threads[idx].sessionId == sessionId,
@@ -1353,6 +1356,10 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
         }
         threads[idx].hasUnseenLatestAssistantMessage = false
         threads[idx].lastSeenAssistantMessageAt = previousLastSeenAssistantMessageAt
+
+        if wasPendingSeen && !pendingSeenSessionIds.contains(sessionId) {
+            pendingSeenSessionIds.append(sessionId)
+        }
     }
 
     /// Trim the previously active thread's view model to shed memory before

--- a/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
@@ -384,6 +384,40 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         )
     }
 
+    func testUnreadRollbackRequeuesDeferredSeenSignal() {
+        guard let threadId = threadManager.activeThreadId,
+              let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {
+            XCTFail("Expected an initial active thread")
+            return
+        }
+
+        threadManager.threads[index].sessionId = "session-requeue"
+        threadManager.threads[index].hasUnseenLatestAssistantMessage = true
+        threadManager.threads[index].latestAssistantMessageAt = Date(timeIntervalSince1970: 5)
+
+        // mark-all-seen defers the seen signal
+        threadManager.markAllThreadsSeen()
+
+        // Fail subsequent sends so markConversationUnread triggers rollback
+        daemonClient.sendOverride = { _ in
+            throw NSError(domain: "ThreadManagerUnseenStateTests", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "offline"
+            ])
+        }
+
+        sentMessages.removeAll()
+
+        threadManager.markConversationUnread(threadId: threadId)
+        waitForPropagation()
+
+        // After rollback the deferred seen signal should be re-queued,
+        // so committing should emit a seen signal for the session.
+        threadManager.commitPendingSeenSignals()
+
+        let seenSignals = sentMessages.compactMap { $0 as? IPCConversationSeenSignal }
+        XCTAssertEqual(seenSignals.map(\.conversationId), ["session-requeue"])
+    }
+
     func testMarkConversationUnreadIgnoresThreadsWithoutAssistantReply() {
         guard let threadId = threadManager.activeThreadId,
               let index = threadManager.threads.firstIndex(where: { $0.id == threadId }) else {


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #13780: when unread delivery fails after mark-all-seen, the deferred seen signal for that session was lost
- Captures `wasPendingSeen` flag before removing sessionId from `pendingSeenSessionIds` in `markConversationUnread`
- Passes the flag to `rollbackUnreadMutationIfNeeded`, which re-adds the sessionId to `pendingSeenSessionIds` on failure
- Adds test `testUnreadRollbackRequeuesDeferredSeenSignal` verifying the fix

## Test plan
- [x] New test: `testUnreadRollbackRequeuesDeferredSeenSignal` covers the mark-all-seen -> mark-unread-fails -> commit-seen-signals path
- [x] Existing rollback and pending-seen tests remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
