### PR TITLE
refactor: move Twilio routes to routes/integrations/twilio.ts

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -209,7 +209,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "daemon/handlers/config-integrations.ts", // Vercel API token + Twitter integration OAuth
       "daemon/handlers/config-telegram.ts", // Telegram bot token management
       "daemon/handlers/config-ingress.ts", // Ingress config (reads Twilio credentials for webhook sync)
-      "runtime/routes/twilio-routes.ts", // Twilio credential management (HTTP control-plane)
+      "runtime/routes/integrations/twilio.ts", // Twilio credential management (HTTP control-plane)
       "security/token-manager.ts", // OAuth token refresh flow
       "email/providers/index.ts", // email provider API key lookup
       "tools/network/script-proxy/session-manager.ts", // proxy credential injection at runtime

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -368,7 +368,7 @@ import {
   handleClearTwilioCredentials,
   handleProvisionTwilioNumber,
   handleSetTwilioCredentials,
-} from "../runtime/routes/twilio-routes.js";
+} from "../runtime/routes/integrations/twilio.js";
 
 initializeDb();
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -122,6 +122,7 @@ import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
 import { handleHealth } from "./routes/identity-routes.js";
 import { identityRouteDefinitions } from "./routes/identity-routes.js";
 import { integrationRouteDefinitions } from "./routes/integration-routes.js";
+import { twilioRouteDefinitions } from "./routes/integrations/twilio.js";
 import { inviteRouteDefinitions } from "./routes/invite-routes.js";
 import { migrationRouteDefinitions } from "./routes/migration-routes.js";
 import type { PairingHandlerContext } from "./routes/pairing-routes.js";
@@ -135,7 +136,6 @@ import { slackShareRouteDefinitions } from "./routes/slack-share-routes.js";
 import { surfaceActionRouteDefinitions } from "./routes/surface-action-routes.js";
 import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.js";
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";
-import { twilioRouteDefinitions } from "./routes/twilio-routes.js";
 import { usageRouteDefinitions } from "./routes/usage-routes.js";
 
 // Re-export for consumers

--- a/assistant/src/runtime/routes/integrations/twilio.ts
+++ b/assistant/src/runtime/routes/integrations/twilio.ts
@@ -17,24 +17,24 @@ import {
   provisionPhoneNumber,
   releasePhoneNumber,
   searchAvailableNumbers,
-} from "../../calls/twilio-rest.js";
-import { getIngressPublicBaseUrl } from "../../config/env.js";
-import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
+} from "../../../calls/twilio-rest.js";
+import { getIngressPublicBaseUrl } from "../../../config/env.js";
+import { loadRawConfig, saveRawConfig } from "../../../config/loader.js";
 import {
   syncTwilioWebhooks,
   triggerGatewayTwilioReconcile,
-} from "../../daemon/handlers/config-ingress.js";
-import type { IngressConfig } from "../../inbound/public-ingress-urls.js";
+} from "../../../daemon/handlers/config-ingress.js";
+import type { IngressConfig } from "../../../inbound/public-ingress-urls.js";
 import {
   deleteSecureKeyAsync,
   getSecureKey,
   setSecureKeyAsync,
-} from "../../security/secure-keys.js";
+} from "../../../security/secure-keys.js";
 import {
   deleteCredentialMetadata,
   upsertCredentialMetadata,
-} from "../../tools/credentials/metadata-store.js";
-import type { RouteDefinition } from "../http-router.js";
+} from "../../../tools/credentials/metadata-store.js";
+import type { RouteDefinition } from "../../http-router.js";
 
 // ---------------------------------------------------------------------------
 // Shared helpers


### PR DESCRIPTION
## Summary
- Move twilio-routes.ts to routes/integrations/twilio.ts with updated import paths
- Delete old twilio-routes.ts file
- Update http-server.ts and test file to import from new location

Part of plan: integ-routes-cleanup.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
