### PR TITLE
fix(clients): rename memory_search to memory_recall in chat display text

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -954,7 +954,7 @@ public struct ToolCallData: Identifiable, Equatable {
             return inputSummary.isEmpty ? "Searched the web" : "Searched for \"\(truncated(inputSummary, to: 50))\""
         case "memory_save", "memory_update":
             return "Saved a memory"
-        case "memory_search":
+        case "memory_recall":
             return inputSummary.isEmpty ? "Recalled memories" : "Recalled info about \"\(truncated(inputSummary, to: 40))\""
         case "task_run":
             return inputSummary.isEmpty ? "Ran a task" : "Ran \"\(truncated(inputSummary, to: 50))\""


### PR DESCRIPTION
## Summary
- Updated `ChatMessage.swift` to match on `memory_recall` instead of `memory_search` for the tool display text ("Recalled memories" / "Recalled info about ...").
- The tool was renamed in #13926 but the Swift client wasn't updated, causing the display text to fall through to the default.
- Test-side fixes were already addressed in #13931.

Addresses review feedback on #13926.

## Test plan
- Verified no other `memory_search` references remain in the clients codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
