### PR TITLE
fix: remove dead activeBindingChannels from signal routing test

### DIFF
--- a/assistant/src/__tests__/emit-signal-routing-intent.test.ts
+++ b/assistant/src/__tests__/emit-signal-routing-intent.test.ts
@@ -7,7 +7,6 @@ const runDeterministicChecksMock = mock();
 const createEventMock = mock();
 const updateEventDedupeKeyMock = mock();
 const dispatchDecisionMock = mock();
-const activeBindingChannels = new Set<string>(["telegram"]);
 
 mock.module("../util/logger.js", () => ({
   getLogger: () =>
@@ -81,8 +80,6 @@ describe("emitNotificationSignal routing intent re-persistence", () => {
     createEventMock.mockReset();
     updateEventDedupeKeyMock.mockReset();
     dispatchDecisionMock.mockReset();
-    activeBindingChannels.clear();
-    activeBindingChannels.add("telegram");
 
     createEventMock.mockReturnValue({ id: "evt-1" });
     runDeterministicChecksMock.mockResolvedValue({ passed: true });
@@ -180,8 +177,6 @@ describe("emitNotificationSignal routing intent re-persistence", () => {
   });
 
   test("excludes unverified binding channels from connected channel candidates", async () => {
-    activeBindingChannels.clear();
-
     const decision = {
       shouldNotify: true,
       selectedChannels: ["vellum"],


### PR DESCRIPTION
Removes unused activeBindingChannels variable and its references from emit-signal-routing-intent.test.ts. The variable was left behind when the channel-guardian-store.js mock was removed in #13972.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
