### PR TITLE
fix: sync `CLI_HELP_REFERENCE` with actual program commands

### DIFF
--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -26,7 +26,7 @@ Commands:
   integrations [options]   Read integration status through the gateway API
   contacts [options]       Manage and query the contact graph
   channels [options]       Query channel status
-  channel-verification-sessions
+  channel-verification-sessions [options]
                            Manage channel verification sessions
   amazon [options]         Shop on Amazon and Amazon Fresh. Requires a session
                            imported from a Ride Shotgun recording.
@@ -35,6 +35,8 @@ Commands:
                            completions bash >> ~/.bashrc)
   notifications [options]  Send and inspect notifications through the unified
                            notification router
+  oauth [options]          Manage OAuth tokens for connected integrations
+  skills                   Browse and install skills from the Vellum catalog
   x|twitter [options]      Post on X and manage connections. Supports OAuth
                            (official API) and browser session paths.
   map [options] <domain>   Auto-navigate a domain and produce a deduplicated API


### PR DESCRIPTION
## Summary
- Add `[options]` to the `channel-verification-sessions` entry in `CLI_HELP_REFERENCE`
- Add missing `oauth` and `skills` commands to the reference snapshot
- Keeps the static help text in sync with `buildCliProgram().helpInformation()`

Addresses feedback from https://github.com/vellum-ai/vellum-assistant/pull/14143

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
