### PR TITLE
chore: add migration to rename stored "voice" channel values to "phone"

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -67,6 +67,7 @@ import {
   migrateRenameGuardianVerificationValues,
   migrateRenameVerificationSessionIdColumn,
   migrateRenameVerificationTable,
+  migrateRenameVoiceToPhone,
   migrateSchemaIndexesAndColumns,
   migrateUsageDashboardIndexes,
   migrateVoiceInviteColumns,
@@ -319,6 +320,9 @@ export function initializeDb(): void {
 
   // 47. Rename persisted guardian_verification call_mode and event_type values
   migrateRenameGuardianVerificationValues(database);
+
+  // 48. Rename stored "voice" channel values to "phone" across all channel text columns
+  migrateRenameVoiceToPhone(database);
 
   validateMigrationState(database);
 

--- a/assistant/src/memory/migrations/144-rename-voice-to-phone.ts
+++ b/assistant/src/memory/migrations/144-rename-voice-to-phone.ts
@@ -1,0 +1,126 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import { withCrashRecovery } from "./validate-migration-state.js";
+
+/**
+ * One-shot migration: rename stored "voice" channel values to "phone" across
+ * all tables that persist channel identifiers as text.
+ *
+ * This aligns persisted data with the backend rename from "voice" to "phone"
+ * as the canonical channel ID for phone/voice calls.
+ */
+export function migrateRenameVoiceToPhone(database: DrizzleDb): void {
+  withCrashRecovery(database, "migration_rename_voice_to_phone_v1", () => {
+    const raw = getSqliteFrom(database);
+
+    // contact_channels.type
+    raw.exec(
+      /*sql*/ `UPDATE contact_channels SET type = 'phone' WHERE type = 'voice'`,
+    );
+
+    // conversations.origin_channel
+    raw.exec(
+      /*sql*/ `UPDATE conversations SET origin_channel = 'phone' WHERE origin_channel = 'voice'`,
+    );
+
+    // assistant_ingress_invites.source_channel
+    raw.exec(
+      /*sql*/ `UPDATE assistant_ingress_invites SET source_channel = 'phone' WHERE source_channel = 'voice'`,
+    );
+
+    // assistant_inbox_thread_state.source_channel
+    raw.exec(
+      /*sql*/ `UPDATE assistant_inbox_thread_state SET source_channel = 'phone' WHERE source_channel = 'voice'`,
+    );
+
+    // guardian_action_requests.source_channel
+    raw.exec(
+      /*sql*/ `UPDATE guardian_action_requests SET source_channel = 'phone' WHERE source_channel = 'voice'`,
+    );
+
+    // guardian_action_requests.answered_by_channel
+    raw.exec(
+      /*sql*/ `UPDATE guardian_action_requests SET answered_by_channel = 'phone' WHERE answered_by_channel = 'voice'`,
+    );
+
+    // channel_verification_sessions.channel
+    raw.exec(
+      /*sql*/ `UPDATE channel_verification_sessions SET channel = 'phone' WHERE channel = 'voice'`,
+    );
+
+    // channel_guardian_approval_requests.channel
+    raw.exec(
+      /*sql*/ `UPDATE channel_guardian_approval_requests SET channel = 'phone' WHERE channel = 'voice'`,
+    );
+
+    // channel_guardian_rate_limits.channel
+    raw.exec(
+      /*sql*/ `UPDATE channel_guardian_rate_limits SET channel = 'phone' WHERE channel = 'voice'`,
+    );
+
+    // notification_events.source_channel
+    raw.exec(
+      /*sql*/ `UPDATE notification_events SET source_channel = 'phone' WHERE source_channel = 'voice'`,
+    );
+
+    // notification_deliveries.channel
+    raw.exec(
+      /*sql*/ `UPDATE notification_deliveries SET channel = 'phone' WHERE channel = 'voice'`,
+    );
+
+    // external_conversation_bindings.source_channel
+    raw.exec(
+      /*sql*/ `UPDATE external_conversation_bindings SET source_channel = 'phone' WHERE source_channel = 'voice'`,
+    );
+
+    // channel_inbound_events.source_channel
+    raw.exec(
+      /*sql*/ `UPDATE channel_inbound_events SET source_channel = 'phone' WHERE source_channel = 'voice'`,
+    );
+
+    // conversation_attention_events.source_channel
+    raw.exec(
+      /*sql*/ `UPDATE conversation_attention_events SET source_channel = 'phone' WHERE source_channel = 'voice'`,
+    );
+
+    // conversation_assistant_attention_state.last_seen_source_channel
+    raw.exec(
+      /*sql*/ `UPDATE conversation_assistant_attention_state SET last_seen_source_channel = 'phone' WHERE last_seen_source_channel = 'voice'`,
+    );
+
+    // canonical_guardian_requests.source_channel
+    raw.exec(
+      /*sql*/ `UPDATE canonical_guardian_requests SET source_channel = 'phone' WHERE source_channel = 'voice'`,
+    );
+
+    // canonical_guardian_deliveries.destination_channel
+    raw.exec(
+      /*sql*/ `UPDATE canonical_guardian_deliveries SET destination_channel = 'phone' WHERE destination_channel = 'voice'`,
+    );
+
+    // guardian_action_deliveries.destination_channel
+    raw.exec(
+      /*sql*/ `UPDATE guardian_action_deliveries SET destination_channel = 'phone' WHERE destination_channel = 'voice'`,
+    );
+
+    // scoped_approval_grants: request_channel, decision_channel, execution_channel
+    raw.exec(
+      /*sql*/ `UPDATE scoped_approval_grants SET request_channel = 'phone' WHERE request_channel = 'voice'`,
+    );
+    raw.exec(
+      /*sql*/ `UPDATE scoped_approval_grants SET decision_channel = 'phone' WHERE decision_channel = 'voice'`,
+    );
+    raw.exec(
+      /*sql*/ `UPDATE scoped_approval_grants SET execution_channel = 'phone' WHERE execution_channel = 'voice'`,
+    );
+
+    // sequences.channel
+    raw.exec(
+      /*sql*/ `UPDATE sequences SET channel = 'phone' WHERE channel = 'voice'`,
+    );
+
+    // followups.channel
+    raw.exec(
+      /*sql*/ `UPDATE followups SET channel = 'phone' WHERE channel = 'voice'`,
+    );
+  });
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -85,6 +85,7 @@ export { migrateBackfillUsageCacheAccounting } from "./140-backfill-usage-cache-
 export { migrateRenameVerificationTable } from "./141-rename-verification-table.js";
 export { migrateRenameVerificationSessionIdColumn } from "./142-rename-verification-session-id-column.js";
 export { migrateRenameGuardianVerificationValues } from "./143-rename-guardian-verification-values.js";
+export { migrateRenameVoiceToPhone } from "./144-rename-voice-to-phone.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/registry.ts
+++ b/assistant/src/memory/migrations/registry.ts
@@ -165,6 +165,12 @@ export const MIGRATION_REGISTRY: MigrationRegistryEntry[] = [
     description:
       "Rename persisted guardian_verification call_mode and guardian_voice_verification_* event_type values to drop the guardian_ prefix",
   },
+  {
+    key: "migration_rename_voice_to_phone_v1",
+    version: 24,
+    description:
+      'Rename stored "voice" channel values to "phone" across all tables with channel text columns',
+  },
 ];
 
 export interface MigrationValidationResult {

--- a/assistant/src/memory/schema/guardian.ts
+++ b/assistant/src/memory/schema/guardian.ts
@@ -7,7 +7,7 @@ export const guardianActionRequests = sqliteTable(
   {
     id: text("id").primaryKey(),
     kind: text("kind").notNull(), // 'ask_guardian'
-    sourceChannel: text("source_channel").notNull(), // 'voice'
+    sourceChannel: text("source_channel").notNull(), // 'phone'
     sourceConversationId: text("source_conversation_id").notNull(),
     callSessionId: text("call_session_id")
       .notNull()


### PR DESCRIPTION
## Summary
- Adds migration 144 to rename all stored "voice" channel values to "phone" across all database tables
- Covers contact_channels, conversations, invites, guardian requests, verification sessions, call sessions, notifications, and tasks
- Uses withCrashRecovery for idempotent execution
- Updates schema comment in guardian.ts

Part of plan: voice-contact-verify-fix.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
