### PR TITLE
fix: regenerate CLI_HELP_REFERENCE to match actual Commander output

### DIFF
--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -6,48 +6,35 @@ export const CLI_HELP_REFERENCE = `Usage: assistant [options] [command]
 Local AI assistant
 
 Options:
-  -V, --version            output the version number
-  -h, --help               display help for command
+  -V, --version                            output the version number
+  -h, --help                               display help for command
 
 Commands:
-  dev [options]            Run the assistant in dev mode
-  sessions                 Manage sessions
-  config                   Manage configuration
-  keys                     Manage API keys in secure storage
-  credentials [options]    Manage credentials in the encrypted vault (API keys,
-                           tokens, passwords)
-  trust                    Manage trust rules
-  memory                   Manage long-term memory indexing/retrieval
-  audit [options]          Show recent tool invocations
-  doctor                   Run diagnostic checks
-  hooks                    Manage hooks
-  mcp                      Manage MCP (Model Context Protocol) servers
-  email [options]          Email operations (provider-agnostic)
-  integrations [options]   Read integration configuration and readiness status
-  contacts [options]       Manage and query the contact graph
-  channels [options]       Query channel status
-  channel-verification-sessions [options]
-                           Manage channel verification sessions
-  amazon [options]         Shop on Amazon and Amazon Fresh. Requires a session
-                           imported from a Ride Shotgun recording.
-  autonomy [options]       View and configure autonomy tiers
-  completions <shell>      Generate shell completion script (e.g. vellum
-                           completions bash >> ~/.bashrc)
-  notifications [options]  Send and inspect notifications through the unified
-                           notification router
-  oauth [options]          Manage OAuth tokens for connected integrations
-  platform [options]       Manage platform integration for containerized
-                           deployments
-  skills                   Browse and install skills from the Vellum catalog
-  x|twitter [options]      Post on X and manage connections. Supports OAuth
-                           (official API) and browser session paths.
-  map [options] <domain>   Auto-navigate a domain and produce a deduplicated API
-                           map. Launches Chrome with CDP, starts a Ride Shotgun
-                           learn session, then analyzes captured network
-                           traffic.
-  influencer [options]     Research influencers on Instagram, TikTok, and
-                           X/Twitter. Uses the Chrome extension relay to browse
-                           each platform. Requires the user to be logged in on
-                           each platform in Chrome.
-  sequence [options]       Manage email sequences
+  dev [options]                            Run the assistant in dev mode
+  sessions                                 Manage sessions
+  config                                   Manage configuration
+  keys                                     Manage API keys in secure storage
+  credentials [options]                    Manage credentials in the encrypted vault (API keys, tokens, passwords)
+  trust                                    Manage trust rules
+  memory                                   Manage long-term memory indexing/retrieval
+  audit [options]                          Show recent tool invocations
+  doctor                                   Run diagnostic checks
+  hooks                                    Manage hooks
+  mcp                                      Manage MCP (Model Context Protocol) servers
+  email [options]                          Email operations (provider-agnostic)
+  integrations [options]                   Read integration configuration and readiness status
+  contacts [options]                       Manage and query the contact graph
+  channels [options]                       Query channel status
+  channel-verification-sessions [options]  Manage channel verification sessions
+  amazon [options]                         Shop on Amazon and Amazon Fresh. Requires a session imported from a Ride Shotgun recording.
+  autonomy [options]                       View and configure autonomy tiers
+  completions <shell>                      Generate shell completion script (e.g. assistant completions bash >> ~/.bashrc)
+  notifications [options]                  Send and inspect notifications through the unified notification router
+  platform [options]                       Manage platform integration for containerized deployments
+  oauth [options]                          Manage OAuth tokens for connected integrations
+  skills                                   Browse and install skills from the Vellum catalog
+  x|twitter [options]                      Post on X and manage connections. Supports OAuth (official API) and browser session paths.
+  map [options] <domain>                   Auto-navigate a domain and produce a deduplicated API map. Launches Chrome with CDP, starts a Ride Shotgun learn session, then analyzes captured network traffic.
+  influencer [options]                     Research influencers on Instagram, TikTok, and X/Twitter. Uses the Chrome extension relay to browse each platform. Requires the user to be logged in on each platform in Chrome.
+  sequence [options]                       Manage email sequences
 `;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for tg-setup-decompose.md.

**Gap:** `CLI_HELP_REFERENCE` in `reference.ts` was out of sync with actual Commander help output. Regenerated from the actual `buildCliProgram().helpInformation()` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
