### PR TITLE
fix: remove rate limit constants re-export from config-channels.ts

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -94,11 +94,7 @@ globalThis.fetch = (async (
 import { eq } from "drizzle-orm";
 
 import { createGuardianBinding } from "../contacts/contacts-write.js";
-import {
-  handleChannelVerificationSession,
-  MAX_SENDS_PER_SESSION,
-  RESEND_COOLDOWN_MS,
-} from "../daemon/handlers/config-channels.js";
+import { handleChannelVerificationSession } from "../daemon/handlers/config-channels.js";
 import type { HandlerContext } from "../daemon/handlers/shared.js";
 import type {
   ChannelVerificationSessionRequest,
@@ -148,6 +144,10 @@ import {
   updateSessionStatus as serviceUpdateSessionStatus,
   validateAndConsumeVerification,
 } from "../runtime/channel-verification-service.js";
+import {
+  MAX_SENDS_PER_SESSION,
+  RESEND_COOLDOWN_MS,
+} from "../runtime/verification-outbound-actions.js";
 import {
   composeVerificationTelegram,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -58,18 +58,6 @@ export type ChannelVerificationSessionResult = Omit<
 >;
 
 // ---------------------------------------------------------------------------
-// Re-export rate limit constants from the shared outbound actions module
-// for backward compatibility with existing consumers.
-// ---------------------------------------------------------------------------
-
-export {
-  DESTINATION_RATE_WINDOW_MS,
-  MAX_SENDS_PER_DESTINATION_WINDOW,
-  MAX_SENDS_PER_SESSION,
-  RESEND_COOLDOWN_MS,
-} from "../../runtime/verification-outbound-actions.js";
-
-// ---------------------------------------------------------------------------
 // Readiness service singleton
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Remove re-export of rate limit constants from config-channels.ts
- Update channel-guardian.test.ts import to use canonical source

Part of plan: pre-launch-legacy-cleanup.md (PR 3 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
