### PR TITLE
fix(gateway): await credential watcher startup before Telegram/Slack reconciliation

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -832,13 +832,6 @@ async function main() {
     });
   }
 
-  if (isTelegramConfigured()) {
-    registerTelegramCommands();
-    reconcileTelegramWebhook(config, telegramCaches).catch((err) => {
-      log.error({ err }, "Failed to reconcile Telegram webhook on startup");
-    });
-  }
-
   // ── Slack Socket Mode lifecycle ──
   let slackSocketClient: SlackSocketModeClient | null = null;
 
@@ -884,12 +877,6 @@ async function main() {
     log.info("Slack Socket Mode client started");
   }
 
-  if (slackReady) {
-    startSlackSocket().catch((err) => {
-      log.error({ err }, "Failed to start Slack Socket Mode on startup");
-    });
-  }
-
   const credentialWatcher = new CredentialWatcher((event) => {
     const changed = detectCredentialChanges(event, log);
 
@@ -932,7 +919,21 @@ async function main() {
     }
   });
 
-  credentialWatcher.start();
+  await credentialWatcher.start();
+
+  // ── Startup side effects (run after credential watcher initial poll) ──
+  if (isTelegramConfigured()) {
+    registerTelegramCommands();
+    reconcileTelegramWebhook(config, telegramCaches).catch((err) => {
+      log.error({ err }, "Failed to reconcile Telegram webhook on startup");
+    });
+  }
+
+  if (slackReady) {
+    startSlackSocket().catch((err) => {
+      log.error({ err }, "Failed to start Slack Socket Mode on startup");
+    });
+  }
 
   const configFileWatcher = new ConfigFileWatcher((event) => {
     // Invalidate the config file cache so subsequent reads pick up fresh values


### PR DESCRIPTION
## Summary
- Reorder gateway startup so `credentialWatcher.start()` is awaited before checking readiness flags
- Move Telegram startup reconciliation and Slack Socket Mode startup to after the credential watcher has completed its initial poll
- This fixes the race condition where `telegramReady`/`slackReady` were always false during startup because the watcher hadn't polled yet

Part of plan: fix-webhook-cred-race.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
