### PR TITLE
docs(skills): note browser chrome CLI dependency in Amazon and Twitter SKILL.md

### DIFF
--- a/assistant/src/config/bundled-skills/amazon/SKILL.md
+++ b/assistant/src/config/bundled-skills/amazon/SKILL.md
@@ -60,10 +60,10 @@ Alternatively, run `assistant amazon variations <asin> --json` to list just the 
 
 ## Important Behavior
 
+- **Chrome extension relay required.** The Amazon CLI uses `assistant browser chrome relay` internally for browser automation. The Chrome extension must be connected before Amazon commands will work. If a command fails with a connection error, tell the user: "Please open Chrome, click the Vellum extension icon, and click Connect — then I'll retry."
 - **Always confirm before placing order.** Never call `order place` without explicit user approval. Show the cart and total first.
 - **Be proactive.** If the user says "order AA batteries", don't ask clarifying questions upfront — search, find the product, and suggest it. Only ask when you need a choice the user hasn't specified.
 - **Handle expired sessions gracefully.** If any command returns `"error": "session_expired"`, run `assistant amazon refresh --json` to re-capture the session.
-- **Handle extension errors.** If a command fails with a message about the browser extension not being connected, tell the user: "Please open Chrome, click the Vellum extension icon, and click Connect — then I'll retry." Do NOT try to interact with the relay directly.
 - **Show prices.** Always show prices when presenting products or the cart summary.
 - **Use `--json` flag** on all commands for reliable parsing.
 - **Do NOT use the browser skill.** All Amazon interaction goes through the CLI, not browser automation.

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -22,7 +22,7 @@ OAuth uses the official X API v2. It is the most reliable connection method and 
 
 ### Browser session (no developer credentials needed)
 
-The browser path is quick to start and useful when the user does not have X developer app credentials. It captures auth cookies from Chrome and uses them to interact with X.
+The browser path is quick to start and useful when the user does not have X developer app credentials. It captures auth cookies from Chrome and uses them to interact with X. Chrome management uses `assistant browser chrome launch` and `assistant browser chrome minimize` CLI commands internally.
 
 - Supports: **all operations** (post, reply, timeline, search, home, bookmarks, notifications, likes, followers, following, media)
 - Setup: Run `assistant x refresh` to open Chrome and capture session cookies automatically.


### PR DESCRIPTION
## Summary
- Add note to Amazon SKILL.md that the CLI uses `assistant browser chrome relay` internally
- Add note to Twitter SKILL.md that the CLI uses `assistant browser chrome launch/minimize` internally
- No references to internal module names in either SKILL.md

Part of plan: amazon-twitter-browser-cli.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
