### PR TITLE
refactor: remove `integrations guardian` CLI subcommand and associated test

### DIFF
--- a/assistant/src/__tests__/integrations-cli.test.ts
+++ b/assistant/src/__tests__/integrations-cli.test.ts
@@ -225,17 +225,6 @@ describe("assistant integrations CLI", () => {
     );
   });
 
-  test("passes channel query for guardian status", async () => {
-    const result = await runCli(
-      ["--json", "guardian", "status", "--channel", "telegram"],
-      { success: true },
-    );
-    expect(result.exitCode).toBe(0);
-    expect(result.fetchCalls[0]?.url).toBe(
-      "http://gateway.test/v1/channel-verification-sessions/status?channel=telegram",
-    );
-  });
-
   test("reads ingress config without gateway fetch", async () => {
     rawConfig = {
       ingress: {

--- a/assistant/src/cli/integrations.ts
+++ b/assistant/src/cli/integrations.ts
@@ -15,8 +15,6 @@ import {
   mintEdgeRelayToken,
 } from "../runtime/auth/token-service.js";
 
-type GuardianChannel = "telegram" | "phone";
-
 function asRecord(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return {};
@@ -252,21 +250,19 @@ export function registerIntegrationsCommand(program: Command): void {
     "after",
     `
 Reads integration configuration and readiness from shared assistant services.
-Some subcommands query the running assistant gateway (\`telegram\`, \`guardian\`);
+Some subcommands query the running assistant gateway (\`telegram\`);
 others read local config or call the underlying provider directly (\`twilio\`, \`ingress\`, \`voice\`).
 
 Integration categories:
   twilio       Twilio voice credential and phone number status
   telegram     Telegram bot configuration and webhook status
-  guardian     Guardian trust verification system for contacts
   ingress      Public ingress URL and local gateway target (config-only)
   voice        Voice/call readiness and ElevenLabs voice ID (config-only)
 
 Examples:
   $ assistant integrations twilio config
   $ assistant integrations twilio numbers --json
-  $ assistant integrations telegram config
-  $ assistant integrations guardian status --channel telegram`,
+  $ assistant integrations telegram config`,
   );
 
   const twilio = integrations
@@ -362,51 +358,6 @@ Examples:
     .action(async (_opts: unknown, cmd: Command) => {
       await runRead(cmd, async () =>
         gatewayGet("/v1/integrations/telegram/config"),
-      );
-    });
-
-  const guardian = integrations
-    .command("guardian")
-    .description("Guardian verification status");
-
-  guardian.addHelpText(
-    "after",
-    `
-Guardian is the trust verification system for contacts. It tracks whether
-contacts on each channel have completed identity verification. Requires
-the assistant to be running.
-
-Examples:
-  $ assistant integrations guardian status
-  $ assistant integrations guardian status --channel phone`,
-  );
-
-  guardian
-    .command("status")
-    .description("Get guardian status for a channel")
-    .option("--channel <channel>", "Channel: telegram|phone", "telegram")
-    .addHelpText(
-      "after",
-      `
-Returns the guardian verification state for the specified channel. Requires
-the assistant to be running.
-
-The --channel flag accepts: telegram, phone. Defaults to telegram if
-not specified. The response includes whether guardian verification is active
-and the current verification state for that channel.
-
-Examples:
-  $ assistant integrations guardian status
-  $ assistant integrations guardian status --channel telegram
-  $ assistant integrations guardian status --channel phone
-  $ assistant integrations guardian status --channel telegram --json`,
-    )
-    .action(async (opts: { channel?: GuardianChannel }, cmd: Command) => {
-      const channel = opts.channel ?? "telegram";
-      await runRead(cmd, async () =>
-        gatewayGet(
-          `/v1/channel-verification-sessions/status${toQueryString({ channel })}`,
-        ),
       );
     });
 


### PR DESCRIPTION
## Summary
- Remove the `guardian` subcommand from `assistant integrations` (status endpoint, help text, type alias)
- Remove the associated test case from integrations-cli.test.ts
- All skill files were already updated to use `channel-verification-sessions status` in PR #14149

Part of plan: remove-guardian-cli.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
