### PR TITLE
fix(gateway): remove redundant startup side effects that double-fire with credential watcher callback

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -919,21 +919,10 @@ async function main() {
     }
   });
 
+  // The credential watcher callback handles startup side effects (Telegram
+  // webhook reconciliation, Slack Socket Mode) during the initial poll, so no
+  // additional post-start triggers are needed here.
   await credentialWatcher.start();
-
-  // ── Startup side effects (run after credential watcher initial poll) ──
-  if (isTelegramConfigured()) {
-    registerTelegramCommands();
-    reconcileTelegramWebhook(config, telegramCaches).catch((err) => {
-      log.error({ err }, "Failed to reconcile Telegram webhook on startup");
-    });
-  }
-
-  if (slackReady) {
-    startSlackSocket().catch((err) => {
-      log.error({ err }, "Failed to start Slack Socket Mode on startup");
-    });
-  }
 
   const configFileWatcher = new ConfigFileWatcher((event) => {
     // Invalidate the config file cache so subsequent reads pick up fresh values


### PR DESCRIPTION
## Summary
Fixes a double-fire bug introduced by PR #14249. When credentials exist at boot, `await credentialWatcher.start()` fires the callback (which triggers Telegram reconciliation and Slack socket start), then the post-await startup block fires them again. This removes the redundant post-await block since the callback is the canonical trigger for these side effects.

**Gap:** Double-fire of startup side effects when credentials exist at boot
**What was expected:** Side effects fire exactly once on boot
**What was found:** Both callback and post-await block fire the same effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
