### PR TITLE
fix: add missing exports to recording-intent-handler test mocks

### DIFF
--- a/assistant/src/__tests__/recording-intent-handler.test.ts
+++ b/assistant/src/__tests__/recording-intent-handler.test.ts
@@ -284,6 +284,8 @@ mock.module("../memory/conversation-queries.js", () => ({
   listConversations: () => [],
   countConversations: () => 0,
   searchConversations: () => [],
+  getMessagesPaginated: () => ({ messages: [], hasMore: false }),
+  getNextMessage: () => null,
 }));
 
 mock.module("../memory/conversation-title-service.js", () => ({
@@ -337,12 +339,17 @@ mock.module("../daemon/handlers/computer-use.js", () => ({
 
 mock.module("../providers/provider-send-message.js", () => ({
   getConfiguredProvider: () => null,
+  resolveConfiguredProvider: () => null,
   extractText: (_response: unknown) => "",
+  extractAllText: (_response: unknown) => "",
+  extractToolUse: (_response: unknown) => [],
   createTimeout: (_ms: number) => ({
     signal: new AbortController().signal,
     cleanup: () => {},
   }),
   userMessage: (text: string) => ({ role: "user", content: text }),
+  userMessageWithImage: (text: string) => ({ role: "user", content: text }),
+  userMessageWithImages: (text: string) => ({ role: "user", content: text }),
 }));
 
 // ── Mock external conversation store ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `getMessagesPaginated` and `getNextMessage` to the `conversation-queries.js` mock in `recording-intent-handler.test.ts` — `session-history.ts` imports these but the mock was missing them, causing Bun to throw SyntaxError
- Add `extractAllText`, `extractToolUse`, `resolveConfiguredProvider`, `userMessageWithImage`, and `userMessageWithImages` to the `provider-send-message.js` mock — same issue, new exports not reflected in the mock

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22796191361/job/66131106771

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
