### PR TITLE
fix: align twilio-setup SKILL.md with config-based auth token read path

### DIFF
--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -11,14 +11,14 @@ You are helping your user configure Twilio for voice calls. Walk through each st
 
 Before you begin, understand how each Twilio value is stored:
 
-| Value        | Type       | Storage method                                | Secret? |
-| ------------ | ---------- | --------------------------------------------- | ------- |
-| Account SID  | Config     | `assistant config set twilio.accountSid`      | No      |
-| Auth Token   | Credential | `assistant credentials set twilio:auth_token` | **Yes** |
-| Phone Number | Config     | `assistant config set twilio.phoneNumber`     | No      |
+| Value        | Type              | Storage method                                | Secret? |
+| ------------ | ----------------- | --------------------------------------------- | ------- |
+| Account SID  | Config            | `assistant config set twilio.accountSid`      | No      |
+| Auth Token   | Credential+Config | `credential_store` prompt, then sync to config | **Yes** |
+| Phone Number | Config            | `assistant config set twilio.phoneNumber`     | No      |
 
 - **Config values** (Account SID, Phone Number) are non-sensitive identifiers. Collect them via normal conversation -- the user can paste them in chat or you can use `AskUserQuestion`.
-- **Credential values** (Auth Token) are secrets. Collect them securely via `credential_store` -- never accept them pasted in plaintext chat.
+- **Auth Token** is a secret. Collect it securely via `credential_store` prompt -- never accept it pasted in plaintext chat. After storing in the credential vault, you MUST also sync it to config so the voice calling system can read it (see Step 2).
 
 ## Retrieving Twilio Credentials
 
@@ -26,7 +26,7 @@ Many steps below require the Account SID and Auth Token. Retrieve them with:
 
 ```bash
 TWILIO_SID=$(assistant config get twilio.accountSid)
-TWILIO_TOKEN=$(assistant credentials reveal twilio:auth_token)
+TWILIO_TOKEN=$(assistant config get twilio.authToken)
 ```
 
 # Checking Current Configuration
@@ -35,11 +35,11 @@ You can determine whether Twilio has been fully set up by checking to see that a
 
 ```bash
 assistant config get twilio.accountSid
-assistant credentials inspect twilio:auth_token --json  # check "hasSecret" field
+assistant config get twilio.authToken
 assistant config get twilio.phoneNumber
 ```
 
-- If `twilio.accountSid` has a value, `hasSecret` is `true`, and `twilio.phoneNumber` is set -- Twilio is fully configured. Offer to show status or reconfigure.
+- If all three config values are non-empty -- Twilio is fully configured. Offer to show status or reconfigure.
 - Otherwise, continue to the missing steps.
 
 # Twilio Setup Steps
@@ -73,10 +73,16 @@ Ask the user for their Auth Token. This IS a secret value, so the user should be
 
 - Call `credential_store` with `action: "prompt"`, `service: "twilio"`, `field: "auth_token"`, `label: "Twilio Auth Token"`, `description: "Enter your Auth Token from the Twilio Console dashboard (click 'Show' to reveal it)"`, `placeholder: "your_auth_token"`.
 
+After the credential is stored, sync it to config so the voice calling system can find it:
+
+```bash
+assistant config set twilio.authToken "$(assistant credentials reveal twilio:auth_token)"
+```
+
 Confirm it has been stored successfully:
 
 ```bash
-assistant credentials inspect "twilio:auth_token"
+assistant config get twilio.authToken
 ```
 
 If credentials are invalid, Twilio API calls in Step 3 will fail -- ask the user to re-enter.
@@ -150,7 +156,7 @@ Retrieve credentials and config values:
 
 ```bash
 TWILIO_SID=$(assistant config get twilio.accountSid)
-TWILIO_TOKEN=$(assistant credentials reveal twilio:auth_token)
+TWILIO_TOKEN=$(assistant config get twilio.authToken)
 PUBLIC_URL=$(assistant config get ingress.publicBaseUrl)
 PHONE_NUMBER=$(assistant config get twilio.phoneNumber)
 ```
@@ -179,6 +185,7 @@ To disconnect Twilio:
 ```bash
 assistant credentials delete twilio:auth_token
 assistant config set twilio.accountSid ""
+assistant config set twilio.authToken ""
 ```
 
 Phone number assignments are preserved. Voice calls will stop until credentials are reconfigured.
@@ -213,7 +220,7 @@ Webhooks on the Twilio phone number may not match the current ingress URL. This 
 
 ```bash
 TWILIO_SID=$(assistant config get twilio.accountSid)
-TWILIO_TOKEN=$(assistant credentials reveal twilio:auth_token)
+TWILIO_TOKEN=$(assistant config get twilio.authToken)
 PUBLIC_URL=$(assistant config get ingress.publicBaseUrl)
 PHONE_NUMBER=$(assistant config get twilio.phoneNumber)
 


### PR DESCRIPTION
## Summary
- After the credential store → config migration (#13960, #13979), the assistant reads `twilio.authToken` from config — but the twilio-setup SKILL.md was still writing it only to the credential store, leaving the config empty and breaking voice calls
- Added a config sync step (`assistant config set twilio.authToken "$(assistant credentials reveal twilio:auth_token)"`) after the credential_store prompt, and updated all retrieval/checking/clearing commands to use `assistant config get twilio.authToken` instead of `assistant credentials reveal/inspect`

## Original prompt
yes, lets take the simple fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
