### PR TITLE
docs: update remaining voice→phone references in docs, JSDoc, and comments

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -483,7 +483,7 @@ Voice invites use a short numeric code (4-10 digits, default 6) instead of a URL
 
 **Creation flow:**
 
-1. Guardian creates a voice invite via `POST /v1/contacts/invites` with `sourceChannel: "voice"` and `expectedExternalUserId` (E.164 phone).
+1. Guardian creates a voice invite via `POST /v1/contacts/invites` with `sourceChannel: "phone"` and `expectedExternalUserId` (E.164 phone).
 2. `invite-service.ts` generates a cryptographically random numeric code (`generateVoiceCode`), hashes it with SHA-256 (`hashVoiceCode`), and stores only the hash.
 3. The one-time plaintext `voiceCode` is returned in the creation response. The raw token is NOT returned for voice invites — redemption uses the identity-bound code flow exclusively.
 4. Guardian communicates the code to the invitee out-of-band.

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -259,7 +259,7 @@ Guardian bindings, verification challenges, and approval requests are all scoped
 
 ### Channel-Aware Guardian Challenges
 
-The channel guardian service generates verification challenge instructions with channel-appropriate wording. The `channelLabel()` function maps `sourceChannel` values to human-readable labels (e.g., `"telegram"` -> `"Telegram"`, `"voice"` -> `"Voice"`), so challenge prompts reference the correct channel name.
+The channel guardian service generates verification challenge instructions with channel-appropriate wording. The `channelLabel()` function maps `sourceChannel` values to human-readable labels (e.g., `"telegram"` -> `"Telegram"`, `"phone"` -> `"Phone"`), so challenge prompts reference the correct channel name.
 
 ### Operator Notes
 

--- a/assistant/docs/runbook-trusted-contacts.md
+++ b/assistant/docs/runbook-trusted-contacts.md
@@ -284,7 +284,7 @@ curl -s -X POST "$BASE/v1/contacts" \
     "displayName": "Bob",
     "role": "contact",
     "channels": [{
-      "type": "voice",
+      "type": "phone",
       "address": "+15551234567",
       "externalUserId": "+15551234567",
       "externalChatId": "+15551234567",

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -277,7 +277,7 @@ describe("redeemVoiceInviteCode", () => {
   test("voice-only invite cannot be redeemed if sourceChannel on invite is not voice", () => {
     // Create a non-voice invite with voice code metadata to simulate a
     // hypothetical misconfiguration. The redemption service filters by
-    // sourceChannel='voice', so non-voice invites are invisible.
+    // sourceChannel='phone', so non-phone invites are invisible.
     const code = generateVoiceCode(6);
     const codeHash = hashVoiceCode(code);
 
@@ -295,7 +295,7 @@ describe("redeemVoiceInviteCode", () => {
       code,
     });
 
-    // findActiveVoiceInvites filters by sourceChannel='voice', so the
+    // findActiveVoiceInvites filters by sourceChannel='phone', so the
     // telegram invite won't be found.
     expect(result).toEqual({ ok: false, reason: "invalid_or_expired" });
   });

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -219,7 +219,7 @@ function buildVoiceCallControlPrompt(opts: {
  * Execute a single voice turn through the daemon session pipeline.
  *
  * Manages the session directly with voice-specific defaults:
- *   - sourceChannel: 'voice'
+ *   - sourceChannel: 'phone'
  *   - event sink wired to the provided callbacks
  *   - abort propagated from the returned handle
  *

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -155,7 +155,7 @@ export interface ToolContext {
    * See {@link TrustClass} in actor-trust-resolver.ts for value semantics.
    */
   trustClass: TrustClass;
-  /** Channel through which the tool invocation originates (e.g. 'telegram', 'voice'). Used for scoped grant consumption. */
+  /** Channel through which the tool invocation originates (e.g. 'telegram', 'phone'). Used for scoped grant consumption. */
   executionChannel?: string;
   /** Voice/call session ID, if the invocation originates from a call. Used for scoped grant consumption. */
   callSessionId?: string;


### PR DESCRIPTION
## Summary
Final documentation cleanup for the voice→phone channel ID rename.

- ARCHITECTURE.md, README.md, runbook: update API examples
- voice-session-bridge.ts, tools/types.ts: update JSDoc
- voice-invite-redemption.test.ts: update explanatory comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
