### PR TITLE
fix: align skill includes tests with metadata.vellum format

### DIFF
--- a/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
+++ b/assistant/src/__tests__/scaffold-managed-skill-tool.test.ts
@@ -147,7 +147,7 @@ describe("scaffold_managed_skill tool", () => {
     // Each frontmatter line must start with a known key -- no injected keys
     for (const line of fmLines) {
       expect(line).toMatch(
-        /^(name|description|emoji|user-invocable|disable-model-invocation):\s/,
+        /^(name|description|emoji|user-invocable|disable-model-invocation|metadata):\s/,
       );
     }
   });
@@ -167,7 +167,7 @@ describe("scaffold_managed_skill tool", () => {
     expect(result.isError).toBe(false);
     const skillFile = join(TEST_DIR, "skills", "parent-skill", "SKILL.md");
     const content = readFileSync(skillFile, "utf-8");
-    expect(content).toContain('includes: ["child-a","child-b"]');
+    expect(content).toContain('"includes":["child-a","child-b"]');
   });
 
   test("normalizes includes — trims and deduplicates", async () => {
@@ -185,7 +185,7 @@ describe("scaffold_managed_skill tool", () => {
     expect(result.isError).toBe(false);
     const skillFile = join(TEST_DIR, "skills", "norm-skill", "SKILL.md");
     const content = readFileSync(skillFile, "utf-8");
-    expect(content).toContain('includes: ["child-a","child-b"]');
+    expect(content).toContain('"includes":["child-a","child-b"]');
   });
 
   test("rejects includes with non-string elements", async () => {
@@ -295,7 +295,7 @@ describe("scaffold_managed_skill tool", () => {
     const parentSkillFile = join(TEST_DIR, "skills", "e2e-parent", "SKILL.md");
     expect(existsSync(parentSkillFile)).toBe(true);
     const parentContent = readFileSync(parentSkillFile, "utf-8");
-    expect(parentContent).toContain('includes: ["e2e-child"]');
+    expect(parentContent).toContain('"includes":["e2e-child"]');
 
     const indexContent = readFileSync(
       join(TEST_DIR, "skills", "SKILLS.md"),

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -468,9 +468,13 @@ describe("includes frontmatter parsing", () => {
   function writeSkillWithIncludes(skillId: string, includes: string): void {
     const skillDir = join(TEST_DIR, "skills", skillId);
     mkdirSync(skillDir, { recursive: true });
+    // includes lives inside metadata.vellum, matching buildSkillMarkdown output.
+    // The raw includes string is interpolated directly so tests can pass both
+    // valid and intentionally malformed values.
+    const metadata = `{"vellum":{"includes":${includes}}}`;
     writeFileSync(
       join(skillDir, "SKILL.md"),
-      `---\nname: "${skillId}"\ndescription: "test"\nincludes: ${includes}\n---\n\nBody.\n`,
+      `---\nname: "${skillId}"\ndescription: "test"\nmetadata: ${metadata}\n---\n\nBody.\n`,
     );
   }
 

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -422,9 +422,18 @@ function parseFrontmatter(
     disableModelInvocation = false;
   }
 
-  const includes = Array.isArray(vellum?.includes)
-    ? vellum.includes
-    : undefined;
+  let includes: string[] | undefined;
+  if (Array.isArray(vellum?.includes)) {
+    const normalized = [
+      ...new Set(
+        vellum.includes
+          .filter((item: unknown): item is string => typeof item === "string")
+          .map((s: string) => s.trim())
+          .filter((s: string) => s.length > 0),
+      ),
+    ];
+    includes = normalized.length > 0 ? normalized : undefined;
+  }
 
   const credentialSetupFor =
     typeof vellum?.["credential-setup-for"] === "string"


### PR DESCRIPTION
## Summary
- Updated `skills.test.ts` helper to write `includes` inside `metadata.vellum` instead of as a top-level frontmatter field
- Updated `scaffold-managed-skill-tool.test.ts` assertions to expect `metadata:` format and added `metadata` to the allowed frontmatter keys regex
- Added normalization (trim, dedupe, filter non-strings) to the `includes` parser in `config/skills.ts` for robustness

## Original prompt
fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22803764037

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
