### PR TITLE
fix(gateway): remove redundant Telegram startup block that double-fires after awaited credential watcher

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -841,13 +841,6 @@ async function main() {
     });
   }
 
-  if (isTelegramConfigured()) {
-    registerTelegramCommands();
-    reconcileTelegramWebhook(telegramCaches).catch((err) => {
-      log.error({ err }, "Failed to reconcile Telegram webhook on startup");
-    });
-  }
-
   // ── Slack Socket Mode lifecycle ──
   let slackSocketClient: SlackSocketModeClient | null = null;
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for ttl-config-cache-gap-closure-plan.md.

**Gap:** Double execution of Telegram startup side effects
**What was expected:** Telegram commands and webhook reconciliation fire once on startup
**What was found:** Both the credential watcher callback and a now-live startup block fire, causing double API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
