### PR TITLE
feat(assistant): add messageId field to ChannelReplyPayload and ChannelDeliveryResult

### DIFF
--- a/assistant/src/runtime/gateway-client.ts
+++ b/assistant/src/runtime/gateway-client.ts
@@ -31,6 +31,8 @@ export interface ChannelReplyPayload {
   ephemeral?: boolean;
   /** Slack user ID — required when `ephemeral` is true. */
   user?: string;
+  /** Telegram message_id for editing an existing message instead of sending a new one. */
+  messageId?: number;
   /** When provided, instructs the delivery endpoint to update an existing message instead of posting a new one. */
   messageTs?: string;
   /** When true, auto-generate Block Kit blocks from text via textToBlocks(). */
@@ -43,6 +45,8 @@ export interface ChannelDeliveryResult {
   ok: boolean;
   /** The message timestamp returned by the delivery endpoint (e.g. Slack message ts). */
   ts?: string;
+  /** The Telegram message_id returned when a new message was sent. */
+  messageId?: number;
 }
 
 interface ManagedOutboundCallbackContext {
@@ -90,11 +94,14 @@ export async function deliverChannelReply(
     );
   }
 
-  let result: ChannelDeliveryResult = { ok: true };
+  const result: ChannelDeliveryResult = { ok: true };
   try {
     const responseBody = (await response.json()) as Record<string, unknown>;
     if (typeof responseBody.ts === "string") {
-      result = { ok: true, ts: responseBody.ts };
+      result.ts = responseBody.ts;
+    }
+    if (typeof responseBody.messageId === "number") {
+      result.messageId = responseBody.messageId;
     }
   } catch {
     // Response may not be JSON for non-Slack channels; that's fine.


### PR DESCRIPTION
## Summary
- Add optional `messageId` field to `ChannelReplyPayload` for Telegram message editing
- Add optional `messageId` field to `ChannelDeliveryResult` for tracking sent message IDs
- Parse `messageId` from gateway delivery response in `deliverChannelReply`

Part of plan: telegram-streaming.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
