### PR TITLE
fix: remove handleUserMessage re-export from sessions.ts

### DIFF
--- a/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
+++ b/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
@@ -67,7 +67,8 @@ mock.module("../util/logger.js", () => ({
   pruneOldLogFiles: () => 0,
 }));
 
-const { handleUserMessage } = await import("../daemon/handlers/sessions.js");
+const { handleUserMessage } =
+  await import("../daemon/handlers/session-user-message.js");
 
 describe("handleUserMessage secret redirect continuation", () => {
   test("resumes the request after secure save with redacted continuation text", async () => {

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -205,10 +205,8 @@ mock.module("../util/logger.js", () => ({
   }),
 }));
 
-import {
-  handleConfirmationResponse,
-  handleUserMessage,
-} from "../daemon/handlers/sessions.js";
+import { handleUserMessage } from "../daemon/handlers/session-user-message.js";
+import { handleConfirmationResponse } from "../daemon/handlers/sessions.js";
 
 interface TestSession {
   messages: Array<{ role: string; content: unknown[] }>;

--- a/assistant/src/__tests__/recording-intent-handler.test.ts
+++ b/assistant/src/__tests__/recording-intent-handler.test.ts
@@ -831,7 +831,7 @@ describe("recording intent handler integration — handleUserMessage", () => {
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleUserMessage } =
-      await import("../daemon/handlers/sessions.js");
+      await import("../daemon/handlers/session-user-message.js");
     await handleUserMessage(
       {
         type: "user_message",
@@ -863,7 +863,7 @@ describe("recording intent handler integration — handleUserMessage", () => {
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleUserMessage } =
-      await import("../daemon/handlers/sessions.js");
+      await import("../daemon/handlers/session-user-message.js");
     await handleUserMessage(
       {
         type: "user_message",
@@ -898,7 +898,7 @@ describe("recording intent handler integration — handleUserMessage", () => {
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleUserMessage } =
-      await import("../daemon/handlers/sessions.js");
+      await import("../daemon/handlers/session-user-message.js");
     await handleUserMessage(
       {
         type: "user_message",
@@ -929,7 +929,7 @@ describe("recording intent handler integration — handleUserMessage", () => {
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleUserMessage } =
-      await import("../daemon/handlers/sessions.js");
+      await import("../daemon/handlers/session-user-message.js");
     await handleUserMessage(
       {
         type: "user_message",
@@ -963,7 +963,7 @@ describe("recording intent handler integration — handleUserMessage", () => {
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleUserMessage } =
-      await import("../daemon/handlers/sessions.js");
+      await import("../daemon/handlers/session-user-message.js");
     await handleUserMessage(
       {
         type: "user_message",
@@ -994,7 +994,7 @@ describe("recording intent handler integration — handleUserMessage", () => {
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleUserMessage } =
-      await import("../daemon/handlers/sessions.js");
+      await import("../daemon/handlers/session-user-message.js");
     await handleUserMessage(
       {
         type: "user_message",
@@ -1025,7 +1025,7 @@ describe("recording intent handler integration — handleUserMessage", () => {
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleUserMessage } =
-      await import("../daemon/handlers/sessions.js");
+      await import("../daemon/handlers/session-user-message.js");
     await handleUserMessage(
       {
         type: "user_message",
@@ -1060,7 +1060,7 @@ describe("recording intent handler integration — handleUserMessage", () => {
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleUserMessage } =
-      await import("../daemon/handlers/sessions.js");
+      await import("../daemon/handlers/session-user-message.js");
     await handleUserMessage(
       {
         type: "user_message",
@@ -1090,7 +1090,7 @@ describe("recording intent handler integration — handleUserMessage", () => {
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleUserMessage } =
-      await import("../daemon/handlers/sessions.js");
+      await import("../daemon/handlers/session-user-message.js");
     await handleUserMessage(
       {
         type: "user_message",
@@ -1118,7 +1118,7 @@ describe("recording intent handler integration — handleUserMessage", () => {
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleUserMessage } =
-      await import("../daemon/handlers/sessions.js");
+      await import("../daemon/handlers/session-user-message.js");
     await handleUserMessage(
       {
         type: "user_message",
@@ -1143,7 +1143,7 @@ describe("recording intent handler integration — handleUserMessage", () => {
     const { ctx, sent, fakeSocket } = createCtx();
 
     const { handleUserMessage } =
-      await import("../daemon/handlers/sessions.js");
+      await import("../daemon/handlers/session-user-message.js");
     await handleUserMessage(
       {
         type: "user_message",

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -61,6 +61,7 @@ import {
   handleHistoryRequest,
   handleMessageContentRequest,
 } from "./session-history.js";
+import { handleUserMessage } from "./session-user-message.js";
 import {
   defineHandlers,
   type HandlerContext,
@@ -68,9 +69,6 @@ import {
   pendingStandaloneSecrets,
   wireEscalationHandler,
 } from "./shared.js";
-// Re-export for backward compatibility — tests and other consumers import from sessions.js
-export { handleUserMessage } from "./session-user-message.js";
-import { handleUserMessage } from "./session-user-message.js";
 
 /**
  * Extract a valid ChannelId from a binding's sourceChannel, which may carry a


### PR DESCRIPTION
## Summary
- Remove unused re-export of `handleUserMessage` from `sessions.ts`
- Update test imports to use `session-user-message.js` directly

Part of plan: pre-launch-legacy-cleanup.md (PR 2 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14055" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
