### PR TITLE
fix: test includes format, logger mock exports, and displayName in load.ts

### DIFF
--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -56,6 +56,8 @@ mock.module("../util/logger.js", () => ({
     new Proxy({} as Record<string, unknown>, {
       get: () => () => {},
     }),
+  isDebug: () => false,
+  truncateForLog: (s: unknown) => String(s),
 }));
 
 await import("../tools/skills/load.js");
@@ -86,8 +88,8 @@ function writeSkillWithIncludes(
   mkdirSync(skillDir, { recursive: true });
   writeFileSync(
     join(skillDir, "SKILL.md"),
-    `---\nname: "${name}"\ndescription: "${description}"\nincludes: ${JSON.stringify(
-      includes,
+    `---\nname: "${name}"\ndescription: "${description}"\nmetadata: ${JSON.stringify(
+      { vellum: { includes } },
     )}\n---\n\n${body}\n`,
   );
 }
@@ -332,7 +334,7 @@ describe("skill_load tool", () => {
     mkdirSync(skillDir, { recursive: true });
     writeFileSync(
       join(skillDir, "SKILL.md"),
-      '---\nname: "Marker Missing"\ndescription: "test"\nincludes: ["nonexistent"]\n---\n\nBody.\n',
+      '---\nname: "Marker Missing"\ndescription: "test"\nmetadata: {"vellum":{"includes":["nonexistent"]}}\n---\n\nBody.\n',
     );
     writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- marker-missing\n");
 
@@ -349,11 +351,11 @@ describe("skill_load tool", () => {
     mkdirSync(dirB, { recursive: true });
     writeFileSync(
       join(dirA, "SKILL.md"),
-      '---\nname: "Cycle A"\ndescription: "test"\nincludes: ["cycle-b"]\n---\n\nBody A.\n',
+      '---\nname: "Cycle A"\ndescription: "test"\nmetadata: {"vellum":{"includes":["cycle-b"]}}\n---\n\nBody A.\n',
     );
     writeFileSync(
       join(dirB, "SKILL.md"),
-      '---\nname: "Cycle B"\ndescription: "test"\nincludes: ["cycle-a"]\n---\n\nBody B.\n',
+      '---\nname: "Cycle B"\ndescription: "test"\nmetadata: {"vellum":{"includes":["cycle-a"]}}\n---\n\nBody B.\n',
     );
     writeFileSync(
       join(TEST_DIR, "skills", "SKILLS.md"),
@@ -381,7 +383,7 @@ describe("skill_load tool", () => {
     mkdirSync(parentDir, { recursive: true });
     writeFileSync(
       join(parentDir, "SKILL.md"),
-      '---\nname: "Parent"\ndescription: "Has children"\nincludes: ["child-skill"]\n---\n\nParent body.\n',
+      '---\nname: "Parent"\ndescription: "Has children"\nmetadata: {"vellum":{"includes":["child-skill"]}}\n---\n\nParent body.\n',
     );
     writeFileSync(
       join(TEST_DIR, "skills", "SKILLS.md"),
@@ -646,7 +648,7 @@ describe("skill_load tool", () => {
     mkdirSync(skillDir, { recursive: true });
     writeFileSync(
       join(skillDir, "SKILL.md"),
-      '---\nname: "Empty Includes"\ndescription: "Has empty array"\nincludes: []\n---\n\nBody.\n',
+      '---\nname: "Empty Includes"\ndescription: "Has empty array"\nmetadata: {"vellum":{"includes":[]}}\n---\n\nBody.\n',
     );
     writeFileSync(join(TEST_DIR, "skills", "SKILLS.md"), "- empty-includes\n");
 

--- a/assistant/src/tools/skills/load.ts
+++ b/assistant/src/tools/skills/load.ts
@@ -126,7 +126,7 @@ export class SkillLoadTool implements Tool {
           continue;
 
         childLines.push(
-          `  - ${child.id}: ${child.name} — ${child.description} (${child.skillFilePath})`,
+          `  - ${child.id}: ${child.displayName} — ${child.description} (${child.skillFilePath})`,
         );
 
         // Load the included skill's body content


### PR DESCRIPTION
## Summary
Fixes 3 gaps identified during plan review for skills-ref-ci-validation.md.

- Update writeSkillWithIncludes to write includes in metadata.vellum JSON format
- Add missing isDebug and truncateForLog exports to logger mock
- Use child.displayName instead of child.name in skill load output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
