### PR TITLE
fix(gateway): prevent in-flight promises from writing stale values after CredentialCache.invalidate()

### DIFF
--- a/gateway/src/__tests__/credential-cache.test.ts
+++ b/gateway/src/__tests__/credential-cache.test.ts
@@ -272,6 +272,48 @@ describe("CredentialCache", () => {
       expect(callCount).toBe(4);
     });
 
+    test("in-flight promise resolving after invalidate does not overwrite cache with stale value", async () => {
+      let resolveOld!: (val: string | undefined) => void;
+      let fetchCount = 0;
+
+      // First readCredential call returns a manually controlled promise
+      readCredentialImpl = async () => {
+        fetchCount++;
+        return new Promise<string | undefined>((resolve) => {
+          resolveOld = resolve;
+        });
+      };
+
+      const cache = new CredentialCache({ ttlMs: 60_000 });
+
+      // Start an in-flight fetch for "key-a" (do NOT resolve yet)
+      const p1 = cache.get("key-a");
+      expect(fetchCount).toBe(1);
+
+      // Invalidate the cache while the fetch is still in-flight
+      cache.invalidate();
+
+      // Now wire up a new readCredential that resolves immediately with "new-value"
+      readCredentialImpl = async () => {
+        fetchCount++;
+        return "new-value";
+      };
+
+      // Start a new fetch for "key-a" after invalidation
+      const p2 = cache.get("key-a");
+      expect(fetchCount).toBe(2);
+
+      // Let p2 resolve first (it returns "new-value")
+      expect(await p2).toBe("new-value");
+
+      // Now resolve the original stale in-flight promise with "old-value"
+      resolveOld("old-value");
+      expect(await p1).toBe("old-value");
+
+      // The cache should still return "new-value", NOT the stale "old-value"
+      expect(await cache.get("key-a")).toBe("new-value");
+    });
+
     test("invalidate clears in-flight entries", async () => {
       let resolveRead!: (val: string | undefined) => void;
       readCredentialImpl = async () => {

--- a/gateway/src/credential-cache.ts
+++ b/gateway/src/credential-cache.ts
@@ -19,6 +19,7 @@ export class CredentialCache {
   /** In-flight promises keyed by credential account, used for deduplication. */
   private readonly inflight = new Map<string, Promise<string | undefined>>();
   private readonly invalidateListeners = new Set<() => void>();
+  private generation = 0;
 
   constructor(opts?: { ttlMs?: number }) {
     this.ttlMs = opts?.ttlMs ?? DEFAULT_TTL_MS;
@@ -63,6 +64,7 @@ export class CredentialCache {
    * all registered invalidation listeners.
    */
   invalidate(): void {
+    this.generation++;
     this.cache.clear();
     this.inflight.clear();
     for (const cb of this.invalidateListeners) {
@@ -92,17 +94,22 @@ export class CredentialCache {
     const existing = this.inflight.get(key);
     if (existing) return existing;
 
+    const gen = this.generation;
     const promise = readCredential(key).then(
       (value) => {
-        this.cache.set(key, {
-          value,
-          expiresAt: Date.now() + this.ttlMs,
-        });
-        this.inflight.delete(key);
+        if (this.generation === gen) {
+          this.cache.set(key, {
+            value,
+            expiresAt: Date.now() + this.ttlMs,
+          });
+          this.inflight.delete(key);
+        }
         return value;
       },
       (err) => {
-        this.inflight.delete(key);
+        if (this.generation === gen) {
+          this.inflight.delete(key);
+        }
         throw err;
       },
     );


### PR DESCRIPTION
## Summary
- Add a generation counter to CredentialCache to guard against stale in-flight promise writes after invalidation
- In-flight fetch promises now check the generation before writing to cache, preventing the race condition where old promises overwrite fresh values
- Add test that reproduces the exact race scenario: in-flight resolves stale after invalidation + new fetch

Part of plan: ttl-config-cache-gap-closure-plan.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
