### PR TITLE
fix: update stale security allowlist path for twitter oauth-client

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -223,7 +223,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "cli/commands/credentials.ts", // CLI credential management commands
       "runtime/http-server.ts", // HTTP server credential lookup
       "daemon/handlers/twitter-auth.ts", // Twitter OAuth token storage
-      "twitter/oauth-client.ts", // Twitter OAuth API client (reads access token for API calls)
+      "cli/commands/twitter/oauth-client.ts", // Twitter OAuth API client (reads access token for API calls)
       "messaging/providers/telegram-bot/adapter.ts", // Telegram bot token lookup for connectivity check
       "runtime/channel-readiness-service.ts", // channel readiness probes for Telegram connectivity
       "messaging/providers/whatsapp/adapter.ts", // WhatsApp credential lookup for connectivity check


### PR DESCRIPTION
## Summary
Updates the `ALLOWED_IMPORTERS` set in the credential security invariants test to reference the new path for `twitter/oauth-client.ts` after it was moved to `cli/commands/twitter/oauth-client.ts`.

**Gap:** Stale allowlist entry in credential security invariants test
**What was expected:** Security allowlist should reference `cli/commands/twitter/oauth-client.ts`
**What was found:** Allowlist still referenced old `twitter/oauth-client.ts` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
