### PR TITLE
feat: add `assistant platform` CLI with `status` and `callback-routes register`

### DIFF
--- a/assistant/src/cli/platform.ts
+++ b/assistant/src/cli/platform.ts
@@ -1,0 +1,178 @@
+import type { Command } from "commander";
+
+import {
+  getPlatformAssistantId,
+  getPlatformBaseUrl,
+  getPlatformInternalApiKey,
+} from "../config/env.js";
+import { getIsContainerized } from "../config/env-registry.js";
+import {
+  registerCallbackRoute,
+  shouldUsePlatformCallbacks,
+} from "../inbound/platform-callback-registration.js";
+import { getCliLogger } from "../util/logger.js";
+import { shouldOutputJson, writeOutput } from "./integrations.js";
+
+const log = getCliLogger("cli");
+
+export function registerPlatformCommand(program: Command): void {
+  const platform = program
+    .command("platform")
+    .description("Manage platform integration for containerized deployments")
+    .option("--json", "Machine-readable compact JSON output");
+
+  platform.addHelpText(
+    "after",
+    `
+The platform subsystem manages callback routing, containerized deployment
+context, and webhook forwarding for assistants running inside platform
+containers. When IS_CONTAINERIZED=true with a configured PLATFORM_BASE_URL
+and PLATFORM_ASSISTANT_ID, external service callbacks (Telegram webhooks,
+Twilio webhooks, OAuth redirects) route through the platform's gateway proxy
+instead of hitting the assistant directly.
+
+Examples:
+  $ assistant platform status --json
+  $ assistant platform callback-routes register --path webhooks/telegram --type telegram --json
+  $ assistant platform status`,
+  );
+
+  // ---------------------------------------------------------------------------
+  // status
+  // ---------------------------------------------------------------------------
+
+  platform
+    .command("status")
+    .description("Show current platform deployment context")
+    .addHelpText(
+      "after",
+      `
+Reads platform-related environment variables and returns the current
+containerized deployment context. Does not require the assistant daemon to
+be running.
+
+Fields:
+  containerized       Whether IS_CONTAINERIZED is set (boolean)
+  baseUrl             PLATFORM_BASE_URL — the platform gateway base URL
+  assistantId         PLATFORM_ASSISTANT_ID — this assistant's platform UUID
+  hasInternalApiKey   Whether PLATFORM_INTERNAL_API_KEY is set (boolean,
+                      value not disclosed)
+
+Examples:
+  $ assistant platform status
+  $ assistant platform status --json`,
+    )
+    .action((_opts: Record<string, unknown>, cmd: Command) => {
+      const result = {
+        containerized: getIsContainerized(),
+        baseUrl: getPlatformBaseUrl(),
+        assistantId: getPlatformAssistantId(),
+        hasInternalApiKey: !!getPlatformInternalApiKey(),
+      };
+
+      writeOutput(cmd, result);
+
+      if (!shouldOutputJson(cmd)) {
+        log.info(`Containerized: ${result.containerized}`);
+        log.info(`Base URL: ${result.baseUrl || "(not set)"}`);
+        log.info(`Assistant ID: ${result.assistantId || "(not set)"}`);
+        log.info(
+          `Internal API key: ${result.hasInternalApiKey ? "set" : "not set"}`,
+        );
+      }
+    });
+
+  // ---------------------------------------------------------------------------
+  // callback-routes
+  // ---------------------------------------------------------------------------
+
+  const callbackRoutes = platform
+    .command("callback-routes")
+    .description("Manage platform callback route registrations");
+
+  callbackRoutes.addHelpText(
+    "after",
+    `
+Callback routes tell the platform gateway how to forward inbound provider
+webhooks to the correct containerized assistant instance. Each route maps a
+callback path and type to a stable external URL that external services
+(Telegram, Twilio, OAuth providers) should use.
+
+Examples:
+  $ assistant platform callback-routes register --path webhooks/telegram --type telegram --json
+  $ assistant platform callback-routes register --path webhooks/twilio/voice --type twilio_voice --json`,
+  );
+
+  // ---------------------------------------------------------------------------
+  // callback-routes register
+  // ---------------------------------------------------------------------------
+
+  callbackRoutes
+    .command("register")
+    .description("Register a callback route with the platform gateway")
+    .requiredOption(
+      "--path <path>",
+      "Callback path (e.g. webhooks/telegram, webhooks/twilio/voice)",
+    )
+    .requiredOption(
+      "--type <type>",
+      "Route type identifier (e.g. telegram, twilio_voice, twilio_status, oauth)",
+    )
+    .addHelpText(
+      "after",
+      `
+Registers a callback route with the platform's internal gateway endpoint so
+the platform knows how to forward inbound provider webhooks to this
+containerized assistant instance.
+
+Arguments:
+  --path    The path portion after the ingress base URL. Leading/trailing
+            slashes are stripped by the platform.
+  --type    The route type identifier used by the platform to classify and
+            route the callback.
+
+Known callback path/type combinations:
+  --path webhooks/telegram          --type telegram
+  --path webhooks/twilio/voice      --type twilio_voice
+  --path webhooks/twilio/status     --type twilio_status
+  --path oauth/callback             --type oauth
+
+Requires a containerized environment (IS_CONTAINERIZED=true) with
+PLATFORM_BASE_URL and PLATFORM_ASSISTANT_ID configured. Returns the
+platform-provided stable callback URL that external services should use.
+
+Examples:
+  $ assistant platform callback-routes register --path webhooks/telegram --type telegram --json
+  $ assistant platform callback-routes register --path webhooks/twilio/voice --type twilio_voice --json`,
+    )
+    .action(async (opts: { path: string; type: string }, cmd: Command) => {
+      try {
+        if (!shouldUsePlatformCallbacks()) {
+          writeOutput(cmd, {
+            success: false,
+            error:
+              "Platform callbacks not available \u2014 not running in containerized mode",
+          });
+          process.exitCode = 1;
+          return;
+        }
+
+        const callbackUrl = await registerCallbackRoute(opts.path, opts.type);
+
+        writeOutput(cmd, {
+          success: true,
+          callbackUrl,
+          callbackPath: opts.path,
+          type: opts.type,
+        });
+
+        if (!shouldOutputJson(cmd)) {
+          log.info(`Callback route registered: ${callbackUrl}`);
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        writeOutput(cmd, { success: false, error: message });
+        process.exitCode = 1;
+      }
+    });
+}

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -24,6 +24,7 @@ import { registerMcpCommand } from "./mcp.js";
 import { registerMemoryCommand } from "./memory.js";
 import { registerNotificationsCommand } from "./notifications.js";
 import { registerOAuthCommand } from "./oauth.js";
+import { registerPlatformCommand } from "./platform.js";
 import { registerSequenceCommand } from "./sequence.js";
 import { registerSessionsCommand } from "./sessions.js";
 import { registerSkillsCommand } from "./skills.js";
@@ -59,6 +60,7 @@ export function buildCliProgram(): Command {
   registerAutonomyCommand(program);
   registerCompletionsCommand(program);
   registerNotificationsCommand(program);
+  registerPlatformCommand(program);
   registerOAuthCommand(program);
   registerSkillsCommand(program);
 

--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -36,6 +36,8 @@ Commands:
   notifications [options]  Send and inspect notifications through the unified
                            notification router
   oauth [options]          Manage OAuth tokens for connected integrations
+  platform [options]       Manage platform integration for containerized
+                           deployments
   skills                   Browse and install skills from the Vellum catalog
   x|twitter [options]      Post on X and manage connections. Supports OAuth
                            (official API) and browser session paths.


### PR DESCRIPTION
## Summary
- Add new `assistant platform` top-level CLI command
- `status` subcommand shows containerized deployment context (env vars)
- `callback-routes register` subcommand registers webhook forwarding routes with the platform gateway

Part of plan: tg-setup-decompose.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)