### PR TITLE
fix: remove dead memberUsername shim from actor trust resolver

### DIFF
--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -249,8 +249,6 @@ export function resolveActorTrust(
       ) === canonicalSenderId
     : false;
 
-  // ContactChannel has no username field — the shim always set it to null.
-  const memberUsername = undefined;
   const memberDisplayName =
     memberMatchesSender &&
     typeof memberRecord?.contact.displayName === "string" &&
@@ -260,7 +258,7 @@ export function resolveActorTrust(
   // Prefer member profile metadata over transient sender metadata so guardian-
   // curated contact details are canonical for assistant-facing identity —
   // but only when the member record actually belongs to the current sender.
-  const resolvedUsername = memberUsername ?? senderUsername;
+  const resolvedUsername = senderUsername;
   const resolvedDisplayName = memberDisplayName ?? senderDisplayName;
   const resolvedIdentifier = resolvedUsername
     ? `@${resolvedUsername}`


### PR DESCRIPTION
## Summary
- Remove dead `memberUsername = undefined` and simplify to `resolvedUsername = senderUsername`

Part of plan: pre-launch-legacy-cleanup.md (PR 19 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
