### PR TITLE
fix: correlate verification responses and cancel timeout on disappear

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -52,6 +52,13 @@ struct ContactDetailView: View {
     /// Incremented whenever SettingsStore publishes a change, forcing SwiftUI to
     /// re-evaluate channel verification state derived from the store.
     @State private var verificationStoreRevision: Int = 0
+    /// Monotonically increasing counter that correlates a verification attempt
+    /// with its one-shot response / timeout so stale callbacks are ignored.
+    @State private var verificationAttempt: UInt64 = 0
+    /// In-flight timeout task for the current verification attempt.
+    @State private var verificationTimeoutTask: Task<Void, Never>?
+    /// In-flight task that clears the success animation checkmark.
+    @State private var verificationSuccessAnimationTask: Task<Void, Never>?
 
     var displayContact: ContactPayload {
         currentContact ?? contact
@@ -97,6 +104,10 @@ struct ContactDetailView: View {
         }
         .onDisappear {
             stopVerificationCountdownTimer()
+            verificationTimeoutTask?.cancel()
+            verificationTimeoutTask = nil
+            verificationSuccessAnimationTask?.cancel()
+            verificationSuccessAnimationTask = nil
         }
         .onReceive(store?.objectWillChange.map { _ in () }.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
             verificationStoreRevision += 1
@@ -937,13 +948,22 @@ struct ContactDetailView: View {
         telegramBootstrapUrl = nil
         telegramBootstrapChannelId = nil
 
+        // Bump the attempt counter so stale responses from previous attempts are ignored.
+        verificationAttempt &+= 1
+        let currentAttempt = verificationAttempt
+
+        // Cancel any lingering timeout from a previous attempt.
+        verificationTimeoutTask?.cancel()
+
         // Stash the previous callback so we can restore it after the one-shot response.
         let previousCallback = daemonClient.onChannelVerificationSessionResponse
 
         // Timeout task that restores the previous handler if the daemon never responds.
-        let timeoutTask = Task { @MainActor in
+        verificationTimeoutTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: 30_000_000_000)
             guard !Task.isCancelled else { return }
+            // Ignore if a newer attempt has started since this timeout was scheduled.
+            guard currentAttempt == verificationAttempt else { return }
             // Only clean up if this verification is still in progress (response hasn't arrived).
             guard verificationInProgress == channel.id else { return }
             daemonClient.onChannelVerificationSessionResponse = previousCallback
@@ -952,8 +972,12 @@ struct ContactDetailView: View {
         }
 
         daemonClient.onChannelVerificationSessionResponse = { [self] response in
+            // Ignore stale responses from a previous verification attempt.
+            guard currentAttempt == verificationAttempt else { return }
+
             // Response arrived — cancel the timeout.
-            timeoutTask.cancel()
+            verificationTimeoutTask?.cancel()
+            verificationTimeoutTask = nil
 
             // Restore the previous handler after consuming this one-shot response.
             daemonClient.onChannelVerificationSessionResponse = previousCallback
@@ -966,8 +990,11 @@ struct ContactDetailView: View {
                     telegramBootstrapChannelId = channel.id
                 } else {
                     verificationSuccessChannelId = channel.id
-                    Task {
+                    // Cancel any prior success animation task before starting a new one.
+                    verificationSuccessAnimationTask?.cancel()
+                    verificationSuccessAnimationTask = Task {
                         try? await Task.sleep(nanoseconds: 5_000_000_000)
+                        guard !Task.isCancelled else { return }
                         if verificationSuccessChannelId == channel.id {
                             verificationSuccessChannelId = nil
                         }
@@ -986,7 +1013,8 @@ struct ContactDetailView: View {
                 contactChannelId: channel.id
             )
         } catch {
-            timeoutTask.cancel()
+            verificationTimeoutTask?.cancel()
+            verificationTimeoutTask = nil
             daemonClient.onChannelVerificationSessionResponse = previousCallback
             errorMessage = "Failed to send verification: \(error.localizedDescription)"
             verificationInProgress = nil


### PR DESCRIPTION
Addresses feedback from PR #14135:

1. Add a verification attempt counter to correlate timeout retries with the correct verification response, preventing stale responses from being consumed by a new attempt.
2. Store the timeout task and cancel it on view disappear to prevent writes to state on a disappeared view.

Fixes both reviewer comments (Codex P2 + Devin).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
