### PR TITLE
fix(gateway): add force-refresh credential retry to Slack deliver handler

### DIFF
--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -299,6 +299,39 @@ describe("slack-deliver endpoint", () => {
     expect(body.error).toContain("not configured");
   });
 
+  test("force-refreshes credential cache when bot token is initially missing", async () => {
+    let callCount = 0;
+    const credentials = {
+      get: async (key: string, opts?: { force?: boolean }) => {
+        if (key === "credential:slack_channel:bot_token") {
+          callCount++;
+          // First call returns undefined; second call with force returns the token
+          if (callCount === 1 && !opts?.force) return undefined;
+          if (callCount === 2 && opts?.force) return "xoxb-refreshed-token";
+        }
+        return undefined;
+      },
+      invalidate: () => {},
+    } as unknown as CredentialCache;
+
+    const handler = createSlackDeliverHandler(makeConfig(), undefined, {
+      credentials,
+    });
+    const req = makeRequest({ chatId: "C123", text: "hello" });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    expect(callCount).toBe(2);
+
+    // Verify the Slack API was called with the refreshed token
+    const slackCall = fetchCalls.find((c) =>
+      c.url.includes("chat.postMessage"),
+    );
+    expect(slackCall).toBeDefined();
+    expect(slackCall!.headers!["authorization"]).toBe(
+      "Bearer xoxb-refreshed-token",
+    );
+  });
+
   test("accepts 'to' as alias for chatId", async () => {
     const handler = createSlackDeliverHandler(
       makeConfig(),

--- a/gateway/src/http/routes/slack-deliver.ts
+++ b/gateway/src/http/routes/slack-deliver.ts
@@ -327,9 +327,21 @@ export function createSlackDeliverHandler(
     if (authResponse) return authResponse;
 
     // Resolve bot token from cache
-    const botToken = caches?.credentials
+    let botToken = caches?.credentials
       ? await caches.credentials.get("credential:slack_channel:bot_token")
       : undefined;
+
+    // One-shot force retry: if token is missing and caches are available,
+    // force-refresh and retry once.
+    if (!botToken && caches?.credentials) {
+      botToken = await caches.credentials.get(
+        "credential:slack_channel:bot_token",
+        { force: true },
+      );
+      if (botToken) {
+        tlog.info("Slack bot token resolved after forced credential refresh");
+      }
+    }
 
     if (!botToken) {
       tlog.error("Slack bot token not configured");


### PR DESCRIPTION
## Summary
- Add one-shot force-refresh retry when the Slack bot token is missing from the credential cache
- Brings Slack deliver to parity with Telegram webhook and Twilio webhook handlers which already have this pattern
- Prevents spurious 503s when credentials are available but not yet cached

Part of plan: fix-webhook-cred-race.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
