### PR TITLE
fix(cli): add help text to chrome intermediate command

### DIFF
--- a/assistant/src/cli/commands/browser-relay.ts
+++ b/assistant/src/cli/commands/browser-relay.ts
@@ -90,6 +90,23 @@ Examples:
     .command("chrome")
     .description("Chrome browser automation via the extension relay");
 
+  chrome.addHelpText(
+    "after",
+    `
+Chrome-specific browser automation. Commands are routed through a Chrome
+extension relay that bridges the assistant to open Chrome tabs. The extension
+must be installed and connected before commands will succeed — use the
+\`relay status\` subcommand to verify connectivity.
+
+Subgroups:
+  relay   Send commands to Chrome tabs via the browser extension relay
+
+Examples:
+  $ assistant browser chrome relay status
+  $ assistant browser chrome relay find-tab --url "*://*.github.com/*"
+  $ assistant browser chrome relay evaluate --tab-id 42 --code "document.title"`,
+  );
+
   const relay = chrome
     .command("relay")
     .description(


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for standalone-influencer-skill.md.

**Gap:** chrome intermediate command missing .addHelpText
**What was expected:** Every command level must have extended help text per CLI AGENTS.md
**What was found:** The chrome command only had .description() but no .addHelpText()

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
