### PR TITLE
fix(gateway): update sendTelegramReply test mocks to return TelegramSendResult

### DIFF
--- a/gateway/src/http/routes/telegram-deliver.test.ts
+++ b/gateway/src/http/routes/telegram-deliver.test.ts
@@ -16,7 +16,9 @@ let sendTypingIndicatorCalls: Array<unknown[]> = [];
 mock.module("../../telegram/send.js", () => ({
   sendTelegramReply: async (...args: unknown[]) => {
     sendTelegramReplyCalls.push(args);
+    return { messageId: 42 };
   },
+  editTelegramMessage: async () => {},
   sendTelegramAttachments: async () => {},
   sendTypingIndicator: async (...args: unknown[]) => {
     sendTypingIndicatorCalls.push(args);
@@ -208,6 +210,7 @@ describe("telegram-deliver endpoint basics", () => {
       sendTelegramReply: async () => {
         throw new Error("Telegram API failure");
       },
+      editTelegramMessage: async () => {},
       sendTelegramAttachments: async () => {},
       sendTypingIndicator: async () => true,
     }));
@@ -225,7 +228,9 @@ describe("telegram-deliver endpoint basics", () => {
     mock.module("../../telegram/send.js", () => ({
       sendTelegramReply: async (...args: unknown[]) => {
         sendTelegramReplyCalls.push(args);
+        return { messageId: 42 };
       },
+      editTelegramMessage: async () => {},
       sendTelegramAttachments: async () => {},
       sendTypingIndicator: async (...args: unknown[]) => {
         sendTypingIndicatorCalls.push(args);

--- a/gateway/src/http/routes/telegram-webhook.test.ts
+++ b/gateway/src/http/routes/telegram-webhook.test.ts
@@ -8,7 +8,7 @@ const callTelegramApiMock = mock(
   (_method: string, _body: Record<string, unknown>, _opts?: unknown) =>
     Promise.resolve({}),
 );
-const sendTelegramReplyMock = mock(() => Promise.resolve());
+const sendTelegramReplyMock = mock(() => Promise.resolve({ messageId: 0 }));
 const handleInboundMock = mock(
   (_config: GatewayConfig, _normalized: unknown, _options?: unknown) =>
     Promise.resolve({ forwarded: true, rejected: false }),


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for telegram-streaming.md.

**Gap:** Test mocks for sendTelegramReply don't return TelegramSendResult
**What was expected:** Mocks should return `{ messageId: number }` matching the new return type
**What was found:** Both telegram-deliver.test.ts and telegram-webhook.test.ts mocks return void

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
