### PR TITLE
fix: remove MainWindowState.activePanel backward-compat property

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowState.swift
@@ -64,38 +64,6 @@ public final class MainWindowState: ObservableObject {
     @Published var layoutConfig: LayoutConfig
     @Published var toastInfo: ToastInfo?
 
-    // MARK: - Backward-Compatible Computed Properties
-
-    /// Derived from `selection` for backward compatibility.
-    var activePanel: SidePanelType? {
-        get {
-            switch selection {
-            case .panel(let type): return type
-            case .app, .appEditing: return .generated
-            default: return nil
-            }
-        }
-        set {
-            if let panel = newValue {
-                selection = .panel(panel)
-            } else {
-                // Only clear if currently showing a panel
-                if case .panel = selection {
-                    selection = nil
-                } else if newValue == nil && activePanel != nil {
-                    // Explicit nil set — clear selection
-                    selection = nil
-                }
-            }
-            // Persist the active panel
-            if let newValue {
-                lastActivePanelString = String(describing: newValue)
-            } else if newValue == nil {
-                lastActivePanelString = nil
-            }
-        }
-    }
-
     /// Whether the main content area is showing a plain, full-window chat
     /// (either an explicit `.thread` selection or `nil` which defaults to chat).
     ///

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -183,10 +183,10 @@ extension MainWindowView {
             }
 
             // MARK: Nav Items (fixed)
-            SidebarNavRow(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: windowState.activePanel == .intelligence) {
+            SidebarNavRow(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: windowState.selection == .panel(.intelligence)) {
                 windowState.togglePanel(.intelligence)
             }
-            SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Things", isActive: windowState.activePanel == .apps) {
+            SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Things", isActive: windowState.selection == .panel(.apps)) {
                 windowState.showAppsPanel()
             }
 
@@ -472,10 +472,10 @@ extension MainWindowView {
                 sidebarSectionDivider(isExpanded: false)
             }
 
-            SidebarNavRow(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: windowState.activePanel == .intelligence, isExpanded: false) {
+            SidebarNavRow(icon: VIcon.brain.rawValue, label: "Intelligence", isActive: windowState.selection == .panel(.intelligence), isExpanded: false) {
                 windowState.togglePanel(.intelligence)
             }
-            SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Things", isActive: windowState.activePanel == .apps, isExpanded: false) {
+            SidebarNavRow(icon: VIcon.layoutGrid.rawValue, label: "Things", isActive: windowState.selection == .panel(.apps), isExpanded: false) {
                 windowState.showAppsPanel()
             }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -90,7 +90,7 @@ struct MainWindowView: View {
     /// When a generated surface is expanded into the workspace, hide the
     /// global sidebar toggle so workspace controls own the top-left slot.
     private var isGeneratedWorkspaceOpen: Bool {
-        windowState.isDynamicExpanded && windowState.activePanel == .generated
+        windowState.isDynamicExpanded
     }
 
     /// Whether the BOOTSTRAP.md first-run ritual is still in progress.


### PR DESCRIPTION
## Summary
- Replace all `activePanel` reads/writes with direct `selection` usage
- Delete `activePanel` computed property from MainWindowState

Part of plan: pre-launch-legacy-cleanup.md (PR 46 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14040" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
