### PR TITLE
fix: remove allFlags() backward-compat method

### DIFF
--- a/clients/macos/vellum-assistantTests/FeatureFlagManagerTests.swift
+++ b/clients/macos/vellum-assistantTests/FeatureFlagManagerTests.swift
@@ -115,10 +115,11 @@ final class MacOSClientFeatureFlagManagerTests: XCTestCase {
         let manager = MacOSClientFeatureFlagManager(environment: env)
 
         // THEN only the VELLUM_FLAG_ variable is loaded
-        XCTAssertEqual(manager.allFlags().count, 1)
-
-        // AND the real flag is enabled
         XCTAssertTrue(manager.isEnabled("real"))
+
+        // AND non-flag env vars are not treated as flags
+        XCTAssertFalse(manager.isEnabled("HOME"))
+        XCTAssertFalse(manager.isEnabled("PATH"))
     }
 
     /// Tests that multiple flags can be loaded simultaneously.
@@ -138,8 +139,7 @@ final class MacOSClientFeatureFlagManagerTests: XCTestCase {
         XCTAssertFalse(manager.isEnabled("beta"))
         XCTAssertTrue(manager.isEnabled("gamma"))
 
-        // AND all three flags are loaded
-        XCTAssertEqual(manager.allFlags().count, 3)
+        // AND all three flags are loaded (verified individually above)
     }
 
     /// Tests that setOverride can enable a flag that was not in the environment.
@@ -188,8 +188,8 @@ final class MacOSClientFeatureFlagManagerTests: XCTestCase {
         // WHEN we create a manager from that environment
         let manager = MacOSClientFeatureFlagManager(environment: env)
 
-        // THEN no flags are loaded
-        XCTAssertEqual(manager.allFlags().count, 0)
+        // THEN no flags are loaded — the empty-name key is not accessible
+        XCTAssertFalse(manager.isEnabled(""))
     }
 
     /// Tests that whitespace in the flag value is trimmed during parsing.

--- a/clients/shared/Utilities/MacOSClientFeatureFlagManager.swift
+++ b/clients/shared/Utilities/MacOSClientFeatureFlagManager.swift
@@ -77,13 +77,6 @@ public final class MacOSClientFeatureFlagManager: @unchecked Sendable {
         return false
     }
 
-    /// Return all overrides (for backward compatibility with tests).
-    public func allFlags() -> [String: Bool] {
-        lock.lock()
-        defer { lock.unlock() }
-        return overrides
-    }
-
     /// Return the resolved state of all macOS-scope flag definitions for UI display.
     public func allFlagStates() -> [MacOSFeatureFlagState] {
         lock.lock()


### PR DESCRIPTION
## Summary
- Delete `allFlags()` method from MacOSClientFeatureFlagManager
- Update tests to use `isEnabled()` assertions instead of `allFlags().count`

Part of plan: pre-launch-legacy-cleanup.md (PR 41 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
