### PR TITLE
fix: use skill ID instead of displayName for menu bar enable/disable operations

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+MenuBar.swift
@@ -253,7 +253,7 @@ extension AppDelegate {
             let item = NSMenuItem(title: "\(emoji) \(skill.name)", action: #selector(toggleSkill(_:)), keyEquivalent: "")
             item.target = self
             item.state = .on
-            item.representedObject = skill.name
+            item.representedObject = skill.id
             skillsSubmenu.addItem(item)
         }
 
@@ -262,7 +262,7 @@ extension AppDelegate {
             let item = NSMenuItem(title: "\(emoji) \(skill.name)", action: #selector(toggleSkill(_:)), keyEquivalent: "")
             item.target = self
             item.state = .off
-            item.representedObject = skill.name
+            item.representedObject = skill.id
             skillsSubmenu.addItem(item)
         }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for skills-ref-ci-validation.md.

**Gap:** Menu bar stores displayName in representedObject, but daemon expects skill ID for enable/disable
**What was expected:** Skill IDs used for daemon operations
**What was found:** After IPC name field changed to displayName, menu bar sends displayName back to daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
