### PR TITLE
feat: read vellum-specific frontmatter fields from metadata.vellum with backward compat

### DIFF
--- a/assistant/src/__tests__/session-skill-tools.test.ts
+++ b/assistant/src/__tests__/session-skill-tools.test.ts
@@ -243,6 +243,7 @@ function makeSkill(id: string, dir?: string): SkillSummary {
   return {
     id,
     name: id,
+    displayName: id,
     description: `Skill ${id}`,
     directoryPath: dir ?? `/skills/${id}`,
     skillFilePath: `/skills/${id}/SKILL.md`,

--- a/assistant/src/__tests__/skill-feature-flags.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags.test.ts
@@ -41,6 +41,7 @@ function makeSkill(
   return {
     id,
     name: `${id} skill`,
+    displayName: `${id} skill`,
     description: `Description for ${id}`,
     directoryPath: `/fake/skills/${id}`,
     skillFilePath: `/fake/skills/${id}/SKILL.md`,

--- a/assistant/src/__tests__/skill-include-graph.test.ts
+++ b/assistant/src/__tests__/skill-include-graph.test.ts
@@ -12,6 +12,7 @@ function makeSkill(id: string, includes?: string[]): SkillSummary {
   return {
     id,
     name: id,
+    displayName: id,
     description: `Skill ${id}`,
     directoryPath: `/skills/${id}`,
     skillFilePath: `/skills/${id}/SKILL.md`,

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -225,6 +225,7 @@ function makeSkill(id: string): SkillSummary {
   return {
     id,
     name: id,
+    displayName: id,
     description: `Skill ${id}`,
     directoryPath: `/skills/${id}`,
     skillFilePath: `/skills/${id}/SKILL.md`,

--- a/assistant/src/__tests__/slash-commands-catalog.test.ts
+++ b/assistant/src/__tests__/slash-commands-catalog.test.ts
@@ -11,6 +11,7 @@ function makeSkill(
   return {
     id,
     name: overrides?.name ?? id,
+    displayName: overrides?.displayName ?? overrides?.name ?? id,
     description: `Description for ${id}`,
     directoryPath: `/skills/${id}`,
     skillFilePath: `/skills/${id}/SKILL.md`,

--- a/assistant/src/__tests__/slash-commands-resolver.test.ts
+++ b/assistant/src/__tests__/slash-commands-resolver.test.ts
@@ -16,6 +16,7 @@ function makeSkill(
   return {
     id,
     name: overrides?.name ?? id,
+    displayName: overrides?.displayName ?? overrides?.name ?? id,
     description: `Description for ${id}`,
     directoryPath: `/skills/${id}`,
     skillFilePath: `/skills/${id}/SKILL.md`,

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -70,6 +70,7 @@ export type SkillSource = "bundled" | "managed" | "workspace" | "extra";
 export interface SkillSummary {
   id: string;
   name: string;
+  displayName: string;
   description: string;
   directoryPath: string;
   skillFilePath: string;
@@ -272,6 +273,7 @@ function getSkillsIndexPath(skillsDir: string): string {
 
 interface ParsedFrontmatter {
   name: string;
+  displayName: string;
   description: string;
   body: string;
   homepage?: string;
@@ -348,22 +350,17 @@ function parseFrontmatter(
   // Parse new optional fields
   const homepage = fields.homepage?.trim() || undefined;
 
-  const userInvocableRaw = fields["user-invocable"]?.trim().toLowerCase();
-  const userInvocable = userInvocableRaw !== "false";
-
-  const disableModelInvocationRaw = fields["disable-model-invocation"]
-    ?.trim()
-    .toLowerCase();
-  const disableModelInvocation = disableModelInvocationRaw === "true";
-
   // Parse metadata as single-line JSON string, extract .vellum namespace
   let metadata: VellumMetadata | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let vellumRaw: any;
   const metadataRaw = fields.metadata?.trim();
   if (metadataRaw) {
     try {
       const parsed = JSON.parse(metadataRaw);
       if (parsed && typeof parsed === "object" && parsed.vellum) {
         metadata = parsed.vellum as VellumMetadata;
+        vellumRaw = parsed.vellum;
       }
     } catch (err) {
       log.warn(
@@ -383,12 +380,50 @@ function parseFrontmatter(
     metadata = { emoji: emojiField };
   }
 
-  const includes = parseIncludes(fields.includes, skillFilePath);
+  // Read vellum-specific fields from metadata.vellum with fallback to top-level frontmatter
+  const vellumUserInvocable = vellumRaw?.["user-invocable"];
+  let userInvocable: boolean;
+  if (typeof vellumUserInvocable === "boolean") {
+    userInvocable = vellumUserInvocable;
+  } else if (typeof vellumUserInvocable === "string") {
+    userInvocable = vellumUserInvocable !== "false";
+  } else {
+    const userInvocableRaw = fields["user-invocable"]?.trim().toLowerCase();
+    userInvocable = userInvocableRaw !== "false";
+  }
+
+  const vellumDisableModelInvocation = vellumRaw?.["disable-model-invocation"];
+  let disableModelInvocation: boolean;
+  if (typeof vellumDisableModelInvocation === "boolean") {
+    disableModelInvocation = vellumDisableModelInvocation;
+  } else if (typeof vellumDisableModelInvocation === "string") {
+    disableModelInvocation = vellumDisableModelInvocation === "true";
+  } else {
+    const disableModelInvocationRaw = fields["disable-model-invocation"]
+      ?.trim()
+      .toLowerCase();
+    disableModelInvocation = disableModelInvocationRaw === "true";
+  }
+
+  const vellumIncludes = vellumRaw?.includes;
+  const includes = Array.isArray(vellumIncludes)
+    ? vellumIncludes
+    : parseIncludes(fields.includes, skillFilePath);
+
   const credentialSetupFor =
-    fields["credential-setup-for"]?.trim() || undefined;
+    (typeof vellumRaw?.["credential-setup-for"] === "string"
+      ? vellumRaw["credential-setup-for"]
+      : undefined) ??
+    (fields["credential-setup-for"]?.trim() || undefined);
+
+  const displayName =
+    (typeof vellumRaw?.["display-name"] === "string"
+      ? vellumRaw["display-name"]
+      : undefined) ?? name;
 
   return {
     name,
+    displayName,
     description,
     body: stripCommentLines(body),
     homepage,
@@ -538,6 +573,7 @@ function readSkillFromDirectory(
     return {
       id: basename(directoryPath),
       name: parsed.name,
+      displayName: parsed.displayName,
       description: parsed.description,
       directoryPath,
       skillFilePath,
@@ -587,6 +623,7 @@ function readBundledSkillFromDirectory(
     return {
       id: basename(directoryPath),
       name: parsed.name,
+      displayName: parsed.displayName,
       description: parsed.description,
       directoryPath,
       skillFilePath,
@@ -646,6 +683,7 @@ function loadBundledSkills(): SkillSummary[] {
     skills.push({
       id: skill.id,
       name: skill.name,
+      displayName: skill.displayName,
       description: skill.description,
       directoryPath: skill.directoryPath,
       skillFilePath: skill.skillFilePath,
@@ -783,6 +821,7 @@ function skillSummaryFromDefinition(
   return {
     id: skill.id,
     name: skill.name,
+    displayName: skill.displayName,
     description: skill.description,
     directoryPath: skill.directoryPath,
     skillFilePath: skill.skillFilePath,
@@ -836,6 +875,7 @@ export function loadSkillCatalog(
           catalog.push({
             id,
             name: parsed.name,
+            displayName: parsed.displayName ?? parsed.name,
             description: parsed.description,
             directoryPath: directory,
             skillFilePath,
@@ -932,6 +972,7 @@ export function loadSkillCatalog(
         const workspaceSkill: SkillSummary = {
           id,
           name: parsed.name,
+          displayName: parsed.displayName ?? parsed.name,
           description: parsed.description,
           directoryPath: directory,
           skillFilePath,
@@ -1057,7 +1098,9 @@ export function resolveSkillSelector(
   }
 
   const exactNameMatches = catalog.filter(
-    (skill) => skill.name.toLowerCase() === needle.toLowerCase(),
+    (skill) =>
+      skill.name.toLowerCase() === needle.toLowerCase() ||
+      skill.displayName.toLowerCase() === needle.toLowerCase(),
   );
   if (exactNameMatches.length === 1) {
     return { skill: exactNameMatches[0] };

--- a/assistant/src/config/system-prompt.ts
+++ b/assistant/src/config/system-prompt.ts
@@ -969,7 +969,7 @@ function formatSkillsCatalog(skills: SkillSummary[]): string {
   const lines = ["<available_skills>"];
   for (const skill of visible) {
     const idAttr = escapeXml(skill.id);
-    const nameAttr = escapeXml(skill.name);
+    const nameAttr = escapeXml(skill.displayName);
     const descAttr =
       skill.id === "mcp-setup"
         ? escapeXml(getMcpSetupDescription())

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -637,7 +637,7 @@ export async function handleSkillDetail(
   if (result.skill) {
     const icon = await ensureSkillIcon(
       result.skill.directoryPath,
-      result.skill.name,
+      result.skill.displayName,
       result.skill.description,
     );
     ctx.send(socket, {

--- a/assistant/src/skills/slash-commands.ts
+++ b/assistant/src/skills/slash-commands.ts
@@ -77,7 +77,7 @@ export function buildInvocableSlashCatalog(
     if (!resolved || resolved.state === "disabled") continue;
     result.set(skill.id.toLowerCase(), {
       canonicalId: skill.id,
-      name: skill.name,
+      name: skill.displayName,
       summary: skill,
     });
   }

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -133,7 +133,7 @@ export class SkillLoadTool implements Tool {
         const childLoaded = loadSkillBySelector(childId);
         if (childLoaded.skill && childLoaded.skill.body.length > 0) {
           includedBodies.push(
-            `--- Included Skill: ${childLoaded.skill.name} (${childId}) ---\n${childLoaded.skill.body}`,
+            `--- Included Skill: ${childLoaded.skill.displayName} (${childId}) ---\n${childLoaded.skill.body}`,
           );
         }
       }
@@ -182,7 +182,7 @@ export class SkillLoadTool implements Tool {
 
     return {
       content: [
-        `Skill: ${skill.name}`,
+        `Skill: ${skill.displayName}`,
         `ID: ${skill.id}`,
         `Description: ${skill.description}`,
         `Path: ${skill.skillFilePath}`,


### PR DESCRIPTION
## Summary
- Add displayName field to SkillSummary for human-readable skill names
- Update parseFrontmatter to read user-invocable, disable-model-invocation, includes, credential-setup-for, and display-name from metadata.vellum with fallback to top-level fields
- Update all UI-facing skill.name references to use skill.displayName

Part of plan: skills-ref-ci-validation.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
