### PR TITLE
fix: restore verification identity guard and legacy key deletion

### DIFF
--- a/assistant/src/__tests__/guardian-grant-minting.test.ts
+++ b/assistant/src/__tests__/guardian-grant-minting.test.ts
@@ -504,46 +504,7 @@ describe("guardian grant minting on tool-approval decisions", () => {
     composeSpy.mockRestore();
   });
 
-  // ── 8. approve_once via legacy parser mints a grant ──
-
-  test("approve_once via legacy parser mints a scoped grant", async () => {
-    const requestId = "req-grant-leg-1";
-    createTestGuardianApproval(requestId);
-    registerPendingInteraction(
-      requestId,
-      CONVERSATION_ID,
-      TOOL_NAME,
-      TOOL_INPUT,
-    );
-
-    // No approvalConversationGenerator => legacy parser path
-    const result = await handleApprovalInterception({
-      conversationId: "guardian-conv-8",
-      content: "yes",
-      conversationExternalId: GUARDIAN_CHAT,
-      sourceChannel: "telegram",
-      actorExternalId: GUARDIAN_USER,
-      replyCallbackUrl: "https://gateway.test/deliver",
-      trustCtx: makeTrustContext(),
-      assistantId: ASSISTANT_ID,
-    });
-
-    expect(result.handled).toBe(true);
-    expect(result.type).toBe("guardian_decision_applied");
-
-    // Verify a grant was minted
-    expect(countGrants()).toBe(1);
-
-    const grant = getLatestGrant();
-    expect(grant).not.toBeNull();
-    expect(grant!.scope_mode).toBe("tool_signature");
-    expect(grant!.tool_name).toBe(TOOL_NAME);
-
-    deliverSpy.mockRestore();
-    composeSpy.mockRestore();
-  });
-
-  // ── 9. Grant TTL is approximately 5 minutes ──
+  // ── 8. Grant TTL is approximately 5 minutes ──
 
   test("minted grant has approximately 5-minute TTL", async () => {
     const requestId = "req-grant-ttl-1";

--- a/assistant/src/memory/channel-verification-sessions.ts
+++ b/assistant/src/memory/channel-verification-sessions.ts
@@ -156,7 +156,7 @@ export function createInboundSession(params: {
     expectedExternalUserId: null,
     expectedChatId: null,
     expectedPhoneE164: null,
-    identityBindingStatus: "bound" as const,
+    identityBindingStatus: null,
     destinationAddress: null,
     lastSentAt: null,
     sendCount: 0,

--- a/assistant/src/runtime/channel-verification-service.ts
+++ b/assistant/src/runtime/channel-verification-service.ts
@@ -100,10 +100,10 @@ function generateNumericSecret(digits: number = 6): string {
 /**
  * Create a new inbound verification session for a guardian candidate.
  *
- * Inbound sessions are not identity-bound: `validateAndConsumeVerification`
- * skips the identity check when no expected-identity fields are set, so
- * code secrecy is the only protection against brute-force guessing during
- * the TTL window. A 32-byte hex secret provides ~2^128 entropy, making
+ * Inbound sessions are not identity-bound (`identityBindingStatus: null`),
+ * so `validateAndConsumeVerification` skips the identity check and code
+ * secrecy is the only protection against brute-force guessing during the
+ * TTL window. A 32-byte hex secret provides ~2^128 entropy, making
  * enumeration infeasible. Identity-bound outbound sessions (created via
  * `createOutboundSession`) use shorter 6-digit numeric codes because the
  * identity check adds a second layer of protection.
@@ -227,10 +227,17 @@ export function validateAndConsumeVerification(
   }
 
   // ── Expected-identity check (outbound sessions) ──
-  // If the session is in 'bound' state, verify the actor matches the expected
-  // identity. If identity_binding_status is 'pending_bootstrap', allow
-  // consumption (bootstrap path handles binding separately).
-  if (challenge.identityBindingStatus === "bound") {
+  // If the session is in 'bound' state AND has at least one expected-identity
+  // field, verify the actor matches. Inbound-only sessions have no expected
+  // identity and rely on code secrecy alone. If identity_binding_status is
+  // 'pending_bootstrap', allow consumption (bootstrap path handles binding
+  // separately).
+  const hasExpectedIdentity =
+    challenge.expectedExternalUserId != null ||
+    challenge.expectedChatId != null ||
+    challenge.expectedPhoneE164 != null;
+
+  if (hasExpectedIdentity && challenge.identityBindingStatus === "bound") {
     let identityMatch = false;
 
     // For voice: verify actorExternalUserId matches expectedPhoneE164

--- a/assistant/src/runtime/routes/inbound-conversation.ts
+++ b/assistant/src/runtime/routes/inbound-conversation.ts
@@ -26,11 +26,11 @@ export async function handleDeleteConversation(
 
   const scopedKey = `asst:${assistantId}:${sourceChannel}:${conversationExternalId}`;
   deleteConversationKey(scopedKey);
-  // external_conversation_bindings is currently assistant-agnostic
-  // (unique by sourceChannel + externalChatId). Restrict mutations to the
-  // canonical self-assistant route so multi-assistant legacy routes do not
-  // clobber each other's bindings.
+  // For the canonical self-assistant, also delete the legacy unscopedkey
+  // and the external conversation binding (which is assistant-agnostic).
   if (assistantId === DAEMON_INTERNAL_ASSISTANT_ID) {
+    const legacyKey = `${sourceChannel}:${conversationExternalId}`;
+    deleteConversationKey(legacyKey);
     externalConversationStore.deleteBindingByChannelChat(
       sourceChannel,
       conversationExternalId,


### PR DESCRIPTION
## Summary
- Restored `hasExpectedIdentity` guard in `validateAndConsumeVerification` so inbound sessions (no expected identity fields) skip the identity check instead of failing
- Set `identityBindingStatus: null` for inbound verification sessions (they have no identity binding)
- Restored legacy conversation key deletion in `handleDeleteConversation` for self-assistant
- Removed test for intentionally-deleted legacy plain-text approval parser

## Original prompt
Fix these failing tests: https://github.com/vellum-ai/vellum-assistant/actions/runs/22797056468/job/66133195339

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
