### PR TITLE
fix: remove session_info correlation backward compat

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -484,15 +484,12 @@ extension ChatViewModel {
         case .sessionInfo(let info):
             // Only claim this session_info if:
             // 1. We don't have a session yet, AND
-            // 2. The correlation ID matches our bootstrap request (if we sent one).
-            //    Session info without a correlation ID is accepted when we have no
-            //    bootstrap correlation (backwards compatibility with older daemons).
+            // 2. The correlation ID matches our bootstrap request.
             if sessionId == nil {
-                if let expected = bootstrapCorrelationId {
-                    guard info.correlationId == expected else {
-                        // This session_info belongs to a different ChatViewModel's request.
-                        break
-                    }
+                guard let expected = bootstrapCorrelationId,
+                      info.correlationId == expected else {
+                    // No pending bootstrap or correlation mismatch — not ours.
+                    break
                 }
 
                 sessionId = info.sessionId


### PR DESCRIPTION
## Summary
- Remove backward-compat path that accepts session_info without correlation ID

Part of plan: pre-launch-legacy-cleanup.md (PR 34 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
