### PR TITLE
Move influencer/ into cli/commands/influencer/

### DIFF
--- a/assistant/src/cli/commands/influencer/client.ts
+++ b/assistant/src/cli/commands/influencer/client.ts
@@ -48,14 +48,14 @@
 import type {
   ExtensionCommand,
   ExtensionResponse,
-} from "../browser-extension-relay/protocol.js";
-import { extensionRelayServer } from "../browser-extension-relay/server.js";
+} from "../../../browser-extension-relay/protocol.js";
+import { extensionRelayServer } from "../../../browser-extension-relay/server.js";
 import {
   initAuthSigningKey,
   isSigningKeyInitialized,
   loadOrCreateSigningKey,
-} from "../runtime/auth/token-service.js";
-import { gatewayPost } from "../runtime/gateway-internal-client.js";
+} from "../../../runtime/auth/token-service.js";
+import { gatewayPost } from "../../../runtime/gateway-internal-client.js";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/assistant/src/cli/commands/influencer/index.ts
+++ b/assistant/src/cli/commands/influencer/index.ts
@@ -12,7 +12,7 @@ import {
   getInfluencerProfile,
   type InfluencerSearchCriteria,
   searchInfluencers,
-} from "../../influencer/client.js";
+} from "./client.js";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/cli/program.ts
+++ b/assistant/src/cli/program.ts
@@ -15,7 +15,7 @@ import { registerDefaultAction } from "./commands/default-action.js";
 import { registerDevCommand } from "./commands/dev.js";
 import { registerDoctorCommand } from "./commands/doctor.js";
 import { registerEmailCommand } from "./commands/email.js";
-import { registerInfluencerCommand } from "./commands/influencer.js";
+import { registerInfluencerCommand } from "./commands/influencer/index.js";
 import { registerKeysCommand } from "./commands/keys.js";
 import { registerMapCommand } from "./commands/map.js";
 import { registerMcpCommand } from "./commands/mcp.js";


### PR DESCRIPTION
## Summary
- Move `assistant/src/influencer/client.ts` into `assistant/src/cli/commands/influencer/`
- Convert `assistant/src/cli/commands/influencer.ts` to `assistant/src/cli/commands/influencer/index.ts`
- Update all import paths to reflect new directory depth

Part of plan: colocate-cli-modules.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
