### PR TITLE
fix: only show 'Compacting context' status when compaction is needed

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -650,6 +650,59 @@ describe("ContextWindowManager", () => {
     );
   });
 
+  test("shouldCompact returns false when below threshold", () => {
+    const provider = createProvider(() => {
+      throw new Error("should not be called");
+    });
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig(),
+    });
+    const history = [message("user", "hello"), message("assistant", "hi")];
+    expect(manager.shouldCompact(history)).toBe(false);
+  });
+
+  test("shouldCompact returns true when above threshold", () => {
+    const provider = createProvider(() => {
+      throw new Error("should not be called");
+    });
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig(),
+    });
+    const long = "x".repeat(240);
+    const history: Message[] = [
+      message("user", `u1 ${long}`),
+      message("assistant", `a1 ${long}`),
+      message("user", `u2 ${long}`),
+      message("assistant", `a2 ${long}`),
+      message("user", `u3 ${long}`),
+      message("assistant", `a3 ${long}`),
+    ];
+    expect(manager.shouldCompact(history)).toBe(true);
+  });
+
+  test("shouldCompact returns false when compaction is disabled", () => {
+    const provider = createProvider(() => {
+      throw new Error("should not be called");
+    });
+    const long = "x".repeat(240);
+    const manager = new ContextWindowManager({
+      provider,
+      systemPrompt: "system prompt",
+      config: makeConfig({ enabled: false }),
+    });
+    const history: Message[] = [
+      message("user", `u1 ${long}`),
+      message("assistant", `a1 ${long}`),
+      message("user", `u2 ${long}`),
+      message("assistant", `a2 ${long}`),
+    ];
+    expect(manager.shouldCompact(history)).toBe(false);
+  });
+
   test("targetInputTokensOverride reduces retained turns beyond normal compaction", async () => {
     const provider = createProvider(() => ({
       content: [{ type: "text", text: "## Goals\n- tight fit summary" }],

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -88,6 +88,22 @@ export class ContextWindowManager {
     this.config = options.config;
   }
 
+  /**
+   * Cheap pre-check: returns true when the estimated token count exceeds
+   * the compaction threshold, so callers can show a status indicator
+   * only when compaction is likely to run.
+   */
+  shouldCompact(messages: Message[]): boolean {
+    if (!this.config.enabled) return false;
+    const estimated = estimatePromptTokens(messages, this.systemPrompt, {
+      providerName: this.provider.name,
+    });
+    const threshold = Math.floor(
+      this.config.maxInputTokens * this.config.compactThreshold,
+    );
+    return estimated >= threshold;
+  }
+
   async maybeCompact(
     messages: Message[],
     signal?: AbortSignal,

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -426,13 +426,15 @@ export async function runAgentLoopImpl(
 
     const isFirstMessage = ctx.messages.length === 1;
 
-    ctx.emitActivityState(
-      "thinking",
-      "thinking_delta",
-      "assistant_turn",
-      reqId,
-      "Compacting context",
-    );
+    if (ctx.contextWindowManager.shouldCompact(ctx.messages)) {
+      ctx.emitActivityState(
+        "thinking",
+        "thinking_delta",
+        "assistant_turn",
+        reqId,
+        "Compacting context",
+      );
+    }
     const compacted = await ctx.contextWindowManager.maybeCompact(
       ctx.messages,
       abortController.signal,


### PR DESCRIPTION
## Summary
- The "Compacting context" activity status was shown unconditionally before calling `maybeCompact()`, causing it to flash in the UI even on new threads where no compaction occurs
- Added a cheap `shouldCompact()` method to `ContextWindowManager` that checks the token threshold without making LLM calls
- Gated the status emission on `shouldCompact()` so it only appears when compaction will actually run

## Test plan
- [x] Added 3 unit tests for `shouldCompact()`: below threshold, above threshold, and disabled
- [x] All 19 existing context-window-manager tests pass
- [ ] Manual: send "hey" in a new thread — should no longer flash "Compacting context"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
