### PR TITLE
fix: restrict ci-perf-macos to main pushes + manual dispatch

### DIFF
--- a/.github/workflows/ci-perf-macos.yaml
+++ b/.github/workflows/ci-perf-macos.yaml
@@ -8,13 +8,7 @@ on:
       - 'clients/shared/**'
       - '.github/workflows/ci-perf-macos.yaml'
       - 'scripts/compare-perf-baselines.sh'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'clients/macos/**'
-      - 'clients/shared/**'
-      - '.github/workflows/ci-perf-macos.yaml'
-      - 'scripts/compare-perf-baselines.sh'
+  workflow_dispatch:
 
 jobs:
   perf-baselines:
@@ -75,8 +69,6 @@ jobs:
 
       - name: Compare baselines
         env:
-          # Only update stored baselines on main branch pushes — not on PR runs,
-          # to prevent a regressing PR from lowering the baseline for future comparisons.
           UPDATE_BASELINE: ${{ github.event_name == 'push' && 'true' || 'false' }}
         run: bash scripts/compare-perf-baselines.sh
 
@@ -86,13 +78,6 @@ jobs:
           if [ -f .perf-baselines/summary.md ]; then
             cat .perf-baselines/summary.md >> "$GITHUB_STEP_SUMMARY"
           fi
-
-      - name: Comment on PR with performance results
-        if: always() && github.event_name == 'pull_request' && hashFiles('.perf-baselines/summary.md') != ''
-        continue-on-error: true
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          path: .perf-baselines/summary.md
 
       - name: Upload new baselines
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Removed `pull_request` trigger from `ci-perf-macos.yaml` — perf tests were running on every PR with no label gate, unlike other PR workflows
- Added `workflow_dispatch` trigger for on-demand runs
- Removed the PR comment step (unreachable without `pull_request` trigger) and stale comment

## Original prompt
Change ci-perf-macos.yaml to only run on pushes to main and give it a manual workflow dispatch trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
