### PR TITLE
refactor: migrate telegram invite transport to shared helper, write to config

### DIFF
--- a/assistant/src/__tests__/telegram-bot-username-resolution.test.ts
+++ b/assistant/src/__tests__/telegram-bot-username-resolution.test.ts
@@ -12,23 +12,28 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // Mutable mock state — tests toggle these before each call
 // ---------------------------------------------------------------------------
 
-let mockMetadata: { accountInfo?: string } | undefined;
+let mockBotUsername: string | undefined;
 let mockSecureKey: string | undefined;
-let mockUpsertCalls: Array<{
-  service: string;
-  key: string;
-  patch: Record<string, unknown>;
+let mockConfigWriteCalls: Array<{
+  path: string;
+  value: unknown;
 }> = [];
 
-mock.module("../tools/credentials/metadata-store.js", () => ({
-  getCredentialMetadata: (_service: string, _key: string) => mockMetadata,
-  upsertCredentialMetadata: (
-    service: string,
-    key: string,
-    patch: Record<string, unknown>,
+mock.module("../telegram/bot-username.js", () => ({
+  getTelegramBotUsername: () => mockBotUsername,
+}));
+
+mock.module("../config/loader.js", () => ({
+  loadRawConfig: () => ({}),
+  setNestedValue: (
+    _obj: Record<string, unknown>,
+    path: string,
+    value: unknown,
   ) => {
-    mockUpsertCalls.push({ service, key, patch });
+    mockConfigWriteCalls.push({ path, value });
   },
+  saveRawConfig: () => {},
+  invalidateConfigCache: () => {},
 }));
 
 mock.module("../security/secure-keys.js", () => ({
@@ -56,9 +61,9 @@ let mockFetchThrows: Error | undefined;
 let fetchCallCount = 0;
 
 beforeEach(() => {
-  mockMetadata = undefined;
+  mockBotUsername = undefined;
   mockSecureKey = undefined;
-  mockUpsertCalls = [];
+  mockConfigWriteCalls = [];
   mockFetchThrows = undefined;
   mockFetchResponse = {
     ok: true,
@@ -86,18 +91,18 @@ const { ensureTelegramBotUsernameResolved } =
 // ---------------------------------------------------------------------------
 
 describe("ensureTelegramBotUsernameResolved", () => {
-  test("(a) early-returns when accountInfo is already cached", async () => {
-    mockMetadata = { accountInfo: "CachedBot" };
+  test("(a) early-returns when bot username is already cached in config", async () => {
+    mockBotUsername = "CachedBot";
     mockSecureKey = "some-token";
 
     await ensureTelegramBotUsernameResolved();
 
     expect(fetchCallCount).toBe(0);
-    expect(mockUpsertCalls).toHaveLength(0);
+    expect(mockConfigWriteCalls).toHaveLength(0);
   });
 
-  test("(b) fetches getMe and caches username on success", async () => {
-    mockMetadata = undefined;
+  test("(b) fetches getMe and writes username to config on success", async () => {
+    mockBotUsername = undefined;
     mockSecureKey = "bot-token-123";
     mockFetchResponse = {
       ok: true,
@@ -108,17 +113,16 @@ describe("ensureTelegramBotUsernameResolved", () => {
     await ensureTelegramBotUsernameResolved();
 
     expect(fetchCallCount).toBe(1);
-    expect(mockUpsertCalls).toEqual([
+    expect(mockConfigWriteCalls).toEqual([
       {
-        service: "telegram",
-        key: "bot_token",
-        patch: { accountInfo: "MyNewBot" },
+        path: "telegram.botUsername",
+        value: "MyNewBot",
       },
     ]);
   });
 
-  test("(c) handles non-200 response gracefully without caching", async () => {
-    mockMetadata = undefined;
+  test("(c) handles non-200 response gracefully without writing to config", async () => {
+    mockBotUsername = undefined;
     mockSecureKey = "bot-token-123";
     mockFetchResponse = {
       ok: false,
@@ -129,11 +133,11 @@ describe("ensureTelegramBotUsernameResolved", () => {
     await ensureTelegramBotUsernameResolved();
 
     expect(fetchCallCount).toBe(1);
-    expect(mockUpsertCalls).toHaveLength(0);
+    expect(mockConfigWriteCalls).toHaveLength(0);
   });
 
   test("(d) handles missing username in response gracefully", async () => {
-    mockMetadata = undefined;
+    mockBotUsername = undefined;
     mockSecureKey = "bot-token-123";
     mockFetchResponse = {
       ok: true,
@@ -144,32 +148,32 @@ describe("ensureTelegramBotUsernameResolved", () => {
     await ensureTelegramBotUsernameResolved();
 
     expect(fetchCallCount).toBe(1);
-    expect(mockUpsertCalls).toHaveLength(0);
+    expect(mockConfigWriteCalls).toHaveLength(0);
   });
 
   test("(e) handles network errors (fetch throws) gracefully", async () => {
-    mockMetadata = undefined;
+    mockBotUsername = undefined;
     mockSecureKey = "bot-token-123";
     mockFetchThrows = new Error("ECONNREFUSED");
 
     await ensureTelegramBotUsernameResolved();
 
     expect(fetchCallCount).toBe(1);
-    expect(mockUpsertCalls).toHaveLength(0);
+    expect(mockConfigWriteCalls).toHaveLength(0);
   });
 
   test("(f) no-ops when no bot token is configured", async () => {
-    mockMetadata = undefined;
+    mockBotUsername = undefined;
     mockSecureKey = undefined;
 
     await ensureTelegramBotUsernameResolved();
 
     expect(fetchCallCount).toBe(0);
-    expect(mockUpsertCalls).toHaveLength(0);
+    expect(mockConfigWriteCalls).toHaveLength(0);
   });
 
-  test("treats whitespace-only accountInfo as uncached", async () => {
-    mockMetadata = { accountInfo: "   " };
+  test("writes to config when bot username not in config", async () => {
+    mockBotUsername = undefined;
     mockSecureKey = "bot-token-123";
     mockFetchResponse = {
       ok: true,
@@ -180,17 +184,16 @@ describe("ensureTelegramBotUsernameResolved", () => {
     await ensureTelegramBotUsernameResolved();
 
     expect(fetchCallCount).toBe(1);
-    expect(mockUpsertCalls).toEqual([
+    expect(mockConfigWriteCalls).toEqual([
       {
-        service: "telegram",
-        key: "bot_token",
-        patch: { accountInfo: "FreshBot" },
+        path: "telegram.botUsername",
+        value: "FreshBot",
       },
     ]);
   });
 
-  test("treats empty-string accountInfo as uncached", async () => {
-    mockMetadata = { accountInfo: "" };
+  test("writes to config when bot username resolved from API", async () => {
+    mockBotUsername = undefined;
     mockSecureKey = "bot-token-456";
     mockFetchResponse = {
       ok: true,
@@ -201,11 +204,10 @@ describe("ensureTelegramBotUsernameResolved", () => {
     await ensureTelegramBotUsernameResolved();
 
     expect(fetchCallCount).toBe(1);
-    expect(mockUpsertCalls).toEqual([
+    expect(mockConfigWriteCalls).toEqual([
       {
-        service: "telegram",
-        key: "bot_token",
-        patch: { accountInfo: "AnotherBot" },
+        path: "telegram.botUsername",
+        value: "AnotherBot",
       },
     ]);
   });

--- a/assistant/src/runtime/channel-invite-transports/telegram.ts
+++ b/assistant/src/runtime/channel-invite-transports/telegram.ts
@@ -10,11 +10,14 @@
  */
 
 import type { ChannelId } from "../../channels/types.js";
-import { getSecureKey } from "../../security/secure-keys.js";
 import {
-  getCredentialMetadata,
-  upsertCredentialMetadata,
-} from "../../tools/credentials/metadata-store.js";
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../config/loader.js";
+import { getSecureKey } from "../../security/secure-keys.js";
+import { getTelegramBotUsername } from "../../telegram/bot-username.js";
 import { getLogger } from "../../util/logger.js";
 import type {
   ChannelInviteAdapter,
@@ -26,37 +29,15 @@ import type {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the Telegram bot username from credential metadata, falling back
- * to the TELEGRAM_BOT_USERNAME environment variable. Mirrors the resolution
- * strategy used in `verification-outbound-actions.ts`.
- */
-function getTelegramBotUsername(): string | undefined {
-  const meta = getCredentialMetadata("telegram", "bot_token");
-  if (
-    meta?.accountInfo &&
-    typeof meta.accountInfo === "string" &&
-    meta.accountInfo.trim().length > 0
-  ) {
-    return meta.accountInfo.trim();
-  }
-  return process.env.TELEGRAM_BOT_USERNAME || undefined;
-}
-
-/**
- * Ensure the Telegram bot username is resolved and cached in credential
- * metadata. When the bot token was configured via CLI `credential set`,
+ * Ensure the Telegram bot username is resolved and cached in config.
+ * When the bot token was configured via CLI `credential set`,
  * `credential_store` tool, or ingress secret redirect, the `getMe` API
- * call that populates `accountInfo` is skipped — this function fills that
+ * call that populates the config is skipped — this function fills that
  * gap so that invite share links can be generated.
  */
 export async function ensureTelegramBotUsernameResolved(): Promise<void> {
-  const meta = getCredentialMetadata("telegram", "bot_token");
-  if (
-    meta?.accountInfo &&
-    typeof meta.accountInfo === "string" &&
-    meta.accountInfo.trim().length > 0
-  ) {
-    return; // Username already cached
+  if (getTelegramBotUsername()) {
+    return; // Username already cached in config
   }
 
   const token = getSecureKey("credential:telegram:bot_token");
@@ -91,9 +72,11 @@ export async function ensureTelegramBotUsernameResolved(): Promise<void> {
       );
       return;
     }
-    upsertCredentialMetadata("telegram", "bot_token", {
-      accountInfo: username,
-    });
+    // Write to config
+    const raw = loadRawConfig();
+    setNestedValue(raw, "telegram.botUsername", username);
+    saveRawConfig(raw);
+    invalidateConfigCache();
   } catch (err) {
     getLogger("telegram-invite").warn(
       { err },


### PR DESCRIPTION
## Summary
- Replace local `getTelegramBotUsername()` with import from shared helper in `channel-invite-transports/telegram.ts`
- Migrate `ensureTelegramBotUsernameResolved()` to read from and write to config instead of credential metadata
- Update test file to mock config module and assert config writes instead of credential metadata writes

Part of plan: tg-setup-decompose.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
