### PR TITLE
fix: remove twitter flat config key fallback from twitter-auth.ts

### DIFF
--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -55,8 +55,8 @@ export async function handleTwitterAuthStart(
   try {
     const raw = loadRawConfig();
     const mode =
-      ((getNestedValue(raw, "twitter.integrationMode") ??
-        raw.twitterIntegrationMode) as string | undefined) ?? "local_byo";
+      (getNestedValue(raw, "twitter.integrationMode") as string | undefined) ??
+      "local_byo";
     if (mode !== "local_byo") {
       ctx.send(socket, {
         type: "twitter_auth_result",
@@ -186,9 +186,10 @@ export function handleTwitterAuthStatus(
     );
     const raw = loadRawConfig();
     const mode =
-      ((getNestedValue(raw, "twitter.integrationMode") ??
-        raw.twitterIntegrationMode) as "local_byo" | "managed" | undefined) ??
-      "local_byo";
+      (getNestedValue(raw, "twitter.integrationMode") as
+        | "local_byo"
+        | "managed"
+        | undefined) ?? "local_byo";
     const meta = getCredentialMetadata("integration:twitter", "access_token");
 
     ctx.send(socket, {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pre-launch-legacy-cleanup.md.

**Gap:** Twitter flat config key fallback not removed from twitter-auth.ts
**What was expected:** All `?? raw.twitterIntegrationMode` fallbacks removed
**What was found:** twitter-auth.ts still had the fallback at 2 locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
