### PR TITLE
fix(gateway): include configFile in Slack deliver force-refresh test

### DIFF
--- a/gateway/src/__tests__/slack-deliver.test.ts
+++ b/gateway/src/__tests__/slack-deliver.test.ts
@@ -342,6 +342,7 @@ describe("slack-deliver endpoint", () => {
 
     const handler = createSlackDeliverHandler(makeConfig(), undefined, {
       credentials,
+      configFile: makeConfigFile(),
     });
     const req = makeRequest({ chatId: "C123", text: "hello" });
     const res = await handler(req);


### PR DESCRIPTION
## Summary
- The force-refresh credential cache test was missing `configFile: makeConfigFile()` in its caches object, so the auth bypass (`deliverAuthBypass: true`) was not active, causing the handler to return 401 instead of 200.

## Original prompt
fix CI for https://github.com/vellum-ai/vellum-assistant/actions/runs/22811696122

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
