### PR TITLE
fix: update stale config/ paths in CODEOWNERS, pre-commit hook, and CI workflows

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -892,7 +892,7 @@ fi
 # Non-blocking reminder to consider whether changes belong in a skill or
 # one of the compiled source files (IDENTITY.md, SOUL.md, etc.) instead.
 
-if tr '\0' '\n' < "$STAGED_ALL_FILE" | grep -q 'assistant/src/config/system-prompt.ts'; then
+if tr '\0' '\n' < "$STAGED_ALL_FILE" | grep -q 'assistant/src/prompts/system-prompt.ts'; then
     echo ""
     echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${YELLOW}⚠️  You are modifying system-prompt.ts — the core system prompt.${NC}"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,9 +15,9 @@ assistant/src/tools/ @siddseethepalli
 
 # Skill system (Aaron)
 assistant/src/skills/ @awlevin
-assistant/src/config/skills.ts @awlevin
-assistant/src/config/skill-state.ts @awlevin
-assistant/src/config/bundled-skills/ @awlevin
+assistant/src/skills/catalog.ts @awlevin
+assistant/src/skills/skill-state.ts @awlevin
+assistant/src/skills/bundled-skills/ @awlevin
 assistant/src/daemon/handlers/skills.ts @awlevin
 assistant/src/daemon/ipc-contract/skills.ts @awlevin
 assistant/src/daemon/session-skill-tools.ts @awlevin
@@ -41,24 +41,24 @@ gateway/src/whatsapp/ @NgoHarrison
 # --- Specific overrides (must come AFTER broad rules) ---
 
 # System prompt ownership
-assistant/src/config/system-prompt.ts @awlevin @siddseethepalli @alex-nork
-assistant/src/config/computer-use-prompt.ts @awlevin @siddseethepalli @alex-nork
-assistant/src/config/templates/ @awlevin @siddseethepalli @alex-nork
+assistant/src/prompts/system-prompt.ts @awlevin @siddseethepalli @alex-nork
+assistant/src/prompts/computer-use-prompt.ts @awlevin @siddseethepalli @alex-nork
+assistant/src/prompts/templates/ @awlevin @siddseethepalli @alex-nork
 
 # Default identity/personality files
-assistant/src/config/templates/IDENTITY.md @awlevin @AnitaKirkovska
-assistant/src/config/templates/USER.md @awlevin @AnitaKirkovska
-assistant/src/config/templates/SOUL.md @awlevin @AnitaKirkovska
-assistant/src/config/templates/BOOTSTRAP.md @awlevin @AnitaKirkovska
+assistant/src/prompts/templates/IDENTITY.md @awlevin @AnitaKirkovska
+assistant/src/prompts/templates/USER.md @awlevin @AnitaKirkovska
+assistant/src/prompts/templates/SOUL.md @awlevin @AnitaKirkovska
+assistant/src/prompts/templates/BOOTSTRAP.md @awlevin @AnitaKirkovska
 
 # Voice / calls (Alex) — overrides tools/, bundled-skills/, routes/
 assistant/src/calls/ @alex-nork
 assistant/src/tools/calls/ @alex-nork
 assistant/src/tools/system/voice-config.ts @alex-nork
-assistant/src/config/calls-schema.ts @alex-nork
-assistant/src/config/bundled-skills/phone-calls/ @alex-nork
-assistant/src/config/bundled-skills/voice-setup/ @alex-nork
-assistant/src/config/bundled-skills/twilio-setup/ @alex-nork
+assistant/src/config/schemas/calls.ts @alex-nork
+assistant/src/skills/bundled-skills/phone-calls/ @alex-nork
+assistant/src/skills/bundled-skills/voice-setup/ @alex-nork
+assistant/src/skills/bundled-skills/twilio-setup/ @alex-nork
 assistant/src/runtime/routes/call-routes.ts @alex-nork
 assistant/src/runtime/middleware/twilio-validation.ts @alex-nork
 assistant/src/runtime/channel-invite-transports/voice.ts @alex-nork
@@ -67,7 +67,7 @@ gateway/src/twilio/ @alex-nork
 
 # Agent-to-agent / agent-to-person overrides (Harrison) — within tools/, bundled-skills/
 assistant/src/tools/subagent/ @NgoHarrison
-assistant/src/config/bundled-skills/subagent/ @NgoHarrison
+assistant/src/skills/bundled-skills/subagent/ @NgoHarrison
 
 # MCP (Vincent) — overrides tools/
 assistant/src/mcp/ @vincent0426
@@ -106,8 +106,8 @@ assistant/src/memory/guardian-* @noanflaherty
 assistant/src/memory/scoped-approval-grants.ts @noanflaherty
 assistant/src/memory/canonical-guardian-store.ts @noanflaherty
 assistant/src/calls/guardian-*.ts @noanflaherty
-assistant/src/config/bundled-skills/guardian-verify-setup/ @noanflaherty
-assistant/src/config/bundled-skills/contacts/ @noanflaherty
+assistant/src/skills/bundled-skills/guardian-verify-setup/ @noanflaherty
+assistant/src/skills/bundled-skills/contacts/ @noanflaherty
 assistant/src/notifications/guardian-question-mode.ts @noanflaherty
 gateway/src/http/routes/channel-verification-session-proxy.ts @noanflaherty
 

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -180,4 +180,4 @@ jobs:
           node-version: '22'
 
       - name: Validate bundled skills against Agent Skills spec
-        run: node scripts/skills/lint-skill-spec.mjs --dir assistant/src/config/bundled-skills --allow-tools-json
+        run: node scripts/skills/lint-skill-spec.mjs --dir assistant/src/skills/bundled-skills --allow-tools-json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1013,9 +1013,9 @@ jobs:
           cp "$ASSISTANT_SRC_DIR/node_modules/tree-sitter-bash/tree-sitter-bash.wasm" daemon-bin/
           rm -rf daemon-bin/node_modules
           rm -rf daemon-bin/bundled-skills
-          cp -R "$ASSISTANT_SRC_DIR/src/config/bundled-skills" daemon-bin/bundled-skills
+          cp -R "$ASSISTANT_SRC_DIR/src/skills/bundled-skills" daemon-bin/bundled-skills
           rm -rf daemon-bin/templates
-          cp -R "$ASSISTANT_SRC_DIR/src/config/templates" daemon-bin/templates
+          cp -R "$ASSISTANT_SRC_DIR/src/prompts/templates" daemon-bin/templates
           rm -rf daemon-bin/hook-templates
           cp -R "$ASSISTANT_SRC_DIR/hook-templates" daemon-bin/hook-templates
           rm -rf daemon-bin/prebuilt


### PR DESCRIPTION
## Summary
Fixes stale path references after config directory reorganization.

**Gaps fixed:**
- **CODEOWNERS** (17 entries): Updated paths from `config/skills.ts`, `config/skill-state.ts`, `config/bundled-skills/`, `config/system-prompt.ts`, `config/computer-use-prompt.ts`, `config/templates/`, and `config/calls-schema.ts` to their new locations under `skills/`, `prompts/`, and `config/schemas/`
- **.githooks/pre-commit**: Updated `system-prompt.ts` staging check from `config/system-prompt.ts` to `prompts/system-prompt.ts`
- **.github/workflows/pr-assistant.yaml**: Updated bundled-skills lint path from `config/bundled-skills` to `skills/bundled-skills`
- **.github/workflows/release.yml**: Updated `bundled-skills` and `templates` copy paths from `config/` to `skills/` and `prompts/` respectively

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
