### PR TITLE
fix: remove legacy secure store fallback for Twilio phone number

### DIFF
--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -4,7 +4,6 @@ import {
   getPublicBaseUrl,
   getTwilioRelayUrl,
 } from "../inbound/public-ingress-urls.js";
-import { getSecureKey } from "../security/secure-keys.js";
 import { ConfigError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 
@@ -26,8 +25,7 @@ export interface TwilioConfig {
  * Resolution order:
  *   1. TWILIO_PHONE_NUMBER env var
  *   2. config.twilio?.phoneNumber
- *   3. secure store credential:twilio:phone_number  (legacy)
- *   4. ""
+ *   3. ""
  */
 export function resolveTwilioPhoneNumber(): string {
   const fromEnv = getTwilioPhoneNumberEnv();
@@ -40,7 +38,7 @@ export function resolveTwilioPhoneNumber(): string {
     // Config may not be available yet during early startup
   }
 
-  return getSecureKey("credential:twilio:phone_number") || "";
+  return "";
 }
 
 export function getTwilioConfig(): TwilioConfig {


### PR DESCRIPTION
## Summary
- Remove `getSecureKey("credential:twilio:phone_number")` fallback from `resolveTwilioPhoneNumber()`

Part of plan: pre-launch-legacy-cleanup.md (PR 24 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
