### PR TITLE
fix: parse stdout for relay error messages in evalInTab

### DIFF
--- a/assistant/src/config/bundled-skills/influencer/scripts/client.ts
+++ b/assistant/src/config/bundled-skills/influencer/scripts/client.ts
@@ -194,7 +194,17 @@ async function evalInTab(tabId: number, script: string): Promise<unknown> {
       stderr += d;
     });
     proc.on("close", (code) => {
-      if (code !== 0) return reject(new Error(stderr || `Exit code ${code}`));
+      if (code !== 0) {
+        // The relay CLI writes structured errors to stdout, not stderr.
+        // Try to parse stdout for a JSON error message before falling back.
+        try {
+          const parsed: RelayResponse = JSON.parse(stdout);
+          if (parsed.error) return reject(new Error(parsed.error));
+        } catch {
+          // stdout wasn't valid JSON — fall through to stderr/exit code
+        }
+        return reject(new Error(stderr || `Exit code ${code}`));
+      }
       try {
         const result: RelayResponse = JSON.parse(stdout);
         if (!result.ok) return reject(new Error(result.error ?? "Eval failed"));


### PR DESCRIPTION
## Summary
Fixes gap where `evalInTab` would discard structured error messages from the browser relay CLI. The relay writes all output (including errors) to stdout, but `evalInTab` only checked stderr on non-zero exit. Now tries to parse stdout JSON first for error messages before falling back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
