### PR TITLE
fix: remove backward-compat ordering comment from shell identity

### DIFF
--- a/assistant/src/permissions/shell-identity.ts
+++ b/assistant/src/permissions/shell-identity.ts
@@ -193,7 +193,7 @@ export function deriveShellActionKeys(
  * Build an ordered list of command candidates for trust-rule matching.
  *
  * Candidate ordering:
- *   1. Raw command (backward compatibility — existing rules match as before)
+ *   1. Raw command (most specific match — the full command as written)
  *   2. Canonical primary command (if simple action) — the full primary segment text
  *   3. Action keys from narrowest to broadest (if simple action)
  *


### PR DESCRIPTION
## Summary
- Remove backward-compat framing from shell command candidate ordering comment

Part of plan: pre-launch-legacy-cleanup.md (PR 26 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
