### PR TITLE
fix: update ARCHITECTURE.md references from deriveActiveSkillIds to deriveActiveSkills

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -276,7 +276,7 @@ graph TB
             SKILL_CATALOG["Skill Catalog<br/>bundled + managed + workspace + extra"]
             SKILL_MANIFEST["SKILL.md + TOOLS.json<br/>per-skill directory"]
             SKILL_PROJECTION["projectSkillTools()<br/>session-level projection"]
-            SKILL_DERIVE["deriveActiveSkillIds()<br/>scan &lt;loaded_skill&gt; markers"]
+            SKILL_DERIVE["deriveActiveSkills()<br/>scan &lt;loaded_skill&gt; markers"]
             SKILL_FACTORY["SkillToolFactory<br/>manifest → Tool objects"]
             SKILL_HOST_RUNNER["Host Script Runner<br/>in-process import + run()"]
             SKILL_SANDBOX_RUNNER["Sandbox Script Runner<br/>isolated subprocess"]

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -1425,7 +1425,7 @@ graph TB
     end
 
     subgraph "Per-Turn Projection (session-skill-tools.ts)"
-        DERIVE["deriveActiveSkillIds(history)<br/>scan all messages for markers"]
+        DERIVE["deriveActiveSkills(history)<br/>scan all messages for markers"]
         UNION["Union: context-derived ∪ preactivated"]
         DIFF["Diff vs previous turn"]
         UNREGISTER["unregisterSkillTools(removedId)<br/>tear down stale tools"]
@@ -1497,7 +1497,7 @@ graph TB
 | `assistant/src/config/skills.ts`                    | Skill catalog loading: bundled, managed, workspace, extra directories                      |
 | `assistant/src/config/bundled-skills/`              | Bundled skill directories (browser, gmail, claude-code, computer-use, weather, etc.)       |
 | `assistant/src/skills/tool-manifest.ts`             | `TOOLS.json` parser and validator                                                          |
-| `assistant/src/skills/active-skill-tools.ts`        | `deriveActiveSkillIds()` — scans history for `<loaded_skill>` markers                      |
+| `assistant/src/skills/active-skill-tools.ts`        | `deriveActiveSkills()` — scans history for `<loaded_skill>` markers                        |
 | `assistant/src/skills/include-graph.ts`             | Include graph builder: `indexCatalogById()`, `validateIncludes()`, cycle/missing detection |
 | `assistant/src/daemon/session-skill-tools.ts`       | `projectSkillTools()` — per-turn projection, register/unregister lifecycle                 |
 | `assistant/src/tools/skills/skill-tool-factory.ts`  | `createSkillToolsFromManifest()` — manifest entries to Tool objects                        |


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pre-launch-legacy-cleanup.md.

**Gap:** Stale documentation references to deleted `deriveActiveSkillIds()`
**What was expected:** Mermaid diagrams must reflect current architecture
**What was found:** 2 ARCHITECTURE.md files referenced the deleted function

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
