### PR TITLE
fix test paths after bundled-skills moved from config/ to skills/

### DIFF
--- a/assistant/src/__tests__/bundled-skill-retrieval-guard.test.ts
+++ b/assistant/src/__tests__/bundled-skill-retrieval-guard.test.ts
@@ -6,7 +6,7 @@ const ASSISTANT_DIR = join(import.meta.dir, "..", "..");
 const BUNDLED_SKILLS_DIR = join(
   ASSISTANT_DIR,
   "src",
-  "config",
+  "skills",
   "bundled-skills",
 );
 

--- a/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
+++ b/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
@@ -17,7 +17,7 @@ const ASSISTANT_DIR = resolve(import.meta.dirname ?? __dirname, "..", "..");
 const SKILL_PATH = resolve(
   ASSISTANT_DIR,
   "src",
-  "config",
+  "skills",
   "bundled-skills",
   "guardian-verify-setup",
   "SKILL.md",

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -120,7 +120,7 @@ afterAll(() => {
 
 const CONFIG_DIR = join(
   dirname(import.meta.dirname!),
-  "config",
+  "skills",
   "bundled-skills",
   "image-studio",
 );

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -670,7 +670,7 @@ describe("ingress-dependent setup skills declare public-ingress", () => {
   const BUNDLED_SKILLS_DIR = join(
     import.meta.dir,
     "..",
-    "config",
+    "skills",
     "bundled-skills",
   );
 

--- a/assistant/src/__tests__/slack-skill.test.ts
+++ b/assistant/src/__tests__/slack-skill.test.ts
@@ -7,7 +7,7 @@ import type { SlackConversation } from "../messaging/providers/slack/types.js";
 const BUNDLED_SKILLS_DIR = join(
   import.meta.dir,
   "..",
-  "config",
+  "skills",
   "bundled-skills",
 );
 


### PR DESCRIPTION
## Summary
- Fix 5 test files that still referenced `config/bundled-skills` after PR #14224 moved the directory to `skills/bundled-skills`
- Affected tests: slack-skill, media-generate-image, bundled-skill-retrieval-guard, skills, guardian-verify-setup-skill-regression

## Original prompt
fix CI in https://github.com/vellum-ai/vellum-assistant/actions/runs/22810044668

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
