### PR TITLE
fix: track delivery results for all channels, not just telegram

### DIFF
--- a/assistant/src/calls/guardian-dispatch.ts
+++ b/assistant/src/calls/guardian-dispatch.ts
@@ -249,10 +249,6 @@ async function dispatchGuardianQuestionInner(
         continue;
       }
 
-      if (result.channel !== "telegram") {
-        continue;
-      }
-
       const delivery = createCanonicalGuardianDelivery({
         requestId: request.id,
         destinationChannel: result.channel,

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -264,10 +264,6 @@ export function notifyGuardianOfAccessRequest(
           continue;
         }
 
-        if (result.channel !== "telegram") {
-          continue;
-        }
-
         const delivery = createCanonicalGuardianDelivery({
           requestId: canonicalRequest.id,
           destinationChannel: result.channel,

--- a/assistant/src/runtime/confirmation-request-guardian-bridge.ts
+++ b/assistant/src/runtime/confirmation-request-guardian-bridge.ts
@@ -181,7 +181,6 @@ export function bridgeConfirmationRequestToGuardian(
     .then((signalResult) => {
       for (const result of signalResult.deliveryResults) {
         if (result.channel === "vellum") continue; // handled in onThreadCreated
-        if (result.channel !== "telegram") continue;
         createCanonicalGuardianDelivery({
           requestId: canonicalRequest.id,
           destinationChannel: result.channel,

--- a/assistant/src/runtime/tool-grant-request-helper.ts
+++ b/assistant/src/runtime/tool-grant-request-helper.ts
@@ -178,7 +178,6 @@ export function createOrReuseToolGrantRequest(
   void signalPromise.then((signalResult) => {
     for (const result of signalResult.deliveryResults) {
       if (result.channel === "vellum") continue; // handled in onThreadCreated
-      if (result.channel !== "telegram") continue;
       createCanonicalGuardianDelivery({
         requestId: canonicalRequest.id,
         destinationChannel: result.channel,


### PR DESCRIPTION
## Summary
- Guardian dispatch and approval request helpers silently dropped delivery results for non-telegram channels (e.g. slack)
- Changed the channel filter in 4 files to handle all non-vellum channels instead of only telegram
- Surfaced from automated review feedback on PR #13696

## Test plan
- [ ] Type-check passes
- [ ] Existing tests pass
- [ ] Slack delivery results are now tracked alongside telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
