### PR TITLE
fix(assistant): prevent redundant finish() edits and add fallback approval delivery

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -208,21 +208,42 @@ export function processChannelMessageInBackground(
       deliveryStatus.markProcessed(eventId);
 
       if (telegramStreaming) {
+        // Retrieve approval metadata from pending interactions (if any)
+        // so approval buttons can be attached to the final streamed message.
+        const prompt = getChannelApprovalPrompt(conversationId);
+        const pending = getApprovalInfoByConversation(conversationId);
+        const approvalMeta =
+          prompt && pending.length > 0
+            ? buildApprovalUIMetadata(prompt, pending[0])
+            : undefined;
         try {
-          // Retrieve approval metadata from pending interactions (if any)
-          // so approval buttons can be attached to the final streamed message.
-          const prompt = getChannelApprovalPrompt(conversationId);
-          const pending = getApprovalInfoByConversation(conversationId);
-          const approvalMeta =
-            prompt && pending.length > 0
-              ? buildApprovalUIMetadata(prompt, pending[0])
-              : undefined;
           await telegramStreaming.finish(approvalMeta);
         } catch (err) {
           log.error(
             { err, conversationId },
             "Telegram streaming finalization failed",
           );
+          // Fallback: deliver approval as a standalone message so buttons
+          // are not permanently lost when finish() fails.
+          if (approvalMeta && replyCallbackUrl) {
+            try {
+              await deliverChannelReply(
+                replyCallbackUrl,
+                {
+                  chatId: externalChatId,
+                  text: approvalMeta.plainTextFallback ?? "Action needed:",
+                  approval: approvalMeta,
+                  assistantId,
+                },
+                mintBearerToken(),
+              );
+            } catch (fallbackErr) {
+              log.error(
+                { err: fallbackErr, conversationId },
+                "Fallback approval delivery also failed",
+              );
+            }
+          }
         }
       }
 

--- a/assistant/src/runtime/telegram-streaming-delivery.ts
+++ b/assistant/src/runtime/telegram-streaming-delivery.ts
@@ -21,6 +21,7 @@ export class TelegramStreamingDelivery {
   private buffer = ""; // Accumulated text not yet sent
   private currentMessageId: number | null = null; // ID of current Telegram message
   private currentMessageText = ""; // Full text of current message
+  private lastSentText = ""; // Last text successfully sent to Telegram
   private lastEditAt = 0; // Timestamp of last edit
   private editTimer: ReturnType<typeof setTimeout> | null = null;
   private messageCount = 0; // Total messages sent
@@ -69,8 +70,15 @@ export class TelegramStreamingDelivery {
       }
     }
 
-    // Final edit with approval buttons if present
+    // Final edit with approval buttons if present.
+    // Skip the edit when text hasn't changed since the last successful
+    // delivery and there are no approval buttons to attach — sending the
+    // same text again would trigger Telegram's "message is not modified"
+    // 400 error.
     if (this.currentMessageId && (this.currentMessageText || approval)) {
+      if (!approval && this.currentMessageText === this.lastSentText) {
+        return;
+      }
       await deliverChannelReply(
         this.opts.callbackUrl,
         {
@@ -82,6 +90,7 @@ export class TelegramStreamingDelivery {
         },
         this.opts.mintBearerToken(),
       );
+      this.lastSentText = this.currentMessageText;
     }
   }
 
@@ -118,6 +127,7 @@ export class TelegramStreamingDelivery {
           this.currentMessageId = result.messageId;
         }
         this.textDelivered = true;
+        this.lastSentText = this.currentMessageText;
         this.messageCount++;
         this.lastEditAt = Date.now();
       })
@@ -167,12 +177,16 @@ export class TelegramStreamingDelivery {
             assistantId: this.opts.assistantId,
           },
           this.opts.mintBearerToken(),
-        ).catch((err) => {
-          log.error(
-            { err, chatId: this.opts.chatId },
-            "Failed to edit message at split boundary",
-          );
-        });
+        )
+          .then(() => {
+            this.lastSentText = cutText;
+          })
+          .catch((err) => {
+            log.error(
+              { err, chatId: this.opts.chatId },
+              "Failed to edit message at split boundary",
+            );
+          });
       }
 
       // Reset and send overflow as a new message
@@ -192,6 +206,7 @@ export class TelegramStreamingDelivery {
           if (result.messageId) {
             this.currentMessageId = result.messageId;
           }
+          this.lastSentText = this.currentMessageText;
           this.messageCount++;
           this.lastEditAt = Date.now();
         })
@@ -206,6 +221,7 @@ export class TelegramStreamingDelivery {
     }
 
     if (this.currentMessageId) {
+      const textSnapshot = this.currentMessageText;
       deliverChannelReply(
         this.opts.callbackUrl,
         {
@@ -215,12 +231,16 @@ export class TelegramStreamingDelivery {
           assistantId: this.opts.assistantId,
         },
         this.opts.mintBearerToken(),
-      ).catch((err) => {
-        log.error(
-          { err, chatId: this.opts.chatId },
-          "Failed to edit streaming message",
-        );
-      });
+      )
+        .then(() => {
+          this.lastSentText = textSnapshot;
+        })
+        .catch((err) => {
+          log.error(
+            { err, chatId: this.opts.chatId },
+            "Failed to edit streaming message",
+          );
+        });
     }
     this.lastEditAt = Date.now();
   }
@@ -239,6 +259,7 @@ export class TelegramStreamingDelivery {
 
     // Send a final edit if we have an active message
     if (this.currentMessageId && this.currentMessageText) {
+      const textSnapshot = this.currentMessageText;
       deliverChannelReply(
         this.opts.callbackUrl,
         {
@@ -248,17 +269,22 @@ export class TelegramStreamingDelivery {
           assistantId: this.opts.assistantId,
         },
         this.opts.mintBearerToken(),
-      ).catch((err) => {
-        log.error(
-          { err, chatId: this.opts.chatId },
-          "Failed to finalize streaming message",
-        );
-      });
+      )
+        .then(() => {
+          this.lastSentText = textSnapshot;
+        })
+        .catch((err) => {
+          log.error(
+            { err, chatId: this.opts.chatId },
+            "Failed to finalize streaming message",
+          );
+        });
     }
 
     // Reset so the next text delta starts a new message
     this.currentMessageId = null;
     this.currentMessageText = "";
+    this.lastSentText = "";
   }
 
   private async sendNewMessage(
@@ -280,6 +306,7 @@ export class TelegramStreamingDelivery {
         this.currentMessageId = result.messageId;
       }
       this.textDelivered = true;
+      this.lastSentText = text;
       this.messageCount++;
     } catch (err) {
       log.error(


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for telegram-streaming.md.

**Gap A:** finish() triggers 'message is not modified' error by sending redundant edit when text hasn't changed
**Gap B:** Approval buttons lost when finish() fails after streaming delivered text

Adds lastSentText tracking to skip no-op edits, and fallback approval delivery in background dispatch when finish() throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
