### PR TITLE
fix: remove assistant-role summary backward compat from window manager

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -452,16 +452,6 @@ describe("ContextWindowManager", () => {
     expect(result.summaryRawResponses).toEqual([rawResponse, rawResponse]);
   });
 
-  test("parses legacy assistant-role context summary messages", () => {
-    const legacySummary: Message = {
-      role: "assistant",
-      content: [
-        { type: "text", text: `${CONTEXT_SUMMARY_MARKER}\n## Goals\n- legacy` },
-      ],
-    };
-    expect(getSummaryFromContextMessage(legacySummary)).toContain("legacy");
-  });
-
   test("does not parse user-authored summary marker text as internal summary", () => {
     const userMessage: Message = {
       role: "user",

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -562,10 +562,6 @@ export function getSummaryFromContextMessage(
   if (INTERNAL_CONTEXT_SUMMARY_MESSAGES.has(message)) {
     return stripContextSummaryTags(text);
   }
-  // Backward compatibility for older in-memory sessions that used assistant-role summaries.
-  if (message.role === "assistant") {
-    return stripContextSummaryTags(text);
-  }
   return null;
 }
 


### PR DESCRIPTION
## Summary
- Remove backward-compat check for assistant-role summary messages in `getSummaryFromContextMessage()`
- Only `INTERNAL_CONTEXT_SUMMARY_MESSAGES` path remains

Part of plan: pre-launch-legacy-cleanup.md (PR 5 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
