### PR TITLE
refactor: rename integration-routes.ts to channel-verification-routes.ts

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -219,7 +219,7 @@ All endpoints are JWT-authenticated via `Authorization: Bearer <jwt>`. Skills an
 
 **Shared Business Logic:**
 
-The HTTP route handlers (`integration-routes.ts`) and the legacy IPC handlers (`config-channels.ts`) both delegate to the same action functions in `verification-outbound-actions.ts`. This module contains transport-agnostic business logic for starting, resending, and cancelling outbound verification flows across Telegram and voice channels. It returns `OutboundActionResult` objects that the transport layer (gateway-forwarded HTTP or IPC) maps to its respective response format.
+The HTTP route handlers (`channel-verification-routes.ts`) and the legacy IPC handlers (`config-channels.ts`) both delegate to the same action functions in `verification-outbound-actions.ts`. This module contains transport-agnostic business logic for starting, resending, and cancelling outbound verification flows across Telegram and voice channels. It returns `OutboundActionResult` objects that the transport layer (gateway-forwarded HTTP or IPC) maps to its respective response format.
 
 **Chat-First Orchestration Flow:**
 
@@ -234,7 +234,7 @@ The HTTP route handlers (`integration-routes.ts`) and the legacy IPC handlers (`
 | File                                                       | Purpose                                                                                                              |
 | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `src/runtime/verification-outbound-actions.ts`             | Shared business logic for start/resend/cancel outbound verification                                                  |
-| `src/runtime/routes/integration-routes.ts`                 | HTTP route handlers for unified verification session API (`/v1/channel-verification-sessions`, `/revoke`, `/status`) |
+| `src/runtime/routes/channel-verification-routes.ts`        | HTTP route handlers for unified verification session API (`/v1/channel-verification-sessions`, `/revoke`, `/status`) |
 | `src/daemon/handlers/config-channels.ts`                   | IPC handler that delegates to the same shared actions                                                                |
 | `src/config/bundled-skills/guardian-verify-setup/SKILL.md` | Skill that teaches the assistant how to orchestrate channel verification via chat                                    |
 
@@ -369,10 +369,10 @@ Both `GET` and `POST` endpoints report `connected: true` only when both `hasBotT
 
 **Key source files:**
 
-| File                                          | Purpose                                                         |
-| --------------------------------------------- | --------------------------------------------------------------- |
-| `src/daemon/handlers/config-slack-channel.ts` | Business logic for get/set/clear Slack channel config           |
-| `src/runtime/routes/integration-routes.ts`    | HTTP route handlers for `/v1/integrations/slack/channel/config` |
+| File                                                | Purpose                                                       |
+| --------------------------------------------------- | ------------------------------------------------------------- |
+| `src/daemon/handlers/config-slack-channel.ts`       | Business logic for get/set/clear Slack channel config         |
+| `src/runtime/routes/channel-verification-routes.ts` | HTTP route handlers for `/v1/channel-verification-sessions/*` |
 
 ### Trusted Contact Access (Channel-Agnostic)
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -324,17 +324,17 @@ Guardian verification and ingress contact management are complementary but indep
 
 ### Key Modules
 
-| File                                            | Purpose                                                                                                                          |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `src/runtime/channel-verification-service.ts`   | Verification lifecycle: `createInboundVerificationSession`, `validateAndConsumeVerification`, `getGuardianBinding`, `isGuardian` |
-| `src/runtime/trust-context-resolver.ts`         | Actor role classification: guardian / non-guardian / unverified_channel                                                          |
-| `src/runtime/routes/inbound-message-handler.ts` | Ingress ACL enforcement, verification-code intercept, escalation creation                                                        |
-| `src/contacts/contact-store.ts`                 | Contact + channel CRUD: `findContactChannel`, `upsertContact`, `updateChannelStatus`, `searchContacts`                           |
-| `src/memory/invite-store.ts`                    | Invite lifecycle: `createInvite`, `redeemInvite` (atomically creates member record)                                              |
-| `src/memory/channel-verification-sessions.ts`   | Guardian binding types and verification challenge persistence                                                                    |
-| `src/memory/guardian-approvals.ts`              | Approval request persistence                                                                                                     |
-| `src/runtime/verification-outbound-actions.ts`  | Shared business logic for outbound verification (start/resend/cancel)                                                            |
-| `src/runtime/routes/integration-routes.ts`      | HTTP route handlers for outbound guardian verification endpoints                                                                 |
+| File                                                | Purpose                                                                                                                          |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `src/runtime/channel-verification-service.ts`       | Verification lifecycle: `createInboundVerificationSession`, `validateAndConsumeVerification`, `getGuardianBinding`, `isGuardian` |
+| `src/runtime/trust-context-resolver.ts`             | Actor role classification: guardian / non-guardian / unverified_channel                                                          |
+| `src/runtime/routes/inbound-message-handler.ts`     | Ingress ACL enforcement, verification-code intercept, escalation creation                                                        |
+| `src/contacts/contact-store.ts`                     | Contact + channel CRUD: `findContactChannel`, `upsertContact`, `updateChannelStatus`, `searchContacts`                           |
+| `src/memory/invite-store.ts`                        | Invite lifecycle: `createInvite`, `redeemInvite` (atomically creates member record)                                              |
+| `src/memory/channel-verification-sessions.ts`       | Guardian binding types and verification challenge persistence                                                                    |
+| `src/memory/guardian-approvals.ts`                  | Approval request persistence                                                                                                     |
+| `src/runtime/verification-outbound-actions.ts`      | Shared business logic for outbound verification (start/resend/cancel)                                                            |
+| `src/runtime/routes/channel-verification-routes.ts` | HTTP route handlers for outbound guardian verification endpoints                                                                 |
 
 ### Chat-Initiated Guardian Verification
 

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -115,7 +115,7 @@ import {
   handleCancelVerificationSession,
   handleCreateVerificationSession,
   handleResendVerificationSession,
-} from "../runtime/routes/integration-routes.js";
+} from "../runtime/routes/channel-verification-routes.js";
 import {
   cancelOutbound,
   resendOutbound,

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -107,6 +107,7 @@ import {
   startGuardianExpirySweep,
   stopGuardianExpirySweep,
 } from "./routes/channel-routes.js";
+import { channelVerificationRouteDefinitions } from "./routes/channel-verification-routes.js";
 import {
   contactCatchAllRouteDefinitions,
   contactRouteDefinitions,
@@ -121,7 +122,6 @@ import { handleGuardianBootstrap } from "./routes/guardian-bootstrap-routes.js";
 import { handleGuardianRefresh } from "./routes/guardian-refresh-routes.js";
 import { handleHealth } from "./routes/identity-routes.js";
 import { identityRouteDefinitions } from "./routes/identity-routes.js";
-import { integrationRouteDefinitions } from "./routes/integration-routes.js";
 import { slackChannelRouteDefinitions } from "./routes/integrations/slack/channel.js";
 import { slackShareRouteDefinitions } from "./routes/integrations/slack/share.js";
 import { telegramRouteDefinitions } from "./routes/integrations/telegram.js";
@@ -878,7 +878,7 @@ export class RuntimeHttpServer {
       ...contactCatchAllRouteDefinitions(),
 
       ...telegramRouteDefinitions(),
-      ...integrationRouteDefinitions(),
+      ...channelVerificationRouteDefinitions(),
       ...slackChannelRouteDefinitions(),
       ...slackShareRouteDefinitions(),
       ...twilioRouteDefinitions(),

--- a/assistant/src/runtime/routes/channel-verification-routes.ts
+++ b/assistant/src/runtime/routes/channel-verification-routes.ts
@@ -1,7 +1,6 @@
 /**
- * Route handlers for integration config endpoints.
+ * Route handlers for channel verification session endpoints.
  *
- * Channel verification (unified session API):
  * POST   /v1/channel-verification-sessions        — create session (inbound challenge, outbound verification, or trusted contact)
  * POST   /v1/channel-verification-sessions/resend  — resend outbound verification code
  * DELETE /v1/channel-verification-sessions         — cancel all active sessions (inbound + outbound)
@@ -225,7 +224,7 @@ export async function handleRevokeVerificationBinding(
 // Route definitions
 // ---------------------------------------------------------------------------
 
-export function integrationRouteDefinitions(): RouteDefinition[] {
+export function channelVerificationRouteDefinitions(): RouteDefinition[] {
   return [
     // Channel verification (unified session API)
     {

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -4,7 +4,7 @@
  * These pure functions encapsulate the business logic for starting, resending,
  * and cancelling outbound verification flows (Telegram, voice, Slack).
  * They return transport-agnostic result objects and are consumed by both the
- * IPC handler (config-channels.ts) and the HTTP route layer (integration-routes.ts).
+ * IPC handler (config-channels.ts) and the HTTP route layer (channel-verification-routes.ts).
  */
 
 import { createHash, randomBytes } from "node:crypto";


### PR DESCRIPTION
## Summary
- Rename integration-routes.ts to channel-verification-routes.ts now that it only contains channel verification session endpoints
- Rename integrationRouteDefinitions() to channelVerificationRouteDefinitions()
- Update all imports, references, and comments across http-server.ts, test files, and verification-outbound-actions.ts

Part of plan: integ-routes-cleanup.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
