### PR TITLE
refactor: extract Telegram routes to routes/integrations/telegram.ts

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -122,6 +122,7 @@ import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
 import { handleHealth } from "./routes/identity-routes.js";
 import { identityRouteDefinitions } from "./routes/identity-routes.js";
 import { integrationRouteDefinitions } from "./routes/integration-routes.js";
+import { telegramRouteDefinitions } from "./routes/integrations/telegram.js";
 import { inviteRouteDefinitions } from "./routes/invite-routes.js";
 import { migrationRouteDefinitions } from "./routes/migration-routes.js";
 import type { PairingHandlerContext } from "./routes/pairing-routes.js";
@@ -875,6 +876,7 @@ export class RuntimeHttpServer {
       // contacts/:id catch-all must follow invite routes to avoid shadowing
       ...contactCatchAllRouteDefinitions(),
 
+      ...telegramRouteDefinitions(),
       ...integrationRouteDefinitions(),
       ...slackShareRouteDefinitions(),
       ...twilioRouteDefinitions(),

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -1,13 +1,6 @@
 /**
  * Route handlers for integration config endpoints.
  *
- * Telegram:
- * GET    /v1/integrations/telegram/config   — get current config status
- * POST   /v1/integrations/telegram/config   — set bot token and configure webhook
- * DELETE /v1/integrations/telegram/config   — clear credentials and deregister webhook
- * POST   /v1/integrations/telegram/commands — register bot commands
- * POST   /v1/integrations/telegram/setup    — composite: set config + register commands
- *
  * Slack channel:
  * GET    /v1/integrations/slack/channel/config — get current config status
  * POST   /v1/integrations/slack/channel/config — validate and store credentials
@@ -33,13 +26,6 @@ import {
   getSlackChannelConfig,
   setSlackChannelConfig,
 } from "../../daemon/handlers/config-slack-channel.js";
-import {
-  clearTelegramConfig,
-  getTelegramConfig,
-  setTelegramCommands,
-  setTelegramConfig,
-  setupTelegram,
-} from "../../daemon/handlers/config-telegram.js";
 import { normalizePhoneNumber } from "../../util/phone.js";
 import { revokePendingSessions } from "../channel-verification-service.js";
 import { httpError } from "../http-errors.js";
@@ -51,65 +37,6 @@ import {
   startOutbound,
 } from "../verification-outbound-actions.js";
 import { verificationRateLimiter } from "../verification-rate-limiter.js";
-
-/**
- * GET /v1/integrations/telegram/config
- */
-export function handleGetTelegramConfig(): Response {
-  const result = getTelegramConfig();
-  return Response.json(result);
-}
-
-/**
- * POST /v1/integrations/telegram/config
- *
- * Body: { botToken?: string }
- */
-export async function handleSetTelegramConfig(req: Request): Promise<Response> {
-  const body = (await req.json()) as { botToken?: string };
-  const result = await setTelegramConfig(body.botToken);
-  const status = result.success ? 200 : 400;
-  return Response.json(result, { status });
-}
-
-/**
- * DELETE /v1/integrations/telegram/config
- */
-export async function handleClearTelegramConfig(): Promise<Response> {
-  const result = await clearTelegramConfig();
-  return Response.json(result);
-}
-
-/**
- * POST /v1/integrations/telegram/commands
- *
- * Body: { commands?: Array<{ command: string; description: string }> }
- */
-export async function handleSetTelegramCommands(
-  req: Request,
-): Promise<Response> {
-  const body = (await req.json()) as {
-    commands?: Array<{ command: string; description: string }>;
-  };
-  const result = await setTelegramCommands(body.commands);
-  const status = result.success ? 200 : 400;
-  return Response.json(result, { status });
-}
-
-/**
- * POST /v1/integrations/telegram/setup
- *
- * Body: { botToken?: string; commands?: Array<{ command: string; description: string }> }
- */
-export async function handleSetupTelegram(req: Request): Promise<Response> {
-  const body = (await req.json()) as {
-    botToken?: string;
-    commands?: Array<{ command: string; description: string }>;
-  };
-  const result = await setupTelegram(body.commands, body.botToken);
-  const status = result.success ? 200 : 400;
-  return Response.json(result, { status });
-}
 
 // ---------------------------------------------------------------------------
 // Slack channel config
@@ -344,32 +271,6 @@ export async function handleRevokeVerificationBinding(
 
 export function integrationRouteDefinitions(): RouteDefinition[] {
   return [
-    // Telegram
-    {
-      endpoint: "integrations/telegram/config",
-      method: "GET",
-      handler: () => handleGetTelegramConfig(),
-    },
-    {
-      endpoint: "integrations/telegram/config",
-      method: "POST",
-      handler: async ({ req }) => handleSetTelegramConfig(req),
-    },
-    {
-      endpoint: "integrations/telegram/config",
-      method: "DELETE",
-      handler: async () => handleClearTelegramConfig(),
-    },
-    {
-      endpoint: "integrations/telegram/commands",
-      method: "POST",
-      handler: async ({ req }) => handleSetTelegramCommands(req),
-    },
-    {
-      endpoint: "integrations/telegram/setup",
-      method: "POST",
-      handler: async ({ req }) => handleSetupTelegram(req),
-    },
     // Slack
     {
       endpoint: "integrations/slack/channel/config",

--- a/assistant/src/runtime/routes/integrations/telegram.ts
+++ b/assistant/src/runtime/routes/integrations/telegram.ts
@@ -1,0 +1,111 @@
+/**
+ * Route handlers for Telegram integration config endpoints.
+ *
+ * GET    /v1/integrations/telegram/config   — get current config status
+ * POST   /v1/integrations/telegram/config   — set bot token and configure webhook
+ * DELETE /v1/integrations/telegram/config   — clear credentials and deregister webhook
+ * POST   /v1/integrations/telegram/commands — register bot commands
+ * POST   /v1/integrations/telegram/setup    — composite: set config + register commands
+ */
+
+import {
+  clearTelegramConfig,
+  getTelegramConfig,
+  setTelegramCommands,
+  setTelegramConfig,
+  setupTelegram,
+} from "../../../daemon/handlers/config-telegram.js";
+import type { RouteDefinition } from "../../http-router.js";
+
+/**
+ * GET /v1/integrations/telegram/config
+ */
+export function handleGetTelegramConfig(): Response {
+  const result = getTelegramConfig();
+  return Response.json(result);
+}
+
+/**
+ * POST /v1/integrations/telegram/config
+ *
+ * Body: { botToken?: string }
+ */
+export async function handleSetTelegramConfig(req: Request): Promise<Response> {
+  const body = (await req.json()) as { botToken?: string };
+  const result = await setTelegramConfig(body.botToken);
+  const status = result.success ? 200 : 400;
+  return Response.json(result, { status });
+}
+
+/**
+ * DELETE /v1/integrations/telegram/config
+ */
+export async function handleClearTelegramConfig(): Promise<Response> {
+  const result = await clearTelegramConfig();
+  return Response.json(result);
+}
+
+/**
+ * POST /v1/integrations/telegram/commands
+ *
+ * Body: { commands?: Array<{ command: string; description: string }> }
+ */
+export async function handleSetTelegramCommands(
+  req: Request,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    commands?: Array<{ command: string; description: string }>;
+  };
+  const result = await setTelegramCommands(body.commands);
+  const status = result.success ? 200 : 400;
+  return Response.json(result, { status });
+}
+
+/**
+ * POST /v1/integrations/telegram/setup
+ *
+ * Body: { botToken?: string; commands?: Array<{ command: string; description: string }> }
+ */
+export async function handleSetupTelegram(req: Request): Promise<Response> {
+  const body = (await req.json()) as {
+    botToken?: string;
+    commands?: Array<{ command: string; description: string }>;
+  };
+  const result = await setupTelegram(body.commands, body.botToken);
+  const status = result.success ? 200 : 400;
+  return Response.json(result, { status });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function telegramRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "integrations/telegram/config",
+      method: "GET",
+      handler: () => handleGetTelegramConfig(),
+    },
+    {
+      endpoint: "integrations/telegram/config",
+      method: "POST",
+      handler: async ({ req }) => handleSetTelegramConfig(req),
+    },
+    {
+      endpoint: "integrations/telegram/config",
+      method: "DELETE",
+      handler: async () => handleClearTelegramConfig(),
+    },
+    {
+      endpoint: "integrations/telegram/commands",
+      method: "POST",
+      handler: async ({ req }) => handleSetTelegramCommands(req),
+    },
+    {
+      endpoint: "integrations/telegram/setup",
+      method: "POST",
+      handler: async ({ req }) => handleSetupTelegram(req),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Extract 5 Telegram handler functions and route definitions from integration-routes.ts into new routes/integrations/telegram.ts
- Update http-server.ts to import and register telegramRouteDefinitions()
- Remove Telegram-specific code from integration-routes.ts

Part of plan: integ-routes-cleanup.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
