### PR TITLE
fix: correct ARCHITECTURE.md Slack channel route file reference

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -369,10 +369,10 @@ Both `GET` and `POST` endpoints report `connected: true` only when both `hasBotT
 
 **Key source files:**
 
-| File                                                | Purpose                                                       |
-| --------------------------------------------------- | ------------------------------------------------------------- |
-| `src/daemon/handlers/config-slack-channel.ts`       | Business logic for get/set/clear Slack channel config         |
-| `src/runtime/routes/channel-verification-routes.ts` | HTTP route handlers for `/v1/channel-verification-sessions/*` |
+| File                                               | Purpose                                                         |
+| -------------------------------------------------- | --------------------------------------------------------------- |
+| `src/daemon/handlers/config-slack-channel.ts`      | Business logic for get/set/clear Slack channel config           |
+| `src/runtime/routes/integrations/slack/channel.ts` | HTTP route handlers for `/v1/integrations/slack/channel/config` |
 
 ### Trusted Contact Access (Channel-Agnostic)
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for integ-routes-cleanup.md.

**Gap:** ARCHITECTURE.md Slack channel config key source files table points to wrong file
**What was expected:** Reference to integrations/slack/channel.ts for Slack channel config routes
**What was found:** Incorrectly referenced channel-verification-routes.ts in the Slack Channel section

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
