### PR TITLE
fix: align iOS session info tests with correlation ID requirement

### DIFF
--- a/clients/ios/Tests/ChatViewModelIOSTests.swift
+++ b/clients/ios/Tests/ChatViewModelIOSTests.swift
@@ -127,7 +127,8 @@ final class ChatViewModelIOSTests: XCTestCase {
     // MARK: - Session Info
 
     func testSessionInfoStoresSessionId() {
-        let info = SessionInfoMessage(sessionId: "ios-sess-123", title: "iOS Test")
+        viewModel.bootstrapCorrelationId = "corr-1"
+        let info = SessionInfoMessage(sessionId: "ios-sess-123", title: "iOS Test", correlationId: "corr-1")
         viewModel.handleServerMessage(.sessionInfo(info))
         XCTAssertEqual(viewModel.sessionId, "ios-sess-123")
     }
@@ -377,7 +378,8 @@ final class ChatViewModelIOSTests: XCTestCase {
             capturedSessionId = sessionId
         }
 
-        let info = SessionInfoMessage(sessionId: "callback-sess", title: "Test")
+        viewModel.bootstrapCorrelationId = "corr-cb"
+        let info = SessionInfoMessage(sessionId: "callback-sess", title: "Test", correlationId: "corr-cb")
         viewModel.handleServerMessage(.sessionInfo(info))
 
         XCTAssertEqual(capturedSessionId, "callback-sess")


### PR DESCRIPTION
## Summary
- Fix two failing iOS tests (`testSessionInfoStoresSessionId`, `testOnSessionCreatedCallbackFires`) that broke after session info handling started requiring `bootstrapCorrelationId` matching.
- Set `bootstrapCorrelationId` on the view model and pass a matching `correlationId` in the `SessionInfoMessage` to match the current implementation.

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22796961308

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
