### PR TITLE
refactor: move Slack share routes to routes/integrations/slack/share.ts

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -233,7 +233,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "media/managed-avatar-client.ts", // managed avatar API key lookup for platform authentication
       "providers/managed-proxy/context.ts", // managed proxy API key lookup for provider initialization
       "mcp/mcp-oauth-provider.ts", // MCP OAuth token/client/discovery persistence
-      "runtime/routes/slack-share-routes.ts", // Slack share routes credential lookup
+      "runtime/routes/integrations/slack/share.ts", // Slack share routes credential lookup
       "mcp/client.ts", // MCP client cached-token lookup
       "oauth/token-persistence.ts", // OAuth token persistence (set/delete tokens)
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)

--- a/assistant/src/__tests__/slack-share-routes.test.ts
+++ b/assistant/src/__tests__/slack-share-routes.test.ts
@@ -64,7 +64,7 @@ mock.module("../util/logger.js", () => ({
 // ---------------------------------------------------------------------------
 
 const { handleListSlackChannels, handleShareToSlackChannel } =
-  await import("../runtime/routes/slack-share-routes.js");
+  await import("../runtime/routes/integrations/slack/share.js");
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -122,6 +122,7 @@ import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
 import { handleHealth } from "./routes/identity-routes.js";
 import { identityRouteDefinitions } from "./routes/identity-routes.js";
 import { integrationRouteDefinitions } from "./routes/integration-routes.js";
+import { slackShareRouteDefinitions } from "./routes/integrations/slack/share.js";
 import { inviteRouteDefinitions } from "./routes/invite-routes.js";
 import { migrationRouteDefinitions } from "./routes/migration-routes.js";
 import type { PairingHandlerContext } from "./routes/pairing-routes.js";
@@ -131,7 +132,6 @@ import {
   pairingRouteDefinitions,
 } from "./routes/pairing-routes.js";
 import { secretRouteDefinitions } from "./routes/secret-routes.js";
-import { slackShareRouteDefinitions } from "./routes/slack-share-routes.js";
 import { surfaceActionRouteDefinitions } from "./routes/surface-action-routes.js";
 import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.js";
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";

--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -14,8 +14,8 @@ import {
 import type { SlackConversation } from "../../../../messaging/providers/slack/types.js";
 import { getSecureKey } from "../../../../security/secure-keys.js";
 import { getLogger } from "../../../../util/logger.js";
-import { httpError } from "../../http-errors.js";
-import type { RouteDefinition } from "../../http-router.js";
+import { httpError } from "../../../http-errors.js";
+import type { RouteDefinition } from "../../../http-router.js";
 
 const log = getLogger("slack-share");
 

--- a/assistant/src/runtime/routes/integrations/slack/share.ts
+++ b/assistant/src/runtime/routes/integrations/slack/share.ts
@@ -5,19 +5,19 @@
  * without going through the legacy IPC-based Slack share flow.
  */
 
-import { getApp } from "../../memory/app-store.js";
+import { getApp } from "../../../../memory/app-store.js";
 import {
   listConversations,
   postMessage,
   userInfo,
-} from "../../messaging/providers/slack/client.js";
-import type { SlackConversation } from "../../messaging/providers/slack/types.js";
-import { getSecureKey } from "../../security/secure-keys.js";
-import { getLogger } from "../../util/logger.js";
-import { httpError } from "../http-errors.js";
-import type { RouteDefinition } from "../http-router.js";
+} from "../../../../messaging/providers/slack/client.js";
+import type { SlackConversation } from "../../../../messaging/providers/slack/types.js";
+import { getSecureKey } from "../../../../security/secure-keys.js";
+import { getLogger } from "../../../../util/logger.js";
+import { httpError } from "../../http-errors.js";
+import type { RouteDefinition } from "../../http-router.js";
 
-const log = getLogger("slack-share-routes");
+const log = getLogger("slack-share");
 
 // ---------------------------------------------------------------------------
 // Shared helpers


### PR DESCRIPTION
## Summary
- Move slack-share-routes.ts to routes/integrations/slack/share.ts with updated import paths
- Delete old slack-share-routes.ts file
- Update http-server.ts to import from new location
- Update test file imports to reference new path

Part of plan: integ-routes-cleanup.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
