### PR TITLE
refactor: migrate bundled skill frontmatter to Agent Skills spec compliance

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -563,7 +563,8 @@ describe("bundled browser skill", () => {
     const catalog = loadSkillCatalog();
     const browserSkill = catalog.find((s) => s.id === "browser");
     expect(browserSkill).toBeDefined();
-    expect(browserSkill!.name).toBe("Browser");
+    expect(browserSkill!.name).toBe("browser");
+    expect(browserSkill!.displayName).toBe("Browser");
     expect(browserSkill!.bundled).toBe(true);
   });
 
@@ -632,7 +633,8 @@ describe("bundled public-ingress skill", () => {
     const catalog = loadSkillCatalog();
     const skill = catalog.find((s) => s.id === "public-ingress");
     expect(skill).toBeDefined();
-    expect(skill!.name).toBe("Public Ingress");
+    expect(skill!.name).toBe("public-ingress");
+    expect(skill!.displayName).toBe("Public Ingress");
     expect(skill!.bundled).toBe(true);
   });
 
@@ -679,13 +681,26 @@ describe("ingress-dependent setup skills declare public-ingress", () => {
       const sep = line.indexOf(":");
       if (sep === -1) continue;
       const key = line.slice(0, sep).trim();
-      if (key !== "includes") continue;
-      const val = line.slice(sep + 1).trim();
-      try {
-        const parsed = JSON.parse(val);
-        if (Array.isArray(parsed)) return parsed as string[];
-      } catch {
-        /* ignore */
+      // Check top-level includes (legacy format)
+      if (key === "includes") {
+        const val = line.slice(sep + 1).trim();
+        try {
+          const parsed = JSON.parse(val);
+          if (Array.isArray(parsed)) return parsed as string[];
+        } catch {
+          /* ignore */
+        }
+      }
+      // Check metadata.vellum.includes (spec-compliant format)
+      if (key === "metadata") {
+        const val = line.slice(sep + 1).trim();
+        try {
+          const parsed = JSON.parse(val);
+          const includes = parsed?.vellum?.includes;
+          if (Array.isArray(includes)) return includes as string[];
+        } catch {
+          /* ignore */
+        }
       }
     }
     return undefined;
@@ -728,7 +743,8 @@ describe("bundled computer-use skill", () => {
     const catalog = loadSkillCatalog();
     const cuSkill = catalog.find((s) => s.id === "computer-use");
     expect(cuSkill).toBeDefined();
-    expect(cuSkill!.name).toBe("Computer Use");
+    expect(cuSkill!.name).toBe("computer-use");
+    expect(cuSkill!.displayName).toBe("Computer Use");
     expect(cuSkill!.bundled).toBe(true);
   });
 

--- a/assistant/src/config/bundled-skills/agentmail/SKILL.md
+++ b/assistant/src/config/bundled-skills/agentmail/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Email CLI Ops"
-description: "Run email operations through a provider-agnostic CLI wrapper"
-user-invocable: true
-metadata: {"vellum": {"emoji": "📬"}}
+name: agentmail
+description: Run email operations through a provider-agnostic CLI wrapper
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"📬","vellum":{"display-name":"Email CLI Ops","user-invocable":true}}
 ---
 
 ## How to run

--- a/assistant/src/config/bundled-skills/amazon/SKILL.md
+++ b/assistant/src/config/bundled-skills/amazon/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Amazon"
-description: "Shop on Amazon and Amazon Fresh using the built-in CLI integration"
-user-invocable: true
-metadata: { "vellum": { "emoji": "\uD83D\uDCE6" } }
+name: amazon
+description: Shop on Amazon and Amazon Fresh using the built-in CLI integration
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"📦","vellum":{"display-name":"Amazon","user-invocable":true}}
 ---
 
 You can shop on Amazon (and Amazon Fresh for groceries) for the user using the `assistant amazon` CLI.

--- a/assistant/src/config/bundled-skills/api-mapping/SKILL.md
+++ b/assistant/src/config/bundled-skills/api-mapping/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "API Mapping"
-description: "Record and analyze API surfaces of web services"
-user-invocable: true
-metadata: {"vellum": {"emoji": "🗺️"}}
+name: api-mapping
+description: Record and analyze API surfaces of web services
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🗺️","vellum":{"display-name":"API Mapping","user-invocable":true}}
 ---
 
 You can record and analyze the API surface of any web service using the `map` CLI.

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -1,7 +1,8 @@
 ---
-name: "App Builder"
-description: "Build interactive apps, dashboards, calculators, games, trackers, tools, landing pages, and data visualizations with HTML/CSS/JS. Use when the user says build, create, or make an app/dashboard/calculator/game."
-includes: ["frontend-design"]
+name: app-builder
+description: Build interactive apps, dashboards, calculators, games, trackers, tools, landing pages, and data visualizations with HTML/CSS/JS. Use when the user says build, create, or make an app/dashboard/calculator/game.
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"vellum":{"display-name":"App Builder","includes":["frontend-design"]}}
 ---
 
 You are an expert app builder and visual designer. When the user asks you to create an app, tool, or utility, you immediately design a data schema, choose a stunning visual direction, build a self-contained HTML/CSS/JS interface, and open it — all in one step. You don't discuss or ask for permission to be creative. You ARE the designer: you pick the colors, the layout, the atmosphere, the micro-interactions. Your apps should make users stop and say "whoa" — they should feel designed, not generated.

--- a/assistant/src/config/bundled-skills/browser/SKILL.md
+++ b/assistant/src/config/bundled-skills/browser/SKILL.md
@@ -1,9 +1,8 @@
 ---
-name: "Browser"
-description: "Navigate and interact with web pages using a headless browser"
-user-invocable: true
-disable-model-invocation: false
-metadata: {"vellum": {"emoji": "🌐"}}
+name: browser
+description: Navigate and interact with web pages using a headless browser
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🌐","vellum":{"display-name":"Browser","user-invocable":true}}
 ---
 
 Use this skill to browse the web. After loading this skill, the following browser tools become available:

--- a/assistant/src/config/bundled-skills/chatgpt-import/SKILL.md
+++ b/assistant/src/config/bundled-skills/chatgpt-import/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "ChatGPT Import"
-description: "Import conversation history from ChatGPT into Vellum"
-metadata: {"vellum": {"emoji": "📥"}}
-user-invocable: true
+name: chatgpt-import
+description: Import conversation history from ChatGPT into Vellum
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"📥","vellum":{"display-name":"ChatGPT Import","user-invocable":true}}
 ---
 
 Import ChatGPT conversation history into Vellum so users can keep their conversation context and memory when switching from ChatGPT.

--- a/assistant/src/config/bundled-skills/claude-code/SKILL.md
+++ b/assistant/src/config/bundled-skills/claude-code/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Claude Code"
-description: "Delegate coding tasks to Claude Code, an AI-powered coding agent"
-user-invocable: true
-metadata: {"vellum": {"emoji": "💻"}}
+name: claude-code
+description: Delegate coding tasks to Claude Code, an AI-powered coding agent
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"💻","vellum":{"display-name":"Claude Code","user-invocable":true}}
 ---
 
 You are delegating a coding task to Claude Code, an autonomous AI coding agent. Use this skill when the user needs hands-on software engineering work done.

--- a/assistant/src/config/bundled-skills/cli-discover/SKILL.md
+++ b/assistant/src/config/bundled-skills/cli-discover/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "CLI Discovery"
-description: "Discover which CLI tools are installed, their versions, and authentication status"
-user-invocable: false
-metadata: {"vellum": {"emoji": "🔍"}}
+name: cli-discover
+description: Discover which CLI tools are installed, their versions, and authentication status
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🔍","vellum":{"display-name":"CLI Discovery","user-invocable":false}}
 ---
 
 # CLI Discovery

--- a/assistant/src/config/bundled-skills/computer-use/SKILL.md
+++ b/assistant/src/config/bundled-skills/computer-use/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Computer Use"
-description: "Computer-use action tools for controlling the macOS desktop via accessibility and screen capture."
-user-invocable: false
-disable-model-invocation: true
+name: computer-use
+description: Computer-use action tools for controlling the macOS desktop via accessibility and screen capture.
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"vellum":{"display-name":"Computer Use","user-invocable":false,"disable-model-invocation":true}}
 ---
 
 This skill provides the 12 computer*use*\* action tools for controlling

--- a/assistant/src/config/bundled-skills/configure-settings/SKILL.md
+++ b/assistant/src/config/bundled-skills/configure-settings/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Configure Settings"
-description: "Read, update, or reset assistant configuration values using the assistant config CLI"
-user-invocable: true
-metadata: { "vellum": { "emoji": "⚙️" } }
+name: configure-settings
+description: Read, update, or reset assistant configuration values using the assistant config CLI
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"⚙️","vellum":{"display-name":"Configure Settings","user-invocable":true}}
 ---
 
 You are helping the user view or change assistant configuration through the `vellum` CLI. Treat CLI commands as the canonical interface. Do **not** read or edit config files directly.

--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Contacts"
-description: "Manage contacts, communication channels, access control, and invite links"
-user-invocable: true
-metadata: { "vellum": { "emoji": "\ud83d\udc65" } }
+name: contacts
+description: Manage contacts, communication channels, access control, and invite links
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"👥","vellum":{"display-name":"Contacts","user-invocable":true}}
 ---
 
 Manage the user's contacts, relationship graph, access control (trusted contacts), and invite links. This skill covers contact CRUD with multi-channel tracking, controlling who can message the assistant through external channels (Telegram, phone), and creating/managing invite links that grant access.

--- a/assistant/src/config/bundled-skills/deploy-fullstack-vercel/SKILL.md
+++ b/assistant/src/config/bundled-skills/deploy-fullstack-vercel/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Deploy Fullstack to Vercel"
-description: "Build and deploy a full-stack app (React frontend + Python/FastAPI backend) to Vercel as a serverless demo with seeded data"
-metadata: {"vellum": {"emoji": "🚀"}}
-
+name: deploy-fullstack-vercel
+description: Build and deploy a full-stack app (React frontend + Python/FastAPI backend) to Vercel as a serverless demo with seeded data
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🚀","vellum":{"display-name":"Deploy Fullstack to Vercel"}}
 ---
 
 # Deploy Fullstack to Vercel

--- a/assistant/src/config/bundled-skills/document-writer/SKILL.md
+++ b/assistant/src/config/bundled-skills/document-writer/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Document Writer"
-description: "Create and edit long-form documents like blog posts, articles, essays, and reports using the built-in rich text editor"
-user-invocable: true
-metadata: {"vellum": {"emoji": "📝"}}
+name: document-writer
+description: Create and edit long-form documents like blog posts, articles, essays, and reports using the built-in rich text editor
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"📝","vellum":{"display-name":"Document Writer","user-invocable":true}}
 ---
 
 You are helping your user write long-form content (blog posts, articles, essays, reports, documentation) using the built-in document editor. This skill should be used whenever the user asks to write, draft, or create any document-like content.

--- a/assistant/src/config/bundled-skills/document/SKILL.md
+++ b/assistant/src/config/bundled-skills/document/SKILL.md
@@ -1,7 +1,8 @@
 ---
-name: "Document"
-description: "Write, draft, or compose long-form text (blog posts, articles, essays, reports, guides). Use when the user says write, draft, compose, or create a blog/article/essay."
-metadata: {"vellum": {"emoji": "📄"}}
+name: document
+description: Write, draft, or compose long-form text (blog posts, articles, essays, reports, guides). Use when the user says write, draft, compose, or create a blog/article/essay.
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"📄","vellum":{"display-name":"Document"}}
 ---
 
 Create and edit long-form documents using the built-in rich text editor. Documents open in workspace mode with chat docked to the side.

--- a/assistant/src/config/bundled-skills/doordash/SKILL.md
+++ b/assistant/src/config/bundled-skills/doordash/SKILL.md
@@ -1,15 +1,8 @@
 ---
-name: "DoorDash"
-description: "Order food, groceries, and convenience items from DoorDash using the built-in CLI integration"
-user-invocable: true
-metadata:
-  {
-    "vellum":
-      {
-        "emoji": "\uD83C\uDF55",
-        "cli": { "command": "doordash", "entry": "doordash-entry.ts" },
-      },
-  }
+name: doordash
+description: Order food, groceries, and convenience items from DoorDash using the built-in CLI integration
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🍕","vellum":{"display-name":"DoorDash","user-invocable":true,"cli":{"command":"doordash","entry":"doordash-entry.ts"}}}
 ---
 
 You can order food from DoorDash for the user using the `doordash` CLI.

--- a/assistant/src/config/bundled-skills/elevenlabs-voice/SKILL.md
+++ b/assistant/src/config/bundled-skills/elevenlabs-voice/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "ElevenLabs Voice"
-description: "Select and tune an ElevenLabs TTS voice — curated voice list, custom/cloned voices via API key, and tuning parameters"
-user-invocable: true
-metadata: { "vellum": { "emoji": "🗣️" } }
+name: elevenlabs-voice
+description: Select and tune an ElevenLabs TTS voice — curated voice list, custom/cloned voices via API key, and tuning parameters
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🗣️","vellum":{"display-name":"ElevenLabs Voice","user-invocable":true}}
 ---
 
 ## Overview

--- a/assistant/src/config/bundled-skills/email-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/email-setup/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Email Setup"
-description: "Create the assistant's own email address via the Vellum hosted API (one-time setup)"
-user-invocable: true
-metadata: { "vellum": { "emoji": "📧" } }
+name: email-setup
+description: Create the assistant's own email address via the Vellum hosted API (one-time setup)
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"📧","vellum":{"display-name":"Email Setup","user-invocable":true}}
 ---
 
 You are setting up your own personal email address. This is a one-time operation — once you have an email, you do not need to run this again.

--- a/assistant/src/config/bundled-skills/followups/SKILL.md
+++ b/assistant/src/config/bundled-skills/followups/SKILL.md
@@ -1,7 +1,8 @@
 ---
-name: "Followups"
-description: "Track sent messages awaiting responses across communication channels"
-metadata: {"vellum": {"emoji": "\ud83d\udce8"}}
+name: followups
+description: Track sent messages awaiting responses across communication channels
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"📨","vellum":{"display-name":"Followups"}}
 ---
 
 Track messages sent on external channels (email, Slack, WhatsApp, etc.) that are awaiting a response.

--- a/assistant/src/config/bundled-skills/frontend-design/SKILL.md
+++ b/assistant/src/config/bundled-skills/frontend-design/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: frontend-design
 description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
+compatibility: "Designed for Vellum personal assistants"
 license: Complete terms in LICENSE.txt
+metadata: {}
 ---
 
 This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.

--- a/assistant/src/config/bundled-skills/google-calendar/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-calendar/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Google Calendar"
-description: "View, create, and manage Google Calendar events and check availability"
-user-invocable: true
-metadata: { "vellum": { "emoji": "📅" } }
+name: google-calendar
+description: View, create, and manage Google Calendar events and check availability
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"📅","vellum":{"display-name":"Google Calendar","user-invocable":true}}
 ---
 
 You are a Google Calendar assistant with full access to the user's calendar. Use the Calendar tools to help them view, create, and manage events.

--- a/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/google-oauth-setup/SKILL.md
@@ -1,10 +1,8 @@
 ---
-name: "Google OAuth Setup"
-description: "Set up Google Cloud OAuth credentials for Gmail and Calendar using browser automation"
-user-invocable: true
-credential-setup-for: "gmail"
-includes: ["browser", "public-ingress"]
-metadata: { "vellum": { "emoji": "\ud83d\udd11" } }
+name: google-oauth-setup
+description: Set up Google Cloud OAuth credentials for Gmail and Calendar using browser automation
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🔑","vellum":{"display-name":"Google OAuth Setup","user-invocable":true,"includes":["browser","public-ingress"],"credential-setup-for":"gmail"}}
 ---
 
 You are helping your user set up Google Cloud OAuth credentials so Gmail and Google Calendar integrations can connect.

--- a/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Guardian Verify Setup"
-description: "Set up channel verification for phone, Telegram, or Slack channels via outbound verification flow"
-user-invocable: true
-metadata: { "vellum": { "emoji": "\ud83d\udd10" } }
+name: guardian-verify-setup
+description: Set up channel verification for phone, Telegram, or Slack channels via outbound verification flow
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🔐","vellum":{"display-name":"Guardian Verify Setup","user-invocable":true}}
 ---
 
 You are helping your user set up channel verification for a messaging channel (phone, Telegram, or Slack). This links their identity as the trusted guardian for the chosen channel. Use gateway control-plane APIs for outbound actions, and use `assistant integrations guardian status` for status reads.

--- a/assistant/src/config/bundled-skills/image-studio/SKILL.md
+++ b/assistant/src/config/bundled-skills/image-studio/SKILL.md
@@ -1,9 +1,8 @@
 ---
-name: "Image Studio"
-description: "Generate and edit images using AI"
-user-invocable: true
-disable-model-invocation: false
-metadata: {"vellum": {"emoji": "🎨"}}
+name: image-studio
+description: Generate and edit images using AI
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🎨","vellum":{"display-name":"Image Studio","user-invocable":true}}
 ---
 
 You are an image generation assistant. When the user asks you to create or edit images, use the `media_generate_image` tool.

--- a/assistant/src/config/bundled-skills/influencer/SKILL.md
+++ b/assistant/src/config/bundled-skills/influencer/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Influencer Research"
-description: "Research influencers on Instagram, TikTok, and X/Twitter using the Chrome extension relay"
-user-invocable: true
-metadata: {"vellum": {"emoji": "🔍"}}
+name: influencer
+description: Research influencers on Instagram, TikTok, and X/Twitter using the Chrome extension relay
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🔍","vellum":{"display-name":"Influencer Research","user-invocable":true}}
 ---
 
 You can research and discover influencers across Instagram, TikTok, and X/Twitter using the `assistant influencer` CLI.

--- a/assistant/src/config/bundled-skills/knowledge-graph/SKILL.md
+++ b/assistant/src/config/bundled-skills/knowledge-graph/SKILL.md
@@ -1,6 +1,8 @@
 ---
-name: "Knowledge Graph"
-description: "Query the entity knowledge graph to explore relationships between people, projects, tools, and other entities tracked in memory"
+name: knowledge-graph
+description: Query the entity knowledge graph to explore relationships between people, projects, tools, and other entities tracked in memory
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"vellum":{"display-name":"Knowledge Graph"}}
 ---
 
 # Knowledge Graph

--- a/assistant/src/config/bundled-skills/macos-automation/SKILL.md
+++ b/assistant/src/config/bundled-skills/macos-automation/SKILL.md
@@ -1,9 +1,8 @@
 ---
-name: "macOS Automation"
-description: "Automate native macOS apps and system interactions via osascript (AppleScript)"
-user-invocable: false
-disable-model-invocation: false
-metadata: {"vellum": {"emoji": "🍎", "os": ["darwin"]}}
+name: macos-automation
+description: Automate native macOS apps and system interactions via osascript (AppleScript)
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🍎","vellum":{"display-name":"macOS Automation","user-invocable":false,"os":["darwin"]}}
 ---
 
 Use this skill to interact with native macOS apps and system-level features via `osascript` (AppleScript) through `host_bash`. Always prefer osascript over browser automation or computer-use for anything involving a native macOS app.

--- a/assistant/src/config/bundled-skills/mcp-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/mcp-setup/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "MCP Setup"
-description: "Add, authenticate, list, and remove MCP (Model Context Protocol) servers"
-user-invocable: false
-metadata: { "vellum": { "emoji": "🔌" } }
+name: mcp-setup
+description: Add, authenticate, list, and remove MCP (Model Context Protocol) servers
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🔌","vellum":{"display-name":"MCP Setup","user-invocable":false}}
 ---
 
 Help users configure MCP servers so external tools (e.g. Linear, GitHub, Notion) become available in conversations.

--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -1,7 +1,8 @@
 ---
-name: "Media Processing"
+name: media-processing
 description: "Ingest and process media files (video, audio, image) through a 3-phase pipeline: preprocess, map (Gemini), and reduce (Claude)"
-metadata: { "vellum": { "emoji": "🎬" } }
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🎬","vellum":{"display-name":"Media Processing"}}
 ---
 
 Ingest and track processing of media files (video, audio, images) through a configurable 3-phase pipeline.

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Messaging"
-description: "Read, search, send, and manage messages across Slack, Gmail, Telegram, and other platforms"
-user-invocable: true
-metadata: { "vellum": { "emoji": "💬" } }
+name: messaging
+description: Read, search, send, and manage messages across Slack, Gmail, Telegram, and other platforms
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"💬","vellum":{"display-name":"Messaging","user-invocable":true}}
 ---
 
 You are a unified messaging assistant with access to multiple platforms (Slack, Gmail, Telegram, and more). Use the messaging tools to help users read, search, organize, draft, and send messages across all connected platforms.

--- a/assistant/src/config/bundled-skills/notifications/SKILL.md
+++ b/assistant/src/config/bundled-skills/notifications/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Notifications"
-description: "Send notifications through the unified notification router"
-user-invocable: true
-metadata: { "vellum": { "emoji": "\ud83d\udd14" } }
+name: notifications
+description: Send notifications through the unified notification router
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🔔","vellum":{"display-name":"Notifications","user-invocable":true}}
 ---
 
 Use `send_notification` for user-facing alerts and notifications. This tool routes through the unified notification pipeline, which handles channel selection, delivery, deduplication, and audit logging.

--- a/assistant/src/config/bundled-skills/notion-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/notion-oauth-setup/SKILL.md
@@ -1,9 +1,8 @@
 ---
-name: "Notion OAuth Setup"
-description: "Create a Notion integration and OAuth credentials for Notion integration using browser automation"
-user-invocable: true
-includes: ["browser", "public-ingress"]
-metadata: {"vellum": {"emoji": "🔑"}}
+name: notion-oauth-setup
+description: Create a Notion integration and OAuth credentials for Notion integration using browser automation
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🔑","vellum":{"display-name":"Notion OAuth Setup","user-invocable":true,"includes":["browser","public-ingress"]}}
 ---
 
 You are helping your user create a Notion integration (OAuth app) so Vellum can connect to their Notion workspace. Walk through each step below using `browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_click`, `browser_type`, and `browser_extract` tools.

--- a/assistant/src/config/bundled-skills/notion/SKILL.md
+++ b/assistant/src/config/bundled-skills/notion/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Notion"
-description: "Read and write Notion pages and databases using the Notion API"
-user-invocable: false
-metadata: {"vellum": {"emoji": "📝"}}
+name: notion
+description: Read and write Notion pages and databases using the Notion API
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"📝","vellum":{"display-name":"Notion","user-invocable":false}}
 ---
 
 You have access to the Notion API via the stored OAuth token for `integration:notion`. Use `bash` with `network_mode: "proxied"` to call the Notion API — the proxy automatically injects the Bearer token for `api.notion.com`.

--- a/assistant/src/config/bundled-skills/oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/oauth-setup/SKILL.md
@@ -1,9 +1,8 @@
 ---
-name: "OAuth Setup"
-description: "Connect any OAuth service — create app credentials and authorize via browser automation"
-user-invocable: true
-includes: ["browser"]
-metadata: {"vellum": {"emoji": "🔑"}}
+name: oauth-setup
+description: Connect any OAuth service — create app credentials and authorize via browser automation
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🔑","vellum":{"display-name":"OAuth Setup","user-invocable":true,"includes":["browser"]}}
 ---
 
 You are helping the user connect an OAuth-based service to Vellum. This is a generic setup flow that works for any provider with a well-known OAuth config.

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -1,10 +1,8 @@
 ---
-name: "Phone Calls"
-description: "Set up Twilio for AI-powered voice calls — both outgoing calls on behalf of the user and incoming calls where the assistant answers as a receptionist"
-user-invocable: true
-metadata:
-  { "vellum": { "emoji": "📞", "requires": { "config": ["calls.enabled"] } } }
-includes: ["public-ingress", "elevenlabs-voice"]
+name: phone-calls
+description: Set up Twilio for AI-powered voice calls — both outgoing calls on behalf of the user and incoming calls where the assistant answers as a receptionist
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"📞","vellum":{"display-name":"Phone Calls","user-invocable":true,"includes":["public-ingress","elevenlabs-voice"],"requires":{"config":["calls.enabled"]}}}
 ---
 
 You are helping the user set up and manage phone calls via Twilio. This skill covers enabling the calls feature, placing outbound calls, receiving inbound calls, and interacting with live calls. Twilio credential storage, phone number provisioning, and public ingress are handled by the **twilio-setup** skill.

--- a/assistant/src/config/bundled-skills/playbooks/SKILL.md
+++ b/assistant/src/config/bundled-skills/playbooks/SKILL.md
@@ -1,7 +1,8 @@
 ---
-name: "Playbooks"
-description: "Trigger-action automation rules for handling incoming messages"
-metadata: {"vellum": {"emoji": "\ud83d\udcd6"}}
+name: playbooks
+description: Trigger-action automation rules for handling incoming messages
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"📖","vellum":{"display-name":"Playbooks"}}
 ---
 
 Playbooks are trigger-action automation rules that tell the assistant how to handle incoming messages matching a pattern.

--- a/assistant/src/config/bundled-skills/public-ingress/SKILL.md
+++ b/assistant/src/config/bundled-skills/public-ingress/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Public Ingress"
-description: "Set up and manage ngrok-based public ingress for webhooks and OAuth callbacks via ingress.publicBaseUrl"
-user-invocable: true
-metadata: { "vellum": { "emoji": "🌍" } }
+name: public-ingress
+description: Set up and manage ngrok-based public ingress for webhooks and OAuth callbacks via ingress.publicBaseUrl
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🌍","vellum":{"display-name":"Public Ingress","user-invocable":true}}
 ---
 
 You are setting up and managing a public ingress tunnel so that external services (Telegram webhooks, OAuth callbacks, etc.) can reach the local Vellum gateway. This skill uses ngrok to create a secure tunnel and persists the public URL as `ingress.publicBaseUrl`.

--- a/assistant/src/config/bundled-skills/reminder/SKILL.md
+++ b/assistant/src/config/bundled-skills/reminder/SKILL.md
@@ -1,7 +1,8 @@
 ---
-name: "Reminder"
-description: "One-time time-based reminders that fire at a specific future time"
-metadata: {"vellum": {"emoji": "🔔"}}
+name: reminder
+description: One-time time-based reminders that fire at a specific future time
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🔔","vellum":{"display-name":"Reminder"}}
 ---
 
 Create, list, and cancel one-time reminders. Reminders fire at a specific future time and either notify the user or execute a message through the assistant.

--- a/assistant/src/config/bundled-skills/restaurant-reservation/SKILL.md
+++ b/assistant/src/config/bundled-skills/restaurant-reservation/SKILL.md
@@ -1,10 +1,8 @@
 ---
-name: "Restaurant Reservation Booking"
-description: "Book reservations on OpenTable or Resy with explicit confirmations"
-user-invocable: true
-disable-model-invocation: true
-includes: ["browser"]
-metadata: {"vellum": {"emoji": "🍽️"}}
+name: restaurant-reservation
+description: Book reservations on OpenTable or Resy with explicit confirmations
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🍽️","vellum":{"display-name":"Restaurant Reservation Booking","user-invocable":true,"disable-model-invocation":true,"includes":["browser"]}}
 ---
 
 Book restaurant reservations on OpenTable or Resy using browser automation.

--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -1,7 +1,8 @@
 ---
-name: "Schedule"
-description: "Recurring automation that dispatches messages on a cron or RRULE schedule"
-metadata: { "vellum": { "emoji": "\ud83d\udcc5" } }
+name: schedule
+description: Recurring automation that dispatches messages on a cron or RRULE schedule
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"📅","vellum":{"display-name":"Schedule"}}
 ---
 
 Manage recurring scheduled automations. Each schedule has an expression (cron or RRULE) that defines when it fires, and a message that gets dispatched to the assistant at trigger time.

--- a/assistant/src/config/bundled-skills/screen-recording/SKILL.md
+++ b/assistant/src/config/bundled-skills/screen-recording/SKILL.md
@@ -1,7 +1,8 @@
 ---
-name: "Screen Recording"
-description: "Record the user's screen as a video file"
-metadata: { "vellum": { "emoji": "🎬", "os": ["darwin"] } }
+name: screen-recording
+description: Record the user's screen as a video file
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🎬","vellum":{"display-name":"Screen Recording","os":["darwin"]}}
 ---
 
 Capture screen recordings as video files attached to the conversation.

--- a/assistant/src/config/bundled-skills/self-upgrade/SKILL.md
+++ b/assistant/src/config/bundled-skills/self-upgrade/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Self Upgrade"
-description: "Upgrade vellum to the latest version, restart the assistant, and restart the gateway"
-user-invocable: true
-metadata: { "vellum": { "emoji": "⬆️" } }
+name: self-upgrade
+description: Upgrade vellum to the latest version, restart the assistant, and restart the gateway
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"⬆️","vellum":{"display-name":"Self Upgrade","user-invocable":true}}
 ---
 
 You are performing a self-upgrade of the Vellum assistant. Follow these steps **in order**. Use the `bash` tool to run each command. Confirm each step succeeds before moving to the next.

--- a/assistant/src/config/bundled-skills/skills-catalog/SKILL.md
+++ b/assistant/src/config/bundled-skills/skills-catalog/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Skills Catalog"
-description: "Discover bundled skills and search/install community skills from Clawhub"
-user-invocable: true
-metadata: { "vellum": { "emoji": "🧩" } }
+name: skills-catalog
+description: Discover bundled skills and search/install community skills from Clawhub
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🧩","vellum":{"display-name":"Skills Catalog","user-invocable":true}}
 ---
 
 You can help the user discover what skills are available and find community skills to extend the assistant's capabilities.

--- a/assistant/src/config/bundled-skills/slack-app-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack-app-setup/SKILL.md
@@ -1,9 +1,8 @@
 ---
-name: "Slack App Setup"
-description: "Connect a Slack app to the Vellum Assistant via Socket Mode with guided app creation and guardian verification"
-user-invocable: true
-includes: ["guardian-verify-setup"]
-metadata: { "vellum": { "emoji": "💬" } }
+name: slack-app-setup
+description: Connect a Slack app to the Vellum Assistant via Socket Mode with guided app creation and guardian verification
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"💬","vellum":{"display-name":"Slack App Setup","user-invocable":true,"includes":["guardian-verify-setup"]}}
 ---
 
 You are helping your user connect a Slack bot to the Vellum Assistant gateway via Socket Mode. The gateway manages the Socket Mode connection — it never hits the assistant runtime directly. When this skill is invoked, walk through each step below using only existing tools.

--- a/assistant/src/config/bundled-skills/slack-digest-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack-digest-setup/SKILL.md
@@ -1,9 +1,8 @@
 ---
-name: "Slack Digest Setup"
-description: "Set up recurring Slack channel digests with scanning schedules, channel configuration, and delivery — codifies best practices for high-quality automated summaries"
-user-invocable: true
-includes: ["slack", "schedule"]
-metadata: { "vellum": { "emoji": "📊" } }
+name: slack-digest-setup
+description: Set up recurring Slack channel digests with scanning schedules, channel configuration, and delivery — codifies best practices for high-quality automated summaries
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"📊","vellum":{"display-name":"Slack Digest Setup","user-invocable":true,"includes":["slack","schedule"]}}
 ---
 
 You are helping your user set up a recurring Slack digest: automated channel scanning on a schedule that delivers prose-style summaries of what's happening across their workspace. This skill walks through configuration, scheduling, and — critically — the execution protocol that ensures every digest is actually useful.

--- a/assistant/src/config/bundled-skills/slack-oauth-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack-oauth-setup/SKILL.md
@@ -1,9 +1,8 @@
 ---
-name: "Slack OAuth Setup"
-description: "Create Slack App and OAuth credentials for Slack integration using browser automation"
-user-invocable: true
-includes: ["browser"]
-metadata: {"vellum": {"emoji": "🔑"}}
+name: slack-oauth-setup
+description: Create Slack App and OAuth credentials for Slack integration using browser automation
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🔑","vellum":{"display-name":"Slack OAuth Setup","user-invocable":true,"includes":["browser"]}}
 ---
 
 You are helping your user create a Slack App and OAuth credentials so the Messaging integration can connect to their Slack workspace. Walk through each step below using `browser_navigate`, `browser_snapshot`, `browser_screenshot`, `browser_click`, `browser_type`, and `browser_extract` tools.

--- a/assistant/src/config/bundled-skills/slack/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Slack"
-description: "Scan channels, summarize threads, and manage Slack with privacy guardrails"
-user-invocable: true
-metadata: { "vellum": { "emoji": "💬" } }
+name: slack
+description: Scan channels, summarize threads, and manage Slack with privacy guardrails
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"💬","vellum":{"display-name":"Slack","user-invocable":true}}
 ---
 
 You are a Slack assistant that helps users stay on top of their Slack workspace. Use the slack tools for channel scanning, thread summarization, and Slack-specific operations.

--- a/assistant/src/config/bundled-skills/start-the-day/SKILL.md
+++ b/assistant/src/config/bundled-skills/start-the-day/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "Start the Day"
-description: "Get a personalized daily briefing with weather, news, and actionable insights"
-user-invocable: true
-metadata: {"vellum": {"emoji": "🌅"}}
+name: start-the-day
+description: Get a personalized daily briefing with weather, news, and actionable insights
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🌅","vellum":{"display-name":"Start the Day","user-invocable":true}}
 ---
 
 You are a personal daily briefing assistant. When the user invokes this skill, generate a concise, actionable briefing tailored to the current moment.

--- a/assistant/src/config/bundled-skills/subagent/SKILL.md
+++ b/assistant/src/config/bundled-skills/subagent/SKILL.md
@@ -1,7 +1,8 @@
 ---
-name: "Subagent"
-description: "Spawn and manage autonomous background agents for parallel work"
-metadata: {"vellum": {"emoji": "\ud83e\udd16"}}
+name: subagent
+description: Spawn and manage autonomous background agents for parallel work
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🤖","vellum":{"display-name":"Subagent"}}
 ---
 
 Subagent orchestration -- spawn background agents to work on tasks in parallel.

--- a/assistant/src/config/bundled-skills/tasks/SKILL.md
+++ b/assistant/src/config/bundled-skills/tasks/SKILL.md
@@ -1,7 +1,8 @@
 ---
-name: "Tasks"
-description: "Two-layer task system with reusable templates and a prioritized work queue"
-metadata: {"vellum": {"emoji": "\u2705"}}
+name: tasks
+description: Two-layer task system with reusable templates and a prioritized work queue
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"✅","vellum":{"display-name":"Tasks"}}
 ---
 
 Two-layer task system: **task templates** (reusable definitions with input placeholders) and **work items** (instances in the Task Queue with priority tiers and status tracking).

--- a/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
@@ -1,9 +1,8 @@
 ---
-name: "Telegram Setup"
-description: "Connect a Telegram bot to the Vellum Assistant gateway with automated webhook registration and credential storage"
-user-invocable: true
-includes: ["public-ingress"]
-metadata: { "vellum": { "emoji": "\ud83e\udd16" } }
+name: telegram-setup
+description: Connect a Telegram bot to the Vellum Assistant gateway with automated webhook registration and credential storage
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🤖","vellum":{"display-name":"Telegram Setup","user-invocable":true,"includes":["public-ingress"]}}
 ---
 
 You are helping your user connect a Telegram bot to the Vellum Assistant gateway. Telegram webhooks are received exclusively by the gateway (the public ingress boundary) — they never hit the assistant runtime directly. When this skill is invoked, walk through each step below using only existing tools.

--- a/assistant/src/config/bundled-skills/time-based-actions/SKILL.md
+++ b/assistant/src/config/bundled-skills/time-based-actions/SKILL.md
@@ -1,7 +1,8 @@
 ---
-name: "Time-Based Actions"
-description: "Unified routing guide for reminders, schedules, notifications, and tasks — prevents common misrouting"
-metadata: {"vellum": {"emoji": "\u23f0"}}
+name: time-based-actions
+description: Unified routing guide for reminders, schedules, notifications, and tasks — prevents common misrouting
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"⏰","vellum":{"display-name":"Time-Based Actions"}}
 ---
 
 Quick-reference decision guide for choosing the right tool when users ask about time-triggered actions, recurring automation, notifications, or task tracking.

--- a/assistant/src/config/bundled-skills/transcribe/SKILL.md
+++ b/assistant/src/config/bundled-skills/transcribe/SKILL.md
@@ -1,7 +1,8 @@
 ---
-name: "Transcribe"
-description: "Transcribe audio and video files using Whisper (cloud API or local)"
-metadata: {"vellum": {"emoji": "🎙️"}}
+name: transcribe
+description: Transcribe audio and video files using Whisper (cloud API or local)
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🎙️","vellum":{"display-name":"Transcribe"}}
 ---
 
 Transcribe audio and video files using OpenAI's Whisper model — either via the cloud API or locally via whisper.cpp.

--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -1,9 +1,8 @@
 ---
-name: "Twilio Setup"
-description: "Configure Twilio credentials and phone numbers for voice calls"
-user-invocable: true
-includes: ["public-ingress"]
-metadata: { "vellum": { "emoji": "\ud83d\udcf1" } }
+name: twilio-setup
+description: Configure Twilio credentials and phone numbers for voice calls
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"📱","vellum":{"display-name":"Twilio Setup","user-invocable":true,"includes":["public-ingress"]}}
 ---
 
 You are helping your user configure Twilio for voice calls. Walk through each step below.

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "X"
-description: "Read and post on X (formerly Twitter) via OAuth or browser session"
-user-invocable: true
-metadata: { "vellum": { "emoji": "𝕏" } }
+name: twitter
+description: Read and post on X (formerly Twitter) via OAuth or browser session
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"𝕏","vellum":{"display-name":"X","user-invocable":true}}
 ---
 
 You are an X (formerly Twitter) assistant. Use the `bash` tool to run `assistant x`, `assistant config`, and `assistant oauth` CLI commands.

--- a/assistant/src/config/bundled-skills/typescript-eval/SKILL.md
+++ b/assistant/src/config/bundled-skills/typescript-eval/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: "TypeScript Evaluation"
-description: "Test TypeScript code snippets before persisting as skills"
-user-invocable: false
-metadata: {"vellum": {"emoji": "🧪"}}
+name: typescript-eval
+description: Test TypeScript code snippets before persisting as skills
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🧪","vellum":{"display-name":"TypeScript Evaluation","user-invocable":false}}
 ---
 
 # TypeScript Evaluation

--- a/assistant/src/config/bundled-skills/vercel-token-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/vercel-token-setup/SKILL.md
@@ -1,9 +1,8 @@
 ---
-name: "Vercel Token Setup"
-description: "Set up a Vercel API token for publishing apps using browser automation"
-includes: ["browser"]
-credential-setup-for: "vercel:api_token"
-metadata: {"vellum": {"emoji": "▲"}}
+name: vercel-token-setup
+description: Set up a Vercel API token for publishing apps using browser automation
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"▲","vellum":{"display-name":"Vercel Token Setup","includes":["browser"],"credential-setup-for":"vercel:api_token"}}
 ---
 
 You are helping your user set up a Vercel API token so they can publish apps to the web.

--- a/assistant/src/config/bundled-skills/voice-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/voice-setup/SKILL.md
@@ -1,9 +1,8 @@
 ---
-name: "Voice Setup"
-description: "Complete voice configuration in chat — PTT key, wake word, microphone permissions, ElevenLabs TTS, and troubleshooting"
-user-invocable: true
-metadata: { "vellum": { "emoji": "🎙️", "os": ["darwin"] } }
-includes: ["elevenlabs-voice"]
+name: voice-setup
+description: Complete voice configuration in chat — PTT key, wake word, microphone permissions, ElevenLabs TTS, and troubleshooting
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"🎙️","vellum":{"display-name":"Voice Setup","user-invocable":true,"includes":["elevenlabs-voice"],"os":["darwin"]}}
 ---
 
 You are helping the user set up and troubleshoot voice features (push-to-talk, wake word, text-to-speech) entirely within this conversation. Do NOT direct the user to the Settings page for initial setup — handle everything in-chat using the tools below.

--- a/assistant/src/config/bundled-skills/watcher/SKILL.md
+++ b/assistant/src/config/bundled-skills/watcher/SKILL.md
@@ -1,7 +1,8 @@
 ---
-name: "Watcher"
-description: "Polling watcher system for monitoring external sources"
-metadata: {"vellum": {"emoji": "👀"}}
+name: watcher
+description: Polling watcher system for monitoring external sources
+compatibility: "Designed for Vellum personal assistants"
+metadata: {"emoji":"👀","vellum":{"display-name":"Watcher"}}
 ---
 
 Create and manage watchers that poll external services for events and process them with an action prompt.

--- a/scripts/skills/migrate-bundled-frontmatter.mjs
+++ b/scripts/skills/migrate-bundled-frontmatter.mjs
@@ -1,0 +1,394 @@
+/**
+ * Migration script: Convert all bundled SKILL.md files to Agent Skills spec-compliant frontmatter.
+ *
+ * For each bundled skill, this script:
+ *   1. Parses the existing frontmatter
+ *   2. Builds a new spec-compliant frontmatter block:
+ *      - `name`: directory name (kebab-case)
+ *      - `description`: kept unchanged
+ *      - `compatibility`: "Designed for Vellum personal assistants"
+ *      - `license`: kept if present
+ *      - `metadata`: JSON object with emoji + vellum sub-object
+ *   3. Writes the updated SKILL.md preserving the original body content
+ *
+ * Usage:
+ *   node scripts/skills/migrate-bundled-frontmatter.mjs
+ */
+
+import { readdirSync, readFileSync, writeFileSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BUNDLED_SKILLS_DIR = resolve(
+  __dirname,
+  "../../assistant/src/config/bundled-skills",
+);
+
+// --- Frontmatter parsing (same logic as lint-skill-spec.mjs) ---
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    throw new Error("SKILL.md must start with YAML frontmatter (---).");
+  }
+
+  const frontmatterRaw = match[1];
+  const body = content.slice(match[0].length);
+  const fields = parseSimpleYaml(frontmatterRaw);
+
+  return { fields, body, frontmatterRaw };
+}
+
+/**
+ * Minimal YAML parser for flat key-value pairs and nested maps.
+ * Handles string values (quoted or unquoted), multiline JSON values,
+ * and multiple levels of nesting.
+ *
+ * Uses the same continuation-line logic as the TypeScript frontmatter.ts
+ * to handle multiline JSON metadata blocks.
+ */
+function parseSimpleYaml(yaml) {
+  const result = {};
+  const lines = yaml.split(/\r?\n/);
+  let currentKey = undefined;
+  let continuationLines = [];
+
+  function flushContinuation() {
+    if (currentKey !== undefined) {
+      if (continuationLines.length > 0) {
+        const joined = continuationLines.map((l) => l.trim()).join(" ");
+        try {
+          JSON.parse(joined);
+          result[currentKey] = joined;
+        } catch {
+          result[currentKey] = joined.replace(/,\s*([}\]])/g, "$1");
+        }
+      } else {
+        result[currentKey] = "";
+      }
+    }
+    currentKey = undefined;
+    continuationLines = [];
+  }
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    // Continuation line: indented and we have a pending key
+    if (currentKey !== undefined && /^\s/.test(line)) {
+      continuationLines.push(trimmed);
+      continue;
+    }
+
+    // Flush any pending multiline value
+    flushContinuation();
+
+    const separatorIndex = trimmed.indexOf(":");
+    if (separatorIndex === -1) continue;
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    let value = trimmed.slice(separatorIndex + 1).trim();
+
+    if (!value) {
+      // Value may continue on subsequent indented lines
+      currentKey = key;
+      continuationLines = [];
+      continue;
+    }
+
+    const isDoubleQuoted = value.startsWith('"') && value.endsWith('"');
+    const isSingleQuoted = value.startsWith("'") && value.endsWith("'");
+    if (isDoubleQuoted || isSingleQuoted) {
+      value = value.slice(1, -1);
+      if (isDoubleQuoted) {
+        value = value.replace(/\\(["\\nr])/g, (_, ch) => {
+          if (ch === "n") return "\n";
+          if (ch === "r") return "\r";
+          return ch;
+        });
+      }
+    }
+
+    result[key] = value;
+  }
+
+  flushContinuation();
+  return result;
+}
+
+// --- Standard top-level fields (Agent Skills spec) ---
+const STANDARD_FIELDS = new Set([
+  "name",
+  "description",
+  "license",
+  "compatibility",
+  "metadata",
+  "allowed-tools",
+]);
+
+// --- Migration logic ---
+
+function migrateSkill(dirName, skillDir) {
+  const skillMdPath = join(skillDir, "SKILL.md");
+  const content = readFileSync(skillMdPath, "utf-8");
+
+  const { fields, body } = parseFrontmatter(content);
+
+  const changes = [];
+
+  // Original name value (for display-name)
+  const originalName = fields.name || dirName;
+
+  // 1. Set name to directory name
+  const newName = dirName;
+  if (originalName !== dirName) {
+    changes.push(`name: "${originalName}" → "${newName}"`);
+  }
+
+  // 2. Keep description
+  const description = fields.description || "";
+
+  // 3. Keep license if present
+  const license = fields.license || undefined;
+
+  // 4. Parse existing metadata JSON (if any)
+  let existingMetadata = {};
+  const metadataRaw = fields.metadata?.trim();
+  if (metadataRaw) {
+    try {
+      existingMetadata = JSON.parse(metadataRaw);
+    } catch {
+      // Try cleaning trailing commas
+      try {
+        existingMetadata = JSON.parse(
+          metadataRaw.replace(/,\s*([}\]])/g, "$1"),
+        );
+      } catch (e2) {
+        console.warn(
+          `  WARNING: Failed to parse metadata JSON for ${dirName}: ${e2.message}`,
+        );
+      }
+    }
+  }
+
+  // 5. Extract emoji from various locations
+  let emoji =
+    existingMetadata?.vellum?.emoji ||
+    existingMetadata?.emoji ||
+    fields.emoji ||
+    undefined;
+
+  if (!emoji) {
+    console.warn(`  WARNING: No emoji found for ${dirName}`);
+  }
+
+  // 6. Build vellum sub-object
+  const vellum = {};
+
+  // display-name: only if original name differs from directory name
+  if (originalName !== dirName) {
+    vellum["display-name"] = originalName;
+    changes.push(`display-name: "${originalName}"`);
+  }
+
+  // user-invocable: only if explicitly set in frontmatter
+  if (fields["user-invocable"] !== undefined) {
+    const val = fields["user-invocable"].trim().toLowerCase();
+    vellum["user-invocable"] = val !== "false";
+    if (val === "false") {
+      changes.push(`user-invocable: false (preserved)`);
+    }
+  } else if (
+    existingMetadata?.vellum?.["user-invocable"] !== undefined
+  ) {
+    vellum["user-invocable"] = existingMetadata.vellum["user-invocable"];
+  }
+  // If not explicitly set anywhere, omit (runtime defaults to true)
+
+  // disable-model-invocation: only if true
+  const dmiFromField = fields["disable-model-invocation"]?.trim().toLowerCase();
+  const dmiFromMetadata =
+    existingMetadata?.vellum?.["disable-model-invocation"];
+  if (dmiFromField === "true" || dmiFromMetadata === true) {
+    vellum["disable-model-invocation"] = true;
+    changes.push(`disable-model-invocation: true (preserved)`);
+  }
+  // Note: if it's explicitly "false", we omit it (false is the default)
+
+  // includes: only if present
+  let includesValue;
+  if (fields.includes) {
+    try {
+      includesValue = JSON.parse(fields.includes);
+    } catch {
+      // Try as raw string
+      includesValue = fields.includes;
+    }
+  }
+  if (existingMetadata?.vellum?.includes) {
+    includesValue = existingMetadata.vellum.includes;
+  }
+  if (includesValue) {
+    vellum["includes"] = includesValue;
+    changes.push(`includes moved to metadata.vellum`);
+  }
+
+  // credential-setup-for: only if present
+  const credSetupFor =
+    fields["credential-setup-for"] ||
+    existingMetadata?.vellum?.["credential-setup-for"];
+  if (credSetupFor) {
+    vellum["credential-setup-for"] = credSetupFor;
+    changes.push(`credential-setup-for moved to metadata.vellum`);
+  }
+
+  // Preserve other existing metadata.vellum fields (cli, requires, os, primaryEnv, install, etc.)
+  if (existingMetadata?.vellum) {
+    for (const [key, val] of Object.entries(existingMetadata.vellum)) {
+      if (
+        key === "emoji" ||
+        key === "display-name" ||
+        key === "user-invocable" ||
+        key === "disable-model-invocation" ||
+        key === "includes" ||
+        key === "credential-setup-for"
+      ) {
+        continue; // Already handled above
+      }
+      vellum[key] = val;
+    }
+  }
+
+  // 7. Build top-level metadata object
+  const newMetadata = {};
+  if (emoji) {
+    newMetadata["emoji"] = emoji;
+  }
+  if (Object.keys(vellum).length > 0) {
+    newMetadata["vellum"] = vellum;
+  }
+
+  // 8. Build the new frontmatter
+  const metadataJson = JSON.stringify(newMetadata);
+
+  let frontmatterLines = [];
+  frontmatterLines.push(`name: ${newName}`);
+
+  // Quote description if it contains colons or other special chars
+  const escapedDescription = escapeYamlValue(description);
+  frontmatterLines.push(`description: ${escapedDescription}`);
+
+  frontmatterLines.push(
+    `compatibility: "Designed for Vellum personal assistants"`,
+  );
+
+  if (license) {
+    frontmatterLines.push(`license: ${escapeYamlValue(license)}`);
+  }
+
+  frontmatterLines.push(`metadata: ${metadataJson}`);
+
+  // Preserve allowed-tools if present
+  if (fields["allowed-tools"]) {
+    frontmatterLines.push(
+      `allowed-tools: ${escapeYamlValue(fields["allowed-tools"])}`,
+    );
+  }
+
+  const newContent = `---\n${frontmatterLines.join("\n")}\n---\n${body}`;
+
+  writeFileSync(skillMdPath, newContent, "utf-8");
+
+  return changes;
+}
+
+/**
+ * Escape a YAML value — quote it if it contains special characters.
+ * If the value already contains double quotes, use appropriate quoting.
+ */
+function escapeYamlValue(value) {
+  if (!value) return '""';
+
+  // If value contains newlines, colons, or other YAML-special chars, quote it
+  if (
+    value.includes(":") ||
+    value.includes("#") ||
+    value.includes("\n") ||
+    value.includes('"') ||
+    value.startsWith("'") ||
+    value.startsWith("{") ||
+    value.startsWith("[") ||
+    value.startsWith("*") ||
+    value.startsWith("&") ||
+    value.startsWith("!") ||
+    value.startsWith("|") ||
+    value.startsWith(">") ||
+    value.startsWith("%") ||
+    value.startsWith("@") ||
+    value.startsWith("`")
+  ) {
+    // Use double quotes with escaping
+    const escaped = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    return `"${escaped}"`;
+  }
+
+  return value;
+}
+
+// --- Main ---
+
+function main() {
+  const entries = readdirSync(BUNDLED_SKILLS_DIR, { withFileTypes: true });
+  const skillDirs = entries
+    .filter((e) => e.isDirectory() && e.name !== "_shared")
+    .filter((e) => {
+      const skillMdPath = join(BUNDLED_SKILLS_DIR, e.name, "SKILL.md");
+      try {
+        return statSync(skillMdPath).isFile();
+      } catch {
+        return false;
+      }
+    })
+    .map((e) => e.name)
+    .sort();
+
+  console.log(`Found ${skillDirs.length} bundled skills to migrate.\n`);
+
+  let totalChanges = 0;
+  const summary = [];
+
+  for (const dirName of skillDirs) {
+    const skillDir = join(BUNDLED_SKILLS_DIR, dirName);
+    try {
+      const changes = migrateSkill(dirName, skillDir);
+      if (changes.length > 0) {
+        console.log(`✓ ${dirName}: ${changes.join(", ")}`);
+      } else {
+        console.log(`✓ ${dirName}: (spec-compliant structure applied)`);
+      }
+      totalChanges += changes.length;
+      summary.push({ name: dirName, changes });
+    } catch (err) {
+      console.error(`✗ ${dirName}: ERROR — ${err.message}`);
+      summary.push({ name: dirName, error: err.message });
+    }
+  }
+
+  console.log(
+    `\nMigration complete. Processed ${skillDirs.length} skills with ${totalChanges} changes.`,
+  );
+
+  // Print any errors
+  const errors = summary.filter((s) => s.error);
+  if (errors.length > 0) {
+    console.error(`\n${errors.length} skill(s) had errors:`);
+    for (const err of errors) {
+      console.error(`  - ${err.name}: ${err.error}`);
+    }
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Create migration script to programmatically update all 58 bundled skill SKILL.md frontmatter
- Set name to match directory name (kebab-case), add display-name in metadata.vellum where needed
- Move user-invocable, disable-model-invocation, includes, credential-setup-for into metadata.vellum
- Add compatibility field to all bundled skills
- Preserve all existing metadata (emoji, cli, requires, os, etc.) and markdown body content
- Update skills.test.ts to match new frontmatter format (name is now kebab-case, includes in metadata.vellum)

Part of plan: skills-ref-ci-validation.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
