### PR TITLE
fix: check startVerificationCall return value for non-thrown errors

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -480,11 +480,22 @@ export async function verifyTrustedContact(
     // Fire-and-forget: initiate Twilio verification call
     (async () => {
       try {
-        await startVerificationCall({
+        const result = await startVerificationCall({
           phoneNumber: normalizedPhone,
           verificationSessionId: sessionResult.sessionId,
           assistantId,
         });
+        if (!result.ok) {
+          log.error(
+            {
+              error: result.error,
+              status: result.status,
+              phoneNumber: normalizedPhone,
+              verificationSessionId: sessionResult.sessionId,
+            },
+            "Failed to initiate verification call for trusted contact",
+          );
+        }
       } catch (err) {
         log.error(
           {


### PR DESCRIPTION
## Summary
- `startVerificationCall` was called in a fire-and-forget async block that only caught exceptions
- `{ ok: false }` returns were silently ignored, leaving pending sessions that never placed a call
- Added return value check to log errors for non-thrown failures
- Surfaced from automated review feedback on PR #14090

## Test plan
- [ ] Type-check passes
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
