### PR TITLE
refactor: replace curl gateway calls with CLI in guardian-verify-setup skill

### DIFF
--- a/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/guardian-verify-setup/SKILL.md
@@ -5,13 +5,10 @@ compatibility: "Designed for Vellum personal assistants"
 metadata: {"emoji":"🔐","vellum":{"display-name":"Guardian Verify Setup","user-invocable":true}}
 ---
 
-You are helping your user set up channel verification for a messaging channel (phone, Telegram, or Slack). This links their identity as the trusted guardian for the chosen channel. Use gateway control-plane APIs for outbound actions, and use `assistant channel-verification-sessions status` for status reads.
+You are helping your user set up channel verification for a messaging channel (phone, Telegram, or Slack). This links their identity as the trusted guardian for the chosen channel. Use the `assistant channel-verification-sessions` CLI for all verification operations.
 
 ## Prerequisites
 
-- Use the injected `INTERNAL_GATEWAY_BASE_URL` for gateway API calls.
-- Never call the daemon runtime port directly; always call the gateway URL.
-- The bearer token is available as the `$GATEWAY_AUTH_TOKEN` environment variable for control-plane `curl` requests.
 - Run shell commands for this skill with `bash`.
 - Keep narration minimal: execute required calls first, then provide a concise status update. Do not narrate internal install/check/load chatter unless something fails.
 
@@ -40,10 +37,7 @@ Based on the chosen channel, ask for the required destination:
 Execute the outbound start request:
 
 ```bash
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/channel-verification-sessions" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
-  -d '{"channel": "<channel>", "destination": "<destination>"}'
+assistant channel-verification-sessions create --channel <channel> --destination "<destination>" --json
 ```
 
 Replace `<channel>` with `phone`, `telegram`, or `slack`, and `<destination>` with the phone number, Telegram destination, or Slack user ID.
@@ -52,7 +46,7 @@ Replace `<channel>` with `phone`, `telegram`, or `slack`, and `<destination>` wi
 
 Report the exact next action based on the channel:
 
-- **Phone**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `POST /v1/channel-verification-sessions` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
+- **Phone**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `create` command already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
 - **Telegram with chat ID** (no `telegramBootstrapUrl` in response): The response includes a `secret` field. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and reply with that 6-digit code to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4).
 - **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."
 - **Slack**: The response includes a `secret` field with the verification code. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to you as a Slack DM. Open the DM from the Vellum bot in Slack and reply with that 6-digit code to complete verification." The DM channel ID is captured automatically during this process for future message delivery. If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4). **After delivering the code, immediately begin the Slack auto-check polling loop** (see [Slack Auto-Check Polling](#slack-auto-check-polling) below).
@@ -67,7 +61,7 @@ Handle each error code:
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `missing_destination` | Ask the user to provide their phone number, Telegram destination, or Slack user ID.                                                                                                                                                                |
 | `invalid_destination` | Tell the user the format is invalid. For phone: suggest E.164 format (+15551234567). For Telegram: explain that group chat IDs (negative numbers) are not supported. For Slack: explain that the value must be a Slack member ID (e.g. U01ABCDEF). |
-| `already_bound`       | Tell the user a guardian is already bound for this channel. Ask if they want to replace it. If yes, re-run the start request with `"rebind": true` added to the JSON body.                                                                         |
+| `already_bound`       | Tell the user a guardian is already bound for this channel. Ask if they want to replace it. If yes, re-run the create command with `--rebind` added.                                                                         |
 | `rate_limited`        | Tell the user they have sent too many verification attempts to this destination. Ask them to wait and try again later.                                                                                                                             |
 | `unsupported_channel` | Tell the user the channel is not supported. Only phone, telegram, and slack are valid.                                                                                                                                                             |
 | `no_bot_username`     | Telegram bot is not configured. Load and run the `telegram-setup` skill first.                                                                                                                                                                     |
@@ -77,15 +71,12 @@ Handle each error code:
 If the user says they did not receive the code or asks to resend:
 
 ```bash
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/channel-verification-sessions/resend" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
-  -d '{"channel": "<channel>"}'
+assistant channel-verification-sessions resend --channel <channel> --json
 ```
 
 On success, report the next action based on the channel:
 
-- **Phone**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `POST /v1/channel-verification-sessions/resend` API call already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
+- **Phone**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects — just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `resend` command already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
 - **Telegram**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and reply with that 6-digit code to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3.
 - **Slack**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to you as a Slack DM. Reply to the DM with that 6-digit code to complete verification. (resent)" If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3. **After delivering the code, immediately begin the Slack auto-check polling loop** (see [Slack Auto-Check Polling](#slack-auto-check-polling) below).
 
@@ -106,10 +97,7 @@ Handle each error code from the resend endpoint:
 If the user wants to cancel the verification:
 
 ```bash
-curl -s -X DELETE "$INTERNAL_GATEWAY_BASE_URL/v1/channel-verification-sessions" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
-  -d '{"channel": "<channel>"}'
+assistant channel-verification-sessions cancel --channel <channel> --json
 ```
 
 Confirm cancellation to the user. On `no_active_session`, tell them there is nothing to cancel.
@@ -193,10 +181,7 @@ If not yet bound, offer to resend (Step 4) or generate a new session (Step 3).
 If the user wants to remove themselves (or the current guardian) from a channel, use the revoke endpoint:
 
 ```bash
-curl -s -X POST "$INTERNAL_GATEWAY_BASE_URL/v1/channel-verification-sessions/revoke" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $GATEWAY_AUTH_TOKEN" \
-  -d '{"channel": "<channel>"}'
+assistant channel-verification-sessions revoke --channel <channel> --json
 ```
 
 Replace `<channel>` with the channel to unbind from (e.g. `phone`, `telegram`, `slack`).

--- a/assistant/src/config/bundled-skills/slack-app-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack-app-setup/SKILL.md
@@ -147,7 +147,7 @@ Load the **guardian-verify-setup** skill to handle the verification flow:
 The guardian-verify-setup skill manages the full outbound verification flow for Slack, including:
 
 - Collecting the user's Slack user ID as the destination
-- Starting the outbound verification session via the gateway endpoint `POST /v1/channel-verification-sessions` with `channel: "slack"` and the user's destination
+- Starting the outbound verification session via `assistant channel-verification-sessions create --channel slack --destination <dest> --json`
 - Sending a verification code via Slack DM
 - Auto-polling for completion (the guardian-verify-setup skill handles this)
 - Checking guardian status to confirm the binding was created

--- a/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/telegram-setup/SKILL.md
@@ -73,7 +73,7 @@ Load the **guardian-verify-setup** skill to handle the verification flow:
 The guardian-verify-setup skill manages the full outbound verification flow for Telegram, including:
 
 - Collecting the user's Telegram chat ID or @handle as the destination
-- Starting the outbound verification session via the gateway endpoint `POST /v1/channel-verification-sessions` with `channel: "telegram"` and the user's destination
+- Starting the outbound verification session via `assistant channel-verification-sessions create --channel telegram --destination <dest> --json`
 - Handling the bootstrap deep-link flow when the user provides an @handle (the response includes a `telegramBootstrapUrl` that the user must click before receiving the code)
 - Guiding the user to send the verification code back in the Telegram bot chat
 - Checking guardian status to confirm the binding was created


### PR DESCRIPTION
## Summary
- Replace 4 raw `curl` calls in guardian-verify-setup skill with `assistant channel-verification-sessions` CLI subcommands (`create`, `resend`, `cancel`, `revoke`)
- Remove `INTERNAL_GATEWAY_BASE_URL` and `GATEWAY_AUTH_TOKEN` prerequisites since the CLI handles auth internally
- Update prose references in telegram-setup and slack-app-setup skills to reference the CLI instead of the gateway endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
