### PR TITLE
fix(assistant): capture text snapshot before async send in telegram streaming

### DIFF
--- a/assistant/src/runtime/telegram-streaming-delivery.ts
+++ b/assistant/src/runtime/telegram-streaming-delivery.ts
@@ -163,11 +163,12 @@ export class TelegramStreamingDelivery {
     this.currentMessageText = this.buffer;
     this.buffer = "";
 
+    const textSnapshot = this.currentMessageText;
     const promise = deliverChannelReply(
       this.opts.callbackUrl,
       {
         chatId: this.opts.chatId,
-        text: this.currentMessageText,
+        text: textSnapshot,
         assistantId: this.opts.assistantId,
       },
       this.opts.mintBearerToken(),
@@ -180,7 +181,7 @@ export class TelegramStreamingDelivery {
           this.currentMessageId = result.messageId;
         }
         this.textDelivered = true;
-        this.lastSentText = this.currentMessageText;
+        this.lastSentText = textSnapshot;
         this.messageCount++;
         this.lastEditAt = Date.now();
         this.initialSendInFlight = false;
@@ -247,12 +248,13 @@ export class TelegramStreamingDelivery {
       // Reset and send overflow as a new message
       this.currentMessageId = null;
       this.currentMessageText = overflow;
+      const overflowSnapshot = this.currentMessageText;
 
       deliverChannelReply(
         this.opts.callbackUrl,
         {
           chatId: this.opts.chatId,
-          text: this.currentMessageText,
+          text: overflowSnapshot,
           assistantId: this.opts.assistantId,
         },
         this.opts.mintBearerToken(),
@@ -261,7 +263,7 @@ export class TelegramStreamingDelivery {
           if (result.messageId) {
             this.currentMessageId = result.messageId;
           }
-          this.lastSentText = this.currentMessageText;
+          this.lastSentText = overflowSnapshot;
           this.messageCount++;
           this.lastEditAt = Date.now();
         })


### PR DESCRIPTION
Fix lastSentText being set from a mutated this.currentMessageText in sendInitialMessage and the overflow path of flushEdit. Both paths now capture a text snapshot before the async deliverChannelReply call and use it in the .then() callback, matching the pattern already used in the regular edit path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
