### PR TITLE
fix(assistant): update delivery segment count after Telegram streaming completion

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -218,6 +218,7 @@ export function processChannelMessageInBackground(
               ? buildApprovalUIMetadata(prompt, pending[0])
               : undefined;
           await telegramStreaming.finish(approvalMeta);
+          deliveryChannels.updateDeliveredSegmentCount(eventId, 1);
         } catch (err) {
           log.error(
             { err, conversationId },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for telegram-streaming.md.

**Gap:** Streaming path skips updateDeliveredSegmentCount, breaking delivery tracking
**What was expected:** Delivery tracking should be updated after streaming delivers text
**What was found:** deliveredSegmentCount remains at 0 for streaming-delivered messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
