### PR TITLE
fix: distinguish embedding vs qdrant degradation reasons in memory retrieval

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -833,11 +833,13 @@ export async function buildMemoryRecall(
     embeddingResult.reason =
       embeddingResult.reason ??
       (collected.semanticUnavailable
-        ? "memory.qdrant_circuit_open"
+        ? isQdrantBreakerOpen()
+          ? "memory.qdrant_circuit_open"
+          : "memory.embedding_unavailable"
         : "memory.semantic_search_failure");
     if (!embeddingResult.degradation) {
       const isQdrantIssue =
-        collected.semanticUnavailable ||
+        isQdrantBreakerOpen() ||
         isQdrantConnectionError(collected.semanticSearchError) ||
         collected.semanticSearchError instanceof QdrantCircuitOpenError;
       const reason: DegradationReason = isQdrantIssue

--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -330,7 +330,7 @@ export async function handleMemoryRecall(
       scopePolicyOverride,
     });
 
-    if (collected.semanticSearchFailed) {
+    if (collected.semanticSearchFailed || collected.semanticUnavailable) {
       degraded = true;
     }
 


### PR DESCRIPTION
Splits semanticUnavailable degradation into embedding_unavailable vs qdrant_circuit_open based on actual cause. Also aligns handlers.ts to check semanticUnavailable alongside semanticSearchFailed for consistency.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
