### PR TITLE
docs(gateway): update ARCHITECTURE.md and README.md for cache-driven config reads

### DIFF
--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -247,15 +247,15 @@ The assistant runtime reads this URL via the centralized `public-ingress-urls.ts
 
 All public-facing URLs are constructed by `assistant/src/inbound/public-ingress-urls.ts`:
 
-| Function                       | URL Pattern                                                                               |
-| ------------------------------ | ----------------------------------------------------------------------------------------- |
-| `getPublicBaseUrl()`           | Resolves the canonical base URL from `ingress.publicBaseUrl` or `INGRESS_PUBLIC_BASE_URL` |
-| `getTwilioVoiceWebhookUrl()`   | `${base}/webhooks/twilio/voice?callSessionId=...`                                         |
-| `getTwilioStatusCallbackUrl()` | `${base}/webhooks/twilio/status`                                                          |
-| `getTwilioConnectActionUrl()`  | `${base}/webhooks/twilio/connect-action`                                                  |
-| `getTwilioRelayUrl()`          | `ws(s)://.../webhooks/twilio/relay`                                                       |
-| `getOAuthCallbackUrl()`        | `${base}/webhooks/oauth/callback`                                                         |
-| `getTelegramWebhookUrl()`      | `${base}/webhooks/telegram`                                                               |
+| Function                       | URL Pattern                                                                                                                                                                     |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getPublicBaseUrl()`           | Resolves the canonical base URL from `ingress.publicBaseUrl` in workspace config or `INGRESS_PUBLIC_BASE_URL` env var (assistant-side; the gateway reads via `ConfigFileCache`) |
+| `getTwilioVoiceWebhookUrl()`   | `${base}/webhooks/twilio/voice?callSessionId=...`                                                                                                                               |
+| `getTwilioStatusCallbackUrl()` | `${base}/webhooks/twilio/status`                                                                                                                                                |
+| `getTwilioConnectActionUrl()`  | `${base}/webhooks/twilio/connect-action`                                                                                                                                        |
+| `getTwilioRelayUrl()`          | `ws(s)://.../webhooks/twilio/relay`                                                                                                                                             |
+| `getOAuthCallbackUrl()`        | `${base}/webhooks/oauth/callback`                                                                                                                                               |
+| `getTelegramWebhookUrl()`      | `${base}/webhooks/telegram`                                                                                                                                                     |
 
 ### Telegram Messaging Flow
 
@@ -591,16 +591,16 @@ Both paths converge at:
       → upsertCredentialMetadata("telegram", "webhook_secret", {})
       → On storage failure: rolls back bot_token + metadata, returns error
     → If webhook secret already exists: upserts metadata anyway (self-heal)
-    → Triggers gateway webhook reconcile
-      → Gateway credential reader picks up new credentials
+    → Credential watcher detects storage change
+      → Invalidates credential cache, triggers side-effect callback
         → Webhook reconciliation registers webhook with Telegram
 ```
 
 The `telegram_config` IPC message supports three actions:
 
 - **`get`** — returns connection status (`hasBotToken`, `botUsername`, `connected`, `hasWebhookSecret`) without exposing secret values
-- **`set`** — validates the bot token against the Telegram API, stores it in secure storage, auto-generates a webhook secret if none exists (with rollback on failure), self-heals webhook_secret metadata if it already exists, and triggers gateway webhook reconciliation
-- **`clear`** — deregisters the webhook by calling Telegram's `deleteWebhook` API directly (while the token is still available), then deletes the bot token and webhook secret from both secure storage and credential metadata, and triggers gateway reconciliation
+- **`set`** — validates the bot token against the Telegram API, stores it in secure storage, auto-generates a webhook secret if none exists (with rollback on failure), and self-heals webhook_secret metadata if it already exists. The gateway's credential watcher detects the storage change and triggers webhook reconciliation automatically
+- **`clear`** — deregisters the webhook by calling Telegram's `deleteWebhook` API directly (while the token is still available), then deletes the bot token and webhook secret from both secure storage and credential metadata. The gateway's credential watcher detects the storage change and updates its readiness state automatically
 
 The gateway reads Telegram credentials via its `credential-reader` module (`gateway/src/credential-reader.ts`), which uses a broker-first fallback strategy: it tries the keychain broker first (a Unix domain socket served by the assistant daemon that proxies macOS Keychain reads), then falls back to the encrypted file store (`~/.vellum/protected/keys.enc`). When the broker is unavailable (e.g., daemon not running, non-macOS platform, or socket env var unset), the encrypted store is used directly.
 
@@ -608,11 +608,11 @@ The gateway reads Telegram credentials via its `credential-reader` module (`gate
 
 On startup, the gateway automatically reconciles the Telegram webhook registration:
 
-1. Reads `INGRESS_PUBLIC_BASE_URL` and Telegram credentials (bot token, webhook secret) from secure storage via the credential reader
+1. Reads the ingress public base URL via `ConfigFileCache.getString("ingress", "publicBaseUrl")` (falling back to the `INGRESS_PUBLIC_BASE_URL` env var) and Telegram credentials (bot token, webhook secret) from secure storage via the credential reader
 2. Calls `getWebhookInfo` to log the current registration state
 3. Unconditionally calls `setWebhook` with the expected URL, secret, and allowed updates (idempotent — Telegram does not expose the current secret via `getWebhookInfo`, so a compare-then-set approach would miss secret rotations)
 
-This also runs when the credential watcher detects changes to Telegram credentials. If the ingress URL changes (e.g., tunnel restart), the assistant daemon triggers an immediate internal reconcile via `POST /internal/telegram/reconcile`, so the webhook re-registers automatically without a gateway restart. Manual webhook registration is no longer required.
+This also runs when the credential watcher detects changes to Telegram credentials. If the ingress URL changes (e.g., tunnel restart), the config file watcher detects the change, invalidates the `ConfigFileCache`, and triggers webhook reconciliation directly — no daemon involvement is needed. Manual webhook registration is no longer required.
 
 ### Routing Auto-Configuration
 
@@ -979,11 +979,11 @@ All webhook paths (`/webhooks/twilio/voice`, `/webhooks/twilio/status`, `/webhoo
 
 For **inbound Twilio signature validation** at the gateway, URL reconstruction now supports multiple candidates in order:
 
-1. `config.ingressPublicBaseUrl` (if configured)
+1. `ConfigFileCache.getString("ingress", "publicBaseUrl")` (if configured)
 2. Forwarded public URL headers from the tunnel/proxy (`X-Forwarded-Proto` + `X-Forwarded-Host`/`X-Original-Host` fallbacks)
 3. Raw request URL (always included as the final fallback)
 
-This makes ingress URL updates smoother in local tunnel workflows because Twilio webhooks can continue validating immediately. For Telegram, ingress URL changes trigger an immediate internal reconcile, so neither channel requires a gateway restart.
+This makes ingress URL updates smoother in local tunnel workflows because Twilio webhooks can continue validating immediately. For Telegram, the config file watcher detects ingress URL changes and triggers webhook reconciliation directly, so neither channel requires a gateway restart.
 
 ### Runtime HTTP Endpoints
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -75,7 +75,7 @@ v1 uses deterministic settings-based routing (no database):
 
 ## Setting up the Telegram webhook
 
-Webhook registration is now handled automatically by the gateway. On startup, the gateway reconciles the Telegram webhook by registering it at `${INGRESS_PUBLIC_BASE_URL}/webhooks/telegram` with the configured secret and allowed updates. This also runs whenever the credential watcher detects changes to the bot token or webhook secret (e.g., secret rotation). If the ingress URL changes (e.g., tunnel restart), the assistant daemon triggers an immediate internal reconcile so the webhook re-registers automatically without a gateway restart.
+Webhook registration is now handled automatically by the gateway. On startup, the gateway reconciles the Telegram webhook by registering it at `${INGRESS_PUBLIC_BASE_URL}/webhooks/telegram` with the configured secret and allowed updates. This also runs whenever the credential watcher detects changes to the bot token or webhook secret (e.g., secret rotation). If the ingress URL changes (e.g., tunnel restart), the config file watcher detects the change and triggers webhook reconciliation directly — no daemon involvement or gateway restart is needed.
 
 For manual setup (or reference), register the webhook with Telegram using the `setWebhook` API method. Pass:
 
@@ -126,7 +126,7 @@ Caller → Twilio → Gateway /webhooks/twilio/voice (no callSessionId)
 
 The `/webhooks/twilio/sms` endpoint receives inbound SMS messages from Twilio. On each request:
 
-1. **Signature validation** — The `X-Twilio-Signature` header is validated using HMAC-SHA1 with the `TWILIO_AUTH_TOKEN`. When behind a tunnel or reverse proxy, the gateway reconstructs the canonical request URL from `INGRESS_PUBLIC_BASE_URL` for validation.
+1. **Signature validation** — The `X-Twilio-Signature` header is validated using HMAC-SHA1 with the `TWILIO_AUTH_TOKEN`. When behind a tunnel or reverse proxy, the gateway reconstructs the canonical request URL from the ingress public base URL (read via `ConfigFileCache` from `ingress.publicBaseUrl` in workspace config, falling back to the `INGRESS_PUBLIC_BASE_URL` env var) for validation.
 2. **MessageSid dedup** — Each `MessageSid` is tracked in an in-memory dedup cache. Duplicate webhook deliveries (Twilio retries) are silently accepted without re-forwarding.
 3. **MMS detection** — The gateway treats a message as MMS when any of the following conditions are met: `NumMedia > 0`, any `MediaUrl<N>` key has a non-empty value, or any `MediaContentType<N>` key has a non-empty value. This catches media attachments even when Twilio omits `NumMedia`. The gateway replies with an unsupported notice ("MMS is not supported yet") and does not forward the payload to the runtime.
 4. **`/new` command** — When the message body is exactly `/new` (case-insensitive, trimmed), the gateway resolves routing first. If routing is rejected, the gateway sends a rejection notice SMS to the sender (matching Telegram rejection semantics) and does not forward the message. If routing succeeds, the gateway resets the conversation via the runtime API and sends a confirmation SMS. The message is never forwarded to the runtime.
@@ -284,7 +284,7 @@ Inbound SMS follows the same gateway-only pattern as voice and Telegram:
 
 ### Signature URL Tightening
 
-When `INGRESS_PUBLIC_BASE_URL` is configured, the gateway prioritizes it as the canonical URL for Twilio signature validation. If the signature only validates against the raw local request URL (fallback), a warning is logged indicating potential drift between the configured ingress URL and the actual webhook registration. The raw URL fallback is preserved for local-dev operability.
+When the ingress public base URL is configured (via `ingress.publicBaseUrl` in workspace config or `INGRESS_PUBLIC_BASE_URL` env var, read through `ConfigFileCache`), the gateway prioritizes it as the canonical URL for Twilio signature validation. If the signature only validates against the raw local request URL (fallback), a warning is logged indicating potential drift between the configured ingress URL and the actual webhook registration. The raw URL fallback is preserved for local-dev operability.
 
 ## Default Mode: Dedicated Routes Only
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for elegant-spinning-newt-v2.md.

**Gap:** Stale documentation references to removed reconcile infrastructure
**What was expected:** Documentation should reflect the new cache-driven architecture
**What was found:** ARCHITECTURE.md and README.md still reference reconcile endpoints, config.ingressPublicBaseUrl, and the old config propagation model

- Update ARCHITECTURE.md to describe credential watcher + cache invalidation model
- Replace config.ingressPublicBaseUrl references with ConfigFileCache read path
- Update README.md Twilio validation description for cache-based reads

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
