### PR TITLE
fix: dedup voice/phone rows in migration 144 to prevent SQLITE_CONSTRAINT

### DIFF
--- a/assistant/src/memory/migrations/144-rename-voice-to-phone.ts
+++ b/assistant/src/memory/migrations/144-rename-voice-to-phone.ts
@@ -66,6 +66,14 @@ export function migrateRenameVoiceToPhone(database: DrizzleDb): void {
     );
 
     // channel_guardian_rate_limits.channel
+    // Dedup: remove voice rows that would collide with existing phone rows
+    // on the UNIQUE index (channel, actor_external_user_id, actor_chat_id).
+    raw.exec(/*sql*/ `DELETE FROM channel_guardian_rate_limits WHERE channel = 'voice' AND EXISTS (
+        SELECT 1 FROM channel_guardian_rate_limits AS t2
+        WHERE t2.channel = 'phone'
+          AND t2.actor_external_user_id = channel_guardian_rate_limits.actor_external_user_id
+          AND t2.actor_chat_id = channel_guardian_rate_limits.actor_chat_id
+      )`);
     raw.exec(
       /*sql*/ `UPDATE channel_guardian_rate_limits SET channel = 'phone' WHERE channel = 'voice'`,
     );


### PR DESCRIPTION
## Summary
- Migration 144 renames `voice` to `phone` in `channel_guardian_rate_limits`
- If both `voice` and `phone` rows exist for the same actor, the UPDATE violates the UNIQUE index
- Added a DELETE to remove duplicate `voice` rows before the UPDATE
- Surfaced from automated review feedback on PR #14081

## Test plan
- [ ] Type-check passes
- [ ] Migration runs without constraint violations when both voice and phone rows exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
