### PR TITLE
fix: allow --url flag to bypass active assistant requirement in client command

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -55,8 +55,12 @@ function parseArgs(): ParsedArgs {
       );
       process.exit(1);
     }
-  } else if (process.env.RUNTIME_URL) {
-    // Explicit env var — skip assistant resolution, will use env values below
+  } else if (
+    process.env.RUNTIME_URL ||
+    flagArgs.includes("--url") ||
+    flagArgs.includes("-u")
+  ) {
+    // Explicit URL provided via env var or flag — skip assistant resolution
     entry = loadLatestAssistant();
   } else {
     const active = getActiveAssistant();


### PR DESCRIPTION
Checks for --url in flagArgs before requiring an active assistant, matching the existing RUNTIME_URL env var bypass. Fixes regression where vellum client --url <url> failed without an active assistant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
