### PR TITLE
fix(gateway): force-refresh Twilio auth token before rejecting on credential-missing

### DIFF
--- a/gateway/src/__tests__/twilio-webhooks.test.ts
+++ b/gateway/src/__tests__/twilio-webhooks.test.ts
@@ -718,3 +718,80 @@ describe("Twilio webhook signature with canonical ingress base URL", () => {
     });
   });
 });
+
+describe("Twilio webhook force retry on credential-missing", () => {
+  test("succeeds after force-refreshing a missing auth token", async () => {
+    const twiml = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
+    fetchMock = mock(
+      async () =>
+        new Response(twiml, {
+          status: 200,
+          headers: { "Content-Type": "text/xml" },
+        }),
+    );
+
+    // First get() returns undefined; second get({ force: true }) returns the token
+    let callCount = 0;
+    const credentials = {
+      get: async (_key: string, opts?: { force?: boolean }) => {
+        callCount++;
+        if (callCount === 1 && !opts?.force) return undefined;
+        return AUTH_TOKEN;
+      },
+      invalidate: () => {},
+    } as unknown as CredentialCache;
+
+    const configFile = {
+      getString: (section: string, key: string) => {
+        if (section === "ingress" && key === "publicBaseUrl") return undefined;
+        return undefined;
+      },
+      getRecord: () => undefined,
+      refreshNow: () => {},
+    } as unknown as ConfigFileCache;
+
+    const handler = createTwilioVoiceWebhookHandler(makeConfig(), {
+      credentials,
+      configFile,
+    });
+
+    const url =
+      "http://localhost:7830/webhooks/twilio/voice?callSessionId=sess-force";
+    const params = { CallSid: "CA123" };
+    const req = buildSignedRequest(url, params, AUTH_TOKEN);
+
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    // The credential cache should have been called at least twice (initial + force)
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test("returns 403 when force refresh also returns undefined", async () => {
+    // Both get() and get({ force: true }) return undefined
+    const credentials = {
+      get: async () => undefined,
+      invalidate: () => {},
+    } as unknown as CredentialCache;
+
+    const configFile = {
+      getString: () => undefined,
+      getRecord: () => undefined,
+      refreshNow: () => {},
+    } as unknown as ConfigFileCache;
+
+    const handler = createTwilioVoiceWebhookHandler(makeConfig(), {
+      credentials,
+      configFile,
+    });
+
+    const url = "http://localhost:7830/webhooks/twilio/voice";
+    const req = new Request(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "CallSid=CA123",
+    });
+
+    const res = await handler(req);
+    expect(res.status).toBe(403);
+  });
+});

--- a/gateway/src/twilio/validate-webhook.ts
+++ b/gateway/src/twilio/validate-webhook.ts
@@ -201,22 +201,45 @@ export async function validateTwilioWebhookRequest(
   }
 
   // Resolve the auth token from cache
-  const authToken = caches?.credentials
+  let authToken = caches?.credentials
     ? await caches.credentials.get("credential:twilio:auth_token")
     : undefined;
 
   // Resolve ingress URL from cache
-  const ingressUrl = caches?.configFile
+  let ingressUrl = caches?.configFile
     ? caches.configFile.getString("ingress", "publicBaseUrl")
     : undefined;
 
-  const resolved: ResolvedValidationContext = { authToken, ingressUrl };
+  let resolved: ResolvedValidationContext = { authToken, ingressUrl };
 
-  const validationDiagnostics = buildValidationDiagnostics(req, resolved);
-  const { logContext: validationLogContext, signatureUrlCandidates } =
+  let validationDiagnostics = buildValidationDiagnostics(req, resolved);
+  let { logContext: validationLogContext, signatureUrlCandidates } =
     validationDiagnostics;
 
   // Fail-closed: reject if no auth token is configured
+  // One-shot force retry: if missing and caches available, try force refresh
+  if (!authToken && caches?.credentials) {
+    const freshAuthToken = await caches.credentials.get(
+      "credential:twilio:auth_token",
+      { force: true },
+    );
+    if (freshAuthToken) {
+      let freshIngressUrl = ingressUrl;
+      if (caches.configFile) {
+        caches.configFile.refreshNow();
+        freshIngressUrl = caches.configFile.getString(
+          "ingress",
+          "publicBaseUrl",
+        );
+      }
+      authToken = freshAuthToken;
+      ingressUrl = freshIngressUrl;
+      resolved = { authToken: freshAuthToken, ingressUrl: freshIngressUrl };
+      validationDiagnostics = buildValidationDiagnostics(req, resolved);
+      ({ logContext: validationLogContext, signatureUrlCandidates } =
+        validationDiagnostics);
+    }
+  }
   if (!authToken) {
     log.error(
       validationLogContext,


### PR DESCRIPTION
## Summary
- When the initial Twilio auth token cache read returns undefined, perform one forced refresh before fail-closing with 403
- If the forced refresh yields a token, rebuild the validation context (including fresh ingress URL) and continue to signature validation
- Add tests for both the successful force-refresh path and the still-missing path

Part of plan: ttl-config-cache-gap-closure-plan.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
