### PR TITLE
fix: set non-zero exit code on service-layer failures in channel-verification-sessions CLI

### DIFF
--- a/assistant/src/cli/channel-verification-sessions.ts
+++ b/assistant/src/cli/channel-verification-sessions.ts
@@ -138,6 +138,9 @@ Examples:
               DAEMON_INTERNAL_ASSISTANT_ID,
             );
             writeOutput(cmd, result);
+            if (!result.success) {
+              process.exitCode = 1;
+            }
             return;
           }
 
@@ -189,6 +192,9 @@ Examples:
             }
 
             writeOutput(cmd, result);
+            if (!result.success) {
+              process.exitCode = 1;
+            }
             return;
           }
 
@@ -199,6 +205,9 @@ Examples:
             opts.sessionId,
           );
           writeOutput(cmd, result);
+          if (!result.success) {
+            process.exitCode = 1;
+          }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           writeOutput(cmd, { ok: false, error: message });
@@ -238,6 +247,9 @@ Examples:
         const channel = opts.channel as ChannelId | undefined;
         const result = getVerificationStatus(channel);
         writeOutput(cmd, result);
+        if (!result.success) {
+          process.exitCode = 1;
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         writeOutput(cmd, { ok: false, error: message });
@@ -285,6 +297,9 @@ Examples:
             originConversationId: opts.originConversationId,
           });
           writeOutput(cmd, result);
+          if (!result.success) {
+            process.exitCode = 1;
+          }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           writeOutput(cmd, { ok: false, error: message });
@@ -364,6 +379,9 @@ Examples:
         const channel = opts.channel as ChannelId | undefined;
         const result = revokeVerificationForChannel(channel);
         writeOutput(cmd, result);
+        if (!result.success) {
+          process.exitCode = 1;
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         writeOutput(cmd, { ok: false, error: message });


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for cli-channel-verify-sessions.md.

**Gap:** Service-layer failures exit with code 0
**What was expected:** CLI should set process.exitCode = 1 when service functions return { success: false }
**What was found:** All subcommand actions wrote results without checking success and setting exit code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
