### PR TITLE
fix: pass scopeId in backfill extraction and remove fallback default

### DIFF
--- a/assistant/src/memory/job-handlers/backfill.ts
+++ b/assistant/src/memory/job-handlers/backfill.ts
@@ -169,6 +169,7 @@ export function backfillEntityRelationsJob(
   const batch = db
     .select({
       id: messages.id,
+      conversationId: messages.conversationId,
       role: messages.role,
       createdAt: messages.createdAt,
       metadata: messages.metadata,
@@ -180,6 +181,7 @@ export function backfillEntityRelationsJob(
     .all();
   if (batch.length === 0) return;
 
+  const scopeCache = new Map<string, string>();
   let queuedExtractEntityJobs = 0;
   let skippedUntrusted = 0;
   for (const message of batch) {
@@ -190,7 +192,12 @@ export function backfillEntityRelationsJob(
       skippedUntrusted += 1;
       continue;
     }
-    enqueueMemoryJob("extract_entities", { messageId: message.id });
+    let scopeId = scopeCache.get(message.conversationId);
+    if (scopeId === undefined) {
+      scopeId = getConversationMemoryScopeId(message.conversationId);
+      scopeCache.set(message.conversationId, scopeId);
+    }
+    enqueueMemoryJob("extract_entities", { messageId: message.id, scopeId });
     queuedExtractEntityJobs += 1;
   }
 

--- a/assistant/src/memory/job-handlers/extraction.ts
+++ b/assistant/src/memory/job-handlers/extraction.ts
@@ -22,7 +22,8 @@ const log = getLogger("memory-jobs-worker");
 
 export async function extractItemsJob(job: MemoryJob): Promise<void> {
   const messageId = asString(job.payload.messageId);
-  if (!messageId) return;
+  const scopeId = asString(job.payload.scopeId);
+  if (!messageId || !scopeId) return;
 
   // If the conversation that owns this message has been marked as failed,
   // skip extraction entirely. This prevents async extraction jobs from
@@ -40,12 +41,6 @@ export async function extractItemsJob(job: MemoryJob): Promise<void> {
     );
     return;
   }
-
-  // Backward compat: old payloads may lack scopeId — default to 'default'
-  const scopeId =
-    typeof job.payload.scopeId === "string" && job.payload.scopeId
-      ? job.payload.scopeId
-      : "default";
 
   await extractAndUpsertMemoryItemsForMessage(
     messageId,


### PR DESCRIPTION
## Summary
- Add explicit `scopeId` to backfill extraction job enqueue
- Remove fallback default of `"default"` from extraction handler

Part of plan: pre-launch-legacy-cleanup.md (PR 15 of 49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
