### PR TITLE
fix: remove legacy feature flag key reads from SettingsAccountTab

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -448,31 +448,10 @@ struct SettingsAccountTab: View {
 
         // Check canonical assistantFeatureFlagValues first (new format)
         if let canonicalFlags = config["assistantFeatureFlagValues"] as? [String: Bool] {
-            let canonicalKeys = [
-                Self.hatchNewAssistantFlagKey,
-                "feature_flags.hatch_new_assistant.enabled"
-            ]
-            for key in canonicalKeys {
-                if let enabled = canonicalFlags[key] {
-                    isHatchFlagEnabled = enabled
-                    isLoadingHatchFlag = false
-                    return
-                }
-            }
-        }
-
-        // Check legacy featureFlags section
-        if let featureFlags = config["featureFlags"] as? [String: Any] {
-            let legacyKeys = [
-                "skills.hatch_new_assistant.enabled",
-                "skills.hatch-new-assistant.enabled"
-            ]
-            for key in legacyKeys {
-                if let enabled = featureFlags[key] as? Bool {
-                    isHatchFlagEnabled = enabled
-                    isLoadingHatchFlag = false
-                    return
-                }
+            if let enabled = canonicalFlags[Self.hatchNewAssistantFlagKey] {
+                isHatchFlagEnabled = enabled
+                isLoadingHatchFlag = false
+                return
             }
         }
         // On failure, default to showing the hatch section


### PR DESCRIPTION
## Summary
- Remove legacy feature flag key fallback reads from SettingsAccountTab
- Only canonical `feature_flags.hatch-new-assistant.enabled` key checked

Part of plan: pre-launch-legacy-cleanup.md (PR 13 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
