### PR TITLE
feat(gateway): add Telegram editMessageText support and return message_id from sends

### DIFF
--- a/gateway/src/http/routes/telegram-deliver.ts
+++ b/gateway/src/http/routes/telegram-deliver.ts
@@ -5,6 +5,7 @@ import { getLogger } from "../../logger.js";
 import { checkDeliverAuth } from "../middleware/deliver-auth.js";
 import type { RuntimeAttachmentMeta } from "../../runtime/client.js";
 import {
+  editTelegramMessage,
   sendTelegramAttachments,
   sendTelegramReply,
   sendTypingIndicator,
@@ -49,6 +50,7 @@ export function createTelegramDeliverHandler(
       attachments?: RuntimeAttachmentMeta[];
       approval?: ApprovalPayload;
       chatAction?: "typing";
+      messageId?: number;
     };
     try {
       body = (await req.json()) as typeof body;
@@ -63,10 +65,23 @@ export function createTelegramDeliverHandler(
       attachments,
       approval,
       chatAction,
+      messageId,
     } = body;
 
     if (!chatId || typeof chatId !== "string") {
       return Response.json({ error: "chatId is required" }, { status: 400 });
+    }
+
+    if (
+      messageId !== undefined &&
+      (typeof messageId !== "number" ||
+        !Number.isInteger(messageId) ||
+        messageId <= 0)
+    ) {
+      return Response.json(
+        { error: "messageId must be a positive integer" },
+        { status: 400 },
+      );
     }
 
     if (chatAction !== undefined && chatAction !== "typing") {
@@ -181,13 +196,32 @@ export function createTelegramDeliverHandler(
       ? { credentials: caches.credentials, configFile: caches.configFile }
       : undefined;
 
+    let sendMessageId: number | undefined;
     try {
       if (chatAction === "typing") {
         await sendTypingIndicator(config, chatId, credentialOpts);
       }
 
       if (text) {
-        await sendTelegramReply(config, chatId, text, approval, credentialOpts);
+        if (messageId !== undefined) {
+          await editTelegramMessage(
+            config,
+            chatId,
+            messageId,
+            text,
+            approval,
+            credentialOpts,
+          );
+        } else {
+          const sendResult = await sendTelegramReply(
+            config,
+            chatId,
+            text,
+            approval,
+            credentialOpts,
+          );
+          sendMessageId = sendResult.messageId;
+        }
       }
 
       if (attachments && attachments.length > 0) {
@@ -212,6 +246,11 @@ export function createTelegramDeliverHandler(
       },
       "Reply sent",
     );
-    return Response.json({ ok: true });
+
+    const responseBody: { ok: true; messageId?: number } = { ok: true };
+    if (sendMessageId !== undefined) {
+      responseBody.messageId = sendMessageId;
+    }
+    return Response.json(responseBody);
   };
 }

--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -12,6 +12,10 @@ import { callTelegramApi, callTelegramApiMultipart } from "./api.js";
 
 const log = getLogger("telegram-send");
 
+export interface TelegramSendResult {
+  messageId: number;
+}
+
 const TELEGRAM_MAX_MESSAGE_LEN = 4000;
 
 /** Telegram Bot API enforces a 1-64 byte limit on InlineKeyboardButton callback_data. */
@@ -51,9 +55,10 @@ export async function sendTelegramReply(
   text: string,
   approval?: ApprovalPayload,
   opts?: { credentials?: CredentialCache; configFile?: ConfigFileCache },
-): Promise<void> {
+): Promise<TelegramSendResult> {
   const chunks = splitText(text, TELEGRAM_MAX_MESSAGE_LEN);
 
+  let lastResult: { message_id: number } | undefined;
   for (let i = 0; i < chunks.length; i++) {
     const payload: Record<string, unknown> = {
       chat_id: chatId,
@@ -66,10 +71,34 @@ export async function sendTelegramReply(
       payload.reply_markup = buildInlineKeyboard(approval);
     }
 
-    await callTelegramApi("sendMessage", payload, opts);
+    lastResult = await callTelegramApi<{ message_id: number }>(
+      "sendMessage",
+      payload,
+      opts,
+    );
   }
 
   log.debug({ chatId, chunks: chunks.length }, "Telegram reply sent");
+  return { messageId: lastResult!.message_id };
+}
+
+export async function editTelegramMessage(
+  config: GatewayConfig,
+  chatId: string,
+  messageId: number,
+  text: string,
+  approval?: ApprovalPayload,
+  opts?: { credentials?: CredentialCache; configFile?: ConfigFileCache },
+): Promise<void> {
+  const payload: Record<string, unknown> = {
+    chat_id: chatId,
+    message_id: messageId,
+    text,
+  };
+  if (approval) {
+    payload.reply_markup = buildInlineKeyboard(approval);
+  }
+  await callTelegramApi("editMessageText", payload, opts);
 }
 
 export async function sendTelegramAttachments(


### PR DESCRIPTION
## Summary
- Add `editTelegramMessage` function for editing existing Telegram messages via `editMessageText` API
- Modify `sendTelegramReply` to return the `message_id` from the Telegram API response
- Update Telegram deliver handler to support message editing when `messageId` is provided, and return `messageId` on new sends

Part of plan: telegram-streaming.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
