### PR TITLE
fix: fail fast when no active assistant in client command

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -60,7 +60,20 @@ function parseArgs(): ParsedArgs {
     entry = loadLatestAssistant();
   } else {
     const active = getActiveAssistant();
-    entry = active ? findAssistantByName(active) : null;
+    if (active) {
+      entry = findAssistantByName(active);
+      if (!entry) {
+        console.error(
+          `Active assistant '${active}' not found in lockfile. Set an active assistant with 'vellum use <name>'.`,
+        );
+        process.exit(1);
+      }
+    } else {
+      console.error(
+        "No active assistant set. Set one with 'vellum use <name>' or specify a name: 'vellum client <name>'.",
+      );
+      process.exit(1);
+    }
   }
 
   let runtimeUrl =


### PR DESCRIPTION
## Summary
- Addresses review feedback on #13936: when no active assistant is set (and no positional name or `RUNTIME_URL`), the `client` command now exits with an actionable error instead of silently falling through to hardcoded defaults (`http://127.0.0.1:7831` / `"default"`)
- Also handles the case where the active assistant no longer exists in the lockfile

## Test plan
- `vellum client` with no active assistant set -> should print error and exit
- `vellum client` with a stale active assistant -> should print error and exit
- `vellum client foo` -> existing behavior unchanged
- `RUNTIME_URL=... vellum client` -> existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13988" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
