### PR TITLE
docs: update ARCHITECTURE.md to reflect accountInfo migration to config

### DIFF
--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -585,7 +585,8 @@ Entry points:
 Both paths converge at:
   → Daemon handler validates token via Telegram getMe API
     → setSecureKey("credential:telegram:bot_token", token)
-    → upsertCredentialMetadata("telegram", "bot_token", {accountInfo: username})
+    → upsertCredentialMetadata("telegram", "bot_token", {})
+    → Stores bot username in config at telegram.botUsername
     → Auto-generates webhook secret if missing
       → setSecureKey("credential:telegram:webhook_secret", secret)
       → upsertCredentialMetadata("telegram", "webhook_secret", {})


### PR DESCRIPTION
## Summary
Updates `gateway/ARCHITECTURE.md` to reflect that `accountInfo` is no longer stored in credential metadata. Updates the `upsertCredentialMetadata` call example and notes that bot username is stored in config.

Fixes gap identified during plan review for acct-info-to-config.md.

**Gap:** Stale documentation in gateway/ARCHITECTURE.md
**What was expected:** Docs should reflect current code where accountInfo is in config
**What was found:** Docs still show the old pattern with accountInfo in credential metadata

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
