### PR TITLE
fix: clear telegram.botUsername from config on disconnect and rollback

### DIFF
--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -181,6 +181,12 @@ export async function setTelegramConfig(
         await deleteSecureKeyAsync("credential:telegram:bot_token");
         deleteCredentialMetadata("telegram", "bot_token");
       }
+      // Always revert the config write — the botUsername was written
+      // optimistically before webhook secret provisioning.
+      const rawRollback = loadRawConfig();
+      setNestedValue(rawRollback, "telegram.botUsername", "");
+      saveRawConfig(rawRollback);
+      invalidateConfigCache();
       return {
         success: false,
         hasBotToken: !isNewToken,
@@ -265,6 +271,13 @@ export async function clearTelegramConfig(): Promise<TelegramConfigResult> {
 
   deleteCredentialMetadata("telegram", "bot_token");
   deleteCredentialMetadata("telegram", "webhook_secret");
+
+  // Clear bot username from config so getTelegramBotUsername() doesn't
+  // return a stale value after disconnect.
+  const raw = loadRawConfig();
+  setNestedValue(raw, "telegram.botUsername", "");
+  saveRawConfig(raw);
+  invalidateConfigCache();
 
   return {
     success: true,


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for tg-setup-decompose.md.

**Gap 1:** `clearTelegramConfig()` now clears `telegram.botUsername` from config alongside credential metadata cleanup
**Gap 2:** `setTelegramConfig()` rollback path now reverts the config write when webhook secret storage fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
