### PR TITLE
fix: sync CLI_HELP_REFERENCE with browser command description

### DIFF
--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -31,7 +31,7 @@ Commands:
   platform [options]                       Manage platform integration for containerized deployments
   oauth [options]                          Manage OAuth tokens for connected integrations
   skills                                   Browse and install skills from the Vellum catalog
-  browser                                  Browser automation and extension relay
+  browser                                  Browser automation commands
   x|twitter [options]                      Post on X and manage connections. Supports OAuth (official API) and browser session paths.
   map [options] <domain>                   Auto-navigate a domain and produce a deduplicated API map. Launches Chrome with CDP, starts a Ride Shotgun learn session, then analyzes captured network traffic.
   sequence [options]                       Manage email sequences


### PR DESCRIPTION
## Summary
- Updated `CLI_HELP_REFERENCE` constant to say "Browser automation commands" instead of "Browser automation and extension relay", matching the current `buildCliProgram()` output after the browser command refactor in #14286.

## Original prompt
fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22822561431

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
