### PR TITLE
fix: remove deleted-status filter from memory fingerprint collision checks

### DIFF
--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -1,4 +1,4 @@
-import { and, eq, ne } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import type { AssistantConfig } from "../../config/types.js";
@@ -87,7 +87,6 @@ export async function handleMemorySave(
         and(
           eq(memoryItems.fingerprint, fingerprint),
           eq(memoryItems.scopeId, scopeId),
-          ne(memoryItems.status, "deleted"),
         ),
       )
       .get();
@@ -209,7 +208,6 @@ export async function handleMemoryUpdate(
         and(
           eq(memoryItems.fingerprint, fingerprint),
           eq(memoryItems.scopeId, scopeId),
-          ne(memoryItems.status, "deleted"),
         ),
       )
       .get();


### PR DESCRIPTION
Removes `ne(status, 'deleted')` filters from fingerprint lookups in `handleMemorySave` and `handleMemoryUpdate`. The UNIQUE index on `(fingerprint, scope_id)` is unconditional, so excluding deleted rows caused UNIQUE constraint violations on INSERT/UPDATE. Now matches `items-extractor.ts` behavior: deleted items are found and reactivated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/13999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
