### PR TITLE
fix: remove dual auth error shape parsing in HTTPDaemonClient

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -2138,16 +2138,10 @@ public final class HTTPTransport {
         // Parse the 401 body to check for terminal (non-refreshable) error codes.
         // The server's auth middleware returns errors in a standard envelope:
         //   { "error": { "code": "...", "message": "..." } }
-        // We also accept a top-level "code" for forward compatibility.
         let terminalCodes: Set<String> = ["credentials_revoked"]
         if let data = responseData,
            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-            let code: String? = {
-                if let errorObj = json["error"] as? [String: Any] {
-                    return errorObj["code"] as? String
-                }
-                return json["code"] as? String
-            }()
+            let code = (json["error"] as? [String: Any])?["code"] as? String
             if let code, terminalCodes.contains(code) {
                 // Explicitly terminal — no refresh possible
                 log.error("Terminal 401 code: \(code) — re-auth required")


### PR DESCRIPTION
## Summary
- Remove fallback to top-level `json["code"]` error parsing
- Only parse canonical `json["error"]["code"]` shape

Part of plan: pre-launch-legacy-cleanup.md (PR 49 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14031" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
