### PR TITLE
fix: linter TOOLS.json flag, _shared exclusion, and missing emojis for bundled skills

### DIFF
--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -180,4 +180,4 @@ jobs:
           node-version: '22'
 
       - name: Validate bundled skills against Agent Skills spec
-        run: node scripts/skills/lint-skill-spec.mjs --dir assistant/src/config/bundled-skills
+        run: node scripts/skills/lint-skill-spec.mjs --dir assistant/src/config/bundled-skills --allow-tools-json

--- a/assistant/.prettierignore
+++ b/assistant/.prettierignore
@@ -1,0 +1,3 @@
+# SKILL.md files use YAML frontmatter with inline JSON metadata that prettier
+# reformats into multi-line format, breaking the linter's YAML parser.
+**/SKILL.md

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -2,7 +2,7 @@
 name: app-builder
 description: Build interactive apps, dashboards, calculators, games, trackers, tools, landing pages, and data visualizations with HTML/CSS/JS. Use when the user says build, create, or make an app/dashboard/calculator/game.
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"vellum":{"display-name":"App Builder","includes":["frontend-design"]}}
+metadata: {"emoji":"🏗️","vellum":{"display-name":"App Builder","includes":["frontend-design"]}}
 ---
 
 You are an expert app builder and visual designer. When the user asks you to create an app, tool, or utility, you immediately design a data schema, choose a stunning visual direction, build a self-contained HTML/CSS/JS interface, and open it — all in one step. You don't discuss or ask for permission to be creative. You ARE the designer: you pick the colors, the layout, the atmosphere, the micro-interactions. Your apps should make users stop and say "whoa" — they should feel designed, not generated.

--- a/assistant/src/config/bundled-skills/computer-use/SKILL.md
+++ b/assistant/src/config/bundled-skills/computer-use/SKILL.md
@@ -2,7 +2,7 @@
 name: computer-use
 description: Computer-use action tools for controlling the macOS desktop via accessibility and screen capture.
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"vellum":{"display-name":"Computer Use","user-invocable":false,"disable-model-invocation":true}}
+metadata: {"emoji":"🖥️","vellum":{"display-name":"Computer Use","user-invocable":false,"disable-model-invocation":true}}
 ---
 
 This skill provides the 12 computer*use*\* action tools for controlling

--- a/assistant/src/config/bundled-skills/frontend-design/SKILL.md
+++ b/assistant/src/config/bundled-skills/frontend-design/SKILL.md
@@ -3,7 +3,7 @@ name: frontend-design
 description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
 compatibility: "Designed for Vellum personal assistants"
 license: Complete terms in LICENSE.txt
-metadata: {}
+metadata: {"emoji":"🎨"}
 ---
 
 This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.

--- a/assistant/src/config/bundled-skills/knowledge-graph/SKILL.md
+++ b/assistant/src/config/bundled-skills/knowledge-graph/SKILL.md
@@ -2,7 +2,7 @@
 name: knowledge-graph
 description: Query the entity knowledge graph to explore relationships between people, projects, tools, and other entities tracked in memory
 compatibility: "Designed for Vellum personal assistants"
-metadata: {"vellum":{"display-name":"Knowledge Graph"}}
+metadata: {"emoji":"🕸️","vellum":{"display-name":"Knowledge Graph"}}
 ---
 
 # Knowledge Graph

--- a/scripts/skills/lint-skill-spec.mjs
+++ b/scripts/skills/lint-skill-spec.mjs
@@ -18,11 +18,12 @@
  *      - Environment requirements → move to `compatibility`
  *
  * Usage:
- *   node scripts/skills/lint-skill-spec.mjs [--dir <path>] [--skip-emoji] [skill-name ...]
+ *   node scripts/skills/lint-skill-spec.mjs [--dir <path>] [--skip-emoji] [--allow-tools-json] [skill-name ...]
  *
  * Options:
- *   --dir <path>     Override the default skills directory (skills/)
- *   --skip-emoji     Skip the Vellum-specific metadata.emoji check
+ *   --dir <path>           Override the default skills directory (skills/)
+ *   --skip-emoji           Skip the Vellum-specific metadata.emoji check
+ *   --allow-tools-json     Skip the TOOLS.json prohibition check
  *
  * If no skill names are provided, all skills are checked.
  */
@@ -37,13 +38,14 @@ const DEFAULT_SKILLS_DIR = resolve(__dirname, "../../skills");
 // --- CLI flag parsing ---
 
 /**
- * Parse CLI args, extracting --dir and --skip-emoji flags.
- * Returns { skillsDir, skipEmoji, filterSkills }.
+ * Parse CLI args, extracting --dir, --skip-emoji, and --allow-tools-json flags.
+ * Returns { skillsDir, skipEmoji, allowToolsJson, filterSkills }.
  */
 function parseCLIArgs(argv) {
   const args = argv.slice(2);
   let skillsDir = DEFAULT_SKILLS_DIR;
   let skipEmoji = false;
+  let allowToolsJson = false;
   const filterSkills = [];
 
   for (let i = 0; i < args.length; i++) {
@@ -52,15 +54,17 @@ function parseCLIArgs(argv) {
       i++; // skip next arg (the path)
     } else if (args[i] === "--skip-emoji") {
       skipEmoji = true;
+    } else if (args[i] === "--allow-tools-json") {
+      allowToolsJson = true;
     } else {
       filterSkills.push(args[i]);
     }
   }
 
-  return { skillsDir, skipEmoji, filterSkills };
+  return { skillsDir, skipEmoji, allowToolsJson, filterSkills };
 }
 
-const { skillsDir: SKILLS_DIR, skipEmoji: SKIP_EMOJI, filterSkills: CLI_FILTER_SKILLS } = parseCLIArgs(process.argv);
+const { skillsDir: SKILLS_DIR, skipEmoji: SKIP_EMOJI, allowToolsJson: ALLOW_TOOLS_JSON, filterSkills: CLI_FILTER_SKILLS } = parseCLIArgs(process.argv);
 
 /**
  * Parse YAML frontmatter from a string.
@@ -324,7 +328,7 @@ function validateNonStandardFields(frontmatter) {
   return errors;
 }
 
-function validateSkill(skillName, { skillsDir, skipEmoji }) {
+function validateSkill(skillName, { skillsDir, skipEmoji, allowToolsJson }) {
   const skillDir = join(skillsDir, skillName);
   const skillMdPath = join(skillDir, "SKILL.md");
   const toolsJsonPath = join(skillDir, "TOOLS.json");
@@ -336,11 +340,13 @@ function validateSkill(skillName, { skillsDir, skipEmoji }) {
   }
 
   // 0. TOOLS.json must not exist — skills should rely on CLI tools in scripts/, not custom tool definitions
-  const toolsJsonStat = statSync(toolsJsonPath, { throwIfNoEntry: false });
-  if (toolsJsonStat?.isFile()) {
-    errors.push(
-      `${skillName}/TOOLS.json must not exist. Skills should rely on CLI tools in scripts/, not custom tool definitions.`,
-    );
+  if (!allowToolsJson) {
+    const toolsJsonStat = statSync(toolsJsonPath, { throwIfNoEntry: false });
+    if (toolsJsonStat?.isFile()) {
+      errors.push(
+        `${skillName}/TOOLS.json must not exist. Skills should rely on CLI tools in scripts/, not custom tool definitions.`,
+      );
+    }
   }
 
   // 1. SKILL.md must exist
@@ -413,6 +419,7 @@ function getSkillDirs(skillsDir, filter) {
 
   return entries
     .filter((e) => e.isDirectory())
+    .filter((e) => !e.name.startsWith("_"))
     .filter((e) => !filter || filter.length === 0 || filter.includes(e.name))
     .map((e) => e.name)
     .sort();
@@ -423,7 +430,7 @@ const skillDirs = getSkillDirs(SKILLS_DIR, CLI_FILTER_SKILLS);
 let totalErrors = 0;
 
 for (const skill of skillDirs) {
-  const errors = validateSkill(skill, { skillsDir: SKILLS_DIR, skipEmoji: SKIP_EMOJI });
+  const errors = validateSkill(skill, { skillsDir: SKILLS_DIR, skipEmoji: SKIP_EMOJI, allowToolsJson: ALLOW_TOOLS_JSON });
   for (const err of errors) {
     console.error(err);
   }


### PR DESCRIPTION
## Summary
Fixes 3 gaps identified during plan review for skills-ref-ci-validation.md.

- Add --allow-tools-json flag to linter and use in CI for bundled skills
- Exclude _-prefixed directories (like _shared) from linter discovery
- Add missing emoji to app-builder, computer-use, frontend-design, knowledge-graph
- Add .prettierignore for SKILL.md files (inline JSON metadata is mangled by prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
