### PR TITLE
chore: stop injecting GATEWAY_AUTH_TOKEN into skill shell environment

### DIFF
--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -9,10 +9,6 @@ import {
   getGatewayInternalBaseUrl,
   getIngressPublicBaseUrl,
 } from "../../config/env.js";
-import {
-  isSigningKeyInitialized,
-  mintEdgeRelayToken,
-} from "../../runtime/auth/token-service.js";
 
 const SAFE_ENV_VARS = [
   "PATH",
@@ -49,11 +45,5 @@ export function buildSanitizedEnv(): Record<string, string> {
   // back to the internal base so commands remain functional in local-only mode.
   const publicGatewayBase = getIngressPublicBaseUrl()?.replace(/\/+$/, "");
   env.GATEWAY_BASE_URL = publicGatewayBase || internalGatewayBase;
-  // Mint a short-lived JWT for gateway authentication when the signing key
-  // is available (daemon context). CLI-only contexts without daemon startup
-  // will not have the key initialized — gracefully skip.
-  if (isSigningKeyInitialized()) {
-    env.GATEWAY_AUTH_TOKEN = mintEdgeRelayToken();
-  }
   return env;
 }


### PR DESCRIPTION
## Summary
- Removed GATEWAY_AUTH_TOKEN injection from buildSanitizedEnv() since no bundled skill depends on it anymore
- Removed now-unused imports (isSigningKeyInitialized, mintEdgeRelayToken)
- INTERNAL_GATEWAY_BASE_URL and GATEWAY_BASE_URL injection preserved

Part of plan: rm-gateway-auth-token-env.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
