### PR TITLE
fix: update stale config/ paths in build scripts and CI workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ Memory conflicts must never surface as user-facing clarification prompts. The co
 
 ## Release Update Hygiene
 
-When shipping a release with user/assistant-facing changes, update `assistant/src/config/templates/UPDATES.md`. Leave empty for no-op releases. Don't modify `~/.vellum/workspace/UPDATES.md` directly. Checkpoint keys (`updates:active_releases`, `updates:completed_releases`) in `memory_checkpoints` track bulletin lifecycle — don't manipulate directly.
+When shipping a release with user/assistant-facing changes, update `assistant/src/prompts/templates/UPDATES.md`. Leave empty for no-op releases. Don't modify `~/.vellum/workspace/UPDATES.md` directly. Checkpoint keys (`updates:active_releases`, `updates:completed_releases`) in `memory_checkpoints` track bulletin lifecycle — don't manipulate directly.
 
 ## See Also
 

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -593,7 +593,7 @@ Release-driven update notification system that surfaces release notes to the ass
 
 **Data flow:**
 
-1. **Bundled template** (`src/config/templates/UPDATES.md`) — source of release notes, maintained per-release in the repo.
+1. **Bundled template** (`src/prompts/templates/UPDATES.md`) — source of release notes, maintained per-release in the repo.
 2. **Startup sync** (`syncUpdateBulletinOnStartup()` in `src/config/update-bulletin.ts`) — materializes the bundled template into the workspace `UPDATES.md` on daemon boot. Uses atomic write (temp + rename) for crash safety.
 3. **System prompt injection** — `buildSystemPrompt()` reads workspace `UPDATES.md` and injects it as a `## Recent Updates` section with judgment-based handling instructions.
 4. **Completion by deletion** — the assistant deletes `UPDATES.md` when it has actioned all updates. Next startup detects the deletion and marks those releases as completed in checkpoint state.
@@ -608,11 +608,11 @@ Release-driven update notification system that surfaces release notes to the ass
 
 | File                                   | Purpose                                                   |
 | -------------------------------------- | --------------------------------------------------------- |
-| `src/config/templates/UPDATES.md`      | Bundled release-note template                             |
+| `src/prompts/templates/UPDATES.md`     | Bundled release-note template                             |
 | `src/config/update-bulletin.ts`        | Startup sync logic (materialize, delete-complete, merge)  |
 | `src/config/update-bulletin-format.ts` | Release block formatter/parser helpers                    |
 | `src/config/update-bulletin-state.ts`  | Checkpoint state helpers for active/completed releases    |
-| `src/config/system-prompt.ts`          | Prompt injection of updates section                       |
+| `src/prompts/system-prompt.ts`         | Prompt injection of updates section                       |
 | `src/daemon/config-watcher.ts`         | File watcher — evicts sessions on UPDATES.md changes      |
 | `src/permissions/defaults.ts`          | Auto-allow rules for file_read/write/edit + rm UPDATES.md |
 
@@ -642,7 +642,7 @@ The assistant feature-flag resolver (`src/config/assistant-feature-flags.ts`) is
 | Enforcement Point                  | Module                                                   | Effect                                                                                                                                                                                                      |
 | ---------------------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **1. Client skill list**           | `resolveSkillStates()` in `skills/skill-state.ts`        | Skills with flag OFF are excluded from the resolved list returned to IPC clients (macOS skill list, settings UI). The skill never appears in the client.                                                    |
-| **2. System prompt skill catalog** | `appendSkillsCatalog()` in `config/system-prompt.ts`     | The model-visible `## Skills Catalog` section in the system prompt filters out flagged-off skills. The model cannot see or reference them.                                                                  |
+| **2. System prompt skill catalog** | `appendSkillsCatalog()` in `prompts/system-prompt.ts`    | The model-visible `## Skills Catalog` section in the system prompt filters out flagged-off skills. The model cannot see or reference them.                                                                  |
 | **3. `skill_load` tool**           | `executeSkillLoad()` in `tools/skills/load.ts`           | If the model attempts to load a flagged-off skill by name, the tool returns an error: `"skill is currently unavailable (disabled by feature flag)"`.                                                        |
 | **4. Runtime tool projection**     | `projectSkillTools()` in `daemon/session-skill-tools.ts` | Even if a skill was previously active in a session (has `<loaded_skill>` markers in history), the per-turn projection drops it when the flag is OFF. Already-registered tools are unregistered.             |
 | **5. Included child skills**       | `executeSkillLoad()` in `tools/skills/load.ts`           | When a parent skill includes children via the `includes` directive, each child is independently checked against its feature flag. Flagged-off children are silently excluded from the loaded skill content. |
@@ -657,7 +657,7 @@ All five enforcement points use `isAssistantFeatureFlagEnabled(skillFlagKey(skil
 | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | `src/config/assistant-feature-flags.ts`         | Canonical resolver: `isAssistantFeatureFlagEnabled()`, `getAssistantFeatureFlagDefaults()`, registry loader        |
 | `src/skills/skill-state.ts`                     | `skillFlagKey()` — derives canonical flag key for skills; `resolveSkillStates()` — enforcement point 1             |
-| `src/config/system-prompt.ts`                   | `appendSkillsCatalog()` — enforcement point 2                                                                      |
+| `src/prompts/system-prompt.ts`                  | `appendSkillsCatalog()` — enforcement point 2                                                                      |
 | `src/tools/skills/load.ts`                      | `executeSkillLoad()` — enforcement points 3 and 5                                                                  |
 | `src/daemon/session-skill-tools.ts`             | `projectSkillTools()` — enforcement point 4                                                                        |
 | `src/config/schema.ts`                          | `assistantFeatureFlagValues` field definition in `AssistantConfig` (Zod schema)                                    |

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -51,9 +51,9 @@ cp .env.example .env
 
 ## Update Bulletin
 
-When a release includes relevant updates, the assistant materializes release notes from the bundled `src/config/templates/UPDATES.md` into `~/.vellum/workspace/UPDATES.md` on startup. The assistant uses judgment to surface updates to the user when relevant, and deletes the file when done.
+When a release includes relevant updates, the assistant materializes release notes from the bundled `src/prompts/templates/UPDATES.md` into `~/.vellum/workspace/UPDATES.md` on startup. The assistant uses judgment to surface updates to the user when relevant, and deletes the file when done.
 
-**For release maintainers:** Update `assistant/src/config/templates/UPDATES.md` with release notes before each relevant release. Leave the template empty (or comment-only) for releases with no user/assistant-facing changes.
+**For release maintainers:** Update `assistant/src/prompts/templates/UPDATES.md` with release notes before each relevant release. Leave the template empty (or comment-only) for releases with no user/assistant-facing changes.
 
 ## Usage
 

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -199,10 +199,10 @@ build_binaries() {
     rm -rf "$SCRIPT_DIR/daemon-bin/node_modules"
     # Copy bundled skills
     rm -rf "$SCRIPT_DIR/daemon-bin/bundled-skills"
-    cp -R "$ASSISTANT_SRC_DIR/src/config/bundled-skills" "$SCRIPT_DIR/daemon-bin/bundled-skills"
+    cp -R "$ASSISTANT_SRC_DIR/src/skills/bundled-skills" "$SCRIPT_DIR/daemon-bin/bundled-skills"
     # Copy non-JS assets not embedded by bun --compile (resolved via resolveBundledDir)
     rm -rf "$SCRIPT_DIR/daemon-bin/templates"
-    cp -R "$ASSISTANT_SRC_DIR/src/config/templates" "$SCRIPT_DIR/daemon-bin/templates"
+    cp -R "$ASSISTANT_SRC_DIR/src/prompts/templates" "$SCRIPT_DIR/daemon-bin/templates"
     rm -rf "$SCRIPT_DIR/daemon-bin/hook-templates"
     cp -R "$ASSISTANT_SRC_DIR/hook-templates" "$SCRIPT_DIR/daemon-bin/hook-templates"
     rm -rf "$SCRIPT_DIR/daemon-bin/prebuilt"
@@ -369,17 +369,17 @@ fi
 
 # Always refresh bundled skills from source (skill assets like SKILL.md aren't
 # tracked by the daemon binary staleness check, so copy unconditionally)
-if [ -d "$ASSISTANT_SRC_DIR/src/config/bundled-skills" ]; then
+if [ -d "$ASSISTANT_SRC_DIR/src/skills/bundled-skills" ]; then
     mkdir -p "$SCRIPT_DIR/daemon-bin"
     rm -rf "$SCRIPT_DIR/daemon-bin/bundled-skills"
-    cp -R "$ASSISTANT_SRC_DIR/src/config/bundled-skills" "$SCRIPT_DIR/daemon-bin/bundled-skills"
+    cp -R "$ASSISTANT_SRC_DIR/src/skills/bundled-skills" "$SCRIPT_DIR/daemon-bin/bundled-skills"
 fi
 
 # Always refresh non-JS assets from source (not embedded by bun --compile)
 mkdir -p "$SCRIPT_DIR/daemon-bin"
-if [ -d "$ASSISTANT_SRC_DIR/src/config/templates" ]; then
+if [ -d "$ASSISTANT_SRC_DIR/src/prompts/templates" ]; then
     rm -rf "$SCRIPT_DIR/daemon-bin/templates"
-    cp -R "$ASSISTANT_SRC_DIR/src/config/templates" "$SCRIPT_DIR/daemon-bin/templates"
+    cp -R "$ASSISTANT_SRC_DIR/src/prompts/templates" "$SCRIPT_DIR/daemon-bin/templates"
 fi
 if [ -d "$ASSISTANT_SRC_DIR/hook-templates" ]; then
     rm -rf "$SCRIPT_DIR/daemon-bin/hook-templates"

--- a/scripts/count-system-prompt-tokens.ts
+++ b/scripts/count-system-prompt-tokens.ts
@@ -17,7 +17,7 @@ import { parseArgs } from 'node:util';
 // buildSystemPrompt depends on modules that resolve workspace paths from
 // ~/.vellum/workspace, config, skills, etc. Import it directly so we get
 // the real compiled prompt.
-import { buildSystemPrompt } from '../assistant/src/config/system-prompt.js';
+import { buildSystemPrompt } from '../assistant/src/prompts/system-prompt.js';
 
 const { values } = parseArgs({
   args: process.argv.slice(2),

--- a/scripts/skills/migrate-bundled-frontmatter.mjs
+++ b/scripts/skills/migrate-bundled-frontmatter.mjs
@@ -22,7 +22,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BUNDLED_SKILLS_DIR = resolve(
   __dirname,
-  "../../assistant/src/config/bundled-skills",
+  "../../assistant/src/skills/bundled-skills",
 );
 
 // --- Frontmatter parsing (same logic as lint-skill-spec.mjs) ---


### PR DESCRIPTION
## Summary
Fixes stale path references in build/CI files after config directory reorganization.

**Gap:** Build/CI scripts reference paths that no longer exist after config reorg
**What was expected:** Scripts reference new file locations
**What was found:** release.yml, build.sh, pr-assistant.yaml still reference old config/bundled-skills and config/templates paths

### Changes
- **release.yml**: `src/config/bundled-skills` -> `src/skills/bundled-skills`, `src/config/templates` -> `src/prompts/templates`
- **build.sh**: All 6 references updated (bundled-skills x3, templates x3)
- **pr-assistant.yaml**: Lint dir `src/config/bundled-skills` -> `src/skills/bundled-skills`
- **CODEOWNERS**: All bundled-skills, templates, and system-prompt paths updated
- **migrate-bundled-frontmatter.mjs**: Bundled skills dir path updated
- **pre-commit hook**: system-prompt.ts path updated
- **count-system-prompt-tokens.ts**: Import path updated
- **AGENTS.md, README.md, ARCHITECTURE.md**: Documentation path references updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
