### PR TITLE
Add resolveInstanceDataDir() helper for CLI instance discovery

### DIFF
--- a/assistant/src/__tests__/platform.test.ts
+++ b/assistant/src/__tests__/platform.test.ts
@@ -1,8 +1,15 @@
 import { randomBytes } from "node:crypto";
-import { existsSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// Mutable homedir override — when set, resolveInstanceDataDir reads from here.
+let homedirOverride: string | undefined;
+mock.module("node:os", () => ({
+  homedir: () => homedirOverride ?? homedir(),
+  tmpdir,
+}));
 
 import {
   ensureDataDir,
@@ -22,6 +29,7 @@ import {
   getWorkspaceHooksDir,
   getWorkspacePromptPath,
   getWorkspaceSkillsDir,
+  resolveInstanceDataDir,
 } from "../util/platform.js";
 
 const originalBaseDataDir = process.env.BASE_DATA_DIR;
@@ -32,6 +40,7 @@ afterEach(() => {
   } else {
     process.env.BASE_DATA_DIR = originalBaseDataDir;
   }
+  homedirOverride = undefined;
 });
 
 // Baseline path characterization: documents current pre-migration path layout.
@@ -136,5 +145,161 @@ describe("workspace path primitives", () => {
   test("workspace helpers honor BASE_DATA_DIR", () => {
     process.env.BASE_DATA_DIR = "/tmp/custom-base";
     expect(getWorkspaceDir()).toBe("/tmp/custom-base/.vellum/workspace");
+  });
+});
+
+describe("resolveInstanceDataDir", () => {
+  function makeTempHome(): string {
+    const dir = join(
+      tmpdir(),
+      `platform-home-${randomBytes(4).toString("hex")}`,
+    );
+    mkdirSync(dir, { recursive: true });
+    homedirOverride = dir;
+    return dir;
+  }
+
+  function writeLockfileToHome(
+    home: string,
+    data: Record<string, unknown>,
+  ): void {
+    writeFileSync(
+      join(home, ".vellum.lock.json"),
+      JSON.stringify(data, null, 2),
+    );
+  }
+
+  test("returns undefined when no lockfile exists", () => {
+    makeTempHome();
+    expect(resolveInstanceDataDir()).toBeUndefined();
+  });
+
+  test("returns sole local assistant instanceDir when no activeAssistant", () => {
+    const home = makeTempHome();
+    writeLockfileToHome(home, {
+      assistants: [
+        {
+          assistantId: "vellum-calm-stork",
+          cloud: "local",
+          resources: {
+            instanceDir:
+              "/Users/test/.local/share/vellum/assistants/vellum-calm-stork",
+          },
+        },
+      ],
+    });
+    expect(resolveInstanceDataDir()).toBe(
+      "/Users/test/.local/share/vellum/assistants/vellum-calm-stork",
+    );
+  });
+
+  test("returns active assistant instanceDir when activeAssistant matches", () => {
+    const home = makeTempHome();
+    writeLockfileToHome(home, {
+      activeAssistant: "vellum-bold-fox",
+      assistants: [
+        {
+          assistantId: "vellum-calm-stork",
+          cloud: "local",
+          resources: {
+            instanceDir:
+              "/Users/test/.local/share/vellum/assistants/vellum-calm-stork",
+          },
+        },
+        {
+          assistantId: "vellum-bold-fox",
+          cloud: "local",
+          resources: {
+            instanceDir:
+              "/Users/test/.local/share/vellum/assistants/vellum-bold-fox",
+          },
+        },
+      ],
+    });
+    expect(resolveInstanceDataDir()).toBe(
+      "/Users/test/.local/share/vellum/assistants/vellum-bold-fox",
+    );
+  });
+
+  test("returns undefined when multiple local assistants and no activeAssistant", () => {
+    const home = makeTempHome();
+    writeLockfileToHome(home, {
+      assistants: [
+        {
+          assistantId: "vellum-calm-stork",
+          cloud: "local",
+          resources: {
+            instanceDir:
+              "/Users/test/.local/share/vellum/assistants/vellum-calm-stork",
+          },
+        },
+        {
+          assistantId: "vellum-bold-fox",
+          cloud: "local",
+          resources: {
+            instanceDir:
+              "/Users/test/.local/share/vellum/assistants/vellum-bold-fox",
+          },
+        },
+      ],
+    });
+    expect(resolveInstanceDataDir()).toBeUndefined();
+  });
+
+  test("returns undefined when lockfile has no assistants array", () => {
+    const home = makeTempHome();
+    writeLockfileToHome(home, { version: 1 });
+    expect(resolveInstanceDataDir()).toBeUndefined();
+  });
+
+  test("returns undefined when lockfile is malformed JSON", () => {
+    const home = makeTempHome();
+    writeFileSync(join(home, ".vellum.lock.json"), "{{not json");
+    expect(resolveInstanceDataDir()).toBeUndefined();
+  });
+
+  test("treats assistants without cloud field as local", () => {
+    const home = makeTempHome();
+    writeLockfileToHome(home, {
+      assistants: [
+        {
+          assistantId: "vellum-quiet-owl",
+          resources: {
+            instanceDir:
+              "/Users/test/.local/share/vellum/assistants/vellum-quiet-owl",
+          },
+        },
+      ],
+    });
+    expect(resolveInstanceDataDir()).toBe(
+      "/Users/test/.local/share/vellum/assistants/vellum-quiet-owl",
+    );
+  });
+
+  test("ignores cloud assistants when resolving", () => {
+    const home = makeTempHome();
+    writeLockfileToHome(home, {
+      assistants: [
+        {
+          assistantId: "vellum-cloud-eagle",
+          cloud: "platform",
+          resources: {
+            instanceDir: "/some/cloud/path",
+          },
+        },
+        {
+          assistantId: "vellum-local-robin",
+          cloud: "local",
+          resources: {
+            instanceDir:
+              "/Users/test/.local/share/vellum/assistants/vellum-local-robin",
+          },
+        },
+      ],
+    });
+    // Only one local assistant, so it auto-selects
+    expect(resolveInstanceDataDir()).toBe(
+      "/Users/test/.local/share/vellum/assistants/vellum-local-robin",
+    );
   });
 });

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -71,6 +71,70 @@ export function readLockfile(): Record<string, unknown> | null {
 }
 
 /**
+ * Resolve the instance data directory from the lockfile at ~/.vellum.lock.json.
+ *
+ * Reads the lockfile from homedir() directly (NOT via readLockfile() which
+ * depends on BASE_DATA_DIR) to avoid circular dependency — this function is
+ * called at CLI bootstrap before BASE_DATA_DIR is set.
+ *
+ * Resolution:
+ *   - If activeAssistant matches a local assistant, returns its instanceDir.
+ *   - If there is exactly one local assistant and no activeAssistant, returns
+ *     its instanceDir (auto-select).
+ *   - Returns undefined in all other cases (no lockfile, no local assistants,
+ *     multiple local assistants with no active selection, malformed JSON).
+ *
+ * Synchronous (uses readFileSync) since it runs at bootstrap before any async
+ * context. Never throws — catches all errors and returns undefined for
+ * graceful degradation.
+ */
+export function resolveInstanceDataDir(): string | undefined {
+  try {
+    const lockPath = join(homedir(), ".vellum.lock.json");
+    if (!existsSync(lockPath)) return undefined;
+
+    const raw = JSON.parse(readFileSync(lockPath, "utf-8"));
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+
+    const assistants = raw.assistants as
+      | Array<Record<string, unknown>>
+      | undefined;
+    if (!Array.isArray(assistants)) return undefined;
+
+    const localAssistants = assistants.filter(
+      (a) => a.cloud === "local" || a.cloud === undefined,
+    );
+    if (localAssistants.length === 0) return undefined;
+
+    const activeAssistant = raw.activeAssistant as string | undefined;
+
+    if (activeAssistant) {
+      const match = localAssistants.find(
+        (a) => a.assistantId === activeAssistant,
+      );
+      if (match) {
+        const resources = match.resources as
+          | Record<string, unknown>
+          | undefined;
+        return resources?.instanceDir as string | undefined;
+      }
+      return undefined;
+    }
+
+    if (localAssistants.length === 1) {
+      const resources = localAssistants[0].resources as
+        | Record<string, unknown>
+        | undefined;
+      return resources?.instanceDir as string | undefined;
+    }
+
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Normalize an assistant ID to its canonical form for DB operations.
  *
  * The system uses "self" as the canonical single-tenant identifier


### PR DESCRIPTION
## Summary
- Add `resolveInstanceDataDir()` to `platform.ts` that reads `~/.vellum.lock.json` directly and resolves the correct instance data directory
- Handles single local assistant auto-select, active assistant matching, and graceful fallback
- Includes 6+ unit tests covering all resolution paths

Part of plan: cli-instance-resolve.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
