### PR TITLE
test: add snapshot test to keep CLI_HELP_REFERENCE in sync

### DIFF
--- a/assistant/src/__tests__/cli-help-reference-sync.test.ts
+++ b/assistant/src/__tests__/cli-help-reference-sync.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildCliProgram } from "../cli/program.js";
+import { CLI_HELP_REFERENCE } from "../cli/reference.js";
+
+/**
+ * Guard test: CLI_HELP_REFERENCE must stay in sync with the actual CLI help
+ * output produced by buildCliProgram().helpInformation().
+ *
+ * The snapshot in reference.ts is embedded in the system prompt (via
+ * system-prompt.ts) so the assistant knows which CLI commands are available.
+ * If the actual CLI program drifts from the snapshot, the system prompt will
+ * contain stale information.
+ *
+ * When this test fails, update CLI_HELP_REFERENCE in
+ * assistant/src/cli/reference.ts to match the current output of
+ * buildCliProgram().helpInformation().
+ */
+describe("CLI_HELP_REFERENCE sync", () => {
+  test("CLI_HELP_REFERENCE matches buildCliProgram().helpInformation()", () => {
+    const program = buildCliProgram();
+    const actual = program.helpInformation();
+
+    expect(actual).toBe(CLI_HELP_REFERENCE);
+  });
+});


### PR DESCRIPTION
Adds a test that compares buildCliProgram().helpInformation() to CLI_HELP_REFERENCE, preventing future drift between the actual CLI help output and the snapshot used in system prompts. Addresses feedback from #14164.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
