### PR TITLE
fix: sync CLI_HELP_REFERENCE integrations description with Commander

### DIFF
--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -23,7 +23,7 @@ Commands:
   hooks                    Manage hooks
   mcp                      Manage MCP (Model Context Protocol) servers
   email [options]          Email operations (provider-agnostic)
-  integrations [options]   Read integration status through the gateway API
+  integrations [options]   Read integration configuration and readiness status
   contacts [options]       Manage and query the contact graph
   channels [options]       Query channel status
   channel-verification-sessions [options]


### PR DESCRIPTION
## Summary
- Updates the integrations command description in CLI_HELP_REFERENCE snapshot to match the actual Commander .description() string
- Changes from 'Read integration status through the gateway API' to 'Read integration configuration and readiness status'

Addresses review feedback from PR #14158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
