### PR TITLE
refactor: migrate verification and config-channels to shared `getTelegramBotUsername()`

### DIFF
--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -44,7 +44,7 @@ import {
   composeVerificationTelegram,
   GUARDIAN_VERIFY_TEMPLATE_KEYS,
 } from "../../runtime/verification-templates.js";
-import { getCredentialMetadata } from "../../tools/credentials/metadata-store.js";
+import { getTelegramBotUsername } from "../../telegram/bot-username.js";
 import { normalizePhoneNumber } from "../../util/phone.js";
 import type {
   ChannelVerificationSessionRequest,
@@ -246,18 +246,6 @@ function toVerificationChannel(channelType: string): ChannelId | null {
     default:
       return null;
   }
-}
-
-function getTelegramBotUsername(): string | undefined {
-  const meta = getCredentialMetadata("telegram", "bot_token");
-  if (
-    meta?.accountInfo &&
-    typeof meta.accountInfo === "string" &&
-    meta.accountInfo.trim().length > 0
-  ) {
-    return meta.accountInfo.trim();
-  }
-  return process.env.TELEGRAM_BOT_USERNAME || undefined;
 }
 
 /**

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -12,7 +12,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { startVerificationCall } from "../calls/call-domain.js";
 import type { ChannelId } from "../channels/types.js";
 import { getGatewayInternalBaseUrl } from "../config/env.js";
-import { getCredentialMetadata } from "../tools/credentials/metadata-store.js";
+import { getTelegramBotUsername } from "../telegram/bot-username.js";
 import { getLogger } from "../util/logger.js";
 import { normalizePhoneNumber } from "../util/phone.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
@@ -73,22 +73,6 @@ function isTelegramChatId(destination: string): boolean {
 export function normalizeTelegramDestination(destination: string): string {
   if (isTelegramChatId(destination)) return destination;
   return destination.replace(/^@/, "").toLowerCase();
-}
-
-/**
- * Get the Telegram bot username from credential metadata.
- * Falls back to process.env.TELEGRAM_BOT_USERNAME.
- */
-function getTelegramBotUsername(): string | undefined {
-  const meta = getCredentialMetadata("telegram", "bot_token");
-  if (
-    meta?.accountInfo &&
-    typeof meta.accountInfo === "string" &&
-    meta.accountInfo.trim().length > 0
-  ) {
-    return meta.accountInfo.trim();
-  }
-  return process.env.TELEGRAM_BOT_USERNAME || undefined;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace local `getTelegramBotUsername()` in `verification-outbound-actions.ts` with import from shared helper
- Replace local `getTelegramBotUsername()` in `config-channels.ts` with import from shared helper
- Remove now-unused `getCredentialMetadata` imports where applicable

Part of plan: tg-setup-decompose.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
