### PR TITLE
fix: remove APIKeyManager default-to-anthropic convenience methods

### DIFF
--- a/clients/macos/vellum-assistant/App/APIKeyManager.swift
+++ b/clients/macos/vellum-assistant/App/APIKeyManager.swift
@@ -21,12 +21,6 @@ extension Notification.Name {
 enum APIKeyManager {
     private static let udPrefix = "vellum_provider_"
 
-    // MARK: - Anthropic (convenience wrappers for backward compatibility)
-
-    static func getKey() -> String? { getKey(for: "anthropic") }
-    static func setKey(_ key: String) { setKey(key, for: "anthropic") }
-    static func deleteKey() { deleteKey(for: "anthropic") }
-
     /// Returns true if any known provider has a key configured.
     static func hasAnyKey() -> Bool {
         for provider in ["anthropic", "openai", "gemini", "fireworks"] {

--- a/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/APIKeyStepView.swift
@@ -76,7 +76,7 @@ struct APIKeyStepView: View {
         .opacity(showContent ? 1 : 0)
         .offset(y: showContent ? 0 : 12)
         .onAppear {
-            if let existingKey = APIKeyManager.getKey() {
+            if let existingKey = APIKeyManager.getKey(for: "anthropic") {
                 apiKey = existingKey
                 hasExistingKey = true
             }
@@ -257,7 +257,7 @@ struct APIKeyStepView: View {
 
         let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        APIKeyManager.setKey(trimmed)
+        APIKeyManager.setKey(trimmed, for: "anthropic")
         APIKeyManager.syncKeyToDaemon(provider: "anthropic", value: trimmed)
 
             saveModelToConfig("claude-opus-4-6")

--- a/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/HatchingStepView.swift
@@ -317,7 +317,7 @@ struct HatchingStepView: View {
     }
 
     private func startRemoteHatch() {
-        let apiKey = APIKeyManager.getKey() ?? ""
+        let apiKey = APIKeyManager.getKey(for: "anthropic") ?? ""
 
         let config = AssistantCli.RemoteHatchConfig(
             remote: state.cloudProvider,

--- a/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
+++ b/clients/macos/vellum-assistant/Features/Onboarding/OnboardingState.swift
@@ -175,7 +175,7 @@ final class OnboardingState {
         hasHatched = false
 
         // Clear stored API key so the user starts fresh
-        APIKeyManager.deleteKey()
+        APIKeyManager.deleteKey(for: "anthropic")
 
         // Reset cloud credentials (in-memory only; not persisted)
         cloudProvider = "local"

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -316,7 +316,7 @@ public final class SettingsStore: ObservableObject {
         self.verificationStatusPollWindow = max(self.verificationStatusPollInterval, verificationStatusPollWindow)
 
         // Seed from UserDefaults / Keychain
-        let anthropicKey = APIKeyManager.getKey()
+        let anthropicKey = APIKeyManager.getKey(for: "anthropic")
         self.hasKey = anthropicKey != nil
         self.maskedKey = Self.maskKey(anthropicKey)
         let braveKey = APIKeyManager.getKey(for: "brave")
@@ -713,7 +713,7 @@ public final class SettingsStore: ObservableObject {
     func saveAPIKey(_ raw: String) {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        APIKeyManager.setKey(trimmed)
+        APIKeyManager.setKey(trimmed, for: "anthropic")
         removeDeletionTombstone(type: "api_key", name: "anthropic")
         syncKeyToDaemon(provider: "anthropic", value: trimmed)
         hasKey = true
@@ -721,7 +721,7 @@ public final class SettingsStore: ObservableObject {
     }
 
     func clearAPIKey() {
-        APIKeyManager.deleteKey()
+        APIKeyManager.deleteKey(for: "anthropic")
         addDeletionTombstone(type: "api_key", name: "anthropic")
         deleteKeyFromDaemon(provider: "anthropic")
         hasKey = false
@@ -811,7 +811,7 @@ public final class SettingsStore: ObservableObject {
     }
 
     func refreshAPIKeyState() {
-        let anthropicKey = APIKeyManager.getKey()
+        let anthropicKey = APIKeyManager.getKey(for: "anthropic")
         hasKey = anthropicKey != nil
         maskedKey = Self.maskKey(anthropicKey)
 
@@ -1157,7 +1157,7 @@ public final class SettingsStore: ObservableObject {
             }
 
             let apiKeyProviders: [(String, String?)] = [
-                ("anthropic", APIKeyManager.getKey()),
+                ("anthropic", APIKeyManager.getKey(for: "anthropic")),
                 ("brave", APIKeyManager.getKey(for: "brave")),
                 ("perplexity", APIKeyManager.getKey(for: "perplexity")),
                 ("gemini", APIKeyManager.getKey(for: "gemini")),


### PR DESCRIPTION
## Summary
- Remove 3 convenience wrappers from APIKeyManager
- Update 4 caller files to pass explicit `for: "anthropic"` parameter

Part of plan: pre-launch-legacy-cleanup.md (PR 45 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
