### PR TITLE
fix: update amazon CDP test path after cli module co-location

### DIFF
--- a/assistant/src/__tests__/amazon-cdp-integration.test.ts
+++ b/assistant/src/__tests__/amazon-cdp-integration.test.ts
@@ -5,18 +5,23 @@
  * management, so we only verify that old inline CDP patterns are absent.
  */
 
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
-const AMAZON_CLI_PATH = join(
+const AMAZON_CLI_DIR = join(
   import.meta.dirname ?? __dirname,
   "..",
   "cli",
   "commands",
-  "amazon.ts",
+  "amazon",
 );
-const amazonSource = readFileSync(AMAZON_CLI_PATH, "utf-8");
+
+// Read all .ts files in the amazon/ directory and concatenate their source
+const amazonSource = readdirSync(AMAZON_CLI_DIR)
+  .filter((f) => f.endsWith(".ts"))
+  .map((f) => readFileSync(join(AMAZON_CLI_DIR, f), "utf-8"))
+  .join("\n");
 
 describe("Amazon CLI CDP integration", () => {
   test("does not define its own CDP_BASE constant", () => {


### PR DESCRIPTION
## Summary
- The amazon CLI module was co-located from `cli/commands/amazon.ts` to `cli/commands/amazon/` directory (#14227), but the CDP regression test still referenced the old single-file path
- Updated the test to read all `.ts` files from the `amazon/` directory instead of a single `amazon.ts` file

## Original prompt
fix CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22810607229

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
