### PR TITLE
fix: update CLI_HELP_REFERENCE to match current browser command description

### DIFF
--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -31,7 +31,7 @@ Commands:
   platform [options]                       Manage platform integration for containerized deployments
   oauth [options]                          Manage OAuth tokens for connected integrations
   skills                                   Browse and install skills from the Vellum catalog
-  browser                                  Browser automation, extension relay, and Chrome CDP management
+  browser                                  Browser automation commands
   x|twitter [options]                      Post on X and manage connections. Supports OAuth (official API) and browser session paths.
   map [options] <domain>                   Auto-navigate a domain and produce a deduplicated API map. Launches Chrome with CDP, starts a Ride Shotgun learn session, then analyzes captured network traffic.
   sequence [options]                       Manage email sequences


### PR DESCRIPTION
## Summary
- Update CLI_HELP_REFERENCE in reference.ts to match the current browser command description ("Browser automation commands" instead of "Browser automation, extension relay, and Chrome CDP management")
- Fixes cli-help-reference-sync.test.ts CI failure

## Original prompt
fix the CI failures in https://github.com/vellum-ai/vellum-assistant/actions/runs/22823066876

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
