### PR TITLE
test: strengthen memory_recall handler test assertions

### DIFF
--- a/assistant/src/tools/memory/handlers.test.ts
+++ b/assistant/src/tools/memory/handlers.test.ts
@@ -398,9 +398,10 @@ describe("handleMemoryRecall", () => {
     expect(result.isError).toBe(false);
     const parsed = parseResult(result.content);
     // Not degraded because embeddings are optional
+    expect(parsed.degraded).toBe(false);
     expect(parsed.sources.semantic).toBe(0);
-    // Still returns results from non-semantic sources
-    expect(parsed.resultCount).toBeGreaterThanOrEqual(0);
+    // Still returns results from non-semantic sources (direct item search)
+    expect(parsed.resultCount).toBeGreaterThan(0);
   });
 
   test("returns lexical results in degraded mode", async () => {
@@ -425,9 +426,8 @@ describe("handleMemoryRecall", () => {
 
     expect(result.isError).toBe(false);
     const parsed = parseResult(result.content);
-    // Lexical search should still find items even without embeddings
-    expect(parsed.sources.lexical).toBeGreaterThanOrEqual(0);
-    expect(parsed.resultCount).toBeGreaterThanOrEqual(0);
+    // Direct item search should still find items even without embeddings
+    expect(parsed.resultCount).toBeGreaterThan(0);
   });
 
   // ── Scope filtering ───────────────────────────────────────────────
@@ -469,10 +469,9 @@ describe("handleMemoryRecall", () => {
 
     // When scope is "conversation", fallbackToDefault is false,
     // so only items from conv-scope-a should appear
-    if (parsed.resultCount > 0) {
-      // Verify the text contains the scoped item, not the default one
-      expect(parsed.text).toContain("scoped to conversation A");
-    }
+    expect(parsed.resultCount).toBeGreaterThan(0);
+    expect(parsed.text).toContain("scoped to conversation A");
+    expect(parsed.text).not.toContain("default scope");
   });
 
   test("default scope includes fallback to default scope", async () => {
@@ -500,9 +499,8 @@ describe("handleMemoryRecall", () => {
     expect(result.isError).toBe(false);
     const parsed = parseResult(result.content);
     // Default scope items should be accessible
-    if (parsed.resultCount > 0) {
-      expect(parsed.text).toContain("global knowledge");
-    }
+    expect(parsed.resultCount).toBeGreaterThan(0);
+    expect(parsed.text).toContain("global knowledge");
   });
 
   // ── Error handling ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Added missing `expect(parsed.degraded).toBe(false)` assertion that the test name claimed to verify
- Replaced `>= 0` assertions with `> 0` so tests actually verify results are returned
- Removed conditional `if (resultCount > 0)` guards in scope filtering tests that allowed vacuous passes
- Added `expect(parsed.text).not.toContain("default scope")` to verify conversation scope exclusion

Addresses review feedback on #13909.

## Test plan
- Tests strengthen assertions — they will now fail if the retrieval pipeline regresses instead of passing vacuously

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
