### PR TITLE
fix(gateway): make CredentialWatcher.start() return Promise and await initial poll

### DIFF
--- a/gateway/src/credential-watcher.ts
+++ b/gateway/src/credential-watcher.ts
@@ -54,8 +54,8 @@ export class CredentialWatcher {
     this.metadataPath = getMetadataPath();
   }
 
-  start(): void {
-    void this.pollOnce();
+  async start(): Promise<void> {
+    await this.pollOnce();
 
     this.watchingDirectory = !existsSync(this.metadataPath);
     const watchTarget = this.watchingDirectory


### PR DESCRIPTION
## Summary
- Change `CredentialWatcher.start()` from `void` to `async` so the initial `pollOnce()` completes before `start()` resolves
- This ensures the credential watcher callback fires with initial credential state before callers proceed
- Update credential watcher tests to `await` the now-async `start()` call

Part of plan: fix-webhook-cred-race.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
