### PR TITLE
fix: make approvalConversationGenerator required in guardian-callback-strategy

### DIFF
--- a/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
@@ -51,7 +51,7 @@ export interface GuardianCallbackDecisionParams {
   bearerToken?: string;
   assistantId: string;
   approvalCopyGenerator?: ApprovalCopyGenerator;
-  approvalConversationGenerator?: ApprovalConversationGenerator;
+  approvalConversationGenerator: ApprovalConversationGenerator;
 }
 
 export interface ApprovalInterceptionResult {
@@ -211,7 +211,7 @@ export async function handleGuardianCallbackDecision(
   const effectivePending =
     senderPending.length > 0 ? senderPending : allGuardianPending;
 
-  if (effectivePending.length > 0 && approvalConversationGenerator && content) {
+  if (effectivePending.length > 0 && content) {
     return handleConversationalDecision({
       guardianApproval,
       allGuardianPending,

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -108,7 +108,7 @@ export async function handleApprovalInterception(
       bearerToken,
       assistantId,
       approvalCopyGenerator,
-      approvalConversationGenerator,
+      approvalConversationGenerator: approvalConversationGenerator!,
     });
     if (guardianResult) {
       return guardianResult;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for pre-launch-legacy-cleanup.md.

**Gap:** approvalConversationGenerator still optional
**What was expected:** Parameter should be required after legacy fallback removal
**What was found:** Still declared with `?` (optional)

Changes:
- Removed `?` from `approvalConversationGenerator` in `GuardianCallbackDecisionParams` interface
- Removed now-redundant truthiness check `&& approvalConversationGenerator` on line 214 (TS2774: always true since required)
- Updated the caller in `guardian-approval-interception.ts` to use non-null assertion (`!`) since the generator is always provided in production channel routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
