### PR TITLE
fix: add missing baseDataDir and daemonPort params to test initializers

### DIFF
--- a/clients/macos/vellum-assistantTests/LockfileAssistantManagedTests.swift
+++ b/clients/macos/vellum-assistantTests/LockfileAssistantManagedTests.swift
@@ -172,6 +172,8 @@ final class LockfileAssistantManagedTests: XCTestCase {
             zone: nil,
             instanceId: nil,
             hatchedAt: "2024-01-01T00:00:00Z",
+            baseDataDir: nil,
+            daemonPort: nil,
             gatewayPort: nil,
             socketPath: nil,
             instanceDir: nil
@@ -190,6 +192,8 @@ final class LockfileAssistantManagedTests: XCTestCase {
             zone: nil,
             instanceId: nil,
             hatchedAt: nil,
+            baseDataDir: nil,
+            daemonPort: nil,
             gatewayPort: nil,
             socketPath: nil,
             instanceDir: nil
@@ -208,6 +212,8 @@ final class LockfileAssistantManagedTests: XCTestCase {
             zone: "us-central1-a",
             instanceId: "inst-1",
             hatchedAt: nil,
+            baseDataDir: nil,
+            daemonPort: nil,
             gatewayPort: nil,
             socketPath: nil,
             instanceDir: nil
@@ -226,6 +232,8 @@ final class LockfileAssistantManagedTests: XCTestCase {
             zone: nil,
             instanceId: nil,
             hatchedAt: nil,
+            baseDataDir: nil,
+            daemonPort: nil,
             gatewayPort: nil,
             socketPath: nil,
             instanceDir: nil
@@ -246,6 +254,8 @@ final class LockfileAssistantManagedTests: XCTestCase {
             zone: nil,
             instanceId: nil,
             hatchedAt: nil,
+            baseDataDir: nil,
+            daemonPort: nil,
             gatewayPort: nil,
             socketPath: nil,
             instanceDir: nil
@@ -264,6 +274,8 @@ final class LockfileAssistantManagedTests: XCTestCase {
             zone: nil,
             instanceId: nil,
             hatchedAt: nil,
+            baseDataDir: nil,
+            daemonPort: nil,
             gatewayPort: nil,
             socketPath: nil,
             instanceDir: nil
@@ -282,6 +294,8 @@ final class LockfileAssistantManagedTests: XCTestCase {
             zone: nil,
             instanceId: nil,
             hatchedAt: nil,
+            baseDataDir: nil,
+            daemonPort: nil,
             gatewayPort: nil,
             socketPath: nil,
             instanceDir: nil
@@ -302,6 +316,8 @@ final class LockfileAssistantManagedTests: XCTestCase {
             zone: nil,
             instanceId: nil,
             hatchedAt: nil,
+            baseDataDir: nil,
+            daemonPort: nil,
             gatewayPort: nil,
             socketPath: nil,
             instanceDir: nil


### PR DESCRIPTION
## Summary
- Fixes test compilation failures caused by #14094 which added `baseDataDir` and `daemonPort` to `LockfileAssistant`
- All 8 `LockfileAssistant()` constructor calls in `LockfileAssistantManagedTests.swift` now include the new parameters (as `nil`)

## Test plan
- [x] Swift build passes (`swift build` in pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14096" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
