### PR TITLE
fix: update twilio-config test mocks for config-based auth token

### DIFF
--- a/assistant/src/__tests__/twilio-config.test.ts
+++ b/assistant/src/__tests__/twilio-config.test.ts
@@ -29,12 +29,11 @@ import { getTwilioConfig } from "../calls/twilio-config.js";
 
 describe("twilio-config", () => {
   beforeEach(() => {
-    mockSecureKeys = {
-      "credential:twilio:auth_token": "test_auth_token",
-    };
+    mockSecureKeys = {};
     mockLoadConfigResult = {
       twilio: {
         accountSid: "AC_test_sid",
+        authToken: "test_auth_token",
         phoneNumber: "+15551234567",
       },
     };
@@ -59,7 +58,13 @@ describe("twilio-config", () => {
   });
 
   test("throws ConfigError when auth token is missing", () => {
-    mockSecureKeys["credential:twilio:auth_token"] = null;
+    mockLoadConfigResult = {
+      twilio: {
+        accountSid: "AC_test_sid",
+        authToken: "",
+        phoneNumber: "+15551234567",
+      },
+    };
     expect(() => getTwilioConfig()).toThrow(
       /Twilio credentials not configured/,
     );
@@ -67,7 +72,11 @@ describe("twilio-config", () => {
 
   test("throws ConfigError when phone number is missing", () => {
     mockLoadConfigResult = {
-      twilio: { accountSid: "AC_test_sid", phoneNumber: "" },
+      twilio: {
+        accountSid: "AC_test_sid",
+        authToken: "test_auth_token",
+        phoneNumber: "",
+      },
     };
     expect(() => getTwilioConfig()).toThrow(
       /Twilio phone number not configured/,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for prelaunch-deprecation-cleanup.md.

**Gap:** twilio-config.test.ts has 2 failing tests after Twilio credential migration
**What was expected:** Test mocks should provide auth token via config mock
**What was found:** Tests still set auth token via mockSecureKeys only

Changes:
- Moved auth token from `mockSecureKeys` to `mockLoadConfigResult.twilio.authToken` in `beforeEach`
- Updated "throws ConfigError when auth token is missing" test to set empty `authToken` in config instead of nulling the secure key
- Added `authToken` to "throws ConfigError when phone number is missing" test's config to ensure it reaches the phone number check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
