### PR TITLE
fix: remove ChromeAccessibilityHelper convenience restart wrapper

### DIFF
--- a/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/ChromeAccessibilityHelper.swift
@@ -97,12 +97,6 @@ final class ChromeAccessibilityHelper {
         }
     }
 
-    /// Convenience: restart with just accessibility flag (backward compat).
-    @MainActor
-    static func restartChromeWithAccessibility(app: NSRunningApplication) async -> Bool {
-        return await restartChromeWithFlags(app: app, flags: ["--force-renderer-accessibility"])
-    }
-
     /// Find a running Chromium browser, preferring Google Chrome.
     static func findRunningChrome() -> NSRunningApplication? {
         // Check Google Chrome first since the UI references "Chrome" specifically,

--- a/clients/macos/vellum-assistant/ComputerUse/Session.swift
+++ b/clients/macos/vellum-assistant/ComputerUse/Session.swift
@@ -463,7 +463,7 @@ final class ComputerUseSession: ObservableObject {
                 let response = alert.runModal()
 
                 if response == .alertFirstButtonReturn {
-                    let restarted = await ChromeAccessibilityHelper.restartChromeWithAccessibility(app: frontApp)
+                    let restarted = await ChromeAccessibilityHelper.restartChromeWithFlags(app: frontApp, flags: ["--force-renderer-accessibility"])
                     if restarted {
                         AccessibilityTreeEnumerator.clearEnhancedAXCache()
                         log.info("\(browserName) restarted — re-enumerating")


### PR DESCRIPTION
## Summary
- Replace `restartChromeWithAccessibility()` call with `restartChromeWithFlags()` in Session.swift
- Delete the convenience wrapper from ChromeAccessibilityHelper

Part of plan: pre-launch-legacy-cleanup.md (PR 44 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
