### PR TITLE
fix(assistant): wrap streaming onEvent callback in try/catch to isolate failures

### DIFF
--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -1131,7 +1131,14 @@ export class DaemonServer {
     const onEvent = options?.onEvent
       ? (msg: ServerMessage) => {
           registrar(msg);
-          options.onEvent!(msg);
+          try {
+            options.onEvent!(msg);
+          } catch (err) {
+            log.error(
+              { err, conversationId },
+              "onEvent callback failed; continuing agent loop",
+            );
+          }
         }
       : registrar;
     if (options?.isInteractive === true) {
@@ -1275,7 +1282,14 @@ export class DaemonServer {
     const onEvent = options?.onEvent
       ? (msg: ServerMessage) => {
           registrar(msg);
-          options.onEvent!(msg);
+          try {
+            options.onEvent!(msg);
+          } catch (err) {
+            log.error(
+              { err, conversationId },
+              "onEvent callback failed; continuing agent loop",
+            );
+          }
         }
       : registrar;
     if (options?.isInteractive === true) {


### PR DESCRIPTION
Wrap the onEvent callback invocation in daemon/server.ts in a try/catch so that exceptions from downstream streaming code (e.g., transient delivery/network failures) don't propagate into runAgentLoop and terminate message processing. Errors are logged but the agent loop continues.

Addresses feedback from PR #14265.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
