### PR TITLE
fix: add missing --strategy flag to twitter CLI help example

### DIFF
--- a/assistant/src/cli/twitter.ts
+++ b/assistant/src/cli/twitter.ts
@@ -144,7 +144,7 @@ Session management:
 
 Examples:
   $ assistant x status
-  $ assistant x post "Hello world"
+  $ assistant x post "Hello world" --strategy auto
   $ assistant x timeline elonmusk --count 10
   $ assistant x search "from:vaborsh AI agents" --product Latest
   $ assistant x strategy set oauth`,


### PR DESCRIPTION
## Summary
- Top-level twitter CLI help showed `assistant x post "Hello world"` without the required `--strategy` flag
- Updated example to include `--strategy auto`
- Surfaced from automated review feedback on PR #13529

## Test plan
- [ ] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
