### PR TITLE
fix: remove deprecated denialReason field from trust resolution

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -930,7 +930,6 @@ describe("call-controller", () => {
     const initialCtx = {
       sourceChannel: "voice" as const,
       trustClass: "unknown" as const,
-      denialReason: "no_binding" as const,
     };
 
     const upgradedCtx = {

--- a/assistant/src/__tests__/guardian-grant-minting.test.ts
+++ b/assistant/src/__tests__/guardian-grant-minting.test.ts
@@ -148,7 +148,6 @@ function makeTrustContext(): TrustContext {
   return {
     sourceChannel: "telegram",
     trustClass: "guardian",
-    denialReason: undefined,
   };
 }
 
@@ -621,6 +620,8 @@ describe("approval interception trust-class regression coverage", () => {
       trustCtx: {
         sourceChannel: "telegram",
         trustClass: "unknown",
+        requesterExternalUserId: "intruder-user-1",
+        guardianExternalUserId: "guardian-1",
       },
       assistantId: ASSISTANT_ID,
     });
@@ -653,7 +654,6 @@ describe("approval interception trust-class regression coverage", () => {
       trustCtx: {
         sourceChannel: "telegram",
         trustClass: "unknown",
-        denialReason: "no_identity",
       },
       assistantId: ASSISTANT_ID,
     });

--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -709,14 +709,12 @@ describe("injectInboundActorContext", () => {
       sourceChannel: "telegram",
       canonicalActorIdentity: null,
       trustClass: "unknown",
-      denialReason: "no_identity",
     };
 
     const result = injectInboundActorContext(baseUserMessage, ctx);
     const text = (result.content[0] as { type: "text"; text: string }).text;
     expect(text).toContain("non-guardian account");
     expect(text).toContain("Do not explain the verification system");
-    expect(text).toContain("denial_reason: no_identity");
   });
 
   test("omits non-guardian behavioral guidance for guardian actors", () => {
@@ -738,7 +736,6 @@ describe("injectInboundActorContext", () => {
       sourceChannel: "voice",
       canonicalActorIdentity: "user-1",
       trustClass: "unknown",
-      denialReason: "no_binding",
     };
 
     const result = injectInboundActorContext(baseUserMessage, ctx);

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -406,7 +406,6 @@ describe("voice-session-bridge", () => {
       trustContext: {
         sourceChannel: "voice",
         trustClass: "unknown",
-        denialReason: "no_binding",
       },
       onTextDelta: () => {},
       onComplete: () => {},
@@ -751,7 +750,6 @@ describe("voice-session-bridge", () => {
       trustContext: {
         sourceChannel: "voice",
         trustClass: "unknown",
-        denialReason: "no_binding",
       },
       onTextDelta: () => {},
       onComplete: () => {},

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -670,7 +670,6 @@ export class RelayConnection {
     recordCallEvent(this.callSessionId, "inbound_acl_denied", {
       from,
       trustClass: resolved.actorTrust.trustClass,
-      denialReason: resolved.actorTrust.denialReason,
       channelId: resolved.actorTrust.memberRecord?.channel.id,
       memberPolicy: resolved.actorTrust.memberRecord?.channel.policy,
     });

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -81,8 +81,6 @@ export interface TrustContext {
   requesterExternalUserId?: string;
   /** Chat/conversation ID the requester is interacting through. */
   requesterChatId?: string;
-  /** Access denial reason, if applicable. See {@link DenialReason}. */
-  denialReason?: "no_binding" | "no_identity";
 }
 
 /**
@@ -113,8 +111,6 @@ export interface InboundActorContext {
   memberStatus?: string;
   /** Member policy when the actor has a contact record. */
   memberPolicy?: string;
-  /** Denial reason when access is blocked. */
-  denialReason?: string;
   /** Free-text notes about this contact. */
   contactNotes?: string;
   /** Number of prior interactions with this contact. */
@@ -138,7 +134,6 @@ export function inboundActorContextFromTrustContext(
     actorMemberDisplayName: ctx.requesterMemberDisplayName,
     trustClass: ctx.trustClass,
     guardianIdentity: ctx.guardianExternalUserId,
-    denialReason: ctx.denialReason,
   };
 }
 
@@ -162,7 +157,6 @@ export function inboundActorContextFromTrust(
       ? channelStatusToMemberStatus(ctx.memberRecord.channel.status)
       : undefined,
     memberPolicy: ctx.memberRecord?.channel.policy ?? undefined,
-    denialReason: ctx.denialReason,
     contactNotes: ctx.memberRecord?.contact.notes ?? undefined,
     contactInteractionCount:
       ctx.memberRecord?.contact.interactionCount ?? undefined,
@@ -778,7 +772,6 @@ export function buildInboundActorContextBlock(
   if (ctx.memberPolicy) {
     lines.push(`member_policy: ${ctx.memberPolicy}`);
   }
-  lines.push(`denial_reason: ${ctx.denialReason ?? "none"}`);
   // Contact metadata — only included when the sender has a contact record
   // with non-default values.
   if (ctx.contactNotes) {

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -52,16 +52,6 @@ export function isUntrustedTrustClass(
 }
 
 /**
- * Reason an actor was denied access during trust resolution.
- *
- * - `'no_binding'`: No guardian binding exists for this (assistant, channel),
- *   so trust cannot be established for any actor.
- * - `'no_identity'`: The inbound message carried no usable identity fields
- *   (e.g. missing external user ID), so the sender could not be identified.
- */
-export type DenialReason = "no_binding" | "no_identity";
-
-/**
  * Fully resolved trust context from the actor trust resolver.
  *
  * This is the intermediate representation between raw inbound identity
@@ -98,8 +88,6 @@ export interface ActorTrustContext {
     channel: ChannelId;
     trustStatus: TrustClass;
   };
-  /** Legacy denial reason for backward-compatible unverified_channel paths. */
-  denialReason?: DenialReason;
 }
 
 /**
@@ -176,7 +164,6 @@ export function resolveActorTrust(
         channel: input.sourceChannel,
         trustStatus: "unknown",
       },
-      denialReason: "no_identity",
     };
   }
 
@@ -280,12 +267,6 @@ export function resolveActorTrust(
     trustClass = "unknown";
   }
 
-  // Denial reason for legacy compatibility
-  let denialReason: DenialReason | undefined;
-  if (!isGuardian && !guardianBindingMatch) {
-    denialReason = "no_binding";
-  }
-
   return {
     canonicalSenderId,
     guardianBindingMatch,
@@ -301,7 +282,6 @@ export function resolveActorTrust(
       channel: input.sourceChannel,
       trustStatus: trustClass,
     },
-    denialReason,
   };
 }
 
@@ -338,6 +318,5 @@ export function toTrustContext(
     requesterMemberDisplayName: ctx.actorMetadata.memberDisplayName,
     requesterExternalUserId: ctx.canonicalSenderId ?? undefined,
     requesterChatId: conversationExternalId,
-    denialReason: ctx.denialReason,
   };
 }

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -35,10 +35,6 @@ function parseTrustRuntimeContext(value: unknown): TrustContext | undefined {
       : undefined;
   if (!rawSourceChannel || !isChannelId(rawSourceChannel)) return undefined;
   const sourceChannel = rawSourceChannel;
-  const denialReason =
-    raw.denialReason === "no_binding" || raw.denialReason === "no_identity"
-      ? raw.denialReason
-      : undefined;
   return {
     sourceChannel,
     trustClass,
@@ -74,7 +70,6 @@ function parseTrustRuntimeContext(value: unknown): TrustContext | undefined {
         : undefined,
     requesterChatId:
       typeof raw.requesterChatId === "string" ? raw.requesterChatId : undefined,
-    denialReason,
   };
 }
 

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -8,8 +8,6 @@ import type {
   ApprovalDecisionResult,
   ApprovalUIMetadata,
 } from "../channel-approval-types.js";
-import type { DenialReason } from "../trust-context-resolver.js";
-export type { DenialReason } from "../trust-context-resolver.js";
 
 /** Canonicalize assistantId for channel ingress paths. */
 export function canonicalChannelAssistantId(_assistantId: string): string {
@@ -113,7 +111,7 @@ export function parseReactionCallbackData(
  */
 export function buildGuardianDenyContext(
   toolName: string,
-  denialReason: DenialReason,
+  denialReason: "no_binding" | "no_identity",
   _sourceChannel: ChannelId,
 ): string {
   if (denialReason === "no_identity") {

--- a/assistant/src/runtime/routes/channel-routes.ts
+++ b/assistant/src/runtime/routes/channel-routes.ts
@@ -40,10 +40,7 @@ export {
   handleChannelInbound,
   handleDeleteConversation,
 } from "./channel-inbound-routes.js";
-export {
-  _setTestPollMaxWait,
-  type DenialReason,
-} from "./channel-route-shared.js";
+export { _setTestPollMaxWait } from "./channel-route-shared.js";
 
 // ---------------------------------------------------------------------------
 // Route definitions

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -146,40 +146,39 @@ export async function handleApprovalInterception(
   const pendingPrompt = getChannelApprovalPrompt(conversationId);
   if (!pendingPrompt) return { handled: false };
 
-  // Legacy unverified-channel equivalent:
-  // unknown trust + explicit denial reason (`no_identity` / `no_binding`).
-  // Unknown without a denial reason means identity-known, non-member sender
-  // in a shared channel; that case must not force-reject someone else's request.
-  const isLegacyUnverifiedSender =
-    trustCtx.trustClass === "unknown" && !!trustCtx.denialReason;
+  // Unverified sender: unknown trust where either the sender's identity
+  // could not be established or no guardian binding exists for the channel.
+  // Identity-known non-member senders in shared channels (unknown trust with
+  // both identity and guardian binding present) must not force-reject.
+  const isUnverifiedSender =
+    trustCtx.trustClass === "unknown" &&
+    (!trustCtx.requesterExternalUserId || !trustCtx.guardianExternalUserId);
 
-  // When the sender is from a legacy-unverified channel actor, auto-deny any
-  // pending confirmation and block self-approval.
-  if (isLegacyUnverifiedSender) {
+  // When the sender is unverified, auto-deny any pending confirmation and
+  // block self-approval.
+  if (isUnverifiedSender) {
     const pending = getApprovalInfoByConversation(conversationId);
     if (pending.length > 0) {
+      const reason: "no_identity" | "no_binding" =
+        !trustCtx.requesterExternalUserId ? "no_identity" : "no_binding";
       handleChannelDecision(
         conversationId,
         { action: "reject", source: "plain_text" },
-        buildGuardianDenyContext(
-          pending[0].toolName,
-          trustCtx.denialReason ?? "no_binding",
-          sourceChannel,
-        ),
+        buildGuardianDenyContext(pending[0].toolName, reason, sourceChannel),
       );
       return { handled: true, type: "decision_applied" };
     }
   }
 
-  // When the sender is a non-guardian and there's a pending guardian approval
-  // for this conversation's request, block self-approval. The non-guardian must
-  // wait for the guardian to decide.
-  //
-  // Include identity-known, non-member senders (`unknown` without denialReason)
-  // so shared-channel participants can't approve/deny someone else's pending request.
+  // When the sender is a non-guardian with established identity and a guardian
+  // binding, block self-approval. The non-guardian must wait for the guardian
+  // to decide. This covers trusted contacts and identity-known non-member
+  // senders in shared channels.
   const isIdentityKnownNonGuardian =
     trustCtx.trustClass === "trusted_contact" ||
-    (trustCtx.trustClass === "unknown" && !trustCtx.denialReason);
+    (trustCtx.trustClass === "unknown" &&
+      !!trustCtx.requesterExternalUserId &&
+      !!trustCtx.guardianExternalUserId);
   if (isIdentityKnownNonGuardian) {
     const pending = getApprovalInfoByConversation(conversationId);
     if (pending.length > 0) {

--- a/assistant/src/runtime/trust-context-resolver.ts
+++ b/assistant/src/runtime/trust-context-resolver.ts
@@ -15,7 +15,6 @@ import {
   type ResolveActorTrustInput,
   toTrustContext,
 } from "./actor-trust-resolver.js";
-export type { DenialReason } from "./actor-trust-resolver.js";
 
 /**
  * Resolve route-level trust context from canonical identity state.


### PR DESCRIPTION
## Summary
- Remove `DenialReason` type and `denialReason` field from `ActorTrustResult`
- Update all consumers to use `trustClass` directly
- Refactor guardian-approval-interception unverified sender detection

Part of plan: pre-launch-legacy-cleanup.md (PR 30 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14030" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
