### PR TITLE
fix: use wasm.file instead of wasm object in doctor.ts error messages

### DIFF
--- a/assistant/src/cli/commands/doctor.ts
+++ b/assistant/src/cli/commands/doctor.ts
@@ -343,11 +343,11 @@ Examples:
           try {
             const wasmStat = statSync(fullPath);
             if (wasmStat.size === 0) {
-              missingWasm.push(`${wasm} (empty)`);
+              missingWasm.push(`${wasm.file} (empty)`);
               wasmOk = false;
             }
           } catch {
-            missingWasm.push(`${wasm} (unreadable)`);
+            missingWasm.push(`${wasm.file} (unreadable)`);
             wasmOk = false;
           }
         }


### PR DESCRIPTION
Fix template literal interpolation in doctor.ts WASM file checks where ${wasm} (an object) was producing [object Object] in error messages instead of the intended file name. Changed to ${wasm.file} consistent with line 340.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
