### PR TITLE
fix: remove backward-compat enabled inference from publicBaseUrl

### DIFF
--- a/assistant/src/config/core-schema.ts
+++ b/assistant/src/config/core-schema.ts
@@ -321,15 +321,7 @@ export const IngressConfigSchema = IngressBaseSchema.default(
   IngressBaseSchema.parse({}),
 ).transform((val) => ({
   ...val,
-  // Backward compatibility: if `enabled` was never explicitly set (undefined),
-  // infer it from whether a publicBaseUrl is configured. Existing users who
-  // have a URL but predate the `enabled` field should not have their webhooks
-  // silently disabled on upgrade.
-  //
-  // When publicBaseUrl is empty and enabled is unset, leave enabled as
-  // undefined so getPublicBaseUrl() can still fall through to the
-  // INGRESS_PUBLIC_BASE_URL env-var fallback (env-only setups).
-  enabled: val.enabled ?? (val.publicBaseUrl ? true : undefined),
+  enabled: val.enabled,
 }));
 
 export const VALID_AVATAR_STRATEGIES = [

--- a/assistant/src/daemon/handlers/config-ingress.ts
+++ b/assistant/src/daemon/handlers/config-ingress.ts
@@ -209,12 +209,7 @@ export async function handleIngressConfig(
       const raw = loadRawConfig();
       const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
       const publicBaseUrl = (ingress.publicBaseUrl as string) ?? "";
-      // Backward compatibility: if `enabled` was never explicitly set,
-      // infer from whether a publicBaseUrl is configured so existing users
-      // who predate the toggle aren't silently disabled.
-      const enabled =
-        (ingress.enabled as boolean | undefined) ??
-        (publicBaseUrl ? true : false);
+      const enabled = (ingress.enabled as boolean | undefined) ?? false;
       ctx.send(socket, {
         type: "ingress_config_response",
         enabled,


### PR DESCRIPTION
## Summary
- Remove `publicBaseUrl`-based inference of `enabled` in core-schema and config-ingress

Part of plan: pre-launch-legacy-cleanup.md (PR 17 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
