### PR TITLE
fix(assistant): prevent telegram streaming from splitting messages when messageId is missing

### DIFF
--- a/assistant/src/runtime/telegram-streaming-delivery.ts
+++ b/assistant/src/runtime/telegram-streaming-delivery.ts
@@ -73,7 +73,17 @@ export class TelegramStreamingDelivery {
         this.currentMessageText += this.buffer;
         this.buffer = "";
       } else {
-        this.currentMessageText = this.buffer;
+        log.warn(
+          {
+            chatId: this.opts.chatId,
+            bufferLen: this.buffer.length,
+            currentMessageTextLen: this.currentMessageText.length,
+            textDelivered: this.textDelivered,
+            initialSendInFlight: this.initialSendInFlight,
+          },
+          "finish() sending as new message because currentMessageId is null",
+        );
+        this.currentMessageText += this.buffer;
         this.buffer = "";
         // Send as new message
         await this.sendNewMessage(this.currentMessageText, approval);
@@ -179,6 +189,11 @@ export class TelegramStreamingDelivery {
       .then((result) => {
         if (result.messageId) {
           this.currentMessageId = result.messageId;
+        } else {
+          log.warn(
+            { chatId: this.opts.chatId },
+            "Initial streaming send succeeded but no messageId in response",
+          );
         }
         this.textDelivered = true;
         this.lastSentText = textSnapshot;
@@ -191,6 +206,10 @@ export class TelegramStreamingDelivery {
           { err, chatId: this.opts.chatId },
           "Failed to send initial streaming message",
         );
+        // Push the initial text back into the buffer so finish() can send
+        // the full accumulated text as a single message
+        this.buffer = this.currentMessageText + this.buffer;
+        this.currentMessageText = "";
         // Fall back: clear guard so future deltas can retry
         this.initialSendInFlight = false;
         this.currentMessageId = null;


### PR DESCRIPTION
## Summary
- Fix finish() else branch to concatenate currentMessageText + buffer instead of overwriting, so full text is sent when messageId is missing
- Add diagnostic log.warn when finish() takes the new-message path and when sendInitialMessage() gets no messageId
- Push initial text back to buffer on sendInitialMessage() failure so nothing is lost

Part of plan: telegram-streaming.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
