### PR TITLE
fix: update test paths after cli/commands/ move

### DIFF
--- a/assistant/src/__tests__/amazon-cdp-integration.test.ts
+++ b/assistant/src/__tests__/amazon-cdp-integration.test.ts
@@ -13,6 +13,7 @@ const AMAZON_CLI_PATH = join(
   import.meta.dirname ?? __dirname,
   "..",
   "cli",
+  "commands",
   "amazon.ts",
 );
 const amazonSource = readFileSync(AMAZON_CLI_PATH, "utf-8");

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -219,8 +219,8 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "calls/twilio-provider.ts", // call infrastructure credential lookup
       "calls/twilio-rest.ts", // Twilio REST API credential lookup
       "runtime/channel-invite-transports/telegram.ts", // Telegram invite transport bot token lookup
-      "cli/keys.ts", // CLI credential management commands
-      "cli/credentials.ts", // CLI credential management commands
+      "cli/commands/keys.ts", // CLI credential management commands
+      "cli/commands/credentials.ts", // CLI credential management commands
       "runtime/http-server.ts", // HTTP server credential lookup
       "daemon/handlers/twitter-auth.ts", // Twitter OAuth token storage
       "twitter/oauth-client.ts", // Twitter OAuth API client (reads access token for API calls)


### PR DESCRIPTION
## Summary
- Update `credential-security-invariants.test.ts` allowlist paths from `cli/keys.ts` and `cli/credentials.ts` to `cli/commands/keys.ts` and `cli/commands/credentials.ts`
- Update `amazon-cdp-integration.test.ts` file path to look for `cli/commands/amazon.ts` instead of `cli/amazon.ts`

## Original prompt
fix ci in https://github.com/vellum-ai/vellum-assistant/actions/runs/22809327990

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
