### PR TITLE
fix: update Swift client memory_search to memory_recall

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -954,7 +954,7 @@ public struct ToolCallData: Identifiable, Equatable {
             return inputSummary.isEmpty ? "Searched the web" : "Searched for \"\(truncated(inputSummary, to: 50))\""
         case "memory_save", "memory_update":
             return "Saved a memory"
-        case "memory_search":
+        case "memory_recall":
             return inputSummary.isEmpty ? "Recalled memories" : "Recalled info about \"\(truncated(inputSummary, to: 40))\""
         case "task_run":
             return inputSummary.isEmpty ? "Ran a task" : "Ran \"\(truncated(inputSummary, to: 50))\""


### PR DESCRIPTION
## Summary
- Updated `case "memory_search":` to `case "memory_recall":` in `ChatMessage.swift` to match the tool rename from PR #13926.
- The original PR renamed `memory_search` → `memory_recall` in the backend but missed the Swift client display text mapping.

## Test plan
- Verified no other `memory_search` references remain in the codebase via grep.
- The Swift client will now correctly show "Recalled memories" for `memory_recall` tool invocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13995" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
