### PR TITLE
fix: add missing invalidateConfigCache calls in config-integrations handler

### DIFF
--- a/assistant/src/daemon/handlers/config-integrations.ts
+++ b/assistant/src/daemon/handlers/config-integrations.ts
@@ -2,6 +2,7 @@ import * as net from "node:net";
 
 import {
   getNestedValue,
+  invalidateConfigCache,
   loadRawConfig,
   saveRawConfig,
   setNestedValue,
@@ -177,6 +178,7 @@ export async function handleTwitterIntegrationConfig(
       const raw = loadRawConfig();
       setNestedValue(raw, "twitter.operationStrategy", value);
       saveRawConfig(raw);
+      invalidateConfigCache();
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: true,
@@ -192,6 +194,7 @@ export async function handleTwitterIntegrationConfig(
       const raw = loadRawConfig();
       setNestedValue(raw, "twitter.integrationMode", msg.mode ?? "local_byo");
       saveRawConfig(raw);
+      invalidateConfigCache();
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: true,
@@ -306,6 +309,7 @@ export async function handleTwitterIntegrationConfig(
         const raw = loadRawConfig();
         setNestedValue(raw, "twitter.accountInfo", "");
         saveRawConfig(raw);
+        invalidateConfigCache();
       }
       ctx.send(socket, {
         type: "twitter_integration_config_response",
@@ -337,6 +341,7 @@ export async function handleTwitterIntegrationConfig(
         const raw = loadRawConfig();
         setNestedValue(raw, "twitter.accountInfo", "");
         saveRawConfig(raw);
+        invalidateConfigCache();
       }
       ctx.send(socket, {
         type: "twitter_integration_config_response",


### PR DESCRIPTION
## Summary
Adds missing `invalidateConfigCache()` calls after `saveRawConfig()` in the disconnect and clear_local_client actions of `handleTwitterIntegrationConfig`. Also adds the same missing call in set_strategy and set_mode actions for consistency. This matches the pattern used in every other config-writing handler.

Fixes gap identified during plan review for acct-info-to-config.md.

**Gap:** Missing invalidateConfigCache() in config-integrations.ts after config writes
**What was expected:** Every config-writing handler should call invalidateConfigCache() after saveRawConfig()
**What was found:** disconnect and clear_local_client actions write config but don't invalidate the cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
