### PR TITLE
refactor: update bundled skills to use `channel-verification-sessions status` instead of `integrations guardian status`

### DIFF
--- a/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
@@ -5,7 +5,7 @@ compatibility: "Designed for Vellum personal assistants"
 metadata: {"emoji":"🔐","vellum":{"display-name":"Guardian Verify Setup","user-invocable":true}}
 ---
 
-You are helping your user set up channel verification for a messaging channel (phone, Telegram, or Slack). This links their identity as the trusted guardian for the chosen channel. Use gateway control-plane APIs for outbound actions, and use `assistant integrations guardian status` for status reads.
+You are helping your user set up channel verification for a messaging channel (phone, Telegram, or Slack). This links their identity as the trusted guardian for the chosen channel. Use gateway control-plane APIs for outbound actions, and use `assistant channel-verification-sessions status` for status reads.
 
 ## Prerequisites
 
@@ -124,7 +124,7 @@ For **voice** verification only: after telling the user their code and instructi
 2. Check the binding status via Vellum CLI:
 
 ```bash
-assistant integrations guardian status --channel phone --json
+assistant channel-verification-sessions status --channel phone --json
 ```
 
 3. If the response shows `bound: true`: immediately send a proactive success message in the current chat — "Voice verification complete! Your phone number is now the trusted guardian." Stop polling.
@@ -155,7 +155,7 @@ For **Slack** verification: after telling the user their code and instructing th
 2. Check the binding status via Vellum CLI:
 
 ```bash
-assistant integrations guardian status --channel slack --json
+assistant channel-verification-sessions status --channel slack --json
 ```
 
 3. If the response shows `bound: true`: immediately send a proactive success message in the current chat — "Slack verification complete! Your Slack account is now the trusted guardian. The DM channel has been captured for future message delivery." Stop polling.
@@ -181,7 +181,7 @@ After the user reports entering the code, verify the binding was created:
 
 ```bash
 CHANNEL="<channel>"
-assistant integrations guardian status --channel "$CHANNEL" --json
+assistant channel-verification-sessions status --channel "$CHANNEL" --json
 ```
 
 If the response shows the channel is bound, confirm success: "Verification complete! Your [channel] identity is now the trusted guardian."

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -52,7 +52,7 @@ Load the `guardian-verify-setup` skill with `channel: "phone"`. The skill handle
 If the user declines, skip this step. To re-check guardian status later:
 
 ```bash
-assistant integrations guardian status --channel phone --json
+assistant channel-verification-sessions status --channel phone --json
 ```
 
 # Making Outbound Calls

--- a/assistant/src/config/bundled-skills/slack-app-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack-app-setup/SKILL.md
@@ -170,7 +170,7 @@ curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/integrations/slack/channel/config" \
 Check guardian binding status:
 
 ```bash
-assistant integrations guardian status --channel slack --json
+assistant channel-verification-sessions status --channel slack --json
 ```
 
 The Settings > Channels > Slack card auto-refreshes on view appear via `fetchSlackChannelConfig()`, so the user will see the "Connected" status badge when they open or re-open that page.

--- a/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
@@ -99,7 +99,7 @@ If routing is misconfigured, inbound Telegram messages will be rejected and the 
 Before reporting success, confirm the guardian binding was actually created. Check guardian binding status via Vellum CLI:
 
 ```bash
-assistant integrations guardian status --channel telegram --json
+assistant channel-verification-sessions status --channel telegram --json
 ```
 
 If the binding is absent and the user said they completed the verification:
@@ -118,7 +118,7 @@ Summarize what was done:
 - Guardian identity: {verified | not configured}
 - Guardian verification status: {verified via outbound flow | skipped}
 - Routing configuration validated
-- To re-check guardian status later, use: `assistant integrations guardian status --channel telegram --json`
+- To re-check guardian status later, use: `assistant channel-verification-sessions status --channel telegram --json`
 
 The gateway automatically detects credentials from the vault, reconciles the Telegram webhook registration, and begins accepting Telegram webhooks shortly. In single-assistant mode, routing is automatically configured — no manual environment variable configuration or webhook registration is needed. If the webhook secret changes later, the gateway's credential watcher will automatically re-register the webhook. If the ingress URL changes (e.g., tunnel restart), the assistant triggers an immediate internal reconcile so the webhook re-registers automatically without a gateway restart.
 


### PR DESCRIPTION
## Summary
- Replace all 8 occurrences of `assistant integrations guardian status` with `assistant channel-verification-sessions status` across 4 bundled skill files
- The channel-verification-sessions CLI already supports the same --channel and --json flags

Part of plan: remove-guardian-cli.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
