### PR TITLE
fix: add missing shouldCompact() to ContextWindowManager test mocks

### DIFF
--- a/assistant/src/__tests__/session-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/session-abort-tool-results.test.ts
@@ -142,6 +142,9 @@ mock.module("../memory/retriever.js", () => ({
 mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
+    shouldCompact() {
+      return false;
+    }
     async maybeCompact() {
       return { compacted: false };
     }

--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -370,6 +370,7 @@ function makeCtx(
     systemPrompt: "system prompt",
 
     contextWindowManager: {
+      shouldCompact: () => false,
       maybeCompact: async () => ({ compacted: false }),
     } as unknown as AgentLoopSessionContext["contextWindowManager"],
     contextCompactedMessageCount: 0,
@@ -799,6 +800,7 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({
         agentLoopRun,
         contextWindowManager: {
+          shouldCompact: () => false,
           // Compaction succeeds but context is still too large
           maybeCompact: async () => ({
             compacted: true,
@@ -1035,6 +1037,7 @@ describe("session-agent-loop", () => {
         agentLoopRun,
         hasNoClient: true,
         contextWindowManager: {
+          shouldCompact: () => false,
           maybeCompact: async () => ({
             compacted: true,
             messages: [

--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -263,6 +263,9 @@ mock.module("../memory/retriever.js", () => ({
 mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
+    shouldCompact() {
+      return false;
+    }
     async maybeCompact() {
       return { compacted: false };
     }

--- a/assistant/src/__tests__/session-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/session-pre-run-repair.test.ts
@@ -159,6 +159,9 @@ mock.module("../agent/loop.js", () => ({
 mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
+    shouldCompact() {
+      return false;
+    }
     async maybeCompact() {
       return { compacted: false };
     }

--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -217,6 +217,9 @@ mock.module("../memory/retriever.js", () => ({
 mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
+    shouldCompact() {
+      return false;
+    }
     async maybeCompact() {
       return { compacted: false };
     }

--- a/assistant/src/__tests__/session-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/session-provider-retry-repair.test.ts
@@ -199,6 +199,9 @@ let forceCompactionEnabled = false;
 mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
+    shouldCompact() {
+      return false;
+    }
     async maybeCompact(
       messages: Message[],
       _signal?: AbortSignal,

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -195,6 +195,9 @@ mock.module("../memory/retriever.js", () => ({
 mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
+    shouldCompact() {
+      return false;
+    }
     async maybeCompact() {
       return { compacted: false };
     }

--- a/assistant/src/__tests__/session-slash-known.test.ts
+++ b/assistant/src/__tests__/session-slash-known.test.ts
@@ -144,6 +144,9 @@ mock.module("../memory/admin.js", () => ({
 mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
+    shouldCompact() {
+      return false;
+    }
     async maybeCompact() {
       return { compacted: false };
     }

--- a/assistant/src/__tests__/session-slash-queue.test.ts
+++ b/assistant/src/__tests__/session-slash-queue.test.ts
@@ -144,6 +144,9 @@ mock.module("../memory/admin.js", () => ({
 mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
+    shouldCompact() {
+      return false;
+    }
     async maybeCompact() {
       return { compacted: false };
     }

--- a/assistant/src/__tests__/session-slash-unknown.test.ts
+++ b/assistant/src/__tests__/session-slash-unknown.test.ts
@@ -151,6 +151,9 @@ mock.module("../memory/admin.js", () => ({
 mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
+    shouldCompact() {
+      return false;
+    }
     async maybeCompact() {
       return { compacted: false };
     }

--- a/assistant/src/__tests__/session-workspace-injection.test.ts
+++ b/assistant/src/__tests__/session-workspace-injection.test.ts
@@ -172,6 +172,9 @@ mock.module("../memory/retrieval-budget.js", () => ({
 }));
 mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
+    shouldCompact() {
+      return false;
+    }
     async maybeCompact() {
       return { compacted: false };
     }

--- a/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
@@ -170,6 +170,9 @@ mock.module("../memory/retrieval-budget.js", () => ({
 }));
 mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
+    shouldCompact() {
+      return false;
+    }
     async maybeCompact() {
       return { compacted: false };
     }


### PR DESCRIPTION
## Summary
- Add `shouldCompact()` method to all `ContextWindowManager` test mocks across 12 test files
- Fixes CI failures caused by `ctx.contextWindowManager.shouldCompact is not a function` after the compaction status indicator was added in b36ac038c

## Original prompt
fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22808074771

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
