### PR TITLE
fix(assistant): add fallback delivery when Telegram streaming partially fails

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -249,8 +249,13 @@ export function processChannelMessageInBackground(
       }
 
       if (replyCallbackUrl) {
-        if (telegramStreaming?.hasDeliveredText) {
-          // Streaming already delivered the text — only send attachments
+        // Streaming fully succeeded — only send attachments since text
+        // was already delivered via streaming edits.
+        const streamingFullyDelivered =
+          telegramStreaming?.hasDeliveredText &&
+          telegramStreaming.finishSucceeded;
+
+        if (streamingFullyDelivered) {
           await deliverAttachmentsOnly(
             conversationId,
             externalChatId,
@@ -259,7 +264,19 @@ export function processChannelMessageInBackground(
             assistantId,
           );
         } else {
-          // Non-streaming path (existing behavior)
+          // Non-streaming path, or streaming partially failed (some text
+          // was delivered but finish/finalization threw). In the partial
+          // failure case the user has a truncated message, so we deliver
+          // the full response to ensure nothing is lost.
+          if (
+            telegramStreaming?.hasDeliveredText &&
+            !telegramStreaming.finishSucceeded
+          ) {
+            log.warn(
+              { conversationId },
+              "Telegram streaming partially failed — falling back to full text delivery",
+            );
+          }
           await deliverReplyViaCallback(
             conversationId,
             externalChatId,

--- a/assistant/src/runtime/telegram-streaming-delivery.ts
+++ b/assistant/src/runtime/telegram-streaming-delivery.ts
@@ -28,6 +28,7 @@ export class TelegramStreamingDelivery {
   private messageCount = 0; // Total messages sent
   private finished = false;
   private textDelivered = false; // True once at least some text was sent
+  private finishOk = false; // True only when finish() completes without error
   private initialSendInFlight = false; // Synchronous guard against duplicate initial sends
   private initialSendPromise: Promise<ChannelDeliveryResult> | null = null; // Tracks in-flight initial send
 
@@ -76,6 +77,7 @@ export class TelegramStreamingDelivery {
         this.buffer = "";
         // Send as new message
         await this.sendNewMessage(this.currentMessageText, approval);
+        this.finishOk = true;
         return;
       }
     }
@@ -87,6 +89,7 @@ export class TelegramStreamingDelivery {
     // 400 error.
     if (this.currentMessageId && (this.currentMessageText || approval)) {
       if (!approval && this.currentMessageText === this.lastSentText) {
+        this.finishOk = true;
         return;
       }
       await deliverChannelReply(
@@ -102,10 +105,16 @@ export class TelegramStreamingDelivery {
       );
       this.lastSentText = this.currentMessageText;
     }
+    this.finishOk = true;
   }
 
   get hasDeliveredText(): boolean {
     return this.textDelivered;
+  }
+
+  /** True only when finish() completed without throwing. */
+  get finishSucceeded(): boolean {
+    return this.finishOk;
   }
 
   // ── Internal ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Added `finishSucceeded` property to `TelegramStreamingDelivery` to track whether `finish()` completed without error
- Changed the streaming delivery decision in `background-dispatch.ts` to only skip non-streaming fallback when streaming **fully** succeeded (text delivered AND finish succeeded)
- When streaming partially fails (some text delivered but finish threw), falls back to `deliverReplyViaCallback` to deliver the complete response so users don't get truncated output
- Added a warning log for the partial failure fallback path

## Test plan
- [ ] Verify that when Telegram streaming fully succeeds, only attachments are delivered (existing behavior preserved)
- [ ] Verify that when streaming delivers no text, full non-streaming delivery occurs (existing behavior preserved)
- [ ] Verify that when streaming delivers partial text but `finish()` fails, the fallback `deliverReplyViaCallback` sends the complete response
- [ ] Verify warning log is emitted in the partial failure case

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
