### PR TITLE
fix: handle '(not set)' literal from config get in contacts skill

### DIFF
--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -194,7 +194,7 @@ fi
 # Prefer backend-provided canonical link when available.
 if [ -z "$INVITE_URL" ]; then
   BOT_USERNAME=$(assistant config get telegram.botUsername)
-  if [ -z "$BOT_USERNAME" ]; then
+  if [ -z "$BOT_USERNAME" ] || [ "$BOT_USERNAME" = "(not set)" ]; then
     echo "error:no_share_url_or_bot_username"
     exit 1
   fi


### PR DESCRIPTION
Addresses feedback from PR #14208.

The contacts SKILL.md reads `BOT_USERNAME` via `assistant config get telegram.botUsername`, but that command prints the literal string `(not set)` when the key is missing. The `-z` check passes for this non-empty string, producing an invalid link like `https://t.me/(not set)?start=...`. This fix adds a check for the `(not set)` literal so the fallback correctly errors with `error:no_share_url_or_bot_username`.

The dead code cleanup (`asRecord`/`gatewayPost` in `cli/gateway-client.ts`) was already addressed in PR #14213 which deleted the entire file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
