### PR TITLE
refactor(twitter): replace Chrome CDP imports with `assistant browser chrome` subprocess calls

### DIFF
--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -5,9 +5,13 @@
  * All commands output JSON to stdout. Use --json for machine-readable output.
  */
 
+import { execFile } from "node:child_process";
 import * as net from "node:net";
+import { promisify } from "node:util";
 
 import { Command } from "commander";
+
+const execFileAsync = promisify(execFile);
 
 import {
   createMessageParser,
@@ -239,7 +243,7 @@ Examples:
 
           // Hide Chrome after capturing session
           try {
-            await minimizeChromeWindow(); // uses default CDP port
+            await minimizeChrome();
           } catch {
             /* best-effort */
           }
@@ -969,13 +973,33 @@ function sendDaemonMessage(
 }
 
 // ---------------------------------------------------------------------------
-// Chrome CDP helpers (shared)
+// Chrome CDP helpers (via `assistant browser chrome` CLI)
 // ---------------------------------------------------------------------------
 
-import {
-  ensureChromeWithCdp,
-  minimizeChromeWindow,
-} from "../../../tools/browser/chrome-cdp.js";
+async function launchChromeCdp(
+  startUrl?: string,
+): Promise<{ baseUrl: string }> {
+  const args = ["browser", "chrome", "launch"];
+  if (startUrl) args.push("--start-url", startUrl);
+  const { stdout } = await execFileAsync("assistant", args);
+  const result = JSON.parse(stdout) as {
+    ok: boolean;
+    baseUrl?: string;
+    error?: string;
+  };
+  if (!result.ok || !result.baseUrl) {
+    throw new Error(result.error ?? "Failed to launch Chrome with CDP");
+  }
+  return { baseUrl: result.baseUrl };
+}
+
+async function minimizeChrome(): Promise<void> {
+  try {
+    await execFileAsync("assistant", ["browser", "chrome", "minimize"]);
+  } catch {
+    // best-effort — same as the original
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Ride Shotgun learn session helper
@@ -1011,9 +1035,7 @@ async function navigateToX(cdpBase: string): Promise<void> {
 async function startLearnSession(
   durationSeconds: number,
 ): Promise<LearnResult> {
-  const cdpSession = await ensureChromeWithCdp({
-    startUrl: "https://x.com/login",
-  });
+  const cdpSession = await launchChromeCdp("https://x.com/login");
   await navigateToX(cdpSession.baseUrl);
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- Replace direct imports of ensureChromeWithCdp and minimizeChromeWindow with subprocess calls to `assistant browser chrome launch` and `assistant browser chrome minimize`
- Add launchChromeCdp() and minimizeChrome() helpers that invoke the CLI

Part of plan: amazon-twitter-browser-cli.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
