### PR TITLE
fix: remove legacy macos/ios channel ID aliases

### DIFF
--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -16,17 +16,8 @@ export function isChannelId(value: unknown): value is ChannelId {
   );
 }
 
-/** Legacy channel IDs that were renamed but may still arrive from pre-rename clients. */
-const LEGACY_CHANNEL_ALIASES: Record<string, ChannelId> = {
-  macos: "vellum",
-  ios: "vellum",
-};
-
 export function parseChannelId(value: unknown): ChannelId | null {
   if (isChannelId(value)) return value;
-  if (typeof value === "string" && value in LEGACY_CHANNEL_ALIASES) {
-    return LEGACY_CHANNEL_ALIASES[value]!;
-  }
   return null;
 }
 


### PR DESCRIPTION
## Summary
- Remove `LEGACY_CHANNEL_ALIASES` map and alias lookup from `parseChannelId()`
- `parseChannelId("macos")` now returns `null` instead of `"vellum"`

Part of plan: pre-launch-legacy-cleanup.md (PR 1 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
