### PR TITLE
split cli/utils.ts into focused modules and add shared logger/db helpers

### DIFF
--- a/assistant/src/cli/commands/audit.ts
+++ b/assistant/src/cli/commands/audit.ts
@@ -1,9 +1,7 @@
 import type { Command } from "commander";
 
 import { getRecentInvocations } from "../../memory/tool-usage-store.js";
-import { getCliLogger } from "../../util/logger.js";
-
-const log = getCliLogger("cli");
+import { log } from "../logger.js";
 
 export function registerAuditCommand(program: Command): void {
   program

--- a/assistant/src/cli/commands/autonomy.ts
+++ b/assistant/src/cli/commands/autonomy.ts
@@ -4,9 +4,7 @@ import { dirname, join } from "node:path";
 
 import type { Command } from "commander";
 
-import { getCliLogger } from "../../util/logger.js";
-
-const log = getCliLogger("cli");
+import { log } from "../logger.js";
 
 // ---------------------------------------------------------------------------
 // Types & constants

--- a/assistant/src/cli/commands/channel-verification-sessions.ts
+++ b/assistant/src/cli/commands/channel-verification-sessions.ts
@@ -1,13 +1,16 @@
 import type { Command } from "commander";
 
-import { CHANNEL_IDS, type ChannelId, isChannelId } from "../../channels/types.js";
+import {
+  CHANNEL_IDS,
+  type ChannelId,
+  isChannelId,
+} from "../../channels/types.js";
 import {
   createInboundChallenge,
   getVerificationStatus,
   revokeVerificationForChannel,
   verifyTrustedContact,
 } from "../../daemon/handlers/config-channels.js";
-import { initializeDb } from "../../memory/db.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../runtime/assistant-scope.js";
 import { revokePendingSessions } from "../../runtime/channel-verification-service.js";
 import {
@@ -18,7 +21,8 @@ import {
 } from "../../runtime/verification-outbound-actions.js";
 import { verificationRateLimiter } from "../../runtime/verification-rate-limiter.js";
 import { normalizePhoneNumber } from "../../util/phone.js";
-import { writeOutput } from "../utils.js";
+import { initializeDb } from "../db.js";
+import { writeOutput } from "../output.js";
 
 /**
  * Validate the --channel option. Returns the validated ChannelId or writes an

--- a/assistant/src/cli/commands/channels.ts
+++ b/assistant/src/cli/commands/channels.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 
-import { gatewayGet, runRead, toQueryString } from "../utils.js";
+import { gatewayGet, toQueryString } from "../gateway-client.js";
+import { runRead } from "../output.js";
 
 export function registerChannelsCommand(program: Command): void {
   const channels = program

--- a/assistant/src/cli/commands/completions.ts
+++ b/assistant/src/cli/commands/completions.ts
@@ -1,8 +1,6 @@
 import type { Command } from "commander";
 
-import { getCliLogger } from "../../util/logger.js";
-
-const log = getCliLogger("cli");
+import { log } from "../logger.js";
 
 export function registerCompletionsCommand(program: Command): void {
   program

--- a/assistant/src/cli/commands/config.ts
+++ b/assistant/src/cli/commands/config.ts
@@ -7,9 +7,7 @@ import {
   setNestedValue,
   syncConfigToLockfile,
 } from "../../config/loader.js";
-import { getCliLogger } from "../../util/logger.js";
-
-const log = getCliLogger("cli");
+import { log } from "../logger.js";
 
 /**
  * Flatten a nested config object into dotted key paths.

--- a/assistant/src/cli/commands/contacts.ts
+++ b/assistant/src/cli/commands/contacts.ts
@@ -16,7 +16,6 @@ import type {
   ContactRole,
   ContactType,
 } from "../../contacts/types.js";
-import { initializeDb } from "../../memory/db.js";
 import {
   createIngressInvite,
   listIngressInvites,
@@ -24,7 +23,8 @@ import {
   redeemVoiceInviteCode,
   revokeIngressInvite,
 } from "../../runtime/invite-service.js";
-import { writeOutput } from "../utils.js";
+import { initializeDb } from "../db.js";
+import { writeOutput } from "../output.js";
 
 export function registerContactsCommand(program: Command): void {
   const contacts = program

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -14,10 +14,8 @@ import {
   listCredentialMetadata,
   upsertCredentialMetadata,
 } from "../../tools/credentials/metadata-store.js";
-import { getCliLogger } from "../../util/logger.js";
-import { shouldOutputJson, writeOutput } from "../utils.js";
-
-const log = getCliLogger("cli");
+import { log } from "../logger.js";
+import { shouldOutputJson, writeOutput } from "../output.js";
 
 // ---------------------------------------------------------------------------
 // Shared helpers

--- a/assistant/src/cli/commands/dev.ts
+++ b/assistant/src/cli/commands/dev.ts
@@ -4,9 +4,7 @@ import { join } from "node:path";
 import type { Command } from "commander";
 
 import { getDaemonStatus, stopDaemon } from "../../daemon/lifecycle.js";
-import { getCliLogger } from "../../util/logger.js";
-
-const log = getCliLogger("cli");
+import { log } from "../logger.js";
 
 export function registerDevCommand(program: Command): void {
   program

--- a/assistant/src/cli/commands/doctor.ts
+++ b/assistant/src/cli/commands/doctor.ts
@@ -10,7 +10,6 @@ import {
   shouldAutoStartDaemon,
 } from "../../daemon/connection-policy.js";
 import { IpcError } from "../../util/errors.js";
-import { getCliLogger } from "../../util/logger.js";
 import {
   getDataDir,
   getDbPath,
@@ -21,8 +20,7 @@ import {
   getWorkspaceHooksDir,
   getWorkspaceSkillsDir,
 } from "../../util/platform.js";
-
-const log = getCliLogger("cli");
+import { log } from "../logger.js";
 
 export function registerDoctorCommand(program: Command): void {
   program

--- a/assistant/src/cli/commands/keys.ts
+++ b/assistant/src/cli/commands/keys.ts
@@ -6,9 +6,7 @@ import {
   getSecureKey,
   setSecureKey,
 } from "../../security/secure-keys.js";
-import { getCliLogger } from "../../util/logger.js";
-
-const log = getCliLogger("cli");
+import { log } from "../logger.js";
 
 export function registerKeysCommand(program: Command): void {
   const keys = program
@@ -59,7 +57,9 @@ Examples:
 
   keys
     .command("set <provider> <key>")
-    .description("Store an API key (e.g. assistant keys set anthropic sk-ant-...)")
+    .description(
+      "Store an API key (e.g. assistant keys set anthropic sk-ant-...)",
+    )
     .addHelpText(
       "after",
       `

--- a/assistant/src/cli/commands/map.ts
+++ b/assistant/src/cli/commands/map.ts
@@ -18,8 +18,8 @@ import {
 } from "../../tools/browser/api-map.js";
 import { ensureChromeWithCdp } from "../../tools/browser/chrome-cdp.js";
 import { loadRecording } from "../../tools/browser/recording-store.js";
-import { getCliLogger } from "../../util/logger.js";
 import { getSocketPath, readSessionToken } from "../../util/platform.js";
+import { getCliLogger } from "../logger.js";
 
 const log = getCliLogger("cli:map");
 

--- a/assistant/src/cli/commands/mcp.ts
+++ b/assistant/src/cli/commands/mcp.ts
@@ -11,9 +11,7 @@ import {
   deleteMcpOAuthCredentials,
   McpOAuthProvider,
 } from "../../mcp/mcp-oauth-provider.js";
-import { getCliLogger } from "../../util/logger.js";
-
-const log = getCliLogger("cli");
+import { log } from "../logger.js";
 
 export const HEALTH_CHECK_TIMEOUT_MS = 10_000;
 

--- a/assistant/src/cli/commands/memory.ts
+++ b/assistant/src/cli/commands/memory.ts
@@ -10,10 +10,9 @@ import {
 } from "../../memory/admin.js";
 import { listPendingConflictDetails } from "../../memory/conflict-store.js";
 import { listConversations } from "../../memory/conversation-queries.js";
-import { initializeDb, rawGet } from "../../memory/db.js";
-import { getCliLogger } from "../../util/logger.js";
-
-const log = getCliLogger("cli");
+import { rawGet } from "../../memory/db.js";
+import { initializeDb } from "../db.js";
+import { log } from "../logger.js";
 
 const SHORT_HASH_LENGTH = 8;
 

--- a/assistant/src/cli/commands/notifications.ts
+++ b/assistant/src/cli/commands/notifications.ts
@@ -1,7 +1,6 @@
 import type { Command } from "commander";
 
 import { getDeliverableChannels } from "../../channels/config.js";
-import { initializeDb } from "../../memory/db.js";
 import { emitNotificationSignal } from "../../notifications/emit-signal.js";
 import { listEvents } from "../../notifications/events-store.js";
 import {
@@ -11,10 +10,9 @@ import {
   NOTIFICATION_SOURCE_EVENT_NAMES,
 } from "../../notifications/signal.js";
 import type { NotificationChannel } from "../../notifications/types.js";
-import { getCliLogger } from "../../util/logger.js";
-import { shouldOutputJson, writeOutput } from "../utils.js";
-
-const log = getCliLogger("cli");
+import { initializeDb } from "../db.js";
+import { log } from "../logger.js";
+import { shouldOutputJson, writeOutput } from "../output.js";
 
 // ---------------------------------------------------------------------------
 // Help text builders

--- a/assistant/src/cli/commands/oauth.ts
+++ b/assistant/src/cli/commands/oauth.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 
 import { withValidToken } from "../../security/token-manager.js";
-import { shouldOutputJson, writeOutput } from "../utils.js";
+import { shouldOutputJson, writeOutput } from "../output.js";
 
 export function registerOAuthCommand(program: Command): void {
   const oauth = program

--- a/assistant/src/cli/commands/platform.ts
+++ b/assistant/src/cli/commands/platform.ts
@@ -10,10 +10,8 @@ import {
   registerCallbackRoute,
   shouldUsePlatformCallbacks,
 } from "../../inbound/platform-callback-registration.js";
-import { getCliLogger } from "../../util/logger.js";
-import { shouldOutputJson, writeOutput } from "../utils.js";
-
-const log = getCliLogger("cli");
+import { log } from "../logger.js";
+import { shouldOutputJson, writeOutput } from "../output.js";
 
 export function registerPlatformCommand(program: Command): void {
   const platform = program

--- a/assistant/src/cli/commands/sequence.ts
+++ b/assistant/src/cli/commands/sequence.ts
@@ -6,7 +6,6 @@
 
 import { Command } from "commander";
 
-import { initializeDb } from "../../memory/db.js";
 import {
   getGuardrailConfig,
   setGuardrailConfig,
@@ -19,6 +18,7 @@ import {
   listSequences,
   updateSequence,
 } from "../../sequence/store.js";
+import { initializeDb } from "../db.js";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/cli/commands/sessions.ts
+++ b/assistant/src/cli/commands/sessions.ts
@@ -11,13 +11,11 @@ import {
   getMessages,
 } from "../../memory/conversation-crud.js";
 import { listConversations } from "../../memory/conversation-queries.js";
-import { initializeDb } from "../../memory/db.js";
 import { initQdrantClient } from "../../memory/qdrant-client.js";
-import { getCliLogger } from "../../util/logger.js";
 import { timeAgo } from "../../util/time.js";
+import { initializeDb } from "../db.js";
 import { sendOneMessage } from "../ipc-client.js";
-
-const log = getCliLogger("cli");
+import { log } from "../logger.js";
 
 export function registerSessionsCommand(program: Command): void {
   const sessions = program.command("sessions").description("Manage sessions");

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -15,14 +15,12 @@ import { gunzipSync } from "node:zlib";
 
 import type { Command } from "commander";
 
-import { getCliLogger } from "../../util/logger.js";
 import {
   getWorkspaceConfigPath,
   getWorkspaceSkillsDir,
   readPlatformToken,
 } from "../../util/platform.js";
-
-const log = getCliLogger("cli");
+import { log } from "../logger.js";
 
 // ---------------------------------------------------------------------------
 // Path helpers

--- a/assistant/src/cli/commands/trust.ts
+++ b/assistant/src/cli/commands/trust.ts
@@ -5,9 +5,7 @@ import {
   getAllRules,
   removeRule,
 } from "../../permissions/trust-store.js";
-import { getCliLogger } from "../../util/logger.js";
-
-const log = getCliLogger("cli");
+import { log } from "../logger.js";
 
 const SHORT_HASH_LENGTH = 8;
 

--- a/assistant/src/cli/db.ts
+++ b/assistant/src/cli/db.ts
@@ -1,0 +1,1 @@
+export { initializeDb } from "../memory/db.js";

--- a/assistant/src/cli/gateway-client.ts
+++ b/assistant/src/cli/gateway-client.ts
@@ -1,5 +1,3 @@
-import type { Command } from "commander";
-
 import { getGatewayInternalBaseUrl } from "../config/env.js";
 import {
   initAuthSigningKey,
@@ -15,22 +13,15 @@ export function asRecord(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-export function shouldOutputJson(cmd: Command): boolean {
-  let current: Command | null = cmd;
-  while (current) {
-    if ((current.opts() as { json?: boolean }).json) return true;
-    current = current.parent;
+export function toQueryString(
+  params: Record<string, string | undefined>,
+): string {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value) query.set(key, value);
   }
-  return false;
-}
-
-export function writeOutput(cmd: Command, payload: unknown): void {
-  const compact = shouldOutputJson(cmd);
-  process.stdout.write(
-    compact
-      ? JSON.stringify(payload) + "\n"
-      : JSON.stringify(payload, null, 2) + "\n",
-  );
+  const encoded = query.toString();
+  return encoded ? `?${encoded}` : "";
 }
 
 function getGatewayToken(): string {
@@ -42,17 +33,6 @@ function getGatewayToken(): string {
   }
 
   return mintEdgeRelayToken();
-}
-
-export function toQueryString(
-  params: Record<string, string | undefined>,
-): string {
-  const query = new URLSearchParams();
-  for (const [key, value] of Object.entries(params)) {
-    if (value) query.set(key, value);
-  }
-  const encoded = query.toString();
-  return encoded ? `?${encoded}` : "";
 }
 
 // CLI-specific gateway helper — uses GATEWAY_AUTH_TOKEN env var for out-of-process
@@ -129,18 +109,4 @@ export async function gatewayPost(
   }
 
   return parsed;
-}
-
-export async function runRead(
-  cmd: Command,
-  reader: () => Promise<unknown>,
-): Promise<void> {
-  try {
-    const result = await reader();
-    writeOutput(cmd, result);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    writeOutput(cmd, { ok: false, error: message });
-    process.exitCode = 1;
-  }
 }

--- a/assistant/src/cli/logger.ts
+++ b/assistant/src/cli/logger.ts
@@ -1,0 +1,6 @@
+import { getCliLogger } from "../util/logger.js";
+
+/** Shared CLI logger instance. Most commands use this directly. */
+export const log = getCliLogger("cli");
+
+export { getCliLogger } from "../util/logger.js";

--- a/assistant/src/cli/output.ts
+++ b/assistant/src/cli/output.ts
@@ -1,0 +1,33 @@
+import type { Command } from "commander";
+
+export function shouldOutputJson(cmd: Command): boolean {
+  let current: Command | null = cmd;
+  while (current) {
+    if ((current.opts() as { json?: boolean }).json) return true;
+    current = current.parent;
+  }
+  return false;
+}
+
+export function writeOutput(cmd: Command, payload: unknown): void {
+  const compact = shouldOutputJson(cmd);
+  process.stdout.write(
+    compact
+      ? JSON.stringify(payload) + "\n"
+      : JSON.stringify(payload, null, 2) + "\n",
+  );
+}
+
+export async function runRead(
+  cmd: Command,
+  reader: () => Promise<unknown>,
+): Promise<void> {
+  try {
+    const result = await reader();
+    writeOutput(cmd, result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    writeOutput(cmd, { ok: false, error: message });
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary
- Split monolithic `cli/utils.ts` into `cli/output.ts` (output formatting), `cli/gateway-client.ts` (gateway HTTP helpers), `cli/logger.ts` (shared CLI logger), and `cli/db.ts` (shared db init)
- Updated 21 command files to import from the new focused modules, eliminating repeated `const log = getCliLogger("cli")` boilerplate across 13 files and shortening `../../memory/db.js` imports in 6 files
- Deleted the old catch-all `cli/utils.ts`

## Original prompt
Split utils.ts into output.ts and gateway-client.ts, add shared logger.ts and db.ts helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
