### PR TITLE
fix(gateway): thread credential cache through Telegram outbound paths and add botToken guard

### DIFF
--- a/gateway/src/__tests__/telegram-deliver-auth.test.ts
+++ b/gateway/src/__tests__/telegram-deliver-auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
 import type { GatewayConfig } from "../config.js";
+import type { CredentialCache } from "../credential-cache.js";
 import { initSigningKey, mintToken } from "../auth/token-service.js";
 import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
 
@@ -72,6 +73,18 @@ afterEach(() => {
   fetchMock = mock(async () => new Response());
 });
 
+/** Create a mock CredentialCache that returns the bot token. */
+function makeCaches() {
+  const credentials = {
+    get: async (key: string) => {
+      if (key === "credential:telegram:bot_token") return "test-bot-token";
+      return undefined;
+    },
+    invalidate: () => {},
+  } as unknown as CredentialCache;
+  return { credentials };
+}
+
 function mockTelegramApi() {
   fetchMock = mock(async () => {
     return new Response(JSON.stringify({ ok: true, result: {} }), {
@@ -114,6 +127,7 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
 
     const handler = createTelegramDeliverHandler(
       makeConfig({ telegramDeliverAuthBypass: true }),
+      makeCaches(),
     );
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",
@@ -178,6 +192,7 @@ describe("/deliver/telegram attachment delivery without assistantId", () => {
 
     const handler = createTelegramDeliverHandler(
       makeConfig({ telegramDeliverAuthBypass: true }),
+      makeCaches(),
     );
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",
@@ -240,6 +255,7 @@ describe("/deliver/telegram ID-only attachment validation", () => {
 
     const handler = createTelegramDeliverHandler(
       makeConfig({ telegramDeliverAuthBypass: true }),
+      makeCaches(),
     );
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",
@@ -267,6 +283,7 @@ describe("/deliver/telegram ID-only attachment validation", () => {
   test("rejects attachment missing id with 400", async () => {
     const handler = createTelegramDeliverHandler(
       makeConfig({ telegramDeliverAuthBypass: true }),
+      makeCaches(),
     );
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",
@@ -313,6 +330,7 @@ describe("/deliver/telegram ID-only attachment validation", () => {
 
     const handler = createTelegramDeliverHandler(
       makeConfig({ telegramDeliverAuthBypass: true }),
+      makeCaches(),
     );
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",
@@ -340,7 +358,7 @@ describe("/deliver/telegram ID-only attachment validation", () => {
 
 describe("/deliver/telegram bearer auth enforcement", () => {
   test("rejects request without Authorization header with 401", async () => {
-    const handler = createTelegramDeliverHandler(makeConfig());
+    const handler = createTelegramDeliverHandler(makeConfig(), makeCaches());
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -354,7 +372,7 @@ describe("/deliver/telegram bearer auth enforcement", () => {
   });
 
   test("rejects request with wrong bearer token with 401", async () => {
-    const handler = createTelegramDeliverHandler(makeConfig());
+    const handler = createTelegramDeliverHandler(makeConfig(), makeCaches());
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",
       headers: {
@@ -371,7 +389,7 @@ describe("/deliver/telegram bearer auth enforcement", () => {
   });
 
   test("rejects request with empty bearer token with 401", async () => {
-    const handler = createTelegramDeliverHandler(makeConfig());
+    const handler = createTelegramDeliverHandler(makeConfig(), makeCaches());
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",
       headers: {
@@ -387,7 +405,7 @@ describe("/deliver/telegram bearer auth enforcement", () => {
 
   test("accepts request with correct bearer token", async () => {
     mockTelegramApi();
-    const handler = createTelegramDeliverHandler(makeConfig());
+    const handler = createTelegramDeliverHandler(makeConfig(), makeCaches());
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",
       headers: {
@@ -407,6 +425,7 @@ describe("/deliver/telegram bearer auth enforcement", () => {
     mockTelegramApi();
     const handler = createTelegramDeliverHandler(
       makeConfig({ telegramDeliverAuthBypass: true }),
+      makeCaches(),
     );
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",
@@ -421,7 +440,7 @@ describe("/deliver/telegram bearer auth enforcement", () => {
   });
 
   test("still rejects non-POST methods before auth check", async () => {
-    const handler = createTelegramDeliverHandler(makeConfig());
+    const handler = createTelegramDeliverHandler(makeConfig(), makeCaches());
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "GET",
     });
@@ -431,7 +450,7 @@ describe("/deliver/telegram bearer auth enforcement", () => {
   });
 
   test("still validates request body after successful auth", async () => {
-    const handler = createTelegramDeliverHandler(makeConfig());
+    const handler = createTelegramDeliverHandler(makeConfig(), makeCaches());
     const req = new Request("http://localhost:7830/deliver/telegram", {
       method: "POST",
       headers: {

--- a/gateway/src/__tests__/telegram-webhook-handler.test.ts
+++ b/gateway/src/__tests__/telegram-webhook-handler.test.ts
@@ -86,11 +86,12 @@ function makeWebhookRequest(
   });
 }
 
-/** Create a mock CredentialCache that returns the webhook secret. */
+/** Create a mock CredentialCache that returns the webhook secret and bot token. */
 function makeCaches(webhookSecret: string | undefined = "test-webhook-secret") {
   const credentials = {
     get: async (key: string) => {
       if (key === "credential:telegram:webhook_secret") return webhookSecret;
+      if (key === "credential:telegram:bot_token") return "test-bot-token";
       return undefined;
     },
     invalidate: () => {},

--- a/gateway/src/http/routes/telegram-deliver.ts
+++ b/gateway/src/http/routes/telegram-deliver.ts
@@ -1,4 +1,5 @@
 import type { GatewayConfig } from "../../config.js";
+import type { CredentialCache } from "../../credential-cache.js";
 import { getLogger } from "../../logger.js";
 import { checkDeliverAuth } from "../middleware/deliver-auth.js";
 import type { RuntimeAttachmentMeta } from "../../runtime/client.js";
@@ -21,7 +22,10 @@ export type ApprovalPayload = {
   plainTextFallback: string;
 };
 
-export function createTelegramDeliverHandler(config: GatewayConfig) {
+export function createTelegramDeliverHandler(
+  config: GatewayConfig,
+  caches?: { credentials?: CredentialCache },
+) {
   return async (req: Request): Promise<Response> => {
     const traceId = req.headers.get("x-trace-id") ?? undefined;
     const tlog = traceId ? log.child({ traceId }) : log;
@@ -172,17 +176,26 @@ export function createTelegramDeliverHandler(config: GatewayConfig) {
       }
     }
 
+    const credentialOpts = caches?.credentials
+      ? { credentials: caches.credentials }
+      : undefined;
+
     try {
       if (chatAction === "typing") {
-        await sendTypingIndicator(config, chatId);
+        await sendTypingIndicator(config, chatId, credentialOpts);
       }
 
       if (text) {
-        await sendTelegramReply(config, chatId, text, approval);
+        await sendTelegramReply(config, chatId, text, approval, credentialOpts);
       }
 
       if (attachments && attachments.length > 0) {
-        await sendTelegramAttachments(config, chatId, attachments);
+        await sendTelegramAttachments(
+          config,
+          chatId,
+          attachments,
+          credentialOpts,
+        );
       }
     } catch (err) {
       tlog.error({ err, chatId }, "Failed to deliver Telegram reply");

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -182,9 +182,14 @@ export function createTelegramWebhookHandler(
       phase: string,
     ): void => {
       if (!callbackQueryId) return;
-      callTelegramApi(config, "answerCallbackQuery", {
-        callback_query_id: callbackQueryId,
-      }).catch((err) => {
+      callTelegramApi(
+        config,
+        "answerCallbackQuery",
+        {
+          callback_query_id: callbackQueryId,
+        },
+        { credentials: caches?.credentials },
+      ).catch((err) => {
         tlog.error(
           { err, callbackQueryId, phase },
           "Failed to acknowledge callback query",
@@ -230,21 +235,21 @@ export function createTelegramWebhookHandler(
           return;
         }
 
-        callTelegramApi(config, "deleteMessage", basePayload).catch(
-          (deleteErr) => {
-            tlog.error(
-              {
-                primaryErr,
-                fallbackErr,
-                deleteErr,
-                chatId,
-                messageId: parsedMessageId,
-                phase,
-              },
-              "Failed to clear inline approval buttons and delete prompt message",
-            );
-          },
-        );
+        callTelegramApi(config, "deleteMessage", basePayload, {
+          credentials: caches?.credentials,
+        }).catch((deleteErr) => {
+          tlog.error(
+            {
+              primaryErr,
+              fallbackErr,
+              deleteErr,
+              chatId,
+              messageId: parsedMessageId,
+              phase,
+            },
+            "Failed to clear inline approval buttons and delete prompt message",
+          );
+        });
       };
 
       // Bot API behavior differs across wrappers/clients for "remove markup".
@@ -252,16 +257,24 @@ export function createTelegramWebhookHandler(
       // keyboard payload if needed. If both fail, delete the prompt message
       // so users are not left with stale actionable buttons — unless the error
       // indicates the markup was already removed (no-op).
-      callTelegramApi(config, "editMessageReplyMarkup", {
-        ...basePayload,
-        reply_markup: null,
-      }).catch((primaryErr) =>
-        callTelegramApi(config, "editMessageReplyMarkup", {
+      callTelegramApi(
+        config,
+        "editMessageReplyMarkup",
+        {
           ...basePayload,
-          reply_markup: { inline_keyboard: [] },
-        }).catch((fallbackErr) =>
-          deleteApprovalPrompt(primaryErr, fallbackErr),
-        ),
+          reply_markup: null,
+        },
+        { credentials: caches?.credentials },
+      ).catch((primaryErr) =>
+        callTelegramApi(
+          config,
+          "editMessageReplyMarkup",
+          {
+            ...basePayload,
+            reply_markup: { inline_keyboard: [] },
+          },
+          { credentials: caches?.credentials },
+        ).catch((fallbackErr) => deleteApprovalPrompt(primaryErr, fallbackErr)),
       );
     };
 
@@ -321,6 +334,8 @@ export function createTelegramWebhookHandler(
             config,
             normalized.message.conversationExternalId,
             "\u26a0\ufe0f This bot is not fully set up yet. Please check the gateway configuration.",
+            undefined,
+            { credentials: caches?.credentials },
           ).catch((err) => {
             tlog.error(
               { err, chatId: normalized.message.conversationExternalId },
@@ -342,6 +357,8 @@ export function createTelegramWebhookHandler(
           config,
           normalized.message.conversationExternalId,
           START_COMMAND_ACK_TEXT,
+          undefined,
+          { credentials: caches?.credentials },
         ).catch((err) => {
           tlog.error(
             { err, chatId: normalized.message.conversationExternalId },
@@ -381,6 +398,8 @@ export function createTelegramWebhookHandler(
               config,
               normalized.message.conversationExternalId,
               "\u26a0\ufe0f This bot is not fully set up yet. Please check the gateway configuration.",
+              undefined,
+              { credentials: caches?.credentials },
             ).catch((err) => {
               tlog.error(
                 { err, chatId: normalized.message.conversationExternalId },
@@ -397,6 +416,8 @@ export function createTelegramWebhookHandler(
             config,
             normalized.message.conversationExternalId,
             "Welcome! I'm having a brief setup hiccup. Please try again in a moment.",
+            undefined,
+            { credentials: caches?.credentials },
           ).catch((err) => {
             tlog.error({ err }, "Failed to send /start fallback reply");
           });
@@ -426,6 +447,8 @@ export function createTelegramWebhookHandler(
           config,
           normalized.message.conversationExternalId,
           "Welcome! I'm having a brief setup hiccup. Please try again in a moment.",
+          undefined,
+          { credentials: caches?.credentials },
         ).catch((replyErr) => {
           tlog.error({ err: replyErr }, "Failed to send /start error fallback");
         });
@@ -461,6 +484,8 @@ export function createTelegramWebhookHandler(
             config,
             normalized.message.conversationExternalId,
             `\u26a0\ufe0f ${ROUTING_REJECTION_NOTICE}`,
+            undefined,
+            { credentials: caches?.credentials },
           ).catch((err) => {
             tlog.error(
               { err, chatId: normalized.message.conversationExternalId },
@@ -478,6 +503,8 @@ export function createTelegramWebhookHandler(
               config,
               normalized.message.conversationExternalId,
               text,
+              undefined,
+              { credentials: caches?.credentials },
             );
           },
           tlog,
@@ -558,6 +585,7 @@ export function createTelegramWebhookHandler(
                   fileName: att.fileName,
                   mimeType: att.mimeType,
                 },
+                { credentials: caches?.credentials },
               );
               return uploadAttachment(config, downloaded);
             }),
@@ -613,6 +641,8 @@ export function createTelegramWebhookHandler(
             config,
             chatId,
             `\u26a0\ufe0f ${ROUTING_REJECTION_NOTICE}`,
+            undefined,
+            { credentials: caches?.credentials },
           ).catch((err) => {
             tlog.error(
               { err, chatId },

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -201,7 +201,9 @@ async function main() {
 
   const { handler: handleTelegramWebhook, dedupCache: telegramDedupCache } =
     createTelegramWebhookHandler(config, { credentials: credentialCache });
-  const handleTelegramDeliver = createTelegramDeliverHandler(config);
+  const handleTelegramDeliver = createTelegramDeliverHandler(config, {
+    credentials: credentialCache,
+  });
   const isTelegramConfigured = () => telegramReady;
   const isWhatsAppConfigured = () => whatsappReady;
 

--- a/gateway/src/telegram/api.ts
+++ b/gateway/src/telegram/api.ts
@@ -177,6 +177,12 @@ export async function callTelegramApi<T>(
     botToken = await opts.credentials.get("credential:telegram:bot_token");
   }
 
+  if (!botToken) {
+    throw new Error(
+      `Telegram ${method} failed: botToken is not available (credentials not provided or credential cache returned undefined)`,
+    );
+  }
+
   return retryableFetch<T>(config, method, () =>
     fetchImpl(`${config.telegramApiBaseUrl}/bot${botToken}/${method}`, {
       method: "POST",
@@ -196,6 +202,12 @@ export async function callTelegramApiMultipart<T>(
   let botToken: string | undefined;
   if (opts?.credentials) {
     botToken = await opts.credentials.get("credential:telegram:bot_token");
+  }
+
+  if (!botToken) {
+    throw new Error(
+      `Telegram ${method} failed: botToken is not available (credentials not provided or credential cache returned undefined)`,
+    );
   }
 
   return retryableFetch<T>(config, method, () =>

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -1,4 +1,5 @@
 import type { GatewayConfig } from "../config.js";
+import type { CredentialCache } from "../credential-cache.js";
 import type { ApprovalPayload } from "../http/routes/telegram-deliver.js";
 import { getLogger } from "../logger.js";
 import {
@@ -48,6 +49,7 @@ export async function sendTelegramReply(
   chatId: string,
   text: string,
   approval?: ApprovalPayload,
+  opts?: { credentials?: CredentialCache },
 ): Promise<void> {
   const chunks = splitText(text, TELEGRAM_MAX_MESSAGE_LEN);
 
@@ -63,7 +65,7 @@ export async function sendTelegramReply(
       payload.reply_markup = buildInlineKeyboard(approval);
     }
 
-    await callTelegramApi(config, "sendMessage", payload);
+    await callTelegramApi(config, "sendMessage", payload, opts);
   }
 
   log.debug({ chatId, chunks: chunks.length }, "Telegram reply sent");
@@ -73,6 +75,7 @@ export async function sendTelegramAttachments(
   config: GatewayConfig,
   chatId: string,
   attachments: RuntimeAttachmentMeta[],
+  opts?: { credentials?: CredentialCache },
 ): Promise<void> {
   const failures: string[] = [];
 
@@ -120,10 +123,10 @@ export async function sendTelegramAttachments(
       const isImage = IMAGE_MIME_PREFIXES.some((p) => mimeType.startsWith(p));
       if (isImage) {
         form.set("photo", blob, filename);
-        await callTelegramApiMultipart(config, "sendPhoto", form);
+        await callTelegramApiMultipart(config, "sendPhoto", form, opts);
       } else {
         form.set("document", blob, filename);
-        await callTelegramApiMultipart(config, "sendDocument", form);
+        await callTelegramApiMultipart(config, "sendDocument", form, opts);
       }
 
       log.debug(
@@ -143,7 +146,7 @@ export async function sendTelegramAttachments(
   if (failures.length > 0) {
     const notice = `\u26a0\ufe0f ${failures.length} attachment(s) could not be delivered: ${failures.join(", ")}`;
     try {
-      await sendTelegramReply(config, chatId, notice);
+      await sendTelegramReply(config, chatId, notice, undefined, opts);
     } catch (err) {
       log.error({ err, chatId }, "Failed to send attachment failure notice");
     }
@@ -153,12 +156,18 @@ export async function sendTelegramAttachments(
 export async function sendTypingIndicator(
   config: GatewayConfig,
   chatId: string,
+  opts?: { credentials?: CredentialCache },
 ): Promise<boolean> {
   try {
-    await callTelegramApi(config, "sendChatAction", {
-      chat_id: chatId,
-      action: "typing",
-    });
+    await callTelegramApi(
+      config,
+      "sendChatAction",
+      {
+        chat_id: chatId,
+        action: "typing",
+      },
+      opts,
+    );
     return true;
   } catch (err) {
     log.debug({ err, chatId }, "Failed to send typing indicator");


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for elegant-spinning-newt-v2.md.

**Gap:** Telegram outbound credential threading + missing botToken guard
**What was expected:** All Telegram API calls should use the credential cache for the bot token
**What was found:** send.ts, webhook handler, deliver handler, and download paths did not thread credentials, causing botToken to be undefined

- Thread CredentialCache through sendTelegramReply, sendTelegramAttachments, sendTypingIndicator
- Wire createTelegramDeliverHandler with credential cache from index.ts
- Pass credentials to all callTelegramApi and downloadTelegramFile calls in webhook handler
- Add botToken guard in callTelegramApi and callTelegramApiMultipart to throw clearly when undefined

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
