### PR TITLE
refactor: extract Slack channel routes to routes/integrations/slack/channel.ts

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -122,6 +122,7 @@ import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
 import { handleHealth } from "./routes/identity-routes.js";
 import { identityRouteDefinitions } from "./routes/identity-routes.js";
 import { integrationRouteDefinitions } from "./routes/integration-routes.js";
+import { slackChannelRouteDefinitions } from "./routes/integrations/slack/channel.js";
 import { slackShareRouteDefinitions } from "./routes/integrations/slack/share.js";
 import { telegramRouteDefinitions } from "./routes/integrations/telegram.js";
 import { twilioRouteDefinitions } from "./routes/integrations/twilio.js";
@@ -878,6 +879,7 @@ export class RuntimeHttpServer {
 
       ...telegramRouteDefinitions(),
       ...integrationRouteDefinitions(),
+      ...slackChannelRouteDefinitions(),
       ...slackShareRouteDefinitions(),
       ...twilioRouteDefinitions(),
       ...channelReadinessRouteDefinitions(),

--- a/assistant/src/runtime/routes/integration-routes.ts
+++ b/assistant/src/runtime/routes/integration-routes.ts
@@ -1,11 +1,6 @@
 /**
  * Route handlers for integration config endpoints.
  *
- * Slack channel:
- * GET    /v1/integrations/slack/channel/config — get current config status
- * POST   /v1/integrations/slack/channel/config — validate and store credentials
- * DELETE /v1/integrations/slack/channel/config — clear credentials
- *
  * Channel verification (unified session API):
  * POST   /v1/channel-verification-sessions        — create session (inbound challenge, outbound verification, or trusted contact)
  * POST   /v1/channel-verification-sessions/resend  — resend outbound verification code
@@ -21,11 +16,6 @@ import {
   revokeVerificationForChannel,
   verifyTrustedContact,
 } from "../../daemon/handlers/config-channels.js";
-import {
-  clearSlackChannelConfig,
-  getSlackChannelConfig,
-  setSlackChannelConfig,
-} from "../../daemon/handlers/config-slack-channel.js";
 import { normalizePhoneNumber } from "../../util/phone.js";
 import { revokePendingSessions } from "../channel-verification-service.js";
 import { httpError } from "../http-errors.js";
@@ -37,40 +27,6 @@ import {
   startOutbound,
 } from "../verification-outbound-actions.js";
 import { verificationRateLimiter } from "../verification-rate-limiter.js";
-
-// ---------------------------------------------------------------------------
-// Slack channel config
-// ---------------------------------------------------------------------------
-
-/**
- * GET /v1/integrations/slack/channel/config
- */
-export function handleGetSlackChannelConfig(): Response {
-  const result = getSlackChannelConfig();
-  return Response.json(result);
-}
-
-/**
- * POST /v1/integrations/slack/channel/config
- *
- * Body: { botToken?: string, appToken?: string }
- */
-export async function handleSetSlackChannelConfig(
-  req: Request,
-): Promise<Response> {
-  const body = (await req.json()) as { botToken?: string; appToken?: string };
-  const result = await setSlackChannelConfig(body.botToken, body.appToken);
-  const status = result.success ? 200 : 400;
-  return Response.json(result, { status });
-}
-
-/**
- * DELETE /v1/integrations/slack/channel/config
- */
-export async function handleClearSlackChannelConfig(): Promise<Response> {
-  const result = await clearSlackChannelConfig();
-  return Response.json(result);
-}
 
 // ---------------------------------------------------------------------------
 // Channel verification (unified session API)
@@ -271,22 +227,6 @@ export async function handleRevokeVerificationBinding(
 
 export function integrationRouteDefinitions(): RouteDefinition[] {
   return [
-    // Slack
-    {
-      endpoint: "integrations/slack/channel/config",
-      method: "GET",
-      handler: () => handleGetSlackChannelConfig(),
-    },
-    {
-      endpoint: "integrations/slack/channel/config",
-      method: "POST",
-      handler: async ({ req }) => handleSetSlackChannelConfig(req),
-    },
-    {
-      endpoint: "integrations/slack/channel/config",
-      method: "DELETE",
-      handler: () => handleClearSlackChannelConfig(),
-    },
     // Channel verification (unified session API)
     {
       endpoint: "channel-verification-sessions",

--- a/assistant/src/runtime/routes/integrations/slack/channel.ts
+++ b/assistant/src/runtime/routes/integrations/slack/channel.ts
@@ -1,0 +1,72 @@
+/**
+ * Route handlers for Slack channel configuration.
+ *
+ * GET    /v1/integrations/slack/channel/config — get current config status
+ * POST   /v1/integrations/slack/channel/config — validate and store credentials
+ * DELETE /v1/integrations/slack/channel/config — clear credentials
+ */
+
+import {
+  clearSlackChannelConfig,
+  getSlackChannelConfig,
+  setSlackChannelConfig,
+} from "../../../../daemon/handlers/config-slack-channel.js";
+import type { RouteDefinition } from "../../../http-router.js";
+
+// ---------------------------------------------------------------------------
+// Slack channel config
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /v1/integrations/slack/channel/config
+ */
+export function handleGetSlackChannelConfig(): Response {
+  const result = getSlackChannelConfig();
+  return Response.json(result);
+}
+
+/**
+ * POST /v1/integrations/slack/channel/config
+ *
+ * Body: { botToken?: string, appToken?: string }
+ */
+export async function handleSetSlackChannelConfig(
+  req: Request,
+): Promise<Response> {
+  const body = (await req.json()) as { botToken?: string; appToken?: string };
+  const result = await setSlackChannelConfig(body.botToken, body.appToken);
+  const status = result.success ? 200 : 400;
+  return Response.json(result, { status });
+}
+
+/**
+ * DELETE /v1/integrations/slack/channel/config
+ */
+export async function handleClearSlackChannelConfig(): Promise<Response> {
+  const result = await clearSlackChannelConfig();
+  return Response.json(result);
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function slackChannelRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "integrations/slack/channel/config",
+      method: "GET",
+      handler: () => handleGetSlackChannelConfig(),
+    },
+    {
+      endpoint: "integrations/slack/channel/config",
+      method: "POST",
+      handler: async ({ req }) => handleSetSlackChannelConfig(req),
+    },
+    {
+      endpoint: "integrations/slack/channel/config",
+      method: "DELETE",
+      handler: () => handleClearSlackChannelConfig(),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Extract 3 Slack channel handler functions and route definitions from integration-routes.ts into new routes/integrations/slack/channel.ts
- Update http-server.ts to import and register slackChannelRouteDefinitions()
- Remove Slack channel-specific code from integration-routes.ts

Part of plan: integ-routes-cleanup.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
