### PR TITLE
ci: add Agent Skills spec validation for bundled skills in pr-assistant workflow

### DIFF
--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -5,6 +5,7 @@ on:
     types: [labeled, synchronize, opened, reopened]
     paths:
       - 'assistant/**'
+      - 'scripts/skills/**'
       - '.github/workflows/pr-assistant.yaml'
 
 concurrency:
@@ -164,3 +165,19 @@ jobs:
           \`\`\`
           vel up assistant --pr $PR_NUMBER
           \`\`\`"
+
+  lint-bundled-skills:
+    name: Lint Bundled Skills
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Validate bundled skills against Agent Skills spec
+        run: node scripts/skills/lint-skill-spec.mjs --dir assistant/src/config/bundled-skills


### PR DESCRIPTION
## Summary
- Add lint-bundled-skills job to pr-assistant.yaml that validates bundled skills against Agent Skills spec
- Job runs on all qualifying PRs without preview label gate
- Add scripts/skills/** to workflow path triggers

Part of plan: skills-ref-ci-validation.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
