### PR TITLE
fix: provision AssistantAPIKey on app launch and assistant switch

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -155,6 +155,62 @@ extension AppDelegate {
         }
     }
 
+    // MARK: - Local Assistant API Key Provisioning
+
+    /// Ensures the current local assistant has a provisioned AssistantAPIKey.
+    /// Safe to call at any time — exits early if the assistant is managed/remote,
+    /// the user isn't authenticated, or a key already exists.
+    func ensureLocalAssistantApiKey() {
+        guard !isCurrentAssistantManaged, !isCurrentAssistantRemote else { return }
+        guard authManager.isAuthenticated else { return }
+
+        let storedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+        guard let assistantId = storedId,
+              let assistant = LockfileAssistant.loadByName(assistantId) else { return }
+
+        // Already provisioned — skip
+        let credentialStorage = KeychainCredentialStorage()
+        let credentialAccount = "vellum_assistant_credential_\(assistant.assistantId)"
+        if let existing = credentialStorage.get(account: credentialAccount), !existing.isEmpty {
+            log.info("Local assistant \(assistant.assistantId, privacy: .public) already has an API key")
+            return
+        }
+
+        // Resolve daemon HTTP endpoint
+        let portString = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "7821"
+        let daemonPort = Int(portString) ?? 7821
+        let daemonBaseURL = "http://localhost:\(daemonPort)"
+
+        Task {
+            // Wait for actor token — may not be available immediately on launch
+            let daemonToken: String
+            if let token = ActorTokenManager.getToken(), !token.isEmpty {
+                daemonToken = token
+            } else if let token = await ActorTokenManager.waitForToken(timeout: 10) {
+                daemonToken = token
+            } else {
+                log.warning("No actor token available for local API key provisioning")
+                return
+            }
+
+            do {
+                let bootstrapService = LocalAssistantBootstrapService(credentialStorage: credentialStorage)
+                let outcome = try await bootstrapService.bootstrap(
+                    runtimeAssistantId: assistant.assistantId,
+                    clientPlatform: "macos",
+                    daemonBaseURL: daemonBaseURL,
+                    daemonToken: daemonToken
+                )
+                switch outcome {
+                case .registeredWithExistingKey(let id), .registeredAndProvisioned(let id):
+                    log.info("Local assistant API key provisioned: \(id, privacy: .public)")
+                }
+            } catch {
+                log.error("Failed to provision local assistant API key: \(error.localizedDescription)")
+            }
+        }
+    }
+
     /// Switches the app to a different lockfile assistant: stops the current
     /// daemon, resets assistant-scoped state, updates persisted state, and
     /// restarts with the new assistant.
@@ -206,6 +262,7 @@ extension AppDelegate {
         if !isCurrentAssistantManaged {
             ensureActorCredentials()
         }
+        ensureLocalAssistantApiKey()
         showMainWindow()
     }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -157,9 +157,17 @@ extension AppDelegate {
 
     // MARK: - Local Assistant API Key Provisioning
 
-    /// Ensures the current local assistant has a provisioned AssistantAPIKey.
-    /// Safe to call at any time — exits early if the assistant is managed/remote,
-    /// the user isn't authenticated, or a key already exists.
+    /// Ensures the current local assistant has a provisioned AssistantAPIKey
+    /// and that the key is injected into the daemon's secret store.
+    ///
+    /// Safe to call at any time — exits early if the assistant is managed/remote
+    /// or the user isn't authenticated. Always calls through to
+    /// `LocalAssistantBootstrapService.bootstrap()` so existing-key re-injection
+    /// and stale-key reprovisioning are handled (not just Keychain presence).
+    ///
+    /// Waits up to 60s for the actor token to become available, retrying every
+    /// 5s, so that assistant switches (which clear then re-bootstrap actor
+    /// credentials) don't race with this method.
     func ensureLocalAssistantApiKey() {
         guard !isCurrentAssistantManaged, !isCurrentAssistantRemote else { return }
         guard authManager.isAuthenticated else { return }
@@ -168,32 +176,34 @@ extension AppDelegate {
         guard let assistantId = storedId,
               let assistant = LockfileAssistant.loadByName(assistantId) else { return }
 
-        // Already provisioned — skip
-        let credentialStorage = KeychainCredentialStorage()
-        let credentialAccount = "vellum_assistant_credential_\(assistant.assistantId)"
-        if let existing = credentialStorage.get(account: credentialAccount), !existing.isEmpty {
-            log.info("Local assistant \(assistant.assistantId, privacy: .public) already has an API key")
-            return
-        }
-
         // Resolve daemon HTTP endpoint
         let portString = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "7821"
         let daemonPort = Int(portString) ?? 7821
         let daemonBaseURL = "http://localhost:\(daemonPort)"
 
         Task {
-            // Wait for actor token — may not be available immediately on launch
+            // Wait for actor token with retries — initial bootstrap may take
+            // longer than a single waitForToken timeout when the daemon is
+            // still coming up or credentials are being rotated after a switch.
             let daemonToken: String
             if let token = ActorTokenManager.getToken(), !token.isEmpty {
                 daemonToken = token
-            } else if let token = await ActorTokenManager.waitForToken(timeout: 10) {
-                daemonToken = token
             } else {
-                log.warning("No actor token available for local API key provisioning")
-                return
+                var token: String?
+                for attempt in 1...6 {
+                    token = await ActorTokenManager.waitForToken(timeout: 10)
+                    if token != nil { break }
+                    log.info("Actor token not yet available (attempt \(attempt)/6), retrying...")
+                }
+                guard let resolved = token else {
+                    log.warning("No actor token available for local API key provisioning after 60s")
+                    return
+                }
+                daemonToken = resolved
             }
 
             do {
+                let credentialStorage = KeychainCredentialStorage()
                 let bootstrapService = LocalAssistantBootstrapService(credentialStorage: credentialStorage)
                 let outcome = try await bootstrapService.bootstrap(
                     runtimeAssistantId: assistant.assistantId,
@@ -202,7 +212,9 @@ extension AppDelegate {
                     daemonToken: daemonToken
                 )
                 switch outcome {
-                case .registeredWithExistingKey(let id), .registeredAndProvisioned(let id):
+                case .registeredWithExistingKey(let id):
+                    log.info("Local assistant API key re-synced to daemon: \(id, privacy: .public)")
+                case .registeredAndProvisioned(let id):
                     log.info("Local assistant API key provisioned: \(id, privacy: .public)")
                 }
             } catch {

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -268,6 +268,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             ensureActorCredentials()
         }
 
+        // Provision an AssistantAPIKey for local assistants so they can
+        // call platform APIs (e.g. managed avatar generation).
+        ensureLocalAssistantApiKey()
+
         if isFirstLaunch {
             // Enter the bootstrap state machine. The sequence is:
             // pendingDaemon → pendingWakeupSend → pendingFirstReply → complete


### PR DESCRIPTION
## Summary
- Adds `ensureLocalAssistantApiKey()` to `AppDelegate` that provisions an AssistantAPIKey for local assistants on every app launch and assistant switch
- Previously, provisioning only ran during onboarding — existing local assistants never got a key, blocking platform API calls (e.g. managed avatar generation)
- Safe to call repeatedly: exits early if assistant is managed/remote, user isn't authenticated, or a key already exists in Keychain

## Test plan
- [x] Verified on `vellum-calm-cub` (local assistant) — key provisioned in Keychain on app launch without re-onboarding
- [ ] Verify managed assistants (`cloud: vellum`) skip provisioning
- [ ] Verify switching from managed to local assistant triggers provisioning
- [ ] Verify no duplicate key writes when key already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
