### PR TITLE
fix: remove legacy conversation key format deletion

### DIFF
--- a/assistant/src/runtime/routes/inbound-conversation.ts
+++ b/assistant/src/runtime/routes/inbound-conversation.ts
@@ -24,15 +24,8 @@ export async function handleDeleteConversation(
     return httpError("BAD_REQUEST", "conversationExternalId is required", 400);
   }
 
-  // Delete the assistant-scoped key unconditionally. The legacy key is
-  // canonical for the self assistant and must not be deleted from non-self
-  // routes, otherwise a non-self reset can accidentally reset self state.
-  const legacyKey = `${sourceChannel}:${conversationExternalId}`;
   const scopedKey = `asst:${assistantId}:${sourceChannel}:${conversationExternalId}`;
   deleteConversationKey(scopedKey);
-  if (assistantId === DAEMON_INTERNAL_ASSISTANT_ID) {
-    deleteConversationKey(legacyKey);
-  }
   // external_conversation_bindings is currently assistant-agnostic
   // (unique by sourceChannel + externalChatId). Restrict mutations to the
   // canonical self-assistant route so multi-assistant legacy routes do not


### PR DESCRIPTION
## Summary
- Remove `legacyKey` construction and `deleteConversationKey(legacyKey)` call

Part of plan: pre-launch-legacy-cleanup.md (PR 21 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
