### PR TITLE
fix: inject top-level metadata emoji into VellumMetadata for bundled skills

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -369,6 +369,17 @@ function parseFrontmatter(
         if (parsedMeta.vellum) {
           metadata = parsedMeta.vellum as VellumMetadata;
         }
+        // Inject top-level emoji into metadata when metadata.vellum doesn't
+        // carry its own emoji. The Agent Skills spec places emoji at the
+        // top level of the metadata JSON, so bundled skills that follow
+        // this convention would otherwise lose their emoji value.
+        if (parsedMeta.emoji) {
+          if (metadata && !metadata.emoji) {
+            metadata.emoji = parsedMeta.emoji;
+          } else if (!metadata) {
+            metadata = { emoji: parsedMeta.emoji };
+          }
+        }
       } else {
         log.warn(
           { err: result.error, skillFilePath },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skills-ref-ci-validation.md.

**Gap:** Bundled skills emoji at metadata.emoji not injected into VellumMetadata
**What was expected:** Emoji available at parsed.metadata.emoji at runtime
**What was found:** Parser extracts metadata from parsedMeta.vellum, losing top-level parsedMeta.emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
