### PR TITLE
fix: remove redundant PTT legacy string key test cases

### DIFF
--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -1030,13 +1030,6 @@ describe("sanitizePttActivationKey", () => {
     expect(sanitizePttActivationKey("arbitrary_value")).toBeUndefined();
     expect(sanitizePttActivationKey("")).toBeUndefined();
   });
-
-  test("returns undefined for legacy string keys", () => {
-    expect(sanitizePttActivationKey("fn")).toBeUndefined();
-    expect(sanitizePttActivationKey("ctrl")).toBeUndefined();
-    expect(sanitizePttActivationKey("fn_shift")).toBeUndefined();
-    expect(sanitizePttActivationKey("none")).toBeUndefined();
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1053,13 +1046,6 @@ describe("resolveChannelCapabilities with PTT metadata", () => {
       pttActivationKey: key,
     });
     expect(caps.pttActivationKey).toBe(key);
-  });
-
-  test("sanitizes legacy string pttActivationKey to undefined", () => {
-    const caps = resolveChannelCapabilities("macos", "macos", {
-      pttActivationKey: "fn",
-    });
-    expect(caps.pttActivationKey).toBeUndefined();
   });
 
   test("sanitizes invalid pttActivationKey to undefined", () => {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pre-launch-legacy-cleanup.md.

**Gap:** PTT legacy test cases retained
**What was expected:** Legacy string key test cases removed
**What was found:** Tests still existed but tested rejection (redundant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
