### PR TITLE
fix: include workflow name in GHA notify step names

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -127,7 +127,7 @@ jobs:
           key: test-durations-${{ github.run_id }}
 
   notify:
-    name: Slack Notification
+    name: Slack Notification (Assistant)
     needs: [lint, typecheck, test]
     if: always()
     continue-on-error: true

--- a/.github/workflows/ci-main-cli.yaml
+++ b/.github/workflows/ci-main-cli.yaml
@@ -41,7 +41,7 @@ jobs:
         run: bun test --coverage
 
   notify:
-    name: Slack Notification
+    name: Slack Notification (CLI)
     needs: [checks]
     if: always()
     continue-on-error: true

--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -39,7 +39,7 @@ jobs:
         run: bun run test
 
   notify:
-    name: Slack Notification
+    name: Slack Notification (Gateway)
     needs: [checks]
     if: always()
     continue-on-error: true

--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -50,7 +50,7 @@ jobs:
         run: ./build.sh test
 
   notify:
-    name: Slack Notification
+    name: Slack Notification (iOS)
     needs: [build]
     if: always()
     continue-on-error: true

--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -39,7 +39,7 @@ jobs:
         run: ./build.sh test
 
   notify:
-    name: Slack Notification
+    name: Slack Notification (macOS)
     needs: [test]
     if: always()
     continue-on-error: true

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -362,7 +362,7 @@ jobs:
         run: exit 1
 
   notify:
-    name: Slack Notification
+    name: Slack Notification (Playwright)
     needs: [prepare, build, playwright]
     if: always() && github.event_name == 'schedule'
     continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
   notify-start:
+    name: Slack Notification (Release Start)
     needs: compute-version
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1702,6 +1703,7 @@ jobs:
           retention-days: 30
 
   notify:
+    name: Slack Notification (Release)
     if: always() && !cancelled()
     needs: [bump-and-tag, publish-npm, publish-meta, build-macos-arm64, build-macos-x64, build-ios, release-ios, push-assistant-manifest, push-gateway-manifest, register-release, release, update-platform, ci-assistant, ci-cli, ci-gateway, ci-playwright]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Renamed all `notify` job `name:` fields from generic "Slack Notification" to include the workflow context (e.g. "Slack Notification (Assistant)", "Slack Notification (Gateway)")
- Added `name:` fields to the release workflow's `notify-start` and `notify` jobs which previously had none

## Original prompt
Rename the GHA `notify` steps so they include the name of the workflow - that way the Slack notification preview contains the workflow name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
