### PR TITLE
fix: align platform validation between bootstrap and refresh routes

### DIFF
--- a/assistant/src/runtime/routes/guardian-refresh-routes.ts
+++ b/assistant/src/runtime/routes/guardian-refresh-routes.ts
@@ -15,7 +15,7 @@ const log = getLogger("guardian-refresh");
 /**
  * Handle POST /v1/guardian/refresh
  *
- * Body: { platform: 'ios' | 'macos', deviceId: string, refreshToken: string }
+ * Body: { platform: 'ios' | 'macos' | 'cli' | 'web', deviceId: string, refreshToken: string }
  * Returns: { guardianPrincipalId, accessToken, accessTokenExpiresAt, refreshToken, refreshTokenExpiresAt, refreshAfter }
  */
 export async function handleGuardianRefresh(req: Request): Promise<Response> {
@@ -36,10 +36,15 @@ export async function handleGuardianRefresh(req: Request): Promise<Response> {
       );
     }
 
-    if (platform !== "ios" && platform !== "macos") {
+    if (
+      platform !== "ios" &&
+      platform !== "macos" &&
+      platform !== "cli" &&
+      platform !== "web"
+    ) {
       return httpError(
         "BAD_REQUEST",
-        'Invalid platform. Must be "ios" or "macos".',
+        'Invalid platform. Must be "ios", "macos", "cli", or "web".',
         400,
       );
     }


### PR DESCRIPTION
## Summary
- Bootstrap route accepts `macos`, `cli`, `web` but refresh route only accepted `ios`, `macos`
- CLI and web clients could bootstrap but could not refresh tokens
- Aligned the refresh route to accept the same platforms as bootstrap (`ios` kept since iOS uses QR pairing flow and also needs refresh)
- Surfaced from automated review feedback on PR #13789

## Test plan
- [ ] Type-check passes
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
