### PR TITLE
refactor: rename "voice" channel ID to "phone" in gateway

### DIFF
--- a/gateway/src/__tests__/channel-verification-session-proxy.test.ts
+++ b/gateway/src/__tests__/channel-verification-session-proxy.test.ts
@@ -143,7 +143,7 @@ describe("channel verification session proxy", () => {
           host: "localhost:7830",
         },
         body: JSON.stringify({
-          channel: "voice",
+          channel: "phone",
           destination: "+15551234567",
         }),
       }),
@@ -151,7 +151,7 @@ describe("channel verification session proxy", () => {
 
     expect(res.status).toBe(200);
     expect(capturedBody).toBe(
-      '{"channel":"voice","destination":"+15551234567"}',
+      '{"channel":"phone","destination":"+15551234567"}',
     );
     expect(capturedHeaders?.get("authorization")).toMatch(/^Bearer ey/);
     expect(capturedHeaders?.has("host")).toBe(false);

--- a/gateway/src/channels/types.ts
+++ b/gateway/src/channels/types.ts
@@ -1,6 +1,6 @@
 export const CHANNEL_IDS = [
   "telegram",
-  "voice",
+  "phone",
   "vellum",
   "whatsapp",
   "slack",
@@ -25,7 +25,7 @@ export const INTERFACE_IDS = [
   "ios",
   "cli",
   "telegram",
-  "voice",
+  "phone",
   "vellum",
   "whatsapp",
   "slack",

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1303,7 +1303,7 @@ export function buildSchema(): Record<string, unknown> {
               name: "channel",
               in: "query",
               required: false,
-              schema: { type: "string", enum: ["voice", "telegram"] },
+              schema: { type: "string", enum: ["phone", "telegram"] },
               description: "Optional channel filter.",
             },
           ],


### PR DESCRIPTION
## Summary
- Renames the channel identifier from "voice" to "phone" in gateway CHANNEL_IDS, INTERFACE_IDS
- Updates API schema enum and verification session proxy tests
- Twilio webhook types and paths are intentionally unchanged (Twilio's own terminology)

Part of plan: voice-contact-verify-fix.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14078" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
