### PR TITLE
fix: send displayName instead of kebab-case name in IPC skills list response

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -113,7 +113,7 @@ export function handleSkillsList(
 
   const skills = resolved.map((r) => ({
     id: r.summary.id,
-    name: r.summary.name,
+    name: r.summary.displayName,
     description: r.summary.description,
     emoji: r.summary.emoji,
     homepage: r.summary.homepage,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skills-ref-ci-validation.md.

**Gap:** handleSkillsList IPC response sends kebab-case name instead of displayName to clients
**What was expected:** Native clients should show human-readable names like 'Phone Calls'
**What was found:** After bundled skills migration, name is kebab-case ('phone-calls') and displayed as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
