### PR TITLE
fix: fall back to raw JSON when Zod metadata validation fails

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -370,10 +370,17 @@ function parseFrontmatter(
           metadata = parsedMeta.vellum as VellumMetadata;
         }
       } else {
+        // Zod validation failed — fall back to raw JSON so we don't lose
+        // all metadata because of a single bad field value.
         log.warn(
           { err: result.error, skillFilePath },
-          "Metadata failed schema validation",
+          "Metadata failed schema validation; falling back to raw JSON",
         );
+        parsedMeta = json;
+        vellum = json?.vellum;
+        if (json?.vellum && typeof json.vellum === "object") {
+          metadata = json.vellum as VellumMetadata;
+        }
       }
     } catch (err) {
       log.warn(


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skills-ref-ci-validation.md.

**Gap:** Zod safeParse all-or-nothing failure loses entire metadata
**What was expected:** Parser resilient to individual bad field values
**What was found:** One invalid field causes total metadata loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
