### PR TITLE
refactor: move Slack channel account metadata from credential metadata to config

### DIFF
--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -5,15 +5,53 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const testDir = mkdtempSync(join(tmpdir(), "slack-channel-cfg-test-"));
 
+// In-memory config store for tests
+let configStore: Record<string, unknown> = {};
+
+function setNestedValue(
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): void {
+  const keys = path.split(".");
+  let current = obj;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i];
+    if (current[key] == null || typeof current[key] !== "object") {
+      current[key] = {};
+    }
+    current = current[key] as Record<string, unknown>;
+  }
+  current[keys[keys.length - 1]] = value;
+}
+
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
+    slack: {
+      deliverAuthBypass: false,
+      teamId:
+        ((configStore.slack as Record<string, unknown>)?.teamId as string) ??
+        "",
+      teamName:
+        ((configStore.slack as Record<string, unknown>)?.teamName as string) ??
+        "",
+      botUserId:
+        ((configStore.slack as Record<string, unknown>)?.botUserId as string) ??
+        "",
+      botUsername:
+        ((configStore.slack as Record<string, unknown>)
+          ?.botUsername as string) ?? "",
+    },
   }),
   loadConfig: () => ({}),
-  loadRawConfig: () => ({}),
-  saveRawConfig: () => {},
+  loadRawConfig: () => structuredClone(configStore),
+  saveRawConfig: (raw: Record<string, unknown>) => {
+    configStore = structuredClone(raw);
+  },
   saveConfig: () => {},
   invalidateConfigCache: () => {},
+  setNestedValue,
 }));
 
 mock.module("../util/platform.js", () => ({
@@ -149,6 +187,7 @@ describe("Slack channel config handler", () => {
   beforeEach(() => {
     secureKeyStore = {};
     credentialMetadataStore = [];
+    configStore = {};
     globalThis.fetch = originalFetch;
   });
 
@@ -171,18 +210,16 @@ describe("Slack channel config handler", () => {
     expect(result.connected).toBe(true);
   });
 
-  test("GET returns metadata when available", () => {
+  test("GET returns metadata from config when available", () => {
     secureKeyStore["credential:slack_channel:bot_token"] = "xoxb-test";
-    credentialMetadataStore.push({
-      service: "slack_channel",
-      field: "bot_token",
-      accountInfo: JSON.stringify({
+    configStore = {
+      slack: {
         teamId: "T123",
         teamName: "TestTeam",
         botUserId: "U_BOT",
         botUsername: "testbot",
-      }),
-    });
+      },
+    };
 
     const result = getSlackChannelConfig();
     expect(result.teamId).toBe("T123");
@@ -209,7 +246,7 @@ describe("Slack channel config handler", () => {
     );
   });
 
-  test("POST validates bot token via Slack auth.test API", async () => {
+  test("POST validates bot token via Slack auth.test API and writes config", async () => {
     globalThis.fetch = (async () => {
       return new Response(
         JSON.stringify({
@@ -231,6 +268,13 @@ describe("Slack channel config handler", () => {
     expect(result.hasBotToken).toBe(true);
     expect(result.teamId).toBe("T_TEAM");
     expect(result.teamName).toBe("MyTeam");
+
+    // Assert metadata was written to config (not credential metadata)
+    const slack = configStore.slack as Record<string, unknown>;
+    expect(slack.teamId).toBe("T_TEAM");
+    expect(slack.teamName).toBe("MyTeam");
+    expect(slack.botUserId).toBe("U_BOT");
+    expect(slack.botUsername).toBe("mybot");
   });
 
   test("POST returns error when Slack auth.test rejects bot token", async () => {
@@ -252,7 +296,7 @@ describe("Slack channel config handler", () => {
     expect(result.error).toContain("invalid_auth");
   });
 
-  test("DELETE clears credentials", async () => {
+  test("DELETE clears credentials and config", async () => {
     secureKeyStore["credential:slack_channel:bot_token"] = "xoxb-test";
     secureKeyStore["credential:slack_channel:app_token"] = "xapp-test";
     credentialMetadataStore.push({
@@ -263,6 +307,14 @@ describe("Slack channel config handler", () => {
       service: "slack_channel",
       field: "app_token",
     });
+    configStore = {
+      slack: {
+        teamId: "T123",
+        teamName: "TestTeam",
+        botUserId: "U_BOT",
+        botUsername: "testbot",
+      },
+    };
 
     const result = await clearSlackChannelConfig();
     expect(result.success).toBe(true);
@@ -277,5 +329,12 @@ describe("Slack channel config handler", () => {
       secureKeyStore["credential:slack_channel:app_token"],
     ).toBeUndefined();
     expect(credentialMetadataStore).toHaveLength(0);
+
+    // Assert config values were cleared
+    const slack = configStore.slack as Record<string, unknown>;
+    expect(slack.teamId).toBe("");
+    expect(slack.teamName).toBe("");
+    expect(slack.botUserId).toBe("");
+    expect(slack.botUsername).toBe("");
   });
 });

--- a/assistant/src/config/schemas/channels.ts
+++ b/assistant/src/config/schemas/channels.ts
@@ -64,6 +64,14 @@ export const SlackConfigSchema = z.object({
   deliverAuthBypass: z
     .boolean({ error: "slack.deliverAuthBypass must be a boolean" })
     .default(false),
+  teamId: z.string({ error: "slack.teamId must be a string" }).default(""),
+  teamName: z.string({ error: "slack.teamName must be a string" }).default(""),
+  botUserId: z
+    .string({ error: "slack.botUserId must be a string" })
+    .default(""),
+  botUsername: z
+    .string({ error: "slack.botUsername must be a string" })
+    .default(""),
 });
 
 export type TwilioConfig = z.infer<typeof TwilioConfigSchema>;

--- a/assistant/src/daemon/handlers/config-slack-channel.ts
+++ b/assistant/src/daemon/handlers/config-slack-channel.ts
@@ -1,11 +1,17 @@
 import {
+  getConfig,
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../config/loader.js";
+import {
   deleteSecureKeyAsync,
   getSecureKey,
   setSecureKeyAsync,
 } from "../../security/secure-keys.js";
 import {
   deleteCredentialMetadata,
-  getCredentialMetadata,
   upsertCredentialMetadata,
 } from "../../tools/credentials/metadata-store.js";
 import { log as _log } from "./shared.js";
@@ -25,37 +31,21 @@ export interface SlackChannelConfigResult {
   warning?: string;
 }
 
-// -- Metadata stored as JSON in accountInfo --
-
-interface SlackChannelMetadata {
-  teamId?: string;
-  teamName?: string;
-  botUserId?: string;
-  botUsername?: string;
-}
-
-function parseMetadata(raw: string | undefined): SlackChannelMetadata {
-  if (!raw) return {};
-  try {
-    return JSON.parse(raw) as SlackChannelMetadata;
-  } catch {
-    return {};
-  }
-}
-
 // -- Business logic --
 
 export function getSlackChannelConfig(): SlackChannelConfigResult {
   const hasBotToken = !!getSecureKey("credential:slack_channel:bot_token");
   const hasAppToken = !!getSecureKey("credential:slack_channel:app_token");
-  const meta = getCredentialMetadata("slack_channel", "bot_token");
-  const metadata = parseMetadata(meta?.accountInfo);
+  const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
   return {
     success: true,
     hasBotToken,
     hasAppToken,
     connected: hasBotToken && hasAppToken,
-    ...metadata,
+    ...(teamId ? { teamId } : {}),
+    ...(teamName ? { teamName } : {}),
+    ...(botUserId ? { botUserId } : {}),
+    ...(botUsername ? { botUsername } : {}),
   };
 }
 
@@ -63,7 +53,12 @@ export async function setSlackChannelConfig(
   botToken?: string,
   appToken?: string,
 ): Promise<SlackChannelConfigResult> {
-  let metadata: SlackChannelMetadata = {};
+  let metadata: {
+    teamId?: string;
+    teamName?: string;
+    botUserId?: string;
+    botUsername?: string;
+  } = {};
   let warning: string | undefined;
 
   // Validate and store bot token
@@ -142,13 +137,24 @@ export async function setSlackChannelConfig(
       };
     }
 
-    upsertCredentialMetadata("slack_channel", "bot_token", {
-      accountInfo: JSON.stringify(metadata),
-    });
+    upsertCredentialMetadata("slack_channel", "bot_token", {});
+
+    const raw = loadRawConfig();
+    setNestedValue(raw, "slack.teamId", metadata.teamId ?? "");
+    setNestedValue(raw, "slack.teamName", metadata.teamName ?? "");
+    setNestedValue(raw, "slack.botUserId", metadata.botUserId ?? "");
+    setNestedValue(raw, "slack.botUsername", metadata.botUsername ?? "");
+    saveRawConfig(raw);
+    invalidateConfigCache();
   } else {
-    // Use existing metadata if no new bot token provided
-    const existingMeta = getCredentialMetadata("slack_channel", "bot_token");
-    metadata = parseMetadata(existingMeta?.accountInfo);
+    // Use existing metadata from config if no new bot token provided
+    const { teamId, teamName, botUserId, botUsername } = getConfig().slack;
+    metadata = {
+      ...(teamId ? { teamId } : {}),
+      ...(teamName ? { teamName } : {}),
+      ...(botUserId ? { botUserId } : {}),
+      ...(botUsername ? { botUsername } : {}),
+    };
   }
 
   // Validate and store app token
@@ -231,6 +237,14 @@ export async function clearSlackChannelConfig(): Promise<SlackChannelConfigResul
 
   deleteCredentialMetadata("slack_channel", "bot_token");
   deleteCredentialMetadata("slack_channel", "app_token");
+
+  const raw = loadRawConfig();
+  setNestedValue(raw, "slack.teamId", "");
+  setNestedValue(raw, "slack.teamName", "");
+  setNestedValue(raw, "slack.botUserId", "");
+  setNestedValue(raw, "slack.botUsername", "");
+  saveRawConfig(raw);
+  invalidateConfigCache();
 
   return {
     success: true,

--- a/assistant/src/runtime/channel-invite-transports/slack.ts
+++ b/assistant/src/runtime/channel-invite-transports/slack.ts
@@ -8,7 +8,7 @@
  */
 
 import type { ChannelId } from "../../channels/types.js";
-import { getCredentialMetadata } from "../../tools/credentials/metadata-store.js";
+import { getConfig } from "../../config/loader.js";
 import type { ChannelInviteAdapter } from "../channel-invite-transport.js";
 
 // ---------------------------------------------------------------------------
@@ -21,26 +21,12 @@ interface SlackBotInfo {
 }
 
 /**
- * Resolve the Slack bot username and team name from credential metadata.
- * Mirrors the metadata parsing pattern in `config-slack-channel.ts`.
+ * Resolve the Slack bot username and team name from config.
  */
 function resolveSlackBotInfo(): SlackBotInfo | undefined {
-  const meta = getCredentialMetadata("slack_channel", "bot_token");
-  if (!meta?.accountInfo) return undefined;
-
-  try {
-    const parsed = JSON.parse(meta.accountInfo) as {
-      botUsername?: string;
-      teamName?: string;
-    };
-    if (!parsed.botUsername) return undefined;
-    return {
-      botUsername: parsed.botUsername,
-      teamName: parsed.teamName,
-    };
-  } catch {
-    return undefined;
-  }
+  const { botUsername, teamName } = getConfig().slack;
+  if (!botUsername) return undefined;
+  return { botUsername, teamName: teamName || undefined };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Move Slack workspace metadata (teamId, teamName, botUserId, botUsername) from credential metadata accountInfo to config
- Update getSlackChannelConfig, setSlackChannelConfig, and clearSlackChannelConfig to use config
- Update Slack invite transport to resolve bot info from config

Part of plan: acct-info-to-config.md (PR 1 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
