### PR TITLE
docs(public-ingress): add ngrok auto-restart troubleshooting

### DIFF
--- a/assistant/src/config/bundled-skills/public-ingress/SKILL.md
+++ b/assistant/src/config/bundled-skills/public-ingress/SKILL.md
@@ -252,3 +252,7 @@ ngrok's free tier allows one tunnel at a time. Stop any other ngrok tunnels befo
 **Cause:** ngrok is forwarding to a different port than the gateway is listening on. This can happen if the gateway port was changed after ngrok was started, or if ngrok was started manually with a hardcoded port.
 
 **Fix:** Stop ngrok (`pkill -f ngrok`), verify the gateway URL with `echo "$INTERNAL_GATEWAY_BASE_URL"`, then re-run this skill to start ngrok on the correct port.
+
+### ngrok automatically restarts with wrong port
+
+If after killing the ngrok process, it automatically re-spawns and is still attached to the incorrect port, check to see if there is a launch agent process configured to auto-restart it. This might exist at `~/Library/LaunchAgents/com.ngrok.tunnel.plist`. If so, it needs to be either removed or updated.


### PR DESCRIPTION
## Summary
- Add troubleshooting entry for ngrok automatically restarting with the wrong port after being killed
- Points users to check for a launch agent at `~/Library/LaunchAgents/com.ngrok.tunnel.plist`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
