### PR TITLE
fix: remove HistoryResponseMessage init without newer fields

### DIFF
--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1294,13 +1294,6 @@ extension IPCHistoryResponse {
     public typealias HistoryToolCallItem = IPCHistoryResponseToolCall
 }
 
-extension IPCHistoryResponseMessage {
-    /// Backward-compatible init without textSegments/contentOrder/surfaces/subagentNotification (added in later IPC versions).
-    public init(role: String, text: String, timestamp: Double, toolCalls: [IPCHistoryResponseToolCall]?, toolCallsBeforeText: Bool?, attachments: [IPCUserMessageAttachment]?) {
-        self.init(id: nil, role: role, text: text, timestamp: timestamp, toolCalls: toolCalls, toolCallsBeforeText: toolCallsBeforeText, attachments: attachments, textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil)
-    }
-}
-
 /// A single scheduled task item returned from the daemon.
 /// Backed by generated `IPCSchedulesListResponseSchedule`.
 public typealias ScheduleItem = IPCSchedulesListResponseSchedule


### PR DESCRIPTION
## Summary
- Remove backward-compat init from IPCHistoryResponseMessage
- No test updates needed -- all existing call sites already use the full init with all parameters

Part of plan: pre-launch-legacy-cleanup.md (PR 36 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14034" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
