### PR TITLE
refactor: replace `integrations ingress` with `config get` in public-ingress skill

### DIFF
--- a/assistant/src/config/bundled-skills/public-ingress/SKILL.md
+++ b/assistant/src/config/bundled-skills/public-ingress/SKILL.md
@@ -22,14 +22,16 @@ This skill installs ngrok, configures authentication, starts a tunnel, discovers
 First, check whether ingress is already configured:
 
 ```bash
-assistant integrations ingress config --json
+assistant config get ingress.publicBaseUrl
+assistant config get ingress.enabled
 ```
 
-The response includes:
+Note: The local gateway target is `http://127.0.0.1:${GATEWAY_PORT}` (default port 7830).
 
-- `publicBaseUrl` — currently configured public ingress URL (if any)
-- `enabled` — whether ingress is enabled
-- `localGatewayTarget` — local gateway URL ngrok should forward to
+The commands return:
+
+- `ingress.publicBaseUrl` — currently configured public ingress URL (if any)
+- `ingress.enabled` — whether ingress is enabled
 
 If `publicBaseUrl` is already set and the tunnel is running (check via `curl -s http://127.0.0.1:4040/api/tunnels`), tell the user the current status and ask if they want to reconfigure or if this is sufficient.
 
@@ -115,7 +117,7 @@ sleep 1
 Start ngrok in the background, tunneling to the local gateway target:
 
 ```bash
-nohup ngrok http "<localGatewayTarget from Step 1>" --log=stdout > /tmp/ngrok.log 2>&1 &
+nohup ngrok http "http://127.0.0.1:${GATEWAY_PORT}" --log=stdout > /tmp/ngrok.log 2>&1 &
 echo $! > /tmp/ngrok.pid
 ```
 
@@ -152,18 +154,7 @@ print(match.group(1))
 ```
 
 ```bash
-assistant integrations ingress config --json | python3 -c "
-import sys, json, re
-
-data = json.load(sys.stdin)
-target = data.get('localGatewayTarget', '')
-match = re.search(r':(\d+)', target)
-if not match:
-    print(f'ERROR: could not extract port from localGatewayTarget: {target}')
-    sys.exit(1)
-
-print(match.group(1))
-"
+echo "${GATEWAY_PORT}"
 ```
 
 Compare the two port numbers. If they differ, warn the user:
@@ -210,7 +201,8 @@ assistant config set ingress.enabled true
 Verify it was saved:
 
 ```bash
-assistant integrations ingress config --json
+assistant config get ingress.publicBaseUrl
+assistant config get ingress.enabled
 ```
 
 ## Step 7: Report Completion
@@ -218,14 +210,14 @@ assistant integrations ingress config --json
 Summarize the setup:
 
 - **Public URL:** `<the-url>` (this is your `ingress.publicBaseUrl`)
-- **Local gateway target:** `<localGatewayTarget from assistant integrations ingress config --json>`
+- **Local gateway target:** `http://127.0.0.1:${GATEWAY_PORT}`
 - **ngrok dashboard:** http://127.0.0.1:4040
 
 Provide useful follow-up commands:
 
 - **Check tunnel status:** `curl -s http://127.0.0.1:4040/api/tunnels | python3 -c "import sys,json; [print(t['public_url']) for t in json.load(sys.stdin)['tunnels']]"`
 - **View ngrok logs:** `cat /tmp/ngrok.log`
-- **Restart tunnel:** `pkill -f ngrok; sleep 1; nohup ngrok http "<localGatewayTarget>" --log=stdout > /tmp/ngrok.log 2>&1 &`
+- **Restart tunnel:** `pkill -f ngrok; sleep 1; nohup ngrok http "http://127.0.0.1:${GATEWAY_PORT}" --log=stdout > /tmp/ngrok.log 2>&1 &`
 - **Stop tunnel:** `pkill -f ngrok`
 - **Rotate URL:** Stop and restart ngrok (free tier assigns a new URL each time; update `ingress.publicBaseUrl` afterward)
 
@@ -247,7 +239,7 @@ The ngrok process may not be running. Check with `ps aux | grep ngrok`. If not r
 
 ### Gateway not reachable on local target
 
-Re-check local gateway target with `assistant integrations ingress config --json`, then run `curl -s "<localGatewayTarget>/healthz"`. If the gateway is not running, start the assistant first.
+Re-check the local gateway target with `assistant config get ingress.publicBaseUrl`. The local gateway target is `http://127.0.0.1:${GATEWAY_PORT}`. Run `curl -s "http://127.0.0.1:${GATEWAY_PORT}/healthz"` to verify it is reachable. If the gateway is not running, start the assistant first.
 
 ### "Too many connections" or tunnel limit errors
 
@@ -259,4 +251,4 @@ ngrok's free tier allows one tunnel at a time. Stop any other ngrok tunnels befo
 
 **Cause:** ngrok is forwarding to a different port than the gateway is listening on. This can happen if `GATEWAY_PORT` was changed after ngrok was started, or if ngrok was started manually with a hardcoded port.
 
-**Fix:** Stop ngrok (`pkill -f ngrok`), verify the gateway port with `assistant integrations ingress config --json`, then re-run this skill to start ngrok on the correct port.
+**Fix:** Stop ngrok (`pkill -f ngrok`), verify the gateway port with `echo ${GATEWAY_PORT}`, then re-run this skill to start ngrok on the correct port.


### PR DESCRIPTION
## Summary
- Replace all `assistant integrations ingress config --json` calls with `assistant config get` equivalents
- Replace `localGatewayTarget` JSON parsing with inline `${GATEWAY_PORT}` env-var computation
- Update troubleshooting section to use new CLI commands

Part of plan: ingress-cli-removal.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
