### PR TITLE
fix(gateway): pass mock CredentialCache in telegram tests after credential refactor

### DIFF
--- a/gateway/src/__tests__/telegram-api-redaction.test.ts
+++ b/gateway/src/__tests__/telegram-api-redaction.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import type { GatewayConfig } from "../config.js";
+import type { CredentialCache } from "../credential-cache.js";
 
 type FetchFn = (
   input: string | URL | Request,
@@ -49,6 +50,14 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
   return merged;
 }
 
+function makeCredentials(botToken: string) {
+  return {
+    get: async (key: string) =>
+      key === "credential:telegram:bot_token" ? botToken : undefined,
+    invalidate: () => {},
+  } as unknown as CredentialCache;
+}
+
 describe("callTelegramApi transport error redaction", () => {
   afterEach(() => {
     fetchMock = mock(async () => new Response());
@@ -79,10 +88,15 @@ describe("callTelegramApi transport error redaction", () => {
 
     let thrown: Error | null = null;
     try {
-      await callTelegramApi(config, "sendMessage", {
-        chat_id: "1",
-        text: "hello",
-      });
+      await callTelegramApi(
+        config,
+        "sendMessage",
+        {
+          chat_id: "1",
+          text: "hello",
+        },
+        { credentials: makeCredentials(tgToken) },
+      );
     } catch (err) {
       thrown = err as Error;
     }
@@ -118,10 +132,15 @@ describe("callTelegramApi transport error redaction", () => {
 
     let thrown: Error | null = null;
     try {
-      await callTelegramApi(config, "sendMessage", {
-        chat_id: "1",
-        text: "hello",
-      });
+      await callTelegramApi(
+        config,
+        "sendMessage",
+        {
+          chat_id: "1",
+          text: "hello",
+        },
+        { credentials: makeCredentials(tgToken) },
+      );
     } catch (err) {
       thrown = err as Error;
     }
@@ -156,10 +175,15 @@ describe("callTelegramApi transport error redaction", () => {
 
     let thrown: Error | null = null;
     try {
-      await callTelegramApi(config, "sendMessage", {
-        chat_id: "1",
-        text: "hello",
-      });
+      await callTelegramApi(
+        config,
+        "sendMessage",
+        {
+          chat_id: "1",
+          text: "hello",
+        },
+        { credentials: makeCredentials(tgToken) },
+      );
     } catch (err) {
       thrown = err as Error;
     }

--- a/gateway/src/__tests__/telegram-send-attachments.test.ts
+++ b/gateway/src/__tests__/telegram-send-attachments.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
 import type { RuntimeAttachmentMeta } from "../runtime/client.js";
 import type { GatewayConfig } from "../config.js";
+import type { CredentialCache } from "../credential-cache.js";
 import { initSigningKey } from "../auth/token-service.js";
 
 const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
@@ -56,6 +57,13 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
 
 const telegramOk = { ok: true, result: { message_id: 1 } };
 
+const mockCredentials = {
+  get: async (key: string) =>
+    key === "credential:telegram:bot_token" ? "test-bot-token" : undefined,
+  invalidate: () => {},
+} as unknown as CredentialCache;
+const credOpts = { credentials: mockCredentials };
+
 describe("sendTelegramAttachments", () => {
   afterEach(() => {
     fetchMock = mock(async () => new Response());
@@ -98,7 +106,7 @@ describe("sendTelegramAttachments", () => {
       kind: "generated_image",
     };
 
-    await sendTelegramAttachments(config, "chat-1", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta], credOpts);
 
     // Should have called: 1) runtime download, 2) telegram sendPhoto
     expect(calls).toHaveLength(2);
@@ -141,7 +149,7 @@ describe("sendTelegramAttachments", () => {
       kind: "filesystem",
     };
 
-    await sendTelegramAttachments(config, "chat-1", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta], credOpts);
 
     expect(calls).toHaveLength(2);
     expect(calls[0]).toContain("/attachments/att-2");
@@ -171,7 +179,7 @@ describe("sendTelegramAttachments", () => {
       kind: "filesystem",
     };
 
-    await sendTelegramAttachments(config, "chat-1", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta], credOpts);
 
     // Should have sent only the failure notice via sendMessage
     expect(calls).toHaveLength(1);
@@ -213,7 +221,7 @@ describe("sendTelegramAttachments", () => {
       kind: "generated_image",
     };
 
-    await sendTelegramAttachments(config, "chat-1", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta], credOpts);
 
     expect(calls).toHaveLength(2);
     // Should use /v1/attachments/ path (no assistantId in URL)
@@ -253,7 +261,7 @@ describe("sendTelegramAttachments", () => {
     // Only provide `id` — no filename, mimeType, sizeBytes, or kind
     const meta: RuntimeAttachmentMeta = { id: "att-id-only" };
 
-    await sendTelegramAttachments(config, "chat-1", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta], credOpts);
 
     expect(calls).toHaveLength(2);
     expect(calls[0]).toContain("/attachments/att-id-only");
@@ -286,7 +294,7 @@ describe("sendTelegramAttachments", () => {
     const config = makeConfig();
     const meta: RuntimeAttachmentMeta = { id: "att-bare" };
 
-    await sendTelegramAttachments(config, "chat-1", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta], credOpts);
 
     expect(calls).toHaveLength(2);
     expect(calls[0]).toContain("/attachments/att-bare");
@@ -324,7 +332,7 @@ describe("sendTelegramAttachments", () => {
     // No sizeBytes in meta — will be hydrated from download payload (200 > 50 limit)
     const meta: RuntimeAttachmentMeta = { id: "att-big" };
 
-    await sendTelegramAttachments(config, "chat-1", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta], credOpts);
 
     // Should download, discover size exceeds limit, skip, then send failure notice
     expect(
@@ -364,7 +372,7 @@ describe("sendTelegramAttachments", () => {
     const config = makeConfig();
     const meta: RuntimeAttachmentMeta = { id: "my-attachment-id" };
 
-    await sendTelegramAttachments(config, "chat-1", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta], credOpts);
 
     expect(calls).toHaveLength(2);
     // Second call is the Telegram API call with FormData
@@ -407,7 +415,7 @@ describe("sendTelegramAttachments", () => {
       kind: "generated_image",
     };
 
-    await sendTelegramAttachments(config, "chat-1", [meta]);
+    await sendTelegramAttachments(config, "chat-1", [meta], credOpts);
 
     expect(calls).toHaveLength(2);
     expect(calls[0]).toContain("/attachments/att-full");
@@ -463,7 +471,7 @@ describe("sendTelegramAttachments", () => {
       },
     ];
 
-    await sendTelegramAttachments(config, "chat-1", attachments);
+    await sendTelegramAttachments(config, "chat-1", attachments, credOpts);
 
     // Should have: download att-fail (fail), download att-ok, sendPhoto for att-ok, sendMessage for notice
     expect(calls.filter((u) => u.includes("sendPhoto"))).toHaveLength(1);

--- a/gateway/src/telegram/send.test.ts
+++ b/gateway/src/telegram/send.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 import type { ApprovalPayload } from "../http/routes/telegram-deliver.js";
 import type { GatewayConfig } from "../config.js";
+import type { CredentialCache } from "../credential-cache.js";
 
 // Mock fetch at the transport level (same pattern as all other test files)
 // instead of mocking ./api.js — mock.module for api.js leaks across test
@@ -65,6 +66,13 @@ function makeTelegramResponse(result: unknown) {
     headers: { "content-type": "application/json" },
   });
 }
+
+const mockCredentials = {
+  get: async (key: string) =>
+    key === "credential:telegram:bot_token" ? "test-bot-token" : undefined,
+  invalidate: () => {},
+} as unknown as CredentialCache;
+const credOpts = { credentials: mockCredentials };
 
 let fetchCalls: { url: string; body: unknown }[];
 
@@ -161,7 +169,7 @@ describe("buildInlineKeyboard", () => {
 
 describe("sendTelegramReply", () => {
   it("sends a plain message without reply_markup when no approval", async () => {
-    await sendTelegramReply(baseConfig, "chat-1", "Hello");
+    await sendTelegramReply(baseConfig, "chat-1", "Hello", undefined, credOpts);
 
     expect(fetchCalls).toHaveLength(1);
     expect(fetchCalls[0].url).toContain("/sendMessage");
@@ -172,7 +180,13 @@ describe("sendTelegramReply", () => {
   });
 
   it("attaches inline keyboard when approval is provided", async () => {
-    await sendTelegramReply(baseConfig, "chat-1", "Approve?", sampleApproval);
+    await sendTelegramReply(
+      baseConfig,
+      "chat-1",
+      "Approve?",
+      sampleApproval,
+      credOpts,
+    );
 
     expect(fetchCalls).toHaveLength(1);
     expect(fetchCalls[0].url).toContain("/sendMessage");
@@ -191,7 +205,13 @@ describe("sendTelegramReply", () => {
   it("attaches inline keyboard only to the last chunk for long messages", async () => {
     // Create a message that exceeds TELEGRAM_MAX_MESSAGE_LEN (4000 chars)
     const longText = "A".repeat(4001);
-    await sendTelegramReply(baseConfig, "chat-1", longText, sampleApproval);
+    await sendTelegramReply(
+      baseConfig,
+      "chat-1",
+      longText,
+      sampleApproval,
+      credOpts,
+    );
 
     expect(fetchCalls).toHaveLength(2);
 


### PR DESCRIPTION
## Summary
- Three telegram test files were not passing mock credentials after the credential cache refactor (#14214), causing CI failures
- Added mock `CredentialCache` objects to `telegram-api-redaction.test.ts`, `telegram-send-attachments.test.ts`, and `telegram/send.test.ts`

## Original prompt
fix the ci failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22810842804

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
