### PR TITLE
fix: remove legacy /v1/calls/* Twilio route aliases from gateway

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -234,17 +234,6 @@ The gateway serves as the single public ingress point for all external callbacks
 | `/readyz`                                  | GET             | Readiness probe                                                                                                                                                                         |
 | `/schema`                                  | GET             | Returns the OpenAPI 3.1 schema for this gateway                                                                                                                                         |
 
-#### Backward-Compatibility Paths
-
-The following legacy paths are aliases that map to their canonical equivalents above:
-
-| Legacy Path                       | Canonical Path                    |
-| --------------------------------- | --------------------------------- |
-| `/v1/calls/twilio/voice-webhook`  | `/webhooks/twilio/voice`          |
-| `/v1/calls/twilio/status`         | `/webhooks/twilio/status`         |
-| `/v1/calls/twilio/connect-action` | `/webhooks/twilio/connect-action` |
-| `/v1/calls/relay`                 | `/webhooks/twilio/relay`          |
-
 ### Tunnel Setup
 
 To receive external callbacks during local development, point a tunnel service at the local gateway (default `http://127.0.0.1:7830`) and configure the resulting public URL:

--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -128,13 +128,6 @@ const EXCLUDED_FROM_SCHEMA = new Set([
   // Internal-only route, used only for daemon-triggered Twilio refreshes
   "/internal/twilio/reconcile",
 
-  // Duplicate webhook paths for Twilio call routing — the canonical
-  // paths under /webhooks/ are documented instead
-  "/v1/calls/twilio/voice-webhook",
-  "/v1/calls/twilio/status",
-  "/v1/calls/twilio/connect-action",
-  "/v1/calls/relay",
-
   // Browser relay WebSocket upgrade — handled pre-router, not a REST endpoint
   "/v1/browser-relay",
 

--- a/gateway/src/http/middleware/rate-limit.ts
+++ b/gateway/src/http/middleware/rate-limit.ts
@@ -44,11 +44,7 @@ function isRateLimitedRoute(url: URL): boolean {
     url.pathname.startsWith("/pairing/") ||
     url.pathname === "/webhooks/oauth/callback" ||
     (url.pathname.startsWith("/v1/") &&
-      url.pathname !== "/v1/calls/twilio/voice-webhook" &&
-      url.pathname !== "/v1/calls/twilio/status" &&
-      url.pathname !== "/v1/calls/twilio/connect-action" &&
       url.pathname !== "/v1/browser-relay" &&
-      url.pathname !== "/v1/browser-relay/token" &&
-      url.pathname !== "/v1/calls/relay")
+      url.pathname !== "/v1/browser-relay/token")
   );
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -214,23 +214,11 @@ async function main() {
       handler: (req) => handleTwilioVoiceWebhook(req),
     },
     {
-      path: "/v1/calls/twilio/voice-webhook",
-      handler: (req) => handleTwilioVoiceWebhook(req),
-    },
-    {
       path: "/webhooks/twilio/status",
       handler: (req) => handleTwilioStatusWebhook(req),
     },
     {
-      path: "/v1/calls/twilio/status",
-      handler: (req) => handleTwilioStatusWebhook(req),
-    },
-    {
       path: "/webhooks/twilio/connect-action",
-      handler: (req) => handleTwilioConnectActionWebhook(req),
-    },
-    {
-      path: "/v1/calls/twilio/connect-action",
       handler: (req) => handleTwilioConnectActionWebhook(req),
     },
     {
@@ -690,10 +678,7 @@ async function main() {
       // ── Pre-router: WebSocket upgrades ──
       // Bun's WS upgrade needs `server.upgrade()` which doesn't return
       // a Response, so these can't go through the route table.
-      if (
-        url.pathname === "/webhooks/twilio/relay" ||
-        url.pathname === "/v1/calls/relay"
-      ) {
+      if (url.pathname === "/webhooks/twilio/relay") {
         const upgradeResult = handleTwilioRelayWs(req, server);
         if (upgradeResult !== undefined) return upgradeResult;
         return undefined as unknown as Response;

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -296,7 +296,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Twilio voice webhook",
           description:
-            "Receives inbound Twilio voice webhooks, validates the X-Twilio-Signature, and forwards to the assistant runtime. Also available at /v1/calls/twilio/voice-webhook for backward compatibility.",
+            "Receives inbound Twilio voice webhooks, validates the X-Twilio-Signature, and forwards to the assistant runtime.",
           operationId: "twilioVoiceWebhook",
           security: [{ TwilioSignature: [] }],
           requestBody: {
@@ -354,7 +354,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Twilio status webhook",
           description:
-            "Receives Twilio call status callbacks, validates the X-Twilio-Signature, and forwards to the assistant runtime. Also available at /v1/calls/twilio/status for backward compatibility.",
+            "Receives Twilio call status callbacks, validates the X-Twilio-Signature, and forwards to the assistant runtime.",
           operationId: "twilioStatusWebhook",
           security: [{ TwilioSignature: [] }],
           requestBody: {
@@ -411,7 +411,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Twilio connect-action webhook",
           description:
-            "Receives Twilio ConversationRelay connect-action callbacks, validates the X-Twilio-Signature, and forwards to the assistant runtime. Also available at /v1/calls/twilio/connect-action for backward compatibility.",
+            "Receives Twilio ConversationRelay connect-action callbacks, validates the X-Twilio-Signature, and forwards to the assistant runtime.",
           operationId: "twilioConnectActionWebhook",
           security: [{ TwilioSignature: [] }],
           requestBody: {
@@ -660,7 +660,7 @@ export function buildSchema(): Record<string, unknown> {
         get: {
           summary: "Twilio ConversationRelay WebSocket",
           description:
-            "Accepts a WebSocket upgrade from Twilio ConversationRelay and bidirectionally proxies frames to the assistant runtime's /v1/calls/relay endpoint. Requires a callSessionId query parameter. Also available at /v1/calls/relay for backward compatibility.",
+            "Accepts a WebSocket upgrade from Twilio ConversationRelay and bidirectionally proxies frames to the assistant runtime's /v1/calls/relay endpoint. Requires a callSessionId query parameter.",
           operationId: "twilioRelayWebsocket",
           parameters: [
             {

--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -25,24 +25,15 @@ function firstHeaderValue(value: string | null): string | undefined {
 function inferWebhookKind(reqUrl: string): TwilioWebhookKind {
   const pathname = new URL(reqUrl).pathname;
 
-  if (
-    pathname === "/webhooks/twilio/voice" ||
-    pathname === "/v1/calls/twilio/voice-webhook"
-  ) {
+  if (pathname === "/webhooks/twilio/voice") {
     return "voice";
   }
 
-  if (
-    pathname === "/webhooks/twilio/status" ||
-    pathname === "/v1/calls/twilio/status"
-  ) {
+  if (pathname === "/webhooks/twilio/status") {
     return "status";
   }
 
-  if (
-    pathname === "/webhooks/twilio/connect-action" ||
-    pathname === "/v1/calls/twilio/connect-action"
-  ) {
+  if (pathname === "/webhooks/twilio/connect-action") {
     return "connect-action";
   }
 


### PR DESCRIPTION
## Summary
- Remove 3 duplicate `/v1/calls/twilio/*` POST routes from gateway
- Remove `/v1/calls/relay` WebSocket upgrade condition
- Clean up schema descriptions, webhook validation, rate limiting, and test allowlist
- Remove backward-compatibility paths section from README

Part of plan: pre-launch-legacy-cleanup.md (PR 12 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
