### PR TITLE
fix: remove stale backward-compat test for extraction scopeId default

### DIFF
--- a/assistant/src/__tests__/memory-regressions.test.ts
+++ b/assistant/src/__tests__/memory-regressions.test.ts
@@ -4415,37 +4415,6 @@ describe("Memory regressions", () => {
     expect(payload.scopeId).toBe("default");
   });
 
-  test("extract_items backward compat: old payloads without scopeId default to default", () => {
-    // Simulate an old-style extract_items job without scopeId
-    const jobId = enqueueMemoryJob("extract_items", {
-      messageId: "legacy-msg-id",
-    });
-
-    const db = getDb();
-    const job = db
-      .select()
-      .from(memoryJobs)
-      .where(eq(memoryJobs.id, jobId))
-      .get();
-
-    expect(job).toBeTruthy();
-    const payload = JSON.parse(job!.payload) as Record<string, unknown>;
-    // Old payloads will not have scopeId — consumers must default to 'default'
-    expect(payload.scopeId).toBeUndefined();
-
-    // Verify the job handler's backward-compat logic: claim and inspect
-    const claimed = claimMemoryJobs(100);
-    const claimedJob = claimed.find((j) => j.id === jobId);
-    expect(claimedJob).toBeTruthy();
-    // The parsed payload should not have scopeId (it was never set)
-    const resolvedScope =
-      typeof claimedJob!.payload.scopeId === "string" &&
-      claimedJob!.payload.scopeId
-        ? claimedJob!.payload.scopeId
-        : "default";
-    expect(resolvedScope).toBe("default");
-  });
-
   // PR-19: extractItemsJob forwards scopeId to extractAndUpsertMemoryItemsForMessage
   test("extractAndUpsertMemoryItemsForMessage accepts optional scopeId without breaking", async () => {
     const db = getDb();


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pre-launch-legacy-cleanup.md.

**Gap:** Test validates behavior that no longer exists
**What was expected:** Tests should match production behavior
**What was found:** Test expected scopeId to default to "default" but handler now skips missing scopeId

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14065" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
