### PR TITLE
fix(assistant): add finishOk in overflow path and avoid duplicate text when textDelivered

### DIFF
--- a/assistant/src/runtime/telegram-streaming-delivery.ts
+++ b/assistant/src/runtime/telegram-streaming-delivery.ts
@@ -83,7 +83,13 @@ export class TelegramStreamingDelivery {
           },
           "finish() sending as new message because currentMessageId is null",
         );
-        this.currentMessageText += this.buffer;
+        if (this.textDelivered) {
+          // Initial text already delivered but no messageId — just send remainder
+          this.currentMessageText = this.buffer;
+        } else {
+          // Initial send failed, buffer has been restored — send everything
+          this.currentMessageText += this.buffer;
+        }
         this.buffer = "";
         // Send as new message
         await this.sendNewMessage(this.currentMessageText, approval);
@@ -125,6 +131,7 @@ export class TelegramStreamingDelivery {
 
         // Send overflow (with approval buttons if present) as a new message
         await this.sendNewMessage(overflow, approval);
+        this.finishOk = true;
         return;
       }
 


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for telegram-streaming.md.

**Gap 1:** Missing finishOk = true in the overflow path of finish() caused finishSucceeded to return false, triggering fallback duplicate delivery for long messages.

**Gap 2:** When initial send succeeded but no messageId was returned, finish() would resend the already-delivered prefix text. Now checks textDelivered to only send the unsent remainder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
