### PR TITLE
fix: rename GHA notify job IDs to include workflow name

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -126,7 +126,7 @@ jobs:
           path: assistant/.test-durations
           key: test-durations-${{ github.run_id }}
 
-  notify:
+  notify-assistant:
     name: Slack Notification (Assistant)
     needs: [lint, typecheck, test]
     if: always()

--- a/.github/workflows/ci-main-cli.yaml
+++ b/.github/workflows/ci-main-cli.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Test with coverage
         run: bun test --coverage
 
-  notify:
+  notify-cli:
     name: Slack Notification (CLI)
     needs: [checks]
     if: always()

--- a/.github/workflows/ci-main-gateway.yaml
+++ b/.github/workflows/ci-main-gateway.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Test
         run: bun run test
 
-  notify:
+  notify-gateway:
     name: Slack Notification (Gateway)
     needs: [checks]
     if: always()

--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -49,7 +49,7 @@ jobs:
         working-directory: clients/ios
         run: ./build.sh test
 
-  notify:
+  notify-ios:
     name: Slack Notification (iOS)
     needs: [build]
     if: always()

--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -38,7 +38,7 @@ jobs:
         working-directory: clients/macos
         run: ./build.sh test
 
-  notify:
+  notify-macos:
     name: Slack Notification (macOS)
     needs: [test]
     if: always()

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -361,7 +361,7 @@ jobs:
         if: steps.tests.outcome == 'failure'
         run: exit 1
 
-  notify:
+  notify-playwright:
     name: Slack Notification (Playwright)
     needs: [prepare, build, playwright]
     if: always() && github.event_name == 'schedule'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1702,7 +1702,7 @@ jobs:
             playwright/test-results/
           retention-days: 30
 
-  notify:
+  notify-release:
     name: Slack Notification (Release)
     if: always() && !cancelled()
     needs: [bump-and-tag, publish-npm, publish-meta, build-macos-arm64, build-macos-x64, build-ios, release-ios, push-assistant-manifest, push-gateway-manifest, register-release, release, update-platform, ci-assistant, ci-cli, ci-gateway, ci-playwright]


### PR DESCRIPTION
## Summary
- Renamed notify job IDs from generic 'notify' to workflow-specific names (e.g. notify-assistant, notify-gateway, notify-macos) so Slack notification previews show which workflow triggered the notification
- Complements #14005 which added workflow names to the job name field

## Original prompt
Rename the GHA notify job IDs so they include the name of the workflow — the Slack notification preview shows the job ID

Generated with Claude Code (https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
