### PR TITLE
fix: add trusted_contact contactChannelId validation to IPC handler

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -539,9 +539,16 @@ export async function handleChannelVerificationSession(
 
   try {
     if (msg.action === "create_session") {
-      if (msg.purpose === "trusted_contact" && msg.contactChannelId) {
+      if (msg.purpose === "trusted_contact" && !msg.contactChannelId) {
+        ctx.send(socket, {
+          type: "channel_verification_session_response",
+          success: false,
+          error: "contactChannelId is required for trusted_contact purpose",
+          channel,
+        });
+      } else if (msg.purpose === "trusted_contact") {
         const result = await verifyTrustedContact(
-          msg.contactChannelId,
+          msg.contactChannelId!,
           DAEMON_INTERNAL_ASSISTANT_ID,
         );
         ctx.send(socket, {

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -187,7 +187,7 @@ export async function handleCreateVerificationSession(
   // function and wraps the result in an HTTP response.
   if (purpose === "trusted_contact") {
     const result = await verifyTrustedContact(
-      body.contactChannelId,
+      body.contactChannelId!,
       assistantId,
     );
     const status = result.success

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -185,7 +185,7 @@ export async function handleCreateVerificationSession(
 
   // Trusted contact verification path — delegates to the shared transport-agnostic
   // function and wraps the result in an HTTP response.
-  if (purpose === "trusted_contact" && body.contactChannelId) {
+  if (purpose === "trusted_contact") {
     const result = await verifyTrustedContact(
       body.contactChannelId,
       assistantId,


### PR DESCRIPTION
Adds the same contactChannelId validation for trusted_contact purpose to the IPC handler in config-channels.ts, matching the HTTP route validation added in PR #14129. Also simplifies the now-redundant condition check in integration-routes.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
