### PR TITLE
move channel-permission-profiles from config/ to channels/

### DIFF
--- a/assistant/src/channels/permission-profiles.ts
+++ b/assistant/src/channels/permission-profiles.ts
@@ -11,7 +11,7 @@
  * Each entry maps a channel ID to a ChannelPermissionProfile.
  */
 
-import { getConfig, saveConfig } from "./loader.js";
+import { getConfig, saveConfig } from "../config/loader.js";
 
 // ── Types ───────────────────────────────────────────────────────────
 

--- a/assistant/src/config/bundled-skills/slack/tools/slack-channel-permissions.ts
+++ b/assistant/src/config/bundled-skills/slack/tools/slack-channel-permissions.ts
@@ -11,7 +11,7 @@ import {
   removeChannelPermissionProfile,
   setAllChannelPermissions,
   setChannelPermissionProfile,
-} from "../../../../config/channel-permission-profiles.js";
+} from "../../../../channels/permission-profiles.js";
 import type {
   ToolContext,
   ToolExecutionResult,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -4,13 +4,13 @@
  * verification, guardian action answers, approval interception, and
  * invite token redemption.
  */
+import { getChannelPermissionProfile } from "../../channels/permission-profiles.js";
 import {
   CHANNEL_IDS,
   INTERFACE_IDS,
   isChannelId,
   parseInterfaceId,
 } from "../../channels/types.js";
-import { getChannelPermissionProfile } from "../../config/channel-permission-profiles.js";
 import { touchContactInteraction } from "../../contacts/contacts-write.js";
 import type { TrustContext } from "../../daemon/session-runtime-assembly.js";
 import * as attachmentsStore from "../../memory/attachments-store.js";

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -1,5 +1,5 @@
 import { consumeGrantForInvocation } from "../approvals/approval-primitive.js";
-import { isToolAllowedInChannel } from "../config/channel-permission-profiles.js";
+import { isToolAllowedInChannel } from "../channels/permission-profiles.js";
 import {
   getCanonicalGuardianRequest,
   updateCanonicalGuardianRequest,


### PR DESCRIPTION
## Summary
- Move `channel-permission-profiles.ts` from `config/` to `channels/permission-profiles.ts`
- Update internal import to point back to `config/loader.js`
- Update all 3 external importers to reference the new path

Part of plan: config-directory-reorg.md (PR 5 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
