### PR TITLE
refactor: replace `integrations ingress` with `config get` in configure-settings skill

### DIFF
--- a/assistant/src/config/bundled-skills/configure-settings/SKILL.md
+++ b/assistant/src/config/bundled-skills/configure-settings/SKILL.md
@@ -13,7 +13,8 @@ When a user asks for setup/status of a specific capability, prefer domain comman
 
 ```bash
 assistant integrations voice config --json
-assistant integrations ingress config --json
+assistant config get ingress.publicBaseUrl
+assistant config get ingress.enabled
 assistant integrations twilio config --json
 assistant email status --json
 ```


### PR DESCRIPTION
## Summary
- Replace `assistant integrations ingress config --json` with `assistant config get ingress.publicBaseUrl` and `assistant config get ingress.enabled` in the Domain Status Reads First section

Part of plan: ingress-cli-removal.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
