### PR TITLE
fix: remove Twitter flat config key fallbacks

### DIFF
--- a/assistant/src/daemon/handlers/config-integrations.ts
+++ b/assistant/src/daemon/handlers/config-integrations.ts
@@ -113,19 +113,18 @@ export async function handleTwitterIntegrationConfig(
     if (msg.action === "get") {
       const raw = loadRawConfig();
       const mode =
-        ((getNestedValue(raw, "twitter.integrationMode") ??
-          raw.twitterIntegrationMode) as "local_byo" | "managed" | undefined) ??
-        "local_byo";
+        (getNestedValue(raw, "twitter.integrationMode") as
+          | "local_byo"
+          | "managed"
+          | undefined) ?? "local_byo";
       const strategy =
-        ((getNestedValue(raw, "twitter.operationStrategy") ??
-          raw.twitterOperationStrategy) as
+        (getNestedValue(raw, "twitter.operationStrategy") as
           | "oauth"
           | "browser"
           | "auto"
           | undefined) ?? "auto";
       const strategyConfigured =
-        (getNestedValue(raw, "twitter.operationStrategy") ??
-          raw.twitterOperationStrategy) !== undefined;
+        getNestedValue(raw, "twitter.operationStrategy") !== undefined;
       const localClientConfigured = hasTwitterClientId();
       const connected = !!getSecureKey(
         "credential:integration:twitter:access_token",
@@ -145,15 +144,13 @@ export async function handleTwitterIntegrationConfig(
     } else if (msg.action === "get_strategy") {
       const raw = loadRawConfig();
       const strategy =
-        ((getNestedValue(raw, "twitter.operationStrategy") ??
-          raw.twitterOperationStrategy) as
+        (getNestedValue(raw, "twitter.operationStrategy") as
           | "oauth"
           | "browser"
           | "auto"
           | undefined) ?? "auto";
       const strategyConfigured =
-        (getNestedValue(raw, "twitter.operationStrategy") ??
-          raw.twitterOperationStrategy) !== undefined;
+        getNestedValue(raw, "twitter.operationStrategy") !== undefined;
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: true,
@@ -181,8 +178,6 @@ export async function handleTwitterIntegrationConfig(
       }
       const raw = loadRawConfig();
       setNestedValue(raw, "twitter.operationStrategy", value);
-      // Migrate: remove legacy flat key if present
-      delete raw.twitterOperationStrategy;
       saveRawConfig(raw);
       ctx.send(socket, {
         type: "twitter_integration_config_response",
@@ -198,8 +193,6 @@ export async function handleTwitterIntegrationConfig(
     } else if (msg.action === "set_mode") {
       const raw = loadRawConfig();
       setNestedValue(raw, "twitter.integrationMode", msg.mode ?? "local_byo");
-      // Migrate: remove legacy flat key if present
-      delete raw.twitterIntegrationMode;
       saveRawConfig(raw);
       ctx.send(socket, {
         type: "twitter_integration_config_response",


### PR DESCRIPTION
## Summary
- Remove `twitterIntegrationMode` and `twitterOperationStrategy` flat key fallbacks
- Only read from nested config paths

Part of plan: pre-launch-legacy-cleanup.md (PR 23 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14032" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
