### PR TITLE
fix: remove InlineVideoAttachmentView static port backward-compat init

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MediaEmbeds/InlineVideoAttachmentView.swift
@@ -71,31 +71,6 @@ struct InlineVideoAttachmentView: View {
     /// tap on the failed tile opens the external player instead of retrying again.
     @State private var hasRetriedOnce = false
 
-    // Backward-compatible initializer that accepts a static port snapshot.
-    // Used by callers that haven't migrated to the closure-based API yet.
-    init(attachment: ChatAttachment, daemonHttpPort: Int?) {
-        self.attachment = attachment
-        let port = daemonHttpPort
-        self.resolveHttpPort = { port }
-
-        if let img = attachment.thumbnailImage {
-            var w: CGFloat = 0
-            var h: CGFloat = 0
-            if let rep = img.representations.first {
-                w = CGFloat(rep.pixelsWide)
-                h = CGFloat(rep.pixelsHigh)
-            }
-            if w <= 0 || h <= 0 {
-                w = img.size.width
-                h = img.size.height
-            }
-            _videoAspectRatio = State(initialValue: w > 0 && h > 0 ? w / h : 3.0 / 4.0)
-            _thumbnailImage = State(initialValue: img)
-        } else {
-            _videoAspectRatio = State(initialValue: 3.0 / 4.0)
-        }
-    }
-
     init(attachment: ChatAttachment, resolveHttpPort: @escaping () -> Int?) {
         self.attachment = attachment
         self.resolveHttpPort = resolveHttpPort


### PR DESCRIPTION
## Summary
- Remove backward-compat init with static `daemonHttpPort` parameter

Part of plan: pre-launch-legacy-cleanup.md (PR 39 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
