### PR TITLE
refactor(assistant): read Twilio auth token from credential store, not config

### DIFF
--- a/assistant/src/__tests__/integration-status.test.ts
+++ b/assistant/src/__tests__/integration-status.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const secureKeyValues = new Map<string, string>();
 let mockTwilioAccountSid: string | undefined;
-let mockTwilioAuthToken: string | undefined;
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (account: string) => secureKeyValues.get(account),
@@ -11,7 +10,7 @@ mock.module("../security/secure-keys.js", () => ({
 mock.module("../config/loader.js", () => ({
   loadConfig: () => ({
     twilio: mockTwilioAccountSid
-      ? { accountSid: mockTwilioAccountSid, authToken: mockTwilioAuthToken }
+      ? { accountSid: mockTwilioAccountSid }
       : undefined,
   }),
 }));
@@ -23,7 +22,6 @@ describe("integration-status", () => {
   beforeEach(() => {
     secureKeyValues.clear();
     mockTwilioAccountSid = undefined;
-    mockTwilioAuthToken = undefined;
   });
 
   describe("getIntegrationSummary", () => {
@@ -43,7 +41,7 @@ describe("integration-status", () => {
       secureKeyValues.set("credential:integration:twitter:access_token", "tok");
       secureKeyValues.set("credential:integration:slack:access_token", "tok");
       mockTwilioAccountSid = "sid";
-      mockTwilioAuthToken = "auth";
+      secureKeyValues.set("credential:twilio:auth_token", "auth");
       secureKeyValues.set("credential:telegram:bot_token", "tok");
       secureKeyValues.set("credential:telegram:webhook_secret", "secret");
 
@@ -55,7 +53,7 @@ describe("integration-status", () => {
 
     test("returns mixed status", () => {
       mockTwilioAccountSid = "sid";
-      mockTwilioAuthToken = "auth";
+      secureKeyValues.set("credential:twilio:auth_token", "auth");
       secureKeyValues.set("credential:telegram:bot_token", "tok");
       secureKeyValues.set("credential:telegram:webhook_secret", "secret");
 
@@ -100,7 +98,7 @@ describe("integration-status", () => {
   describe("formatIntegrationSummary", () => {
     test("shows checkmarks and crosses", () => {
       mockTwilioAccountSid = "sid";
-      mockTwilioAuthToken = "auth";
+      secureKeyValues.set("credential:twilio:auth_token", "auth");
       secureKeyValues.set("credential:telegram:bot_token", "tok");
       secureKeyValues.set("credential:telegram:webhook_secret", "secret");
 
@@ -122,7 +120,7 @@ describe("integration-status", () => {
       secureKeyValues.set("credential:integration:twitter:access_token", "tok");
       secureKeyValues.set("credential:integration:slack:access_token", "tok");
       mockTwilioAccountSid = "sid";
-      mockTwilioAuthToken = "auth";
+      secureKeyValues.set("credential:twilio:auth_token", "auth");
       secureKeyValues.set("credential:telegram:bot_token", "tok");
       secureKeyValues.set("credential:telegram:webhook_secret", "secret");
 

--- a/assistant/src/__tests__/twilio-provider.test.ts
+++ b/assistant/src/__tests__/twilio-provider.test.ts
@@ -35,7 +35,7 @@ let mockAccountSid: string | undefined = "AC_test_account";
 
 mock.module("../config/loader.js", () => ({
   loadConfig: () => ({
-    twilio: { accountSid: mockAccountSid, authToken: mockAuthToken },
+    twilio: { accountSid: mockAccountSid },
   }),
 }));
 

--- a/assistant/src/calls/twilio-config.ts
+++ b/assistant/src/calls/twilio-config.ts
@@ -4,6 +4,7 @@ import {
   getPublicBaseUrl,
   getTwilioRelayUrl,
 } from "../inbound/public-ingress-urls.js";
+import { getSecureKey } from "../security/secure-keys.js";
 import { ConfigError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 
@@ -44,7 +45,7 @@ export function resolveTwilioPhoneNumber(): string {
 export function getTwilioConfig(): TwilioConfig {
   const config = loadConfig();
   const accountSid = config.twilio?.accountSid || "";
-  const authToken = config.twilio?.authToken || "";
+  const authToken = getSecureKey("credential:twilio:auth_token") || "";
   const phoneNumber = resolveTwilioPhoneNumber();
   const webhookBaseUrl = getPublicBaseUrl(config);
 
@@ -57,7 +58,7 @@ export function getTwilioConfig(): TwilioConfig {
 
   if (!accountSid || !authToken) {
     throw new ConfigError(
-      "Twilio credentials not configured. Set twilio.accountSid and twilio.authToken via config.",
+      "Twilio credentials not configured. Set twilio.accountSid via config and store auth token via credential store.",
     );
   }
   if (!phoneNumber) {

--- a/assistant/src/calls/twilio-provider.ts
+++ b/assistant/src/calls/twilio-provider.ts
@@ -1,6 +1,6 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 
-import { loadConfig } from "../config/loader.js";
+import { getSecureKey } from "../security/secure-keys.js";
 import { ProviderError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -275,17 +275,12 @@ export class TwilioConversationRelayProvider implements VoiceProvider {
   // ── Webhook signature verification ──────────────────────────────────
 
   /**
-   * Returns the Twilio auth token from config, or null if not configured.
+   * Returns the Twilio auth token from the credential store, or null if not configured.
    * Exposed as a static method so callers (e.g. the HTTP server webhook
    * middleware) can check availability independently.
    */
   static getAuthToken(): string | null {
-    try {
-      const config = loadConfig();
-      return config.twilio?.authToken || null;
-    } catch {
-      return null;
-    }
+    return getSecureKey("credential:twilio:auth_token") || null;
   }
 
   /**

--- a/assistant/src/calls/twilio-rest.ts
+++ b/assistant/src/calls/twilio-rest.ts
@@ -7,6 +7,7 @@
  */
 
 import { loadConfig } from "../config/loader.js";
+import { getSecureKey } from "../security/secure-keys.js";
 import { ConfigError, ProviderError } from "../util/errors.js";
 
 export interface TwilioCredentials {
@@ -25,14 +26,18 @@ function resolveAccountSid(): string | undefined {
   }
 }
 
-/** Resolve Twilio credentials from config. Throws if not configured. */
+/** Resolve the Twilio Auth Token from the credential store. */
+function resolveAuthToken(): string | undefined {
+  return getSecureKey("credential:twilio:auth_token") || undefined;
+}
+
+/** Resolve Twilio credentials from config (SID) and credential store (token). Throws if not configured. */
 export function getTwilioCredentials(): TwilioCredentials {
   const accountSid = resolveAccountSid();
-  const config = loadConfig();
-  const authToken = config.twilio?.authToken || undefined;
+  const authToken = resolveAuthToken();
   if (!accountSid || !authToken) {
     throw new ConfigError(
-      "Twilio credentials not configured. Set twilio.accountSid and twilio.authToken via config.",
+      "Twilio credentials not configured. Set twilio.accountSid via config and store auth token via credential store.",
     );
   }
   return { accountSid, authToken };
@@ -41,8 +46,7 @@ export function getTwilioCredentials(): TwilioCredentials {
 /** Check whether Twilio credentials are present (non-throwing). */
 export function hasTwilioCredentials(): boolean {
   try {
-    const config = loadConfig();
-    return !!resolveAccountSid() && !!config.twilio?.authToken;
+    return !!resolveAccountSid() && !!resolveAuthToken();
   } catch {
     return false;
   }

--- a/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/twilio-setup/SKILL.md
@@ -11,14 +11,14 @@ You are helping your user configure Twilio for voice calls. Walk through each st
 
 Before you begin, understand how each Twilio value is stored:
 
-| Value        | Type              | Storage method                                | Secret? |
-| ------------ | ----------------- | --------------------------------------------- | ------- |
-| Account SID  | Config            | `assistant config set twilio.accountSid`      | No      |
-| Auth Token   | Credential+Config | `credential_store` prompt, then sync to config | **Yes** |
-| Phone Number | Config            | `assistant config set twilio.phoneNumber`     | No      |
+| Value        | Type       | Storage method                                | Secret? |
+| ------------ | ---------- | --------------------------------------------- | ------- |
+| Account SID  | Config     | `assistant config set twilio.accountSid`      | No      |
+| Auth Token   | Credential | `assistant credentials set twilio:auth_token` | **Yes** |
+| Phone Number | Config     | `assistant config set twilio.phoneNumber`     | No      |
 
 - **Config values** (Account SID, Phone Number) are non-sensitive identifiers. Collect them via normal conversation -- the user can paste them in chat or you can use `AskUserQuestion`.
-- **Auth Token** is a secret. Collect it securely via `credential_store` prompt -- never accept it pasted in plaintext chat. After storing in the credential vault, you MUST also sync it to config so the voice calling system can read it (see Step 2).
+**Auth Token** is a secret. Collect it securely via `credential_store` prompt -- never accept it pasted in plaintext chat.
 
 ## Retrieving Twilio Credentials
 
@@ -26,7 +26,7 @@ Many steps below require the Account SID and Auth Token. Retrieve them with:
 
 ```bash
 TWILIO_SID=$(assistant config get twilio.accountSid)
-TWILIO_TOKEN=$(assistant config get twilio.authToken)
+TWILIO_TOKEN=$(assistant credentials reveal twilio:auth_token)
 ```
 
 # Checking Current Configuration
@@ -35,7 +35,7 @@ You can determine whether Twilio has been fully set up by checking to see that a
 
 ```bash
 assistant config get twilio.accountSid
-assistant config get twilio.authToken
+assistant credentials inspect twilio:auth_token --json  # check "hasSecret" field
 assistant config get twilio.phoneNumber
 ```
 
@@ -73,16 +73,10 @@ Ask the user for their Auth Token. This IS a secret value, so the user should be
 
 - Call `credential_store` with `action: "prompt"`, `service: "twilio"`, `field: "auth_token"`, `label: "Twilio Auth Token"`, `description: "Enter your Auth Token from the Twilio Console dashboard (click 'Show' to reveal it)"`, `placeholder: "your_auth_token"`.
 
-After the credential is stored, sync it to config so the voice calling system can find it:
-
-```bash
-assistant config set twilio.authToken "$(assistant credentials reveal twilio:auth_token)"
-```
-
 Confirm it has been stored successfully:
 
 ```bash
-assistant config get twilio.authToken
+assistant credentials inspect "twilio:auth_token"
 ```
 
 If credentials are invalid, Twilio API calls in Step 3 will fail -- ask the user to re-enter.
@@ -156,7 +150,7 @@ Retrieve credentials and config values:
 
 ```bash
 TWILIO_SID=$(assistant config get twilio.accountSid)
-TWILIO_TOKEN=$(assistant config get twilio.authToken)
+TWILIO_TOKEN=$(assistant credentials reveal twilio:auth_token)
 PUBLIC_URL=$(assistant config get ingress.publicBaseUrl)
 PHONE_NUMBER=$(assistant config get twilio.phoneNumber)
 ```
@@ -185,7 +179,6 @@ To disconnect Twilio:
 ```bash
 assistant credentials delete twilio:auth_token
 assistant config set twilio.accountSid ""
-assistant config set twilio.authToken ""
 ```
 
 Phone number assignments are preserved. Voice calls will stop until credentials are reconfigured.
@@ -220,7 +213,7 @@ Webhooks on the Twilio phone number may not match the current ingress URL. This 
 
 ```bash
 TWILIO_SID=$(assistant config get twilio.accountSid)
-TWILIO_TOKEN=$(assistant config get twilio.authToken)
+TWILIO_TOKEN=$(assistant credentials reveal twilio:auth_token)
 PUBLIC_URL=$(assistant config get ingress.publicBaseUrl)
 PHONE_NUMBER=$(assistant config get twilio.phoneNumber)
 

--- a/assistant/src/config/schemas/channels.ts
+++ b/assistant/src/config/schemas/channels.ts
@@ -4,9 +4,6 @@ export const TwilioConfigSchema = z.object({
   accountSid: z
     .string({ error: "twilio.accountSid must be a string" })
     .default(""),
-  authToken: z
-    .string({ error: "twilio.authToken must be a string" })
-    .default(""),
   phoneNumber: z
     .string({ error: "twilio.phoneNumber must be a string" })
     .default(""),

--- a/assistant/src/runtime/middleware/twilio-validation.ts
+++ b/assistant/src/runtime/middleware/twilio-validation.ts
@@ -73,8 +73,8 @@ export async function validateTwilioWebhook(
 
   if (!authToken) {
     log.error(
-      "Twilio auth token not found in config — cannot verify webhook HMAC signature. " +
-        "Rejecting request. Set twilio.authToken via config.",
+      "Twilio auth token not found in credential store — cannot verify webhook HMAC signature. " +
+        "Rejecting request. Store auth token via credential store (twilio:auth_token).",
     );
     return httpError("FORBIDDEN", "Forbidden", 403);
   }

--- a/assistant/src/runtime/routes/integrations/twilio.ts
+++ b/assistant/src/runtime/routes/integrations/twilio.ts
@@ -164,7 +164,6 @@ export async function handleSetTwilioCredentials(
   const raw = loadRawConfig();
   const twilio = (raw?.twilio ?? {}) as Record<string, unknown>;
   twilio.accountSid = body.accountSid;
-  twilio.authToken = body.authToken;
   saveRawConfig({ ...raw, twilio });
 
   upsertCredentialMetadata("twilio", "account_sid", {
@@ -220,7 +219,6 @@ export async function handleClearTwilioCredentials(): Promise<Response> {
   const raw = loadRawConfig();
   const twilio = (raw?.twilio ?? {}) as Record<string, unknown>;
   delete twilio.accountSid;
-  delete twilio.authToken;
   saveRawConfig({ ...raw, twilio });
 
   deleteCredentialMetadata("twilio", "account_sid");


### PR DESCRIPTION
## Summary
- Remove `authToken` from `TwilioConfigSchema` — the auth token is a secret and should only live in the credential store, not in plaintext config
- Update all runtime code (`twilio-rest.ts`, `twilio-config.ts`, `twilio-provider.ts`) to read the auth token via `getSecureKey("credential:twilio:auth_token")` instead of `config.twilio?.authToken`
- Revert SKILL.md changes from #14126 so the twilio-setup skill documents auth token as a credential-only value (using `assistant credentials reveal/inspect` instead of `assistant config get`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
