### PR TITLE
fix: remove legacy trust store pattern migration (tool:** → **)

### DIFF
--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -217,47 +217,6 @@ function backfillDefaults(rules: TrustRule[]): boolean {
   return changed;
 }
 
-/**
- * Update persisted starter-bundle rules whose pattern matches a known legacy
- * format (e.g. the old "tool:**" prefix was changed to standalone "**").
- * Returns true when at least one rule was updated.
- *
- * Only rules with a recognised legacy pattern are migrated. If a user has
- * intentionally customised a starter rule's pattern (e.g. narrowed it), it is
- * left untouched.
- */
-function migrateStarterRulePatterns(rules: TrustRule[]): boolean {
-  const templatesByID = new Map(getStarterBundleRules().map((t) => [t.id, t]));
-  let changed = false;
-  for (const rule of rules) {
-    const template = templatesByID.get(rule.id);
-    if (!template || rule.pattern === template.pattern) continue;
-    // Only migrate patterns that match a known legacy format.
-    // The "tool:**" prefix (e.g. "file_read:**") was the original pattern
-    // before it was changed to standalone "**".
-    if (!isLegacyStarterPattern(rule.pattern, rule.tool)) continue;
-    log.info(
-      {
-        ruleId: rule.id,
-        oldPattern: rule.pattern,
-        newPattern: template.pattern,
-      },
-      "Migrated starter rule pattern to current template",
-    );
-    rule.pattern = template.pattern;
-    changed = true;
-  }
-  return changed;
-}
-
-/** Recognises legacy starter-rule patterns that should be auto-migrated. */
-function isLegacyStarterPattern(pattern: string, tool: string): boolean {
-  // Legacy format used "tool:**" prefixes, e.g. "file_read:**", "glob:**".
-  // Only match the exact legacy pattern for this specific tool to avoid
-  // silently resetting user-customised patterns.
-  return pattern === `${tool}:**`;
-}
-
 function loadFromDisk(): TrustRule[] {
   const path = getTrustPath();
   let rules: TrustRule[] = [];
@@ -319,12 +278,6 @@ function loadFromDisk(): TrustRule[] {
 
   // Backfill default rules at their declared priority
   if (backfillDefaults(rules)) {
-    needsSave = true;
-  }
-
-  // Migrate persisted starter rules whose pattern has drifted from the
-  // current template (e.g. old "tool:**" → "**").
-  if (migrateStarterRulePatterns(rules)) {
     needsSave = true;
   }
 
@@ -686,8 +639,6 @@ export interface AcceptStarterBundleResult {
  */
 export function acceptStarterBundle(): AcceptStarterBundleResult {
   // Re-read from disk to avoid lost updates.
-  // loadFromDisk() also runs migrateStarterRulePatterns() to fix any
-  // stale patterns (e.g. old "tool:**" → "**") before we get here.
   cachedRules = null;
   cachedStarterBundleAccepted = null;
   const rules = [...getRules()];


### PR DESCRIPTION
## Summary
- Delete `migrateStarterRulePatterns()` and `isLegacyStarterPattern()` functions
- Remove migration call from `loadFromDisk()`

Part of plan: pre-launch-legacy-cleanup.md (PR 28 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
