### PR TITLE
fix: add config clearing commands to slack-app-setup SKILL.md

### DIFF
--- a/assistant/src/config/bundled-skills/slack-app-setup/SKILL.md
+++ b/assistant/src/config/bundled-skills/slack-app-setup/SKILL.md
@@ -171,4 +171,8 @@ To disconnect Slack:
 ```bash
 assistant credentials delete slack_channel:bot_token
 assistant credentials delete slack_channel:app_token
+assistant config set slack.teamId ""
+assistant config set slack.teamName ""
+assistant config set slack.botUserId ""
+assistant config set slack.botUsername ""
 ```


### PR DESCRIPTION
## Summary
Adds `assistant config set` commands to clear `slack.teamId`, `slack.teamName`, `slack.botUserId`, and `slack.botUsername` in the "Clearing Credentials" section of the slack-app-setup SKILL.md, matching what `clearSlackChannelConfig()` does programmatically.

Fixes gap identified during plan review for acct-info-to-config.md.

**Gap:** SKILL.md "Clearing Credentials" section does not clear config metadata
**What was expected:** Clearing section should clear config values in addition to credentials
**What was found:** Only credential delete commands were present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
