### PR TITLE
fix: remove dead deriveActiveSkillIds exports from test mocks

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -41,7 +41,7 @@ mock.module("../config/skills.js", () => ({
 }));
 
 mock.module("../skills/active-skill-tools.js", () => {
-  // Shared parsing logic for both deriveActiveSkills and deriveActiveSkillIds
+  // Shared parsing logic for deriveActiveSkills
   const parseMarkers = (messages: Message[]) => {
     // Two-pass approach matching real implementation:
     // 1. Collect tool_use IDs where name === 'skill_load'
@@ -81,8 +81,6 @@ mock.module("../skills/active-skill-tools.js", () => {
 
   return {
     deriveActiveSkills: (messages: Message[]) => parseMarkers(messages),
-    deriveActiveSkillIds: (messages: Message[]) =>
-      parseMarkers(messages).map((e) => e.id),
   };
 });
 

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -95,8 +95,6 @@ mock.module("../skills/active-skill-tools.js", () => {
 
   return {
     deriveActiveSkills: (messages: Message[]) => parseMarkers(messages),
-    deriveActiveSkillIds: (messages: Message[]) =>
-      parseMarkers(messages).map((e) => e.id),
   };
 });
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pre-launch-legacy-cleanup.md.

**Gap:** Test mock modules still export removed `deriveActiveSkillIds`
**What was expected:** All references cleaned up after function removal
**What was found:** 2 test files still had dead mock exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
