### PR TITLE
fix: handlers-telegram-config test mock for config-based bot username

### DIFF
--- a/assistant/src/__tests__/handlers-telegram-config.test.ts
+++ b/assistant/src/__tests__/handlers-telegram-config.test.ts
@@ -8,11 +8,12 @@ const testDir = mkdtempSync(join(tmpdir(), "handlers-telegram-cfg-test-"));
 
 // Track loadRawConfig / saveRawConfig calls
 let rawConfigStore: Record<string, unknown> = {};
+let mockBotUsername = "";
 
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
-    telegram: { botUsername: "" },
+    telegram: { botUsername: mockBotUsername },
   }),
   loadConfig: () => ({}),
   loadRawConfig: () => ({ ...rawConfigStore }),
@@ -217,6 +218,7 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
 describe("Telegram config handler", () => {
   beforeEach(() => {
     rawConfigStore = {};
+    mockBotUsername = "";
     secureKeyStore = {};
     setSecureKeyOverride = null;
     credentialMetadataStore = [];
@@ -253,6 +255,7 @@ describe("Telegram config handler", () => {
     secureKeyStore["credential:telegram:bot_token"] = "test-bot-token";
     secureKeyStore["credential:telegram:webhook_secret"] =
       "test-webhook-secret";
+    mockBotUsername = "my_test_bot";
     credentialMetadataStore.push({
       service: "telegram",
       field: "bot_token",


### PR DESCRIPTION
## Summary
Fixes test regression from telegram bot username migration.

**Gap:** The 'get action returns correct state when configured' test set bot username via credential metadata but production code now reads from config. Updated mock to control `telegram.botUsername` via a mutable variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
