### PR TITLE
fix: restore workspace metadata storage and app_token validation in slack-app-setup skill

### DIFF
--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -237,6 +237,10 @@ Examples:
       "--allowed-tools <tools>",
       "Comma-separated tool names that may use this credential",
     )
+    .option(
+      "--account-info <json>",
+      "JSON string of account metadata to associate with this credential",
+    )
     .addHelpText(
       "after",
       `
@@ -250,13 +254,19 @@ updated with any provided flags. Omitted flags leave existing metadata intact.
 Examples:
   $ assistant credentials set twilio:account_sid AC1234567890
   $ assistant credentials set fal:api_key key_live_abc --label "fal-prod" --description "Image generation"
-  $ assistant credentials set github:token ghp_abc --allowed-tools "bash,host_bash"`,
+  $ assistant credentials set github:token ghp_abc --allowed-tools "bash,host_bash"
+  $ assistant credentials set slack_channel:bot_token xoxb-abc --account-info '{"teamId":"T123","teamName":"My Workspace"}'`,
     )
     .action(
       async (
         name: string,
         value: string,
-        opts: { label?: string; description?: string; allowedTools?: string },
+        opts: {
+          label?: string;
+          description?: string;
+          allowedTools?: string;
+          accountInfo?: string;
+        },
         cmd: Command,
       ) => {
         try {
@@ -293,6 +303,7 @@ Examples:
             alias: opts.label,
             usageDescription: opts.description,
             allowedTools,
+            accountInfo: opts.accountInfo,
           });
 
           writeOutput(cmd, {

--- a/assistant/src/config/bundled-skills/slack-app-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack-app-setup/SKILL.md
@@ -97,6 +97,20 @@ Collect the app token securely:
 
 - Call `credential_store` with `action: "prompt"`, `service: "slack_channel"`, `field: "app_token"`, `label: "App-Level Token"`, `placeholder: "xapp-..."`, `description: "Paste the App-Level Token you just generated"`
 
+After collection, validate the app token format:
+
+```bash
+APP_TOKEN=$(assistant credentials reveal slack_channel:app_token)
+if [[ "$APP_TOKEN" != xapp-* ]]; then
+  echo "ERROR: App token must start with xapp-"
+  assistant credentials delete slack_channel:app_token
+  exit 1
+fi
+echo "App token format valid"
+```
+
+If the token does not start with `xapp-`, inform the user it is invalid, delete it, and ask them to re-enter (repeat the collection above).
+
 ## Step 3: Install App & Collect Bot Token
 
 Tell the user to navigate to **Settings > Install App** in the sidebar, then click **Install to Workspace** and authorize the requested permissions (already pre-configured from the manifest).
@@ -105,7 +119,7 @@ After installation, collect the bot token securely:
 
 - Call `credential_store` with `action: "prompt"`, `service: "slack_channel"`, `field: "bot_token"`, `label: "Bot User OAuth Token"`, `placeholder: "xoxb-..."`, `description: "Paste the Bot User OAuth Token shown after installing"`
 
-## Step 4: Validate Bot Token
+## Step 4: Validate Bot Token & Store Workspace Metadata
 
 ```bash
 BOT_TOKEN=$(assistant credentials reveal slack_channel:bot_token)
@@ -114,7 +128,20 @@ AUTH_RESPONSE=$(curl -sf -X POST "https://slack.com/api/auth.test" \
 echo "$AUTH_RESPONSE" | jq .
 ```
 
-If `ok` is `true`, report the bot username and workspace from the response. If `ok` is `false`, the token is invalid — ask the user to re-enter (repeat Step 3).
+If `ok` is `false`, the token is invalid — ask the user to re-enter (repeat Step 3).
+
+If `ok` is `true`, parse the response and persist workspace metadata so the Settings UI can display the connected bot and workspace:
+
+```bash
+TEAM_ID=$(echo "$AUTH_RESPONSE" | jq -r '.team_id')
+TEAM_NAME=$(echo "$AUTH_RESPONSE" | jq -r '.team')
+BOT_USER_ID=$(echo "$AUTH_RESPONSE" | jq -r '.user_id')
+BOT_USERNAME=$(echo "$AUTH_RESPONSE" | jq -r '.user')
+ACCOUNT_INFO="{\"teamId\":\"$TEAM_ID\",\"teamName\":\"$TEAM_NAME\",\"botUserId\":\"$BOT_USER_ID\",\"botUsername\":\"$BOT_USERNAME\"}"
+assistant credentials set slack_channel:bot_token "$BOT_TOKEN" --account-info "$ACCOUNT_INFO"
+```
+
+Report the bot username and workspace from the response.
 
 Socket Mode connects automatically once both credentials are stored — no further action needed.
 


### PR DESCRIPTION
## Summary
- Added `--account-info` flag to `assistant credentials set` CLI to support persisting JSON account metadata alongside credentials
- Updated slack-app-setup SKILL.md Step 4 to parse `auth.test` response and store workspace metadata (teamId, teamName, botUserId, botUsername) via the new flag, restoring Settings UI display
- Added app_token format validation in Step 2 that checks for the `xapp-` prefix and rejects invalid tokens

Addresses feedback from PR #14204.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
