### PR TITLE
fix: remove guardianCtx backward-compat fallback in retry sweep

### DIFF
--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -134,9 +134,7 @@ export async function sweepFailedEvents(
       | undefined;
     const assistantId =
       typeof payload.assistantId === "string" ? payload.assistantId : undefined;
-    // Backward-compat: events persisted before the guardianCtx → trustCtx
-    // rename still carry the old key name.
-    const rawTrustCtx = payload.trustCtx ?? payload.guardianCtx;
+    const rawTrustCtx = payload.trustCtx;
     const parsedTrustContext = parseTrustRuntimeContext(rawTrustCtx);
 
     // If the stored payload had guardian context data but it couldn't be parsed


### PR DESCRIPTION
## Summary
- Remove `?? payload.guardianCtx` fallback, use `payload.trustCtx` directly

Part of plan: pre-launch-legacy-cleanup.md (PR 20 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
