### PR TITLE
fix: validate VellumMetadata fields in Zod safeParse fallback

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -382,7 +382,9 @@ function parseFrontmatter(
         }
       } else {
         // Zod validation failed — fall back to raw JSON so we don't lose
-        // all metadata because of a single bad field value.
+        // all metadata because of a single bad field value.  We coerce
+        // critical array fields so downstream code that iterates them
+        // (e.g. `.join()`, `for...of`, `.some()`) won't crash.
         log.warn(
           { err: result.error, skillFilePath },
           "Metadata failed schema validation; falling back to raw JSON",
@@ -390,7 +392,24 @@ function parseFrontmatter(
         parsedMeta = json;
         vellum = json?.vellum;
         if (json?.vellum && typeof json.vellum === "object") {
-          metadata = json.vellum as VellumMetadata;
+          const raw = json.vellum as Record<string, unknown>;
+
+          // Coerce `os` to string[] — a bare string is wrapped in an array.
+          if (raw.os !== undefined) {
+            raw.os = Array.isArray(raw.os) ? raw.os : [raw.os];
+          }
+
+          // Coerce `requires` sub-fields to arrays.
+          if (raw.requires && typeof raw.requires === "object") {
+            const req = raw.requires as Record<string, unknown>;
+            for (const key of ["bins", "anyBins", "env", "config"] as const) {
+              if (req[key] !== undefined && !Array.isArray(req[key])) {
+                req[key] = [];
+              }
+            }
+          }
+
+          metadata = raw as unknown as VellumMetadata;
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- When Zod validation fails for skill metadata, the fallback cast raw JSON as VellumMetadata without validation
- Non-array fields like `os`, `requires.bins`, `requires.env` could crash downstream code expecting arrays
- Added field-level validation/coercion in the fallback path

## Test plan
- [x] Type-check passes
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
