### PR TITLE
fix: remove deprecated messageId surface attachment path

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1394,16 +1394,7 @@ extension ChatViewModel {
                 surfaceRef: SurfaceRef(from: msg, surface: surface)
             )
 
-            // If messageId is provided, attach to that specific message (rarely used now that
-            // surfaces come directly in history_response, but kept for backwards compatibility)
-            if let messageId = msg.messageId,
-               let messageUUID = UUID(uuidString: messageId),
-               let index = messages.firstIndex(where: { $0.id == messageUUID }) {
-                log.info("Attaching surface to message by messageId: \(messageId)")
-                let surfIdx = messages[index].inlineSurfaces.count
-                messages[index].inlineSurfaces.append(inlineSurface)
-                messages[index].contentOrder.append(.surface(surfIdx))
-            } else if let existingId = currentAssistantMessageId,
+            if let existingId = currentAssistantMessageId,
                let index = messages.firstIndex(where: { $0.id == existingId }) {
                 log.info("Attaching surface to currentAssistantMessage: \(existingId)")
                 let surfIdx = messages[index].inlineSurfaces.count


### PR DESCRIPTION
## Summary
- Remove messageId-based surface attachment lookup branch

Part of plan: pre-launch-legacy-cleanup.md (PR 35 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
