### PR TITLE
fix: replace wildcard sentinel in FTS query expansion with undefined fallthrough

### DIFF
--- a/assistant/src/memory/search/query-expansion.test.ts
+++ b/assistant/src/memory/search/query-expansion.test.ts
@@ -20,12 +20,16 @@ describe("expandQueryForFTS", () => {
     expect(result).toEqual(["authentication"]);
   });
 
-  test("returns wildcard for empty input", () => {
-    expect(expandQueryForFTS("")).toEqual(["*"]);
+  test("returns empty array for empty input", () => {
+    expect(expandQueryForFTS("")).toEqual([]);
   });
 
-  test("returns wildcard for whitespace-only input", () => {
-    expect(expandQueryForFTS("   ")).toEqual(["*"]);
+  test("returns empty array for whitespace-only input", () => {
+    expect(expandQueryForFTS("   ")).toEqual([]);
+  });
+
+  test("returns empty array for punctuation-only input", () => {
+    expect(expandQueryForFTS("???")).toEqual([]);
   });
 
   test("returns original tokens when all are stop words", () => {
@@ -53,5 +57,9 @@ describe("buildFTSQuery", () => {
   test("strips double-quote characters from keywords", () => {
     const result = buildFTSQuery(['say "hello"', "world"]);
     expect(result).toBe('"say hello" OR "world"');
+  });
+
+  test("returns undefined for empty keywords", () => {
+    expect(buildFTSQuery([])).toBeUndefined();
   });
 });

--- a/assistant/src/memory/search/query-expansion.ts
+++ b/assistant/src/memory/search/query-expansion.ts
@@ -75,18 +75,19 @@ const STOP_WORDS = new Set([
  * Extract meaningful keywords from a conversational query by tokenizing,
  * stripping punctuation, and removing stop words.
  *
- * Returns `["*"]` for empty input (match-all fallback).
+ * Returns an empty array for empty/punctuation-only input so the caller
+ * can fall through to the default FTS query builder.
  */
 export function expandQueryForFTS(query: string): string[] {
   const trimmed = query.trim();
   if (trimmed.length === 0) {
-    return ["*"];
+    return [];
   }
 
   const tokens = trimmed.split(/[^\w]+/).filter((token) => token.length > 0);
 
   if (tokens.length === 0) {
-    return ["*"];
+    return [];
   }
 
   const keywords = tokens.filter(
@@ -107,9 +108,9 @@ export function expandQueryForFTS(query: string): string[] {
  *
  * Example: `["discuss", "API", "design"]` -> `"discuss" OR "API" OR "design"`
  */
-export function buildFTSQuery(keywords: string[]): string {
+export function buildFTSQuery(keywords: string[]): string | undefined {
   if (keywords.length === 0) {
-    return '"*"';
+    return undefined;
   }
 
   return keywords.map((kw) => `"${kw.replaceAll('"', "")}"`).join(" OR ");


### PR DESCRIPTION
## Summary
- `expandQueryForFTS` now returns `[]` instead of `["*"]` for empty/punctuation-only input
- `buildFTSQuery` now returns `undefined` instead of `'"*"'` for empty keyword arrays
- This lets the caller in `retriever.ts` fall through to the existing `buildFtsMatchQuery` builder instead of producing a broken FTS5 match query
- Addresses Codex review feedback on #13891 (the punctuation-splitting and quote-escaping feedback was already addressed in prior commits)

## Test plan
- Updated query-expansion tests to verify empty/punctuation-only input returns `[]` / `undefined`
- All 12 query-expansion tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
