### PR TITLE
fix: remove Twitter credential legacy dual-writes and fallback reads

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -97,7 +97,7 @@ declare -a SAFE_LINE_PATTERNS=(
     "[.?]+[a-zA-Z0-9_]*[Cc]lient[Ss]ecret([^\"'/]*$|[^\"'/]*//.*)$"
     # TS/JS: secret/key variable assigned from a function call.
     # E.g. `const clientSecret = getSecureKey(keyVault)` or
-    # `getSecureKey('credential:integration:twitter:oauth_client_secret')`.
+    # `getSecureKey('credential:integration:twitter:client_secret')`.
     # Allows either no quoted args, or quoted args containing `:` (key paths).
     # Raw alphanumeric strings like `"sk_live_..."` are still rejected.
     "(client[_-]?[Ss]ecret|[Pp]rivate[_-]?[Kk]ey)[[:space:]]*=[[:space:]]*(get[A-Za-z]*|create[A-Za-z]*|load[A-Za-z]*|read[A-Za-z]*|delete[A-Za-z]*|set[A-Za-z]*)\(([^\"']*$|[^\"']*[\"'][^\"']*:[^\"']*[\"'][^\"']*$)"
@@ -243,9 +243,9 @@ if [ "${1:-}" = "--self-test" ]; then
     SAFE_FUNC_CALL_SECRET='const clientSecret = getSecureKey(keyVault)'
     SAFE_CREATE_PRIVATE_KEY='const key = createPrivateKey(keyPem)'
     # Function-call with quoted key path (colon-separated identifier) — must be whitelisted
-    SAFE_FUNC_CALL_KEY_PATH="const clientSecret = getSecureKey('credential:integration:twitter:oauth_client_secret') || undefined;"
+    SAFE_FUNC_CALL_KEY_PATH="const clientSecret = getSecureKey('credential:integration:twitter:client_secret') || undefined;"
     # Function-call with key path followed by a hardcoded secret fallback — must NOT be whitelisted
-    UNSAFE_FUNC_CALL_KEY_PATH_FALLBACK="const clientSecret = getSecureKey('credential:integration:twitter:oauth_client_secret') || \"sk_live_12345678901234567890\""
+    UNSAFE_FUNC_CALL_KEY_PATH_FALLBACK="const clientSecret = getSecureKey('credential:integration:twitter:client_secret') || \"sk_live_12345678901234567890\""
     # Function-call with literal secret in args — must NOT be whitelisted
     UNSAFE_FUNC_CALL_LITERAL='const clientSecret = getSecureKey("sk_live_12345678901234567890")'
     UNSAFE_FUNC_CALL_SINGLE_QUOTE="const privateKey = loadPrivateKey('real_secret_key_value_12345')"

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Twitter integration supports two operation paths: **OAuth** (X API v2) and **Bro
 
 **Available tools**: `twitter_post` — posts a tweet via the strategy router (OAuth or CDP depending on configuration). Read operations (timeline, search, etc.) use the browser path.
 
-**Setup**: For OAuth posting, store your Twitter app's Client ID via the credential vault (`credential:integration:twitter:oauth_client_id`), optionally store a Client Secret, and initiate the OAuth2 flow from the Settings UI. For browser operations, ensure Chrome is running with remote debugging enabled and an authenticated x.com tab.
+**Setup**: For OAuth posting, store your Twitter app's Client ID via the credential vault (`credential:integration:twitter:client_id`), optionally store a Client Secret, and initiate the OAuth2 flow from the Settings UI. For browser operations, ensure Chrome is running with remote debugging enabled and an authenticated x.com tab.
 
 </details>
 

--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -143,7 +143,7 @@ Twitter uses a standalone OAuth2 flow separate from the unified messaging layer.
 
 #### Twitter OAuth2 Flow
 
-Twitter's OAuth2 flow delegates to the shared **connect orchestrator** (`oauth/connect-orchestrator.ts`). The Twitter provider profile in the registry defines auth/token URLs, default scopes, and an identity verifier. The daemon handler (`daemon/handlers/oauth-connect.ts`) resolves credentials from the keychain using canonical names (`client_id`, `client_secret`) with fallback to legacy names (`oauth_client_id`, `oauth_client_secret`), then calls `orchestrateOAuthConnect()`.
+Twitter's OAuth2 flow delegates to the shared **connect orchestrator** (`oauth/connect-orchestrator.ts`). The Twitter provider profile in the registry defines auth/token URLs, default scopes, and an identity verifier. The daemon handler (`daemon/handlers/oauth-connect.ts`) resolves credentials from the keychain using canonical names (`client_id`, `client_secret`), then calls `orchestrateOAuthConnect()`.
 
 ```mermaid
 sequenceDiagram
@@ -222,7 +222,7 @@ The strategy is persisted in the Vellum config file as `twitter.operationStrateg
 | Flow                  | PKCE (S256), optional client secret, via connect orchestrator                                                      |
 | Default scopes        | `tweet.read`, `tweet.write`, `users.read`, `offline.access` (from provider profile)                                |
 | Identity verification | Provider profile `identityVerifier` → `GET https://api.x.com/2/users/me` with Bearer token                         |
-| Credential names      | Canonical: `client_id`, `client_secret`; reads fall back to legacy `oauth_client_id`, `oauth_client_secret`        |
+| Credential names      | `client_id`, `client_secret`                                                                                       |
 | IPC messages          | `oauth_connect_start` / `oauth_connect_result` (generic), plus legacy `twitter_auth_start` / `twitter_auth_status` |
 
 #### Twitter Credential Metadata Structure
@@ -274,7 +274,7 @@ Note: OAuth2 scopes (`tweet.read`, `tweet.write`, `users.read`, `offline.access`
 | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | PKCE by default, optional client_secret            | Desktop apps prefer PKCE; some providers (Slack) require a secret, which is stored in credential metadata for autonomous refresh                                                                                                                                        |
 | Shared connect orchestrator                        | All OAuth providers route through `orchestrateOAuthConnect()`, which resolves profiles, enforces scope policy, runs the flow, stores tokens, and verifies identity. Adding a provider is a declarative profile entry, not new orchestration code                        |
-| Canonical credential naming                        | Writes use `client_id`/`client_secret`; reads fall back to legacy `oauth_client_id`/`oauth_client_secret` for backward compatibility                                                                                                                                    |
+| Canonical credential naming                        | All reads and writes use `client_id`/`client_secret` as canonical field names                                                                                                                                                                                           |
 | Gateway callback transport                         | OAuth callbacks are now routed through the gateway at `${ingress.publicBaseUrl}/webhooks/oauth/callback` instead of a loopback redirect URI. This enables OAuth flows to work in remote and tunneled deployments.                                                       |
 | Unified `MessagingProvider` interface              | All platforms implement the same contract; generic tools work immediately for new providers                                                                                                                                                                             |
 | Twitter outside unified messaging                  | Twitter is a broadcast/read platform, not a conversation platform — it doesn't fit the `MessagingProvider` contract                                                                                                                                                     |
@@ -370,7 +370,7 @@ Result is a discriminated union: `{ success, deferred, grantedScopes, accountInf
 
 `assistant/src/daemon/handlers/oauth-connect.ts` handles `oauth_connect_start` messages. The handler:
 
-1. Resolves client credentials from the keychain using canonical names (`client_id`, `client_secret`) with fallback to legacy names (`oauth_client_id`, `oauth_client_secret`).
+1. Resolves client credentials from the keychain using canonical names (`client_id`, `client_secret`).
 2. Validates that required credentials exist (including `client_secret` when the provider requires it).
 3. Delegates to `orchestrateOAuthConnect()`.
 4. Sends `oauth_connect_result` back to the client.

--- a/assistant/src/__tests__/handlers-twitter-config.test.ts
+++ b/assistant/src/__tests__/handlers-twitter-config.test.ts
@@ -258,7 +258,7 @@ describe("Twitter integration config handler", () => {
 
   test("get action returns correct status when configured and connected", () => {
     rawConfigStore = { twitter: { integrationMode: "local_byo" } };
-    secureKeyStore["credential:integration:twitter:oauth_client_id"] =
+    secureKeyStore["credential:integration:twitter:client_id"] =
       "test-client-id";
     secureKeyStore["credential:integration:twitter:access_token"] =
       "test-access-token";
@@ -336,12 +336,12 @@ describe("Twitter integration config handler", () => {
     expect(res.success).toBe(true);
     expect(res.localClientConfigured).toBe(true);
 
-    expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_id"],
-    ).toBe("my-client-id");
-    expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_secret"],
-    ).toBe("my-client-secret");
+    expect(secureKeyStore["credential:integration:twitter:client_id"]).toBe(
+      "my-client-id",
+    );
+    expect(secureKeyStore["credential:integration:twitter:client_secret"]).toBe(
+      "my-client-secret",
+    );
   });
 
   test("set_local_client without clientId returns error", async () => {
@@ -360,9 +360,8 @@ describe("Twitter integration config handler", () => {
   });
 
   test("clear_local_client removes credentials", async () => {
-    secureKeyStore["credential:integration:twitter:oauth_client_id"] =
-      "my-client-id";
-    secureKeyStore["credential:integration:twitter:oauth_client_secret"] =
+    secureKeyStore["credential:integration:twitter:client_id"] = "my-client-id";
+    secureKeyStore["credential:integration:twitter:client_secret"] =
       "my-client-secret";
 
     const msg: TwitterIntegrationConfigRequest = {
@@ -385,16 +384,15 @@ describe("Twitter integration config handler", () => {
     expect(res.connected).toBe(false);
 
     expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_id"],
+      secureKeyStore["credential:integration:twitter:client_id"],
     ).toBeUndefined();
     expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_secret"],
+      secureKeyStore["credential:integration:twitter:client_secret"],
     ).toBeUndefined();
   });
 
   test("clear_local_client also disconnects if connected", async () => {
-    secureKeyStore["credential:integration:twitter:oauth_client_id"] =
-      "my-client-id";
+    secureKeyStore["credential:integration:twitter:client_id"] = "my-client-id";
     secureKeyStore["credential:integration:twitter:access_token"] =
       "test-token";
     secureKeyStore["credential:integration:twitter:refresh_token"] =
@@ -435,8 +433,7 @@ describe("Twitter integration config handler", () => {
   });
 
   test("disconnect removes tokens and metadata", async () => {
-    secureKeyStore["credential:integration:twitter:oauth_client_id"] =
-      "my-client-id";
+    secureKeyStore["credential:integration:twitter:client_id"] = "my-client-id";
     secureKeyStore["credential:integration:twitter:access_token"] =
       "test-token";
     secureKeyStore["credential:integration:twitter:refresh_token"] =
@@ -473,9 +470,9 @@ describe("Twitter integration config handler", () => {
       secureKeyStore["credential:integration:twitter:refresh_token"],
     ).toBeUndefined();
     // Client credentials should still be present after disconnect
-    expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_id"],
-    ).toBe("my-client-id");
+    expect(secureKeyStore["credential:integration:twitter:client_id"]).toBe(
+      "my-client-id",
+    );
     expect(deletedMetadata).toContainEqual({
       service: "integration:twitter",
       field: "access_token",
@@ -542,8 +539,8 @@ describe("Twitter integration config handler", () => {
 
   test("set_local_client without secret clears stale secret", async () => {
     // Pre-populate an old client secret
-    secureKeyStore["credential:integration:twitter:oauth_client_id"] = "old-id";
-    secureKeyStore["credential:integration:twitter:oauth_client_secret"] =
+    secureKeyStore["credential:integration:twitter:client_id"] = "old-id";
+    secureKeyStore["credential:integration:twitter:client_secret"] =
       "old-secret";
 
     const msg: TwitterIntegrationConfigRequest = {
@@ -564,12 +561,12 @@ describe("Twitter integration config handler", () => {
     expect(res.success).toBe(true);
     expect(res.localClientConfigured).toBe(true);
 
-    expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_id"],
-    ).toBe("new-id");
+    expect(secureKeyStore["credential:integration:twitter:client_id"]).toBe(
+      "new-id",
+    );
     // Stale secret should be cleared
     expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_secret"],
+      secureKeyStore["credential:integration:twitter:client_secret"],
     ).toBeUndefined();
   });
 
@@ -652,18 +649,18 @@ describe("Twitter integration config handler", () => {
     expect(res.success).toBe(true);
     expect(res.localClientConfigured).toBe(true);
 
+    expect(secureKeyStore["credential:integration:twitter:client_id"]).toBe(
+      "id-only",
+    );
     expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_id"],
-    ).toBe("id-only");
-    expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_secret"],
+      secureKeyStore["credential:integration:twitter:client_secret"],
     ).toBeUndefined();
   });
 
   test("set_local_client overwrites existing credentials", async () => {
     // Set initial credentials
-    secureKeyStore["credential:integration:twitter:oauth_client_id"] = "old-id";
-    secureKeyStore["credential:integration:twitter:oauth_client_secret"] =
+    secureKeyStore["credential:integration:twitter:client_id"] = "old-id";
+    secureKeyStore["credential:integration:twitter:client_secret"] =
       "old-secret";
 
     const msg: TwitterIntegrationConfigRequest = {
@@ -686,12 +683,12 @@ describe("Twitter integration config handler", () => {
     expect(res.localClientConfigured).toBe(true);
 
     // Verify overwritten values
-    expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_id"],
-    ).toBe("new-id");
-    expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_secret"],
-    ).toBe("new-secret");
+    expect(secureKeyStore["credential:integration:twitter:client_id"]).toBe(
+      "new-id",
+    );
+    expect(secureKeyStore["credential:integration:twitter:client_secret"]).toBe(
+      "new-secret",
+    );
   });
 
   test("clear_local_client when no credentials exist (idempotent)", async () => {
@@ -719,9 +716,8 @@ describe("Twitter integration config handler", () => {
 
   test("disconnect when not connected (idempotent) preserves client credentials", async () => {
     // Only client credentials, no access token
-    secureKeyStore["credential:integration:twitter:oauth_client_id"] =
-      "my-client-id";
-    secureKeyStore["credential:integration:twitter:oauth_client_secret"] =
+    secureKeyStore["credential:integration:twitter:client_id"] = "my-client-id";
+    secureKeyStore["credential:integration:twitter:client_secret"] =
       "my-client-secret";
 
     const msg: TwitterIntegrationConfigRequest = {
@@ -744,19 +740,18 @@ describe("Twitter integration config handler", () => {
     expect(res.connected).toBe(false);
     // Client credentials should NOT be removed by disconnect
     expect(res.localClientConfigured).toBe(true);
-    expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_id"],
-    ).toBe("my-client-id");
-    expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_secret"],
-    ).toBe("my-client-secret");
+    expect(secureKeyStore["credential:integration:twitter:client_id"]).toBe(
+      "my-client-id",
+    );
+    expect(secureKeyStore["credential:integration:twitter:client_secret"]).toBe(
+      "my-client-secret",
+    );
   });
 
   test("disconnect preserves client credentials when access token exists", async () => {
     // Set up both client credentials and tokens
-    secureKeyStore["credential:integration:twitter:oauth_client_id"] =
-      "my-client-id";
-    secureKeyStore["credential:integration:twitter:oauth_client_secret"] =
+    secureKeyStore["credential:integration:twitter:client_id"] = "my-client-id";
+    secureKeyStore["credential:integration:twitter:client_secret"] =
       "my-client-secret";
     secureKeyStore["credential:integration:twitter:access_token"] =
       "active-token";
@@ -795,12 +790,12 @@ describe("Twitter integration config handler", () => {
       secureKeyStore["credential:integration:twitter:refresh_token"],
     ).toBeUndefined();
     // Client credentials preserved
-    expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_id"],
-    ).toBe("my-client-id");
-    expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_secret"],
-    ).toBe("my-client-secret");
+    expect(secureKeyStore["credential:integration:twitter:client_id"]).toBe(
+      "my-client-id",
+    );
+    expect(secureKeyStore["credential:integration:twitter:client_secret"]).toBe(
+      "my-client-secret",
+    );
     // Metadata deleted
     expect(deletedMetadata).toContainEqual({
       service: "integration:twitter",
@@ -810,9 +805,8 @@ describe("Twitter integration config handler", () => {
 
   test("clear_local_client cascades to remove tokens and metadata", async () => {
     // Set up client credentials, tokens, and metadata
-    secureKeyStore["credential:integration:twitter:oauth_client_id"] =
-      "my-client-id";
-    secureKeyStore["credential:integration:twitter:oauth_client_secret"] =
+    secureKeyStore["credential:integration:twitter:client_id"] = "my-client-id";
+    secureKeyStore["credential:integration:twitter:client_secret"] =
       "my-client-secret";
     secureKeyStore["credential:integration:twitter:access_token"] =
       "active-token";
@@ -845,10 +839,10 @@ describe("Twitter integration config handler", () => {
 
     // Everything should be gone
     expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_id"],
+      secureKeyStore["credential:integration:twitter:client_id"],
     ).toBeUndefined();
     expect(
-      secureKeyStore["credential:integration:twitter:oauth_client_secret"],
+      secureKeyStore["credential:integration:twitter:client_secret"],
     ).toBeUndefined();
     expect(
       secureKeyStore["credential:integration:twitter:access_token"],
@@ -892,8 +886,7 @@ describe("Twitter integration config handler", () => {
 
   test("get status reflects localClientConfigured when only clientId exists", () => {
     // Only clientId, no secret
-    secureKeyStore["credential:integration:twitter:oauth_client_id"] =
-      "id-only";
+    secureKeyStore["credential:integration:twitter:client_id"] = "id-only";
 
     const msg: TwitterIntegrationConfigRequest = {
       type: "twitter_integration_config",
@@ -945,9 +938,9 @@ describe("Twitter integration config handler", () => {
 
   test("response messages never contain raw credential values", () => {
     // Set up credentials and tokens
-    secureKeyStore["credential:integration:twitter:oauth_client_id"] =
+    secureKeyStore["credential:integration:twitter:client_id"] =
       "secret-client-id-abc123";
-    secureKeyStore["credential:integration:twitter:oauth_client_secret"] =
+    secureKeyStore["credential:integration:twitter:client_secret"] =
       "secret-client-secret-xyz789";
     secureKeyStore["credential:integration:twitter:access_token"] =
       "secret-access-token-def456";

--- a/assistant/src/__tests__/oauth-connect-handler.test.ts
+++ b/assistant/src/__tests__/oauth-connect-handler.test.ts
@@ -301,10 +301,10 @@ describe("OAuth connect handler", () => {
     expect(result.error).toContain("timed out");
   });
 
-  test("oauth_client_id key variant is also checked", async () => {
-    // Store with the oauth_client_id variant
-    secureKeyStore["credential:integration:twitter:oauth_client_id"] =
-      "test-client-id-alt";
+  test("client_id resolved via alias service name", async () => {
+    // Store with the canonical service name (integration:twitter)
+    secureKeyStore["credential:integration:twitter:client_id"] =
+      "test-client-id-canonical";
 
     orchestratorResult = {
       success: true,
@@ -329,8 +329,8 @@ describe("OAuth connect handler", () => {
     expect(result).toBeDefined();
     expect(result.success).toBe(true);
 
-    // Verify the alt key was used
-    expect(lastOrchestratorOptions!.clientId).toBe("test-client-id-alt");
+    // Verify the canonical key was used
+    expect(lastOrchestratorOptions!.clientId).toBe("test-client-id-canonical");
   });
 
   test("openUrl callback sends open_url IPC message", async () => {

--- a/assistant/src/__tests__/twitter-auth-handler.test.ts
+++ b/assistant/src/__tests__/twitter-auth-handler.test.ts
@@ -264,9 +264,9 @@ describe("Twitter auth handler", () => {
 
     test("succeeds with valid config (mock orchestrator)", async () => {
       rawConfigStore = { twitter: { integrationMode: "local_byo" } };
-      secureKeyStore["credential:integration:twitter:oauth_client_id"] =
+      secureKeyStore["credential:integration:twitter:client_id"] =
         "test-client-id";
-      secureKeyStore["credential:integration:twitter:oauth_client_secret"] =
+      secureKeyStore["credential:integration:twitter:client_secret"] =
         "test-client-secret";
 
       orchestratorResult = {
@@ -298,9 +298,9 @@ describe("Twitter auth handler", () => {
 
     test("delegates to orchestrateOAuthConnect with correct options", async () => {
       rawConfigStore = { twitter: { integrationMode: "local_byo" } };
-      secureKeyStore["credential:integration:twitter:oauth_client_id"] =
+      secureKeyStore["credential:integration:twitter:client_id"] =
         "test-client-id";
-      secureKeyStore["credential:integration:twitter:oauth_client_secret"] =
+      secureKeyStore["credential:integration:twitter:client_secret"] =
         "test-client-secret";
 
       orchestratorResult = {
@@ -327,7 +327,7 @@ describe("Twitter auth handler", () => {
 
     test("fails fast with actionable error when no ingress URL is configured", async () => {
       rawConfigStore = { twitter: { integrationMode: "local_byo" } };
-      secureKeyStore["credential:integration:twitter:oauth_client_id"] =
+      secureKeyStore["credential:integration:twitter:client_id"] =
         "test-client-id";
       mockIngressPublicBaseUrl = undefined;
 
@@ -364,7 +364,7 @@ describe("Twitter auth handler", () => {
 
     test("maps orchestrator error result to twitter_auth_result", async () => {
       rawConfigStore = { twitter: { integrationMode: "local_byo" } };
-      secureKeyStore["credential:integration:twitter:oauth_client_id"] =
+      secureKeyStore["credential:integration:twitter:client_id"] =
         "test-client-id";
 
       orchestratorResult = {
@@ -394,7 +394,7 @@ describe("Twitter auth handler", () => {
     describe("auth hardening", () => {
       test("OAuth cancel path returns sanitized failure", async () => {
         rawConfigStore = { twitter: { integrationMode: "local_byo" } };
-        secureKeyStore["credential:integration:twitter:oauth_client_id"] =
+        secureKeyStore["credential:integration:twitter:client_id"] =
           "test-client-id";
 
         orchestratorError = new Error(
@@ -419,7 +419,7 @@ describe("Twitter auth handler", () => {
 
       test("OAuth timeout path returns sanitized failure", async () => {
         rawConfigStore = { twitter: { integrationMode: "local_byo" } };
-        secureKeyStore["credential:integration:twitter:oauth_client_id"] =
+        secureKeyStore["credential:integration:twitter:client_id"] =
           "test-client-id";
 
         orchestratorError = new Error(
@@ -446,7 +446,7 @@ describe("Twitter auth handler", () => {
 
       test("error payload never includes secrets or raw provider bodies", async () => {
         rawConfigStore = { twitter: { integrationMode: "local_byo" } };
-        secureKeyStore["credential:integration:twitter:oauth_client_id"] =
+        secureKeyStore["credential:integration:twitter:client_id"] =
           "test-client-id";
 
         orchestratorError = new Error(
@@ -481,7 +481,7 @@ describe("Twitter auth handler", () => {
 
       test("succeeds even when identity verification returns no accountInfo", async () => {
         rawConfigStore = { twitter: { integrationMode: "local_byo" } };
-        secureKeyStore["credential:integration:twitter:oauth_client_id"] =
+        secureKeyStore["credential:integration:twitter:client_id"] =
           "test-client-id";
 
         // Identity verification is non-fatal in the orchestrator — accountInfo may be undefined

--- a/assistant/src/daemon/handlers/config-integrations.ts
+++ b/assistant/src/daemon/handlers/config-integrations.ts
@@ -96,12 +96,9 @@ export async function handleVercelApiConfig(
   }
 }
 
-/** Check whether a Twitter client ID has been stored (canonical key first, legacy fallback). */
+/** Check whether a Twitter client ID has been stored. */
 function hasTwitterClientId(): boolean {
-  return !!(
-    getSecureKey("credential:integration:twitter:client_id") ??
-    getSecureKey("credential:integration:twitter:oauth_client_id")
-  );
+  return !!getSecureKey("credential:integration:twitter:client_id");
 }
 
 export async function handleTwitterIntegrationConfig(
@@ -223,10 +220,9 @@ export async function handleTwitterIntegrationConfig(
         });
         return;
       }
-      // Read previous value from canonical key first, fall back to legacy
-      const previousClientId =
-        getSecureKey("credential:integration:twitter:client_id") ??
-        getSecureKey("credential:integration:twitter:oauth_client_id");
+      const previousClientId = getSecureKey(
+        "credential:integration:twitter:client_id",
+      );
       // Write canonical key (async — writes broker + encrypted store)
       const storedId = await setSecureKeyAsync(
         "credential:integration:twitter:client_id",
@@ -243,11 +239,6 @@ export async function handleTwitterIntegrationConfig(
         });
         return;
       }
-      // Also write legacy key for backward compatibility
-      await setSecureKeyAsync(
-        "credential:integration:twitter:oauth_client_id",
-        msg.clientId,
-      );
       if (msg.clientSecret) {
         // Write canonical key
         const storedSecret = await setSecureKeyAsync(
@@ -261,16 +252,9 @@ export async function handleTwitterIntegrationConfig(
               "credential:integration:twitter:client_id",
               previousClientId,
             );
-            await setSecureKeyAsync(
-              "credential:integration:twitter:oauth_client_id",
-              previousClientId,
-            );
           } else {
             await deleteSecureKeyAsync(
               "credential:integration:twitter:client_id",
-            );
-            await deleteSecureKeyAsync(
-              "credential:integration:twitter:oauth_client_id",
             );
           }
           ctx.send(socket, {
@@ -283,18 +267,10 @@ export async function handleTwitterIntegrationConfig(
           });
           return;
         }
-        // Also write legacy key for backward compatibility
-        await setSecureKeyAsync(
-          "credential:integration:twitter:oauth_client_secret",
-          msg.clientSecret,
-        );
       } else {
         // Clear any stale secret when updating client without a secret (e.g. switching to PKCE)
         await deleteSecureKeyAsync(
           "credential:integration:twitter:client_secret",
-        );
-        await deleteSecureKeyAsync(
-          "credential:integration:twitter:oauth_client_secret",
         );
       }
       ctx.send(socket, {
@@ -321,23 +297,13 @@ export async function handleTwitterIntegrationConfig(
           ),
         );
       }
-      // Remove both canonical and legacy client credential keys
+      // Remove client credential keys
       deleteResults.push(
         await deleteSecureKeyAsync("credential:integration:twitter:client_id"),
       );
       deleteResults.push(
         await deleteSecureKeyAsync(
           "credential:integration:twitter:client_secret",
-        ),
-      );
-      deleteResults.push(
-        await deleteSecureKeyAsync(
-          "credential:integration:twitter:oauth_client_id",
-        ),
-      );
-      deleteResults.push(
-        await deleteSecureKeyAsync(
-          "credential:integration:twitter:oauth_client_secret",
         ),
       );
       const hasDeleteError = deleteResults.some((r) => r === "error");
@@ -366,7 +332,7 @@ export async function handleTwitterIntegrationConfig(
       const dr2 = await deleteSecureKeyAsync(
         "credential:integration:twitter:refresh_token",
       );
-      // Client credentials (client_id, oauth_client_id, etc.) are intentionally
+      // Client credentials (client_id, client_secret) are intentionally
       // preserved so the user can re-connect without reconfiguring.
       const disconnectFailed = dr1 === "error" || dr2 === "error";
       if (!disconnectFailed) {

--- a/assistant/src/daemon/handlers/oauth-connect.ts
+++ b/assistant/src/daemon/handlers/oauth-connect.ts
@@ -6,10 +6,7 @@ import {
   resolveService,
 } from "../../oauth/provider-profiles.js";
 import { getSecureKey } from "../../security/secure-keys.js";
-import {
-  assertMetadataWritable,
-  getCredentialMetadata,
-} from "../../tools/credentials/metadata-store.js";
+import { assertMetadataWritable } from "../../tools/credentials/metadata-store.js";
 import type { OAuthConnectStartRequest } from "../ipc-protocol.js";
 import { defineHandlers, type HandlerContext, log } from "./shared.js";
 
@@ -26,6 +23,20 @@ function sanitizeOAuthError(message: string): string {
     return "The authorization request was denied. Please try again.";
   }
   return "OAuth authentication failed. Please try again.";
+}
+
+/** Resolve client_secret from the keychain, checking canonical then alias service name. */
+function getClientSecret(
+  resolvedService: string,
+  rawService: string,
+): string | undefined {
+  return (
+    getSecureKey(`credential:${resolvedService}:client_secret`) ??
+    (resolvedService !== rawService
+      ? getSecureKey(`credential:${rawService}:client_secret`)
+      : undefined) ??
+    undefined
+  );
 }
 
 export async function handleOAuthConnectStart(
@@ -60,30 +71,10 @@ export async function handleOAuthConnectStart(
     // Look up client credentials from the keychain under the canonical
     // service name first, then fall back to the original (alias) name
     // in case the user stored credentials under the unresolved key.
-    let clientId =
-      getSecureKey(`credential:${resolvedService}:client_id`) ??
-      getSecureKey(`credential:${resolvedService}:oauth_client_id`);
+    let clientId = getSecureKey(`credential:${resolvedService}:client_id`);
 
     if (!clientId && resolvedService !== msg.service) {
-      clientId =
-        getSecureKey(`credential:${msg.service}:client_id`) ??
-        getSecureKey(`credential:${msg.service}:oauth_client_id`);
-    }
-
-    // Fall back to credential metadata for legacy installs where client
-    // credentials were stored only in metadata (not in the keychain).
-    // Check both canonical and alias service keys, matching the keychain
-    // lookup pattern above.
-    if (!clientId) {
-      const meta = getCredentialMetadata(resolvedService, "access_token");
-      if (meta?.oauth2ClientId) {
-        clientId = meta.oauth2ClientId;
-      } else if (resolvedService !== msg.service) {
-        const aliasMeta = getCredentialMetadata(msg.service, "access_token");
-        if (aliasMeta?.oauth2ClientId) {
-          clientId = aliasMeta.oauth2ClientId;
-        }
-      }
+      clientId = getSecureKey(`credential:${msg.service}:client_id`);
     }
 
     if (!clientId) {
@@ -95,31 +86,7 @@ export async function handleOAuthConnectStart(
       return;
     }
 
-    let clientSecret =
-      getSecureKey(`credential:${resolvedService}:client_secret`) ??
-      getSecureKey(`credential:${resolvedService}:oauth_client_secret`) ??
-      undefined;
-
-    if (!clientSecret && resolvedService !== msg.service) {
-      clientSecret =
-        getSecureKey(`credential:${msg.service}:client_secret`) ??
-        getSecureKey(`credential:${msg.service}:oauth_client_secret`) ??
-        undefined;
-    }
-
-    // Fall back to credential metadata for legacy installs — check both
-    // canonical and alias service keys, matching the keychain lookup pattern.
-    if (!clientSecret) {
-      const meta = getCredentialMetadata(resolvedService, "access_token");
-      if (meta?.oauth2ClientSecret) {
-        clientSecret = meta.oauth2ClientSecret;
-      } else if (resolvedService !== msg.service) {
-        const aliasMeta = getCredentialMetadata(msg.service, "access_token");
-        if (aliasMeta?.oauth2ClientSecret) {
-          clientSecret = aliasMeta.oauth2ClientSecret;
-        }
-      }
-    }
+    const clientSecret = getClientSecret(resolvedService, msg.service);
 
     // Fail early when client_secret is required but missing — guide the
     // user to collect it from the keychain rather than letting the OAuth

--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -66,10 +66,7 @@ export async function handleTwitterAuthStart(
       return;
     }
 
-    // Read canonical key first, fall back to legacy for backward compatibility
-    const clientId =
-      getSecureKey("credential:integration:twitter:client_id") ??
-      getSecureKey("credential:integration:twitter:oauth_client_id");
+    const clientId = getSecureKey("credential:integration:twitter:client_id");
     if (!clientId) {
       ctx.send(socket, {
         type: "twitter_auth_result",
@@ -81,9 +78,7 @@ export async function handleTwitterAuthStart(
     }
 
     const clientSecret =
-      (getSecureKey("credential:integration:twitter:client_secret") ??
-        getSecureKey("credential:integration:twitter:oauth_client_secret")) ||
-      undefined;
+      getSecureKey("credential:integration:twitter:client_secret") || undefined;
 
     // Fail fast if no public ingress URL is configured — Twitter OAuth
     // callbacks must route through the gateway, never via loopback.

--- a/assistant/src/tools/credentials/vault.ts
+++ b/assistant/src/tools/credentials/vault.ts
@@ -33,12 +33,12 @@ import { toPolicyFromInput, validatePolicyInput } from "./policy-validate.js";
 const log = getLogger("credential-vault");
 
 /**
- * Look up a stored client_id or client_secret for a service.
- * Checks common field names across both the canonical and alias service names.
+ * Look up a stored OAuth field (e.g. client_id or client_secret) for a service.
+ * Checks both the canonical and alias service names.
  */
 function findStoredOAuthField(
   service: string,
-  fieldNames: string[],
+  field: string,
 ): string | undefined {
   const servicesToCheck = [service];
   // Also check the alias if the input is the canonical name, or vice versa
@@ -47,30 +47,9 @@ function findStoredOAuthField(
     if (alias === service) servicesToCheck.push(canonical);
   }
   for (const svc of servicesToCheck) {
-    for (const field of fieldNames) {
-      const value = getSecureKey(`credential:${svc}:${field}`);
-      if (value) return value;
-    }
+    const value = getSecureKey(`credential:${svc}:${field}`);
+    if (value) return value;
   }
-
-  // Legacy fallback: check credential metadata on the access_token record.
-  // Older OAuth2 flows stored client_id/client_secret only in metadata JSON.
-  // New flows persist them in the keychain (checked above) for defense in depth.
-  const metadataKey = fieldNames.some((f) => f.includes("client_id"))
-    ? ("oauth2ClientId" as const)
-    : ("oauth2ClientSecret" as const);
-  for (const svc of servicesToCheck) {
-    const meta = getCredentialMetadata(svc, "access_token");
-    const value = meta?.[metadataKey];
-    if (value) {
-      log.debug(
-        { service: svc, field: metadataKey },
-        "OAuth client credential resolved from metadata (legacy fallback)",
-      );
-      return value;
-    }
-  }
-
   return undefined;
 }
 
@@ -781,13 +760,10 @@ class CredentialStoreTool implements Tool {
         // Look up client_id/client_secret from stored credentials if not provided
         const clientId =
           (input.client_id as string | undefined) ??
-          findStoredOAuthField(service, ["client_id", "oauth_client_id"]);
+          findStoredOAuthField(service, "client_id");
         const clientSecret =
           (input.client_secret as string | undefined) ??
-          findStoredOAuthField(service, [
-            "client_secret",
-            "oauth_client_secret",
-          ]);
+          findStoredOAuthField(service, "client_secret");
 
         // Early guardrails that stay in vault.ts (credential resolution is vault-specific)
         const inputScopes = input.scopes as string[] | undefined;


### PR DESCRIPTION
## Summary
- Remove dual-writes to legacy `oauth_client_id`/`oauth_client_secret` keys
- Remove fallback reads from legacy credential keys
- Simplify OAuth credential resolution to canonical keys only

Part of plan: pre-launch-legacy-cleanup.md (PR 22 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
