### PR TITLE
Update phone-setup test case for mixed credential flow

### DIFF
--- a/playwright/cases/phone-setup.md
+++ b/playwright/cases/phone-setup.md
@@ -15,21 +15,19 @@ Verify that we're able to configure everything needed for the assistant to be ab
 2. Open a chat thread
 3. Send the message "Can you make phone calls for me?"
 4. Verify that the assistant responds in the affirmative that it is able to make phone calls, but that some initial setup is needed. If prompted, state that you already have a Twilio account.
-5. You will be asked to provide your Twilio Account SID, your Twilio Auth Token, and your ngrok Auth Token, all through new windows that pop open titled "Secure Credential." Use fill_secure_credential for each one with these env var names:
-   - `TWILIO_ACCOUNT_SID` for the Twilio Account SID
-   - `TWILIO_AUTH_TOKEN` for the Twilio Auth Token
-   - `NGROK_AUTH_TOKEN` for the ngrok Auth Token
-6. Verify that you were able to supply all three credentials through a secure window and were NOT encouraged to provide them conversationally through the chat interface.
-7. You should be asked what voice you want the assistant to have and be presented with a few options to choose from. Pick any voice.
-8. You should be offered to make a test call to your phone number. You can reject this offer.
-9. Once it seems like phone calling is fully set up, go to Preferences -> Settings -> Channels. There you should see that phone calling is fully configured.
-
-**IMPORTANT**: ALL steps above must be completed and verified for the test to pass. Do not report pass if you haven't gotten through every step.
+5. You should first be asked for your Twilio Account SID. Provide this conversationally through the chat.
+6. You should then be asked for your Twilio Auth Token. Verify that you are asked to supply it securely through a separate window. Use the `fill_secure_credential` tool to enter it.
+7. From there, continue the conversation naturally. At some point, you should be asked for your ngrok Auth Token. Verify that you are asked to supply it securely through a separate window. Use the `fill_secure_credential` tool to enter it.
+8. Continue the conversation naturally. At some point you should be asked what voice you want the assistant to have and be presented with a few options to choose from. Pick any voice.
+9. You should be offered to make a test call to your phone number. You can reject this offer.
+10. Once it seems like phone calling is fully set up, go to Preferences -> Settings -> Channels. There you should see that phone calling is fully configured.
 
 
 ## Expected
+- You were able to complete all steps
 - The assistant initially responds in the affirmative that it is able to make phone calls
-- The assistant should offer a secure pop-up prompting you to enter your Twilio Account SID, Twilio Auth Token, and ngrok Auth Token and should NOT necourage you to provide them conversationally
+- The assistant should ask for yout Twilio Account SID conversationally
+- The assistant should ask for your Twilio Auth Token and ngrok Auth Token through a separate secure pop-up
 - At some point you should be presented with a selection of voice options to choose from for the assistant.
 - Once set up is complete, you should be offered to make a test call to your phone number.
 - Phone calling should display as being fully configured under Preferences -> Settings -> Channels


### PR DESCRIPTION
## Summary
- Update phone-setup e2e test to expect Twilio Account SID provided conversationally rather than via secure window
- Auth Token and ngrok Auth Token should still be requested via secure credential pop-up
- Reorder and clarify test steps to match the updated assistant behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
