### PR TITLE
fix: remove backward-compat nested type aliases from IPCMessages

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+BundleHandling.swift
@@ -101,8 +101,8 @@ extension AppDelegate {
 
     func unpackAndLoadBundle(
         filePath: String,
-        manifest: OpenBundleResponseMessage.Manifest,
-        signatureResult: OpenBundleResponseMessage.SignatureResult,
+        manifest: IPCOpenBundleResponseManifest,
+        signatureResult: IPCOpenBundleResponseSignatureResult,
         bundleSizeBytes: Int,
         onSuccess: (() -> Void)? = nil,
         onError: ((String) -> Void)? = nil

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationViewModel.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleConfirmationViewModel.swift
@@ -6,9 +6,9 @@ import VellumAssistantShared
 @MainActor
 @Observable
 final class BundleConfirmationViewModel {
-    let manifest: OpenBundleResponseMessage.Manifest
-    let scanResult: OpenBundleResponseMessage.ScanResult
-    let signatureResult: OpenBundleResponseMessage.SignatureResult
+    let manifest: IPCOpenBundleResponseManifest
+    let scanResult: IPCOpenBundleResponseScanResult
+    let signatureResult: IPCOpenBundleResponseSignatureResult
     let bundleSizeBytes: Int
     let filePath: String
 

--- a/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
+++ b/clients/macos/vellum-assistant/Features/Sharing/BundleSandbox.swift
@@ -39,8 +39,8 @@ enum BundleSandbox {
     /// Returns the UUID and the directory URL where the contents were extracted.
     static func unpack(
         filePath: String,
-        manifest: OpenBundleResponseMessage.Manifest,
-        signatureResult: OpenBundleResponseMessage.SignatureResult,
+        manifest: IPCOpenBundleResponseManifest,
+        signatureResult: IPCOpenBundleResponseSignatureResult,
         bundleSizeBytes: Int
     ) throws -> (uuid: String, directory: URL) {
         let uuid = UUID().uuidString.lowercased()

--- a/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatDynamicPreviewRegressionTests.swift
@@ -435,7 +435,7 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
             actions: nil,
             display: nil
         )
-        let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
+        let historyItems: [IPCHistoryResponseMessage] = [
             IPCHistoryResponseMessage(
                 id: nil,
                 role: "assistant",
@@ -480,7 +480,7 @@ final class ChatDynamicPreviewRegressionTests: XCTestCase {
             actions: nil,
             display: nil
         )
-        let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
+        let historyItems: [IPCHistoryResponseMessage] = [
             IPCHistoryResponseMessage(
                 id: nil,
                 role: "assistant",

--- a/clients/macos/vellum-assistantTests/ChatMediaEmbedBaselineTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatMediaEmbedBaselineTests.swift
@@ -203,7 +203,7 @@ final class ChatMediaEmbedBaselineTests: XCTestCase {
     // MARK: - History hydration preserves URLs as plain text
 
     func testPopulateFromHistoryWithMediaURLsHasNoEmbeds() {
-        let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
+        let historyItems: [IPCHistoryResponseMessage] = [
             IPCHistoryResponseMessage(
                 id: nil,
                 role: "assistant",

--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -1770,7 +1770,7 @@ final class ChatViewModelTests: XCTestCase {
             id: "hist-att-1", filename: "chart.png", mimeType: "image/png",
             data: "iVBORw0KGgo=", extractedText: nil, sizeBytes: nil, thumbnailData: nil
         )
-        let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
+        let historyItems: [IPCHistoryResponseMessage] = [
             IPCHistoryResponseMessage(id: nil, role: "user", text: "Show me a chart", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: nil, textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil),
             IPCHistoryResponseMessage(id: nil, role: "assistant", text: "Here is your chart", timestamp: 2000, toolCalls: nil, toolCallsBeforeText: nil, attachments: [attachment], textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil),
         ]
@@ -1789,7 +1789,7 @@ final class ChatViewModelTests: XCTestCase {
             id: "hist-att-2", filename: "report.pdf", mimeType: "application/pdf",
             data: "JVBER", extractedText: nil, sizeBytes: nil, thumbnailData: nil
         )
-        let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
+        let historyItems: [IPCHistoryResponseMessage] = [
             IPCHistoryResponseMessage(id: nil, role: "assistant", text: "", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: [attachment], textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil),
         ]
 
@@ -1803,7 +1803,7 @@ final class ChatViewModelTests: XCTestCase {
     }
 
     func testPopulateFromHistorySkipsEmptyMessagesWithNoAttachments() {
-        let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
+        let historyItems: [IPCHistoryResponseMessage] = [
             IPCHistoryResponseMessage(id: nil, role: "assistant", text: "", timestamp: 1000, toolCalls: nil, toolCallsBeforeText: nil, attachments: nil, textSegments: nil, contentOrder: nil, surfaces: nil, subagentNotification: nil),
         ]
 
@@ -1864,7 +1864,7 @@ final class ChatViewModelTests: XCTestCase {
 
     func testPopulateFromHistoryUsesTextSegments() {
         let toolCall = IPCHistoryResponseToolCall(name: "memory_save", input: ["key": AnyCodable("task")], result: "saved", isError: nil, imageData: nil)
-        let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
+        let historyItems: [IPCHistoryResponseMessage] = [
             IPCHistoryResponseMessage(
                 id: nil,
                 role: "assistant",
@@ -1890,7 +1890,7 @@ final class ChatViewModelTests: XCTestCase {
 
     func testPopulateFromHistoryFallsBackToLegacy() {
         let toolCall = IPCHistoryResponseToolCall(name: "bash", input: ["command": AnyCodable("ls")], result: "file.txt", isError: nil, imageData: nil)
-        let historyItems: [HistoryResponseMessage.HistoryMessageItem] = [
+        let historyItems: [IPCHistoryResponseMessage] = [
             IPCHistoryResponseMessage(
                 id: nil,
                 role: "assistant",

--- a/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/ChatGallerySection.swift
@@ -506,12 +506,12 @@ struct ChatGallerySection: View {
                             input: ["command": AnyCodable("npm install express")],
                             riskLevel: "medium",
                             allowlistOptions: [
-                                ConfirmationRequestMessage.ConfirmationAllowlistOption(
+                                IPCConfirmationRequestAllowlistOption(
                                     label: "exact", description: "This exact command", pattern: "npm install express"
                                 ),
                             ],
                             scopeOptions: [
-                                ConfirmationRequestMessage.ConfirmationScopeOption(
+                                IPCConfirmationRequestScopeOption(
                                     label: "This project", scope: "project"
                                 ),
                             ],

--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -34,9 +34,9 @@ public struct ToolConfirmationData: Equatable {
     public let toolName: String
     public let input: [String: AnyCodable]
     public let riskLevel: String
-    public let diff: ConfirmationRequestMessage.ConfirmationDiffInfo?
-    public let allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption]
-    public let scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption]
+    public let diff: IPCConfirmationRequestDiff?
+    public let allowlistOptions: [IPCConfirmationRequestAllowlistOption]
+    public let scopeOptions: [IPCConfirmationRequestScopeOption]
     public let executionTarget: String?
     /// When false, hide "Always Allow" and trust-rule persistence controls.
     public let persistentDecisionsAllowed: Bool
@@ -646,7 +646,7 @@ public struct ToolConfirmationData: Equatable {
         }
     }
 
-    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: ConfirmationRequestMessage.ConfirmationDiffInfo? = nil, allowlistOptions: [ConfirmationRequestMessage.ConfirmationAllowlistOption] = [], scopeOptions: [ConfirmationRequestMessage.ConfirmationScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, temporaryOptionsAvailable: [String] = [], state: ToolConfirmationState = .pending) {
+    public init(requestId: String, toolName: String, input: [String: AnyCodable] = [:], riskLevel: String, diff: IPCConfirmationRequestDiff? = nil, allowlistOptions: [IPCConfirmationRequestAllowlistOption] = [], scopeOptions: [IPCConfirmationRequestScopeOption] = [], executionTarget: String? = nil, persistentDecisionsAllowed: Bool = true, temporaryOptionsAvailable: [String] = [], state: ToolConfirmationState = .pending) {
         self.requestId = requestId
         self.toolName = toolName
         self.input = input

--- a/clients/shared/Features/Chat/ChatViewModel.swift
+++ b/clients/shared/Features/Chat/ChatViewModel.swift
@@ -2125,7 +2125,7 @@ public final class ChatViewModel: ObservableObject {
     ///     (older page fetched on demand). When `false`, the standard initial-load
     ///     or reconnect-catch-up logic applies.
     public func populateFromHistory(
-        _ historyMessages: [HistoryResponseMessage.HistoryMessageItem],
+        _ historyMessages: [IPCHistoryResponseMessage],
         hasMore: Bool = false,
         oldestTimestamp: Double? = nil,
         isPaginationLoad: Bool = false

--- a/clients/shared/Features/Chat/ToolConfirmationBubble.swift
+++ b/clients/shared/Features/Chat/ToolConfirmationBubble.swift
@@ -1008,10 +1008,10 @@ private struct ScopePickerRow: View {
                 input: ["command": AnyCodable("npm install express")],
                 riskLevel: "medium",
                 allowlistOptions: [
-                    ConfirmationRequestMessage.ConfirmationAllowlistOption(label: "exact", description: "This exact command", pattern: "npm install express"),
+                    IPCConfirmationRequestAllowlistOption(label: "exact", description: "This exact command", pattern: "npm install express"),
                 ],
                 scopeOptions: [
-                    ConfirmationRequestMessage.ConfirmationScopeOption(label: "This project", scope: "project"),
+                    IPCConfirmationRequestScopeOption(label: "This project", scope: "project"),
                 ],
                 executionTarget: "host"
             ),
@@ -1056,12 +1056,12 @@ private struct ScopePickerRow: View {
                 input: ["command": AnyCodable("ls -la ~/Library/Application\\ Support/")],
                 riskLevel: "medium",
                 allowlistOptions: [
-                    ConfirmationRequestMessage.ConfirmationAllowlistOption(label: "exact", description: "This exact command", pattern: "ls -la ~/Library/Application\\ Support/"),
-                    ConfirmationRequestMessage.ConfirmationAllowlistOption(label: "prefix", description: "Any \"ls -la ~/Library/Application\\\" command", pattern: "ls -la ~/Library/Application*"),
-                    ConfirmationRequestMessage.ConfirmationAllowlistOption(label: "tool", description: "Any ls command", pattern: "ls *"),
+                    IPCConfirmationRequestAllowlistOption(label: "exact", description: "This exact command", pattern: "ls -la ~/Library/Application\\ Support/"),
+                    IPCConfirmationRequestAllowlistOption(label: "prefix", description: "Any \"ls -la ~/Library/Application\\\" command", pattern: "ls -la ~/Library/Application*"),
+                    IPCConfirmationRequestAllowlistOption(label: "tool", description: "Any ls command", pattern: "ls *"),
                 ],
                 scopeOptions: [
-                    ConfirmationRequestMessage.ConfirmationScopeOption(label: "This project", scope: "project"),
+                    IPCConfirmationRequestScopeOption(label: "This project", scope: "project"),
                 ],
                 executionTarget: "host"
             ),
@@ -1135,11 +1135,11 @@ private struct ScopePickerRow: View {
                 input: ["command": AnyCodable("npm test")],
                 riskLevel: "medium",
                 allowlistOptions: [
-                    ConfirmationRequestMessage.ConfirmationAllowlistOption(label: "exact", description: "This exact command", pattern: "npm test"),
+                    IPCConfirmationRequestAllowlistOption(label: "exact", description: "This exact command", pattern: "npm test"),
                 ],
                 scopeOptions: [
-                    ConfirmationRequestMessage.ConfirmationScopeOption(label: "This project", scope: "project"),
-                    ConfirmationRequestMessage.ConfirmationScopeOption(label: "Everywhere", scope: "everywhere"),
+                    IPCConfirmationRequestScopeOption(label: "This project", scope: "project"),
+                    IPCConfirmationRequestScopeOption(label: "Everywhere", scope: "everywhere"),
                 ],
                 executionTarget: "host"
             ),
@@ -1156,13 +1156,13 @@ private struct ScopePickerRow: View {
                 input: ["command": AnyCodable("git push origin main")],
                 riskLevel: "medium",
                 allowlistOptions: [
-                    ConfirmationRequestMessage.ConfirmationAllowlistOption(label: "exact", description: "This exact command", pattern: "git push origin main"),
-                    ConfirmationRequestMessage.ConfirmationAllowlistOption(label: "prefix", description: "Any \"git push\" command", pattern: "git push *"),
-                    ConfirmationRequestMessage.ConfirmationAllowlistOption(label: "tool", description: "Any git command", pattern: "git *"),
+                    IPCConfirmationRequestAllowlistOption(label: "exact", description: "This exact command", pattern: "git push origin main"),
+                    IPCConfirmationRequestAllowlistOption(label: "prefix", description: "Any \"git push\" command", pattern: "git push *"),
+                    IPCConfirmationRequestAllowlistOption(label: "tool", description: "Any git command", pattern: "git *"),
                 ],
                 scopeOptions: [
-                    ConfirmationRequestMessage.ConfirmationScopeOption(label: "This project", scope: "project"),
-                    ConfirmationRequestMessage.ConfirmationScopeOption(label: "Everywhere", scope: "everywhere"),
+                    IPCConfirmationRequestScopeOption(label: "This project", scope: "project"),
+                    IPCConfirmationRequestScopeOption(label: "Everywhere", scope: "everywhere"),
                 ],
                 executionTarget: "host"
             ),

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1287,12 +1287,6 @@ public typealias SessionListResponseMessage = IPCSessionListResponse
 /// Backed by generated `IPCHistoryResponse`.
 public typealias HistoryResponseMessage = IPCHistoryResponse
 
-extension IPCHistoryResponse {
-    /// Backward-compatible alias for the nested message item type.
-    public typealias HistoryMessageItem = IPCHistoryResponseMessage
-    /// Backward-compatible alias for the nested tool call type.
-    public typealias HistoryToolCallItem = IPCHistoryResponseToolCall
-}
 
 extension IPCHistoryResponseMessage {
     /// Backward-compatible init without textSegments/contentOrder/surfaces/subagentNotification (added in later IPC versions).
@@ -1542,13 +1536,6 @@ public typealias SecretRequestMessage = IPCSecretRequest
 /// Backed by generated `IPCConfirmationRequest`.
 public typealias ConfirmationRequestMessage = IPCConfirmationRequest
 
-// Backward-compatible nested type aliases so call sites like
-// `ConfirmationRequestMessage.ConfirmationAllowlistOption` keep compiling.
-extension IPCConfirmationRequest {
-    public typealias ConfirmationAllowlistOption = IPCConfirmationRequestAllowlistOption
-    public typealias ConfirmationScopeOption = IPCConfirmationRequestScopeOption
-    public typealias ConfirmationDiffInfo = IPCConfirmationRequestDiff
-}
 
 // Equatable conformance for generated types used in SwiftUI previews and tests.
 // Explicit `==` implementations because auto-synthesis requires conformance in the declaring file.
@@ -1694,13 +1681,6 @@ public typealias ToolNamesListResponseMessage = IPCToolNamesListResponse
 /// Backed by generated `IPCOpenBundleResponse`.
 public typealias OpenBundleResponseMessage = IPCOpenBundleResponse
 
-// Backward-compatible nested type aliases so call sites like
-// `OpenBundleResponseMessage.Manifest` keep compiling.
-extension IPCOpenBundleResponse {
-    public typealias Manifest = IPCOpenBundleResponseManifest
-    public typealias ScanResult = IPCOpenBundleResponseScanResult
-    public typealias SignatureResult = IPCOpenBundleResponseSignatureResult
-}
 
 // camelCase computed properties on the generated Manifest type so existing
 // call sites (e.g. `manifest.formatVersion`, `manifest.createdAt`) keep working.


### PR DESCRIPTION
## Summary
- Remove 8 nested type aliases from IPCMessages.swift
- Update 20+ call sites to use generated type names directly

Part of plan: pre-launch-legacy-cleanup.md (PR 42 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
