### PR TITLE
fix test paths after templates moved to prompts/

### DIFF
--- a/assistant/src/__tests__/onboarding-template-contract.test.ts
+++ b/assistant/src/__tests__/onboarding-template-contract.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
-const templatesDir = join(import.meta.dirname, "..", "config", "templates");
+const templatesDir = join(import.meta.dirname, "..", "prompts", "templates");
 const bootstrap = readFileSync(join(templatesDir, "BOOTSTRAP.md"), "utf-8");
 const identity = readFileSync(join(templatesDir, "IDENTITY.md"), "utf-8");
 const user = readFileSync(join(templatesDir, "USER.md"), "utf-8");

--- a/assistant/src/__tests__/update-template-contract.test.ts
+++ b/assistant/src/__tests__/update-template-contract.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, test } from "bun:test";
 const TEMPLATE_PATH = join(
   import.meta.dirname,
   "..",
-  "config",
+  "prompts",
   "templates",
   "UPDATES.md",
 );


### PR DESCRIPTION
## Summary
- Fix paths in onboarding-template-contract.test.ts and update-template-contract.test.ts to reference prompts/templates/ instead of config/templates/ after the extraction in #14218

## Original prompt
fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22809875799
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
