### PR TITLE
fix: remove defensive fallback for legacy permission mode in checker

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -808,26 +808,6 @@ export async function check(
     }
   }
 
-  // Any unrecognized mode (including raw "legacy" that somehow bypassed loader
-  // migration) is treated as workspace mode — fail-closed relative to the old
-  // risk-only fallthrough that would auto-allow low-risk operations everywhere.
-  if (
-    permissionsMode !== "strict" &&
-    permissionsMode !== "workspace" &&
-    !matchedRule &&
-    risk !== RiskLevel.High
-  ) {
-    if (toolName === "bash" && !getConfig().sandbox.enabled) {
-      // Fall through to risk-based policy below
-    } else if (isWorkspaceScopedInvocation(toolName, input, workingDir)) {
-      return {
-        decision: "allow",
-        reason:
-          "Workspace mode (normalized): workspace-scoped operation auto-allowed",
-      };
-    }
-  }
-
   // Auto-allow low-risk bundled skill tools even without explicit trust rules.
   // These are first-party tools with a vetted risk declaration — applying the
   // same policy as the per-tool default allow rules for browser tools, but


### PR DESCRIPTION
## Summary
- Remove defensive fallback for unrecognized permission modes in checker.ts
- Only `strict` and `workspace` modes remain valid

Part of plan: pre-launch-legacy-cleanup.md (PR 8 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14054" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
