### PR TITLE
fix: remove unused SkillSummaryItem typealias

### DIFF
--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1090,9 +1090,6 @@ extension IPCSkillsListResponseSkill {
     }
 }
 
-/// Backward-compatible alias for code referencing the old name.
-public typealias SkillSummaryItem = SkillInfo
-
 /// Response containing the list of available skills.
 /// Backed by generated `IPCSkillsListResponse`.
 public typealias SkillsListResponseMessage = IPCSkillsListResponse


### PR DESCRIPTION
## Summary
- Remove unused `SkillSummaryItem` typealias from IPCMessages.swift

Part of plan: pre-launch-legacy-cleanup.md (PR 10 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
