### PR TITLE
fix: remove VoiceTranscriptionWindow dummy manager fallback

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Voice.swift
@@ -110,10 +110,9 @@ extension AppDelegate {
                 )
                 let quickInputActive = self?.quickInputWindow?.isVisible ?? false
                 let isDictation = self?.voiceInput?.currentMode == .dictation
-                if !mainWindowActive && !hasActiveConvo && !quickInputActive && !isDictation {
-                    let window = VoiceTranscriptionWindow(
-                        voiceModeManager: self?.mainWindow?.voiceModeManager
-                    )
+                if !mainWindowActive && !hasActiveConvo && !quickInputActive && !isDictation,
+                   let manager = self?.mainWindow?.voiceModeManager {
+                    let window = VoiceTranscriptionWindow(voiceModeManager: manager)
                     window.show()
                     self?.voiceTranscriptionWindow = window
                 }

--- a/clients/macos/vellum-assistant/Features/Voice/VoiceTranscriptionWindow.swift
+++ b/clients/macos/vellum-assistant/Features/Voice/VoiceTranscriptionWindow.swift
@@ -51,20 +51,14 @@ final class VoiceTranscriptionWindow {
     private let baseHeight: CGFloat = 140
     private let margin: CGFloat = 16
 
-    init(voiceModeManager: VoiceModeManager? = nil) {
+    init(voiceModeManager: VoiceModeManager) {
         self.voiceModeManager = voiceModeManager
     }
 
     func show() {
-        let rootView: AnyView
-        if let manager = voiceModeManager {
-            rootView = AnyView(VoiceTranscriptionView(voiceModeManager: manager))
-        } else {
-            // Fallback: create a dummy manager for backward compatibility
-            let fallback = VoiceModeManager()
-            rootView = AnyView(VoiceTranscriptionView(voiceModeManager: fallback))
-        }
+        guard let manager = voiceModeManager else { return }
 
+        let rootView = VoiceTranscriptionView(voiceModeManager: manager)
         let hostingController = NSHostingController(rootView: rootView)
 
         let panel = NSPanel(


### PR DESCRIPTION
## Summary
- Make `voiceModeManager` required (non-optional) in VoiceTranscriptionWindow
- Remove dummy manager fallback in `show()`

Part of plan: pre-launch-legacy-cleanup.md (PR 40 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14036" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
