### PR TITLE
fix: remove content order fallback in ChatViewModel

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1707,24 +1707,4 @@ public struct ChatMessage: Identifiable, Equatable {
         }
         isContentStripped = true
     }
-
-    /// Build a default content order from the legacy `arrivedBeforeText` flag.
-    public static func buildDefaultContentOrder(
-        textSegmentCount: Int,
-        toolCallCount: Int,
-        arrivedBeforeText: Bool,
-        surfaceCount: Int = 0
-    ) -> [ContentBlockRef] {
-        var order: [ContentBlockRef] = []
-        if arrivedBeforeText {
-            for i in 0..<toolCallCount { order.append(.toolCall(i)) }
-            for i in 0..<textSegmentCount { order.append(.text(i)) }
-            for i in 0..<surfaceCount { order.append(.surface(i)) }
-        } else {
-            for i in 0..<textSegmentCount { order.append(.text(i)) }
-            for i in 0..<toolCallCount { order.append(.toolCall(i)) }
-            for i in 0..<surfaceCount { order.append(.surface(i)) }
-        }
-        return order
-    }
 }

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2287,19 +2287,12 @@ public final class ChatViewModel: ObservableObject {
             // Populate inlineSurfaces from history
             chatMsg.inlineSurfaces = inlineSurfaces
 
-            // Use daemon-provided segments/order when available; fall back to legacy.
-            // The daemon always provides contentOrder when there are any content blocks,
-            // so we should use it even when textSegments is empty (e.g., widget-only turns).
-            if let segments = item.textSegments, let orderStrings = item.contentOrder {
+            // Use daemon-provided segments/order.
+            if let segments = item.textSegments {
                 chatMsg.textSegments = segments
+            }
+            if let orderStrings = item.contentOrder {
                 chatMsg.contentOrder = Self.parseContentOrder(orderStrings)
-            } else {
-                chatMsg.contentOrder = ChatMessage.buildDefaultContentOrder(
-                    textSegmentCount: chatMsg.textSegments.count,
-                    toolCallCount: toolCalls.count,
-                    arrivedBeforeText: toolsBeforeText,
-                    surfaceCount: inlineSurfaces.count
-                )
             }
 
             // Log contentOrder for debugging widget restoration


### PR DESCRIPTION
## Summary
- Remove `buildDefaultContentOrder()` fallback branch from ChatViewModel
- Delete `buildDefaultContentOrder()` static method from ChatMessage

Part of plan: pre-launch-legacy-cleanup.md (PR 33 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
