### PR TITLE
fix(assistant): isolate config-loader-backfill test mocks to prevent cross-test contamination

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -8,7 +8,15 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Mocks — declared before imports that depend on platform/logger
@@ -67,6 +75,12 @@ mock.module("../util/platform.js", () => ({
   isLinux: () => false,
   isWindows: () => false,
 }));
+
+// Restore all mocked modules after this file's tests complete to prevent
+// cross-test contamination when running grouped with other test files.
+afterAll(() => {
+  mock.restore();
+});
 
 import {
   deepMergeMissing,


### PR DESCRIPTION
## Summary
- Add afterAll mock.restore() to config-loader-backfill.test.ts to prevent module-level mock leakage
- Ensures the test passes reliably when run in grouped test commands alongside other test files

Part of plan: ttl-config-cache-gap-closure-plan.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
