### PR TITLE
fix(gateway): force-refresh WhatsApp app secret before rejecting on credential-missing

### DIFF
--- a/gateway/src/http/routes/whatsapp-webhook.test.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.test.ts
@@ -194,6 +194,72 @@ describe("whatsapp-webhook", () => {
     expect(body.error).toBe("Webhook signature validation not configured");
   });
 
+  it("force-refreshes app secret when initial cache read returns undefined, then proceeds normally", async () => {
+    let callCount = 0;
+    const caches = {
+      credentials: {
+        get: async (key: string, opts?: { force?: boolean }) => {
+          if (key === "credential:whatsapp:app_secret") {
+            callCount++;
+            // First call (non-forced) returns undefined; second call (forced) returns a valid secret
+            if (callCount === 1 && !opts?.force) return undefined;
+            return "refreshed-app-secret";
+          }
+          if (key === "credential:whatsapp:webhook_verify_token")
+            return "verify-token";
+          if (key === "credential:whatsapp:phone_number_id")
+            return "test-phone-id";
+          if (key === "credential:whatsapp:access_token")
+            return "test-access-token";
+          return undefined;
+        },
+        invalidate: () => {},
+      } as unknown as CredentialCache,
+    };
+
+    normalizeWhatsAppWebhookMock.mockImplementation(() => []);
+
+    const { handler } = createWhatsAppWebhookHandler(baseConfig, caches);
+    const res = await handler(
+      buildPostReq({ object: "whatsapp_business_account", entry: [] }),
+    );
+
+    // Should succeed (200) because the forced refresh returned a valid secret
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    // The credential cache should have been called at least twice for app_secret
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it("returns 500 when force-refresh also returns undefined for app secret", async () => {
+    const caches = {
+      credentials: {
+        get: async (key: string) => {
+          // Always return undefined for app_secret — both normal and forced reads
+          if (key === "credential:whatsapp:app_secret") return undefined;
+          if (key === "credential:whatsapp:webhook_verify_token")
+            return "verify-token";
+          if (key === "credential:whatsapp:phone_number_id")
+            return "test-phone-id";
+          if (key === "credential:whatsapp:access_token")
+            return "test-access-token";
+          return undefined;
+        },
+        invalidate: () => {},
+      } as unknown as CredentialCache,
+    };
+
+    const { handler } = createWhatsAppWebhookHandler(baseConfig, caches);
+    const res = await handler(
+      buildPostReq({ object: "whatsapp_business_account", entry: [] }),
+    );
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("Webhook signature validation not configured");
+  });
+
   it("rejects POST when signature verification fails", async () => {
     verifyWhatsAppWebhookSignatureMock.mockImplementation(() => false);
 

--- a/gateway/src/http/routes/whatsapp-webhook.ts
+++ b/gateway/src/http/routes/whatsapp-webhook.ts
@@ -114,9 +114,25 @@ export function createWhatsAppWebhookHandler(
       ? await caches.credentials.get("credential:whatsapp:app_secret")
       : undefined;
 
+    // If the initial cache read returned undefined but a credential cache is available,
+    // attempt one forced refresh before fail-closing — the credential may have been
+    // written after the TTL cache was last populated.
+    let effectiveAppSecret = appSecret;
+    if (!effectiveAppSecret && caches?.credentials) {
+      effectiveAppSecret = await caches.credentials.get(
+        "credential:whatsapp:app_secret",
+        { force: true },
+      );
+      if (effectiveAppSecret) {
+        tlog.info(
+          "WhatsApp app secret resolved after forced credential refresh",
+        );
+      }
+    }
+
     // Signature validation is required — reject requests when the app secret is not configured
     // rather than silently accepting unauthenticated payloads (fail-closed).
-    if (!appSecret) {
+    if (!effectiveAppSecret) {
       tlog.warn("WhatsApp app secret is not configured — rejecting request");
       return Response.json(
         { error: "Webhook signature validation not configured" },
@@ -127,7 +143,7 @@ export function createWhatsAppWebhookHandler(
     let signatureValid = verifyWhatsAppWebhookSignature(
       req.headers,
       rawBody,
-      appSecret,
+      effectiveAppSecret,
     );
 
     // One-shot force retry: if verification failed and caches are available,


### PR DESCRIPTION
## Summary
- When the initial WhatsApp app secret cache read returns undefined, perform one forced refresh before fail-closing with 500
- If the forced refresh yields a valid secret, proceed with signature validation normally
- Add tests for both the successful force-refresh path and the still-missing path

Part of plan: ttl-config-cache-gap-closure-plan.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
