### PR TITLE
fix: update buildSkillMarkdown to write metadata.vellum format for parser compat

### DIFF
--- a/assistant/src/__tests__/managed-store.test.ts
+++ b/assistant/src/__tests__/managed-store.test.ts
@@ -96,34 +96,47 @@ describe("buildSkillMarkdown", () => {
     expect(result.endsWith("\n")).toBe(true);
   });
 
-  test("includes optional emoji", () => {
+  test("includes optional emoji in metadata.vellum", () => {
     const result = buildSkillMarkdown({
       name: "Emoji Skill",
       description: "Has an emoji",
       bodyMarkdown: "Body.",
       emoji: "🧪",
     });
-    expect(result).toContain('emoji: "🧪"');
+    expect(result).toContain("metadata:");
+    const metadataLine = result
+      .split("\n")
+      .find((l) => l.startsWith("metadata:"));
+    const json = JSON.parse(metadataLine!.slice("metadata: ".length));
+    expect(json.vellum.emoji).toBe("🧪");
   });
 
-  test("includes user-invocable=false when specified", () => {
+  test("includes user-invocable=false in metadata.vellum", () => {
     const result = buildSkillMarkdown({
       name: "Internal",
       description: "Not user invocable",
       bodyMarkdown: "Body.",
       userInvocable: false,
     });
-    expect(result).toContain("user-invocable: false");
+    const metadataLine = result
+      .split("\n")
+      .find((l) => l.startsWith("metadata:"));
+    const json = JSON.parse(metadataLine!.slice("metadata: ".length));
+    expect(json.vellum["user-invocable"]).toBe(false);
   });
 
-  test("includes disable-model-invocation when true", () => {
+  test("includes disable-model-invocation in metadata.vellum", () => {
     const result = buildSkillMarkdown({
       name: "Manual",
       description: "Manual only",
       bodyMarkdown: "Body.",
       disableModelInvocation: true,
     });
-    expect(result).toContain("disable-model-invocation: true");
+    const metadataLine = result
+      .split("\n")
+      .find((l) => l.startsWith("metadata:"));
+    const json = JSON.parse(metadataLine!.slice("metadata: ".length));
+    expect(json.vellum["disable-model-invocation"]).toBe(true);
   });
 
   test("escapes double quotes in name and description", () => {
@@ -188,33 +201,37 @@ describe("buildSkillMarkdown", () => {
     expect(skill!.name).toBe("path\\name");
   });
 
-  test("includes field emits JSON array in frontmatter", () => {
+  test("includes field emits JSON array in metadata.vellum", () => {
     const result = buildSkillMarkdown({
       name: "Parent",
       description: "Has children",
       bodyMarkdown: "Body.",
       includes: ["child-a", "child-b"],
     });
-    expect(result).toContain('includes: ["child-a","child-b"]');
+    const metadataLine = result
+      .split("\n")
+      .find((l) => l.startsWith("metadata:"));
+    const json = JSON.parse(metadataLine!.slice("metadata: ".length));
+    expect(json.vellum.includes).toEqual(["child-a", "child-b"]);
   });
 
-  test("omits includes when not provided", () => {
+  test("omits metadata when no vellum fields provided", () => {
     const result = buildSkillMarkdown({
       name: "Solo",
       description: "No children",
       bodyMarkdown: "Body.",
     });
-    expect(result).not.toContain("includes");
+    expect(result).not.toContain("metadata:");
   });
 
-  test("omits includes when empty array", () => {
+  test("omits metadata when includes is empty array and no other vellum fields", () => {
     const result = buildSkillMarkdown({
       name: "Empty",
       description: "Empty array",
       bodyMarkdown: "Body.",
       includes: [],
     });
-    expect(result).not.toContain("includes:");
+    expect(result).not.toContain("metadata:");
   });
 
   test("includes round-trips through write and catalog load", () => {

--- a/assistant/src/skills/managed-store.ts
+++ b/assistant/src/skills/managed-store.ts
@@ -65,18 +65,28 @@ export function buildSkillMarkdown(input: BuildSkillMarkdownInput): string {
   const lines: string[] = ["---"];
   lines.push(`name: "${esc(input.name)}"`);
   lines.push(`description: "${esc(input.description)}"`);
+
+  // Build metadata object matching the format parseFrontmatter expects:
+  // metadata: {"vellum":{"emoji":"...","user-invocable":false,...}}
+  const vellum: Record<string, unknown> = {};
   if (input.emoji) {
-    lines.push(`emoji: "${esc(input.emoji)}"`);
+    vellum.emoji = input.emoji;
   }
   if (input.userInvocable === false) {
-    lines.push("user-invocable: false");
+    vellum["user-invocable"] = false;
   }
   if (input.disableModelInvocation === true) {
-    lines.push("disable-model-invocation: true");
+    vellum["disable-model-invocation"] = true;
   }
   if (input.includes && input.includes.length > 0) {
-    lines.push(`includes: ${JSON.stringify(input.includes)}`);
+    vellum.includes = input.includes;
   }
+
+  if (Object.keys(vellum).length > 0) {
+    const metadata = { vellum };
+    lines.push(`metadata: ${JSON.stringify(metadata)}`);
+  }
+
   lines.push("---");
   lines.push("");
   lines.push(input.bodyMarkdown);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skills-ref-ci-validation.md.

**Gap:** buildSkillMarkdown writes top-level fields the parser no longer reads
**What was expected:** Managed skills roundtrip correctly through create/write/parse
**What was found:** buildSkillMarkdown writes top-level emoji, user-invocable, etc. that parser ignores after backward compat removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
