### PR TITLE
feat(assistant): enable streaming delivery for Telegram in background dispatch

### DIFF
--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -208,3 +208,43 @@ export async function deliverReplyViaCallback(
     break;
   }
 }
+
+/**
+ * Deliver only the attachments from the last assistant message, skipping text.
+ * Used when streaming already delivered the text content and only file
+ * attachments remain to be sent via the normal delivery path.
+ */
+export async function deliverAttachmentsOnly(
+  conversationId: string,
+  externalChatId: string,
+  callbackUrl: string,
+  bearerToken?: string,
+  assistantId?: string,
+): Promise<void> {
+  const msgs = getMessages(conversationId);
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    if (msgs[i].role !== "assistant") continue;
+
+    const linked = attachmentsStore.getAttachmentMetadataForMessage(msgs[i].id);
+    if (linked.length === 0) return;
+
+    const replyAttachments: RuntimeAttachmentMetadata[] = linked.map((a) => ({
+      id: a.id,
+      filename: a.originalFilename,
+      mimeType: a.mimeType,
+      sizeBytes: a.sizeBytes,
+      kind: a.kind,
+    }));
+
+    await deliverChannelReply(
+      callbackUrl,
+      {
+        chatId: externalChatId,
+        attachments: replyAttachments,
+        assistantId,
+      },
+      bearerToken,
+    );
+    break;
+  }
+}

--- a/assistant/src/runtime/routes/channel-delivery-routes.ts
+++ b/assistant/src/runtime/routes/channel-delivery-routes.ts
@@ -5,6 +5,7 @@
 import * as deliveryStatus from "../../memory/delivery-status.js";
 import { httpError } from "../http-errors.js";
 export {
+  deliverAttachmentsOnly,
   type DeliverReplyOptions,
   deliverReplyViaCallback,
 } from "../channel-reply-delivery.js";

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -31,8 +31,12 @@ import type {
   ApprovalCopyGenerator,
   MessageProcessor,
 } from "../../http-types.js";
+import { TelegramStreamingDelivery } from "../../telegram-streaming-delivery.js";
 import { resolveRoutingState } from "../../trust-context-resolver.js";
-import { deliverReplyViaCallback } from "../channel-delivery-routes.js";
+import {
+  deliverAttachmentsOnly,
+  deliverReplyViaCallback,
+} from "../channel-delivery-routes.js";
 import { deliverGeneratedApprovalPrompt } from "../guardian-approval-prompt.js";
 
 const log = getLogger("runtime-http");
@@ -156,6 +160,16 @@ export function processChannelMessageInBackground(
       }
     }
 
+    const telegramStreaming =
+      sourceChannel === "telegram" && replyCallbackUrl
+        ? new TelegramStreamingDelivery({
+            callbackUrl: replyCallbackUrl,
+            chatId: externalChatId,
+            mintBearerToken,
+            assistantId,
+          })
+        : undefined;
+
     try {
       const cmdIntent =
         commandIntent && typeof commandIntent.type === "string"
@@ -183,6 +197,9 @@ export function processChannelMessageInBackground(
           trustContext: trustCtx,
           isInteractive: resolveRoutingState(trustCtx).promptWaitingAllowed,
           ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
+          ...(telegramStreaming
+            ? { onEvent: (msg) => telegramStreaming.onEvent(msg) }
+            : {}),
         },
         sourceChannel,
         sourceInterface,
@@ -190,18 +207,49 @@ export function processChannelMessageInBackground(
       deliveryCrud.linkMessage(eventId, userMessageId);
       deliveryStatus.markProcessed(eventId);
 
+      if (telegramStreaming) {
+        try {
+          // Retrieve approval metadata from pending interactions (if any)
+          // so approval buttons can be attached to the final streamed message.
+          const prompt = getChannelApprovalPrompt(conversationId);
+          const pending = getApprovalInfoByConversation(conversationId);
+          const approvalMeta =
+            prompt && pending.length > 0
+              ? buildApprovalUIMetadata(prompt, pending[0])
+              : undefined;
+          await telegramStreaming.finish(approvalMeta);
+        } catch (err) {
+          log.error(
+            { err, conversationId },
+            "Telegram streaming finalization failed",
+          );
+        }
+      }
+
       if (replyCallbackUrl) {
-        await deliverReplyViaCallback(
-          conversationId,
-          externalChatId,
-          replyCallbackUrl,
-          mintBearerToken(),
-          assistantId,
-          {
-            onSegmentDelivered: (count) =>
-              deliveryChannels.updateDeliveredSegmentCount(eventId, count),
-          },
-        );
+        if (telegramStreaming?.hasDeliveredText) {
+          // Streaming already delivered the text — only send attachments
+          await deliverAttachmentsOnly(
+            conversationId,
+            externalChatId,
+            replyCallbackUrl,
+            mintBearerToken(),
+            assistantId,
+          );
+        } else {
+          // Non-streaming path (existing behavior)
+          await deliverReplyViaCallback(
+            conversationId,
+            externalChatId,
+            replyCallbackUrl,
+            mintBearerToken(),
+            assistantId,
+            {
+              onSegmentDelivered: (count) =>
+                deliveryChannels.updateDeliveredSegmentCount(eventId, count),
+            },
+          );
+        }
       }
     } catch (err) {
       log.error(


### PR DESCRIPTION
## Summary
- Wire `TelegramStreamingDelivery` into `processChannelMessageInBackground` for Telegram channels
- Pass `onEvent` callback to `processMessage` to stream text deltas to Telegram in real time
- Skip post-loop text delivery when streaming handled it; still deliver attachments separately
- Fall back to non-streaming delivery if streaming fails or delivers no text

Part of plan: telegram-streaming.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
