### PR TITLE
fix: remove push-to-talk legacy string key format

### DIFF
--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -1014,11 +1014,16 @@ describe("sanitizePttActivationKey", () => {
     expect(sanitizePttActivationKey(undefined)).toBeUndefined();
   });
 
-  test("passes through valid keys", () => {
-    expect(sanitizePttActivationKey("fn")).toBe("fn");
-    expect(sanitizePttActivationKey("ctrl")).toBe("ctrl");
-    expect(sanitizePttActivationKey("fn_shift")).toBe("fn_shift");
-    expect(sanitizePttActivationKey("none")).toBe("none");
+  test("passes through valid JSON PTTActivator payloads", () => {
+    const modifierOnly = JSON.stringify({
+      kind: "modifierOnly",
+      modifierFlags: 8388608,
+    });
+    expect(sanitizePttActivationKey(modifierOnly)).toBe(modifierOnly);
+    const keyPayload = JSON.stringify({ kind: "key", keyCode: 49 });
+    expect(sanitizePttActivationKey(keyPayload)).toBe(keyPayload);
+    const nonePayload = JSON.stringify({ kind: "none" });
+    expect(sanitizePttActivationKey(nonePayload)).toBe(nonePayload);
   });
 
   test("returns undefined for invalid keys", () => {
@@ -1028,6 +1033,13 @@ describe("sanitizePttActivationKey", () => {
     expect(sanitizePttActivationKey("arbitrary_value")).toBeUndefined();
     expect(sanitizePttActivationKey("")).toBeUndefined();
   });
+
+  test("returns undefined for legacy string keys", () => {
+    expect(sanitizePttActivationKey("fn")).toBeUndefined();
+    expect(sanitizePttActivationKey("ctrl")).toBeUndefined();
+    expect(sanitizePttActivationKey("fn_shift")).toBeUndefined();
+    expect(sanitizePttActivationKey("none")).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1035,11 +1047,22 @@ describe("sanitizePttActivationKey", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveChannelCapabilities with PTT metadata", () => {
-  test("sanitizes valid pttActivationKey", () => {
+  test("sanitizes valid JSON PTTActivator pttActivationKey", () => {
+    const key = JSON.stringify({
+      kind: "modifierOnly",
+      modifierFlags: 8388608,
+    });
+    const caps = resolveChannelCapabilities("macos", "macos", {
+      pttActivationKey: key,
+    });
+    expect(caps.pttActivationKey).toBe(key);
+  });
+
+  test("sanitizes legacy string pttActivationKey to undefined", () => {
     const caps = resolveChannelCapabilities("macos", "macos", {
       pttActivationKey: "fn",
     });
-    expect(caps.pttActivationKey).toBe("fn");
+    expect(caps.pttActivationKey).toBeUndefined();
   });
 
   test("sanitizes invalid pttActivationKey to undefined", () => {
@@ -1050,8 +1073,12 @@ describe("resolveChannelCapabilities with PTT metadata", () => {
   });
 
   test("passes through microphonePermissionGranted", () => {
+    const key = JSON.stringify({
+      kind: "modifierOnly",
+      modifierFlags: 8388608,
+    });
     const caps = resolveChannelCapabilities("macos", "macos", {
-      pttActivationKey: "fn",
+      pttActivationKey: key,
       microphonePermissionGranted: true,
     });
     expect(caps.microphonePermissionGranted).toBe(true);

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -507,7 +507,7 @@ export function buildChannelAwarenessSection(): string {
     "",
     "### Push-to-talk awareness",
     "- The `<channel_capabilities>` block may include `ptt_activation_key` and `ptt_enabled` fields indicating the user's push-to-talk configuration.",
-    "- You can change the push-to-talk activation key using the `voice_config_update` tool. Valid keys: fn (Fn/Globe key), ctrl (Control key), fn_shift (Fn+Shift), none (disable PTT).",
+    '- You can change the push-to-talk activation key using the `voice_config_update` tool. The key is provided as a JSON PTTActivator payload (e.g. `{"kind":"modifierOnly","modifierFlags":8388608}` for Fn).',
     "- When the user asks about voice input or push-to-talk settings, use the tool to apply changes directly rather than directing them to settings.",
     "- When `microphone_permission_granted` is `false`, guide the user to grant microphone access in System Settings before using voice features.",
     "",

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -169,21 +169,16 @@ export function inboundActorContextFromTrust(
   };
 }
 
-/** Legacy push-to-talk activation key values (pre-custom-key support). */
-const PTT_KEY_LEGACY = new Set(["fn", "ctrl", "fn_shift", "none"]);
-
 /**
- * Validate a PTT activation key string. Accepts both legacy string values
- * (fn, ctrl, fn_shift, none) and JSON PTTActivator payloads from the
- * custom key feature. Returns the key as-is if valid, undefined otherwise.
+ * Validate a PTT activation key string. Accepts JSON PTTActivator payloads
+ * from the custom key feature. Returns the key as-is if valid, undefined otherwise.
  */
 export function sanitizePttActivationKey(
   key: string | undefined | null,
 ): string | undefined {
   if (key == null) return undefined;
-  if (PTT_KEY_LEGACY.has(key)) return key;
 
-  // Try parsing as a JSON PTTActivator payload
+  // Parse as a JSON PTTActivator payload
   if (key.startsWith("{")) {
     try {
       const parsed = JSON.parse(key) as { kind?: string };
@@ -247,14 +242,8 @@ const KEY_CODE_NAMES: Record<number, string> = {
   57: "Caps Lock",
 };
 
-/** Derive a human-readable label from a PTT activation key value (legacy string or JSON). */
+/** Derive a human-readable label from a PTT activation key JSON value. */
 function pttKeyLabel(raw: string): string {
-  // Legacy string values
-  if (raw === "fn") return "Fn (Globe)";
-  if (raw === "ctrl") return "Ctrl";
-  if (raw === "fn_shift") return "Fn+Shift";
-  if (raw === "none") return "none";
-
   // JSON PTTActivator payload
   if (raw.startsWith("{")) {
     try {


### PR DESCRIPTION
## Summary
- Remove `PTT_KEY_LEGACY` set and legacy string key acceptance
- Only JSON PTTActivator format now accepted
- Remove legacy PTT key test cases

Part of plan: pre-launch-legacy-cleanup.md (PR 9 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
