### PR TITLE
test(assistant): add finishSucceeded assertion to overflow split test

### DIFF
--- a/assistant/src/runtime/telegram-streaming-delivery.test.ts
+++ b/assistant/src/runtime/telegram-streaming-delivery.test.ts
@@ -297,6 +297,8 @@ describe("TelegramStreamingDelivery", () => {
     expect(overflowPayload.messageId).toBeUndefined();
     // Overflow should contain the remainder: 25 + 4500 - 4000 = 525 chars
     expect((overflowPayload.text as string).length).toBe(525);
+
+    expect(delivery.finishSucceeded).toBe(true);
   });
 
   // ── Test 8: ignores events after finish() is called ─────────────────

--- a/assistant/src/runtime/telegram-streaming-delivery.ts
+++ b/assistant/src/runtime/telegram-streaming-delivery.ts
@@ -125,6 +125,7 @@ export class TelegramStreamingDelivery {
 
         // Send overflow (with approval buttons if present) as a new message
         await this.sendNewMessage(overflow, approval);
+        this.finishOk = true;
         return;
       }
 


### PR DESCRIPTION
## Summary
Adds missing finishSucceeded assertion to the overflow split test case in telegram-streaming-delivery.test.ts, and fixes the underlying bug where finishOk was not set to true in the overflow path of finish().

**Gap:** Test 7 didn't assert delivery.finishSucceeded, missing regression coverage for the finishOk bug in the overflow path. The overflow path in finish() was also missing the `finishOk = true` assignment before its early return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
