### PR TITLE
fix: resolve daemon port and avatar path from lockfile for multi-instance setups

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -176,9 +176,10 @@ extension AppDelegate {
         guard let assistantId = storedId,
               let assistant = LockfileAssistant.loadByName(assistantId) else { return }
 
-        // Resolve daemon HTTP endpoint
-        let portString = ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "7821"
-        let daemonPort = Int(portString) ?? 7821
+        // Resolve daemon HTTP endpoint from lockfile, with env override and fallback
+        let daemonPort = assistant.daemonPort
+            ?? Int(ProcessInfo.processInfo.environment["RUNTIME_HTTP_PORT"] ?? "")
+            ?? 7821
         let daemonBaseURL = "http://localhost:\(daemonPort)"
 
         Task {

--- a/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Avatar/AvatarAppearanceManager.swift
@@ -90,7 +90,16 @@ final class AvatarAppearanceManager {
     }
 
     private var customAvatarURL: URL {
-        Self.workspaceCustomAvatarURL()
+        // Resolve from the connected assistant's baseDataDir so multi-instance
+        // setups (e.g. XDG-based paths) find the correct avatar file.
+        if let assistantId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+           let assistant = LockfileAssistant.loadByName(assistantId),
+           let baseDataDir = assistant.baseDataDir {
+            // baseDataDir is the .vellum root (e.g. ~/.local/share/vellum/assistants/foo/.vellum)
+            return URL(fileURLWithPath: baseDataDir)
+                .appendingPathComponent("workspace/data/avatar/custom-avatar.png")
+        }
+        return Self.workspaceCustomAvatarURL()
     }
 
     /// The assistant's display name, loaded once from IDENTITY.md to avoid repeated disk I/O.

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/IdentityData.swift
@@ -241,6 +241,8 @@ struct LockfileAssistant {
     let zone: String?
     let instanceId: String?
     let hatchedAt: String?
+    let baseDataDir: String?
+    let daemonPort: Int?
     let gatewayPort: Int?
     let socketPath: String?
     let instanceDir: String?
@@ -324,6 +326,8 @@ struct LockfileAssistant {
                 zone: entry["zone"] as? String,
                 instanceId: entry["instanceId"] as? String,
                 hatchedAt: entry["hatchedAt"] as? String,
+                baseDataDir: entry["baseDataDir"] as? String,
+                daemonPort: resources?["daemonPort"] as? Int,
                 gatewayPort: resources?["gatewayPort"] as? Int,
                 socketPath: resources?["socketPath"] as? String,
                 instanceDir: resources?["instanceDir"] as? String


### PR DESCRIPTION
## Summary
- Parse `baseDataDir` and `resources.daemonPort` from lockfile into `LockfileAssistant`
- `ensureLocalAssistantApiKey()` now reads the daemon port from the lockfile instead of hardcoding 7821, fixing API key injection into the wrong daemon in multi-instance setups
- `AvatarAppearanceManager` now resolves the avatar file path from the connected assistant's `baseDataDir`, fixing avatar not displaying after generation in multi-instance setups

## Test plan
- [x] Verified managed avatar generation succeeds (HTTP 200 from platform)
- [x] Verified avatar PNG written to correct instance-specific path
- [x] Rebuild macOS app and confirm avatar displays after generation
- [ ] Test with single-instance setup to verify fallback behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
