### PR TITLE
fix: remove hasMore backward-compat default in populateFromHistory

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
@@ -451,7 +451,7 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
             ),
         ]
 
-        viewModel.populateFromHistory(historyItems)
+        viewModel.populateFromHistory(historyItems, hasMore: false)
 
         XCTAssertEqual(viewModel.messages.count, 1)
         let msg = viewModel.messages[0]
@@ -496,7 +496,7 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
             ),
         ]
 
-        viewModel.populateFromHistory(historyItems)
+        viewModel.populateFromHistory(historyItems, hasMore: false)
 
         XCTAssertEqual(viewModel.messages.count, 1)
         let msg = viewModel.messages[0]

--- a/clients/macos/vellum-assistantTests/ChatMediaEmbedBaselineTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatMediaEmbedBaselineTests.swift
@@ -219,7 +219,7 @@ final class ChatMediaEmbedBaselineTests: XCTestCase {
             ),
         ]
 
-        viewModel.populateFromHistory(historyItems)
+        viewModel.populateFromHistory(historyItems, hasMore: false)
 
         XCTAssertEqual(viewModel.messages.count, 1)
         let msg = viewModel.messages[0]

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1775,7 +1775,7 @@ final class ChatViewModelTests: XCTestCase {
             IPCHistoryResponseMessage(id: nil, role: "assistant", text: "Here is your chart", timestamp: 2000, toolCalls: nil, toolCallsBeforeText: nil, attachments: [attachment], textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil),
         ]
 
-        viewModel.populateFromHistory(historyItems)
+        viewModel.populateFromHistory(historyItems, hasMore: false)
 
         XCTAssertEqual(viewModel.messages.count, 2)
         XCTAssertEqual(viewModel.messages[1].role, .assistant)
@@ -1793,7 +1793,7 @@ final class ChatViewModelTests: XCTestCase {
             IPCHistoryResponseMessage(id: nil, role: "assistant", text: "", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: [attachment], textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil),
         ]
 
-        viewModel.populateFromHistory(historyItems)
+        viewModel.populateFromHistory(historyItems, hasMore: false)
 
         // Attachment-only message (empty text, no tool calls) should NOT be skipped
         XCTAssertEqual(viewModel.messages.count, 1)
@@ -1807,7 +1807,7 @@ final class ChatViewModelTests: XCTestCase {
             IPCHistoryResponseMessage(id: nil, role: "assistant", text: "", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: nil, textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil),
         ]
 
-        viewModel.populateFromHistory(historyItems)
+        viewModel.populateFromHistory(historyItems, hasMore: false)
 
         // Empty message with no text, no tool calls, no attachments should be skipped
         XCTAssertEqual(viewModel.messages.count, 0)
@@ -1880,7 +1880,7 @@ final class ChatViewModelTests: XCTestCase {
             ),
         ]
 
-        viewModel.populateFromHistory(historyItems)
+        viewModel.populateFromHistory(historyItems, hasMore: false)
 
         XCTAssertEqual(viewModel.messages.count, 1)
         let msg = viewModel.messages[0]
@@ -1906,7 +1906,7 @@ final class ChatViewModelTests: XCTestCase {
             ),
         ]
 
-        viewModel.populateFromHistory(historyItems)
+        viewModel.populateFromHistory(historyItems, hasMore: false)
 
         XCTAssertEqual(viewModel.messages.count, 1)
         let msg = viewModel.messages[0]

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2117,8 +2117,7 @@ public final class ChatViewModel: ObservableObject {
     ///
     /// - Parameters:
     ///   - historyMessages: The message items from the daemon's history response.
-    ///   - hasMore: Whether the daemon has older pages available. Defaults to `false`
-    ///     for backward compatibility with older daemons that don't send this field.
+    ///   - hasMore: Whether the daemon has older pages available.
     ///   - oldestTimestamp: The timestamp of the oldest message in the response (ms since epoch).
     ///     Used as the cursor for the next pagination request.
     ///   - isPaginationLoad: When `true`, messages are prepended to the existing list
@@ -2126,7 +2125,7 @@ public final class ChatViewModel: ObservableObject {
     ///     or reconnect-catch-up logic applies.
     public func populateFromHistory(
         _ historyMessages: [IPCHistoryResponseMessage],
-        hasMore: Bool = false,
+        hasMore: Bool,
         oldestTimestamp: Double? = nil,
         isPaginationLoad: Bool = false
     ) {


### PR DESCRIPTION
## Summary
- Remove default value from `hasMore` parameter in `populateFromHistory`
- Update all callers to explicitly pass `hasMore`

Part of plan: pre-launch-legacy-cleanup.md (PR 32 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14038" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
