### PR TITLE
refactor: shared `getTelegramBotUsername()` reading from config, migrate config-telegram.ts

### DIFF
--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -2,6 +2,12 @@ import * as net from "node:net";
 
 import { getIngressPublicBaseUrl } from "../../config/env.js";
 import {
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../config/loader.js";
+import {
   registerCallbackRoute,
   shouldUsePlatformCallbacks,
 } from "../../inbound/platform-callback-registration.js";
@@ -10,9 +16,9 @@ import {
   getSecureKey,
   setSecureKeyAsync,
 } from "../../security/secure-keys.js";
+import { getTelegramBotUsername } from "../../telegram/bot-username.js";
 import {
   deleteCredentialMetadata,
-  getCredentialMetadata,
   upsertCredentialMetadata,
 } from "../../tools/credentials/metadata-store.js";
 import type {
@@ -60,8 +66,7 @@ export type TelegramConfigResult = Omit<TelegramConfigResponse, "type">;
 export function getTelegramConfig(): TelegramConfigResult {
   const hasBotToken = !!getSecureKey("credential:telegram:bot_token");
   const hasWebhookSecret = !!getSecureKey("credential:telegram:webhook_secret");
-  const meta = getCredentialMetadata("telegram", "bot_token");
-  const botUsername = meta?.accountInfo ?? undefined;
+  const botUsername = getTelegramBotUsername();
   return {
     success: true,
     hasBotToken,
@@ -145,10 +150,16 @@ export async function setTelegramConfig(
     };
   }
 
-  // Store metadata with bot username
+  // Store metadata with bot username (kept for consumers that haven't migrated yet)
   upsertCredentialMetadata("telegram", "bot_token", {
     accountInfo: botUsername,
   });
+
+  // Dual-write: persist bot username to config for the new config-based path
+  const raw = loadRawConfig();
+  setNestedValue(raw, "telegram.botUsername", botUsername);
+  saveRawConfig(raw);
+  invalidateConfigCache();
 
   // Ensure webhook secret exists (generate if missing)
   let hasWebhookSecret = !!getSecureKey("credential:telegram:webhook_secret");

--- a/assistant/src/telegram/bot-username.ts
+++ b/assistant/src/telegram/bot-username.ts
@@ -1,0 +1,13 @@
+import { getConfig } from "../config/loader.js";
+
+/**
+ * Read the Telegram bot username from config, falling back to the
+ * TELEGRAM_BOT_USERNAME env var.
+ */
+export function getTelegramBotUsername(): string | undefined {
+  const value = getConfig().telegram.botUsername;
+  if (value.trim().length > 0) {
+    return value.trim();
+  }
+  return process.env.TELEGRAM_BOT_USERNAME || undefined;
+}


### PR DESCRIPTION
## Summary
- Create shared `getTelegramBotUsername()` helper in `assistant/src/telegram/bot-username.ts` that reads from config with env var fallback
- Migrate `getTelegramConfig()` in config-telegram.ts to use the shared helper instead of reading from credential metadata
- Add dual-write in `setTelegramConfig()` to write bot username to both config and credential metadata during transition

Part of plan: tg-setup-decompose.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
