### PR TITLE
fix: remove dead isGeneratedWorkspaceOpen computed property

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -87,12 +87,6 @@ struct MainWindowView: View {
     /// but requires complex window geometry inspection.
     let trafficLightPadding: CGFloat = 78
 
-    /// When a generated surface is expanded into the workspace, hide the
-    /// global sidebar toggle so workspace controls own the top-left slot.
-    private var isGeneratedWorkspaceOpen: Bool {
-        windowState.isDynamicExpanded
-    }
-
     /// Whether the BOOTSTRAP.md first-run ritual is still in progress.
     /// When true, the client shows a chat-only interface — no Home Base dashboard.
     private var isBootstrapOnboardingActive: Bool {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pre-launch-legacy-cleanup.md.

**Gap:** Dead computed property isGeneratedWorkspaceOpen
**What was expected:** Unused code removed per project rules
**What was found:** Property defined but never referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
