### PR TITLE
fix: add missing displayName to mock skill catalogs and regenerate IPC Swift

### DIFF
--- a/assistant/src/__tests__/session-slash-known.test.ts
+++ b/assistant/src/__tests__/session-slash-known.test.ts
@@ -161,6 +161,7 @@ mock.module("../config/skills.js", () => ({
     {
       id: "start-the-day",
       name: "Start the Day",
+      displayName: "Start the Day",
       description: "Morning routine skill",
       directoryPath: "/skills/start-the-day",
       skillFilePath: "/skills/start-the-day/SKILL.md",

--- a/assistant/src/__tests__/session-slash-queue.test.ts
+++ b/assistant/src/__tests__/session-slash-queue.test.ts
@@ -161,6 +161,7 @@ mock.module("../config/skills.js", () => ({
     {
       id: "start-the-day",
       name: "Start the Day",
+      displayName: "Start the Day",
       description: "Morning routine skill",
       directoryPath: "/skills/start-the-day",
       skillFilePath: "/skills/start-the-day/SKILL.md",

--- a/assistant/src/__tests__/session-slash-unknown.test.ts
+++ b/assistant/src/__tests__/session-slash-unknown.test.ts
@@ -168,6 +168,7 @@ mock.module("../config/skills.js", () => ({
     {
       id: "start-the-day",
       name: "Start the Day",
+      displayName: "Start the Day",
       description: "Morning routine skill",
       directoryPath: "/skills/start-the-day",
       skillFilePath: "/skills/start-the-day/SKILL.md",
@@ -178,6 +179,7 @@ mock.module("../config/skills.js", () => ({
     {
       id: "browser",
       name: "Browser",
+      displayName: "Browser",
       description:
         "Navigate and interact with web pages using a headless browser",
       directoryPath: "/skills/browser",

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -685,7 +685,7 @@ public struct IPCChannelVerificationSessionRequest: Codable, Sendable {
     public let channel: String?
     public let sessionId: String?
     public let rebind: Bool?
-    /// E.164 phone number for voice, Telegram handle/chat-id. Used by outbound actions.
+    /// E.164 phone number for phone, Telegram handle/chat-id. Used by outbound actions.
     public let destination: String?
     /// Origin conversation ID so completion/failure pointers can route back.
     public let originConversationId: String?


### PR DESCRIPTION
## Summary
- Add missing `displayName` field to mock `SkillSummary` objects in `session-slash-known`, `session-slash-queue`, and `session-slash-unknown` tests — the field was added to the interface but test mocks weren't updated, causing `buildInvocableSlashCatalog` to read `undefined` instead of the skill name
- Regenerate IPC Swift bindings to pick up a doc-comment change (voice → phone)

## Original prompt
help me fix these CI failures https://github.com/vellum-ai/vellum-assistant/actions/runs/22802739379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
