### PR TITLE
rename: voice → phone channel ID in backend

### DIFF
--- a/assistant/src/__tests__/call-controller.test.ts
+++ b/assistant/src/__tests__/call-controller.test.ts
@@ -868,7 +868,7 @@ describe("call-controller", () => {
 
   test("handleCallerUtterance: passes guardian context to startVoiceTurn", async () => {
     const trustCtx = {
-      sourceChannel: "voice" as const,
+      sourceChannel: "phone" as const,
       trustClass: "trusted_contact" as const,
       guardianExternalUserId: "+15550009999",
       guardianChatId: "+15550009999",
@@ -928,12 +928,12 @@ describe("call-controller", () => {
 
   test("setTrustContext: subsequent turns use updated guardian context", async () => {
     const initialCtx = {
-      sourceChannel: "voice" as const,
+      sourceChannel: "phone" as const,
       trustClass: "unknown" as const,
     };
 
     const upgradedCtx = {
-      sourceChannel: "voice" as const,
+      sourceChannel: "phone" as const,
       trustClass: "guardian" as const,
       guardianExternalUserId: "+15550003333",
       guardianChatId: "+15550003333",

--- a/assistant/src/__tests__/callback-handoff-copy.test.ts
+++ b/assistant/src/__tests__/callback-handoff-copy.test.ts
@@ -16,14 +16,14 @@ function buildSignal(
   return {
     signalId: "test-signal-1",
     createdAt: Date.now(),
-    sourceChannel: "voice",
+    sourceChannel: "phone",
     sourceSessionId: "test-session-1",
     sourceEventName: "ingress.access_request.callback_handoff",
     contextPayload: {
       requestId: "req-123",
       requestCode: null,
       callSessionId: "call-456",
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       reason: "timeout",
       callbackOptIn: true,
       callerPhoneNumber: "+15551234567",

--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -319,7 +319,7 @@ describe("guardian service challenge validation", () => {
   });
 
   test("createInboundVerificationSession produces a non-empty instruction for voice channel", () => {
-    const result = createInboundVerificationSession("voice");
+    const result = createInboundVerificationSession("phone");
     expect(result.instruction).toBeDefined();
     expect(result.instruction.length).toBeGreaterThan(0);
     expect(result.instruction).toContain(`the code: ${result.secret}`);
@@ -419,10 +419,10 @@ describe("guardian service challenge validation", () => {
   });
 
   test("validateAndConsumeVerification succeeds with voice channel", () => {
-    const { secret } = createInboundVerificationSession("voice");
+    const { secret } = createInboundVerificationSession("phone");
 
     const result = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "phone-user-1",
       "voice-chat-1",
@@ -435,13 +435,13 @@ describe("guardian service challenge validation", () => {
 
     // validateAndConsumeVerification no longer creates bindings — that is
     // now handled by the caller (verification-intercept / relay-server).
-    const binding = getGuardianBinding("asst-1", "voice");
+    const binding = getGuardianBinding("asst-1", "phone");
     expect(binding).toBeNull();
   });
 
   test("voice and telegram guardian challenges are independent", () => {
     const telegramChallenge = createInboundVerificationSession("telegram");
-    const voiceChallenge = createInboundVerificationSession("voice");
+    const voiceChallenge = createInboundVerificationSession("phone");
 
     // Validate voice challenge against telegram channel should fail
     const crossResult = validateAndConsumeVerification(
@@ -454,7 +454,7 @@ describe("guardian service challenge validation", () => {
 
     // Validate voice challenge against correct channel should succeed
     const voiceResult = validateAndConsumeVerification(
-      "voice",
+      "phone",
       voiceChallenge.secret,
       "user-1",
       "chat-1",
@@ -569,14 +569,14 @@ describe("guardian identity check", () => {
 
   test("isGuardian works for voice channel", () => {
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "phone-user-1",
       guardianPrincipalId: "phone-user-1",
       guardianDeliveryChatId: "voice-chat-1",
     });
 
-    expect(isGuardian("asst-1", "voice", "phone-user-1")).toBe(true);
-    expect(isGuardian("asst-1", "voice", "phone-user-2")).toBe(false);
+    expect(isGuardian("asst-1", "phone", "phone-user-1")).toBe(true);
+    expect(isGuardian("asst-1", "phone", "phone-user-2")).toBe(false);
     // Telegram guardian should not match voice channel
     expect(isGuardian("asst-1", "telegram", "phone-user-1")).toBe(false);
   });
@@ -779,7 +779,7 @@ describe("guardian approval request CRUD", () => {
       runId: "run-voice-1",
       requestId: "req-voice-1",
       conversationId: "conv-voice-1",
-      channel: "voice",
+      channel: "phone",
       requesterExternalUserId: "phone-user-99",
       requesterChatId: "voice-chat-99",
       guardianExternalUserId: "phone-user-42",
@@ -791,12 +791,12 @@ describe("guardian approval request CRUD", () => {
     expect(request.id).toBeDefined();
     expect(request.runId).toBe("run-voice-1");
     expect(request.requestId).toBe("req-voice-1");
-    expect(request.channel).toBe("voice");
+    expect(request.channel).toBe("phone");
     expect(request.status).toBe("pending");
 
     const found = getPendingApprovalForRequest("req-voice-1");
     expect(found).not.toBeNull();
-    expect(found!.channel).toBe("voice");
+    expect(found!.channel).toBe("phone");
   });
 
   test("getPendingApprovalByGuardianChat works for voice channel", () => {
@@ -804,7 +804,7 @@ describe("guardian approval request CRUD", () => {
       runId: "run-voice-2",
       requestId: "req-voice-2",
       conversationId: "conv-voice-2",
-      channel: "voice",
+      channel: "phone",
       requesterExternalUserId: "phone-user-99",
       requesterChatId: "voice-chat-99",
       guardianExternalUserId: "phone-user-42",
@@ -813,9 +813,9 @@ describe("guardian approval request CRUD", () => {
       expiresAt: Date.now() + 300_000,
     });
 
-    const found = getPendingApprovalByGuardianChat("voice", "voice-chat-42");
+    const found = getPendingApprovalByGuardianChat("phone", "voice-chat-42");
     expect(found).not.toBeNull();
-    expect(found!.channel).toBe("voice");
+    expect(found!.channel).toBe("phone");
 
     // Should not find it under a different channel
     const notFound = getPendingApprovalByGuardianChat(
@@ -970,7 +970,7 @@ describe("verification rate limiting store", () => {
 
     const rl42 = getRateLimit("telegram", "user-42", "chat-42");
     const rl99 = getRateLimit("telegram", "user-99", "chat-99");
-    const rlVoice = getRateLimit("voice", "user-42", "chat-42");
+    const rlVoice = getRateLimit("phone", "user-42", "chat-42");
 
     expect(rl42).not.toBeNull();
     expect(rl42!.invalidAttempts).toBe(1);
@@ -1137,7 +1137,7 @@ describe("channel-scoped guardian resolution", () => {
     });
     // Create guardian binding on voice with a different user
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "user-beta",
       guardianPrincipalId: "user-beta",
       guardianDeliveryChatId: "chat-beta",
@@ -1145,10 +1145,10 @@ describe("channel-scoped guardian resolution", () => {
 
     // user-alpha is guardian for telegram but not voice
     expect(isGuardian("self", "telegram", "user-alpha")).toBe(true);
-    expect(isGuardian("self", "voice", "user-alpha")).toBe(false);
+    expect(isGuardian("self", "phone", "user-alpha")).toBe(false);
 
     // user-beta is guardian for voice but not telegram
-    expect(isGuardian("self", "voice", "user-beta")).toBe(true);
+    expect(isGuardian("self", "phone", "user-beta")).toBe(true);
     expect(isGuardian("self", "telegram", "user-beta")).toBe(false);
   });
 
@@ -1160,14 +1160,14 @@ describe("channel-scoped guardian resolution", () => {
       guardianDeliveryChatId: "chat-alpha",
     });
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "user-beta",
       guardianPrincipalId: "user-beta",
       guardianDeliveryChatId: "chat-beta",
     });
 
     const bindingTelegram = getGuardianBinding("self", "telegram");
-    const bindingVoice = getGuardianBinding("self", "voice");
+    const bindingVoice = getGuardianBinding("self", "phone");
 
     expect(bindingTelegram).not.toBeNull();
     expect(bindingVoice).not.toBeNull();
@@ -1183,7 +1183,7 @@ describe("channel-scoped guardian resolution", () => {
       guardianDeliveryChatId: "chat-alpha",
     });
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "user-beta",
       guardianPrincipalId: "user-beta",
       guardianDeliveryChatId: "chat-beta",
@@ -1192,7 +1192,7 @@ describe("channel-scoped guardian resolution", () => {
     serviceRevokeBinding("self", "telegram");
 
     expect(getGuardianBinding("self", "telegram")).toBeNull();
-    expect(getGuardianBinding("self", "voice")).not.toBeNull();
+    expect(getGuardianBinding("self", "phone")).not.toBeNull();
   });
 
   test("validateAndConsumeVerification scoped to channel", () => {
@@ -1200,11 +1200,11 @@ describe("channel-scoped guardian resolution", () => {
     const { secret: secretTelegram } =
       createInboundVerificationSession("telegram");
     // Create challenge on voice
-    const { secret: secretVoice } = createInboundVerificationSession("voice");
+    const { secret: secretVoice } = createInboundVerificationSession("phone");
 
     // Attempting to consume telegram challenge on voice should fail
     const crossResult = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secretTelegram,
       "user-1",
       "chat-1",
@@ -1221,7 +1221,7 @@ describe("channel-scoped guardian resolution", () => {
     expect(resultTelegram.success).toBe(true);
 
     const resultVoice = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secretVoice,
       "user-2",
       "chat-2",
@@ -1229,7 +1229,7 @@ describe("channel-scoped guardian resolution", () => {
     expect(resultVoice.success).toBe(true);
 
     const bindingTelegram = getGuardianBinding("self", "telegram");
-    const bindingVoice = getGuardianBinding("self", "voice");
+    const bindingVoice = getGuardianBinding("self", "phone");
     expect(bindingTelegram).toBeNull();
     expect(bindingVoice).toBeNull();
   });
@@ -1366,7 +1366,7 @@ describe("IPC handler channel-aware guardian status", () => {
     const msg: ChannelVerificationSessionRequest = {
       type: "channel_verification_session",
       action: "status",
-      channel: "voice",
+      channel: "phone",
     };
 
     await handleChannelVerificationSession(msg, mockSocket, ctx);
@@ -1374,7 +1374,7 @@ describe("IPC handler channel-aware guardian status", () => {
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
-    expect(resp!.channel).toBe("voice");
+    expect(resp!.channel).toBe("phone");
     expect(resp!.assistantId).toBe("self");
     expect(resp!.bound).toBe(false);
   });
@@ -1475,7 +1475,7 @@ describe("IPC handler channel-aware guardian status", () => {
     const msg: ChannelVerificationSessionRequest = {
       type: "channel_verification_session",
       action: "status",
-      channel: "voice",
+      channel: "phone",
       // assistantId omitted — should default to 'self'
     };
 
@@ -1484,7 +1484,7 @@ describe("IPC handler channel-aware guardian status", () => {
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.assistantId).toBe("self");
-    expect(resp!.channel).toBe("voice");
+    expect(resp!.channel).toBe("phone");
   });
 
   test("status action for unbound voice does not return guardianDeliveryChatId", async () => {
@@ -1492,7 +1492,7 @@ describe("IPC handler channel-aware guardian status", () => {
     const msg: ChannelVerificationSessionRequest = {
       type: "channel_verification_session",
       action: "status",
-      channel: "voice",
+      channel: "phone",
     };
 
     await handleChannelVerificationSession(msg, mockSocket, ctx);
@@ -1505,13 +1505,13 @@ describe("IPC handler channel-aware guardian status", () => {
   });
 
   test("status action includes hasPendingChallenge when challenge exists", async () => {
-    createInboundVerificationSession("voice");
+    createInboundVerificationSession("phone");
 
     const { ctx, lastResponse } = createMockCtx();
     const msg: ChannelVerificationSessionRequest = {
       type: "channel_verification_session",
       action: "status",
-      channel: "voice",
+      channel: "phone",
     };
 
     await handleChannelVerificationSession(msg, mockSocket, ctx);
@@ -1527,7 +1527,7 @@ describe("IPC handler channel-aware guardian status", () => {
     const msg: ChannelVerificationSessionRequest = {
       type: "channel_verification_session",
       action: "status",
-      channel: "voice",
+      channel: "phone",
     };
 
     await handleChannelVerificationSession(msg, mockSocket, ctx);
@@ -1549,7 +1549,7 @@ describe("voice guardian challenge generation", () => {
   });
 
   test("createInboundVerificationSession for voice returns a high-entropy hex secret", () => {
-    const result = createInboundVerificationSession("voice");
+    const result = createInboundVerificationSession("phone");
 
     expect(result.challengeId).toBeDefined();
     expect(result.secret).toBeDefined();
@@ -1565,13 +1565,13 @@ describe("voice guardian challenge generation", () => {
   });
 
   test("voice challenge verifyCommand contains the hex secret", () => {
-    const result = createInboundVerificationSession("voice");
+    const result = createInboundVerificationSession("phone");
 
     expect(result.verifyCommand).toBe(result.secret);
   });
 
   test("voice challenge instruction contains voice-specific copy", () => {
-    const result = createInboundVerificationSession("voice");
+    const result = createInboundVerificationSession("phone");
 
     // Inbound challenges use high-entropy hex, so the voice template says
     // "enter the code" rather than "six-digit code".
@@ -1580,8 +1580,8 @@ describe("voice guardian challenge generation", () => {
   });
 
   test("voice challenge secrets are different across calls", () => {
-    const result1 = createInboundVerificationSession("voice");
-    const result2 = createInboundVerificationSession("voice");
+    const result1 = createInboundVerificationSession("phone");
+    const result2 = createInboundVerificationSession("phone");
 
     // High-entropy hex secrets: collision probability is negligible
     expect(result1.secret).toMatch(/^[0-9a-f]{64}$/);
@@ -1589,7 +1589,7 @@ describe("voice guardian challenge generation", () => {
   });
 
   test("voice ttlSeconds is 600 (10 minutes)", () => {
-    const result = createInboundVerificationSession("voice");
+    const result = createInboundVerificationSession("phone");
     expect(result.ttlSeconds).toBe(600);
   });
 });
@@ -1604,10 +1604,10 @@ describe("voice guardian challenge validation", () => {
   });
 
   test("validateAndConsumeVerification succeeds with correct voice secret", () => {
-    const { secret } = createInboundVerificationSession("voice");
+    const { secret } = createInboundVerificationSession("phone");
 
     const result = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "voice-user-1",
       "voice-chat-1",
@@ -1620,24 +1620,24 @@ describe("voice guardian challenge validation", () => {
   });
 
   test("validateAndConsumeVerification does not create a guardian binding for voice (caller responsibility)", () => {
-    const { secret } = createInboundVerificationSession("voice");
+    const { secret } = createInboundVerificationSession("phone");
 
     validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "voice-user-1",
       "voice-chat-1",
     );
 
-    const binding = getGuardianBinding("asst-1", "voice");
+    const binding = getGuardianBinding("asst-1", "phone");
     expect(binding).toBeNull();
   });
 
   test("validateAndConsumeVerification fails with wrong voice secret", () => {
-    createInboundVerificationSession("voice");
+    createInboundVerificationSession("phone");
 
     const result = validateAndConsumeVerification(
-      "voice",
+      "phone",
       "000000",
       "voice-user-1",
       "voice-chat-1",
@@ -1652,7 +1652,7 @@ describe("voice guardian challenge validation", () => {
   });
 
   test("voice and telegram guardian challenges are independent", () => {
-    const voiceChallenge = createInboundVerificationSession("voice");
+    const voiceChallenge = createInboundVerificationSession("phone");
     const telegramChallenge = createInboundVerificationSession("telegram");
 
     // Voice secret against telegram channel should fail
@@ -1666,7 +1666,7 @@ describe("voice guardian challenge validation", () => {
 
     // Voice secret against correct channel should succeed
     const voiceResult = validateAndConsumeVerification(
-      "voice",
+      "phone",
       voiceChallenge.secret,
       "voice-user-1",
       "voice-chat-1",
@@ -1684,10 +1684,10 @@ describe("voice guardian challenge validation", () => {
   });
 
   test("consumed voice challenge cannot be reused", () => {
-    const { secret } = createInboundVerificationSession("voice");
+    const { secret } = createInboundVerificationSession("phone");
 
     const result1 = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "voice-user-1",
       "voice-chat-1",
@@ -1695,7 +1695,7 @@ describe("voice guardian challenge validation", () => {
     expect(result1.success).toBe(true);
 
     const result2 = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "voice-user-2",
       "voice-chat-2",
@@ -1705,19 +1705,19 @@ describe("voice guardian challenge validation", () => {
 
   test("validateAndConsumeVerification succeeds even with existing voice binding (conflict check is caller responsibility)", () => {
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "old-voice-user",
       guardianPrincipalId: "old-voice-user",
       guardianDeliveryChatId: "old-voice-chat",
     });
 
-    const oldBinding = getGuardianBinding("asst-1", "voice");
+    const oldBinding = getGuardianBinding("asst-1", "phone");
     expect(oldBinding).not.toBeNull();
     expect(oldBinding!.guardianExternalUserId).toBe("old-voice-user");
 
-    const { secret } = createInboundVerificationSession("voice");
+    const { secret } = createInboundVerificationSession("phone");
     const result = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "new-voice-user",
       "new-voice-chat",
@@ -1727,7 +1727,7 @@ describe("voice guardian challenge validation", () => {
     expect(result.success).toBe(true);
 
     // The original binding is untouched (no side effects)
-    const binding = getGuardianBinding("asst-1", "voice");
+    const binding = getGuardianBinding("asst-1", "phone");
     expect(binding).not.toBeNull();
     expect(binding!.guardianExternalUserId).toBe("old-voice-user");
   });
@@ -1744,48 +1744,48 @@ describe("voice guardian identity and revocation", () => {
 
   test("isGuardian works for voice channel", () => {
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "voice-user-1",
       guardianPrincipalId: "voice-user-1",
       guardianDeliveryChatId: "voice-chat-1",
     });
 
-    expect(isGuardian("asst-1", "voice", "voice-user-1")).toBe(true);
-    expect(isGuardian("asst-1", "voice", "voice-user-2")).toBe(false);
+    expect(isGuardian("asst-1", "phone", "voice-user-1")).toBe(true);
+    expect(isGuardian("asst-1", "phone", "voice-user-2")).toBe(false);
     // Voice guardian should not match telegram channel
     expect(isGuardian("asst-1", "telegram", "voice-user-1")).toBe(false);
   });
 
   test("getGuardianBinding returns voice binding", () => {
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "voice-user-1",
       guardianPrincipalId: "voice-user-1",
       guardianDeliveryChatId: "voice-chat-1",
     });
 
-    const binding = getGuardianBinding("asst-1", "voice");
+    const binding = getGuardianBinding("asst-1", "phone");
     expect(binding).not.toBeNull();
-    expect(binding!.channel).toBe("voice");
+    expect(binding!.channel).toBe("phone");
     expect(binding!.guardianExternalUserId).toBe("voice-user-1");
   });
 
   test("revokeBinding clears active voice guardian binding", () => {
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "voice-user-1",
       guardianPrincipalId: "voice-user-1",
       guardianDeliveryChatId: "voice-chat-1",
     });
 
-    const result = serviceRevokeBinding("asst-1", "voice");
+    const result = serviceRevokeBinding("asst-1", "phone");
     expect(result).toBe(true);
-    expect(getGuardianBinding("asst-1", "voice")).toBeNull();
+    expect(getGuardianBinding("asst-1", "phone")).toBeNull();
   });
 
   test("revokeBinding for voice does not affect telegram binding", () => {
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "voice-user-1",
       guardianPrincipalId: "voice-user-1",
       guardianDeliveryChatId: "voice-chat-1",
@@ -1797,9 +1797,9 @@ describe("voice guardian identity and revocation", () => {
       guardianDeliveryChatId: "tg-chat-1",
     });
 
-    serviceRevokeBinding("asst-1", "voice");
+    serviceRevokeBinding("asst-1", "phone");
 
-    expect(getGuardianBinding("asst-1", "voice")).toBeNull();
+    expect(getGuardianBinding("asst-1", "phone")).toBeNull();
     expect(getGuardianBinding("asst-1", "telegram")).not.toBeNull();
   });
 });
@@ -1814,11 +1814,11 @@ describe("voice guardian rate limiting", () => {
   });
 
   test("repeated invalid voice submissions hit rate limit", () => {
-    createInboundVerificationSession("voice");
+    createInboundVerificationSession("phone");
 
     for (let i = 0; i < 5; i++) {
       const result = validateAndConsumeVerification(
-        "voice",
+        "phone",
         `${100000 + i}`,
         "voice-user-1",
         "voice-chat-1",
@@ -1828,30 +1828,30 @@ describe("voice guardian rate limiting", () => {
 
     // The 6th attempt should be rate-limited
     const result = validateAndConsumeVerification(
-      "voice",
+      "phone",
       "999999",
       "voice-user-1",
       "voice-chat-1",
     );
     expect(result.success).toBe(false);
 
-    const rl = getRateLimit("voice", "voice-user-1", "voice-chat-1");
+    const rl = getRateLimit("phone", "voice-user-1", "voice-chat-1");
     expect(rl).not.toBeNull();
     expect(rl!.lockedUntil).not.toBeNull();
   });
 
   test("voice rate limit does not affect telegram rate limit", () => {
-    createInboundVerificationSession("voice");
+    createInboundVerificationSession("phone");
     for (let i = 0; i < 5; i++) {
       validateAndConsumeVerification(
-        "voice",
+        "phone",
         `${100000 + i}`,
         "user-1",
         "chat-1",
       );
     }
 
-    const voiceRl = getRateLimit("voice", "user-1", "chat-1");
+    const voiceRl = getRateLimit("phone", "user-1", "chat-1");
     expect(voiceRl).not.toBeNull();
     expect(voiceRl!.lockedUntil).not.toBeNull();
 
@@ -1861,31 +1861,31 @@ describe("voice guardian rate limiting", () => {
   });
 
   test("successful voice verification resets rate limit", () => {
-    const { secret: _s } = createInboundVerificationSession("voice");
+    const { secret: _s } = createInboundVerificationSession("phone");
     validateAndConsumeVerification(
-      "voice",
+      "phone",
       "000000",
       "voice-user-1",
       "voice-chat-1",
     );
     validateAndConsumeVerification(
-      "voice",
+      "phone",
       "111111",
       "voice-user-1",
       "voice-chat-1",
     );
 
     // Valid attempt should succeed (under the 5-attempt threshold)
-    const { secret } = createInboundVerificationSession("voice");
+    const { secret } = createInboundVerificationSession("phone");
     const result = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "voice-user-1",
       "voice-chat-1",
     );
     expect(result.success).toBe(true);
 
-    const rl = getRateLimit("voice", "voice-user-1", "voice-chat-1");
+    const rl = getRateLimit("phone", "voice-user-1", "voice-chat-1");
     expect(rl).not.toBeNull();
     expect(rl!.invalidAttempts).toBe(0);
     expect(rl!.lockedUntil).toBeNull();
@@ -1902,61 +1902,61 @@ describe("pending challenge lookup", () => {
   });
 
   test("findPendingSessionForChannel returns pending challenge", () => {
-    createInboundVerificationSession("voice");
+    createInboundVerificationSession("phone");
 
-    const pending = findPendingSessionForChannel("voice");
+    const pending = findPendingSessionForChannel("phone");
     expect(pending).not.toBeNull();
-    expect(pending!.channel).toBe("voice");
+    expect(pending!.channel).toBe("phone");
     expect(pending!.status).toBe("pending");
   });
 
   test("findPendingSessionForChannel returns null when no challenge exists", () => {
-    const pending = findPendingSessionForChannel("voice");
+    const pending = findPendingSessionForChannel("phone");
     expect(pending).toBeNull();
   });
 
   test("findPendingSessionForChannel returns null for different channel", () => {
     createInboundVerificationSession("telegram");
 
-    const pending = findPendingSessionForChannel("voice");
+    const pending = findPendingSessionForChannel("phone");
     expect(pending).toBeNull();
   });
 
   test("findPendingSessionForChannel returns null after challenge is consumed", () => {
-    const { secret } = createInboundVerificationSession("voice");
+    const { secret } = createInboundVerificationSession("phone");
     validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "voice-user-1",
       "voice-chat-1",
     );
 
-    const pending = findPendingSessionForChannel("voice");
+    const pending = findPendingSessionForChannel("phone");
     expect(pending).toBeNull();
   });
 
   test("getPendingSession service helper returns pending voice challenge", () => {
-    createInboundVerificationSession("voice");
+    createInboundVerificationSession("phone");
 
-    const pending = getPendingSession("voice");
+    const pending = getPendingSession("phone");
     expect(pending).not.toBeNull();
-    expect(pending!.channel).toBe("voice");
+    expect(pending!.channel).toBe("phone");
   });
 
   test("getPendingSession returns null when no challenge exists", () => {
-    const pending = getPendingSession("voice");
+    const pending = getPendingSession("phone");
     expect(pending).toBeNull();
   });
 
   test("creating a new challenge revokes prior pending challenges", () => {
-    createInboundVerificationSession("voice");
-    const pending1 = findPendingSessionForChannel("voice");
+    createInboundVerificationSession("phone");
+    const pending1 = findPendingSessionForChannel("phone");
     expect(pending1).not.toBeNull();
     const firstId = pending1!.id;
 
     // Creating a second challenge should revoke the first
-    createInboundVerificationSession("voice");
-    const pending2 = findPendingSessionForChannel("voice");
+    createInboundVerificationSession("phone");
+    const pending2 = findPendingSessionForChannel("phone");
     expect(pending2).not.toBeNull();
     expect(pending2!.id).not.toBe(firstId);
   });
@@ -1976,7 +1976,7 @@ describe("IPC handler voice guardian verification", () => {
     const msg: ChannelVerificationSessionRequest = {
       type: "channel_verification_session",
       action: "create_session",
-      channel: "voice",
+      channel: "phone",
     };
 
     await handleChannelVerificationSession(msg, mockSocket, ctx);
@@ -1988,7 +1988,7 @@ describe("IPC handler voice guardian verification", () => {
     expect(resp!.secret).toMatch(/^[0-9a-f]{64}$/);
     expect(resp!.instruction).toBeDefined();
     expect(resp!.instruction).toContain("enter the code");
-    expect(resp!.channel).toBe("voice");
+    expect(resp!.channel).toBe("phone");
   });
 
   test("status for voice reflects unbound state", async () => {
@@ -1996,7 +1996,7 @@ describe("IPC handler voice guardian verification", () => {
     const msg: ChannelVerificationSessionRequest = {
       type: "channel_verification_session",
       action: "status",
-      channel: "voice",
+      channel: "phone",
     };
 
     await handleChannelVerificationSession(msg, mockSocket, ctx);
@@ -2004,14 +2004,14 @@ describe("IPC handler voice guardian verification", () => {
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
-    expect(resp!.channel).toBe("voice");
+    expect(resp!.channel).toBe("phone");
     expect(resp!.bound).toBe(false);
     expect(resp!.guardianExternalUserId).toBeUndefined();
   });
 
   test("status for voice reflects bound state", async () => {
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "voice-user-1",
       guardianPrincipalId: "voice-user-1",
       guardianDeliveryChatId: "voice-chat-1",
@@ -2021,7 +2021,7 @@ describe("IPC handler voice guardian verification", () => {
     const msg: ChannelVerificationSessionRequest = {
       type: "channel_verification_session",
       action: "status",
-      channel: "voice",
+      channel: "phone",
     };
 
     await handleChannelVerificationSession(msg, mockSocket, ctx);
@@ -2032,12 +2032,12 @@ describe("IPC handler voice guardian verification", () => {
     expect(resp!.bound).toBe(true);
     expect(resp!.guardianExternalUserId).toBe("voice-user-1");
     expect(resp!.guardianDeliveryChatId).toBe("voice-chat-1");
-    expect(resp!.channel).toBe("voice");
+    expect(resp!.channel).toBe("phone");
   });
 
   test("revoke for voice clears active binding", async () => {
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "voice-user-1",
       guardianPrincipalId: "voice-user-1",
       guardianDeliveryChatId: "voice-chat-1",
@@ -2047,7 +2047,7 @@ describe("IPC handler voice guardian verification", () => {
     const msg: ChannelVerificationSessionRequest = {
       type: "channel_verification_session",
       action: "revoke",
-      channel: "voice",
+      channel: "phone",
     };
 
     await handleChannelVerificationSession(msg, mockSocket, ctx);
@@ -2058,12 +2058,12 @@ describe("IPC handler voice guardian verification", () => {
     expect(resp!.bound).toBe(false);
 
     // Verify binding is actually revoked
-    expect(getGuardianBinding("self", "voice")).toBeNull();
+    expect(getGuardianBinding("self", "phone")).toBeNull();
   });
 
   test("revoke for voice does not affect telegram binding", async () => {
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "voice-user-1",
       guardianPrincipalId: "voice-user-1",
       guardianDeliveryChatId: "voice-chat-1",
@@ -2079,12 +2079,12 @@ describe("IPC handler voice guardian verification", () => {
     const msg: ChannelVerificationSessionRequest = {
       type: "channel_verification_session",
       action: "revoke",
-      channel: "voice",
+      channel: "phone",
     };
 
     await handleChannelVerificationSession(msg, mockSocket, ctx);
 
-    expect(getGuardianBinding("self", "voice")).toBeNull();
+    expect(getGuardianBinding("self", "phone")).toBeNull();
     expect(getGuardianBinding("self", "telegram")).not.toBeNull();
   });
 });
@@ -2102,7 +2102,7 @@ describe("outbound verification sessions", () => {
 
   test("createOutboundSession creates a session with expected identity fields", () => {
     const result = createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
     });
@@ -2113,7 +2113,7 @@ describe("outbound verification sessions", () => {
     expect(result.expiresAt).toBeGreaterThan(Date.now());
     expect(result.ttlSeconds).toBe(600);
 
-    const session = serviceFindActiveSession("voice");
+    const session = serviceFindActiveSession("phone");
     expect(session).not.toBeNull();
     expect(session!.expectedPhoneE164).toBe("+15551234567");
     expect(session!.destinationAddress).toBe("+15551234567");
@@ -2142,14 +2142,14 @@ describe("outbound verification sessions", () => {
 
   test("validateAndConsumeVerification succeeds with correct secret and matching identity (voice)", () => {
     const { secret } = createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedPhoneE164: "+15551234567",
       expectedExternalUserId: "+15551234567",
       destinationAddress: "+15551234567",
     });
 
     const result = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "+15551234567",
       "voice-chat-1",
@@ -2180,14 +2180,14 @@ describe("outbound verification sessions", () => {
 
   test("validateAndConsumeVerification rejects correct secret with wrong identity (anti-oracle)", () => {
     const { secret } = createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedPhoneE164: "+15551234567",
       expectedExternalUserId: "+15551234567",
       destinationAddress: "+15551234567",
     });
 
     const result = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "+15559999999",
       "voice-chat-wrong",
@@ -2228,7 +2228,7 @@ describe("outbound verification sessions", () => {
     const challengeHash = createHash("sha256").update(secret).digest("hex");
     createVerificationSession({
       id: "session-expired",
-      channel: "voice",
+      channel: "phone",
       challengeHash,
       expiresAt: Date.now() - 1000,
       status: "awaiting_response",
@@ -2237,7 +2237,7 @@ describe("outbound verification sessions", () => {
     });
 
     const result = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "+15551234567",
       "voice-chat-1",
@@ -2250,7 +2250,7 @@ describe("outbound verification sessions", () => {
 
   test("revoked outbound session is rejected", () => {
     const { secret, sessionId } = createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
     });
@@ -2259,7 +2259,7 @@ describe("outbound verification sessions", () => {
     serviceUpdateSessionStatus(sessionId, "revoked");
 
     const result = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "+15551234567",
       "voice-chat-1",
@@ -2272,14 +2272,14 @@ describe("outbound verification sessions", () => {
 
   test("outbound session cannot be consumed twice (replay prevention)", () => {
     const { secret } = createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedPhoneE164: "+15551234567",
       expectedExternalUserId: "+15551234567",
       destinationAddress: "+15551234567",
     });
 
     const result1 = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "+15551234567",
       "voice-chat-1",
@@ -2287,7 +2287,7 @@ describe("outbound verification sessions", () => {
     expect(result1.success).toBe(true);
 
     const result2 = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "+15551234567",
       "voice-chat-1",
@@ -2343,23 +2343,23 @@ describe("outbound verification sessions", () => {
 
   test("creating a new outbound session auto-revokes prior pending/awaiting sessions", () => {
     const { sessionId: firstId } = createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
     });
 
-    const first = serviceFindActiveSession("voice");
+    const first = serviceFindActiveSession("phone");
     expect(first).not.toBeNull();
     expect(first!.id).toBe(firstId);
 
     // Create a second session — first should be revoked
     const { sessionId: secondId } = createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedPhoneE164: "+15559876543",
       destinationAddress: "+15559876543",
     });
 
-    const second = serviceFindActiveSession("voice");
+    const second = serviceFindActiveSession("phone");
     expect(second).not.toBeNull();
     expect(second!.id).toBe(secondId);
 
@@ -2378,19 +2378,19 @@ describe("outbound verification sessions", () => {
 
   test("findActiveSession returns the most recent active session", () => {
     createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
     });
 
-    const session = serviceFindActiveSession("voice");
+    const session = serviceFindActiveSession("phone");
     expect(session).not.toBeNull();
     expect(session!.status).toBe("awaiting_response");
     expect(session!.expectedPhoneE164).toBe("+15551234567");
   });
 
   test("findActiveSession returns null when no active session exists", () => {
-    const session = serviceFindActiveSession("voice");
+    const session = serviceFindActiveSession("phone");
     expect(session).toBeNull();
   });
 
@@ -2398,13 +2398,13 @@ describe("outbound verification sessions", () => {
 
   test("findSessionByIdentity returns session matching phone E164", () => {
     createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
     });
 
     const session = serviceFindSessionByIdentity(
-      "voice",
+      "phone",
       undefined,
       undefined,
       "+15551234567",
@@ -2428,13 +2428,13 @@ describe("outbound verification sessions", () => {
 
   test("findSessionByIdentity returns null for non-matching identity", () => {
     createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
     });
 
     const session = serviceFindSessionByIdentity(
-      "voice",
+      "phone",
       undefined,
       undefined,
       "+15559999999",
@@ -2491,7 +2491,7 @@ describe("outbound verification sessions", () => {
 
   test("updateSessionDelivery updates delivery tracking fields", () => {
     const { sessionId } = createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
     });
@@ -2499,7 +2499,7 @@ describe("outbound verification sessions", () => {
     const now = Date.now();
     storeUpdateSessionDelivery(sessionId, now, 1, now + 30_000);
 
-    const session = serviceFindActiveSession("voice");
+    const session = serviceFindActiveSession("phone");
     expect(session).not.toBeNull();
     expect(session!.lastSentAt).toBe(now);
     expect(session!.sendCount).toBe(1);
@@ -2530,7 +2530,7 @@ describe("outbound verification sessions", () => {
 
   test("Voice identity match succeeds via expectedExternalUserId", () => {
     const { secret } = createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedExternalUserId: "voice-user-42",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
@@ -2538,7 +2538,7 @@ describe("outbound verification sessions", () => {
 
     // Actor matches expectedExternalUserId
     const result = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "voice-user-42",
       "voice-chat-1",
@@ -2562,7 +2562,7 @@ describe("outbound voice verification", () => {
     const msg: ChannelVerificationSessionRequest = {
       type: "channel_verification_session",
       action: "create_session",
-      channel: "voice",
+      channel: "phone",
       destination: "+15551234567",
     };
 
@@ -2576,10 +2576,10 @@ describe("outbound voice verification", () => {
     expect(resp!.expiresAt).toBeGreaterThan(Date.now());
     expect(resp!.nextResendAt).toBeGreaterThan(Date.now());
     expect(resp!.sendCount).toBe(1);
-    expect(resp!.channel).toBe("voice");
+    expect(resp!.channel).toBe("phone");
 
     // Verify the session was created with expected identity
-    const session = serviceFindActiveSession("voice");
+    const session = serviceFindActiveSession("phone");
     expect(session).not.toBeNull();
     expect(session!.expectedPhoneE164).toBe("+15551234567");
     expect(session!.destinationAddress).toBe("+15551234567");
@@ -2588,7 +2588,7 @@ describe("outbound voice verification", () => {
   test("start_outbound rejects when active binding exists (rebind=false)", async () => {
     // Create an existing guardian binding
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "+15551234567",
       guardianPrincipalId: "+15551234567",
       guardianDeliveryChatId: "voice-chat-1",
@@ -2598,7 +2598,7 @@ describe("outbound voice verification", () => {
     const msg: ChannelVerificationSessionRequest = {
       type: "channel_verification_session",
       action: "create_session",
-      channel: "voice",
+      channel: "phone",
       destination: "+15559876543",
       rebind: false,
     };
@@ -2614,7 +2614,7 @@ describe("outbound voice verification", () => {
   test("start_outbound allows rebind when rebind=true", async () => {
     // Create an existing guardian binding
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "+15551234567",
       guardianPrincipalId: "+15551234567",
       guardianDeliveryChatId: "voice-chat-1",
@@ -2624,7 +2624,7 @@ describe("outbound voice verification", () => {
     const msg: ChannelVerificationSessionRequest = {
       type: "channel_verification_session",
       action: "create_session",
-      channel: "voice",
+      channel: "phone",
       destination: "+15559876543",
       rebind: true,
     };
@@ -2644,7 +2644,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
         destination: "+15551234567",
       },
       mockSocket,
@@ -2657,7 +2657,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "resend_session",
-        channel: "voice",
+        channel: "phone",
       },
       mockSocket,
       ctx,
@@ -2676,7 +2676,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
         destination: "+15551234567",
       },
       mockSocket,
@@ -2687,7 +2687,7 @@ describe("outbound voice verification", () => {
     expect(startResponse!.success).toBe(true);
 
     // Manually update the session's nextResendAt to the past to simulate cooldown elapsed
-    const session = serviceFindActiveSession("voice");
+    const session = serviceFindActiveSession("phone");
     expect(session).not.toBeNull();
     storeUpdateSessionDelivery(
       session!.id,
@@ -2702,7 +2702,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "resend_session",
-        channel: "voice",
+        channel: "phone",
       },
       mockSocket,
       ctx,
@@ -2722,7 +2722,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
         destination: "+15551234567",
       },
       mockSocket,
@@ -2730,7 +2730,7 @@ describe("outbound voice verification", () => {
     );
 
     // Set the send count to MAX_SENDS_PER_SESSION and nextResendAt to the past
-    const session = serviceFindActiveSession("voice");
+    const session = serviceFindActiveSession("phone");
     expect(session).not.toBeNull();
     storeUpdateSessionDelivery(
       session!.id,
@@ -2745,7 +2745,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "resend_session",
-        channel: "voice",
+        channel: "phone",
       },
       mockSocket,
       ctx,
@@ -2764,7 +2764,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
         destination: "+15551234567",
       },
       mockSocket,
@@ -2772,7 +2772,7 @@ describe("outbound voice verification", () => {
     );
 
     // Verify session exists
-    const sessionBefore = serviceFindActiveSession("voice");
+    const sessionBefore = serviceFindActiveSession("phone");
     expect(sessionBefore).not.toBeNull();
 
     // Cancel it
@@ -2781,7 +2781,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "cancel_session",
-        channel: "voice",
+        channel: "phone",
       },
       mockSocket,
       ctx,
@@ -2790,17 +2790,17 @@ describe("outbound voice verification", () => {
     const resp = lastResponse();
     expect(resp).not.toBeNull();
     expect(resp!.success).toBe(true);
-    expect(resp!.channel).toBe("voice");
+    expect(resp!.channel).toBe("phone");
 
     // Verify session is no longer active
-    const sessionAfter = serviceFindActiveSession("voice");
+    const sessionAfter = serviceFindActiveSession("phone");
     expect(sessionAfter).toBeNull();
   });
 
   test("inbound voice from expected identity + correct code succeeds", () => {
     // Create an outbound session
     const { secret } = createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedPhoneE164: "+15551234567",
       expectedExternalUserId: "+15551234567",
       destinationAddress: "+15551234567",
@@ -2808,7 +2808,7 @@ describe("outbound voice verification", () => {
 
     // Validate with matching identity
     const result = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "+15551234567",
       "voice-chat-1",
@@ -2823,7 +2823,7 @@ describe("outbound voice verification", () => {
   test("inbound voice from wrong identity + correct code is rejected", () => {
     // Create an outbound session with expected identity +15551234567
     const { secret } = createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedPhoneE164: "+15551234567",
       expectedExternalUserId: "+15551234567",
       destinationAddress: "+15551234567",
@@ -2831,7 +2831,7 @@ describe("outbound voice verification", () => {
 
     // Try to validate with a different phone number (anti-oracle: same generic error)
     const result = validateAndConsumeVerification(
-      "voice",
+      "phone",
       secret,
       "+15559999999",
       "voice-chat-wrong",
@@ -2871,7 +2871,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
         // no destination — unified create_session creates an inbound challenge
       },
       mockSocket,
@@ -2890,7 +2890,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
         destination: "not-a-phone",
       },
       mockSocket,
@@ -2909,7 +2909,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
         destination: "(555) 123-4567",
       },
       mockSocket,
@@ -2923,7 +2923,7 @@ describe("outbound voice verification", () => {
     expect(resp!.secret).toBeDefined();
 
     // Verify the session was created with the normalized E.164 number
-    const session = serviceFindActiveSession("voice");
+    const session = serviceFindActiveSession("phone");
     expect(session).not.toBeNull();
     expect(session!.expectedPhoneE164).toBe("+15551234567");
     expect(session!.destinationAddress).toBe("+15551234567");
@@ -2943,7 +2943,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "cancel_session",
-        channel: "voice",
+        channel: "phone",
       },
       mockSocket,
       ctx,
@@ -3501,7 +3501,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
         destination: "+15551234567",
       },
       mockSocket,
@@ -3519,10 +3519,10 @@ describe("outbound voice verification", () => {
     expect(resp!.expiresAt).toBeGreaterThan(Date.now());
     expect(resp!.nextResendAt).toBeGreaterThan(Date.now());
     expect(resp!.sendCount).toBe(1);
-    expect(resp!.channel).toBe("voice");
+    expect(resp!.channel).toBe("phone");
 
     // Verify the session was created with expected identity
-    const session = serviceFindActiveSession("voice");
+    const session = serviceFindActiveSession("phone");
     expect(session).not.toBeNull();
     expect(session!.expectedPhoneE164).toBe("+15551234567");
     expect(session!.destinationAddress).toBe("+15551234567");
@@ -3543,7 +3543,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
         destination: "not-a-phone",
       },
       mockSocket,
@@ -3562,7 +3562,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
         destination: "555-123-4567",
       },
       mockSocket,
@@ -3578,7 +3578,7 @@ describe("outbound voice verification", () => {
     expect(resp!.secret!.length).toBe(6);
 
     // Verify the session was created with the normalized E.164 number
-    const session = serviceFindActiveSession("voice");
+    const session = serviceFindActiveSession("phone");
     expect(session).not.toBeNull();
     expect(session!.expectedPhoneE164).toBe("+15551234567");
     expect(session!.destinationAddress).toBe("+15551234567");
@@ -3594,7 +3594,7 @@ describe("outbound voice verification", () => {
 
   test("start_outbound for voice rejects when binding exists (rebind=false)", async () => {
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "+15551234567",
       guardianPrincipalId: "+15551234567",
       guardianDeliveryChatId: "+15551234567",
@@ -3605,7 +3605,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
         destination: "+15559876543",
         rebind: false,
       },
@@ -3626,7 +3626,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
         destination: "+15551234567",
       },
       mockSocket,
@@ -3639,7 +3639,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "resend_session",
-        channel: "voice",
+        channel: "phone",
       },
       mockSocket,
       ctx,
@@ -3658,7 +3658,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
         destination: "+15551234567",
       },
       mockSocket,
@@ -3671,7 +3671,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "cancel_session",
-        channel: "voice",
+        channel: "phone",
       },
       mockSocket,
       ctx,
@@ -3682,7 +3682,7 @@ describe("outbound voice verification", () => {
     expect(resp!.success).toBe(true);
 
     // Session should no longer be active
-    const session = serviceFindActiveSession("voice");
+    const session = serviceFindActiveSession("phone");
     expect(session).toBeNull();
   });
 
@@ -3695,7 +3695,7 @@ describe("outbound voice verification", () => {
       db.insert(channelVerificationSessions)
         .values({
           id: `rate-limit-voice-${i}`,
-          channel: "voice",
+          channel: "phone",
           challengeHash: `hash-${i}`,
           expiresAt: now + 600_000,
           status: "awaiting_response",
@@ -3713,7 +3713,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
         destination: "+15551234567",
       },
       mockSocket,
@@ -3732,7 +3732,7 @@ describe("outbound voice verification", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
       },
       mockSocket,
       ctx,
@@ -3768,7 +3768,7 @@ describe("M1–M4 hardening coverage", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
         destination: "+15551234567",
       },
       mockSocket,
@@ -3792,7 +3792,7 @@ describe("M1–M4 hardening coverage", () => {
       {
         type: "channel_verification_session",
         action: "create_session",
-        channel: "voice",
+        channel: "phone",
         destination: "+15551234567",
       },
       mockSocket,
@@ -3800,7 +3800,7 @@ describe("M1–M4 hardening coverage", () => {
     );
 
     // Move past cooldown
-    const session = serviceFindActiveSession("voice");
+    const session = serviceFindActiveSession("phone");
     expect(session).not.toBeNull();
     storeUpdateSessionDelivery(
       session!.id,
@@ -3815,7 +3815,7 @@ describe("M1–M4 hardening coverage", () => {
       {
         type: "channel_verification_session",
         action: "resend_session",
-        channel: "voice",
+        channel: "phone",
       },
       mockSocket,
       ctx,
@@ -3869,7 +3869,7 @@ describe("M1–M4 hardening coverage", () => {
 
     // Identity-bound: 6-digit numeric code
     const boundResult = createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
       identityBindingStatus: "bound",
@@ -3883,7 +3883,7 @@ describe("M1–M4 hardening coverage", () => {
   test("all identity-bound channels (voice, Telegram chat ID) use 6-digit numeric codes", () => {
     // Voice (phone E.164)
     const voicePhoneResult = createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
     });
@@ -3904,7 +3904,7 @@ describe("M1–M4 hardening coverage", () => {
 
     // Voice (explicit codeDigits)
     const voiceResult = createOutboundSession({
-      channel: "voice",
+      channel: "phone",
       expectedPhoneE164: "+15551234567",
       destinationAddress: "+15551234567",
       codeDigits: 6,

--- a/assistant/src/__tests__/channel-invite-transport.test.ts
+++ b/assistant/src/__tests__/channel-invite-transport.test.ts
@@ -112,7 +112,7 @@ describe("createInviteAdapterRegistry", () => {
     "email",
     "slack",
     "telegram",
-    "voice",
+    "phone",
     "whatsapp",
   ] as const;
 

--- a/assistant/src/__tests__/channel-policy.test.ts
+++ b/assistant/src/__tests__/channel-policy.test.ts
@@ -100,7 +100,7 @@ describe("channel policy registry", () => {
       ["vellum", "start_new_conversation"],
       ["telegram", "continue_existing_conversation"],
       ["slack", "continue_existing_conversation"],
-      ["voice", "not_deliverable"],
+      ["phone", "not_deliverable"],
     ];
 
     for (const [channelId, expected] of expectedStrategies) {
@@ -124,12 +124,12 @@ describe("channel policy registry", () => {
   // ── Voice channel policy ─────────────────────────────────────────────
 
   test("voice is not a deliverable notification channel", () => {
-    expect(isNotificationDeliverable("voice")).toBe(false);
-    expect(getDeliverableChannels()).not.toContain("voice");
+    expect(isNotificationDeliverable("phone")).toBe(false);
+    expect(getDeliverableChannels()).not.toContain("phone");
   });
 
   test("voice uses not_deliverable strategy", () => {
-    expect(getConversationStrategy("voice")).toBe("not_deliverable");
+    expect(getConversationStrategy("phone")).toBe("not_deliverable");
   });
 
   test("deliverable channels include vellum and telegram", () => {

--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -113,28 +113,28 @@ describe("ChannelReadinessService", () => {
   });
 
   test("local checks run on every call (no caching of local results)", async () => {
-    const probe = makeProbe("voice", [
+    const probe = makeProbe("phone", [
       { name: "creds", passed: true, message: "ok" },
     ]);
     service.registerProbe(probe);
 
-    await service.getReadiness("voice");
-    await service.getReadiness("voice");
+    await service.getReadiness("phone");
+    await service.getReadiness("phone");
 
     expect(probe.localCallCount).toBe(2);
   });
 
   test("cache miss runs local checks and returns snapshot", async () => {
-    const probe = makeProbe("voice", [
+    const probe = makeProbe("phone", [
       { name: "creds", passed: true, message: "ok" },
       { name: "phone", passed: false, message: "missing" },
     ]);
     service.registerProbe(probe);
 
-    const [snapshot] = await service.getReadiness("voice");
+    const [snapshot] = await service.getReadiness("phone");
 
     expect(probe.localCallCount).toBe(1);
-    expect(snapshot.channel).toBe("voice");
+    expect(snapshot.channel).toBe("phone");
     expect(snapshot.ready).toBe(false);
     expect(snapshot.localChecks).toHaveLength(2);
     expect(snapshot.reasons).toEqual([{ code: "phone", text: "missing" }]);
@@ -142,13 +142,13 @@ describe("ChannelReadinessService", () => {
 
   test("includeRemote=true runs remote checks on cache miss", async () => {
     const probe = makeProbe(
-      "voice",
+      "phone",
       [{ name: "creds", passed: true, message: "ok" }],
       [{ name: "api_check", passed: true, message: "remote ok" }],
     );
     service.registerProbe(probe);
 
-    const [snapshot] = await service.getReadiness("voice", true);
+    const [snapshot] = await service.getReadiness("phone", true);
 
     expect(probe.remoteCallCount).toBe(1);
     expect(snapshot.remoteChecks).toHaveLength(1);
@@ -157,32 +157,32 @@ describe("ChannelReadinessService", () => {
 
   test("cached remote checks reused within TTL", async () => {
     const probe = makeProbe(
-      "voice",
+      "phone",
       [{ name: "creds", passed: true, message: "ok" }],
       [{ name: "api_check", passed: true, message: "remote ok" }],
     );
     service.registerProbe(probe);
 
     // First call populates cache
-    await service.getReadiness("voice", true);
+    await service.getReadiness("phone", true);
     expect(probe.remoteCallCount).toBe(1);
 
     // Second call within TTL should reuse cache
-    const [snapshot] = await service.getReadiness("voice", true);
+    const [snapshot] = await service.getReadiness("phone", true);
     expect(probe.remoteCallCount).toBe(1);
     expect(snapshot.remoteChecks).toHaveLength(1);
   });
 
   test("stale cache triggers remote check re-run", async () => {
     const probe = makeProbe(
-      "voice",
+      "phone",
       [{ name: "creds", passed: true, message: "ok" }],
       [{ name: "api_check", passed: true, message: "remote ok" }],
     );
     service.registerProbe(probe);
 
     // First call
-    await service.getReadiness("voice", true);
+    await service.getReadiness("phone", true);
     expect(probe.remoteCallCount).toBe(1);
 
     // Manually age the cached snapshot beyond TTL
@@ -190,35 +190,35 @@ describe("ChannelReadinessService", () => {
       service as unknown as {
         snapshots: Map<string, { checkedAt: number }>;
       }
-    ).snapshots.get("voice::__default__")!;
+    ).snapshots.get("phone::__default__")!;
     cached.checkedAt = Date.now() - REMOTE_TTL_MS - 1;
 
     // Second call should re-run remote checks
-    await service.getReadiness("voice", true);
+    await service.getReadiness("phone", true);
     expect(probe.remoteCallCount).toBe(2);
   });
 
   test("invalidateChannel clears cache for specific channel", async () => {
     const probe = makeProbe(
-      "voice",
+      "phone",
       [{ name: "creds", passed: true, message: "ok" }],
       [{ name: "api_check", passed: true, message: "remote ok" }],
     );
     service.registerProbe(probe);
 
-    await service.getReadiness("voice", true);
+    await service.getReadiness("phone", true);
     expect(probe.remoteCallCount).toBe(1);
 
-    service.invalidateChannel("voice");
+    service.invalidateChannel("phone");
 
     // After invalidation, remote checks should run again
-    await service.getReadiness("voice", true);
+    await service.getReadiness("phone", true);
     expect(probe.remoteCallCount).toBe(2);
   });
 
   test("invalidateAll clears all cached snapshots", async () => {
     const voiceProbe = makeProbe(
-      "voice",
+      "phone",
       [{ name: "creds", passed: true, message: "ok" }],
       [{ name: "api", passed: true, message: "ok" }],
     );
@@ -273,7 +273,7 @@ describe("ChannelReadinessService", () => {
 
   test("getReadiness with no channel returns all registered channels", async () => {
     service.registerProbe(
-      makeProbe("voice", [{ name: "a", passed: true, message: "ok" }]),
+      makeProbe("phone", [{ name: "a", passed: true, message: "ok" }]),
     );
     service.registerProbe(
       makeProbe("telegram", [{ name: "b", passed: true, message: "ok" }]),
@@ -283,43 +283,43 @@ describe("ChannelReadinessService", () => {
 
     expect(snapshots).toHaveLength(2);
     const channels = snapshots.map((s) => s.channel).sort();
-    expect(channels).toEqual(["telegram", "voice"]);
+    expect(channels).toEqual(["phone", "telegram"]);
   });
 
   test("cached remote checks preserve original checkedAt (TTL not reset on reuse)", async () => {
     const probe = makeProbe(
-      "voice",
+      "phone",
       [{ name: "creds", passed: true, message: "ok" }],
       [{ name: "api_check", passed: true, message: "remote ok" }],
     );
     service.registerProbe(probe);
 
     // First call populates cache with freshly fetched remote checks
-    const [first] = await service.getReadiness("voice", true);
+    const [first] = await service.getReadiness("phone", true);
     const originalCheckedAt = first.checkedAt;
     expect(probe.remoteCallCount).toBe(1);
 
     // Second call within TTL reuses cache — checkedAt must stay at the original value
-    const [second] = await service.getReadiness("voice", true);
+    const [second] = await service.getReadiness("phone", true);
     expect(probe.remoteCallCount).toBe(1);
     expect(second.checkedAt).toBe(originalCheckedAt);
   });
 
   test("includeRemote runs remote checks when cache exists without remote data", async () => {
     const probe = makeProbe(
-      "voice",
+      "phone",
       [{ name: "creds", passed: true, message: "ok" }],
       [{ name: "api_check", passed: true, message: "remote ok" }],
     );
     service.registerProbe(probe);
 
     // First call without includeRemote — cache has no remote data
-    await service.getReadiness("voice", false);
+    await service.getReadiness("phone", false);
     expect(probe.remoteCallCount).toBe(0);
 
     // Second call with includeRemote — should run remote checks even though
     // the cached snapshot exists (because it has no remoteChecks)
-    const [snapshot] = await service.getReadiness("voice", true);
+    const [snapshot] = await service.getReadiness("phone", true);
     expect(probe.remoteCallCount).toBe(1);
     expect(snapshot.remoteChecks).toHaveLength(1);
     expect(snapshot.remoteChecks![0].passed).toBe(true);
@@ -327,13 +327,13 @@ describe("ChannelReadinessService", () => {
 
   test("failed remote check makes channel not ready", async () => {
     const probe = makeProbe(
-      "voice",
+      "phone",
       [{ name: "creds", passed: true, message: "ok" }],
       [{ name: "api_check", passed: false, message: "API unreachable" }],
     );
     service.registerProbe(probe);
 
-    const [snapshot] = await service.getReadiness("voice", true);
+    const [snapshot] = await service.getReadiness("phone", true);
 
     expect(snapshot.ready).toBe(false);
     expect(snapshot.reasons).toEqual([
@@ -343,19 +343,19 @@ describe("ChannelReadinessService", () => {
 
   test("fresh cached remote failures do not affect local-only readiness", async () => {
     const probe = makeProbe(
-      "voice",
+      "phone",
       [{ name: "creds", passed: true, message: "ok" }],
       [{ name: "api_check", passed: false, message: "API unreachable" }],
     );
     service.registerProbe(probe);
 
     // Prime remote cache with a failing check
-    await service.getReadiness("voice", true);
+    await service.getReadiness("phone", true);
 
     // Immediately call with includeRemote=false (cache is still fresh within TTL).
     // The cached remote failure should be surfaced for visibility but must NOT
     // affect readiness when the caller explicitly opted out of remote checks.
-    const [snapshot] = await service.getReadiness("voice", false);
+    const [snapshot] = await service.getReadiness("phone", false);
     expect(snapshot.ready).toBe(true);
     expect(snapshot.reasons).toEqual([]);
     // Remote checks are still visible for informational purposes
@@ -365,25 +365,25 @@ describe("ChannelReadinessService", () => {
 
   test("stale cached remote failures do not affect local-only readiness", async () => {
     const probe = makeProbe(
-      "voice",
+      "phone",
       [{ name: "creds", passed: true, message: "ok" }],
       [{ name: "api_check", passed: false, message: "API unreachable" }],
     );
     service.registerProbe(probe);
 
     // Prime remote cache with a failing check
-    await service.getReadiness("voice", true);
+    await service.getReadiness("phone", true);
 
     // Age snapshot beyond TTL so remote checks are stale
     const cached = (
       service as unknown as {
         snapshots: Map<string, { checkedAt: number }>;
       }
-    ).snapshots.get("voice::__default__")!;
+    ).snapshots.get("phone::__default__")!;
     cached.checkedAt = Date.now() - REMOTE_TTL_MS - 1;
 
     // Local-only call should not be blocked by stale remote failure
-    const [snapshot] = await service.getReadiness("voice", false);
+    const [snapshot] = await service.getReadiness("phone", false);
     expect(snapshot.stale).toBe(true);
     expect(snapshot.ready).toBe(true);
     expect(snapshot.reasons).toEqual([]);
@@ -391,15 +391,15 @@ describe("ChannelReadinessService", () => {
 
   test("remote cache uses fixed internal scope (no per-assistantId scoping)", async () => {
     const probe = makeProbe(
-      "voice",
+      "phone",
       [{ name: "local", passed: true, message: "ok" }],
       [{ name: "remote", passed: true, message: "ok" }],
     );
     service.registerProbe(probe);
 
     // All calls share the same cache key since there is no assistantId dimension
-    await service.getReadiness("voice", true);
-    await service.getReadiness("voice", true);
+    await service.getReadiness("phone", true);
+    await service.getReadiness("phone", true);
 
     expect(probe.remoteCallCount).toBe(1);
   });
@@ -432,7 +432,7 @@ describe("ChannelReadinessService", () => {
     >[number];
     try {
       const readinessService = createReadinessService();
-      [snapshot] = await readinessService.getReadiness("voice");
+      [snapshot] = await readinessService.getReadiness("phone");
     } finally {
       probeLocalGatewayHealthSpy.mockRestore();
     }

--- a/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
+++ b/assistant/src/__tests__/confirmation-request-guardian-bridge.test.ts
@@ -251,9 +251,9 @@ describe("bridgeConfirmationRequestToGuardian", () => {
   });
 
   test("skips when no guardian binding exists for channel", () => {
-    const canonicalRequest = makeCanonicalRequest({ sourceChannel: "voice" });
+    const canonicalRequest = makeCanonicalRequest({ sourceChannel: "phone" });
     const trustContext = makeTrustedContactContext({
-      sourceChannel: "voice",
+      sourceChannel: "phone",
     });
 
     const result = bridgeConfirmationRequestToGuardian({

--- a/assistant/src/__tests__/gateway-client-managed-outbound.test.ts
+++ b/assistant/src/__tests__/gateway-client-managed-outbound.test.ts
@@ -35,7 +35,7 @@ describe("gateway-client managed outbound lane", () => {
 
   test("translates managed callback URL into managed outbound-send request", async () => {
     await deliverChannelReply(
-      "https://platform.test/v1/internal/managed-gateway/outbound-send/?route_id=route-123&assistant_id=assistant-123&source_channel=voice&source_update_id=CA-inbound-123&callback_token=runtime-token",
+      "https://platform.test/v1/internal/managed-gateway/outbound-send/?route_id=route-123&assistant_id=assistant-123&source_channel=phone&source_update_id=CA-inbound-123&callback_token=runtime-token",
       {
         chatId: "+15550001111",
         text: "hello from runtime",
@@ -74,7 +74,7 @@ describe("gateway-client managed outbound lane", () => {
     };
     expect(body.route_id).toBe("route-123");
     expect(body.assistant_id).toBe("assistant-123");
-    expect(body.normalized_send.sourceChannel).toBe("voice");
+    expect(body.normalized_send.sourceChannel).toBe("phone");
     expect(body.normalized_send.message.to).toBe("+15550001111");
     expect(body.normalized_send.message.content).toBe("hello from runtime");
     expect(body.normalized_send.message.externalMessageId).toStartWith(
@@ -109,7 +109,7 @@ describe("gateway-client managed outbound lane", () => {
     ) as unknown as typeof globalThis.fetch;
 
     await deliverChannelReply(
-      "https://platform.test/v1/internal/managed-gateway/outbound-send/?route_id=route-retry&assistant_id=assistant-retry&source_channel=voice&source_update_id=CA-retry",
+      "https://platform.test/v1/internal/managed-gateway/outbound-send/?route_id=route-retry&assistant_id=assistant-retry&source_channel=phone&source_update_id=CA-retry",
       {
         chatId: "+15550002222",
         text: "retry this outbound send",

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -176,15 +176,15 @@ beforeEach(() => {
 
 describe("startOutbound", () => {
   test("Voice: returns missing_destination when destination is absent", async () => {
-    const result = await startOutbound({ channel: "voice" });
+    const result = await startOutbound({ channel: "phone" });
     expect(result.success).toBe(false);
     expect(result.error).toBe("missing_destination");
-    expect(result.channel).toBe("voice");
+    expect(result.channel).toBe("phone");
   });
 
   test("Voice: returns invalid_destination for garbage phone number", async () => {
     const result = await startOutbound({
-      channel: "voice",
+      channel: "phone",
       destination: "notaphone",
     });
     expect(result.success).toBe(false);
@@ -193,7 +193,7 @@ describe("startOutbound", () => {
 
   test("Voice: succeeds with valid E.164 number", async () => {
     const result = await startOutbound({
-      channel: "voice",
+      channel: "phone",
       destination: "+15551234567",
     });
     expect(result.success).toBe(true);
@@ -202,12 +202,12 @@ describe("startOutbound", () => {
     expect(result.expiresAt).toBeGreaterThan(Date.now());
     expect(result.nextResendAt).toBeGreaterThan(Date.now());
     expect(result.sendCount).toBe(1);
-    expect(result.channel).toBe("voice");
+    expect(result.channel).toBe("phone");
   });
 
   test("Voice: succeeds with loose phone format (parentheses + dashes)", async () => {
     const result = await startOutbound({
-      channel: "voice",
+      channel: "phone",
       destination: "(555) 987-6543",
     });
     expect(result.success).toBe(true);
@@ -264,14 +264,14 @@ describe("startOutbound", () => {
   });
 
   test("voice: returns missing_destination when absent", async () => {
-    const result = await startOutbound({ channel: "voice" });
+    const result = await startOutbound({ channel: "phone" });
     expect(result.success).toBe(false);
     expect(result.error).toBe("missing_destination");
   });
 
   test("voice: returns invalid_destination for garbage", async () => {
     const result = await startOutbound({
-      channel: "voice",
+      channel: "phone",
       destination: "badphone",
     });
     expect(result.success).toBe(false);
@@ -280,7 +280,7 @@ describe("startOutbound", () => {
 
   test("voice: succeeds with valid phone", async () => {
     const result = await startOutbound({
-      channel: "voice",
+      channel: "phone",
       destination: "+15559876543",
     });
     expect(result.success).toBe(true);
@@ -292,7 +292,7 @@ describe("startOutbound", () => {
   test("voice: passes originConversationId to startVerificationCall", async () => {
     voiceCallInitCalls.length = 0;
     const result = await startOutbound({
-      channel: "voice",
+      channel: "phone",
       destination: "+15559876543",
       originConversationId: "conv-origin-linkage-test",
     });
@@ -305,7 +305,7 @@ describe("startOutbound", () => {
   test("voice: succeeds without originConversationId (backward compat)", async () => {
     voiceCallInitCalls.length = 0;
     const result = await startOutbound({
-      channel: "voice",
+      channel: "phone",
       destination: "+15551119999",
     });
     expect(result.success).toBe(true);
@@ -326,7 +326,7 @@ describe("startOutbound", () => {
 
 describe("resendOutbound", () => {
   test("returns no_active_session when no session exists", () => {
-    const result = resendOutbound({ channel: "voice" });
+    const result = resendOutbound({ channel: "phone" });
     expect(result.success).toBe(false);
     expect(result.error).toBe("no_active_session");
   });
@@ -334,7 +334,7 @@ describe("resendOutbound", () => {
   test("Voice: succeeds when an active session exists and cooldown has passed", async () => {
     // Start a session first
     const startResult = await startOutbound({
-      channel: "voice",
+      channel: "phone",
       destination: "+15551112222",
     });
     expect(startResult.success).toBe(true);
@@ -349,7 +349,7 @@ describe("resendOutbound", () => {
       );
     }
 
-    const resendResult = resendOutbound({ channel: "voice" });
+    const resendResult = resendOutbound({ channel: "phone" });
     expect(resendResult.success).toBe(true);
     expect(resendResult.verificationSessionId).toBeDefined();
     expect(resendResult.sendCount).toBe(2);
@@ -357,7 +357,7 @@ describe("resendOutbound", () => {
 
   test("Voice: preserves originConversationId on resend", async () => {
     const startResult = await startOutbound({
-      channel: "voice",
+      channel: "phone",
       destination: "+15551113333",
     });
     expect(startResult.success).toBe(true);
@@ -372,7 +372,7 @@ describe("resendOutbound", () => {
     }
 
     const resendResult = resendOutbound({
-      channel: "voice",
+      channel: "phone",
       originConversationId: "conv-resend-voice-origin",
     });
     expect(resendResult.success).toBe(true);
@@ -382,7 +382,7 @@ describe("resendOutbound", () => {
   test("voice: preserves originConversationId on resend and passes it to call initiation", async () => {
     voiceCallInitCalls.length = 0;
     const startResult = await startOutbound({
-      channel: "voice",
+      channel: "phone",
       destination: "+15559991111",
     });
     expect(startResult.success).toBe(true);
@@ -397,7 +397,7 @@ describe("resendOutbound", () => {
     }
 
     const resendResult = resendOutbound({
-      channel: "voice",
+      channel: "phone",
       originConversationId: "conv-resend-voice-origin",
     });
     expect(resendResult.success).toBe(true);
@@ -421,21 +421,21 @@ describe("resendOutbound", () => {
 
 describe("cancelOutbound", () => {
   test("returns no_active_session when no session exists", () => {
-    const result = cancelOutbound({ channel: "voice" });
+    const result = cancelOutbound({ channel: "phone" });
     expect(result.success).toBe(false);
     expect(result.error).toBe("no_active_session");
   });
 
   test("succeeds when an active session exists", async () => {
     const startResult = await startOutbound({
-      channel: "voice",
+      channel: "phone",
       destination: "+15553334444",
     });
     expect(startResult.success).toBe(true);
 
-    const cancelResult = cancelOutbound({ channel: "voice" });
+    const cancelResult = cancelOutbound({ channel: "phone" });
     expect(cancelResult.success).toBe(true);
-    expect(cancelResult.channel).toBe("voice");
+    expect(cancelResult.channel).toBe("phone");
   });
 });
 
@@ -457,16 +457,16 @@ describe("HTTP route: handleCreateVerificationSession (guardian path)", () => {
 
   test("creates inbound challenge when destination is absent", async () => {
     // Without a destination, the unified handler takes the inbound challenge path.
-    const req = jsonRequest({ channel: "voice" });
+    const req = jsonRequest({ channel: "phone" });
     const resp = await handleCreateVerificationSession(req, "self");
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as Record<string, unknown>;
     expect(body.success).toBe(true);
-    expect(body.channel).toBe("voice");
+    expect(body.channel).toBe("phone");
   });
 
   test("returns 200 for valid voice start", async () => {
-    const req = jsonRequest({ channel: "voice", destination: "+15559999999" });
+    const req = jsonRequest({ channel: "phone", destination: "+15559999999" });
     const resp = await handleCreateVerificationSession(req, "self");
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as Record<string, unknown>;
@@ -488,7 +488,7 @@ describe("HTTP route: handleResendVerificationSession (guardian path)", () => {
   });
 
   test("returns 400 for no_active_session", async () => {
-    const req = jsonRequest({ channel: "voice" });
+    const req = jsonRequest({ channel: "phone" });
     const resp = await handleResendVerificationSession(req);
     expect(resp.status).toBe(400);
     const body = (await resp.json()) as { error?: string };
@@ -498,7 +498,7 @@ describe("HTTP route: handleResendVerificationSession (guardian path)", () => {
   test("passes originConversationId through on successful resend", async () => {
     // Start a session first
     const startReq = jsonRequest({
-      channel: "voice",
+      channel: "phone",
       destination: "+15556667777",
     });
     const startResp = await handleCreateVerificationSession(startReq, "self");
@@ -516,7 +516,7 @@ describe("HTTP route: handleResendVerificationSession (guardian path)", () => {
     }
 
     const resendReq = jsonRequest({
-      channel: "voice",
+      channel: "phone",
       originConversationId: "conv-resend-http-origin",
     });
     const resendResp = await handleResendVerificationSession(resendReq);
@@ -542,7 +542,7 @@ describe("HTTP route: handleCancelVerificationSession (guardian path)", () => {
   test("returns 200 even when no active session exists", async () => {
     // The unified cancel handler silently cancels both inbound and outbound —
     // no error if nothing is active.
-    const req = jsonRequest({ channel: "voice" });
+    const req = jsonRequest({ channel: "phone" });
     const resp = await handleCancelVerificationSession(req);
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as Record<string, unknown>;
@@ -552,14 +552,14 @@ describe("HTTP route: handleCancelVerificationSession (guardian path)", () => {
   test("returns 200 when active session is cancelled", async () => {
     // Start a session
     const startReq = jsonRequest({
-      channel: "voice",
+      channel: "phone",
       destination: "+15558887777",
     });
     const startResp = await handleCreateVerificationSession(startReq, "self");
     expect(startResp.status).toBe(200);
 
     // Cancel it
-    const cancelReq = jsonRequest({ channel: "voice" });
+    const cancelReq = jsonRequest({ channel: "phone" });
     const cancelResp = await handleCancelVerificationSession(cancelReq);
     expect(cancelResp.status).toBe(200);
     const body = (await cancelResp.json()) as Record<string, unknown>;
@@ -574,7 +574,7 @@ describe("HTTP route: handleCancelVerificationSession (guardian path)", () => {
 describe("origin conversation linkage", () => {
   test("startOutbound voice echoes originConversationId in result (first number)", async () => {
     const result = await startOutbound({
-      channel: "voice",
+      channel: "phone",
       destination: "+15551119999",
       originConversationId: "conv-origin-voice-test-1",
     });
@@ -584,7 +584,7 @@ describe("origin conversation linkage", () => {
 
   test("startOutbound voice echoes originConversationId in result (second number)", async () => {
     const result = await startOutbound({
-      channel: "voice",
+      channel: "phone",
       destination: "+15552229999",
       originConversationId: "conv-origin-voice-test",
     });
@@ -604,7 +604,7 @@ describe("origin conversation linkage", () => {
 
   test("startOutbound without originConversationId returns undefined for field", async () => {
     const result = await startOutbound({
-      channel: "voice",
+      channel: "phone",
       destination: "+15553338888",
     });
     expect(result.success).toBe(true);
@@ -613,7 +613,7 @@ describe("origin conversation linkage", () => {
 
   test("HTTP handleCreateVerificationSession passes originConversationId through", async () => {
     const req = jsonRequest({
-      channel: "voice",
+      channel: "phone",
       destination: "+15557776666",
       originConversationId: "conv-origin-http-test",
     });
@@ -626,7 +626,7 @@ describe("origin conversation linkage", () => {
 
   test("voice call initiation receives originConversationId", async () => {
     const result = await startOutbound({
-      channel: "voice",
+      channel: "phone",
       destination: "+15554443333",
       originConversationId: "conv-origin-voice-init",
     });
@@ -647,7 +647,7 @@ describe("origin conversation linkage", () => {
 
     // Start a voice session (no origin initially)
     const startResult = await startOutbound({
-      channel: "voice",
+      channel: "phone",
       destination: "+15552228888",
     });
     expect(startResult.success).toBe(true);
@@ -664,7 +664,7 @@ describe("origin conversation linkage", () => {
 
     // Resend with origin conversation ID
     const resendResult = resendOutbound({
-      channel: "voice",
+      channel: "phone",
       originConversationId: "conv-resend-origin-linkage",
     });
     expect(resendResult.success).toBe(true);

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -304,7 +304,7 @@ describe("non-member access request notification", () => {
   test("cross-channel fallback: voice guardian binding resolves for Telegram access request", async () => {
     // Only a voice guardian binding exists — no Telegram binding
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "guardian-voice-user",
       guardianDeliveryChatId: "guardian-voice-chat",
       guardianPrincipalId: "test-principal-id",
@@ -324,7 +324,7 @@ describe("non-member access request notification", () => {
       string,
       unknown
     >;
-    expect(payload.guardianBindingChannel).toBe("voice");
+    expect(payload.guardianBindingChannel).toBe("phone");
 
     // Canonical request has the voice guardian's external user ID
     const pending = listCanonicalGuardianRequests({
@@ -415,7 +415,7 @@ describe("access-request-helper unit tests", () => {
   test("notifyGuardianOfAccessRequest uses cross-channel binding when source-channel binding is missing", () => {
     // Only voice binding exists
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "guardian-voice",
       guardianDeliveryChatId: "voice-chat",
       guardianPrincipalId: "test-principal-id",
@@ -444,7 +444,7 @@ describe("access-request-helper unit tests", () => {
       string,
       unknown
     >;
-    expect(payload.guardianBindingChannel).toBe("voice");
+    expect(payload.guardianBindingChannel).toBe("phone");
   });
 
   test("notifyGuardianOfAccessRequest prefers source-channel binding over cross-channel fallback", () => {
@@ -457,7 +457,7 @@ describe("access-request-helper unit tests", () => {
       verifiedVia: "test",
     });
     createGuardianBinding({
-      channel: "voice",
+      channel: "phone",
       guardianExternalUserId: "guardian-voice",
       guardianDeliveryChatId: "voice-chat",
       guardianPrincipalId: "test-principal-voice",
@@ -492,7 +492,7 @@ describe("access-request-helper unit tests", () => {
   test("notifyGuardianOfAccessRequest for voice channel includes actorDisplayName in contextPayload", () => {
     const result = notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       conversationExternalId: "+15559998888",
       actorExternalId: "+15559998888",
       actorDisplayName: "Alice Caller",
@@ -505,7 +505,7 @@ describe("access-request-helper unit tests", () => {
       string,
       unknown
     >;
-    expect(payload.sourceChannel).toBe("voice");
+    expect(payload.sourceChannel).toBe("phone");
     expect(payload.actorDisplayName).toBe("Alice Caller");
     expect(payload.actorExternalId).toBe("+15559998888");
     expect(payload.senderIdentifier).toBe("Alice Caller");
@@ -514,7 +514,7 @@ describe("access-request-helper unit tests", () => {
     const pending = listCanonicalGuardianRequests({
       status: "pending",
       requesterExternalUserId: "+15559998888",
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       kind: "access_request",
     });
     expect(pending.length).toBe(1);
@@ -584,7 +584,7 @@ describe("access-request-helper unit tests", () => {
 
     const result = notifyGuardianOfAccessRequest({
       canonicalAssistantId: "self",
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       conversationExternalId: "+15556667777",
       actorExternalId: "+15556667777",
       actorDisplayName: "Noah",

--- a/assistant/src/__tests__/notification-decision-fallback.test.ts
+++ b/assistant/src/__tests__/notification-decision-fallback.test.ts
@@ -64,7 +64,7 @@ function makeSignal(
   return {
     signalId: "sig-fallback-guardian-1",
     createdAt: Date.now(),
-    sourceChannel: "voice",
+    sourceChannel: "phone",
     sourceSessionId: "call-session-1",
     sourceEventName: "guardian.question",
     contextPayload: {

--- a/assistant/src/__tests__/session-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/session-runtime-assembly.test.ts
@@ -631,7 +631,7 @@ describe("injectInboundActorContext", () => {
 
   test("prepends inbound_actor_context block to user message", () => {
     const ctx: InboundActorContext = {
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       canonicalActorIdentity: "guardian-user-1",
       actorIdentifier: "+15550001111",
       actorDisplayName: "Guardian Name",
@@ -648,7 +648,7 @@ describe("injectInboundActorContext", () => {
     const text = (injected as { type: "text"; text: string }).text;
     expect(text).toContain("<inbound_actor_context>");
     expect(text).toContain("trust_class: guardian");
-    expect(text).toContain("source_channel: voice");
+    expect(text).toContain("source_channel: phone");
     expect(text).toContain("canonical_actor_identity: guardian-user-1");
     expect(text).toContain("actor_display_name: Guardian Name");
     expect(text).toContain("actor_sender_display_name: Guardian Name");
@@ -733,7 +733,7 @@ describe("injectInboundActorContext", () => {
 
   test("omits member_status and member_policy when not provided", () => {
     const ctx: InboundActorContext = {
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       canonicalActorIdentity: "user-1",
       trustClass: "unknown",
     };
@@ -779,7 +779,7 @@ describe("applyRuntimeInjections with inboundActorContext", () => {
   test("injects inbound actor context when provided", () => {
     const result = applyRuntimeInjections(baseMessages, {
       inboundActorContext: {
-        sourceChannel: "voice",
+        sourceChannel: "phone",
         canonicalActorIdentity: "requester-1",
         actorIdentifier: "+15550002222",
         trustClass: "trusted_contact",

--- a/assistant/src/__tests__/slack-block-formatting.test.ts
+++ b/assistant/src/__tests__/slack-block-formatting.test.ts
@@ -93,7 +93,7 @@ describe("isSlackCallbackUrl", () => {
   test("returns false for managed outbound URLs", () => {
     expect(
       isSlackCallbackUrl(
-        "http://localhost:7830/v1/internal/managed-gateway/outbound-send/?route_id=r1&assistant_id=a1&source_channel=voice",
+        "http://localhost:7830/v1/internal/managed-gateway/outbound-send/?route_id=r1&assistant_id=a1&source_channel=phone",
       ),
     ).toBe(false);
   });

--- a/assistant/src/__tests__/verification-session-intent-routing.test.ts
+++ b/assistant/src/__tests__/verification-session-intent-routing.test.ts
@@ -157,8 +157,8 @@ describe("channel hint extraction", () => {
     );
     expect(result.kind).toBe("direct_setup");
     if (result.kind === "direct_setup") {
-      expect(result.channelHint).toBe("voice");
-      expect(result.rewrittenContent).toContain("voice channel");
+      expect(result.channelHint).toBe("phone");
+      expect(result.rewrittenContent).toContain("phone channel");
     }
   });
 

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -148,7 +148,7 @@ describe("redeemVoiceInviteCode", () => {
     const codeHash = hashVoiceCode(code);
 
     const { invite } = createInvite({
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       maxUses: opts.maxUses ?? 1,
       expiresInMs: opts.expiresInMs,
       expectedExternalUserId: opts.callerPhone ?? "+15551234567",
@@ -165,7 +165,7 @@ describe("redeemVoiceInviteCode", () => {
 
     const result = redeemVoiceInviteCode({
       callerExternalUserId: phone,
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       code,
     });
 
@@ -184,14 +184,14 @@ describe("redeemVoiceInviteCode", () => {
 
     const result = redeemVoiceInviteCode({
       callerExternalUserId: phone,
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       code,
     });
 
     expect(result.ok).toBe(true);
 
     const channelResult = findContactChannel({
-      channelType: "voice",
+      channelType: "phone",
       externalUserId: phone,
     });
 
@@ -206,7 +206,7 @@ describe("redeemVoiceInviteCode", () => {
 
     const result = redeemVoiceInviteCode({
       callerExternalUserId: "+19999999999",
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       code,
     });
 
@@ -218,7 +218,7 @@ describe("redeemVoiceInviteCode", () => {
 
     const result = redeemVoiceInviteCode({
       callerExternalUserId: "+15551234567",
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       code: "000000",
     });
 
@@ -231,7 +231,7 @@ describe("redeemVoiceInviteCode", () => {
 
     const result = redeemVoiceInviteCode({
       callerExternalUserId: phone,
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       code,
     });
 
@@ -245,7 +245,7 @@ describe("redeemVoiceInviteCode", () => {
     // First redemption succeeds
     const first = redeemVoiceInviteCode({
       callerExternalUserId: phone,
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       code,
     });
     expect(first.ok).toBe(true);
@@ -253,7 +253,7 @@ describe("redeemVoiceInviteCode", () => {
     // Second redemption fails — max uses exhausted
     const second = redeemVoiceInviteCode({
       callerExternalUserId: phone,
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       code,
     });
     expect(second).toEqual({ ok: false, reason: "invalid_or_expired" });
@@ -267,7 +267,7 @@ describe("redeemVoiceInviteCode", () => {
 
     const result = redeemVoiceInviteCode({
       callerExternalUserId: phone,
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       code,
     });
 
@@ -291,7 +291,7 @@ describe("redeemVoiceInviteCode", () => {
 
     const result = redeemVoiceInviteCode({
       callerExternalUserId: "+15551234567",
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       code,
     });
 
@@ -306,7 +306,7 @@ describe("redeemVoiceInviteCode", () => {
 
     // Pre-create an active member for this phone on voice channel
     upsertContactChannel({
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       externalUserId: phone,
       status: "active",
       policy: "allow",
@@ -314,7 +314,7 @@ describe("redeemVoiceInviteCode", () => {
 
     const result = redeemVoiceInviteCode({
       callerExternalUserId: phone,
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       code,
     });
 
@@ -331,7 +331,7 @@ describe("redeemVoiceInviteCode", () => {
     const { code } = createVoiceInvite({ callerPhone: phone });
 
     upsertContactChannel({
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       externalUserId: phone,
       status: "blocked",
       policy: "deny",
@@ -339,7 +339,7 @@ describe("redeemVoiceInviteCode", () => {
 
     const result = redeemVoiceInviteCode({
       callerExternalUserId: phone,
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       code,
     });
 
@@ -349,7 +349,7 @@ describe("redeemVoiceInviteCode", () => {
   test("empty callerExternalUserId fails", () => {
     const result = redeemVoiceInviteCode({
       callerExternalUserId: "",
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       code: "123456",
     });
 

--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -257,9 +257,9 @@ function grantParams(
     scopeMode: "tool_signature",
     toolName: TOOL_NAME,
     inputDigest: computeToolApprovalDigest(TOOL_NAME, TOOL_INPUT),
-    requestChannel: "voice",
+    requestChannel: "phone",
     decisionChannel: "telegram",
-    executionChannel: "voice",
+    executionChannel: "phone",
     conversationId: CONVERSATION_ID,
     callSessionId: CALL_SESSION_ID,
     expiresAt: futureExpiry,
@@ -285,7 +285,7 @@ describe("voice bridge confirmation handling (grant consumption via primitive)",
     setupBridgeDeps(() => mockData.session);
 
     const trustContext: TrustContext = {
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       trustClass: "trusted_contact",
       requesterExternalUserId: "caller-123",
     };
@@ -329,7 +329,7 @@ describe("voice bridge confirmation handling (grant consumption via primitive)",
     setupBridgeDeps(() => mockData.session);
 
     const trustContext: TrustContext = {
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       trustClass: "trusted_contact",
       requesterExternalUserId: "caller-123",
     };
@@ -367,7 +367,7 @@ describe("voice bridge confirmation handling (grant consumption via primitive)",
     setupBridgeDeps(() => mockData.session);
 
     const trustContext: TrustContext = {
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       trustClass: "trusted_contact",
     };
 
@@ -397,7 +397,7 @@ describe("voice bridge confirmation handling (grant consumption via primitive)",
     setupBridgeDeps(() => mockData.session);
 
     const trustContext: TrustContext = {
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       trustClass: "guardian",
     };
 

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -323,8 +323,8 @@ describe("voice-session-bridge", () => {
     await new Promise((r) => setTimeout(r, 50));
 
     expect(capturedTurnChannelContext).toEqual({
-      userMessageChannel: "voice",
-      assistantMessageChannel: "voice",
+      userMessageChannel: "phone",
+      assistantMessageChannel: "phone",
     });
   });
 
@@ -358,7 +358,7 @@ describe("voice-session-bridge", () => {
       content: "Hello",
       isInbound: true,
       trustContext: {
-        sourceChannel: "voice",
+        sourceChannel: "phone",
         trustClass: "trusted_contact",
         guardianExternalUserId: "+15550009999",
         guardianChatId: "+15550009999",
@@ -404,7 +404,7 @@ describe("voice-session-bridge", () => {
       content: "Hello",
       isInbound: true,
       trustContext: {
-        sourceChannel: "voice",
+        sourceChannel: "phone",
         trustClass: "unknown",
       },
       onTextDelta: () => {},
@@ -447,7 +447,7 @@ describe("voice-session-bridge", () => {
       content: "Hello",
       isInbound: true,
       trustContext: {
-        sourceChannel: "voice",
+        sourceChannel: "phone",
         trustClass: "guardian",
         guardianExternalUserId: "+15550001111",
         guardianChatId: "+15550001111",
@@ -482,7 +482,7 @@ describe("voice-session-bridge", () => {
     injectDeps(() => session);
 
     const trustCtx = {
-      sourceChannel: "voice" as const,
+      sourceChannel: "phone" as const,
       trustClass: "guardian" as const,
       guardianExternalUserId: "+15550001111",
       guardianChatId: "+15550001111",
@@ -527,7 +527,7 @@ describe("voice-session-bridge", () => {
       content: "Hello there",
       isInbound: true,
       trustContext: {
-        sourceChannel: "voice",
+        sourceChannel: "phone",
         trustClass: "trusted_contact",
       },
       onTextDelta: () => {},
@@ -587,7 +587,7 @@ describe("voice-session-bridge", () => {
       content: "Hi",
       isInbound: true,
       trustContext: {
-        sourceChannel: "voice",
+        sourceChannel: "phone",
         trustClass: "trusted_contact",
       },
       onTextDelta: () => {},
@@ -675,7 +675,7 @@ describe("voice-session-bridge", () => {
       content: "Delete everything",
       isInbound: true,
       trustContext: {
-        sourceChannel: "voice",
+        sourceChannel: "phone",
         trustClass: "trusted_contact",
         guardianExternalUserId: "+15550009999",
         guardianChatId: "+15550009999",
@@ -748,7 +748,7 @@ describe("voice-session-bridge", () => {
       content: "Make a request",
       isInbound: true,
       trustContext: {
-        sourceChannel: "voice",
+        sourceChannel: "phone",
         trustClass: "unknown",
       },
       onTextDelta: () => {},
@@ -880,7 +880,7 @@ describe("voice-session-bridge", () => {
       content: "List files",
       isInbound: true,
       trustContext: {
-        sourceChannel: "voice",
+        sourceChannel: "phone",
         trustClass: "guardian",
         guardianExternalUserId: "+15550001111",
         guardianChatId: "+15550001111",
@@ -953,7 +953,7 @@ describe("voice-session-bridge", () => {
       content: "check github status",
       isInbound: true,
       trustContext: {
-        sourceChannel: "voice",
+        sourceChannel: "phone",
         trustClass: "guardian",
         guardianExternalUserId: "+15550001111",
         guardianChatId: "+15550001111",

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -456,10 +456,10 @@ const accessRequestResolver: GuardianRequestResolver = {
     // Voice approvals: directly activate the trusted contact without minting
     // a verification session. The caller is already on the line and the
     // relay server's in-call wait loop will detect the approved status.
-    if (channel === "voice") {
+    if (channel === "phone") {
       try {
         upsertContactChannel({
-          sourceChannel: "voice",
+          sourceChannel: "phone",
           externalUserId: requesterExternalUserId,
           externalChatId: requesterChatId,
           status: "active",

--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -136,7 +136,7 @@ async function dispatchGuardianQuestionInner(
     const request = createCanonicalGuardianRequest({
       kind: "pending_question",
       sourceType: "voice",
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       conversationId,
       callSessionId,
       pendingQuestionId: pendingQuestion.id,
@@ -203,7 +203,7 @@ async function dispatchGuardianQuestionInner(
       request.requestCode ?? request.id.slice(0, 6).toUpperCase();
     const signalResult = await emitNotificationSignal({
       sourceEventName: "guardian.question",
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       sourceSessionId: callSessionId,
       attentionHints: {
         requiresAction: true,

--- a/assistant/src/calls/relay-access-wait.ts
+++ b/assistant/src/calls/relay-access-wait.ts
@@ -251,7 +251,7 @@ export function emitAccessRequestCallbackHandoff(
   if (fromNumber) {
     try {
       const contactResult = findContactChannel({
-        channelType: "voice",
+        channelType: "phone",
         externalUserId: fromNumber,
         externalChatId: fromNumber,
       });
@@ -277,7 +277,7 @@ export function emitAccessRequestCallbackHandoff(
 
   void emitNotificationSignal({
     sourceEventName: "ingress.access_request.callback_handoff",
-    sourceChannel: "voice",
+    sourceChannel: "phone",
     sourceSessionId,
     attentionHints: {
       requiresAction: false,
@@ -289,7 +289,7 @@ export function emitAccessRequestCallbackHandoff(
       requestId: params.accessRequestId,
       requestCode: canonicalRequest?.requestCode ?? null,
       callSessionId: params.callSessionId,
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       reason: params.reason,
       callbackOptIn: true,
       callerPhoneNumber: fromNumber,
@@ -297,7 +297,7 @@ export function emitAccessRequestCallbackHandoff(
       requesterExternalUserId: fromNumber,
       requesterChatId: fromNumber,
       requesterMemberId,
-      requesterMemberSourceChannel: requesterMemberId ? "voice" : null,
+      requesterMemberSourceChannel: requesterMemberId ? "phone" : null,
     },
     dedupeKey,
   })

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -726,10 +726,10 @@ export class RelayConnection {
         "assistant",
         JSON.stringify([{ type: "text", text: codeMsg }]),
         {
-          userMessageChannel: "voice",
-          assistantMessageChannel: "voice",
-          userMessageInterface: "voice",
-          assistantMessageInterface: "voice",
+          userMessageChannel: "phone",
+          assistantMessageChannel: "phone",
+          userMessageInterface: "phone",
+          assistantMessageInterface: "phone",
         },
       );
     }
@@ -782,7 +782,7 @@ export class RelayConnection {
     if (!params.skipMemberActivation) {
       try {
         upsertContactChannel({
-          sourceChannel: "voice",
+          sourceChannel: "phone",
           externalUserId: fromNumber,
           externalChatId: fromNumber,
           displayName: callerName,
@@ -799,7 +799,7 @@ export class RelayConnection {
 
     const updatedTrust = resolveActorTrust({
       assistantId,
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       conversationExternalId: fromNumber,
       actorExternalId: fromNumber,
     });
@@ -959,9 +959,9 @@ export class RelayConnection {
             "Guardian binding conflict: another user already holds the voice binding",
           );
         } else {
-          revokeGuardianBinding("voice");
+          revokeGuardianBinding("phone");
           createGuardianBinding({
-            channel: "voice",
+            channel: "phone",
             guardianExternalUserId: fromNumber,
             guardianDeliveryChatId: fromNumber,
             guardianPrincipalId: result.canonicalPrincipal!,
@@ -985,7 +985,7 @@ export class RelayConnection {
             successSession.initiatedFromConversationId,
             "verification_succeeded",
             successSession.toNumber,
-            { channel: "voice" },
+            { channel: "phone" },
           ).catch((err) => {
             log.warn(
               {
@@ -1011,7 +1011,7 @@ export class RelayConnection {
         if (this.controller) {
           const verifiedActorTrust = resolveActorTrust({
             assistantId,
-            sourceChannel: "voice",
+            sourceChannel: "phone",
             conversationExternalId: fromNumber,
             actorExternalId: fromNumber,
           });
@@ -1055,7 +1055,7 @@ export class RelayConnection {
             "verification_failed",
             failSession.toNumber,
             {
-              channel: "voice",
+              channel: "phone",
               reason: "Max verification attempts exceeded",
             },
           ).catch((err) => {
@@ -1197,7 +1197,7 @@ export class RelayConnection {
     try {
       const accessResult = notifyGuardianOfAccessRequest({
         canonicalAssistantId: this.accessRequestAssistantId,
-        sourceChannel: "voice",
+        sourceChannel: "phone",
         conversationExternalId: this.accessRequestFromNumber,
         actorExternalId: this.accessRequestFromNumber,
         actorDisplayName: callerName,
@@ -1587,7 +1587,7 @@ export class RelayConnection {
    */
   private resolveGuardianLabel(): string {
     // Look up the guardian contact for a displayName fallback
-    const voiceGuardian = findGuardianForChannel("voice");
+    const voiceGuardian = findGuardianForChannel("phone");
     const guardianChannels = voiceGuardian ? null : listGuardianChannels();
     const guardianContact = voiceGuardian?.contact ?? guardianChannels?.contact;
 
@@ -1922,10 +1922,10 @@ export class RelayConnection {
             "user",
             JSON.stringify([{ type: "text", text: msg.voicePrompt }]),
             {
-              userMessageChannel: "voice",
-              assistantMessageChannel: "voice",
-              userMessageInterface: "voice",
-              assistantMessageInterface: "voice",
+              userMessageChannel: "phone",
+              assistantMessageChannel: "phone",
+              userMessageInterface: "phone",
+              assistantMessageInterface: "phone",
             },
           );
         } catch (err) {

--- a/assistant/src/calls/relay-setup-router.ts
+++ b/assistant/src/calls/relay-setup-router.ts
@@ -87,7 +87,7 @@ export function routeSetup(ctx: SetupContext): {
 
   const actorTrust = resolveActorTrust({
     assistantId,
-    sourceChannel: "voice",
+    sourceChannel: "phone",
     conversationExternalId: otherPartyNumber,
     actorExternalId: otherPartyNumber || undefined,
   });
@@ -159,7 +159,7 @@ export function routeSetup(ctx: SetupContext): {
   }
 
   // ── Inbound call ACL evaluation ─────────────────────────────────
-  const pendingChallenge = getPendingSession("voice");
+  const pendingChallenge = getPendingSession("phone");
 
   if (actorTrust.trustClass === "unknown" && !pendingChallenge) {
     // Check for blocked caller

--- a/assistant/src/calls/relay-verification.ts
+++ b/assistant/src/calls/relay-verification.ts
@@ -126,7 +126,7 @@ export function attemptVerificationCode(
   } = params;
 
   const result = validateAndConsumeVerification(
-    "voice",
+    "phone",
     enteredCode,
     verificationFromNumber,
     verificationFromNumber,
@@ -144,7 +144,7 @@ export function attemptVerificationCode(
     if (result.verificationType === "guardian") {
       const existingBinding = getGuardianBinding(
         verificationAssistantId,
-        "voice",
+        "phone",
       );
       if (
         existingBinding &&
@@ -257,7 +257,7 @@ export function attemptInviteCodeRedemption(
   const result = redeemVoiceInviteCode({
     assistantId: inviteRedemptionAssistantId,
     callerExternalUserId: inviteRedemptionFromNumber,
-    sourceChannel: "voice",
+    sourceChannel: "phone",
     code: enteredCode,
   });
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -283,7 +283,7 @@ export async function startVoiceTurn(
 
   // Get or create the session
   const transport = {
-    channelId: "voice" as ChannelId,
+    channelId: "phone" as ChannelId,
   };
   const session = await deps.getOrCreateSession(opts.conversationId, transport);
 
@@ -321,11 +321,11 @@ export async function startVoiceTurn(
   session.setTrustContext(opts.trustContext ?? null);
   session.setCommandIntent(null);
   session.setTurnChannelContext({
-    userMessageChannel: "voice",
-    assistantMessageChannel: "voice",
+    userMessageChannel: "phone",
+    assistantMessageChannel: "phone",
   });
   session.setChannelCapabilities(
-    resolveChannelCapabilities("voice", undefined),
+    resolveChannelCapabilities("phone", undefined),
   );
   session.setVoiceCallControlPrompt(voiceCallControlPrompt);
 
@@ -392,7 +392,7 @@ export async function startVoiceTurn(
               toolName: msg.toolName,
               inputDigest,
               consumingRequestId: msg.requestId,
-              executionChannel: "voice",
+              executionChannel: "phone",
               conversationId: opts.conversationId,
               callSessionId: opts.callSessionId,
               requesterExternalUserId:

--- a/assistant/src/channels/config.ts
+++ b/assistant/src/channels/config.ts
@@ -72,7 +72,7 @@ const CHANNEL_POLICIES = {
       codeRedemptionEnabled: true,
     },
   },
-  voice: {
+  phone: {
     notification: {
       deliveryEnabled: false,
       conversationStrategy: "not_deliverable",

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -1,6 +1,6 @@
 export const CHANNEL_IDS = [
   "telegram",
-  "voice",
+  "phone",
   "vellum",
   "whatsapp",
   "slack",
@@ -43,7 +43,7 @@ export const INTERFACE_IDS = [
   "ios",
   "cli",
   "telegram",
-  "voice",
+  "phone",
   "vellum",
   "whatsapp",
   "slack",

--- a/assistant/src/cli/contacts.ts
+++ b/assistant/src/cli/contacts.ts
@@ -672,7 +672,7 @@ Examples:
             const result = redeemVoiceInviteCode({
               code: opts.code,
               callerExternalUserId: opts.callerExternalUserId,
-              sourceChannel: "voice",
+              sourceChannel: "phone",
               ...(opts.assistantId ? { assistantId: opts.assistantId } : {}),
             });
             if (result.ok) {

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -153,7 +153,7 @@ If they agree, ask for their personal phone number and place a test call with a 
 
 Link the user's phone number as the trusted voice guardian so the assistant can verify inbound callers.
 
-Load the guardian-verify-setup skill with `channel: "voice"`:
+Load the guardian-verify-setup skill with `channel: "phone"`:
 
 ```
 skill_load skill=guardian-verify-setup
@@ -164,7 +164,7 @@ The skill handles the full verification flow (outbound call, code entry, confirm
 To re-check guardian status later:
 
 ```bash
-assistant integrations guardian status --channel voice --json
+assistant integrations guardian status --channel phone --json
 ```
 
 ## Caller Identity

--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -185,7 +185,7 @@ Tell the user: **"Twilio is configured. Your assistant's phone number is {phoneN
 
 Link the user's phone number as the trusted voice guardian so the assistant can verify inbound callers.
 
-Load the guardian-verify-setup skill with `channel: "voice"`:
+Load the guardian-verify-setup skill with `channel: "phone"`:
 
 ```
 skill_load skill=guardian-verify-setup
@@ -196,7 +196,7 @@ The skill handles the full verification flow (outbound call, code entry, confirm
 To re-check guardian status later:
 
 ```bash
-assistant integrations guardian status --channel voice --json
+assistant integrations guardian status --channel phone --json
 ```
 
 ## Clearing Credentials

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -236,7 +236,7 @@ const SESSION_TTL_SECONDS = 600;
 function toVerificationChannel(channelType: string): ChannelId | null {
   switch (channelType) {
     case "phone":
-      return "voice";
+      return "phone";
     case "telegram":
       return "telegram";
     case "slack":

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -139,7 +139,7 @@ function resolveTurnInterface(sourceInterface?: string): InterfaceId {
 function resolveCanonicalRequestSourceType(
   sourceChannel: string | undefined,
 ): "desktop" | "channel" | "voice" {
-  if (sourceChannel === "voice") {
+  if (sourceChannel === "phone") {
     return "voice";
   }
   if (sourceChannel === "vellum") {

--- a/assistant/src/daemon/session-notifiers.ts
+++ b/assistant/src/daemon/session-notifiers.ts
@@ -114,10 +114,10 @@ export function registerSessionNotifiers(
         JSON.stringify([{ type: "text", text: questionText }]),
         {
           ...provenanceFromTrustContext(ctx.trustContext),
-          userMessageChannel: "voice",
-          assistantMessageChannel: "voice",
-          userMessageInterface: "voice",
-          assistantMessageInterface: "voice",
+          userMessageChannel: "phone",
+          assistantMessageChannel: "phone",
+          userMessageInterface: "phone",
+          assistantMessageInterface: "phone",
         },
       );
 

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -345,7 +345,7 @@ export function resolveChannelCapabilities(
       };
     }
     case "telegram":
-    case "voice":
+    case "phone":
     case "whatsapp":
     case "slack":
     case "email":

--- a/assistant/src/daemon/verification-session-intent.ts
+++ b/assistant/src/daemon/verification-session-intent.ts
@@ -10,7 +10,7 @@ export type VerificationSessionIntentResult =
   | {
       kind: "direct_setup";
       rewrittenContent: string;
-      channelHint?: "voice" | "telegram" | "slack";
+      channelHint?: "phone" | "telegram" | "slack";
     };
 
 // -- Direct setup patterns ----------------------------------------------------
@@ -48,9 +48,9 @@ const CONCEPTUAL_PATTERNS: RegExp[] = [
 
 const CHANNEL_HINT_PATTERNS: Array<{
   pattern: RegExp;
-  channel: "voice" | "telegram" | "slack";
+  channel: "phone" | "telegram" | "slack";
 }> = [
-  { pattern: /\b(?:voice|call|phone\s*call|by\s+phone)\b/i, channel: "voice" },
+  { pattern: /\b(?:voice|call|phone\s*call|by\s+phone)\b/i, channel: "phone" },
   { pattern: /\btelegram\b/i, channel: "telegram" },
   { pattern: /\bslack\b/i, channel: "slack" },
 ];
@@ -72,7 +72,7 @@ function isDirectSetupIntent(text: string): boolean {
 
 function extractChannelHint(
   text: string,
-): "voice" | "telegram" | "slack" | undefined {
+): "phone" | "telegram" | "slack" | undefined {
   for (const { pattern, channel } of CHANNEL_HINT_PATTERNS) {
     if (pattern.test(text)) return channel;
   }

--- a/assistant/src/memory/invite-store.ts
+++ b/assistant/src/memory/invite-store.ts
@@ -331,7 +331,7 @@ export function findActiveVoiceInvites(params: {
     .from(assistantIngressInvites)
     .where(
       and(
-        eq(assistantIngressInvites.sourceChannel, "voice"),
+        eq(assistantIngressInvites.sourceChannel, "phone"),
         eq(assistantIngressInvites.status, "active"),
         eq(
           assistantIngressInvites.expectedExternalUserId,

--- a/assistant/src/memory/migrations/036-normalize-phone-identities.ts
+++ b/assistant/src/memory/migrations/036-normalize-phone-identities.ts
@@ -33,7 +33,7 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
     .get(checkpointKey);
   if (checkpoint) return;
 
-  const PHONE_CHANNELS = ["sms", "voice", "whatsapp"];
+  const PHONE_CHANNELS = ["sms", "phone", "whatsapp"];
 
   /**
    * Unique key scope definition for collision detection.

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -82,7 +82,7 @@ export function buildAccessRequestIdentityLine(
       : undefined,
   );
 
-  if (sourceChannel === "voice" && callerName) {
+  if (sourceChannel === "phone" && callerName) {
     const safeName = sanitizeIdentityField(callerName);
     const safeId = sanitizeIdentityField(
       str(payload.actorExternalId, requester),

--- a/assistant/src/notifications/signal.ts
+++ b/assistant/src/notifications/signal.ts
@@ -11,7 +11,7 @@ import type { GuardianQuestionPayload } from "./guardian-question-mode.js";
 export const NOTIFICATION_SOURCE_CHANNELS = [
   { id: "assistant_tool", description: "Assistant skill/tool invocation" },
   { id: "vellum", description: "Vellum native client (macOS/iOS)" },
-  { id: "voice", description: "Voice call pipeline" },
+  { id: "phone", description: "Phone call pipeline" },
   { id: "telegram", description: "Telegram channel" },
   { id: "slack", description: "Slack channel" },
   { id: "scheduler", description: "Scheduled task runner (reminders, cron)" },

--- a/assistant/src/runtime/approval-message-composer.ts
+++ b/assistant/src/runtime/approval-message-composer.ts
@@ -257,7 +257,7 @@ export function getFallbackMessage(context: ApprovalMessageContext): string {
       // Detect whether the code is a short numeric (identity-bound outbound)
       // or a high-entropy hex (inbound challenge/bootstrap) and adjust wording.
       const isNumeric = /^\d{4,8}$/.test(code);
-      if (context.channel === "voice") {
+      if (context.channel === "phone") {
         if (isNumeric) {
           return `To complete guardian verification, speak or enter the ${code.length}-digit code: ${code}.`;
         }

--- a/assistant/src/runtime/channel-invite-transports/voice.ts
+++ b/assistant/src/runtime/channel-invite-transports/voice.ts
@@ -22,7 +22,7 @@ import type {
 // ---------------------------------------------------------------------------
 
 export const voiceInviteAdapter: ChannelInviteAdapter = {
-  channel: "voice" as ChannelId,
+  channel: "phone" as ChannelId,
 
   buildShareLink(_params: {
     rawToken: string;

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -34,7 +34,7 @@ function hasIngressConfigured(): boolean {
 // ── Voice Probe ─────────────────────────────────────────────────────────────
 
 const voiceProbe: ChannelProbe = {
-  channel: "voice",
+  channel: "phone",
   async runLocalChecks(): Promise<ReadinessCheckResult[]> {
     const results: ReadinessCheckResult[] = [];
 

--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -49,7 +49,7 @@ interface ManagedOutboundCallbackContext {
   requestUrl: string;
   routeId: string;
   assistantId: string;
-  sourceChannel: "voice";
+  sourceChannel: "phone";
   sourceUpdateId?: string;
   callbackToken?: string;
 }
@@ -136,7 +136,7 @@ function parseManagedOutboundCallback(
   const assistantId = parsed.searchParams.get("assistant_id")?.trim();
   const sourceChannel = parsed.searchParams.get("source_channel")?.trim();
 
-  if (!routeId || !assistantId || sourceChannel !== "voice") {
+  if (!routeId || !assistantId || sourceChannel !== "phone") {
     throw new Error(
       "Managed outbound callback URL is missing required route_id, assistant_id, or source_channel.",
     );

--- a/assistant/src/runtime/invite-redemption-service.ts
+++ b/assistant/src/runtime/invite-redemption-service.ts
@@ -285,7 +285,7 @@ export function redeemInvite(params: {
 export function redeemVoiceInviteCode(params: {
   assistantId?: string;
   callerExternalUserId: string;
-  sourceChannel: "voice";
+  sourceChannel: "phone";
   code: string;
 }): VoiceRedemptionOutcome {
   const { callerExternalUserId, code } = params;
@@ -325,16 +325,16 @@ export function redeemVoiceInviteCode(params: {
   }
 
   // Channel enforcement: voice invites can only be redeemed on the voice channel
-  if (invite.sourceChannel !== "voice") {
+  if (invite.sourceChannel !== "phone") {
     return { ok: false, reason: "invalid_or_expired" };
   }
 
   // Check for existing membership
   const canonicalCallerId =
-    canonicalizeInboundIdentity("voice" as ChannelId, callerExternalUserId) ??
+    canonicalizeInboundIdentity("phone" as ChannelId, callerExternalUserId) ??
     callerExternalUserId;
   const voiceContactResult = findContactChannel({
-    channelType: "voice",
+    channelType: "phone",
     externalUserId: canonicalCallerId,
   });
   const existingVoiceChannel = voiceContactResult?.channel ?? null;
@@ -367,7 +367,7 @@ export function redeemVoiceInviteCode(params: {
     getSqlite()
       .transaction(() => {
         const writeResult = upsertContactChannel({
-          sourceChannel: "voice",
+          sourceChannel: "phone",
           externalUserId: callerExternalUserId,
           externalChatId: callerExternalUserId,
           displayName: preservedDisplayName,

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -167,7 +167,7 @@ export async function createIngressInvite(params: {
   let voiceCode: string | undefined;
   let voiceCodeHash: string | undefined;
   let effectiveGuardianName: string | undefined;
-  const isVoice = params.sourceChannel === "voice";
+  const isVoice = params.sourceChannel === "phone";
 
   // For non-voice invites: generate a 6-digit invite code for guardian-mediated
   // redemption. The plaintext code is returned once in the response; only the
@@ -351,7 +351,7 @@ export function redeemIngressInviteTyped(params: {
 export function redeemVoiceInviteCode(params: {
   assistantId?: string;
   callerExternalUserId: string;
-  sourceChannel: "voice";
+  sourceChannel: "phone";
   code: string;
 }): VoiceRedemptionOutcome {
   return redeemVoiceInviteCodeTyped(params);

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -211,7 +211,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
 function resolveCanonicalRequestSourceType(
   sourceChannel: string | undefined,
 ): "desktop" | "channel" | "voice" {
-  if (sourceChannel === "voice") {
+  if (sourceChannel === "phone") {
     return "voice";
   }
   if (sourceChannel === "vellum") {

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -202,7 +202,7 @@ export async function handleCreateVerificationSession(
     // (e.g. "+15551234567" vs "(555) 123-4567", or "@User" vs "user")
     let rateLimitKey: string | undefined = body.destination;
     if (rateLimitKey) {
-      if (body.channel === "voice") {
+      if (body.channel === "phone") {
         rateLimitKey = normalizePhoneNumber(rateLimitKey) ?? rateLimitKey;
       } else if (body.channel === "telegram") {
         rateLimitKey = normalizeTelegramDestination(rateLimitKey);

--- a/assistant/src/runtime/routes/invite-routes.ts
+++ b/assistant/src/runtime/routes/invite-routes.ts
@@ -39,7 +39,7 @@ export function handleListInvites(url: URL): Response {
 /**
  * POST /v1/contacts/invites
  *
- * For voice invites, pass `sourceChannel: "voice"` with required
+ * For voice invites, pass `sourceChannel: "phone"` with required
  * `expectedExternalUserId` (E.164 phone). Voice codes are always 6 digits.
  * The response will include a one-time `voiceCode` field that must be
  * communicated to the invited user out-of-band.
@@ -108,7 +108,7 @@ export async function handleRedeemInvite(req: Request): Promise<Response> {
     const result = redeemVoiceInviteCode({
       assistantId: body.assistantId as string | undefined,
       callerExternalUserId,
-      sourceChannel: "voice",
+      sourceChannel: "phone",
       code,
     });
 

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -246,7 +246,7 @@ export async function startOutbound(
       params.rebind,
       originConversationId,
     );
-  } else if (channel === "voice") {
+  } else if (channel === "phone") {
     return startOutboundVoice(
       params.destination,
       assistantId,
@@ -740,7 +740,7 @@ export function resendOutbound(
       channel,
       originConversationId,
     };
-  } else if (channel === "voice") {
+  } else if (channel === "phone") {
     const newSession = createOutboundSession({
       channel,
       expectedPhoneE164: destination,

--- a/assistant/src/util/canonicalize-identity.ts
+++ b/assistant/src/util/canonicalize-identity.ts
@@ -14,7 +14,7 @@ import type { ChannelId } from "../channels/types.js";
 import { normalizePhoneNumber } from "./phone.js";
 
 /** Channels whose raw sender IDs are phone numbers. */
-const PHONE_CHANNELS: ReadonlySet<ChannelId> = new Set(["voice", "whatsapp"]);
+const PHONE_CHANNELS: ReadonlySet<ChannelId> = new Set(["phone", "whatsapp"]);
 
 /**
  * Canonicalize a raw inbound sender identity for the given channel.


### PR DESCRIPTION
## Summary
- Renames the `"voice"` channel ID to `"phone"` in `CHANNEL_IDS`, `INTERFACE_IDS`, `CHANNEL_POLICIES`, and `NOTIFICATION_SOURCE_CHANNELS`
- Updates all ~50 source and test files that reference the channel ID as string literals
- Preserves `sourceType: "voice"` (canonical request source types), Twilio webhook paths, regex input patterns, and user-facing display strings

Part of plan: voice-contact-verify-fix.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
