### PR TITLE
fix(tests): mock getSecureKey correctly in twilio-config tests

### DIFF
--- a/assistant/src/__tests__/twilio-config.test.ts
+++ b/assistant/src/__tests__/twilio-config.test.ts
@@ -29,11 +29,12 @@ import { getTwilioConfig } from "../calls/twilio-config.js";
 
 describe("twilio-config", () => {
   beforeEach(() => {
-    mockSecureKeys = {};
+    mockSecureKeys = {
+      "credential:twilio:auth_token": "test_auth_token",
+    };
     mockLoadConfigResult = {
       twilio: {
         accountSid: "AC_test_sid",
-        authToken: "test_auth_token",
         phoneNumber: "+15551234567",
       },
     };
@@ -58,10 +59,10 @@ describe("twilio-config", () => {
   });
 
   test("throws ConfigError when auth token is missing", () => {
+    mockSecureKeys = {};
     mockLoadConfigResult = {
       twilio: {
         accountSid: "AC_test_sid",
-        authToken: "",
         phoneNumber: "+15551234567",
       },
     };
@@ -74,7 +75,6 @@ describe("twilio-config", () => {
     mockLoadConfigResult = {
       twilio: {
         accountSid: "AC_test_sid",
-        authToken: "test_auth_token",
         phoneNumber: "",
       },
     };


### PR DESCRIPTION
## Summary
- Fixed `twilio-config.test.ts` which had 2 failing tests because `authToken` was mocked on the config object, but `getTwilioConfig()` reads it from `getSecureKey("credential:twilio:auth_token")`
- Set `mockSecureKeys["credential:twilio:auth_token"]` in `beforeEach` so the happy path and phone-number-missing tests get past the credentials check

## Original prompt
fix CI issues in https://github.com/vellum-ai/vellum-assistant/actions/runs/22821733374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
