### PR TITLE
fix: return 400 when trusted_contact request missing contactChannelId

### DIFF
--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -175,6 +175,14 @@ export async function handleCreateVerificationSession(
 
   const purpose = body.purpose ?? "guardian";
 
+  if (purpose === "trusted_contact" && !body.contactChannelId) {
+    return httpError(
+      "BAD_REQUEST",
+      "contactChannelId is required for trusted_contact purpose",
+      400,
+    );
+  }
+
   // Trusted contact verification path — delegates to the shared transport-agnostic
   // function and wraps the result in an HTTP response.
   if (purpose === "trusted_contact" && body.contactChannelId) {


### PR DESCRIPTION
## Summary
- Requests with `purpose: "trusted_contact"` but no `contactChannelId` silently fell through to the guardian inbound challenge path
- Added validation to return 400 when contactChannelId is missing for trusted_contact purpose
- Surfaced from automated review feedback on PR #14090

## Test plan
- [x] Type-check passes
- [x] Existing tests pass (no test file for this route)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
