### PR TITLE
fix: reuse token estimate between shouldCompact and maybeCompact

### DIFF
--- a/assistant/src/__tests__/context-window-manager.test.ts
+++ b/assistant/src/__tests__/context-window-manager.test.ts
@@ -650,7 +650,7 @@ describe("ContextWindowManager", () => {
     );
   });
 
-  test("shouldCompact returns false when below threshold", () => {
+  test("shouldCompact returns needed=false with estimatedTokens when below threshold", () => {
     const provider = createProvider(() => {
       throw new Error("should not be called");
     });
@@ -660,10 +660,12 @@ describe("ContextWindowManager", () => {
       config: makeConfig(),
     });
     const history = [message("user", "hello"), message("assistant", "hi")];
-    expect(manager.shouldCompact(history)).toBe(false);
+    const result = manager.shouldCompact(history);
+    expect(result.needed).toBe(false);
+    expect(result.estimatedTokens).toBeGreaterThan(0);
   });
 
-  test("shouldCompact returns true when above threshold", () => {
+  test("shouldCompact returns needed=true with estimatedTokens when above threshold", () => {
     const provider = createProvider(() => {
       throw new Error("should not be called");
     });
@@ -681,10 +683,12 @@ describe("ContextWindowManager", () => {
       message("user", `u3 ${long}`),
       message("assistant", `a3 ${long}`),
     ];
-    expect(manager.shouldCompact(history)).toBe(true);
+    const result = manager.shouldCompact(history);
+    expect(result.needed).toBe(true);
+    expect(result.estimatedTokens).toBeGreaterThan(0);
   });
 
-  test("shouldCompact returns false when compaction is disabled", () => {
+  test("shouldCompact returns needed=false with zero estimatedTokens when disabled", () => {
     const provider = createProvider(() => {
       throw new Error("should not be called");
     });
@@ -700,7 +704,9 @@ describe("ContextWindowManager", () => {
       message("user", `u2 ${long}`),
       message("assistant", `a2 ${long}`),
     ];
-    expect(manager.shouldCompact(history)).toBe(false);
+    const result = manager.shouldCompact(history);
+    expect(result.needed).toBe(false);
+    expect(result.estimatedTokens).toBe(0);
   });
 
   test("targetInputTokensOverride reduces retained turns beyond normal compaction", async () => {

--- a/assistant/src/__tests__/session-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/session-abort-tool-results.test.ts
@@ -143,7 +143,7 @@ mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
     shouldCompact() {
-      return false;
+      return { needed: false, estimatedTokens: 0 };
     }
     async maybeCompact() {
       return { compacted: false };

--- a/assistant/src/__tests__/session-agent-loop.test.ts
+++ b/assistant/src/__tests__/session-agent-loop.test.ts
@@ -370,7 +370,7 @@ function makeCtx(
     systemPrompt: "system prompt",
 
     contextWindowManager: {
-      shouldCompact: () => false,
+      shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
       maybeCompact: async () => ({ compacted: false }),
     } as unknown as AgentLoopSessionContext["contextWindowManager"],
     contextCompactedMessageCount: 0,
@@ -767,7 +767,7 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({
         agentLoopRun,
         contextWindowManager: {
-          shouldCompact: () => false,
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
           maybeCompact: async () => ({ compacted: false }),
         } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });
@@ -801,7 +801,7 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({
         agentLoopRun,
         contextWindowManager: {
-          shouldCompact: () => false,
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
           // Compaction succeeds but context is still too large
           maybeCompact: async () => ({
             compacted: true,
@@ -894,7 +894,7 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({
         agentLoopRun,
         contextWindowManager: {
-          shouldCompact: () => false,
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
           maybeCompact: async () => ({ compacted: false }),
         } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });
@@ -950,7 +950,7 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({
         agentLoopRun,
         contextWindowManager: {
-          shouldCompact: () => false,
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
           maybeCompact: async () => ({ compacted: false }),
         } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });
@@ -1040,7 +1040,7 @@ describe("session-agent-loop", () => {
         agentLoopRun,
         hasNoClient: true,
         contextWindowManager: {
-          shouldCompact: () => false,
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
           maybeCompact: async () => ({
             compacted: true,
             messages: [
@@ -1108,7 +1108,7 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({
         agentLoopRun,
         contextWindowManager: {
-          shouldCompact: () => false,
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
           maybeCompact: async () => ({ compacted: false }),
         } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });
@@ -1169,7 +1169,7 @@ describe("session-agent-loop", () => {
       const ctx = makeCtx({
         agentLoopRun,
         contextWindowManager: {
-          shouldCompact: () => false,
+          shouldCompact: () => ({ needed: false, estimatedTokens: 0 }),
           maybeCompact: async () => ({ compacted: false }),
         } as unknown as AgentLoopSessionContext["contextWindowManager"],
       });

--- a/assistant/src/__tests__/session-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/session-confirmation-signals.test.ts
@@ -188,6 +188,9 @@ mock.module("../memory/retriever.js", () => ({
 mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
+    shouldCompact() {
+      return { needed: false, estimatedTokens: 0 };
+    }
     async maybeCompact() {
       return { compacted: false };
     }

--- a/assistant/src/__tests__/session-conflict-gate.test.ts
+++ b/assistant/src/__tests__/session-conflict-gate.test.ts
@@ -264,7 +264,7 @@ mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
     shouldCompact() {
-      return false;
+      return { needed: false, estimatedTokens: 0 };
     }
     async maybeCompact() {
       return { compacted: false };

--- a/assistant/src/__tests__/session-pre-run-repair.test.ts
+++ b/assistant/src/__tests__/session-pre-run-repair.test.ts
@@ -160,7 +160,7 @@ mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
     shouldCompact() {
-      return false;
+      return { needed: false, estimatedTokens: 0 };
     }
     async maybeCompact() {
       return { compacted: false };

--- a/assistant/src/__tests__/session-profile-injection.test.ts
+++ b/assistant/src/__tests__/session-profile-injection.test.ts
@@ -218,7 +218,7 @@ mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
     shouldCompact() {
-      return false;
+      return { needed: false, estimatedTokens: 0 };
     }
     async maybeCompact() {
       return { compacted: false };

--- a/assistant/src/__tests__/session-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/session-provider-retry-repair.test.ts
@@ -200,7 +200,7 @@ mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
     shouldCompact() {
-      return false;
+      return { needed: false, estimatedTokens: 0 };
     }
     async maybeCompact(
       messages: Message[],

--- a/assistant/src/__tests__/session-queue.test.ts
+++ b/assistant/src/__tests__/session-queue.test.ts
@@ -196,7 +196,7 @@ mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
     shouldCompact() {
-      return false;
+      return { needed: false, estimatedTokens: 0 };
     }
     async maybeCompact() {
       return { compacted: false };

--- a/assistant/src/__tests__/session-slash-known.test.ts
+++ b/assistant/src/__tests__/session-slash-known.test.ts
@@ -145,7 +145,7 @@ mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
     shouldCompact() {
-      return false;
+      return { needed: false, estimatedTokens: 0 };
     }
     async maybeCompact() {
       return { compacted: false };

--- a/assistant/src/__tests__/session-slash-queue.test.ts
+++ b/assistant/src/__tests__/session-slash-queue.test.ts
@@ -145,7 +145,7 @@ mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
     shouldCompact() {
-      return false;
+      return { needed: false, estimatedTokens: 0 };
     }
     async maybeCompact() {
       return { compacted: false };

--- a/assistant/src/__tests__/session-slash-unknown.test.ts
+++ b/assistant/src/__tests__/session-slash-unknown.test.ts
@@ -152,7 +152,7 @@ mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
     shouldCompact() {
-      return false;
+      return { needed: false, estimatedTokens: 0 };
     }
     async maybeCompact() {
       return { compacted: false };

--- a/assistant/src/__tests__/session-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/session-workspace-cache-state.test.ts
@@ -132,6 +132,9 @@ mock.module("../memory/retrieval-budget.js", () => ({
 mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     constructor() {}
+    shouldCompact() {
+      return { needed: false, estimatedTokens: 0 };
+    }
     async maybeCompact() {
       return { compacted: false };
     }

--- a/assistant/src/__tests__/session-workspace-injection.test.ts
+++ b/assistant/src/__tests__/session-workspace-injection.test.ts
@@ -173,7 +173,7 @@ mock.module("../memory/retrieval-budget.js", () => ({
 mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     shouldCompact() {
-      return false;
+      return { needed: false, estimatedTokens: 0 };
     }
     async maybeCompact() {
       return { compacted: false };

--- a/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/session-workspace-tool-tracking.test.ts
@@ -171,7 +171,7 @@ mock.module("../memory/retrieval-budget.js", () => ({
 mock.module("../context/window-manager.js", () => ({
   ContextWindowManager: class {
     shouldCompact() {
-      return false;
+      return { needed: false, estimatedTokens: 0 };
     }
     async maybeCompact() {
       return { compacted: false };

--- a/assistant/src/context/window-manager.ts
+++ b/assistant/src/context/window-manager.ts
@@ -52,6 +52,11 @@ export interface ContextWindowResult {
   reason?: string;
 }
 
+export interface ShouldCompactResult {
+  needed: boolean;
+  estimatedTokens: number;
+}
+
 export interface ContextWindowCompactOptions {
   lastCompactedAt?: number;
   /** Bypass the threshold check and force compaction. Used for context-too-large error recovery. */
@@ -69,6 +74,12 @@ export interface ContextWindowCompactOptions {
    * than the normal `config.targetInputTokens` during forced recovery.
    */
   targetInputTokensOverride?: number;
+  /**
+   * Pre-computed token estimate from a prior `shouldCompact()` call.
+   * When provided, `maybeCompact()` skips its own `estimatePromptTokens()`
+   * call, avoiding a redundant O(history) tokenization pass.
+   */
+  precomputedEstimate?: number;
 }
 
 export interface ContextWindowManagerOptions {
@@ -89,19 +100,20 @@ export class ContextWindowManager {
   }
 
   /**
-   * Cheap pre-check: returns true when the estimated token count exceeds
-   * the compaction threshold, so callers can show a status indicator
-   * only when compaction is likely to run.
+   * Cheap pre-check: returns whether the estimated token count exceeds
+   * the compaction threshold, along with the estimated token count so
+   * callers can pass it into `maybeCompact()` via `precomputedEstimate`
+   * to avoid a redundant tokenization pass.
    */
-  shouldCompact(messages: Message[]): boolean {
-    if (!this.config.enabled) return false;
+  shouldCompact(messages: Message[]): ShouldCompactResult {
+    if (!this.config.enabled) return { needed: false, estimatedTokens: 0 };
     const estimated = estimatePromptTokens(messages, this.systemPrompt, {
       providerName: this.provider.name,
     });
     const threshold = Math.floor(
       this.config.maxInputTokens * this.config.compactThreshold,
     );
-    return estimated >= threshold;
+    return { needed: estimated >= threshold, estimatedTokens: estimated };
   }
 
   async maybeCompact(
@@ -109,11 +121,11 @@ export class ContextWindowManager {
     signal?: AbortSignal,
     options?: ContextWindowCompactOptions,
   ): Promise<ContextWindowResult> {
-    const previousEstimatedInputTokens = estimatePromptTokens(
-      messages,
-      this.systemPrompt,
-      { providerName: this.provider.name },
-    );
+    const previousEstimatedInputTokens =
+      options?.precomputedEstimate ??
+      estimatePromptTokens(messages, this.systemPrompt, {
+        providerName: this.provider.name,
+      });
     const thresholdTokens = Math.floor(
       this.config.maxInputTokens * this.config.compactThreshold,
     );

--- a/assistant/src/daemon/session-agent-loop.ts
+++ b/assistant/src/daemon/session-agent-loop.ts
@@ -426,7 +426,8 @@ export async function runAgentLoopImpl(
 
     const isFirstMessage = ctx.messages.length === 1;
 
-    if (ctx.contextWindowManager.shouldCompact(ctx.messages)) {
+    const compactCheck = ctx.contextWindowManager.shouldCompact(ctx.messages);
+    if (compactCheck.needed) {
       ctx.emitActivityState(
         "thinking",
         "thinking_delta",
@@ -438,7 +439,10 @@ export async function runAgentLoopImpl(
     const compacted = await ctx.contextWindowManager.maybeCompact(
       ctx.messages,
       abortController.signal,
-      { lastCompactedAt: ctx.contextCompactedAt ?? undefined },
+      {
+        lastCompactedAt: ctx.contextCompactedAt ?? undefined,
+        precomputedEstimate: compactCheck.estimatedTokens,
+      },
     );
     if (compacted.compacted) {
       ctx.messages = compacted.messages;


### PR DESCRIPTION
## Summary
- Addresses review feedback from PR #14169: `shouldCompact()` and `maybeCompact()` both independently called `estimatePromptTokens()`, doubling the O(history) tokenization work on every turn.
- `shouldCompact()` now returns `{ needed: boolean; estimatedTokens: number }` instead of a plain boolean, so the caller can pass the pre-computed estimate into `maybeCompact()`.
- Added `precomputedEstimate?: number` to `ContextWindowCompactOptions` so `maybeCompact()` skips its own `estimatePromptTokens()` call when the estimate is already available.
- Updated `session-agent-loop.ts` to thread the estimate through, and updated all test mocks to match the new return type.

## Test plan
- [x] All 19 context-window-manager tests pass
- [x] TypeScript type check passes
- [x] ESLint and Prettier pass
- [x] All mock `shouldCompact` implementations across 11 test files updated to return the new shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
