### PR TITLE
fix(gateway): add warn-level logging when route preconditions reject requests

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -260,6 +260,10 @@ async function main() {
   ): (() => Response | null) => {
     return () => {
       if (!check()) {
+        log.warn(
+          { integration: name },
+          `${name} integration not configured — rejecting request with 503`,
+        );
         return Response.json(
           { error: `${name} integration not configured` },
           { status: 503 },


### PR DESCRIPTION
## Summary
- Add warn-level log line to the `requireConfigured` precondition helper so 503 rejections are visible in logs
- Previously, precondition rejections were completely silent, making credential startup issues impossible to debug

Part of plan: fix-webhook-cred-race.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
