### PR TITLE
fix: make identityFound non-optional in IPCContractGenerated

### DIFF
--- a/assistant/src/daemon/ipc-contract/workspace.ts
+++ b/assistant/src/daemon/ipc-contract/workspace.ts
@@ -57,8 +57,8 @@ export interface WorkspaceFileReadResponse {
 
 export interface IdentityGetResponse {
   type: "identity_get_response";
-  /** Whether an IDENTITY.md file was found. When false, all fields are empty defaults. Optional for backwards compat with older daemons. */
-  found?: boolean;
+  /** Whether an IDENTITY.md file was found. When false, all fields are empty defaults. */
+  found: boolean;
   name: string;
   role: string;
   personality: string;

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1576,7 +1576,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             return first
         }
 
-        guard let response, response.found != false else { return nil }
+        guard let response, response.found else { return nil }
         return RemoteIdentityInfo(
             name: response.name,
             role: response.role,

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2505,8 +2505,8 @@ public struct IPCIdentityGetRequest: Codable, Sendable {
 
 public struct IPCIdentityGetResponse: Codable, Sendable {
     public let type: String
-    /// Whether an IDENTITY.md file was found. When false, all fields are empty defaults. Optional for backwards compat with older daemons.
-    public let found: Bool?
+    /// Whether an IDENTITY.md file was found. When false, all fields are empty defaults.
+    public let found: Bool
     public let name: String
     public let role: String
     public let personality: String
@@ -2517,7 +2517,7 @@ public struct IPCIdentityGetResponse: Codable, Sendable {
     public let createdAt: String?
     public let originSystem: String?
 
-    public init(type: String, found: Bool? = nil, name: String, role: String, personality: String, emoji: String, home: String, version: String? = nil, assistantId: String? = nil, createdAt: String? = nil, originSystem: String? = nil) {
+    public init(type: String, found: Bool, name: String, role: String, personality: String, emoji: String, home: String, version: String? = nil, assistantId: String? = nil, createdAt: String? = nil, originSystem: String? = nil) {
         self.type = type
         self.found = found
         self.name = name


### PR DESCRIPTION
## Summary
- Change `found: Bool?` to `found: Bool` in IPCContractGenerated
- Update TypeScript source (`ipc-contract/workspace.ts`) to make `found` non-optional
- Simplify DaemonClient guard to use non-optional `found`

Part of plan: pre-launch-legacy-cleanup.md (PR 37 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
