### PR TITLE
fix: normalize phone numbers before rate-limit check to prevent bypass

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -315,7 +315,9 @@ export async function verifyTrustedContact(
   const effectiveDestination =
     verificationChannel === "telegram"
       ? normalizeTelegramDestination(destination)
-      : destination;
+      : verificationChannel === "phone"
+        ? (normalizePhoneNumber(destination) ?? destination)
+        : destination;
 
   const recentSendCount = countRecentSendsToDestination(
     verificationChannel,


### PR DESCRIPTION
## Summary
- Phone rate-limit check used raw destination format but storage used normalized E.164
- Different phone formats could bypass the throttle by not matching stored records
- Normalize phone destination before the rate-limit check, consistent with how telegram is handled
- Surfaced from automated review feedback on PR #14090

## Test plan
- [ ] Type-check passes
- [ ] Existing tests pass
- [ ] Rate limit check now uses normalized phone format

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
