### PR TITLE
fix: update guardian skill regression test to use new CLI command

### DIFF
--- a/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
+++ b/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
@@ -55,7 +55,7 @@ describe("guardian-verify-setup skill — voice auto-followup", () => {
         .split("## Voice Auto-Check Polling")[1]
         ?.split("## Step 6")[0] ?? "";
     expect(pollingSection).toContain(
-      "assistant integrations guardian status --channel phone --json",
+      "assistant channel-verification-sessions status --channel phone --json",
     );
   });
 


### PR DESCRIPTION
## Summary
- The `integrations guardian` CLI subcommand was removed in #14151 and replaced with `channel-verification-sessions`, but the regression test was not updated to match
- Update the expected CLI command in `guardian-verify-setup-skill-regression.test.ts` from `assistant integrations guardian status` to `assistant channel-verification-sessions status`

## Original prompt
fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22805559613

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
