### PR TITLE
Auto-resolve BASE_DATA_DIR at CLI bootstrap from lockfile

### DIFF
--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { Command } from "commander";
 
@@ -793,6 +793,52 @@ describe("assistant credentials CLI", () => {
       const parsed = JSON.parse(result.stdout);
       expect(parsed.ok).toBe(false);
       expect(parsed.error).toContain("not found");
+    });
+  });
+
+  // =========================================================================
+  // instance-scoped BASE_DATA_DIR
+  // =========================================================================
+
+  describe("instance-scoped BASE_DATA_DIR", () => {
+    let savedBaseDataDir: string | undefined;
+
+    beforeEach(() => {
+      savedBaseDataDir = process.env.BASE_DATA_DIR;
+    });
+
+    afterEach(() => {
+      if (savedBaseDataDir === undefined) {
+        delete process.env.BASE_DATA_DIR;
+      } else {
+        process.env.BASE_DATA_DIR = savedBaseDataDir;
+      }
+    });
+
+    test("credential reveal reads from instance-scoped store when BASE_DATA_DIR is set", async () => {
+      // Point BASE_DATA_DIR to a temp directory (simulating instance-scoped dir)
+      const tmpDir = (await import("node:os")).tmpdir();
+      const instanceDir = (await import("node:path")).join(
+        tmpDir,
+        `vellum-test-instance-${Date.now()}`,
+      );
+      process.env.BASE_DATA_DIR = instanceDir;
+
+      // Seed a credential in the mock store
+      seedCredential("twilio", "auth_token", "instance_secret_abc123");
+
+      // Run `credentials reveal twilio:auth_token`
+      const result = await runCli(["reveal", "twilio:auth_token", "--json"]);
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.value).toBe("instance_secret_abc123");
+
+      // Verify the correct key was looked up in the secure store
+      expect(secureKeyStore.has("credential:twilio:auth_token")).toBe(true);
+      expect(secureKeyStore.get("credential:twilio:auth_token")).toBe(
+        "instance_secret_abc123",
+      );
     });
   });
 

--- a/assistant/src/index.ts
+++ b/assistant/src/index.ts
@@ -1,5 +1,17 @@
 #!/usr/bin/env bun
 
 import { buildCliProgram } from "./cli/program.js";
+import { resolveInstanceDataDir } from "./util/platform.js";
+
+// Auto-resolve BASE_DATA_DIR from the lockfile when running as a standalone CLI.
+// The daemon always has BASE_DATA_DIR set by the launcher (cli/src/lib/local.ts),
+// but the CLI process doesn't — so credential commands and other path-dependent
+// operations would read from ~/.vellum instead of the instance-scoped directory.
+if (!process.env.BASE_DATA_DIR) {
+  const instanceDir = resolveInstanceDataDir();
+  if (instanceDir) {
+    process.env.BASE_DATA_DIR = instanceDir;
+  }
+}
 
 buildCliProgram().parse();


### PR DESCRIPTION
## Summary
- Wire up `resolveInstanceDataDir()` at CLI entry point to auto-set `BASE_DATA_DIR` before command parsing
- Ensures credential commands and path-dependent operations target the correct instance directory
- Add integration test validating credential lookup with instance-scoped `BASE_DATA_DIR`

Part of plan: cli-instance-resolve.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
