### PR TITLE
fix: add channel-verification-sessions to CLI help reference

### DIFF
--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -27,6 +27,8 @@ Commands:
                            gateway API
   contacts [options]       Manage and query the contact graph
   channels [options]       Query channel status
+  channel-verification-sessions
+                           Manage channel verification sessions
   amazon [options]         Shop on Amazon and Amazon Fresh. Requires a session
                            imported from a Ride Shotgun recording.
   autonomy [options]       View and configure autonomy tiers


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for cli-channel-verify-sessions.md.

**Gap:** CLI help reference not updated with new command
**What was expected:** reference.ts should include channel-verification-sessions so the AI assistant knows it exists
**What was found:** No entry for channel-verification-sessions in the CLI help reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
