### PR TITLE
fix: re-arm seen flush timer on rollback and scope test failure injection

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1359,6 +1359,7 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         if wasPendingSeen && !pendingSeenSessionIds.contains(sessionId) {
             pendingSeenSessionIds.append(sessionId)
+            schedulePendingSeenSignals()
         }
     }
 

--- a/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadManagerUnseenStateTests.swift
@@ -398,11 +398,15 @@ final class ThreadManagerUnseenStateTests: XCTestCase {
         // mark-all-seen defers the seen signal
         threadManager.markAllThreadsSeen()
 
-        // Fail subsequent sends so markConversationUnread triggers rollback
-        daemonClient.sendOverride = { _ in
-            throw NSError(domain: "ThreadManagerUnseenStateTests", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "offline"
-            ])
+        // Fail only unread signals so markConversationUnread triggers rollback,
+        // while allowing seen signals from commitPendingSeenSignals to succeed.
+        daemonClient.sendOverride = { [weak self] message in
+            if message is IPCConversationUnreadSignal {
+                throw NSError(domain: "ThreadManagerUnseenStateTests", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "offline"
+                ])
+            }
+            self?.sentMessages.append(message)
         }
 
         sentMessages.removeAll()


### PR DESCRIPTION
Re-arms schedulePendingSeenSignals() after rollback re-queues a session, preventing orphaned entries. Scopes the throwing sendOverride in the test to only affect unread signals so commitPendingSeenSignals can record seen signals correctly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
