### PR TITLE
fix: platform.ts help text and JSON output field naming

### DIFF
--- a/assistant/src/cli/platform.ts
+++ b/assistant/src/cli/platform.ts
@@ -48,8 +48,8 @@ Examples:
       "after",
       `
 Reads platform-related environment variables and returns the current
-containerized deployment context. Does not require the assistant daemon to
-be running.
+containerized deployment context. Does not require the assistant to be
+running.
 
 Fields:
   containerized       Whether IS_CONTAINERIZED is set (boolean)
@@ -149,7 +149,7 @@ Examples:
       try {
         if (!shouldUsePlatformCallbacks()) {
           writeOutput(cmd, {
-            success: false,
+            ok: false,
             error:
               "Platform callbacks not available \u2014 not running in containerized mode",
           });
@@ -160,7 +160,7 @@ Examples:
         const callbackUrl = await registerCallbackRoute(opts.path, opts.type);
 
         writeOutput(cmd, {
-          success: true,
+          ok: true,
           callbackUrl,
           callbackPath: opts.path,
           type: opts.type,
@@ -171,7 +171,7 @@ Examples:
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        writeOutput(cmd, { success: false, error: message });
+        writeOutput(cmd, { ok: false, error: message });
         process.exitCode = 1;
       }
     });


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for tg-setup-decompose.md.

**Gap 1:** Help text used 'daemon' instead of 'assistant' in user-facing text
**Gap 2:** JSON output used 'success' instead of codebase-standard 'ok'

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
