### PR TITLE
fix: pin Bun version to 1.3.9 across all GHA workflows

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -98,7 +98,7 @@ jobs:
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: '1.3.9'
 
       - name: Build binaries
         if: ${{ !inputs.release_version }}
@@ -250,7 +250,7 @@ jobs:
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: '1.3.9'
 
       - name: Install Playwright dependencies
         if: ${{ !inputs.use_xcode }}

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: '1.3.9'
 
       - name: Build binaries
         run: ./build.sh binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -590,7 +590,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: '1.3.9'
 
       - uses: actions/setup-node@v4
         with:
@@ -696,7 +696,7 @@ jobs:
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: '1.3.9'
 
       - name: Build binaries
         run: |
@@ -985,7 +985,7 @@ jobs:
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: '1.3.9'
 
       - name: Build Bun binaries (x64)
         run: |
@@ -1315,7 +1315,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: '1.3.9'
 
       - name: Update vel dependency
         env:
@@ -1359,7 +1359,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.9
+          bun-version: '1.3.9'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -1389,7 +1389,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.9
+          bun-version: '1.3.9'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -1412,7 +1412,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.9
+          bun-version: '1.3.9'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -1662,7 +1662,7 @@ jobs:
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: '1.3.9'
 
       - name: Install Playwright dependencies
         working-directory: playwright


### PR DESCRIPTION
## Summary
- Replaced `bun-version: latest` with `bun-version: '1.3.9'` in `pr-macos.yaml`, `playwright.yaml` (2 places), and `release.yml` (5 places)
- Normalized unquoted `bun-version: 1.3.9` to quoted `'1.3.9'` in `release.yml` (3 places) for consistency
- All 22 bun-version references across workflows now use the same pinned, quoted value

## Original prompt
Fix Bun version inconsistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
