### PR TITLE
fix: add shouldCompact() to remaining contextWindowManager override mocks

### DIFF
--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -767,6 +767,7 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({
         agentLoopRun,
         contextWindowManager: {
+          shouldCompact: () => false,
           maybeCompact: async () => ({ compacted: false }),
         } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });
@@ -893,6 +894,7 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({
         agentLoopRun,
         contextWindowManager: {
+          shouldCompact: () => false,
           maybeCompact: async () => ({ compacted: false }),
         } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });
@@ -948,6 +950,7 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({
         agentLoopRun,
         contextWindowManager: {
+          shouldCompact: () => false,
           maybeCompact: async () => ({ compacted: false }),
         } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });
@@ -1105,6 +1108,7 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({
         agentLoopRun,
         contextWindowManager: {
+          shouldCompact: () => false,
           maybeCompact: async () => ({ compacted: false }),
         } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });
@@ -1165,6 +1169,7 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({
         agentLoopRun,
         contextWindowManager: {
+          shouldCompact: () => false,
           maybeCompact: async () => ({ compacted: false }),
         } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });


### PR DESCRIPTION
## Summary
- Add `shouldCompact()` to 5 remaining `contextWindowManager` override mocks in session-agent-loop.test.ts
- PR #14187 only fixed the base `makeCtx` definition and 2 custom mocks, but missed the 8-space-indented overrides passed to `makeCtx()` calls in the context window exhaustion test group

## Original prompt
fix ci in https://github.com/vellum-ai/vellum-assistant/actions/runs/22808155157

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
