### PR TITLE
refactor(amazon): inline network-recording-types imports as local types

### DIFF
--- a/assistant/src/cli/commands/amazon/client.ts
+++ b/assistant/src/cli/commands/amazon/client.ts
@@ -51,9 +51,17 @@
 import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 
-import type { ExtractedCredential } from "../../../tools/browser/network-recording-types.js";
-
 const execFileAsync = promisify(execFile);
+
+export interface ExtractedCredential {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  httpOnly: boolean;
+  secure: boolean;
+  expires?: number;
+}
 
 interface RelayResponse {
   ok: boolean;

--- a/assistant/src/cli/commands/amazon/index.ts
+++ b/assistant/src/cli/commands/amazon/index.ts
@@ -9,6 +9,7 @@ import { Command } from "commander";
 
 import {
   addToCart,
+  type ExtractedCredential,
   getCheckoutSummary,
   getFreshDeliverySlots,
   getPaymentMethods,
@@ -873,8 +874,7 @@ async function extractSessionFromChromeCookies(): Promise<
   }
 
   // 4. Decrypt each cookie
-  const cookies: import("../../../tools/browser/network-recording-types.js").ExtractedCredential[] =
-    [];
+  const cookies: ExtractedCredential[] = [];
   for (const line of rawOutput.split("\n")) {
     const parts = line.split("|");
     if (parts.length < 7) continue;

--- a/assistant/src/cli/commands/amazon/request-extractor.ts
+++ b/assistant/src/cli/commands/amazon/request-extractor.ts
@@ -9,8 +9,46 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import type { SessionRecording } from "../../../tools/browser/network-recording-types.js";
 import { getDataDir } from "../../../util/platform.js";
+
+interface NetworkRecordedRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  postData?: string;
+}
+
+interface NetworkRecordedEntry {
+  requestId: string;
+  resourceType: string;
+  timestamp: number;
+  request: NetworkRecordedRequest;
+  response?: unknown;
+}
+
+interface SessionRecording {
+  id: string;
+  startedAt: number;
+  endedAt: number;
+  targetDomain?: string;
+  networkEntries: NetworkRecordedEntry[];
+  cookies: Array<{
+    name: string;
+    value: string;
+    domain: string;
+    path: string;
+    httpOnly: boolean;
+    secure: boolean;
+    expires?: number;
+  }>;
+  observations: Array<{
+    ocrText: string;
+    appName?: string;
+    windowTitle?: string;
+    timestamp: number;
+    captureIndex: number;
+  }>;
+}
 
 export type AmazonRequestKey =
   | "search"


### PR DESCRIPTION
## Summary
- Replace import of ExtractedCredential from network-recording-types.js in client.ts with a local interface
- Replace import of SessionRecording from network-recording-types.js in request-extractor.ts with local interfaces
- Replace inline type import in index.ts with import from ./client.js

Part of plan: amazon-twitter-browser-cli.md (PR 4 of 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
