### PR TITLE
fix: return undefined from extractToolUse mock in recording test

### DIFF
--- a/assistant/src/__tests__/recording-intent-handler.test.ts
+++ b/assistant/src/__tests__/recording-intent-handler.test.ts
@@ -342,7 +342,7 @@ mock.module("../providers/provider-send-message.js", () => ({
   resolveConfiguredProvider: () => null,
   extractText: (_response: unknown) => "",
   extractAllText: (_response: unknown) => "",
-  extractToolUse: (_response: unknown) => [],
+  extractToolUse: (_response: unknown) => undefined,
   createTimeout: (_ms: number) => ({
     signal: new AbortController().signal,
     cleanup: () => {},


### PR DESCRIPTION
Changes extractToolUse mock to return undefined instead of [] to match the real function's ToolUseContent | undefined return type. The previous [] was truthy and would incorrectly enter tool-use branches.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14003" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
