### PR TITLE
refactor: move Twitter accountInfo from credential metadata to config

### DIFF
--- a/assistant/src/__tests__/handlers-twitter-config.test.ts
+++ b/assistant/src/__tests__/handlers-twitter-config.test.ts
@@ -257,16 +257,13 @@ describe("Twitter integration config handler", () => {
   });
 
   test("get action returns correct status when configured and connected", () => {
-    rawConfigStore = { twitter: { integrationMode: "local_byo" } };
+    rawConfigStore = {
+      twitter: { integrationMode: "local_byo", accountInfo: "@testuser" },
+    };
     secureKeyStore["credential:integration:twitter:client_id"] =
       "test-client-id";
     secureKeyStore["credential:integration:twitter:access_token"] =
       "test-access-token";
-    credentialMetadataStore.push({
-      service: "integration:twitter",
-      field: "access_token",
-      accountInfo: "@testuser",
-    });
 
     const msg: TwitterIntegrationConfigRequest = {
       type: "twitter_integration_config",
@@ -392,16 +389,12 @@ describe("Twitter integration config handler", () => {
   });
 
   test("clear_local_client also disconnects if connected", async () => {
+    rawConfigStore = { twitter: { accountInfo: "@testuser" } };
     secureKeyStore["credential:integration:twitter:client_id"] = "my-client-id";
     secureKeyStore["credential:integration:twitter:access_token"] =
       "test-token";
     secureKeyStore["credential:integration:twitter:refresh_token"] =
       "test-refresh";
-    credentialMetadataStore.push({
-      service: "integration:twitter",
-      field: "access_token",
-      accountInfo: "@testuser",
-    });
 
     const msg: TwitterIntegrationConfigRequest = {
       type: "twitter_integration_config",
@@ -426,23 +419,17 @@ describe("Twitter integration config handler", () => {
     expect(
       secureKeyStore["credential:integration:twitter:refresh_token"],
     ).toBeUndefined();
-    expect(deletedMetadata).toContainEqual({
-      service: "integration:twitter",
-      field: "access_token",
-    });
+    // accountInfo should be cleared from config
+    expect(getNestedValue(rawConfigStore, "twitter.accountInfo")).toBe("");
   });
 
-  test("disconnect removes tokens and metadata", async () => {
+  test("disconnect removes tokens and clears accountInfo from config", async () => {
+    rawConfigStore = { twitter: { accountInfo: "@testuser" } };
     secureKeyStore["credential:integration:twitter:client_id"] = "my-client-id";
     secureKeyStore["credential:integration:twitter:access_token"] =
       "test-token";
     secureKeyStore["credential:integration:twitter:refresh_token"] =
       "test-refresh";
-    credentialMetadataStore.push({
-      service: "integration:twitter",
-      field: "access_token",
-      accountInfo: "@testuser",
-    });
 
     const msg: TwitterIntegrationConfigRequest = {
       type: "twitter_integration_config",
@@ -473,10 +460,8 @@ describe("Twitter integration config handler", () => {
     expect(secureKeyStore["credential:integration:twitter:client_id"]).toBe(
       "my-client-id",
     );
-    expect(deletedMetadata).toContainEqual({
-      service: "integration:twitter",
-      field: "access_token",
-    });
+    // accountInfo should be cleared from config
+    expect(getNestedValue(rawConfigStore, "twitter.accountInfo")).toBe("");
   });
 
   test("set_local_client returns error when setSecureKey fails for client ID", async () => {
@@ -750,6 +735,7 @@ describe("Twitter integration config handler", () => {
 
   test("disconnect preserves client credentials when access token exists", async () => {
     // Set up both client credentials and tokens
+    rawConfigStore = { twitter: { accountInfo: "@connected_user" } };
     secureKeyStore["credential:integration:twitter:client_id"] = "my-client-id";
     secureKeyStore["credential:integration:twitter:client_secret"] =
       "my-client-secret";
@@ -757,11 +743,6 @@ describe("Twitter integration config handler", () => {
       "active-token";
     secureKeyStore["credential:integration:twitter:refresh_token"] =
       "active-refresh";
-    credentialMetadataStore.push({
-      service: "integration:twitter",
-      field: "access_token",
-      accountInfo: "@connected_user",
-    });
 
     const msg: TwitterIntegrationConfigRequest = {
       type: "twitter_integration_config",
@@ -796,15 +777,13 @@ describe("Twitter integration config handler", () => {
     expect(secureKeyStore["credential:integration:twitter:client_secret"]).toBe(
       "my-client-secret",
     );
-    // Metadata deleted
-    expect(deletedMetadata).toContainEqual({
-      service: "integration:twitter",
-      field: "access_token",
-    });
+    // accountInfo cleared from config
+    expect(getNestedValue(rawConfigStore, "twitter.accountInfo")).toBe("");
   });
 
-  test("clear_local_client cascades to remove tokens and metadata", async () => {
-    // Set up client credentials, tokens, and metadata
+  test("clear_local_client cascades to remove tokens and clears accountInfo from config", async () => {
+    // Set up client credentials, tokens, and accountInfo in config
+    rawConfigStore = { twitter: { accountInfo: "@connected_user" } };
     secureKeyStore["credential:integration:twitter:client_id"] = "my-client-id";
     secureKeyStore["credential:integration:twitter:client_secret"] =
       "my-client-secret";
@@ -812,11 +791,6 @@ describe("Twitter integration config handler", () => {
       "active-token";
     secureKeyStore["credential:integration:twitter:refresh_token"] =
       "active-refresh";
-    credentialMetadataStore.push({
-      service: "integration:twitter",
-      field: "access_token",
-      accountInfo: "@connected_user",
-    });
 
     const msg: TwitterIntegrationConfigRequest = {
       type: "twitter_integration_config",
@@ -850,14 +824,12 @@ describe("Twitter integration config handler", () => {
     expect(
       secureKeyStore["credential:integration:twitter:refresh_token"],
     ).toBeUndefined();
-    expect(deletedMetadata).toContainEqual({
-      service: "integration:twitter",
-      field: "access_token",
-    });
+    // accountInfo should be cleared from config
+    expect(getNestedValue(rawConfigStore, "twitter.accountInfo")).toBe("");
   });
 
-  test("get status with partial state — access token but no metadata", () => {
-    // Only access token exists, no credential metadata
+  test("get status with partial state — access token but no accountInfo in config", () => {
+    // Only access token exists, no accountInfo in config
     secureKeyStore["credential:integration:twitter:access_token"] =
       "orphan-token";
 
@@ -938,17 +910,13 @@ describe("Twitter integration config handler", () => {
 
   test("response messages never contain raw credential values", () => {
     // Set up credentials and tokens
+    rawConfigStore = { twitter: { accountInfo: "@testuser" } };
     secureKeyStore["credential:integration:twitter:client_id"] =
       "secret-client-id-abc123";
     secureKeyStore["credential:integration:twitter:client_secret"] =
       "secret-client-secret-xyz789";
     secureKeyStore["credential:integration:twitter:access_token"] =
       "secret-access-token-def456";
-    credentialMetadataStore.push({
-      service: "integration:twitter",
-      field: "access_token",
-      accountInfo: "@testuser",
-    });
 
     const msg: TwitterIntegrationConfigRequest = {
       type: "twitter_integration_config",

--- a/assistant/src/__tests__/twitter-auth-handler.test.ts
+++ b/assistant/src/__tests__/twitter-auth-handler.test.ts
@@ -22,6 +22,23 @@ function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
   return current;
 }
 
+function setNestedValue(
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): void {
+  const keys = path.split(".");
+  let current = obj;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i]!;
+    if (current[key] == null || typeof current[key] !== "object") {
+      current[key] = {};
+    }
+    current = current[key] as Record<string, unknown>;
+  }
+  current[keys[keys.length - 1]!] = value;
+}
+
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
     ui: {},
@@ -34,6 +51,7 @@ mock.module("../config/loader.js", () => ({
   saveConfig: () => {},
   invalidateConfigCache: () => {},
   getNestedValue,
+  setNestedValue,
 }));
 
 mock.module("../inbound/public-ingress-urls.js", () => ({
@@ -294,6 +312,12 @@ describe("Twitter auth handler", () => {
       expect(result).toBeDefined();
       expect(result.success).toBe(true);
       expect(result.accountInfo).toBe("@testuser");
+
+      // accountInfo should be persisted to config, not credential metadata
+      expect(getNestedValue(rawConfigStore, "twitter.accountInfo")).toBe(
+        "@testuser",
+      );
+      expect(credentialMetadataStore).toHaveLength(0);
     });
 
     test("delegates to orchestrateOAuthConnect with correct options", async () => {
@@ -533,14 +557,11 @@ describe("Twitter auth handler", () => {
     });
 
     test("returns connected with account info when token exists", () => {
-      rawConfigStore = { twitter: { integrationMode: "local_byo" } };
+      rawConfigStore = {
+        twitter: { integrationMode: "local_byo", accountInfo: "@testuser" },
+      };
       secureKeyStore["credential:integration:twitter:access_token"] =
         "test-access-token";
-      credentialMetadataStore.push({
-        service: "integration:twitter",
-        field: "access_token",
-        accountInfo: "@testuser",
-      });
 
       const msg: TwitterAuthStatusRequest = { type: "twitter_auth_status" };
       const { ctx, sent } = createTestContext();

--- a/assistant/src/daemon/handlers/config-integrations.ts
+++ b/assistant/src/daemon/handlers/config-integrations.ts
@@ -13,7 +13,6 @@ import {
 } from "../../security/secure-keys.js";
 import {
   deleteCredentialMetadata,
-  getCredentialMetadata,
   upsertCredentialMetadata,
 } from "../../tools/credentials/metadata-store.js";
 import type {
@@ -126,7 +125,9 @@ export async function handleTwitterIntegrationConfig(
       const connected = !!getSecureKey(
         "credential:integration:twitter:access_token",
       );
-      const meta = getCredentialMetadata("integration:twitter", "access_token");
+      const accountInfo = getNestedValue(raw, "twitter.accountInfo") as
+        | string
+        | undefined;
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: true,
@@ -134,7 +135,7 @@ export async function handleTwitterIntegrationConfig(
         managedAvailable: false,
         localClientConfigured,
         connected,
-        accountInfo: meta?.accountInfo ?? undefined,
+        accountInfo: accountInfo ?? undefined,
         strategy,
         strategyConfigured,
       });
@@ -302,6 +303,9 @@ export async function handleTwitterIntegrationConfig(
       const hasDeleteError = deleteResults.some((r) => r === "error");
       if (!hasDeleteError) {
         deleteCredentialMetadata("integration:twitter", "access_token");
+        const raw = loadRawConfig();
+        setNestedValue(raw, "twitter.accountInfo", "");
+        saveRawConfig(raw);
       }
       ctx.send(socket, {
         type: "twitter_integration_config_response",
@@ -330,6 +334,9 @@ export async function handleTwitterIntegrationConfig(
       const disconnectFailed = dr1 === "error" || dr2 === "error";
       if (!disconnectFailed) {
         deleteCredentialMetadata("integration:twitter", "access_token");
+        const raw = loadRawConfig();
+        setNestedValue(raw, "twitter.accountInfo", "");
+        saveRawConfig(raw);
       }
       ctx.send(socket, {
         type: "twitter_integration_config_response",

--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -2,17 +2,16 @@ import * as net from "node:net";
 
 import {
   getNestedValue,
+  invalidateConfigCache,
   loadConfig,
   loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
 } from "../../config/loader.js";
 import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
 import { orchestrateOAuthConnect } from "../../oauth/connect-orchestrator.js";
 import { getSecureKey } from "../../security/secure-keys.js";
-import {
-  assertMetadataWritable,
-  getCredentialMetadata,
-  upsertCredentialMetadata,
-} from "../../tools/credentials/metadata-store.js";
+import { assertMetadataWritable } from "../../tools/credentials/metadata-store.js";
 import { ConfigError } from "../../util/errors.js";
 import type {
   TwitterAuthStartRequest,
@@ -146,15 +145,16 @@ export async function handleTwitterAuthStart(
       return;
     }
 
-    // Persist accountInfo to credential metadata so twitter_auth_status
+    // Persist accountInfo to config so twitter_auth_status
     // can display the @username on subsequent checks.
     if (result.accountInfo) {
       try {
-        upsertCredentialMetadata("integration:twitter", "access_token", {
-          accountInfo: result.accountInfo,
-        });
+        const raw = loadRawConfig();
+        setNestedValue(raw, "twitter.accountInfo", result.accountInfo);
+        saveRawConfig(raw);
+        invalidateConfigCache();
       } catch {
-        // Non-fatal — auth succeeded even if metadata write fails
+        // Non-fatal — auth succeeded even if config write fails
       }
     }
 
@@ -190,12 +190,14 @@ export function handleTwitterAuthStatus(
         | "local_byo"
         | "managed"
         | undefined) ?? "local_byo";
-    const meta = getCredentialMetadata("integration:twitter", "access_token");
+    const accountInfo = getNestedValue(raw, "twitter.accountInfo") as
+      | string
+      | undefined;
 
     ctx.send(socket, {
       type: "twitter_auth_status_response",
       connected: !!accessToken,
-      accountInfo: meta?.accountInfo ?? undefined,
+      accountInfo: accountInfo ?? undefined,
       mode,
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Move Twitter accountInfo from credential metadata to twitter.accountInfo config key
- Update twitter-auth and config-integrations handlers to read/write config instead of credential metadata
- Clear twitter.accountInfo on disconnect and clear_local_client actions

Part of plan: acct-info-to-config.md (PR 2 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
