### PR TITLE
fix: add timeout to channel verification one-shot callback

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -939,7 +939,22 @@ struct ContactDetailView: View {
 
         // Stash the previous callback so we can restore it after the one-shot response.
         let previousCallback = daemonClient.onChannelVerificationSessionResponse
+
+        // Timeout task that restores the previous handler if the daemon never responds.
+        let timeoutTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 30_000_000_000)
+            guard !Task.isCancelled else { return }
+            // Only clean up if this verification is still in progress (response hasn't arrived).
+            guard verificationInProgress == channel.id else { return }
+            daemonClient.onChannelVerificationSessionResponse = previousCallback
+            errorMessage = "Verification timed out — please try again"
+            verificationInProgress = nil
+        }
+
         daemonClient.onChannelVerificationSessionResponse = { [self] response in
+            // Response arrived — cancel the timeout.
+            timeoutTask.cancel()
+
             // Restore the previous handler after consuming this one-shot response.
             daemonClient.onChannelVerificationSessionResponse = previousCallback
             // Also forward to the previous handler so SettingsStore still processes it.
@@ -971,6 +986,7 @@ struct ContactDetailView: View {
                 contactChannelId: channel.id
             )
         } catch {
+            timeoutTask.cancel()
             daemonClient.onChannelVerificationSessionResponse = previousCallback
             errorMessage = "Failed to send verification: \(error.localizedDescription)"
             verificationInProgress = nil


### PR DESCRIPTION
## Summary
- ContactDetailView's channel verification callback had no timeout
- If the daemon never responds, `verificationInProgress` was never cleared and the callback remained installed indefinitely
- Added a 30-second timeout that restores the previous handler and clears state
- Surfaced from automated review feedback on PR #13816

## Test plan
- [ ] Lint passes
- [ ] Manual test: initiate verification, verify timeout clears state after 30s if no response

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
