### PR TITLE
fix: sync browser command description between reference.ts and browser-relay.ts

### DIFF
--- a/assistant/src/cli/commands/browser-relay.ts
+++ b/assistant/src/cli/commands/browser-relay.ts
@@ -76,7 +76,9 @@ async function readStdin(): Promise<string> {
 export function registerBrowserRelayCommand(program: Command): void {
   const browser = program
     .command("browser")
-    .description("Browser automation commands");
+    .description(
+      "Browser automation, extension relay, and Chrome CDP management",
+    );
 
   browser.addHelpText(
     "after",

--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -31,7 +31,7 @@ Commands:
   platform [options]                       Manage platform integration for containerized deployments
   oauth [options]                          Manage OAuth tokens for connected integrations
   skills                                   Browse and install skills from the Vellum catalog
-  browser                                  Browser automation commands
+  browser                                  Browser automation, extension relay, and Chrome CDP management
   x|twitter [options]                      Post on X and manage connections. Supports OAuth (official API) and browser session paths.
   map [options] <domain>                   Auto-navigate a domain and produce a deduplicated API map. Launches Chrome with CDP, starts a Ride Shotgun learn session, then analyzes captured network traffic.
   sequence [options]                       Manage email sequences


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for browser-chrome-cli.md.

**Gap:** browser command description mismatch
**What was expected:** The `.description()` on the browser command in browser-relay.ts should match the CLI_HELP_REFERENCE entry in reference.ts
**What was found:** Both files had "Browser automation commands" but should use the richer "Browser automation, extension relay, and Chrome CDP management" description that reflects the chrome CDP capabilities added by the plan.

Updated both files to use "Browser automation, extension relay, and Chrome CDP management" so the guard test cli-help-reference-sync.test.ts passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
