### PR TITLE
fix: clean up duplicated comment in assistant-config.ts

### DIFF
--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -20,7 +20,6 @@ export interface LocalInstanceResources {
    * at `~/.vellum`); subsequent assistants use
    * `~/.local/share/vellum/assistants/<name>/` (workspace at
    * `~/.local/share/vellum/assistants/<name>/.vellum`).
-   * The daemon's `.vellum/` directory lives inside it. Equivalent to
    * The daemon's `.vellum/` directory lives inside it.
    */
   instanceDir: string;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for prelaunch-deprecation-cleanup.md.

**Gap:** Duplicated comment line in assistant-config.ts
**What was expected:** Clean comment after removing baseDataDir
**What was found:** Duplicated sentence with dangling fragment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13996" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
