### PR TITLE
refactor: stop dual-writing Telegram botUsername to credential metadata

### DIFF
--- a/assistant/src/__tests__/handlers-telegram-config.test.ts
+++ b/assistant/src/__tests__/handlers-telegram-config.test.ts
@@ -344,12 +344,12 @@ describe("Telegram config handler", () => {
     );
     // Verify webhook secret was generated
     expect(secureKeyStore["credential:telegram:webhook_secret"]).toBeDefined();
-    // Verify metadata was stored
-    expect(
-      credentialMetadataStore.find(
-        (m) => m.service === "telegram" && m.field === "bot_token",
-      )?.accountInfo,
-    ).toBe("test_bot");
+    // Verify metadata record exists (for policy checks) without accountInfo
+    const botTokenMeta = credentialMetadataStore.find(
+      (m) => m.service === "telegram" && m.field === "bot_token",
+    );
+    expect(botTokenMeta).toBeDefined();
+    expect(botTokenMeta?.accountInfo).toBeUndefined();
   });
 
   test("set action with invalid token returns error", async () => {

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -148,12 +148,10 @@ export async function setTelegramConfig(
     };
   }
 
-  // Store metadata with bot username (kept for consumers that haven't migrated yet)
-  upsertCredentialMetadata("telegram", "bot_token", {
-    accountInfo: botUsername,
-  });
+  // Store credential metadata record for policy checks
+  upsertCredentialMetadata("telegram", "bot_token", {});
 
-  // Dual-write: persist bot username to config for the new config-based path
+  // Persist bot username to config for the config-based path
   const raw = loadRawConfig();
   setNestedValue(raw, "telegram.botUsername", botUsername);
   saveRawConfig(raw);


### PR DESCRIPTION
## Summary
- Remove accountInfo from Telegram credential metadata upsert call
- Keep credential metadata record for policy checks (without accountInfo)
- Config-based botUsername write remains unchanged

Part of plan: acct-info-to-config.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
