### PR TITLE
fix: update slack-skill test for Agent Skills spec frontmatter

### DIFF
--- a/assistant/src/__tests__/slack-skill.test.ts
+++ b/assistant/src/__tests__/slack-skill.test.ts
@@ -125,11 +125,11 @@ describe("slack skill SKILL.md", () => {
   );
 
   test("has correct frontmatter name", () => {
-    expect(skillMd).toContain('name: "Slack"');
+    expect(skillMd).toContain("name: slack");
   });
 
   test("is user-invocable", () => {
-    expect(skillMd).toContain("user-invocable: true");
+    expect(skillMd).toContain('"user-invocable":true');
   });
 
   test("mentions privacy rules", () => {


### PR DESCRIPTION
## Summary
- Update `slack-skill.test.ts` to match the new Agent Skills spec frontmatter format from PR #14104
- `name: "Slack"` → `name: slack` (lowercase, unquoted per spec)
- `user-invocable: true` → `"user-invocable":true` (now nested in metadata JSON)

## Original prompt
fix the CI failure in https://github.com/vellum-ai/vellum-assistant/actions/runs/22802840035

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
