### PR TITLE
fix(gateway): add length validation and no-op error handling for Telegram message edits

### DIFF
--- a/gateway/src/telegram/send.ts
+++ b/gateway/src/telegram/send.ts
@@ -90,6 +90,12 @@ export async function editTelegramMessage(
   approval?: ApprovalPayload,
   opts?: { credentials?: CredentialCache; configFile?: ConfigFileCache },
 ): Promise<void> {
+  if (text.length > TELEGRAM_MAX_MESSAGE_LEN) {
+    throw new Error(
+      `Text length ${text.length} exceeds Telegram's ${TELEGRAM_MAX_MESSAGE_LEN}-character limit for message edits`,
+    );
+  }
+
   const payload: Record<string, unknown> = {
     chat_id: chatId,
     message_id: messageId,
@@ -98,7 +104,22 @@ export async function editTelegramMessage(
   if (approval) {
     payload.reply_markup = buildInlineKeyboard(approval);
   }
-  await callTelegramApi("editMessageText", payload, opts);
+
+  try {
+    await callTelegramApi("editMessageText", payload, opts);
+  } catch (err) {
+    // Telegram returns "message is not modified" when the new text is identical
+    // to what's already displayed. Treat this as a no-op success rather than
+    // propagating a hard failure.
+    if (
+      err instanceof Error &&
+      err.message.includes("message is not modified")
+    ) {
+      log.debug({ chatId, messageId }, "Edit skipped: message is not modified");
+      return;
+    }
+    throw err;
+  }
 }
 
 export async function sendTelegramAttachments(


### PR DESCRIPTION
Add text length validation in `editTelegramMessage` to reject texts exceeding `TELEGRAM_MAX_MESSAGE_LEN` (since edits can't be split like sends). Also catch Telegram's "message is not modified" error and treat it as a no-op success instead of a hard 502 failure.

Addresses feedback from #14261.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
