### PR TITLE
refactor(twitter): inline error class imports as local definitions

### DIFF
--- a/assistant/src/cli/commands/twitter/client.ts
+++ b/assistant/src/cli/commands/twitter/client.ts
@@ -4,8 +4,18 @@
  * go through the browser's authenticated session.
  */
 
-import { ProviderError } from "../../../util/errors.js";
 import { loadSession, type TwitterSession } from "./session.js";
+
+class ProviderError extends Error {
+  constructor(
+    message: string,
+    public readonly provider: string,
+    public readonly statusCode?: number,
+  ) {
+    super(message);
+    this.name = "ProviderError";
+  }
+}
 
 const CDP_BASE = "http://localhost:9222";
 

--- a/assistant/src/cli/commands/twitter/session.ts
+++ b/assistant/src/cli/commands/twitter/session.ts
@@ -9,7 +9,13 @@ import {
   createSessionStore,
   importFromRecordingBase,
 } from "../../../util/cookie-session.js";
-import { ConfigError } from "../../../util/errors.js";
+
+class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}
 
 export type TwitterSession = CookieSession;
 


### PR DESCRIPTION
## Summary
- Replace import of ProviderError from util/errors.js in client.ts with a local class definition
- Replace import of ConfigError from util/errors.js in session.ts with a local class definition
- Both classes are simple Error subclasses; instanceof checks in session.ts continue working

Part of plan: amazon-twitter-browser-cli.md (PR 5 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
