### PR TITLE
feat(assistant): thread onEvent streaming callback through MessageProcessor to agent loop

### DIFF
--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -141,6 +141,8 @@ export interface SessionCreateOptions {
   strictPrivateSideEffects?: boolean;
   /** Channel command intent metadata (e.g. Telegram /start). */
   commandIntent?: { type: string; payload?: string; languageCode?: string };
+  /** Optional callback to receive real-time agent loop events (text deltas, tool starts, etc.). */
+  onEvent?: (msg: ServerMessage) => void;
 }
 
 /**

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1127,7 +1127,13 @@ export class DaemonServer {
 
     // Register pending interactions so channel approval interception can
     // find the session by requestId when confirmation/secret events fire.
-    const onEvent = makePendingInteractionRegistrar(session, conversationId);
+    const registrar = makePendingInteractionRegistrar(session, conversationId);
+    const onEvent = options?.onEvent
+      ? (msg: ServerMessage) => {
+          registrar(msg);
+          options.onEvent!(msg);
+        }
+      : registrar;
     if (options?.isInteractive === true) {
       // Interactive HTTP paths (e.g. channel ingress) still run without an IPC
       // socket. Route prompter events through the registrar callback so
@@ -1265,7 +1271,13 @@ export class DaemonServer {
 
     // Register pending interactions so channel approval interception can
     // find the session by requestId when confirmation/secret events fire.
-    const onEvent = makePendingInteractionRegistrar(session, conversationId);
+    const registrar = makePendingInteractionRegistrar(session, conversationId);
+    const onEvent = options?.onEvent
+      ? (msg: ServerMessage) => {
+          registrar(msg);
+          options.onEvent!(msg);
+        }
+      : registrar;
     if (options?.isInteractive === true) {
       // Interactive HTTP paths (e.g. channel ingress) still run without an IPC
       // socket. Route prompter events through the registrar callback so

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -2,7 +2,11 @@
  * Shared types for the runtime HTTP server and its route handlers.
  */
 import type { ChannelId, InterfaceId } from "../channels/types.js";
-import type { SurfaceData, SurfaceType } from "../daemon/ipc-contract/surfaces.js";
+import type {
+  SurfaceData,
+  SurfaceType,
+} from "../daemon/ipc-contract/surfaces.js";
+import type { ServerMessage } from "../daemon/ipc-protocol.js";
 import type { Session } from "../daemon/session.js";
 import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import type {
@@ -122,6 +126,8 @@ export interface RuntimeMessageSessionOptions {
   isInteractive?: boolean;
   /** Channel command intent metadata (e.g. Telegram /start). */
   commandIntent?: { type: string; payload?: string; languageCode?: string };
+  /** Optional callback to receive real-time agent loop events (text deltas, tool starts, etc.). */
+  onEvent?: (msg: ServerMessage) => void;
 }
 
 export type MessageProcessor = (


### PR DESCRIPTION
## Summary
- Add optional `onEvent` callback to `RuntimeMessageSessionOptions` for receiving real-time agent loop events
- Add matching `onEvent` field to `SessionCreateOptions` so the callback flows through to the daemon
- Compose the new callback with the existing pending interaction registrar in both `processMessage()` and `persistAndProcessMessage()`
- Enables downstream consumers (e.g. Telegram streaming) to receive text deltas as they're generated

Part of plan: telegram-streaming.md (PR 3 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
