### PR TITLE
fix: add tts_voice_id to SETTING_TO_KEY broadcast map

### DIFF
--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -219,6 +219,7 @@ registerHook(
 
     const SETTING_TO_KEY: Record<string, string> = {
       activation_key: "pttActivationKey",
+      tts_voice_id: "ttsVoiceId",
       wake_word_enabled: "wakeWordEnabled",
       wake_word_keyword: "wakeWordKeyword",
       wake_word_timeout: "wakeWordTimeoutSeconds",


### PR DESCRIPTION
Adds tts_voice_id to the SETTING_TO_KEY map so broadcastToAllClients fires when TTS voice is changed, ensuring all connected clients receive the update.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
