### PR TITLE
fix: remove defaultLocalResources() fallback and require resources

### DIFF
--- a/cli/src/__tests__/multi-local.test.ts
+++ b/cli/src/__tests__/multi-local.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 // Create a temp directory that acts as a fake home, so allocateLocalResources()
-// and defaultLocalResources() never touch the real ~/.vellum directory.
+// never touches the real ~/.vellum directory.
 const testDir = mkdtempSync(join(tmpdir(), "cli-multi-local-test-"));
 process.env.BASE_DATA_DIR = testDir;
 
@@ -31,7 +31,6 @@ mock.module("../lib/port-probe.js", () => ({
 
 import {
   allocateLocalResources,
-  defaultLocalResources,
   resolveTargetAssistant,
   setActiveAssistant,
   getActiveAssistant,
@@ -153,18 +152,6 @@ describe("multi-local", () => {
       // THEN the daemon port skips all occupied ports
       expect(res.daemonPort).toBeGreaterThan(DEFAULT_DAEMON_PORT + 1);
       expect(portsInUse.has(res.daemonPort)).toBe(false);
-    });
-  });
-
-  describe("defaultLocalResources() returns legacy paths", () => {
-    test("instanceDir is homedir", () => {
-      const res = defaultLocalResources();
-      expect(res.instanceDir).toBe(testDir);
-    });
-
-    test("daemonPort is DEFAULT_DAEMON_PORT", () => {
-      const res = defaultLocalResources();
-      expect(res.daemonPort).toBe(DEFAULT_DAEMON_PORT);
     });
   });
 

--- a/cli/src/commands/ps.ts
+++ b/cli/src/commands/ps.ts
@@ -3,7 +3,6 @@ import { homedir } from "os";
 import { join } from "path";
 
 import {
-  defaultLocalResources,
   findAssistantByName,
   getActiveAssistant,
   loadAllAssistants,
@@ -216,7 +215,12 @@ function formatDetectionInfo(proc: DetectedProcess): string {
 }
 
 async function getLocalProcesses(entry: AssistantEntry): Promise<TableRow[]> {
-  const resources = entry.resources ?? defaultLocalResources();
+  if (!entry.resources) {
+    throw new Error(
+      `Local assistant '${entry.assistantId}' is missing resource configuration. Re-hatch to fix.`,
+    );
+  }
+  const resources = entry.resources;
   const vellumDir = join(resources.instanceDir, ".vellum");
 
   const specs: ProcessSpec[] = [
@@ -409,9 +413,7 @@ async function listAllAssistants(): Promise<void> {
       // process isn't running, the assistant is sleeping — skip the
       // network health check to avoid a misleading "unreachable" status.
       let health: { status: string; detail: string | null };
-      const resources =
-        a.resources ??
-        (a.cloud === "local" ? defaultLocalResources() : undefined);
+      const resources = a.resources;
       if (a.cloud === "local" && resources) {
         const pid = readPidFile(resources.pidFile);
         const alive = pid !== null && isProcessAlive(pid);

--- a/cli/src/commands/recover.ts
+++ b/cli/src/commands/recover.ts
@@ -58,9 +58,14 @@ export async function recover(): Promise<void> {
   unlinkSync(metadataPath);
 
   // 6. Start daemon + gateway (same as wake)
-  await startLocalDaemon();
+  if (!entry.resources) {
+    throw new Error(
+      `Recovered assistant '${name}' is missing resource configuration. Re-hatch to fix.`,
+    );
+  }
+  await startLocalDaemon(false, entry.resources);
   if (!process.env.VELLUM_DESKTOP_APP) {
-    await startGateway();
+    await startGateway(undefined, false, entry.resources);
   }
 
   console.log(`✅ Recovered assistant '${name}'.`);

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -4,7 +4,6 @@ import { homedir } from "os";
 import { basename, dirname, join } from "path";
 
 import {
-  defaultLocalResources,
   findAssistantByName,
   loadAllAssistants,
   removeAssistantEntry,
@@ -45,20 +44,20 @@ function extractHostFromUrl(url: string): string {
 async function retireLocal(name: string, entry: AssistantEntry): Promise<void> {
   console.log("\u{1F5D1}\ufe0f  Stopping local assistant...\n");
 
-  const resources = entry.resources ?? defaultLocalResources();
+  if (!entry.resources) {
+    throw new Error(
+      `Local assistant '${name}' is missing resource configuration. Re-hatch to fix.`,
+    );
+  }
+  const resources = entry.resources;
   const vellumDir = join(resources.instanceDir, ".vellum");
 
   // Check whether another local assistant shares the same data directory.
-  // Legacy entries without `resources` all resolve to ~/.vellum/ — if we
-  // blindly kill processes and archive the directory, we'd destroy the
-  // other assistant's running daemon and data.
   const otherSharesDir = loadAllAssistants().some((other) => {
     if (other.cloud !== "local") return false;
     if (other.assistantId === name) return false;
-    const otherVellumDir = join(
-      (other.resources ?? defaultLocalResources()).instanceDir,
-      ".vellum",
-    );
+    if (!other.resources) return false;
+    const otherVellumDir = join(other.resources.instanceDir, ".vellum");
     return otherVellumDir === vellumDir;
   });
 

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -1,10 +1,7 @@
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 
-import {
-  defaultLocalResources,
-  resolveTargetAssistant,
-} from "../lib/assistant-config.js";
+import { resolveTargetAssistant } from "../lib/assistant-config.js";
 import type { AssistantEntry } from "../lib/assistant-config.js";
 import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
 
@@ -15,8 +12,12 @@ type ActiveCallLease = {
 };
 
 function getAssistantRootDir(entry: AssistantEntry): string {
-  const resources = entry.resources ?? defaultLocalResources();
-  return join(resources.instanceDir, ".vellum");
+  if (!entry.resources) {
+    throw new Error(
+      `Local assistant '${entry.assistantId}' is missing resource configuration. Re-hatch to fix.`,
+    );
+  }
+  return join(entry.resources.instanceDir, ".vellum");
 }
 
 function readActiveCallLeases(vellumDir: string): ActiveCallLease[] {
@@ -70,7 +71,13 @@ export async function sleep(): Promise<void> {
     process.exit(1);
   }
 
-  const resources = entry.resources ?? defaultLocalResources();
+  if (!entry.resources) {
+    console.error(
+      `Error: Local assistant '${entry.assistantId}' is missing resource configuration. Re-hatch to fix.`,
+    );
+    process.exit(1);
+  }
+  const resources = entry.resources;
   const assistantPidFile = resources.pidFile;
   const socketFile = resources.socketPath;
   const vellumDir = getAssistantRootDir(entry);

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -1,10 +1,7 @@
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 
-import {
-  defaultLocalResources,
-  resolveTargetAssistant,
-} from "../lib/assistant-config.js";
+import { resolveTargetAssistant } from "../lib/assistant-config.js";
 import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
 import { startLocalDaemon, startGateway } from "../lib/local";
 
@@ -38,7 +35,13 @@ export async function wake(): Promise<void> {
     process.exit(1);
   }
 
-  const resources = entry.resources ?? defaultLocalResources();
+  if (!entry.resources) {
+    console.error(
+      `Error: Local assistant '${entry.assistantId}' is missing resource configuration. Re-hatch to fix.`,
+    );
+    process.exit(1);
+  }
+  const resources = entry.resources;
 
   const pidFile = resources.pidFile;
   const socketFile = resources.socketPath;

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -282,24 +282,6 @@ export async function allocateLocalResources(
 }
 
 /**
- * Return default resources representing the legacy single-instance layout.
- * @deprecated All new instances should use `allocateLocalResources()`.
- * Retained only for callers that need to normalize legacy lockfile entries
- * that lack a `resources` field.
- */
-export function defaultLocalResources(): LocalInstanceResources {
-  const vellumDir = join(homedir(), ".vellum");
-  return {
-    instanceDir: homedir(),
-    daemonPort: DEFAULT_DAEMON_PORT,
-    gatewayPort: DEFAULT_GATEWAY_PORT,
-    qdrantPort: DEFAULT_QDRANT_PORT,
-    socketPath: join(vellumDir, "vellum.sock"),
-    pidFile: join(vellumDir, "vellum.pid"),
-  };
-}
-
-/**
  * Read the assistant config file and sync client-relevant values to the
  * lockfile. This lets external tools (e.g. vel) discover the platform URL
  * without importing the assistant config schema.

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -13,7 +13,6 @@ import { homedir, hostname, networkInterfaces, platform } from "os";
 import { dirname, join } from "path";
 
 import {
-  defaultLocalResources,
   loadLatestAssistant,
   type LocalInstanceResources,
 } from "./assistant-config.js";
@@ -216,18 +215,16 @@ function resolveDaemonMainPath(assistantIndex: string): string {
 
 async function startDaemonFromSource(
   assistantIndex: string,
-  resources?: LocalInstanceResources,
+  resources: LocalInstanceResources,
 ): Promise<void> {
   const daemonMainPath = resolveDaemonMainPath(assistantIndex);
 
-  const defaults = defaultLocalResources();
-  const res = resources ?? defaults;
   // Ensure the directory containing PID/socket files exists. For named
   // instances this is instanceDir/.vellum/ (matching daemon's getRootDir()).
-  mkdirSync(dirname(res.pidFile), { recursive: true });
+  mkdirSync(dirname(resources.pidFile), { recursive: true });
 
-  const pidFile = res.pidFile;
-  const socketFile = res.socketPath;
+  const pidFile = resources.pidFile;
+  const socketFile = resources.socketPath;
 
   // --- Lifecycle guard: prevent split-brain daemon state ---
   if (existsSync(pidFile)) {
@@ -305,19 +302,17 @@ async function startDaemonFromSource(
 // assistant-side equivalent.
 async function startDaemonWatchFromSource(
   assistantIndex: string,
-  resources?: LocalInstanceResources,
+  resources: LocalInstanceResources,
 ): Promise<void> {
   const mainPath = resolveDaemonMainPath(assistantIndex);
   if (!existsSync(mainPath)) {
     throw new Error(`Daemon main.ts not found at ${mainPath}`);
   }
 
-  const defaults = defaultLocalResources();
-  const res = resources ?? defaults;
-  mkdirSync(dirname(res.pidFile), { recursive: true });
+  mkdirSync(dirname(resources.pidFile), { recursive: true });
 
-  const pidFile = res.pidFile;
-  const socketFile = res.socketPath;
+  const pidFile = resources.pidFile;
+  const socketFile = resources.socketPath;
 
   // --- Lifecycle guard: prevent split-brain daemon state ---
   // If a daemon is already running, skip spawning a new one.
@@ -641,7 +636,7 @@ function getLocalLanIPv4(): string | undefined {
 // assistant-side equivalent.
 export async function startLocalDaemon(
   watch: boolean = false,
-  resources?: LocalInstanceResources,
+  resources: LocalInstanceResources,
 ): Promise<void> {
   if (process.env.VELLUM_DESKTOP_APP && !watch) {
     // When running inside the desktop app, the CLI owns the daemon lifecycle.
@@ -656,10 +651,8 @@ export async function startLocalDaemon(
       );
     }
 
-    const defaults = defaultLocalResources();
-    const res = resources ?? defaults;
-    const pidFile = res.pidFile;
-    const socketFile = res.socketPath;
+    const pidFile = resources.pidFile;
+    const socketFile = resources.socketPath;
 
     // If a daemon is already running, skip spawning a new one.
     // This prevents cascading kill→restart cycles when multiple callers
@@ -831,13 +824,10 @@ export async function startLocalDaemon(
           "  Ensure the daemon binary is bundled alongside the CLI, or run from the source tree.",
       );
     }
-    const defaults = defaultLocalResources();
-    const res = resources ?? defaults;
-
     if (watch) {
       await startDaemonWatchFromSource(assistantIndex, resources);
 
-      const socketReady = await waitForSocketFile(res.socketPath, 60000);
+      const socketReady = await waitForSocketFile(resources.socketPath, 60000);
       if (socketReady) {
         console.log("   Assistant socket ready\n");
       } else {
@@ -848,7 +838,7 @@ export async function startLocalDaemon(
     } else {
       await startDaemonFromSource(assistantIndex, resources);
 
-      const socketReady = await waitForSocketFile(res.socketPath, 60000);
+      const socketReady = await waitForSocketFile(resources.socketPath, 60000);
       if (socketReady) {
         console.log("   Assistant socket ready\n");
       } else {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pre-launch-legacy-cleanup.md.

**Gap:** `defaultLocalResources()` fallback still exists and is widely used
**What was expected:** Resources required on local entries, no fallback
**What was found:** 7+ callers still used `?? defaultLocalResources()`

### Changes
- Removed `defaultLocalResources()` from `assistant-config.ts`
- All local entry callers (`retire.ts`, `ps.ts`, `sleep.ts`, `wake.ts`) now assert `entry.resources` is present
- `startLocalDaemon()`, `startDaemonFromSource()`, `startDaemonWatchFromSource()` in `local.ts` now require `resources` parameter (no longer optional)
- Updated `recover.ts` to pass `entry.resources` explicitly
- Removed `defaultLocalResources()` tests from `multi-local.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
