### PR TITLE
fix: wrap bare string requires values in arrays instead of dropping them

### DIFF
--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -404,7 +404,7 @@ function parseFrontmatter(
             const req = raw.requires as Record<string, unknown>;
             for (const key of ["bins", "anyBins", "env", "config"] as const) {
               if (req[key] !== undefined && !Array.isArray(req[key])) {
-                req[key] = [];
+                req[key] = typeof req[key] === "string" ? [req[key]] : [];
               }
             }
           }


### PR DESCRIPTION
Fixes the Zod safeParse fallback in skills.ts where non-array requires sub-fields (bins, anyBins, env, config) were coerced to empty arrays, silently dropping valid string values like "git". Now wraps bare strings in arrays (matching the os field pattern) while still coercing truly invalid types to empty arrays.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
