### PR TITLE
fix: remove legacy requestKind fallback in guardian question mode

### DIFF
--- a/assistant/src/__tests__/guardian-question-mode.test.ts
+++ b/assistant/src/__tests__/guardian-question-mode.test.ts
@@ -87,10 +87,9 @@ describe("guardian-question-mode", () => {
 
     expect(resolved.mode).toBe("answer");
     expect(resolved.requestKind).toBe("pending_question");
-    expect(resolved.legacyFallbackUsed).toBe(false);
   });
 
-  test("resolve mode uses legacy fallback when requestKind is missing", () => {
+  test("resolve mode defaults to approval when requestKind is missing", () => {
     const resolved = resolveGuardianQuestionInstructionMode({
       requestCode: "A1B2C3",
       questionText: "Allow host bash?",
@@ -99,7 +98,6 @@ describe("guardian-question-mode", () => {
 
     expect(resolved.mode).toBe("approval");
     expect(resolved.requestKind).toBeNull();
-    expect(resolved.legacyFallbackUsed).toBe(true);
   });
 
   test("resolve mode treats pending_question with toolName as approval-mode", () => {
@@ -115,7 +113,6 @@ describe("guardian-question-mode", () => {
 
     expect(resolved.mode).toBe("approval");
     expect(resolved.requestKind).toBe("pending_question");
-    expect(resolved.legacyFallbackUsed).toBe(false);
   });
 
   test("resolveGuardianInstructionModeFromFields returns null for unknown request kind", () => {

--- a/assistant/src/notifications/decision-engine.ts
+++ b/assistant/src/notifications/decision-engine.ts
@@ -546,15 +546,6 @@ function enforceGuardianRequestCode(
   const modeResolution = resolveGuardianQuestionInstructionMode(
     signal.contextPayload,
   );
-  if (modeResolution.legacyFallbackUsed) {
-    log.warn(
-      {
-        signalId: signal.signalId,
-        requestKind: modeResolution.requestKind,
-      },
-      "guardian.question payload missing/invalid typed fields; using legacy instruction-mode fallback",
-    );
-  }
   const nextCopy: Partial<Record<NotificationChannel, RenderedChannelCopy>> = {
     ...decision.renderedCopy,
   };

--- a/assistant/src/notifications/guardian-question-mode.ts
+++ b/assistant/src/notifications/guardian-question-mode.ts
@@ -143,7 +143,6 @@ export type GuardianQuestionPayload =
 export interface GuardianQuestionModeResolution {
   mode: GuardianQuestionInstructionMode;
   requestKind: GuardianQuestionRequestKind | null;
-  legacyFallbackUsed: boolean;
 }
 
 function nonEmptyString(value: unknown): string | null {
@@ -427,8 +426,10 @@ export function stripConflictingGuardianRequestInstructions(
 /**
  * Resolve guardian reply instruction mode from request kind.
  *
- * Backward compatibility: if requestKind is missing/unknown, fall back to
- * toolName presence so previously persisted payloads keep working.
+ * Requires a valid requestKind in the payload. When the payload cannot be
+ * fully parsed as a typed guardian question, falls back to field-level
+ * requestKind resolution. If requestKind is missing or unknown, defaults
+ * to "approval" mode.
  */
 export function resolveGuardianQuestionInstructionMode(
   payload: Record<string, unknown>,
@@ -444,7 +445,6 @@ export function resolveGuardianQuestionInstructionMode(
         parsedToolName,
       ),
       requestKind: parsed.requestKind,
-      legacyFallbackUsed: false,
     };
   }
 
@@ -456,14 +456,11 @@ export function resolveGuardianQuestionInstructionMode(
     return {
       mode: requestKindResolution.mode,
       requestKind: requestKindResolution.requestKind,
-      legacyFallbackUsed: true,
     };
   }
 
-  const toolName = nonEmptyString(payload.toolName);
   return {
-    mode: toolName ? "approval" : "answer",
+    mode: "approval",
     requestKind: null,
-    legacyFallbackUsed: true,
   };
 }


### PR DESCRIPTION
## Summary
- Remove `legacyFallbackUsed` flag and toolName-based inference
- Require `requestKind` in guardian question mode resolution
- Remove legacy warning log from decision engine

Part of plan: pre-launch-legacy-cleanup.md (PR 14 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
