### PR TITLE
rename voice channel ID to phone in macOS Swift client

### DIFF
--- a/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationFlowView.swift
+++ b/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationFlowView.swift
@@ -404,7 +404,7 @@ struct ChannelVerificationFlowView: View {
                         if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                     }
                 }
-            } else if state.channel == "voice" || state.channel == "sms" {
+            } else if state.channel == "phone" || state.channel == "sms" {
                 Text("This is your personal phone number")
                     .font(VFont.caption)
                     .foregroundColor(VColor.textMuted)

--- a/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationModels.swift
+++ b/clients/macos/vellum-assistant/Features/ChannelVerification/ChannelVerificationModels.swift
@@ -34,7 +34,7 @@ struct ChannelVerificationState {
                !displayName.isEmpty {
                 return displayName
             }
-        } else if channel == "sms" || channel == "voice" {
+        } else if channel == "sms" || channel == "phone" {
             if let displayName = displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
                !displayName.isEmpty {
                 return displayName
@@ -103,7 +103,7 @@ extension SettingsStore {
                 outboundCode: smsOutboundCode,
                 bootstrapUrl: nil
             )
-        case "voice":
+        case "phone":
             return ChannelVerificationState(
                 channel: channel,
                 identity: voiceVerificationIdentity,
@@ -199,7 +199,7 @@ func verificationInstructionSubtext(channel: String, botUsername: String?, phone
     if channel == "telegram" {
         let handle = botUsername.map { "@\($0)" } ?? "your bot"
         return "Message \(handle) with the below code within the next 10 minutes"
-    } else if channel == "voice" {
+    } else if channel == "phone" {
         let number = phoneNumber ?? "your assistant"
         return "Call \(number) and say the six-digit code below within the next 10 minutes"
     } else {
@@ -212,7 +212,7 @@ func verificationInstructionSubtext(channel: String, botUsername: String?, phone
 func verificationDestinationPlaceholder(for channel: String) -> String {
     switch channel {
     case "telegram": return "@username or chat ID"
-    case "sms", "voice": return "+1234567890"
+    case "sms", "phone": return "+1234567890"
     case "slack": return "Slack user ID"
     default: return "Destination"
     }

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -6,9 +6,9 @@ import VellumAssistantShared
 /// channels with verification status, and action buttons.
 @MainActor
 struct ContactDetailView: View {
-    private static let allChannelTypes = ["telegram", "sms", "email", "whatsapp", "voice", "slack"]
+    private static let allChannelTypes = ["telegram", "sms", "email", "whatsapp", "phone", "slack"]
 
-    private static let verificationSupportedChannels: Set<String> = ["telegram", "sms", "voice", "slack"]
+    private static let verificationSupportedChannels: Set<String> = ["telegram", "sms", "phone", "slack"]
 
     /// Channels that support 6-digit code invites from this view. Voice invites
     /// require additional fields not available here, so they are excluded.
@@ -856,7 +856,7 @@ struct ContactDetailView: View {
         switch type {
         case "telegram":
             return .send
-        case "voice":
+        case "phone":
             return .phoneCall
         case "sms":
             return .phoneCall
@@ -875,7 +875,7 @@ struct ContactDetailView: View {
         case "sms": return "SMS"
         case "email": return "Email"
         case "whatsapp": return "WhatsApp"
-        case "voice": return "Voice"
+        case "phone": return "Voice"
         case "slack": return "Slack"
         default: return type.capitalized
         }
@@ -1188,7 +1188,7 @@ struct ContactDetailView: View {
                     ),
                     ContactChannelPayload(
                         id: "ch-g3",
-                        type: "voice",
+                        type: "phone",
                         address: "+15551234567",
                         isPrimary: false,
                         status: "pending",

--- a/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactsListView.swift
@@ -273,7 +273,7 @@ struct ContactsListView: View {
         switch type {
         case "telegram": return .send
         case "sms": return .messageSquare
-        case "voice": return .phoneCall
+        case "phone": return .phoneCall
         case "email": return .mail
         case "slack": return .hash
         default: return .messageCircle
@@ -285,7 +285,7 @@ struct ContactsListView: View {
         switch type {
         case "telegram": return "Telegram"
         case "sms": return "SMS"
-        case "voice": return "Voice"
+        case "phone": return "Voice"
         case "email": return "Email"
         case "slack": return "Slack"
         default: return type.capitalized
@@ -336,7 +336,7 @@ struct ContactsListView: View {
                         isPrimary: false, status: "verified", policy: "allow"
                     ),
                     ContactChannelPayload(
-                        id: "ch-3", type: "voice", address: "+15551234567",
+                        id: "ch-3", type: "phone", address: "+15551234567",
                         isPrimary: false, status: "verified", policy: "allow"
                     ),
                 ]

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsChannelsTab.swift
@@ -65,7 +65,7 @@ struct SettingsChannelsTab: View {
             store.refreshAssistantEmail()
             store.refreshApprovedDevices()
             store.refreshChannelVerificationStatus(channel: "telegram")
-            store.refreshChannelVerificationStatus(channel: "voice")
+            store.refreshChannelVerificationStatus(channel: "phone")
             store.refreshChannelVerificationStatus(channel: "slack")
             store.refreshTelegramApprovedMembers()
             store.refreshSlackApprovedMembers()
@@ -636,7 +636,7 @@ struct SettingsChannelsTab: View {
             // voice verification initiates an outbound call which requires a valid caller number)
             if store.twilioHasCredentials && store.twilioPhoneNumber != nil {
                 Divider().background(VColor.surfaceBorder)
-                channelVerificationView(channel: "voice")
+                channelVerificationView(channel: "phone")
             }
         }
         .padding(VSpacing.lg)

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -607,7 +607,7 @@ public final class SettingsStore: ObservableObject {
                         ? "A guardian is already bound. Revoke it first or replace it."
                         : response.error
                 }
-            case "voice":
+            case "phone":
                 self.voiceVerificationInProgress = false
                 if response.success {
                     self.voiceVerificationIdentity = response.guardianExternalUserId
@@ -700,7 +700,7 @@ public final class SettingsStore: ObservableObject {
         // Refresh channel verification status on init
         refreshChannelVerificationStatus(channel: "telegram")
         refreshChannelVerificationStatus(channel: "sms")
-        refreshChannelVerificationStatus(channel: "voice")
+        refreshChannelVerificationStatus(channel: "phone")
         refreshChannelVerificationStatus(channel: "slack")
 
         // Ingress config is refreshed by onAppear in SettingsPanel,
@@ -1507,7 +1507,7 @@ public final class SettingsStore: ObservableObject {
             smsVerificationError = nil
             smsVerificationAlreadyBound = false
             smsVerificationInstruction = nil
-        case "voice":
+        case "phone":
             voiceVerificationInProgress = true
             voiceVerificationError = nil
             voiceVerificationAlreadyBound = false
@@ -1530,7 +1530,7 @@ public final class SettingsStore: ObservableObject {
                 case "sms":
                     smsVerificationInProgress = false
                     smsVerificationError = "Daemon is not connected. Reconnect and try again."
-                case "voice":
+                case "phone":
                     voiceVerificationInProgress = false
                     voiceVerificationError = "Daemon is not connected. Reconnect and try again."
                 case "slack":
@@ -1558,7 +1558,7 @@ public final class SettingsStore: ObservableObject {
             case "sms":
                 smsVerificationInProgress = false
                 smsVerificationError = "Failed to start verification. Try again."
-            case "voice":
+            case "phone":
                 voiceVerificationInProgress = false
                 voiceVerificationError = "Failed to start verification. Try again."
             case "slack":
@@ -1580,7 +1580,7 @@ public final class SettingsStore: ObservableObject {
         case "sms":
             smsVerificationInProgress = false
             smsVerificationInstruction = nil
-        case "voice":
+        case "phone":
             voiceVerificationInProgress = false
             voiceVerificationInstruction = nil
         case "slack":
@@ -1607,7 +1607,7 @@ public final class SettingsStore: ObservableObject {
             telegramVerificationInstruction = nil
         case "sms":
             smsVerificationInstruction = nil
-        case "voice":
+        case "phone":
             voiceVerificationInstruction = nil
         case "slack":
             slackVerificationInstruction = nil
@@ -1801,7 +1801,7 @@ public final class SettingsStore: ObservableObject {
             smsVerificationInProgress = true
             smsVerificationError = nil
             smsVerificationAlreadyBound = false
-        case "voice":
+        case "phone":
             voiceVerificationInProgress = true
             voiceVerificationError = nil
             voiceVerificationAlreadyBound = false
@@ -1821,7 +1821,7 @@ public final class SettingsStore: ObservableObject {
                 case "sms":
                     smsVerificationInProgress = false
                     smsVerificationError = "Daemon is not connected. Reconnect and try again."
-                case "voice":
+                case "phone":
                     voiceVerificationInProgress = false
                     voiceVerificationError = "Daemon is not connected. Reconnect and try again."
                 case "slack":
@@ -1846,7 +1846,7 @@ public final class SettingsStore: ObservableObject {
             case "sms":
                 smsVerificationInProgress = false
                 smsVerificationError = "Failed to start verification. Try again."
-            case "voice":
+            case "phone":
                 voiceVerificationInProgress = false
                 voiceVerificationError = "Failed to start verification. Try again."
             case "slack":
@@ -1877,7 +1877,7 @@ public final class SettingsStore: ObservableObject {
             telegramVerificationInProgress = false
         case "sms":
             smsVerificationInProgress = false
-        case "voice":
+        case "phone":
             voiceVerificationInProgress = false
         case "slack":
             slackVerificationInProgress = false
@@ -1909,7 +1909,7 @@ public final class SettingsStore: ObservableObject {
             smsOutboundNextResendAt = nil
             smsOutboundSendCount = 0
             smsOutboundCode = nil
-        case "voice":
+        case "phone":
             voiceOutboundSessionId = nil
             voiceOutboundExpiresAt = nil
             voiceOutboundNextResendAt = nil
@@ -1975,7 +1975,7 @@ public final class SettingsStore: ObservableObject {
             if let nextResendAt { smsOutboundNextResendAt = nextResendAt }
             if let sendCount { smsOutboundSendCount = sendCount }
             if let secret { smsOutboundCode = secret }
-        case "voice":
+        case "phone":
             if sessionId != voiceOutboundSessionId {
                 voiceOutboundNextResendAt = nil
                 voiceOutboundSendCount = 0
@@ -2013,7 +2013,7 @@ public final class SettingsStore: ObservableObject {
         let inProgressChannels = [
             ("telegram", telegramVerificationInProgress),
             ("sms", smsVerificationInProgress),
-            ("voice", voiceVerificationInProgress),
+            ("phone", voiceVerificationInProgress),
             ("slack", slackVerificationInProgress),
         ].filter(\.1)
         if inProgressChannels.count == 1 {
@@ -2035,7 +2035,7 @@ public final class SettingsStore: ObservableObject {
             telegramVerificationInstruction = nil
         case "sms":
             smsVerificationInstruction = nil
-        case "voice":
+        case "phone":
             voiceVerificationInstruction = nil
         case "slack":
             slackVerificationInstruction = nil
@@ -2063,7 +2063,7 @@ public final class SettingsStore: ObservableObject {
                 if self.smsVerificationError == nil {
                     self.smsVerificationError = "Timed out waiting for verification instructions. Try again."
                 }
-            case "voice":
+            case "phone":
                 self.voiceVerificationInProgress = false
                 self.voiceVerificationInstruction = nil
                 if self.voiceVerificationError == nil {
@@ -2084,7 +2084,7 @@ public final class SettingsStore: ObservableObject {
     }
 
     private func startVerificationStatusPolling(for channel: String) {
-        guard channel == "telegram" || channel == "sms" || channel == "voice" || channel == "slack" else { return }
+        guard channel == "telegram" || channel == "sms" || channel == "phone" || channel == "slack" else { return }
         stopVerificationStatusPolling(for: channel)
         verificationStatusPollingDeadlines[channel] = Date().addingTimeInterval(verificationStatusPollWindow)
         scheduleVerificationStatusPoll(for: channel, delay: verificationStatusPollInterval)

--- a/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
+++ b/clients/macos/vellum-assistantTests/SettingsStoreChannelVerificationTests.swift
@@ -469,13 +469,13 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
         // None of these should crash
         orphanStore.refreshChannelVerificationStatus(channel: "telegram")
         orphanStore.refreshChannelVerificationStatus(channel: "sms")
-        orphanStore.refreshChannelVerificationStatus(channel: "voice")
+        orphanStore.refreshChannelVerificationStatus(channel: "phone")
         orphanStore.startChannelVerification(channel: "telegram")
         orphanStore.startChannelVerification(channel: "sms")
-        orphanStore.startChannelVerification(channel: "voice")
+        orphanStore.startChannelVerification(channel: "phone")
         orphanStore.revokeChannelVerification(channel: "telegram")
         orphanStore.revokeChannelVerification(channel: "sms")
-        orphanStore.revokeChannelVerification(channel: "voice")
+        orphanStore.revokeChannelVerification(channel: "phone")
     }
 
     // MARK: - Successful response clears previous error
@@ -535,7 +535,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
 
         let telegramStatus = statusMessages.filter { $0.channel == "telegram" }
         let smsStatus = statusMessages.filter { $0.channel == "sms" }
-        let voiceStatus = statusMessages.filter { $0.channel == "voice" }
+        let voiceStatus = statusMessages.filter { $0.channel == "phone" }
 
         XCTAssertEqual(telegramStatus.count, 1)
         XCTAssertEqual(smsStatus.count, 1)
@@ -696,13 +696,13 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
     // MARK: - Voice Channel Verification
 
     func testStartVoiceVerificationSetsInProgressAndSendsSession() {
-        store.startChannelVerification(channel: "voice")
+        store.startChannelVerification(channel: "phone")
 
         XCTAssertTrue(store.voiceVerificationInProgress)
         XCTAssertNil(store.voiceVerificationError)
 
         let verificationMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let sessionMessages = verificationMessages.filter { $0.action == "create_session" && $0.channel == "voice" }
+        let sessionMessages = verificationMessages.filter { $0.action == "create_session" && $0.channel == "phone" }
         XCTAssertEqual(sessionMessages.count, 1)
     }
 
@@ -714,7 +714,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             instruction: nil,
             bound: true,
             guardianExternalUserId: "+15559876543",
-            channel: "voice",
+            channel: "phone",
             assistantId: "self",
             guardianDeliveryChatId: nil,
             error: nil
@@ -740,7 +740,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             instruction: nil,
             bound: nil,
             guardianExternalUserId: nil,
-            channel: "voice",
+            channel: "phone",
             assistantId: "self",
             guardianDeliveryChatId: nil,
             error: "Voice channel not configured"
@@ -755,17 +755,17 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
     }
 
     func testRevokeVoiceVerificationSendsRevokeAction() {
-        store.revokeChannelVerification(channel: "voice")
+        store.revokeChannelVerification(channel: "phone")
 
         let verificationMessages = sentMessages.compactMap { $0 as? ChannelVerificationSessionRequestMessage }
-        let revokeMessages = verificationMessages.filter { $0.action == "revoke" && $0.channel == "voice" }
+        let revokeMessages = verificationMessages.filter { $0.action == "revoke" && $0.channel == "phone" }
         XCTAssertEqual(revokeMessages.count, 1)
     }
 
     func testRevokeVoiceVerificationClearsInstruction() {
         store.voiceVerificationInstruction = "Call and say 123456"
 
-        store.revokeChannelVerification(channel: "voice")
+        store.revokeChannelVerification(channel: "phone")
 
         XCTAssertNil(store.voiceVerificationInstruction)
     }
@@ -779,7 +779,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             verificationStatusPollWindow: 2.0
         )
 
-        shortTimeoutStore.startChannelVerification(channel: "voice")
+        shortTimeoutStore.startChannelVerification(channel: "phone")
 
         shortTimeoutStore.voiceVerificationInstruction = "Call and say 123456"
 
@@ -801,7 +801,7 @@ final class SettingsStoreChannelVerificationTests: XCTestCase {
             instruction: nil,
             bound: true,
             guardianExternalUserId: "+15559876543",
-            channel: "voice",
+            channel: "phone",
             assistantId: "self",
             guardianDeliveryChatId: nil,
             error: nil

--- a/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
+++ b/clients/macos/vellum-assistantTests/ThreadSessionRestorerTests.swift
@@ -599,7 +599,7 @@ struct ThreadSessionRestorerTests {
 
         let response = makeSessionListResponse(sessions: [
             (id: "s1", title: "Voice Call", updatedAt: 2000, threadType: nil,
-             channelBinding: ["sourceChannel": "voice", "externalChatId": "call-123"]),
+             channelBinding: ["sourceChannel": "phone", "externalChatId": "call-123"]),
         ])
         restorer.handleSessionListResponse(response)
 
@@ -626,7 +626,7 @@ struct ThreadSessionRestorerTests {
             (id: "s2", title: "Telegram Chat", updatedAt: 3000, threadType: nil,
              channelBinding: ["sourceChannel": "telegram", "externalChatId": "789"]),
             (id: "s3", title: "Voice Call", updatedAt: 2000, threadType: nil,
-             channelBinding: ["sourceChannel": "voice", "externalChatId": "call-456"]),
+             channelBinding: ["sourceChannel": "phone", "externalChatId": "call-456"]),
             (id: "s4", title: "Another Desktop Chat", updatedAt: 1000, threadType: nil, channelBinding: nil),
         ])
         restorer.handleSessionListResponse(response)


### PR DESCRIPTION
## Summary
- Renames all `"voice"` channel-ID string literals to `"phone"` in the macOS Swift client (8 files)
- Display labels ("Voice"), Swift property names (`voiceVerificationInProgress`, etc.), and Twilio API capability keys (`caps["voice"]`) are intentionally unchanged
- Regenerated IPC contract types

Part of plan: voice-contact-verify-fix.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
