### PR TITLE
fix: remove MemberStatus/MemberPolicy legacy type aliases

### DIFF
--- a/assistant/src/contacts/index.ts
+++ b/assistant/src/contacts/index.ts
@@ -14,7 +14,5 @@ export type {
   ContactChannel,
   ContactRole,
   ContactWithChannels,
-  MemberPolicy,
-  MemberStatus,
 } from "./types.js";
 export { CHANNEL_TYPES } from "./types.js";

--- a/assistant/src/contacts/types.ts
+++ b/assistant/src/contacts/types.ts
@@ -54,14 +54,6 @@ export type ChannelStatus =
   | "unverified";
 export type ChannelPolicy = "allow" | "deny" | "escalate";
 
-/**
- * Legacy aliases — semantic names used by API consumers and the ingress
- * pipeline. MemberStatus omits `"unverified"` because the external API maps
- * that value to `"pending"`.
- */
-export type MemberStatus = "pending" | "active" | "revoked" | "blocked";
-export type MemberPolicy = "allow" | "deny" | "escalate";
-
 export interface ContactChannel {
   id: string;
   contactId: string;

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -18,7 +18,7 @@ import {
   findGuardianForChannel,
   listGuardianChannels,
 } from "../contacts/contact-store.js";
-import type { MemberStatus } from "../contacts/types.js";
+import type { ChannelStatus } from "../contacts/types.js";
 import {
   createCanonicalGuardianDelivery,
   createCanonicalGuardianRequest,
@@ -56,7 +56,7 @@ export interface AccessRequestParams {
   actorExternalId?: string;
   actorDisplayName?: string;
   actorUsername?: string;
-  previousMemberStatus?: MemberStatus;
+  previousMemberStatus?: Exclude<ChannelStatus, "unverified">;
 }
 
 export type AccessRequestResult =

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -14,7 +14,6 @@ import type {
   ChannelStatus,
   ContactChannel,
   ContactWithChannels,
-  MemberStatus,
 } from "../../../contacts/types.js";
 import * as deliveryCrud from "../../../memory/delivery-crud.js";
 import * as deliveryStatus from "../../../memory/delivery-status.js";
@@ -93,10 +92,10 @@ function parseGuardianVerifyCode(content: string): string | undefined {
   return undefined;
 }
 
-/** Map ChannelStatus to the legacy MemberStatus for API consumers. */
+/** Map ChannelStatus to the API-facing member status (excludes "unverified"). */
 export function channelStatusToMemberStatus(
   status: ChannelStatus,
-): MemberStatus {
+): Exclude<ChannelStatus, "unverified"> {
   if (status === "unverified") return "pending";
   return status;
 }


### PR DESCRIPTION
## Summary
- Remove `MemberStatus` and `MemberPolicy` type aliases from contacts/types.ts
- Update all importing files to use canonical types directly

Part of plan: pre-launch-legacy-cleanup.md (PR 6 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14018" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
