### PR TITLE
docs: reference Agent Skills specification in skill-writing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,8 @@ Do not add new tool registrations using the `class ____Tool implements Tool` pat
 
 Skills must be self-contained and portable — no coupling to daemon tools, internals, or repo-specific modules. Use `scripts/` for supporting logic with inline dependencies. No interactive prompts. Relative paths only. Ask: "Could this skill be copied into a different project and still work?"
 
+Follow the [Agent Skills specification](https://agentskills.io/specification) for SKILL.md format, directory structure, and naming conventions.
+
 ## User-Facing Terminology: "daemon" vs "assistant"
 
 "Daemon" is an internal implementation detail. In all user-facing text — CLI output, error messages, help strings, SKILL.md instructions that would be relayed to users, README documentation, and UI strings — use **"assistant"** instead of "daemon". Internal code (variable names, class names, file paths, log messages, comments explaining architecture) may continue using "daemon" since users don't see those. When in doubt, ask: "Would a user ever read this?" If yes, say "assistant".

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -7,6 +7,12 @@
   - Do not create new assistant tools and reference them from SKILL.md — this couples skills to Vellum internals and breaks compatibility with other agent systems
   - Do not include a TOOLS.json file in skill directories — skills should rely on CLI tools in `scripts/`, not custom tool definitions
 
+- **Follow the [Agent Skills specification](https://agentskills.io/specification)**
+  - All skills must conform to the spec's SKILL.md format: required YAML frontmatter (`name`, `description`), optional fields (`license`, `compatibility`, `metadata`, `allowed-tools`), and Markdown body
+  - The `name` field must match the parent directory name, use only lowercase alphanumeric characters and hyphens (1-64 chars), and must not start/end with a hyphen or contain consecutive hyphens
+  - Use the spec's directory structure: `SKILL.md` at root, `scripts/` for executable code, `references/` for supplementary docs, `assets/` for static resources
+  - Follow progressive disclosure: keep `description` keyword-rich for discovery (~100 tokens), keep `SKILL.md` body under 500 lines (< 5000 tokens recommended), and move detailed reference material to `references/`
+
 - **API interactions use Vellum's outbound proxy**
   - Outbound network traffic from the bash tool is automatically intercepted by an outbound proxy in a manner that's transparent to the assistant
   - Update proxy settings so the bash tool can inject correct auth headers for approved domains
@@ -15,7 +21,7 @@
 - **Write portable instructions**
   - Avoid referring to tools by specific names (prefer "Take a browser screenshot" over "Use browser_screen_grab")
   - It is fine to refer to tools/utils/etc. directly by name if it is bundled with the skill (likely in `scripts/`)
-  - Use standard frontmatter according to the [Agent Skills specification](https://agentskills.io/home) — linters validate this
+  - Use standard frontmatter according to the [Agent Skills specification](https://agentskills.io/specification) — linters validate this
 
 - **Vellum-specific extensions**
   - If you must do something Vellum-system specific, use the `metadata` field to connect the skill in a structured way


### PR DESCRIPTION
## Summary
- Add a new bullet to skills/AGENTS.md referencing the Agent Skills specification with key requirements (SKILL.md format, naming rules, directory structure, progressive disclosure)
- Update existing agentskills.io/home link to agentskills.io/specification in skills/AGENTS.md
- Add spec reference to the Skill Independence section in root AGENTS.md

Part of plan: skills-agentskills-spec-ref.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
