### PR TITLE
fix: restore previous verification callback on view disappear

### DIFF
--- a/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
+++ b/clients/macos/vellum-assistant/Features/Contacts/ContactDetailView.swift
@@ -59,6 +59,9 @@ struct ContactDetailView: View {
     @State private var verificationTimeoutTask: Task<Void, Never>?
     /// In-flight task that clears the success animation checkmark.
     @State private var verificationSuccessAnimationTask: Task<Void, Never>?
+    /// The previous verification callback captured when installing the one-shot
+    /// handler, so it can be restored if the view disappears mid-verification.
+    @State private var previousVerificationCallback: ((ChannelVerificationSessionResponseMessage) -> Void)?
 
     var displayContact: ContactPayload {
         currentContact ?? contact
@@ -108,6 +111,13 @@ struct ContactDetailView: View {
             verificationTimeoutTask = nil
             verificationSuccessAnimationTask?.cancel()
             verificationSuccessAnimationTask = nil
+            // If a verification was in flight, restore the previous callback so
+            // SettingsStore's handler isn't permanently lost.
+            if verificationInProgress != nil {
+                daemonClient?.onChannelVerificationSessionResponse = previousVerificationCallback
+                previousVerificationCallback = nil
+                verificationInProgress = nil
+            }
         }
         .onReceive(store?.objectWillChange.map { _ in () }.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher()) { _ in
             verificationStoreRevision += 1
@@ -955,8 +965,10 @@ struct ContactDetailView: View {
         // Cancel any lingering timeout from a previous attempt.
         verificationTimeoutTask?.cancel()
 
-        // Stash the previous callback so we can restore it after the one-shot response.
+        // Stash the previous callback so we can restore it after the one-shot response
+        // or if the view disappears mid-verification.
         let previousCallback = daemonClient.onChannelVerificationSessionResponse
+        previousVerificationCallback = previousCallback
 
         // Timeout task that restores the previous handler if the daemon never responds.
         verificationTimeoutTask = Task { @MainActor in
@@ -967,6 +979,7 @@ struct ContactDetailView: View {
             // Only clean up if this verification is still in progress (response hasn't arrived).
             guard verificationInProgress == channel.id else { return }
             daemonClient.onChannelVerificationSessionResponse = previousCallback
+            previousVerificationCallback = nil
             errorMessage = "Verification timed out — please try again"
             verificationInProgress = nil
         }
@@ -981,6 +994,7 @@ struct ContactDetailView: View {
 
             // Restore the previous handler after consuming this one-shot response.
             daemonClient.onChannelVerificationSessionResponse = previousCallback
+            previousVerificationCallback = nil
             // Also forward to the previous handler so SettingsStore still processes it.
             previousCallback?(response)
 
@@ -1016,6 +1030,7 @@ struct ContactDetailView: View {
             verificationTimeoutTask?.cancel()
             verificationTimeoutTask = nil
             daemonClient.onChannelVerificationSessionResponse = previousCallback
+            previousVerificationCallback = nil
             errorMessage = "Failed to send verification: \(error.localizedDescription)"
             verificationInProgress = nil
         }


### PR DESCRIPTION
When ContactDetailView disappears during an in-flight verification, the onDisappear handler cancels the timeout task but doesn't restore the previous callback or clear verificationInProgress. This leaves the one-shot closure permanently installed on daemonClient.onChannelVerificationSessionResponse, breaking all future verification responses.

This PR:
- Adds a @State property to track the previous verification callback at the instance level
- Restores the callback and clears verification state in onDisappear
- Ensures the stored callback is cleared after restoration in all code paths
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
