### PR TITLE
fix: remove VSidePanel init without pinnedContent

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/DirectoryPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/DirectoryPanel.swift
@@ -33,7 +33,7 @@ struct DirectoryPanel: View {
     @State private var isLoadingDocuments = false
 
     var body: some View {
-        VSidePanel(title: "Directory", onClose: onClose) {
+        VSidePanel(title: "Directory", onClose: onClose, pinnedContent: { EmptyView() }) {
             VStack(spacing: 0) {
                 // Tab bar
                 HStack(spacing: VSpacing.xs) {

--- a/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSidePanel.swift
@@ -50,19 +50,10 @@ public struct VSidePanel<PinnedContent: View, Content: View>: View {
     }
 }
 
-// Backward-compatible init (no pinnedContent)
-public extension VSidePanel where PinnedContent == EmptyView {
-    init(title: String, titleFont: Font = VFont.panelTitle, uppercased: Bool = false, onClose: (() -> Void)? = nil,
-         @ViewBuilder content: @escaping () -> Content) {
-        self.init(title: title, titleFont: titleFont, uppercased: uppercased, onClose: onClose,
-                  pinnedContent: { EmptyView() }, content: content)
-    }
-}
-
 #Preview("VSidePanel") {
     ZStack {
         VColor.background.ignoresSafeArea()
-        VSidePanel(title: "Inspector", onClose: {}) {
+        VSidePanel(title: "Inspector", onClose: {}, pinnedContent: { EmptyView() }) {
             VStack(alignment: .leading, spacing: VSpacing.md) {
                 Text("Panel content here")
                     .font(VFont.body)

--- a/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
+++ b/clients/shared/DesignSystem/Components/Layout/VSplitView.swift
@@ -181,7 +181,7 @@ public extension VSplitView where Panel == EmptyView {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(VColor.surface)
                 } panel: {
-                    VSidePanel(title: "Panel") {
+                    VSidePanel(title: "Panel", pinnedContent: { EmptyView() }) {
                         Text("Side panel")
                             .font(VFont.body)
                             .foregroundColor(VColor.textSecondary)

--- a/clients/shared/DesignSystem/Gallery/Sections/LayoutGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/LayoutGallerySection.swift
@@ -33,7 +33,7 @@ struct LayoutGallerySection: View {
             )
 
             VCard(padding: 0) {
-                VSidePanel(title: "Inspector", onClose: {}) {
+                VSidePanel(title: "Inspector", onClose: {}, pinnedContent: { EmptyView() }) {
                     VStack(alignment: .leading, spacing: VSpacing.md) {
                         Text("Panel content goes here")
                             .font(VFont.body)
@@ -112,7 +112,7 @@ struct LayoutGallerySection: View {
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .background(VColor.surface)
                     } panel: {
-                        VSidePanel(title: "Details", onClose: { showPanel = false }) {
+                        VSidePanel(title: "Details", onClose: { showPanel = false }, pinnedContent: { EmptyView() }) {
                             Text("Side panel content")
                                 .font(VFont.body)
                                 .foregroundColor(VColor.textSecondary)


### PR DESCRIPTION
## Summary
- Remove backward-compat init extension from VSidePanel that provided convenience init without `pinnedContent` parameter
- Update all 5 call sites to explicitly pass `pinnedContent: { EmptyView() }`

Part of plan: pre-launch-legacy-cleanup.md (PR 38 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
