### PR TITLE
fix: migration covers origin_interface and message metadata voice-to-phone

### DIFF
--- a/assistant/src/memory/migrations/144-rename-voice-to-phone.ts
+++ b/assistant/src/memory/migrations/144-rename-voice-to-phone.ts
@@ -22,6 +22,19 @@ export function migrateRenameVoiceToPhone(database: DrizzleDb): void {
       /*sql*/ `UPDATE conversations SET origin_channel = 'phone' WHERE origin_channel = 'voice'`,
     );
 
+    // conversations.origin_interface
+    raw.exec(
+      /*sql*/ `UPDATE conversations SET origin_interface = 'phone' WHERE origin_interface = 'voice'`,
+    );
+
+    // messages.metadata — JSON blobs may contain "voice" as a channel/interface value
+    // (e.g. userMessageChannel, provenanceSourceChannel). Replace the quoted JSON
+    // string so that messageMetadataSchema (which uses z.enum(CHANNEL_IDS)) can
+    // still parse historical rows.
+    raw.exec(
+      /*sql*/ `UPDATE messages SET metadata = REPLACE(metadata, '"voice"', '"phone"') WHERE metadata LIKE '%"voice"%'`,
+    );
+
     // assistant_ingress_invites.source_channel
     raw.exec(
       /*sql*/ `UPDATE assistant_ingress_invites SET source_channel = 'phone' WHERE source_channel = 'voice'`,


### PR DESCRIPTION
## Summary
Fixes two gaps in the voice-to-phone channel rename migration:

- Adds UPDATE for conversations.origin_interface column (was missed, causing parseInterfaceId to return null for old voice rows)
- Handles historical message metadata JSON blobs that contain "voice" as a channel value

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
