### PR TITLE
fix: remove DaemonConfig socket path compat init

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -104,7 +104,9 @@ extension AppDelegate {
                 // switching between local instances connects to the correct daemon
                 // and authenticates with the correct session token.
                 let socketPath = assistant?.socketPath ?? DaemonClient.resolveSocketPath()
-                let config = DaemonConfig(socketPath: socketPath, instanceDir: assistant?.instanceDir)
+                let instanceDir = assistant?.instanceDir
+                let featureFlagToken = instanceDir.map { readFeatureFlagToken(environment: ["BASE_DATA_DIR": $0]) } ?? readFeatureFlagToken()
+                let config = DaemonConfig(transport: .socket(path: socketPath), instanceDir: instanceDir, featureFlagToken: featureFlagToken)
                 services.reconfigureDaemonClient(config: config)
             }
             return

--- a/clients/shared/IPC/DaemonConfig.swift
+++ b/clients/shared/IPC/DaemonConfig.swift
@@ -107,25 +107,6 @@ public struct DaemonConfig {
     public let featureFlagToken: String?
 
     #if os(macOS)
-    /// Socket path, for backwards compatibility.
-    /// Returns the socket path if using socket transport, otherwise the default path.
-    public var socketPath: String {
-        switch transport {
-        case .socket(let path):
-            return path
-        case .http, .tcp:
-            return resolveSocketPath()
-        }
-    }
-
-    /// Convenience initializer for socket transport (backwards compatible).
-    public init(socketPath: String, instanceDir: String? = nil) {
-        self.transport = .socket(path: socketPath)
-        self.transportMetadata = .defaultLocal
-        self.instanceDir = instanceDir
-        self.featureFlagToken = instanceDir.map { readFeatureFlagToken(environment: ["BASE_DATA_DIR": $0]) } ?? readFeatureFlagToken()
-    }
-
     public static var `default`: DaemonConfig {
         return DaemonConfig(transport: .socket(path: resolveSocketPath()))
     }


### PR DESCRIPTION
## Summary
- Update AppDelegate to use `DaemonConfig(transport: .socket(path:))` directly
- Remove convenience `init(socketPath:instanceDir:)` and `socketPath` computed property

Part of plan: pre-launch-legacy-cleanup.md (PR 31 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14033" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
