### PR TITLE
feat(gateway): migrate dynamic reads to cache APIs with one-shot force retry

### DIFF
--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -1,5 +1,6 @@
 import { buildTelegramTransportMetadata } from "../../channels/transport-hints.js";
 import type { GatewayConfig } from "../../config.js";
+import type { CredentialCache } from "../../credential-cache.js";
 import { DedupCache } from "../../dedup-cache.js";
 import { handleInbound } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
@@ -44,7 +45,10 @@ const rejectionLimiter = new RejectionRateLimiter();
 const START_COMMAND_ACK_TEXT =
   "Starting up... you'll get my first message in a moment.";
 
-export function createTelegramWebhookHandler(config: GatewayConfig) {
+export function createTelegramWebhookHandler(
+  config: GatewayConfig,
+  caches?: { credentials?: CredentialCache },
+) {
   const dedupCache = new DedupCache();
 
   const handler = async (req: Request): Promise<Response> => {
@@ -65,11 +69,36 @@ export function createTelegramWebhookHandler(config: GatewayConfig) {
       return Response.json({ error: "Payload too large" }, { status: 413 });
     }
 
-    // Verify webhook secret
-    if (
-      !config.telegramWebhookSecret ||
-      !verifyWebhookSecret(req.headers, config.telegramWebhookSecret)
-    ) {
+    // Verify webhook secret — prefer cache, fall back to config
+    let webhookSecret: string | undefined;
+    if (caches?.credentials) {
+      webhookSecret = await caches.credentials.get(
+        "credential:telegram:webhook_secret",
+      );
+    }
+    webhookSecret ??= config.telegramWebhookSecret;
+
+    let secretVerified =
+      !!webhookSecret && verifyWebhookSecret(req.headers, webhookSecret);
+
+    // One-shot force retry: if verification failed and caches are available,
+    // force-refresh the webhook secret and retry once.
+    if (!secretVerified && caches?.credentials) {
+      const freshSecret = await caches.credentials.get(
+        "credential:telegram:webhook_secret",
+        { force: true },
+      );
+      if (freshSecret) {
+        secretVerified = verifyWebhookSecret(req.headers, freshSecret);
+        if (secretVerified) {
+          tlog.info(
+            "Telegram webhook secret verified after forced credential refresh",
+          );
+        }
+      }
+    }
+
+    if (!secretVerified) {
       tlog.warn("Telegram webhook request failed secret verification");
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }

--- a/gateway/src/http/routes/twilio-connect-action-webhook.ts
+++ b/gateway/src/http/routes/twilio-connect-action-webhook.ts
@@ -4,13 +4,19 @@ import {
   CircuitBreakerOpenError,
   forwardTwilioConnectActionWebhook,
 } from "../../runtime/client.js";
-import { validateTwilioWebhookRequest } from "../../twilio/validate-webhook.js";
+import {
+  validateTwilioWebhookRequest,
+  type TwilioValidationCaches,
+} from "../../twilio/validate-webhook.js";
 
 const log = getLogger("twilio-connect-action-webhook");
 
-export function createTwilioConnectActionWebhookHandler(config: GatewayConfig) {
+export function createTwilioConnectActionWebhookHandler(
+  config: GatewayConfig,
+  caches?: TwilioValidationCaches,
+) {
   return async (req: Request): Promise<Response> => {
-    const validation = await validateTwilioWebhookRequest(req, config);
+    const validation = await validateTwilioWebhookRequest(req, config, caches);
     if (validation instanceof Response) return validation;
 
     const { params } = validation;

--- a/gateway/src/http/routes/twilio-status-webhook.ts
+++ b/gateway/src/http/routes/twilio-status-webhook.ts
@@ -4,13 +4,19 @@ import {
   CircuitBreakerOpenError,
   forwardTwilioStatusWebhook,
 } from "../../runtime/client.js";
-import { validateTwilioWebhookRequest } from "../../twilio/validate-webhook.js";
+import {
+  validateTwilioWebhookRequest,
+  type TwilioValidationCaches,
+} from "../../twilio/validate-webhook.js";
 
 const log = getLogger("twilio-status-webhook");
 
-export function createTwilioStatusWebhookHandler(config: GatewayConfig) {
+export function createTwilioStatusWebhookHandler(
+  config: GatewayConfig,
+  caches?: TwilioValidationCaches,
+) {
   return async (req: Request): Promise<Response> => {
-    const validation = await validateTwilioWebhookRequest(req, config);
+    const validation = await validateTwilioWebhookRequest(req, config, caches);
     if (validation instanceof Response) return validation;
 
     const { params } = validation;

--- a/gateway/src/http/routes/twilio-voice-webhook.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.ts
@@ -9,7 +9,10 @@ import {
   resolveAssistantByPhoneNumber,
   isRejection,
 } from "../../routing/resolve-assistant.js";
-import { validateTwilioWebhookRequest } from "../../twilio/validate-webhook.js";
+import {
+  validateTwilioWebhookRequest,
+  type TwilioValidationCaches,
+} from "../../twilio/validate-webhook.js";
 
 const log = getLogger("twilio-voice-webhook");
 
@@ -17,9 +20,12 @@ const log = getLogger("twilio-voice-webhook");
 const REJECT_TWIML =
   '<?xml version="1.0" encoding="UTF-8"?><Response><Reject reason="rejected"/></Response>';
 
-export function createTwilioVoiceWebhookHandler(config: GatewayConfig) {
+export function createTwilioVoiceWebhookHandler(
+  config: GatewayConfig,
+  caches?: TwilioValidationCaches,
+) {
   return async (req: Request): Promise<Response> => {
-    const validation = await validateTwilioWebhookRequest(req, config);
+    const validation = await validateTwilioWebhookRequest(req, config, caches);
     if (validation instanceof Response) return validation;
 
     const { params } = validation;

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -1,6 +1,7 @@
 import { timingSafeEqual } from "crypto";
 import { buildWhatsAppTransportMetadata } from "../../channels/transport-hints.js";
 import type { GatewayConfig } from "../../config.js";
+import type { CredentialCache } from "../../credential-cache.js";
 import { StringDedupCache } from "../../dedup-cache.js";
 import { handleInbound } from "../../handlers/handle-inbound.js";
 import { getLogger } from "../../logger.js";
@@ -33,7 +34,10 @@ const log = getLogger("whatsapp-webhook");
 
 const rejectionLimiter = new RejectionRateLimiter();
 
-export function createWhatsAppWebhookHandler(config: GatewayConfig) {
+export function createWhatsAppWebhookHandler(
+  config: GatewayConfig,
+  caches?: { credentials?: CredentialCache },
+) {
   // 24-hour TTL — WhatsApp message IDs are globally unique and never reused
   const dedupCache = new StringDedupCache(24 * 60 * 60_000);
 
@@ -92,9 +96,18 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
       return Response.json({ error: "Payload too large" }, { status: 413 });
     }
 
+    // Resolve app secret — prefer cache, fall back to config
+    let appSecret: string | undefined;
+    if (caches?.credentials) {
+      appSecret = await caches.credentials.get(
+        "credential:whatsapp:app_secret",
+      );
+    }
+    appSecret ??= config.whatsappAppSecret;
+
     // Signature validation is required — reject requests when the app secret is not configured
     // rather than silently accepting unauthenticated payloads (fail-closed).
-    if (!config.whatsappAppSecret) {
+    if (!appSecret) {
       tlog.warn("WhatsApp app secret is not configured — rejecting request");
       return Response.json(
         { error: "Webhook signature validation not configured" },
@@ -102,13 +115,34 @@ export function createWhatsAppWebhookHandler(config: GatewayConfig) {
       );
     }
 
-    if (
-      !verifyWhatsAppWebhookSignature(
-        req.headers,
-        rawBody,
-        config.whatsappAppSecret,
-      )
-    ) {
+    let signatureValid = verifyWhatsAppWebhookSignature(
+      req.headers,
+      rawBody,
+      appSecret,
+    );
+
+    // One-shot force retry: if verification failed and caches are available,
+    // force-refresh the app secret and retry once.
+    if (!signatureValid && caches?.credentials) {
+      const freshAppSecret = await caches.credentials.get(
+        "credential:whatsapp:app_secret",
+        { force: true },
+      );
+      if (freshAppSecret) {
+        signatureValid = verifyWhatsAppWebhookSignature(
+          req.headers,
+          rawBody,
+          freshAppSecret,
+        );
+        if (signatureValid) {
+          tlog.info(
+            "WhatsApp webhook signature verified after forced credential refresh",
+          );
+        }
+      }
+    }
+
+    if (!signatureValid) {
       tlog.warn("WhatsApp webhook signature verification failed");
       return Response.json({ error: "Forbidden" }, { status: 403 });
     }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -10,8 +10,10 @@ import {
   validateEdgeToken,
   mintBrowserRelayToken,
 } from "./auth/token-exchange.js";
+import { ConfigFileCache } from "./config-file-cache.js";
 import { ConfigFileWatcher } from "./config-file-watcher.js";
 import { loadConfig, isSlackChannelConfigured } from "./config.js";
+import { CredentialCache } from "./credential-cache.js";
 import {
   buildCredentialServiceMappings,
   applyCredentialChanges,
@@ -119,8 +121,22 @@ async function main() {
   initSigningKey(signingKey);
   log.info("JWT signing key initialized");
 
+  // ── TTL caches ──
+  // Instantiate caches for credential and config file reads.
+  // These are passed into handler factories so handlers read from cached
+  // values with automatic TTL refresh instead of the mutable GatewayConfig.
+  // During the compatibility phase, both cache reads and legacy config field
+  // reads coexist — caches are preferred, with config as fallback.
+  const credentialCache = new CredentialCache();
+  const configFileCache = new ConfigFileCache();
+
+  const twilioValidationCaches = {
+    credentials: credentialCache,
+    configFile: configFileCache,
+  };
+
   const { handler: handleTelegramWebhook, dedupCache: telegramDedupCache } =
-    createTelegramWebhookHandler(config);
+    createTelegramWebhookHandler(config, { credentials: credentialCache });
   const handleTelegramDeliver = createTelegramDeliverHandler(config);
   const handleTelegramReconcile = createTelegramReconcileHandler(config);
   const handleTwilioReconcile = createTwilioReconcileHandler(config);
@@ -131,16 +147,22 @@ async function main() {
   const isWhatsAppConfigured = () =>
     !!(config.whatsappPhoneNumberId && config.whatsappAccessToken);
 
-  const handleTwilioVoiceWebhook = createTwilioVoiceWebhookHandler(config);
-  const handleTwilioStatusWebhook = createTwilioStatusWebhookHandler(config);
+  const handleTwilioVoiceWebhook = createTwilioVoiceWebhookHandler(
+    config,
+    twilioValidationCaches,
+  );
+  const handleTwilioStatusWebhook = createTwilioStatusWebhookHandler(
+    config,
+    twilioValidationCaches,
+  );
   const handleTwilioConnectActionWebhook =
-    createTwilioConnectActionWebhookHandler(config);
+    createTwilioConnectActionWebhookHandler(config, twilioValidationCaches);
   const handleTwilioRelayWs = createTwilioRelayWebsocketHandler(config);
   const handleBrowserRelayWs = createBrowserRelayWebsocketHandler(config);
   const twilioRelayWebsocketHandlers = getRelayWebsocketHandlers();
   const browserRelayWebsocketHandlers = getBrowserRelayWebsocketHandlers();
   const { handler: handleWhatsAppWebhook, dedupCache: whatsappDedupCache } =
-    createWhatsAppWebhookHandler(config);
+    createWhatsAppWebhookHandler(config, { credentials: credentialCache });
   const handleWhatsAppDeliver = createWhatsAppDeliverHandler(config);
   const handleSlackDeliver = createSlackDeliverHandler(config, (threadTs) => {
     slackSocketClient?.trackThread(threadTs);
@@ -730,20 +752,30 @@ async function main() {
   telegramDedupCache.startCleanup();
   whatsappDedupCache.startCleanup();
 
+  const telegramCaches = {
+    credentials: credentialCache,
+    configFile: configFileCache,
+  };
+
   function registerTelegramCommands(): void {
-    callTelegramApi(config, "setMyCommands", {
-      commands: [
-        { command: "new", description: "Start a new conversation" },
-        { command: "help", description: "Show available commands" },
-      ],
-    }).catch((err) => {
+    callTelegramApi(
+      config,
+      "setMyCommands",
+      {
+        commands: [
+          { command: "new", description: "Start a new conversation" },
+          { command: "help", description: "Show available commands" },
+        ],
+      },
+      { credentials: credentialCache },
+    ).catch((err) => {
       log.error({ err }, "Failed to register Telegram bot commands");
     });
   }
 
   if (isTelegramConfigured()) {
     registerTelegramCommands();
-    reconcileTelegramWebhook(config).catch((err) => {
+    reconcileTelegramWebhook(config, telegramCaches).catch((err) => {
       log.error({ err }, "Failed to reconcile Telegram webhook on startup");
     });
   }
@@ -808,10 +840,15 @@ async function main() {
       log,
     );
 
+    // Invalidate the credential cache so subsequent reads pick up fresh values
+    if (changed.size > 0) {
+      credentialCache.invalidate();
+    }
+
     // Side effects keyed by service name
     if (changed.has("telegram") && isTelegramConfigured()) {
       registerTelegramCommands();
-      reconcileTelegramWebhook(config).catch((err) => {
+      reconcileTelegramWebhook(config, telegramCaches).catch((err) => {
         log.error(
           { err },
           "Failed to reconcile Telegram webhook after credential change",
@@ -828,9 +865,12 @@ async function main() {
   const configFileWatcher = new ConfigFileWatcher((event) => {
     applyConfigFileMappings(event.data, event.changedKeys, config);
 
+    // Invalidate the config file cache so subsequent reads pick up fresh values
+    configFileCache.invalidate();
+
     // Side effect: reconcile Telegram webhook when ingress URL changes
     if (event.changedKeys.has("ingress") && isTelegramConfigured()) {
-      reconcileTelegramWebhook(config).catch((err) => {
+      reconcileTelegramWebhook(config, telegramCaches).catch((err) => {
         log.error(
           { err },
           "Failed to reconcile Telegram webhook after ingress URL change",

--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -1,3 +1,4 @@
+import type { CredentialCache } from "../credential-cache.js";
 import type { GatewayConfig } from "../config.js";
 import { fetchImpl } from "../fetch.js";
 import { getLogger } from "../logger.js";
@@ -169,17 +170,21 @@ export async function callTelegramApi<T>(
   config: GatewayConfig,
   method: string,
   body: Record<string, unknown>,
+  opts?: { credentials?: CredentialCache },
 ): Promise<T> {
+  let botToken: string | undefined;
+  if (opts?.credentials) {
+    botToken = await opts.credentials.get("credential:telegram:bot_token");
+  }
+  botToken ??= config.telegramBotToken;
+
   return retryableFetch<T>(config, method, () =>
-    fetchImpl(
-      `${config.telegramApiBaseUrl}/bot${config.telegramBotToken}/${method}`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(config.telegramTimeoutMs),
-      },
-    ),
+    fetchImpl(`${config.telegramApiBaseUrl}/bot${botToken}/${method}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(config.telegramTimeoutMs),
+    }),
   );
 }
 
@@ -187,15 +192,19 @@ export async function callTelegramApiMultipart<T>(
   config: GatewayConfig,
   method: string,
   form: FormData,
+  opts?: { credentials?: CredentialCache },
 ): Promise<T> {
+  let botToken: string | undefined;
+  if (opts?.credentials) {
+    botToken = await opts.credentials.get("credential:telegram:bot_token");
+  }
+  botToken ??= config.telegramBotToken;
+
   return retryableFetch<T>(config, method, () =>
-    fetchImpl(
-      `${config.telegramApiBaseUrl}/bot${config.telegramBotToken}/${method}`,
-      {
-        method: "POST",
-        body: form,
-        signal: AbortSignal.timeout(config.telegramTimeoutMs),
-      },
-    ),
+    fetchImpl(`${config.telegramApiBaseUrl}/bot${botToken}/${method}`, {
+      method: "POST",
+      body: form,
+      signal: AbortSignal.timeout(config.telegramTimeoutMs),
+    }),
   );
 }

--- a/gateway/src/telegram/webhook-manager.ts
+++ b/gateway/src/telegram/webhook-manager.ts
@@ -1,3 +1,5 @@
+import type { CredentialCache } from "../credential-cache.js";
+import type { ConfigFileCache } from "../config-file-cache.js";
 import type { GatewayConfig } from "../config.js";
 import { callTelegramApi } from "./api.js";
 import { getLogger } from "../logger.js";
@@ -13,6 +15,12 @@ interface WebhookInfo {
 
 const ALLOWED_UPDATES = ["message", "edited_message", "callback_query"];
 
+/** Options bag for optional cache injection into webhook reconciliation. */
+export type WebhookManagerCaches = {
+  credentials?: CredentialCache;
+  configFile?: ConfigFileCache;
+};
+
 /**
  * Reconciles the Telegram webhook registration against the expected state
  * derived from the gateway's ingress URL and current webhook secret.
@@ -24,15 +32,35 @@ const ALLOWED_UPDATES = ["message", "edited_message", "callback_query"];
  */
 export async function reconcileTelegramWebhook(
   config: GatewayConfig,
+  caches?: WebhookManagerCaches,
 ): Promise<void> {
-  if (!config.telegramBotToken || !config.telegramWebhookSecret) {
+  // Resolve credentials — prefer cache, fall back to config
+  let botToken: string | undefined;
+  let webhookSecret: string | undefined;
+  if (caches?.credentials) {
+    botToken = await caches.credentials.get("credential:telegram:bot_token");
+    webhookSecret = await caches.credentials.get(
+      "credential:telegram:webhook_secret",
+    );
+  }
+  botToken ??= config.telegramBotToken;
+  webhookSecret ??= config.telegramWebhookSecret;
+
+  if (!botToken || !webhookSecret) {
     log.debug(
       "Skipping webhook reconciliation: Telegram credentials not configured",
     );
     return;
   }
 
-  if (!config.ingressPublicBaseUrl) {
+  // Resolve ingress URL — prefer cache, fall back to config
+  let ingressUrl: string | undefined;
+  if (caches?.configFile) {
+    ingressUrl = caches.configFile.getString("ingress", "publicBaseUrl");
+  }
+  ingressUrl ??= config.ingressPublicBaseUrl;
+
+  if (!ingressUrl) {
     log.debug(
       "Skipping webhook reconciliation: INGRESS_PUBLIC_BASE_URL not set",
     );
@@ -41,10 +69,15 @@ export async function reconcileTelegramWebhook(
 
   // Strip trailing slashes to avoid double-slash in the path
   // (e.g. "https://example.com/" + "/webhooks/telegram" => "https://example.com//webhooks/telegram")
-  const baseUrl = config.ingressPublicBaseUrl.replace(/\/+$/, "");
+  const baseUrl = ingressUrl.replace(/\/+$/, "");
   const expectedUrl = `${baseUrl}/webhooks/telegram`;
 
-  const info = await callTelegramApi<WebhookInfo>(config, "getWebhookInfo", {});
+  const info = await callTelegramApi<WebhookInfo>(
+    config,
+    "getWebhookInfo",
+    {},
+    caches?.credentials ? { credentials: caches.credentials } : undefined,
+  );
 
   log.info(
     {
@@ -55,11 +88,16 @@ export async function reconcileTelegramWebhook(
     "Reconciling Telegram webhook",
   );
 
-  await callTelegramApi(config, "setWebhook", {
-    url: expectedUrl,
-    secret_token: config.telegramWebhookSecret,
-    allowed_updates: ALLOWED_UPDATES,
-  });
+  await callTelegramApi(
+    config,
+    "setWebhook",
+    {
+      url: expectedUrl,
+      secret_token: webhookSecret,
+      allowed_updates: ALLOWED_UPDATES,
+    },
+    caches?.credentials ? { credentials: caches.credentials } : undefined,
+  );
 
   log.info({ url: expectedUrl }, "Telegram webhook registered successfully");
 }

--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -1,3 +1,5 @@
+import type { CredentialCache } from "../credential-cache.js";
+import type { ConfigFileCache } from "../config-file-cache.js";
 import type { GatewayConfig } from "../config.js";
 import { getLogger } from "../logger.js";
 import { verifyTwilioSignature } from "./verify.js";
@@ -155,17 +157,28 @@ export type TwilioValidationSuccess = {
   params: Record<string, string>;
 };
 
+/** Options bag for optional cache injection into Twilio webhook validation. */
+export type TwilioValidationCaches = {
+  credentials?: CredentialCache;
+  configFile?: ConfigFileCache;
+};
+
 /**
  * Validate an incoming Twilio webhook request:
  * - Enforces POST method
  * - Enforces payload size limits
  * - Validates X-Twilio-Signature via HMAC-SHA1
  *
+ * When caches are provided, reads the auth token and ingress URL from them.
+ * On signature failure, performs one forced refresh of the auth token and
+ * ingress URL, then retries validation once before rejecting.
+ *
  * Returns the parsed body on success, or a Response on failure.
  */
 export async function validateTwilioWebhookRequest(
   req: Request,
   config: GatewayConfig,
+  caches?: TwilioValidationCaches,
 ): Promise<TwilioValidationSuccess | Response> {
   if (req.method !== "POST") {
     return Response.json({ error: "Method not allowed" }, { status: 405 });
@@ -173,19 +186,44 @@ export async function validateTwilioWebhookRequest(
 
   // Payload size guard (Content-Length header)
   const contentLength = req.headers.get("content-length");
-  const validationDiagnostics = buildValidationDiagnostics(req, config);
-  const { logContext: validationLogContext, signatureUrlCandidates } =
-    validationDiagnostics;
   if (contentLength && Number(contentLength) > config.maxWebhookPayloadBytes) {
-    log.warn(
-      { contentLength, ...validationLogContext },
-      "Twilio webhook payload too large",
-    );
+    log.warn({ contentLength }, "Twilio webhook payload too large");
     return Response.json({ error: "Payload too large" }, { status: 413 });
   }
 
+  // Resolve the auth token — prefer cache when available, fall back to config
+  let authToken: string | undefined;
+  if (caches?.credentials) {
+    authToken = await caches.credentials.get("credential:twilio:auth_token");
+  }
+  authToken ??= config.twilioAuthToken;
+
+  // Resolve ingress URL — prefer cache when available, fall back to config
+  let ingressUrl: string | undefined;
+  if (caches?.configFile) {
+    ingressUrl = caches.configFile.getString("ingress", "publicBaseUrl");
+  }
+  ingressUrl ??= config.ingressPublicBaseUrl;
+
+  // Build a transient config overlay for URL candidate generation so the
+  // diagnostics and candidate builder use the cache-resolved values.
+  const effectiveConfig: GatewayConfig = caches
+    ? {
+        ...config,
+        twilioAuthToken: authToken,
+        ingressPublicBaseUrl: ingressUrl,
+      }
+    : config;
+
+  const validationDiagnostics = buildValidationDiagnostics(
+    req,
+    effectiveConfig,
+  );
+  const { logContext: validationLogContext, signatureUrlCandidates } =
+    validationDiagnostics;
+
   // Fail-closed: reject if no auth token is configured
-  if (!config.twilioAuthToken) {
+  if (!authToken) {
     log.error(
       validationLogContext,
       "Twilio auth token not configured — rejecting webhook (fail-closed)",
@@ -226,13 +264,57 @@ export async function validateTwilioWebhookRequest(
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const signatureCandidateUrls = signatureUrlCandidates.map((c) => c.url);
-  const validatingIndex = findValidatingCandidateIndex(
+  let signatureCandidateUrls = signatureUrlCandidates.map((c) => c.url);
+  let validatingIndex = findValidatingCandidateIndex(
     signatureCandidateUrls,
     params,
     signature,
-    config.twilioAuthToken!,
+    authToken,
   );
+
+  // One-shot force retry: if validation failed and caches are available,
+  // force-refresh the auth token and ingress URL then retry once.
+  if (validatingIndex === -1 && caches?.credentials) {
+    const freshAuthToken = await caches.credentials.get(
+      "credential:twilio:auth_token",
+      { force: true },
+    );
+    let freshIngressUrl: string | undefined;
+    if (caches.configFile) {
+      caches.configFile.refreshNow();
+      freshIngressUrl = caches.configFile.getString("ingress", "publicBaseUrl");
+    }
+
+    const retryAuthToken = freshAuthToken ?? config.twilioAuthToken;
+    const retryIngressUrl = freshIngressUrl ?? config.ingressPublicBaseUrl;
+
+    if (retryAuthToken) {
+      // Rebuild candidates with potentially updated ingress URL
+      const retryConfig: GatewayConfig = {
+        ...config,
+        twilioAuthToken: retryAuthToken,
+        ingressPublicBaseUrl: retryIngressUrl,
+      };
+      const retryDiagnostics = buildValidationDiagnostics(req, retryConfig);
+      const retryCandidateUrls = retryDiagnostics.signatureUrlCandidates.map(
+        (c) => c.url,
+      );
+      validatingIndex = findValidatingCandidateIndex(
+        retryCandidateUrls,
+        params,
+        signature,
+        retryAuthToken,
+      );
+
+      if (validatingIndex !== -1) {
+        log.info(
+          "Twilio webhook signature validated after forced credential refresh",
+        );
+        // Update references for the success log below
+        signatureCandidateUrls = retryCandidateUrls;
+      }
+    }
+  }
 
   if (validatingIndex === -1) {
     log.warn(
@@ -242,7 +324,10 @@ export async function validateTwilioWebhookRequest(
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const validatingCandidate = signatureUrlCandidates[validatingIndex];
+  const validatingCandidate = signatureUrlCandidates[validatingIndex] ?? {
+    source: "configured_ingress" as const,
+    url: signatureCandidateUrls[validatingIndex],
+  };
   const successLogContext = {
     ...validationLogContext,
     validatedCandidateSource: validatingCandidate.source,
@@ -254,14 +339,14 @@ export async function validateTwilioWebhookRequest(
   // a likely drift between the configured ingress URL and the actual webhook
   // registration — the ingress URL should match what Twilio is signing against.
   if (
-    config.ingressPublicBaseUrl &&
+    effectiveConfig.ingressPublicBaseUrl &&
     validatingIndex === signatureCandidateUrls.length - 1 &&
     signatureCandidateUrls.length > 1
   ) {
     log.warn(
       {
         ...successLogContext,
-        ingressPublicBaseUrl: config.ingressPublicBaseUrl,
+        ingressPublicBaseUrl: effectiveConfig.ingressPublicBaseUrl,
       },
       "Twilio signature validated against raw request URL fallback — " +
         "INGRESS_PUBLIC_BASE_URL may be stale or mismatched with the actual webhook registration",

--- a/gateway/src/whatsapp/api.ts
+++ b/gateway/src/whatsapp/api.ts
@@ -1,3 +1,4 @@
+import type { CredentialCache } from "../credential-cache.js";
 import type { GatewayConfig } from "../config.js";
 import { fetchImpl } from "../fetch.js";
 import { getLogger } from "../logger.js";
@@ -139,6 +140,37 @@ async function retryableWhatsAppFetch<T>(
   throw lastError ?? new Error(`WhatsApp ${operation} failed after retries`);
 }
 
+/** Options bag for optional credential cache injection into WhatsApp API calls. */
+export type WhatsAppApiCaches = {
+  credentials?: CredentialCache;
+};
+
+/**
+ * Resolve WhatsApp credentials from cache (preferred) or config (fallback).
+ * Returns undefined fields if neither source has the value.
+ */
+async function resolveWhatsAppCredentials(
+  config: GatewayConfig,
+  caches?: WhatsAppApiCaches,
+): Promise<{
+  phoneNumberId: string | undefined;
+  accessToken: string | undefined;
+}> {
+  let phoneNumberId: string | undefined;
+  let accessToken: string | undefined;
+  if (caches?.credentials) {
+    phoneNumberId = await caches.credentials.get(
+      "credential:whatsapp:phone_number_id",
+    );
+    accessToken = await caches.credentials.get(
+      "credential:whatsapp:access_token",
+    );
+  }
+  phoneNumberId ??= config.whatsappPhoneNumberId;
+  accessToken ??= config.whatsappAccessToken;
+  return { phoneNumberId, accessToken };
+}
+
 export interface WhatsAppSendMessageResult {
   messaging_product: string;
   contacts: Array<{ input: string; wa_id: string }>;
@@ -153,8 +185,13 @@ export async function sendWhatsAppTextMessage(
   config: GatewayConfig,
   to: string,
   text: string,
+  caches?: WhatsAppApiCaches,
 ): Promise<WhatsAppSendMessageResult> {
-  if (!config.whatsappPhoneNumberId || !config.whatsappAccessToken) {
+  const { phoneNumberId, accessToken } = await resolveWhatsAppCredentials(
+    config,
+    caches,
+  );
+  if (!phoneNumberId || !accessToken) {
     throw new Error("WhatsApp credentials not configured");
   }
 
@@ -162,24 +199,21 @@ export async function sendWhatsAppTextMessage(
     config,
     "sendMessage",
     () =>
-      fetchImpl(
-        `${WHATSAPP_API_BASE}/${config.whatsappPhoneNumberId}/messages`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${config.whatsappAccessToken}`,
-          },
-          body: JSON.stringify({
-            messaging_product: "whatsapp",
-            recipient_type: "individual",
-            to,
-            type: "text",
-            text: { body: text, preview_url: false },
-          }),
-          signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+      fetchImpl(`${WHATSAPP_API_BASE}/${phoneNumberId}/messages`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
         },
-      ),
+        body: JSON.stringify({
+          messaging_product: "whatsapp",
+          recipient_type: "individual",
+          to,
+          type: "text",
+          text: { body: text, preview_url: false },
+        }),
+        signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+      }),
   );
 }
 
@@ -196,8 +230,13 @@ export async function uploadWhatsAppMedia(
   blob: Blob,
   filename: string,
   mimeType: string,
+  caches?: WhatsAppApiCaches,
 ): Promise<WhatsAppMediaUploadResult> {
-  if (!config.whatsappPhoneNumberId || !config.whatsappAccessToken) {
+  const { phoneNumberId, accessToken } = await resolveWhatsAppCredentials(
+    config,
+    caches,
+  );
+  if (!phoneNumberId || !accessToken) {
     throw new Error("WhatsApp credentials not configured");
   }
 
@@ -210,17 +249,14 @@ export async function uploadWhatsAppMedia(
       form.set("file", blob, filename);
       form.set("type", mimeType);
 
-      return fetchImpl(
-        `${WHATSAPP_API_BASE}/${config.whatsappPhoneNumberId}/media`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${config.whatsappAccessToken}`,
-          },
-          body: form,
-          signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+      return fetchImpl(`${WHATSAPP_API_BASE}/${phoneNumberId}/media`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
         },
-      );
+        body: form,
+        signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+      });
     },
   );
 }
@@ -238,8 +274,13 @@ export async function sendWhatsAppMediaMessage(
   mediaId: string,
   filename?: string,
   caption?: string,
+  caches?: WhatsAppApiCaches,
 ): Promise<WhatsAppSendMessageResult> {
-  if (!config.whatsappPhoneNumberId || !config.whatsappAccessToken) {
+  const { phoneNumberId, accessToken } = await resolveWhatsAppCredentials(
+    config,
+    caches,
+  );
+  if (!phoneNumberId || !accessToken) {
     throw new Error("WhatsApp credentials not configured");
   }
 
@@ -252,24 +293,21 @@ export async function sendWhatsAppMediaMessage(
     config,
     "sendMediaMessage",
     () =>
-      fetchImpl(
-        `${WHATSAPP_API_BASE}/${config.whatsappPhoneNumberId}/messages`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${config.whatsappAccessToken}`,
-          },
-          body: JSON.stringify({
-            messaging_product: "whatsapp",
-            recipient_type: "individual",
-            to,
-            type: mediaType,
-            [mediaType]: mediaPayload,
-          }),
-          signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+      fetchImpl(`${WHATSAPP_API_BASE}/${phoneNumberId}/messages`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
         },
-      ),
+        body: JSON.stringify({
+          messaging_product: "whatsapp",
+          recipient_type: "individual",
+          to,
+          type: mediaType,
+          [mediaType]: mediaPayload,
+        }),
+        signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+      }),
   );
 }
 
@@ -283,8 +321,13 @@ export async function sendWhatsAppInteractiveMessage(
   to: string,
   bodyText: string,
   buttons: Array<{ id: string; title: string }>,
+  caches?: WhatsAppApiCaches,
 ): Promise<WhatsAppSendMessageResult> {
-  if (!config.whatsappPhoneNumberId || !config.whatsappAccessToken) {
+  const { phoneNumberId, accessToken } = await resolveWhatsAppCredentials(
+    config,
+    caches,
+  );
+  if (!phoneNumberId || !accessToken) {
     throw new Error("WhatsApp credentials not configured");
   }
 
@@ -292,33 +335,30 @@ export async function sendWhatsAppInteractiveMessage(
     config,
     "sendInteractiveMessage",
     () =>
-      fetchImpl(
-        `${WHATSAPP_API_BASE}/${config.whatsappPhoneNumberId}/messages`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${config.whatsappAccessToken}`,
-          },
-          body: JSON.stringify({
-            messaging_product: "whatsapp",
-            recipient_type: "individual",
-            to,
-            type: "interactive",
-            interactive: {
-              type: "button",
-              body: { text: bodyText },
-              action: {
-                buttons: buttons.map((b) => ({
-                  type: "reply",
-                  reply: { id: b.id, title: b.title },
-                })),
-              },
-            },
-          }),
-          signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+      fetchImpl(`${WHATSAPP_API_BASE}/${phoneNumberId}/messages`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
         },
-      ),
+        body: JSON.stringify({
+          messaging_product: "whatsapp",
+          recipient_type: "individual",
+          to,
+          type: "interactive",
+          interactive: {
+            type: "button",
+            body: { text: bodyText },
+            action: {
+              buttons: buttons.map((b) => ({
+                type: "reply",
+                reply: { id: b.id, title: b.title },
+              })),
+            },
+          },
+        }),
+        signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+      }),
   );
 }
 
@@ -338,8 +378,10 @@ export interface WhatsAppMediaMetadata {
 export async function getWhatsAppMediaMetadata(
   config: GatewayConfig,
   mediaId: string,
+  caches?: WhatsAppApiCaches,
 ): Promise<WhatsAppMediaMetadata> {
-  if (!config.whatsappAccessToken) {
+  const { accessToken } = await resolveWhatsAppCredentials(config, caches);
+  if (!accessToken) {
     throw new Error("WhatsApp credentials not configured");
   }
 
@@ -349,7 +391,7 @@ export async function getWhatsAppMediaMetadata(
     () =>
       fetchImpl(`${WHATSAPP_API_BASE}/${mediaId}`, {
         headers: {
-          Authorization: `Bearer ${config.whatsappAccessToken}`,
+          Authorization: `Bearer ${accessToken}`,
         },
         signal: AbortSignal.timeout(config.whatsappTimeoutMs),
       }),
@@ -364,15 +406,17 @@ export async function getWhatsAppMediaMetadata(
 export async function downloadWhatsAppMediaBytes(
   config: GatewayConfig,
   mediaUrl: string,
+  caches?: WhatsAppApiCaches,
 ): Promise<Response> {
-  if (!config.whatsappAccessToken) {
+  const { accessToken } = await resolveWhatsAppCredentials(config, caches);
+  if (!accessToken) {
     throw new Error("WhatsApp credentials not configured");
   }
 
   return retryableWhatsAppRawFetch(config, "downloadMedia", () =>
     fetchImpl(mediaUrl, {
       headers: {
-        Authorization: `Bearer ${config.whatsappAccessToken}`,
+        Authorization: `Bearer ${accessToken}`,
       },
       signal: AbortSignal.timeout(config.whatsappTimeoutMs),
     }),
@@ -478,26 +522,28 @@ async function retryableWhatsAppRawFetch(
 export async function markWhatsAppMessageRead(
   config: GatewayConfig,
   messageId: string,
+  caches?: WhatsAppApiCaches,
 ): Promise<void> {
-  if (!config.whatsappPhoneNumberId || !config.whatsappAccessToken) return;
+  const { phoneNumberId, accessToken } = await resolveWhatsAppCredentials(
+    config,
+    caches,
+  );
+  if (!phoneNumberId || !accessToken) return;
 
   try {
-    await fetchImpl(
-      `${WHATSAPP_API_BASE}/${config.whatsappPhoneNumberId}/messages`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${config.whatsappAccessToken}`,
-        },
-        body: JSON.stringify({
-          messaging_product: "whatsapp",
-          status: "read",
-          message_id: messageId,
-        }),
-        signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+    await fetchImpl(`${WHATSAPP_API_BASE}/${phoneNumberId}/messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
       },
-    );
+      body: JSON.stringify({
+        messaging_product: "whatsapp",
+        status: "read",
+        message_id: messageId,
+      }),
+      signal: AbortSignal.timeout(config.whatsappTimeoutMs),
+    });
   } catch (err) {
     log.debug({ err, messageId }, "Failed to mark WhatsApp message as read");
   }


### PR DESCRIPTION
## Summary
- Instantiate CredentialCache and ConfigFileCache in gateway index, wire to watchers for invalidation
- Migrate handler credential/config reads to cache APIs with one-shot force retry for auth-sensitive paths
- Preserve existing GatewayConfig fields and side effects for compatibility (cleanup in subsequent PRs)

Part of plan: elegant-spinning-newt-v2.md (PR 3 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
