### PR TITLE
fix: update tests for voice→phone rename and regenerate IPC

### DIFF
--- a/assistant/src/__tests__/call-pointer-message-composer.test.ts
+++ b/assistant/src/__tests__/call-pointer-message-composer.test.ts
@@ -74,22 +74,22 @@ describe("getPointerFallbackMessage", () => {
     expect(msg).toContain("failed: no answer");
   });
 
-  test("verification_succeeded defaults to voice channel", () => {
+  test("verification_succeeded defaults to phone channel", () => {
     const msg = getPointerFallbackMessage({
       scenario: "verification_succeeded",
       phoneNumber: "+15559876543",
     });
-    expect(msg).toContain("Guardian verification (voice)");
+    expect(msg).toContain("Guardian verification (phone)");
     expect(msg).toContain("succeeded");
   });
 
-  test("verification_succeeded with custom channel", () => {
+  test("verification_succeeded with explicit phone channel", () => {
     const msg = getPointerFallbackMessage({
       scenario: "verification_succeeded",
       phoneNumber: "+15559876543",
       channel: "phone",
     });
-    expect(msg).toContain("Guardian verification (voice)");
+    expect(msg).toContain("Guardian verification (phone)");
   });
 
   test("verification_failed without reason", () => {
@@ -164,7 +164,7 @@ describe("buildPointerInstruction", () => {
       channel: "phone",
     };
     const instruction = buildPointerInstruction(ctx);
-    expect(instruction).toContain("Channel: voice");
+    expect(instruction).toContain("Channel: phone");
   });
 
   test("omits optional fields when not provided", () => {

--- a/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
+++ b/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
@@ -143,7 +143,7 @@ describe("guardian-verify-setup skill — voice auto-followup", () => {
       skillContent.split("## Step 3")[1]?.split("## Step 4")[0] ?? "";
     const voiceBullet = step3Section
       .split("\n")
-      .filter((line) => /^\s*-\s+\*\*Voice\*\*/.test(line))
+      .filter((line) => /^\s*-\s+\*\*Phone\*\*/.test(line))
       .join("\n");
     expect(voiceBullet).not.toHaveLength(0);
     expect(voiceBullet).not.toContain("wait for the user to confirm");

--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -309,9 +309,9 @@ describe("Guardian verification routing section in system prompt", () => {
     expect(prompt).toContain("verify my Telegram account");
   });
 
-  test('routing section includes trigger phrase "verify voice channel"', () => {
+  test('routing section includes trigger phrase "verify phone channel"', () => {
     const prompt = buildSystemPrompt();
-    expect(prompt).toContain("verify voice channel");
+    expect(prompt).toContain("verify phone channel");
   });
 
   test('routing section includes trigger phrase "verify my phone number"', () => {
@@ -329,11 +329,11 @@ describe("Guardian verification routing section in system prompt", () => {
     expect(prompt).toContain("guardian-verify-setup");
   });
 
-  test("routing section mentions voice and telegram channels but not legacy channels", () => {
+  test("routing section mentions phone and telegram channels but not legacy channels", () => {
     const prompt = buildSystemPrompt();
     const routingStart = prompt.indexOf("## Routing: Guardian Verification");
     const routingSection = prompt.substring(routingStart, routingStart + 1000);
-    expect(routingSection).toContain("voice");
+    expect(routingSection).toContain("phone");
     expect(routingSection).toContain("telegram");
   });
 

--- a/assistant/src/__tests__/session-slash-known.test.ts
+++ b/assistant/src/__tests__/session-slash-known.test.ts
@@ -161,6 +161,7 @@ mock.module("../config/skills.js", () => ({
     {
       id: "start-the-day",
       name: "Start the Day",
+      displayName: "Start the Day",
       description: "Morning routine skill",
       directoryPath: "/skills/start-the-day",
       skillFilePath: "/skills/start-the-day/SKILL.md",

--- a/assistant/src/__tests__/session-slash-queue.test.ts
+++ b/assistant/src/__tests__/session-slash-queue.test.ts
@@ -161,6 +161,7 @@ mock.module("../config/skills.js", () => ({
     {
       id: "start-the-day",
       name: "Start the Day",
+      displayName: "Start the Day",
       description: "Morning routine skill",
       directoryPath: "/skills/start-the-day",
       skillFilePath: "/skills/start-the-day/SKILL.md",

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -685,7 +685,7 @@ public struct IPCChannelVerificationSessionRequest: Codable, Sendable {
     public let channel: String?
     public let sessionId: String?
     public let rebind: Bool?
-    /// E.164 phone number for voice, Telegram handle/chat-id. Used by outbound actions.
+    /// E.164 phone number for phone, Telegram handle/chat-id. Used by outbound actions.
     public let destination: String?
     /// Origin conversation ID so completion/failure pointers can route back.
     public let originConversationId: String?


### PR DESCRIPTION
## Summary
- Update test expectations in `intent-routing`, `guardian-verify-setup-skill-regression`, and `call-pointer-message-composer` to match the voice→phone channel rename from recent PRs
- Add missing `displayName` field to slash skill mocks in `session-slash-known` and `session-slash-queue` tests (required after SkillSummary schema change)
- Regenerate IPC Swift code to reflect updated JSDoc comment in channel verification protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
