### PR TITLE
docs: final voice→phone channel ID references in architecture and runbook docs

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -2014,7 +2014,7 @@ Producer → NotificationSignal → Candidate Generation → Decision Engine (LL
 - **`conversationStrategy`** — how the notification pipeline materializes conversations for the channel:
   - `start_new_conversation` — creates a fresh conversation per delivery (e.g. vellum desktop/mobile threads)
   - `continue_existing_conversation` — intended to append to an existing channel-scoped conversation; currently materializes a background audit conversation per delivery (e.g. Telegram)
-  - `not_deliverable` — channel cannot receive notifications (e.g. voice)
+  - `not_deliverable` — channel cannot receive notifications (e.g. phone)
 
 Helper functions: `getDeliverableChannels()`, `getChannelPolicy()`, `isNotificationDeliverable()`, `getConversationStrategy()`.
 

--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -242,7 +242,7 @@ Two trust gates enforce trust-class-based access control over the memory pipelin
 
 - **Read gate** (`session-memory.ts`): When the current session's actor is untrusted, the memory recall pipeline returns a no-op context — no recall injection, no dynamic profile, no conflict resolution. This ensures untrusted actors cannot surface or exploit previously extracted memory.
 
-Trust policy is **cross-channel and trust-class-based**: decisions use `trustContext.trustClass`, not the channel string. Desktop/IPC sessions default to `trustClass: 'guardian'`. External channels (Telegram, SMS, WhatsApp, voice) provide explicit trust context via the resolver. Messages without provenance metadata are treated as trusted (guardian); all new messages carry provenance.
+Trust policy is **cross-channel and trust-class-based**: decisions use `trustContext.trustClass`, not the channel string. Desktop/IPC sessions default to `trustClass: 'guardian'`. External channels (Telegram, SMS, WhatsApp, phone) provide explicit trust context via the resolver. Messages without provenance metadata are treated as trusted (guardian); all new messages carry provenance.
 
 ---
 

--- a/assistant/docs/architecture/security.md
+++ b/assistant/docs/architecture/security.md
@@ -312,7 +312,7 @@ The `allowOneTimeSend` config gate (default: `false`) enables a secondary "Send 
 
 ## Channel-Agnostic Scoped Approval Grants
 
-Scoped approval grants are a channel-agnostic primitive that allows a guardian's approval decision on one channel (e.g., Telegram) to authorize a tool execution on a different channel (e.g., voice). Each grant authorizes exactly one tool execution and is consumed atomically.
+Scoped approval grants are a channel-agnostic primitive that allows a guardian's approval decision on one channel (e.g., Telegram) to authorize a tool execution on a different channel (e.g., phone). Each grant authorizes exactly one tool execution and is consumed atomically.
 
 ### Scope Modes
 

--- a/assistant/docs/runbook-trusted-contacts.md
+++ b/assistant/docs/runbook-trusted-contacts.md
@@ -36,7 +36,7 @@ curl -s "$BASE/v1/contacts?channelType=telegram" \
   -H "Authorization: Bearer $TOKEN" | jq
 
 # Voice contacts only
-curl -s "$BASE/v1/contacts?channelType=voice" \
+curl -s "$BASE/v1/contacts?channelType=phone" \
   -H "Authorization: Bearer $TOKEN" | jq
 ```
 

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -90,7 +90,7 @@ Each policy defines:
 | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
 | `start_new_conversation`         | Creates a fresh conversation per delivery. The thread is surfaced via IPC.                                                                                                                                                                   | `vellum`                                 |
 | `continue_existing_conversation` | Looks up a previously bound conversation by binding key (sourceChannel + externalChatId) and appends to it. When no bound conversation exists (first delivery to a destination), creates a new one and upserts the binding for future reuse. | `telegram`, `whatsapp`, `slack`, `email` |
-| `not_deliverable`                | Channel cannot receive notifications. Pairing returns null IDs.                                                                                                                                                                              | `voice`                                  |
+| `not_deliverable`                | Channel cannot receive notifications. Pairing returns null IDs.                                                                                                                                                                              | `phone`                                  |
 
 ### Helper Functions
 

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -728,7 +728,7 @@ sequenceDiagram
         WS->>WS: extract speaker metadata + map speaker identity
         WS->>Ctrl: handleCallerUtterance(transcript, speakerContext)
         Ctrl->>Bridge: startVoiceTurn()
-        Bridge->>RunOrch: startRun(conversationId, content, {sourceChannel: 'voice', eventSink})
+        Bridge->>RunOrch: startRun(conversationId, content, {sourceChannel: 'phone', eventSink})
         RunOrch->>Session: route to session pipeline
         Session->>LLM: agent loop (tools, memory, skills)
         LLM-->>Session: text tokens (streaming)
@@ -810,7 +810,7 @@ sequenceDiagram
     WS->>WS: detect isInbound (`session.initiatedFromConversationId == null`)
 
     alt Pending voice guardian challenge exists
-        WS->>GuardianSvc: getPendingSession(assistantId, 'voice')
+        WS->>GuardianSvc: getPendingSession(assistantId, 'phone')
         WS->>WS: enter verification_pending state
         WS->>Caller: TTS "Please enter your six-digit verification code"
         loop DTMF / spoken digit attempts (max 3)
@@ -832,7 +832,7 @@ sequenceDiagram
     end
 
     Ctrl->>Bridge: startVoiceTurn([CALL_OPENING])
-    Bridge->>RunOrch: startRun(conversationId, [CALL_OPENING], {sourceChannel: 'voice', eventSink})
+    Bridge->>RunOrch: startRun(conversationId, [CALL_OPENING], {sourceChannel: 'phone', eventSink})
     RunOrch->>Session: route to session pipeline
     Note over Session: Session runtime assembly injects<br/>voice channel context + system prompt
     Session->>LLM: agent loop (initial greeting turn)
@@ -845,7 +845,7 @@ sequenceDiagram
         Caller->>WS: prompt (caller utterance)
         WS->>Ctrl: handleCallerUtterance(transcript, speakerContext)
         Ctrl->>Bridge: startVoiceTurn()
-        Bridge->>RunOrch: startRun(conversationId, content, {sourceChannel: 'voice', eventSink})
+        Bridge->>RunOrch: startRun(conversationId, content, {sourceChannel: 'phone', eventSink})
         RunOrch->>Session: route to session pipeline
         Session->>LLM: agent loop (tools, memory, skills)
         LLM-->>Session: text tokens (streaming)


### PR DESCRIPTION
## Summary
Final documentation fixes for the voice→phone channel ID rename.

- runbook-trusted-contacts.md: fix curl query parameter
- notifications/README.md: fix channel policy table
- ARCHITECTURE.md: fix channel examples (assistant + gateway)
- memory.md, security.md: fix channel enumerations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
