### PR TITLE
fix: adjust import.meta.dirname relative paths after cli/commands/ move

### DIFF
--- a/assistant/src/cli/commands/dev.ts
+++ b/assistant/src/cli/commands/dev.ts
@@ -95,7 +95,7 @@ Examples:
         }
       }
 
-      const mainPath = `${import.meta.dirname}/../daemon/main.ts`;
+      const mainPath = `${import.meta.dirname}/../../daemon/main.ts`;
 
       const useWatch = opts.watch === true;
       log.info(
@@ -104,7 +104,7 @@ Examples:
         } (Ctrl+C to stop)`,
       );
 
-      const repoRoot = join(import.meta.dirname, "..", "..", "..");
+      const repoRoot = join(import.meta.dirname, "..", "..", "..", "..");
       const args = useWatch ? ["--watch", "run", mainPath] : ["run", mainPath];
       const child = spawn("bun", args, {
         stdio: "inherit",

--- a/assistant/src/cli/commands/doctor.ts
+++ b/assistant/src/cli/commands/doctor.ts
@@ -325,7 +325,7 @@ Examples:
       const missingWasm: string[] = [];
       for (const wasm of wasmFiles) {
         const dir = import.meta.dirname ?? __dirname;
-        let fullPath = `${dir}/../../node_modules/${wasm.pkg}/${wasm.file}`;
+        let fullPath = `${dir}/../../../node_modules/${wasm.pkg}/${wasm.file}`;
         // In compiled binaries, fall back to Resources/ or next to the binary
         if (!existsSync(fullPath) && dir.startsWith("/$bunfs/")) {
           const { dirname: pathDirname, join: pathJoin } =

--- a/assistant/src/cli/commands/skills.ts
+++ b/assistant/src/cli/commands/skills.ts
@@ -37,8 +37,8 @@ function getSkillsIndexPath(): string {
 function getRepoSkillsDir(): string | undefined {
   if (!process.env.VELLUM_DEV) return undefined;
 
-  // assistant/src/cli/skills.ts -> ../../../skills/
-  const candidate = join(import.meta.dir, "..", "..", "..", "skills");
+  // assistant/src/cli/commands/skills.ts -> ../../../../skills/
+  const candidate = join(import.meta.dir, "..", "..", "..", "..", "skills");
   if (existsSync(join(candidate, "catalog.json"))) {
     return candidate;
   }


### PR DESCRIPTION
Addresses feedback from PR #14209. Fixes broken relative paths in dev.ts, doctor.ts, and skills.ts after files were moved from cli/ to cli/commands/.

## Changes

- **dev.ts**: Fixed daemon `main.ts` path (`../daemon/main.ts` -> `../../daemon/main.ts`) and `repoRoot` calculation (added one more `..` to resolve to actual repo root instead of `assistant/`)
- **doctor.ts**: Fixed WASM `node_modules` path (`../../node_modules/` -> `../../../node_modules/`) to correctly resolve to `assistant/node_modules/`
- **skills.ts**: Fixed repo skills directory path (added one more `..` to resolve to repo-level `skills/` instead of `assistant/skills/`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
