### PR TITLE
fix: use narrower gateway ban pattern for public-ingress skill guard

### DIFF
--- a/assistant/src/__tests__/bundled-skill-retrieval-guard.test.ts
+++ b/assistant/src/__tests__/bundled-skill-retrieval-guard.test.ts
@@ -76,6 +76,7 @@ const GATEWAY_RETRIEVAL_BANLIST: Array<{
   {
     skillPath: "public-ingress/SKILL.md",
     bannedSnippets: [
+      'curl -s "$INTERNAL_GATEWAY_BASE_URL/v1/',
       "security find-generic-password",
       "secret-tool lookup service vellum-assistant account credential:ngrok:authtoken",
     ],


### PR DESCRIPTION
Replaces the blanket INTERNAL_GATEWAY_BASE_URL ban (removed in #14161) with a narrower pattern that catches direct gateway curl retrieval calls while allowing legitimate ngrok target usage of the env var.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
