### PR TITLE
fix: final voice→phone stragglers in CLI help, skills, tests, and revert migration 036

### DIFF
--- a/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
+++ b/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
@@ -55,7 +55,7 @@ describe("guardian-verify-setup skill — voice auto-followup", () => {
         .split("## Voice Auto-Check Polling")[1]
         ?.split("## Step 6")[0] ?? "";
     expect(pollingSection).toContain(
-      "assistant integrations guardian status --channel voice --json",
+      "assistant integrations guardian status --channel phone --json",
     );
   });
 

--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -378,27 +378,27 @@ the assistant to be running.
 
 Examples:
   $ assistant integrations guardian status
-  $ assistant integrations guardian status --channel voice`,
+  $ assistant integrations guardian status --channel phone`,
   );
 
   guardian
     .command("status")
     .description("Get guardian status for a channel")
-    .option("--channel <channel>", "Channel: telegram|voice", "telegram")
+    .option("--channel <channel>", "Channel: telegram|phone", "telegram")
     .addHelpText(
       "after",
       `
 Returns the guardian verification state for the specified channel. Requires
 the assistant to be running.
 
-The --channel flag accepts: telegram, voice. Defaults to telegram if
+The --channel flag accepts: telegram, phone. Defaults to telegram if
 not specified. The response includes whether guardian verification is active
 and the current verification state for that channel.
 
 Examples:
   $ assistant integrations guardian status
   $ assistant integrations guardian status --channel telegram
-  $ assistant integrations guardian status --channel voice
+  $ assistant integrations guardian status --channel phone
   $ assistant integrations guardian status --channel telegram --json`,
     )
     .action(async (opts: { channel?: GuardianChannel }, cmd: Command) => {

--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: true
 metadata: { "vellum": { "emoji": "\ud83d\udc65" } }
 ---
 
-Manage the user's contacts, relationship graph, access control (trusted contacts), and invite links. This skill covers contact CRUD with multi-channel tracking, controlling who can message the assistant through external channels (Telegram, voice), and creating/managing invite links that grant access.
+Manage the user's contacts, relationship graph, access control (trusted contacts), and invite links. This skill covers contact CRUD with multi-channel tracking, controlling who can message the assistant through external channels (Telegram, phone), and creating/managing invite links that grant access.
 
 ## Prerequisites
 
@@ -74,7 +74,7 @@ Trusted contacts control who is allowed to send messages to the assistant throug
 - **Contact channel**: A user identity (external user ID or chat ID) on a specific messaging platform, stored as an entry in a contact's `channels` array. Each channel entry has its own `status` and `policy`.
 - **Policy**: Controls what the contact channel can do -- `allow` (can message freely) or `deny` (blocked from messaging).
 - **Status**: The channel's lifecycle state -- `active` (currently effective), `revoked` (access removed), or `blocked` (explicitly denied).
-- **Channel type**: The messaging platform (e.g., `telegram`, `voice`).
+- **Channel type**: The messaging platform (e.g., `telegram`, `phone`).
 
 ### List trusted contacts
 
@@ -103,7 +103,7 @@ The response contains `{ ok: true, contacts: [...] }` where each contact has:
 - `displayName` -- human-readable name
 - `channels` -- array of channel entries, each with:
   - `id` -- channel ID (needed for status/policy changes)
-  - `channel` -- the channel type (e.g., `telegram`, `voice`)
+  - `channel` -- the channel type (e.g., `telegram`, `phone`)
   - `externalUserId` -- the user's ID on that channel
   - `externalChatId` -- the chat ID on that channel
   - `displayName` -- channel-specific display name
@@ -174,7 +174,7 @@ assistant channels readiness --json
 
 The response contains `{ success: true, snapshots: [...] }` where each snapshot has:
 
-- `channel` -- the channel type (e.g., `telegram`, `email`, `whatsapp`, `slack`, `voice`)
+- `channel` -- the channel type (e.g., `telegram`, `email`, `whatsapp`, `slack`, `phone`)
 - `ready` -- boolean indicating whether the channel is fully operational
 - `checkedAt` -- timestamp (ms since epoch) of when readiness was evaluated
 - `stale` -- boolean indicating whether cached remote check data is outdated
@@ -268,12 +268,12 @@ Use this when the guardian wants to authorize a specific phone number to call th
 **Important**: The response includes a `voiceCode` field that is only returned at creation time and cannot be retrieved later. Extract and present it clearly.
 
 ```bash
-assistant contacts invites create --source-channel voice --expected-external-user-id "<phone_E164>" --friend-name "<invitee_name>" --guardian-name "<guardian_name>" --max-uses 1 --note "<optional note, e.g. the person it is for>" --json
+assistant contacts invites create --source-channel phone --expected-external-user-id "<phone_E164>" --friend-name "<invitee_name>" --guardian-name "<guardian_name>" --max-uses 1 --note "<optional note, e.g. the person it is for>" --json
 ```
 
 Required flags:
 
-- `--source-channel` -- must be `voice`
+- `--source-channel` -- must be `phone`
 - `--expected-external-user-id` -- the invitee's phone number in E.164 format (e.g., `+15551234567`)
 - `--friend-name` -- the invitee's display name (e.g., "Mom", "Dr. Smith"). Used during the voice verification call to personalize the experience.
 - `--guardian-name` -- the guardian's display name (e.g., "Alex"). Used during the voice verification call so the invitee knows who invited them.
@@ -401,7 +401,7 @@ assistant contacts invites list --source-channel telegram --json
 For voice invites:
 
 ```bash
-assistant contacts invites list --source-channel voice --json
+assistant contacts invites list --source-channel phone --json
 ```
 
 For email, WhatsApp, or Slack invites:
@@ -414,7 +414,7 @@ assistant contacts invites list --source-channel slack --json
 
 Optional query parameters:
 
-- `--source-channel` -- filter by channel (e.g., `telegram`, `voice`, `email`, `whatsapp`, `slack`)
+- `--source-channel` -- filter by channel (e.g., `telegram`, `phone`, `email`, `whatsapp`, `slack`)
 - `--status` -- filter by status (`active`, `revoked`, `redeemed`, `expired`)
 
 The response contains `{ ok: true, invites: [...] }` where each invite has:
@@ -520,10 +520,10 @@ Each channel has:
 
 **"Revoke invite"** / **"Cancel invite link"** -- List invites to identify the target, confirm, then revoke with `assistant contacts invites revoke <invite_id> --json`.
 
-**"Create a voice invite for +15551234567"** -- Create a voice invite with `assistant contacts invites create --source-channel voice --expected-external-user-id "+15551234567" --friend-name "<name>" --guardian-name "<name>"`. Present the invite code and instructions: the person must call from that number and enter the code.
+**"Create a voice invite for +15551234567"** -- Create a voice invite with `assistant contacts invites create --source-channel phone --expected-external-user-id "+15551234567" --friend-name "<name>" --guardian-name "<name>"`. Present the invite code and instructions: the person must call from that number and enter the code.
 
-**"Let my mom call in"** / **"Invite someone by phone"** -- Ask for the phone number in E.164 format, create a voice invite with `assistant contacts invites create --source-channel voice`, and present the code + calling instructions.
+**"Let my mom call in"** / **"Invite someone by phone"** -- Ask for the phone number in E.164 format, create a voice invite with `assistant contacts invites create --source-channel phone`, and present the code + calling instructions.
 
-**"Show my voice invites"** / **"List phone invites"** -- List invites with `assistant contacts invites list --source-channel voice --json`, present active invites with bound phone number and expiration info.
+**"Show my voice invites"** / **"List phone invites"** -- List invites with `assistant contacts invites list --source-channel phone --json`, present active invites with bound phone number and expiration info.
 
 **"Revoke voice invite"** / **"Cancel the phone invite for +15551234567"** -- List voice invites, identify the target by phone number or note, confirm, then revoke with `assistant contacts invites revoke <invite_id> --json`.

--- a/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "Guardian Verify Setup"
-description: "Set up channel verification for voice, Telegram, or Slack channels via outbound verification flow"
+description: "Set up channel verification for phone, Telegram, or Slack channels via outbound verification flow"
 user-invocable: true
 metadata: { "vellum": { "emoji": "\ud83d\udd10" } }
 ---
 
-You are helping your user set up channel verification for a messaging channel (voice, Telegram, or Slack). This links their identity as the trusted guardian for the chosen channel. Use gateway control-plane APIs for outbound actions, and use `assistant integrations guardian status` for status reads.
+You are helping your user set up channel verification for a messaging channel (phone, Telegram, or Slack). This links their identity as the trusted guardian for the chosen channel. Use gateway control-plane APIs for outbound actions, and use `assistant integrations guardian status` for status reads.
 
 ## Prerequisites
 
@@ -29,7 +29,7 @@ If the user's intent already specifies a channel (e.g. "verify my phone number f
 
 Based on the chosen channel, ask for the required destination:
 
-- **Voice**: Ask for their phone number. Accept any common format (e.g. +15551234567, (555) 123-4567, 555-123-4567). The API normalizes it to E.164.
+- **Phone**: Ask for their phone number. Accept any common format (e.g. +15551234567, (555) 123-4567, 555-123-4567). The API normalizes it to E.164.
 - **Telegram**: Ask for their Telegram chat ID (numeric) or @handle. Explain:
   - If they know their numeric chat ID, provide it directly. The bot will send the code to that chat.
   - If they only know their @handle, the flow uses a bootstrap deep-link that they must click first.
@@ -52,7 +52,7 @@ Replace `<channel>` with `phone`, `telegram`, or `slack`, and `<destination>` wi
 
 Report the exact next action based on the channel:
 
-- **Voice**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `POST /v1/channel-verification-sessions` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
+- **Phone**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `POST /v1/channel-verification-sessions` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
 - **Telegram with chat ID** (no `telegramBootstrapUrl` in response): The response includes a `secret` field. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and reply with that 6-digit code to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4).
 - **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."
 - **Slack**: The response includes a `secret` field with the verification code. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to you as a Slack DM. Open the DM from the Vellum bot in Slack and reply with that 6-digit code to complete verification." The DM channel ID is captured automatically during this process for future message delivery. If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4). **After delivering the code, immediately begin the Slack auto-check polling loop** (see [Slack Auto-Check Polling](#slack-auto-check-polling) below).
@@ -85,7 +85,7 @@ curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/channel-verification-sessions/res
 
 On success, report the next action based on the channel:
 
-- **Voice**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `POST /v1/channel-verification-sessions/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
+- **Phone**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `POST /v1/channel-verification-sessions/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
 - **Telegram**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and reply with that 6-digit code to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3.
 - **Slack**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to you as a Slack DM. Reply to the DM with that 6-digit code to complete verification. (resent)" If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3. **After delivering the code, immediately begin the Slack auto-check polling loop** (see [Slack Auto-Check Polling](#slack-auto-check-polling) below).
 

--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -186,7 +186,7 @@ Tell the user: **"Twilio is configured. Your assistant's phone number is {phoneN
 
 Link the user's phone number as the trusted voice guardian so the assistant can verify inbound callers.
 
-Load the guardian-verify-setup skill with `channel: "voice"`:
+Load the guardian-verify-setup skill with `channel: "phone"`:
 
 ```
 skill_load skill=guardian-verify-setup
@@ -197,7 +197,7 @@ The skill handles the full verification flow (outbound call, code entry, confirm
 To re-check guardian status later:
 
 ```bash
-assistant integrations guardian status --channel voice --json
+assistant integrations guardian status --channel phone --json
 ```
 
 ## Clearing Credentials

--- a/assistant/src/memory/migrations/036-normalize-phone-identities.ts
+++ b/assistant/src/memory/migrations/036-normalize-phone-identities.ts
@@ -33,7 +33,7 @@ export function migrateNormalizePhoneIdentities(database: DrizzleDb): void {
     .get(checkpointKey);
   if (checkpoint) return;
 
-  const PHONE_CHANNELS = ["sms", "phone", "whatsapp"];
+  const PHONE_CHANNELS = ["sms", "voice", "whatsapp"];
 
   /**
    * Unique key scope definition for collision detection.

--- a/gateway/src/__tests__/channel-verification-session-proxy.test.ts
+++ b/gateway/src/__tests__/channel-verification-session-proxy.test.ts
@@ -90,7 +90,7 @@ describe("channel verification session proxy", () => {
     );
     await handler.handleGetVerificationStatus(
       new Request(
-        "http://localhost:7830/v1/channel-verification-sessions/status?channel=voice",
+        "http://localhost:7830/v1/channel-verification-sessions/status?channel=phone",
         { method: "GET" },
       ),
     );
@@ -113,7 +113,7 @@ describe("channel verification session proxy", () => {
 
     expect(captured).toEqual([
       "http://localhost:7821/v1/channel-verification-sessions",
-      "http://localhost:7821/v1/channel-verification-sessions/status?channel=voice",
+      "http://localhost:7821/v1/channel-verification-sessions/status?channel=phone",
       "http://localhost:7821/v1/channel-verification-sessions",
       "http://localhost:7821/v1/channel-verification-sessions/resend",
       "http://localhost:7821/v1/channel-verification-sessions",
@@ -195,7 +195,7 @@ describe("channel verification session proxy", () => {
     );
     const res = await handler.handleGetVerificationStatus(
       new Request(
-        "http://localhost:7830/v1/channel-verification-sessions/status?channel=voice",
+        "http://localhost:7830/v1/channel-verification-sessions/status?channel=phone",
       ),
     );
 
@@ -211,7 +211,7 @@ describe("channel verification session proxy", () => {
     const handler = createChannelVerificationSessionProxyHandler(makeConfig());
     const res = await handler.handleGetVerificationStatus(
       new Request(
-        "http://localhost:7830/v1/channel-verification-sessions/status?channel=voice",
+        "http://localhost:7830/v1/channel-verification-sessions/status?channel=phone",
       ),
     );
 


### PR DESCRIPTION
## Summary
Fixes final remaining gaps from plan review for voice-contact-verify-fix.md.

- CLI integrations.ts help text (3 places)
- twilio-setup SKILL.md (2 places)
- guardian-verify-setup skill regression test (1 place)
- gateway verification session proxy test (4 places)
- contacts SKILL.md (10+ places) — critical for invite service
- guardian-verify-setup SKILL.md description (4 places + bonus line 32)
- Revert migration 036 to preserve immutability

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
