### PR TITLE
fix(gateway): thread credential cache through WhatsApp outbound paths

### DIFF
--- a/gateway/src/http/routes/whatsapp-deliver.ts
+++ b/gateway/src/http/routes/whatsapp-deliver.ts
@@ -1,6 +1,8 @@
 import type { GatewayConfig } from "../../config.js";
+import type { CredentialCache } from "../../credential-cache.js";
 import { getLogger } from "../../logger.js";
 import type { RuntimeAttachmentMeta } from "../../runtime/client.js";
+import type { WhatsAppApiCaches } from "../../whatsapp/api.js";
 import { checkDeliverAuth } from "../middleware/deliver-auth.js";
 import {
   sendWhatsAppAttachments,
@@ -20,7 +22,14 @@ export type ApprovalPayload = {
   plainTextFallback: string;
 };
 
-export function createWhatsAppDeliverHandler(config: GatewayConfig) {
+export function createWhatsAppDeliverHandler(
+  config: GatewayConfig,
+  caches?: { credentials?: CredentialCache },
+) {
+  const apiCaches: WhatsAppApiCaches | undefined = caches?.credentials
+    ? { credentials: caches.credentials }
+    : undefined;
+
   return async (req: Request): Promise<Response> => {
     const traceId = req.headers.get("x-trace-id") ?? undefined;
     const tlog = traceId ? log.child({ traceId }) : log;
@@ -156,7 +165,7 @@ export function createWhatsAppDeliverHandler(config: GatewayConfig) {
 
     try {
       if (text) {
-        await sendWhatsAppReply(config, to, text, approval);
+        await sendWhatsAppReply(config, to, text, approval, apiCaches);
         textSent = true;
       }
     } catch (err) {
@@ -165,7 +174,12 @@ export function createWhatsAppDeliverHandler(config: GatewayConfig) {
     }
 
     if (attachments && attachments.length > 0) {
-      const result = await sendWhatsAppAttachments(config, to, attachments);
+      const result = await sendWhatsAppAttachments(
+        config,
+        to,
+        attachments,
+        apiCaches,
+      );
 
       if (result.allFailed && !textSent) {
         // Nothing was delivered at all -- signal failure so the caller can retry

--- a/gateway/src/http/routes/whatsapp-webhook.test.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.test.ts
@@ -275,6 +275,7 @@ describe("whatsapp-webhook", () => {
     expect(markWhatsAppMessageReadMock).toHaveBeenCalledWith(
       baseConfig,
       "wamid-1",
+      expect.objectContaining({ credentials: expect.anything() }),
     );
   });
 
@@ -714,6 +715,7 @@ describe("whatsapp-webhook", () => {
     expect(markWhatsAppMessageReadMock).toHaveBeenCalledWith(
       baseConfig,
       "wamid-read-media",
+      expect.objectContaining({ credentials: expect.anything() }),
     );
   });
 

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -25,6 +25,7 @@ import { downloadWhatsAppFile } from "../../whatsapp/download.js";
 import {
   markWhatsAppMessageRead,
   WhatsAppNonRetryableError,
+  type WhatsAppApiCaches,
 } from "../../whatsapp/api.js";
 import { normalizeWhatsAppWebhook } from "../../whatsapp/normalize.js";
 import { sendWhatsAppReply } from "../../whatsapp/send.js";
@@ -40,6 +41,11 @@ export function createWhatsAppWebhookHandler(
 ) {
   // 24-hour TTL — WhatsApp message IDs are globally unique and never reused
   const dedupCache = new StringDedupCache(24 * 60 * 60_000);
+
+  // Build API caches from the credential cache for outbound WhatsApp calls
+  const apiCaches: WhatsAppApiCaches | undefined = caches?.credentials
+    ? { credentials: caches.credentials }
+    : undefined;
 
   const handler = async (req: Request): Promise<Response> => {
     const traceId = req.headers.get("x-trace-id") ?? undefined;
@@ -193,12 +199,14 @@ export function createWhatsAppWebhookHandler(
       );
 
       // Mark message as read (best-effort, do not await)
-      markWhatsAppMessageRead(config, whatsappMessageId).catch((err) => {
-        tlog.debug(
-          { err, messageId: whatsappMessageId },
-          "Failed to mark WhatsApp message as read",
-        );
-      });
+      markWhatsAppMessageRead(config, whatsappMessageId, apiCaches).catch(
+        (err) => {
+          tlog.debug(
+            { err, messageId: whatsappMessageId },
+            "Failed to mark WhatsApp message as read",
+          );
+        },
+      );
 
       // Resolve routing once so we can gate further operations on it
       const routing = resolveAssistant(config, from, from);
@@ -210,21 +218,25 @@ export function createWhatsAppWebhookHandler(
             { from, reason: routing.reason },
             "Routing rejected /new command",
           );
-          sendWhatsAppReply(config, from, ROUTING_REJECTION_NOTICE).catch(
-            (err) => {
-              tlog.error(
-                { err, to: from },
-                "Failed to send /new routing rejection notice",
-              );
-            },
-          );
+          sendWhatsAppReply(
+            config,
+            from,
+            ROUTING_REJECTION_NOTICE,
+            undefined,
+            apiCaches,
+          ).catch((err) => {
+            tlog.error(
+              { err, to: from },
+              "Failed to send /new routing rejection notice",
+            );
+          });
         } else {
           await handleNewCommand(
             config,
             event.sourceChannel,
             event.message.conversationExternalId,
             async (text) => {
-              await sendWhatsAppReply(config, from, text);
+              await sendWhatsAppReply(config, from, text, undefined, apiCaches);
             },
             tlog,
           );
@@ -240,14 +252,18 @@ export function createWhatsAppWebhookHandler(
           "Routing rejected inbound WhatsApp message",
         );
         if (rejectionLimiter.shouldSend(from)) {
-          sendWhatsAppReply(config, from, ROUTING_REJECTION_NOTICE).catch(
-            (err) => {
-              tlog.error(
-                { err, to: from },
-                "Failed to send routing rejection notice",
-              );
-            },
-          );
+          sendWhatsAppReply(
+            config,
+            from,
+            ROUTING_REJECTION_NOTICE,
+            undefined,
+            apiCaches,
+          ).catch((err) => {
+            tlog.error(
+              { err, to: from },
+              "Failed to send routing rejection notice",
+            );
+          });
         }
         dedupCache.mark(whatsappMessageId);
         continue;
@@ -364,14 +380,18 @@ export function createWhatsAppWebhookHandler(
           whatsappMessageId,
           () => {
             if (rejectionLimiter.shouldSend(from)) {
-              sendWhatsAppReply(config, from, ROUTING_REJECTION_NOTICE).catch(
-                (err) => {
-                  tlog.error(
-                    { err, to: from },
-                    "Failed to send routing rejection notice",
-                  );
-                },
-              );
+              sendWhatsAppReply(
+                config,
+                from,
+                ROUTING_REJECTION_NOTICE,
+                undefined,
+                apiCaches,
+              ).catch((err) => {
+                tlog.error(
+                  { err, to: from },
+                  "Failed to send routing rejection notice",
+                );
+              });
             }
           },
           tlog,

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -221,7 +221,9 @@ async function main() {
   const browserRelayWebsocketHandlers = getBrowserRelayWebsocketHandlers();
   const { handler: handleWhatsAppWebhook, dedupCache: whatsappDedupCache } =
     createWhatsAppWebhookHandler(config, { credentials: credentialCache });
-  const handleWhatsAppDeliver = createWhatsAppDeliverHandler(config);
+  const handleWhatsAppDeliver = createWhatsAppDeliverHandler(config, {
+    credentials: credentialCache,
+  });
   const handleSlackDeliver = createSlackDeliverHandler(
     config,
     (threadTs) => {

--- a/gateway/src/whatsapp/send.ts
+++ b/gateway/src/whatsapp/send.ts
@@ -12,6 +12,7 @@ import {
   uploadWhatsAppMedia,
   sendWhatsAppMediaMessage,
   type WhatsAppMediaType,
+  type WhatsAppApiCaches,
 } from "./api.js";
 
 const log = getLogger("whatsapp-send");
@@ -65,6 +66,7 @@ export async function sendWhatsAppReply(
   to: string,
   text: string,
   approval?: ApprovalPayload,
+  caches?: WhatsAppApiCaches,
 ): Promise<void> {
   if (approval) {
     // WhatsApp interactive buttons: up to 3 buttons, 20-char titles, 1024-char body.
@@ -78,7 +80,7 @@ export async function sendWhatsAppReply(
 
     // If text fits in the interactive body limit, send as single interactive message
     if (text.length <= WHATSAPP_INTERACTIVE_BODY_MAX_LEN) {
-      await sendWhatsAppInteractiveMessage(config, to, text, buttons);
+      await sendWhatsAppInteractiveMessage(config, to, text, buttons, caches);
       log.debug({ to }, "WhatsApp interactive approval reply sent");
       return;
     }
@@ -87,20 +89,27 @@ export async function sendWhatsAppReply(
     // interactive message with truncated body and buttons at the end
     const chunks = splitText(text, WHATSAPP_MAX_MESSAGE_LEN);
     for (let i = 0; i < chunks.length - 1; i++) {
-      await sendWhatsAppTextMessage(config, to, chunks[i]);
+      await sendWhatsAppTextMessage(config, to, chunks[i], caches);
     }
 
     const lastChunk = chunks[chunks.length - 1];
     if (lastChunk.length <= WHATSAPP_INTERACTIVE_BODY_MAX_LEN) {
-      await sendWhatsAppInteractiveMessage(config, to, lastChunk, buttons);
+      await sendWhatsAppInteractiveMessage(
+        config,
+        to,
+        lastChunk,
+        buttons,
+        caches,
+      );
     } else {
       // Last chunk still too long — send it as text, then a short interactive prompt
-      await sendWhatsAppTextMessage(config, to, lastChunk);
+      await sendWhatsAppTextMessage(config, to, lastChunk, caches);
       await sendWhatsAppInteractiveMessage(
         config,
         to,
         "Choose an action:",
         buttons,
+        caches,
       );
     }
 
@@ -111,7 +120,7 @@ export async function sendWhatsAppReply(
   const chunks = splitText(text, WHATSAPP_MAX_MESSAGE_LEN);
 
   for (const chunk of chunks) {
-    await sendWhatsAppTextMessage(config, to, chunk);
+    await sendWhatsAppTextMessage(config, to, chunk, caches);
   }
 
   log.debug({ to, chunks: chunks.length }, "WhatsApp reply sent");
@@ -127,6 +136,7 @@ export async function sendWhatsAppAttachments(
   config: GatewayConfig,
   to: string,
   attachments: RuntimeAttachmentMeta[],
+  caches?: WhatsAppApiCaches,
 ): Promise<AttachmentResult> {
   const failures: string[] = [];
 
@@ -169,6 +179,7 @@ export async function sendWhatsAppAttachments(
         blob,
         filename,
         mimeType,
+        caches,
       );
       await sendWhatsAppMediaMessage(
         config,
@@ -176,6 +187,8 @@ export async function sendWhatsAppAttachments(
         mediaType,
         uploaded.id,
         filename,
+        undefined,
+        caches,
       );
 
       log.debug(
@@ -195,7 +208,7 @@ export async function sendWhatsAppAttachments(
   if (failures.length > 0) {
     const notice = `${failures.length} attachment(s) could not be delivered: ${failures.join(", ")}`;
     try {
-      await sendWhatsAppReply(config, to, notice);
+      await sendWhatsAppReply(config, to, notice, undefined, caches);
     } catch (err) {
       log.error({ err, to }, "Failed to send attachment failure notice");
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for elegant-spinning-newt-v2.md.

**Gap:** WhatsApp outbound credential threading
**What was expected:** All WhatsApp API calls should use the credential cache for credentials
**What was found:** send.ts, webhook handler, and deliver handler did not thread caches, causing credentials to be undefined

- Thread WhatsAppApiCaches through sendWhatsAppReply and sendWhatsAppAttachments
- Wire createWhatsAppDeliverHandler with credential cache from index.ts
- Pass caches to markWhatsAppMessageRead in webhook handler
- Update all callers to pass credentials through

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
