### PR TITLE
refactor: remove accountInfo field from credential metadata system

### DIFF
--- a/assistant/src/__tests__/credential-metadata-store.test.ts
+++ b/assistant/src/__tests__/credential-metadata-store.test.ts
@@ -502,7 +502,6 @@ describe("credential metadata store", () => {
             allowedDomains: ["github.com"],
             usageDescription: "GitHub PAT",
             grantedScopes: ["repo", "user"],
-            accountInfo: "octocat",
             createdAt: 1700000000000,
             updatedAt: 1700000000000,
           },
@@ -542,7 +541,6 @@ describe("credential metadata store", () => {
 
       // Original v1 fields preserved
       expect(records[0].grantedScopes).toEqual(["repo", "user"]);
-      expect(records[0].accountInfo).toBe("octocat");
       expect(records[1].expiresAt).toBe(1800000000000);
       expect(records[2].oauth2TokenUrl).toBe(
         "https://connect.stripe.com/oauth/token",

--- a/assistant/src/__tests__/credentials-cli.test.ts
+++ b/assistant/src/__tests__/credentials-cli.test.ts
@@ -93,7 +93,6 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
       usageDescription?: string;
       expiresAt?: number | null;
       grantedScopes?: string[];
-      accountInfo?: string | null;
       alias?: string | null;
       injectionTemplates?: unknown[] | null;
     },
@@ -318,7 +317,6 @@ describe("assistant credentials CLI", () => {
         expect(cred).toHaveProperty("usageDescription");
         expect(cred).toHaveProperty("allowedTools");
         expect(cred).toHaveProperty("allowedDomains");
-        expect(cred).toHaveProperty("accountInfo");
         expect(cred).toHaveProperty("grantedScopes");
         expect(cred).toHaveProperty("expiresAt");
         expect(cred).toHaveProperty("createdAt");
@@ -635,7 +633,6 @@ describe("assistant credentials CLI", () => {
       expect(parsed).toHaveProperty("usageDescription");
       expect(parsed).toHaveProperty("allowedTools");
       expect(parsed).toHaveProperty("allowedDomains");
-      expect(parsed).toHaveProperty("accountInfo");
       expect(parsed).toHaveProperty("grantedScopes");
       expect(parsed).toHaveProperty("expiresAt");
       expect(parsed).toHaveProperty("injectionTemplateCount");

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -66,7 +66,6 @@ function buildCredentialOutput(
     usageDescription: metadata.usageDescription ?? null,
     allowedTools: metadata.allowedTools,
     allowedDomains: metadata.allowedDomains,
-    accountInfo: metadata.accountInfo ?? null,
     grantedScopes: metadata.grantedScopes ?? null,
     expiresAt: metadata.expiresAt
       ? new Date(metadata.expiresAt).toISOString()
@@ -101,7 +100,6 @@ function printCredentialHuman(output: Record<string, unknown>): void {
     log.info(
       `    Domains:     ${(output.allowedDomains as string[]).join(", ")}`,
     );
-  if (output.accountInfo) log.info(`    Account:     ${output.accountInfo}`);
   if (output.grantedScopes)
     log.info(
       `    Scopes:      ${(output.grantedScopes as string[]).join(", ")}`,
@@ -237,10 +235,6 @@ Examples:
       "--allowed-tools <tools>",
       "Comma-separated tool names that may use this credential",
     )
-    .option(
-      "--account-info <json>",
-      "JSON string of account metadata to associate with this credential",
-    )
     .addHelpText(
       "after",
       `
@@ -254,8 +248,7 @@ updated with any provided flags. Omitted flags leave existing metadata intact.
 Examples:
   $ assistant credentials set twilio:account_sid AC1234567890
   $ assistant credentials set fal:api_key key_live_abc --label "fal-prod" --description "Image generation"
-  $ assistant credentials set github:token ghp_abc --allowed-tools "bash,host_bash"
-  $ assistant credentials set slack_channel:bot_token xoxb-abc --account-info '{"teamId":"T123","teamName":"My Workspace"}'`,
+  $ assistant credentials set github:token ghp_abc --allowed-tools "bash,host_bash"`,
     )
     .action(
       async (
@@ -265,7 +258,6 @@ Examples:
           label?: string;
           description?: string;
           allowedTools?: string;
-          accountInfo?: string;
         },
         cmd: Command,
       ) => {
@@ -303,7 +295,6 @@ Examples:
             alias: opts.label,
             usageDescription: opts.description,
             allowedTools,
-            accountInfo: opts.accountInfo,
           });
 
           writeOutput(cmd, {
@@ -472,7 +463,6 @@ Examples:
             usageDescription: null,
             allowedTools: [],
             allowedDomains: [],
-            accountInfo: null,
             grantedScopes: null,
             expiresAt: null,
             createdAt: null,

--- a/assistant/src/config/bundled-skills/slack-app-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack-app-setup/SKILL.md
@@ -137,8 +137,10 @@ TEAM_ID=$(echo "$AUTH_RESPONSE" | jq -r '.team_id')
 TEAM_NAME=$(echo "$AUTH_RESPONSE" | jq -r '.team')
 BOT_USER_ID=$(echo "$AUTH_RESPONSE" | jq -r '.user_id')
 BOT_USERNAME=$(echo "$AUTH_RESPONSE" | jq -r '.user')
-ACCOUNT_INFO="{\"teamId\":\"$TEAM_ID\",\"teamName\":\"$TEAM_NAME\",\"botUserId\":\"$BOT_USER_ID\",\"botUsername\":\"$BOT_USERNAME\"}"
-assistant credentials set slack_channel:bot_token "$BOT_TOKEN" --account-info "$ACCOUNT_INFO"
+assistant config set slack.teamId "$TEAM_ID"
+assistant config set slack.teamName "$TEAM_NAME"
+assistant config set slack.botUserId "$BOT_USER_ID"
+assistant config set slack.botUsername "$BOT_USERNAME"
 ```
 
 Report the bot username and workspace from the response.

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { CLI_HELP_REFERENCE } from "../cli/reference.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getBaseDataDir, getIsContainerized } from "../config/env-registry.js";
-import { getConfig } from "../config/loader.js";
+import { getConfig, getNestedValue, loadRawConfig } from "../config/loader.js";
 import { skillFlagKey } from "../config/skill-state.js";
 import { loadSkillCatalog, type SkillSummary } from "../config/skills.js";
 import { listCredentialMetadata } from "../tools/credentials/metadata-store.js";
@@ -634,11 +634,14 @@ function buildIntegrationSection(): string {
   );
   if (oauthCreds.length === 0) return "";
 
+  const raw = loadRawConfig();
   const lines = ["## Connected Services", ""];
   for (const cred of oauthCreds) {
-    const state = cred.accountInfo
-      ? `Connected (${cred.accountInfo})`
-      : "Connected";
+    const acctInfo = getNestedValue(
+      raw,
+      `integrations.accountInfo.${cred.service}`,
+    ) as string | undefined;
+    const state = acctInfo ? `Connected (${acctInfo})` : "Connected";
     lines.push(`- **${cred.service}**: ${state}`);
   }
 

--- a/assistant/src/tools/credentials/metadata-store.ts
+++ b/assistant/src/tools/credentials/metadata-store.ts
@@ -23,7 +23,6 @@ export interface CredentialMetadata {
   usageDescription?: string;
   expiresAt?: number;
   grantedScopes?: string[];
-  accountInfo?: string;
   /** OAuth2 token endpoint — enables autonomous token refresh without an IntegrationDefinition. */
   oauth2TokenUrl?: string;
   /** OAuth2 client ID — paired with oauth2TokenUrl for refresh. */
@@ -113,8 +112,6 @@ function migrateRecordV1toV2(
     grantedScopes: Array.isArray(record.grantedScopes)
       ? (record.grantedScopes as string[])
       : undefined,
-    accountInfo:
-      typeof record.accountInfo === "string" ? record.accountInfo : undefined,
     oauth2TokenUrl:
       typeof record.oauth2TokenUrl === "string"
         ? record.oauth2TokenUrl
@@ -220,8 +217,6 @@ export function upsertCredentialMetadata(
     /** Pass `null` to explicitly clear a previously-set expiry. */
     expiresAt?: number | null;
     grantedScopes?: string[];
-    /** Pass `null` to explicitly clear a previously-set account info. */
-    accountInfo?: string | null;
     oauth2TokenUrl?: string;
     oauth2ClientId?: string;
     /** Pass `null` to explicitly clear a previously-set client secret. */
@@ -262,13 +257,6 @@ export function upsertCredentialMetadata(
     }
     if (policy?.grantedScopes !== undefined)
       existing.grantedScopes = policy.grantedScopes;
-    if (policy?.accountInfo !== undefined) {
-      if (policy.accountInfo == null) {
-        delete existing.accountInfo;
-      } else {
-        existing.accountInfo = policy.accountInfo;
-      }
-    }
     if (policy?.oauth2TokenUrl !== undefined)
       existing.oauth2TokenUrl = policy.oauth2TokenUrl;
     if (policy?.oauth2ClientId !== undefined)
@@ -311,7 +299,6 @@ export function upsertCredentialMetadata(
     usageDescription: policy?.usageDescription,
     expiresAt: policy?.expiresAt ?? undefined,
     grantedScopes: policy?.grantedScopes,
-    accountInfo: policy?.accountInfo ?? undefined,
     oauth2TokenUrl: policy?.oauth2TokenUrl,
     oauth2ClientId: policy?.oauth2ClientId,
     oauth2ClientSecret: policy?.oauth2ClientSecret ?? undefined,


### PR DESCRIPTION
## Summary
- Remove accountInfo from CredentialMetadata interface and upsertCredentialMetadata policy
- Remove --account-info option from credentials CLI
- Update SKILL.md to use config set for Slack workspace metadata
- Update system-prompt.ts to read accountInfo from config instead of credential metadata
- Clean up all tests

Part of plan: acct-info-to-config.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
