### PR TITLE
feat: auto-load references/ markdown files when loading a skill

### DIFF
--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -558,6 +558,70 @@ describe("skill_load tool", () => {
     expect(result.content).not.toContain("<loaded_skill");
   });
 
+  test("skill with references/ directory appends reference file contents", async () => {
+    // Create a skill with a references/ subdirectory
+    const skillDir = join(TEST_DIR, "skills", "with-refs");
+    mkdirSync(skillDir, { recursive: true });
+    mkdirSync(join(skillDir, "references"), { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      '---\nname: "With Refs"\ndescription: "Has references"\n---\n\nMain body.\n',
+    );
+    writeFileSync(
+      join(skillDir, "references", "GUIDE.md"),
+      "# Guide\n\nDetailed guide content.",
+    );
+    writeFileSync(
+      join(skillDir, "references", "TROUBLESHOOTING.md"),
+      "# Troubleshooting\n\nFix things here.",
+    );
+    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- with-refs\n");
+
+    const result = await executeSkillLoad({ skill: "with-refs" });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Main body.");
+    // Reference files should be appended with headers
+    expect(result.content).toContain("--- Reference: Guide ---");
+    expect(result.content).toContain("Detailed guide content.");
+    expect(result.content).toContain("--- Reference: Troubleshooting ---");
+    expect(result.content).toContain("Fix things here.");
+  });
+
+  test("skill without references/ directory loads normally", async () => {
+    writeSkill("no-refs", "No Refs", "No references dir", "Just body.");
+    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- no-refs\n");
+
+    const result = await executeSkillLoad({ skill: "no-refs" });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Just body.");
+    expect(result.content).not.toContain("--- Reference:");
+  });
+
+  test("references/ directory ignores non-markdown files", async () => {
+    const skillDir = join(TEST_DIR, "skills", "refs-filter");
+    mkdirSync(skillDir, { recursive: true });
+    mkdirSync(join(skillDir, "references"), { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      '---\nname: "Refs Filter"\ndescription: "Filters non-md"\n---\n\nBody.\n',
+    );
+    writeFileSync(
+      join(skillDir, "references", "GUIDE.md"),
+      "# Guide\n\nGuide content.",
+    );
+    writeFileSync(
+      join(skillDir, "references", "data.json"),
+      '{"key": "value"}',
+    );
+    writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- refs-filter\n");
+
+    const result = await executeSkillLoad({ skill: "refs-filter" });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("--- Reference: Guide ---");
+    expect(result.content).not.toContain("data.json");
+    expect(result.content).not.toContain('"key"');
+  });
+
   test('skill with empty includes array loads successfully as "none"', async () => {
     // Write a skill with `includes: []` directly in frontmatter.
     // The parser normalizes this to undefined, so it should behave identically

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -1003,6 +1003,46 @@ function applyFeatureGatedSections(body: string): string {
   return result;
 }
 
+/**
+ * Scan for a `references/` subdirectory within a skill directory and append
+ * the contents of any `.md` files found there to the skill body. Each
+ * reference file is labeled with a `--- Reference: <Name> ---` header.
+ * Files are appended in alphabetical order for deterministic output.
+ * Non-`.md` files are ignored. Errors are logged as warnings and the
+ * original body is returned unchanged.
+ */
+function appendReferenceFiles(body: string, directoryPath: string): string {
+  try {
+    const refsDir = join(directoryPath, "references");
+    if (!existsSync(refsDir) || !statSync(refsDir).isDirectory()) {
+      return body;
+    }
+
+    const entries = readdirSync(refsDir);
+    const mdFiles = entries
+      .filter((f) => f.toLowerCase().endsWith(".md"))
+      .sort((a, b) => a.localeCompare(b));
+
+    if (mdFiles.length === 0) return body;
+
+    let result = body;
+    for (const filename of mdFiles) {
+      const fileContents = readFileSync(join(refsDir, filename), "utf-8");
+      const displayName = filename
+        .replace(/\.md$/i, "")
+        .replace(/[-_]/g, " ")
+        .replace(/\b\w/g, (c) => c.toUpperCase())
+        .replace(/\B\w+/g, (w) => w.toLowerCase());
+      result += `\n\n--- Reference: ${displayName} ---\n${fileContents}`;
+    }
+
+    return result;
+  } catch (err) {
+    log.warn({ err, directoryPath }, "Failed to read reference files");
+    return body;
+  }
+}
+
 function loadSkillDefinition(skill: SkillSummary): SkillLookupResult {
   let loaded: SkillDefinition | null;
   if (skill.bundled) {
@@ -1029,6 +1069,8 @@ function loadSkillDefinition(skill: SkillSummary): SkillLookupResult {
   loaded.body = loaded.body.replaceAll("{baseDir}", loaded.directoryPath);
   // Strip feature-gated sections based on assistant feature flags
   loaded.body = applyFeatureGatedSections(loaded.body);
+  // Auto-load reference files from references/ subdirectory
+  loaded.body = appendReferenceFiles(loaded.body, loaded.directoryPath);
   return { skill: loaded };
 }
 


### PR DESCRIPTION
## Summary
- Add `appendReferenceFiles()` function to `skills.ts` that scans for a `references/` subdirectory and appends `.md` files to the skill body during load
- Reference files are labeled with `--- Reference: <Name> ---` headers, sorted alphabetically, with non-`.md` files ignored
- Add 3 tests covering: references loaded, no references dir, non-md files filtered

Part of plan: skill-refs-autoload.md (PR 1 of 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
