### PR TITLE
refactor(assistant): remove GATEWAY_BASE_URL env injection from safe-env

### DIFF
--- a/assistant/src/__tests__/host-shell-tool.test.ts
+++ b/assistant/src/__tests__/host-shell-tool.test.ts
@@ -500,32 +500,23 @@ describe("host_bash — environment setup", () => {
     expect(result.content.trim()).not.toBe("HOME=");
   });
 
-  test("injects INTERNAL_GATEWAY_BASE_URL and GATEWAY_BASE_URL for host_bash commands", async () => {
+  test("injects INTERNAL_GATEWAY_BASE_URL for host_bash commands", async () => {
     const originalGatewayBase = process.env.GATEWAY_INTERNAL_BASE_URL;
-    const originalIngressBase = process.env.INGRESS_PUBLIC_BASE_URL;
     process.env.GATEWAY_INTERNAL_BASE_URL = "http://gateway.internal:9000/";
-    process.env.INGRESS_PUBLIC_BASE_URL = "https://gw.example.com/";
     try {
       const result = await hostShellTool.execute(
         {
-          command: 'echo "$INTERNAL_GATEWAY_BASE_URL|$GATEWAY_BASE_URL"',
+          command: 'echo "$INTERNAL_GATEWAY_BASE_URL"',
         },
         makeContext(),
       );
       expect(result.isError).toBe(false);
-      expect(result.content.trim()).toBe(
-        "http://gateway.internal:9000|https://gw.example.com",
-      );
+      expect(result.content.trim()).toBe("http://gateway.internal:9000");
     } finally {
       if (originalGatewayBase === undefined) {
         delete process.env.GATEWAY_INTERNAL_BASE_URL;
       } else {
         process.env.GATEWAY_INTERNAL_BASE_URL = originalGatewayBase;
-      }
-      if (originalIngressBase === undefined) {
-        delete process.env.INGRESS_PUBLIC_BASE_URL;
-      } else {
-        process.env.INGRESS_PUBLIC_BASE_URL = originalIngressBase;
       }
     }
   });

--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -464,16 +464,6 @@ describe("buildSanitizedEnv", () => {
     delete process.env.GATEWAY_INTERNAL_BASE_URL;
   });
 
-  test("injects GATEWAY_BASE_URL from public ingress when configured", () => {
-    process.env.GATEWAY_INTERNAL_BASE_URL = "http://gateway.internal:9000/";
-    process.env.INGRESS_PUBLIC_BASE_URL = "https://gw.example.com/";
-    const env = buildSanitizedEnv();
-    expect(env.INTERNAL_GATEWAY_BASE_URL).toBe("http://gateway.internal:9000");
-    expect(env.GATEWAY_BASE_URL).toBe("https://gw.example.com");
-    delete process.env.GATEWAY_INTERNAL_BASE_URL;
-    delete process.env.INGRESS_PUBLIC_BASE_URL;
-  });
-
   test("result is a plain object with no prototype-inherited secrets", () => {
     const env = buildSanitizedEnv();
     const keys = Object.keys(env);
@@ -497,7 +487,6 @@ describe("buildSanitizedEnv", () => {
       "GPG_TTY",
       "GNUPGHOME",
       "INTERNAL_GATEWAY_BASE_URL",
-      "GATEWAY_BASE_URL",
     ];
     for (const key of keys) {
       expect(safeKeys).toContain(key);

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -2248,7 +2248,6 @@ describe("buildSanitizedEnv — baseline: credential exclusion", () => {
       "GPG_TTY",
       "GNUPGHOME",
       "INTERNAL_GATEWAY_BASE_URL",
-      "GATEWAY_BASE_URL",
     ];
 
     const env = buildSanitizedEnv();

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -5,10 +5,7 @@
  *
  * Shared by the sandbox bash tool and skill sandbox runner.
  */
-import {
-  getGatewayInternalBaseUrl,
-  getIngressPublicBaseUrl,
-} from "../../config/env.js";
+import { getGatewayInternalBaseUrl } from "../../config/env.js";
 
 const SAFE_ENV_VARS = [
   "PATH",
@@ -41,9 +38,5 @@ export function buildSanitizedEnv(): Record<string, string> {
   // Always inject an internal gateway base for local control-plane/API calls.
   const internalGatewayBase = getGatewayInternalBaseUrl();
   env.INTERNAL_GATEWAY_BASE_URL = internalGatewayBase;
-  // Inject a public gateway base when ingress is configured; otherwise fall
-  // back to the internal base so commands remain functional in local-only mode.
-  const publicGatewayBase = getIngressPublicBaseUrl()?.replace(/\/+$/, "");
-  env.GATEWAY_BASE_URL = publicGatewayBase || internalGatewayBase;
   return env;
 }

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -30,7 +30,7 @@ All assistant API requests from clients, CLI, skills, and user-facing tooling **
 
 **SKILL.md proxied outbound pattern:** For outbound third-party API calls from skills that require stored credentials, default to `bash` with `network_mode: "proxied"` and `credential_ids` instead of manual token/keychain plumbing. This keeps credentials out of chat and enforces credential policies consistently.
 
-**SKILL.md gateway URL pattern:** For gateway control-plane writes/actions that are not exposed through a CLI read command, use `$INTERNAL_GATEWAY_BASE_URL` (injected by `bash` and `host_bash`). `$GATEWAY_BASE_URL` is also injected and resolves to the configured public ingress URL when set (falling back to the internal gateway target). Do not hardcode `localhost`/ports in skill examples, and do not instruct users/agents to manually export either variable from Settings.
+**SKILL.md gateway URL pattern:** For gateway control-plane writes/actions that are not exposed through a CLI read command, use `$INTERNAL_GATEWAY_BASE_URL` (injected by `bash` and `host_bash`). Do not hardcode `localhost`/ports in skill examples, and do not instruct users/agents to manually export the variable from Settings. For public ingress URLs (e.g. OAuth redirect URIs, webhook registration), use `assistant config get ingress.publicBaseUrl` or load the `public-ingress` skill — do not inject public URLs as environment variables.
 
 ### Channel Identity Vocabulary
 


### PR DESCRIPTION
## Summary
- Remove `GATEWAY_BASE_URL` injection from `buildSanitizedEnv()` — skills should use `assistant config get ingress.publicBaseUrl` or the `public-ingress` skill for public URLs instead of an env var
- Update `gateway/AGENTS.md` to document the CLI-based pattern for public ingress URLs
- Remove associated tests for the deleted env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
