### PR TITLE
refactor: remove dead activation_key references from tool-side-effects

### DIFF
--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -214,9 +214,7 @@ registerHook(
 registerHook(
   "voice_config_update",
   (_name, input, _result, { broadcastToAllClients }) => {
-    const setting =
-      (input.setting as string) ??
-      (input.activation_key ? "activation_key" : undefined);
+    const setting = input.setting as string | undefined;
     if (!setting) return;
 
     const SETTING_TO_KEY: Record<string, string> = {
@@ -230,7 +228,7 @@ registerHook(
 
     // Coerce the value to the correct type before broadcasting, matching
     // the validation logic in the tool's execute method.
-    const raw = input.value ?? input.activation_key;
+    const raw = input.value;
     let coerced: string | boolean | number = raw as string;
     if (setting === "wake_word_enabled") {
       coerced = raw === true || raw === "true";


### PR DESCRIPTION
## Summary
- Cleans up dead `input.activation_key` references in `tool-side-effects.ts` that were left behind by PR #13949 (which removed the legacy `activation_key` parameter from the voice-config tool schema)
- The `activation_key` fallback logic on lines 217-219 and 233 was now dead code since the tool no longer accepts `activation_key` as a direct input parameter

## Test plan
- Verified the simplified logic is equivalent when `input.activation_key` is always `undefined`
- No behavioral change — dead code removal only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
