### PR TITLE
fix: update stale test mocks for telegram bot username migration

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -37,13 +37,10 @@ mock.module("../config/env.js", () => ({
   getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
 }));
 
-// Telegram credential metadata mock — provides the bot username for deep-link construction
+// Telegram bot username mock — production code now reads from config via getTelegramBotUsername()
 let mockBotUsername: string | undefined = "test_bot";
-mock.module("../tools/credentials/metadata-store.js", () => ({
-  getCredentialMetadata: (_service: string, _key: string) =>
-    mockBotUsername ? { accountInfo: mockBotUsername } : null,
-  upsertCredentialMetadata: () => {},
-  deleteCredentialMetadata: () => {},
+mock.module("../telegram/bot-username.js", () => ({
+  getTelegramBotUsername: () => mockBotUsername,
 }));
 
 // Call domain mock — outbound voice verification calls are fire-and-forget.

--- a/assistant/src/__tests__/guardian-outbound-http.test.ts
+++ b/assistant/src/__tests__/guardian-outbound-http.test.ts
@@ -48,13 +48,10 @@ mock.module("../config/env.js", () => ({
   getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
 }));
 
-// Telegram credential metadata mock
+// Telegram bot username mock — production code now reads from config via getTelegramBotUsername()
 let mockBotUsername: string | undefined = "test_bot";
-mock.module("../tools/credentials/metadata-store.js", () => ({
-  getCredentialMetadata: (_service: string, _key: string) =>
-    mockBotUsername ? { accountInfo: mockBotUsername } : null,
-  upsertCredentialMetadata: () => {},
-  deleteCredentialMetadata: () => {},
+mock.module("../telegram/bot-username.js", () => ({
+  getTelegramBotUsername: () => mockBotUsername,
 }));
 
 // Voice call mock

--- a/assistant/src/__tests__/handlers-telegram-config.test.ts
+++ b/assistant/src/__tests__/handlers-telegram-config.test.ts
@@ -12,6 +12,7 @@ let rawConfigStore: Record<string, unknown> = {};
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
+    telegram: { botUsername: "" },
   }),
   loadConfig: () => ({}),
   loadRawConfig: () => ({ ...rawConfigStore }),
@@ -20,6 +21,22 @@ mock.module("../config/loader.js", () => ({
   },
   saveConfig: () => {},
   invalidateConfigCache: () => {},
+  setNestedValue: (
+    obj: Record<string, unknown>,
+    path: string,
+    value: unknown,
+  ) => {
+    const keys = path.split(".");
+    let current = obj;
+    for (let i = 0; i < keys.length - 1; i++) {
+      const key = keys[i];
+      if (current[key] == null || typeof current[key] !== "object") {
+        current[key] = {};
+      }
+      current = current[key] as Record<string, unknown>;
+    }
+    current[keys[keys.length - 1]] = value;
+  },
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for tg-setup-decompose.md.

**Gap 1:** Updated `handlers-telegram-config.test.ts` config/loader mock to include `telegram` config key and `setNestedValue`
**Gap 2:** Updated `guardian-outbound-http.test.ts` and `channel-guardian.test.ts` to mock `telegram/bot-username.js` instead of stale metadata-store path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
