### PR TITLE
fix: prevent text loss on below-threshold tool_use_start and remove dead code in telegram streaming

### DIFF
--- a/assistant/src/runtime/telegram-streaming-delivery.test.ts
+++ b/assistant/src/runtime/telegram-streaming-delivery.test.ts
@@ -122,8 +122,8 @@ describe("TelegramStreamingDelivery", () => {
     expect(secondPayload.text).toBe("a".repeat(25) + "b".repeat(10));
   });
 
-  // ── Test 3: sends full text as new message when messageId missing ───
-  test("sends full text as new message when messageId is missing", async () => {
+  // ── Test 3: sends remainder as new message when messageId missing ───
+  test("sends remainder as new message when messageId is missing", async () => {
     // First call: no messageId in response; second call: with messageId
     mockDeliverChannelReply.mockReset();
     let localCallCount = 0;
@@ -150,9 +150,10 @@ describe("TelegramStreamingDelivery", () => {
 
     expect(mockDeliverChannelReply).toHaveBeenCalledTimes(2);
 
-    // Second call should contain the FULL accumulated text (not just remainder)
+    // The initial text was already delivered (just without a messageId),
+    // so the second call should contain only the remainder (buffer text)
     const secondPayload = callPayload(1);
-    expect(secondPayload.text).toBe("a".repeat(25) + "b".repeat(10));
+    expect(secondPayload.text).toBe("b".repeat(10));
     // It's sent as a new message (no messageId in payload) since the first
     // call didn't return one
     expect(secondPayload.messageId).toBeUndefined();
@@ -349,6 +350,66 @@ describe("TelegramStreamingDelivery", () => {
     const overflowPayload = callPayload(2);
     expect((overflowPayload.text as string).length).toBe(100);
     expect(overflowPayload.messageId).toBeUndefined();
+  });
+
+  // ── Test 5f: preserves below-threshold text across tool_use_start ───
+  test("preserves below-threshold text across tool_use_start", async () => {
+    const delivery = createDelivery();
+
+    // Send text below MIN_INITIAL_CHARS threshold
+    delivery.onEvent({
+      type: "assistant_text_delta",
+      text: "Hi! ", // 4 chars, well below 20
+    });
+    await flushPromises();
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(0); // not sent yet
+
+    // tool_use_start
+    delivery.onEvent({
+      type: "tool_use_start",
+      toolName: "memory_recall",
+      input: {},
+    });
+    await flushPromises();
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(0); // still not sent
+
+    // More text after tool (enough to trigger initial send when combined)
+    delivery.onEvent({
+      type: "assistant_text_delta",
+      text: "What can I help with?", // 21 chars, combined = 25 >= 20
+    });
+    await flushPromises();
+
+    // Should have sent initial message with ALL text (pre-tool + post-tool)
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(1);
+    const payload = callPayload(0);
+    expect(payload.text).toBe("Hi! What can I help with?");
+
+    await delivery.finish();
+    expect(delivery.finishSucceeded).toBe(true);
+  });
+
+  // ── Test 5g: delivers below-threshold text when tool_use_start is followed by finish ─
+  test("delivers below-threshold text when tool_use_start is followed by finish", async () => {
+    const delivery = createDelivery();
+
+    delivery.onEvent({
+      type: "assistant_text_delta",
+      text: "Hi!", // 3 chars
+    });
+    delivery.onEvent({
+      type: "tool_use_start",
+      toolName: "lookup",
+      input: {},
+    });
+
+    await delivery.finish();
+
+    // The "Hi!" should have been sent as a new message during finish
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(1);
+    const payload = callPayload(0);
+    expect(payload.text).toBe("Hi!");
+    expect(delivery.finishSucceeded).toBe(true);
   });
 
   // ── Test 6: skips final edit when text hasn't changed ───────────────

--- a/assistant/src/runtime/telegram-streaming-delivery.ts
+++ b/assistant/src/runtime/telegram-streaming-delivery.ts
@@ -31,7 +31,6 @@ export class TelegramStreamingDelivery {
   private finishOk = false; // True only when finish() completes without error
   private initialSendInFlight = false; // Synchronous guard against duplicate initial sends
   private initialSendPromise: Promise<ChannelDeliveryResult> | null = null; // Tracks in-flight initial send
-  private pausedForTool = false; // True when a tool_use_start has paused streaming
 
   constructor(opts: TelegramStreamingOptions) {
     this.opts = opts;
@@ -46,24 +45,14 @@ export class TelegramStreamingDelivery {
         this.onTextDelta(msg.text);
         break;
       case "tool_use_start":
-        this.pausedForTool = true;
-        // Flush buffer into currentMessageText but do NOT reset message state.
-        // This keeps the current Telegram message alive so the next text delta
-        // can resume appending to it instead of starting a new message.
-        if (this.buffer.length > 0) {
+        // Flush buffer and send an edit so the message is up-to-date before the tool runs
+        if (this.buffer.length > 0 && this.currentMessageId) {
+          this.flushEdit();
+        } else if (this.buffer.length > 0) {
+          // No message sent yet — just move buffer to currentMessageText
           this.currentMessageText += this.buffer;
           this.buffer = "";
         }
-        // Send an edit with current text so it's up to date before the tool runs
-        if (
-          this.currentMessageId &&
-          this.currentMessageText !== this.lastSentText
-        ) {
-          this.flushEdit();
-        }
-        break;
-      case "tool_result":
-        this.pausedForTool = false;
         break;
       case "message_complete":
         // Don't finalize here — let finish() handle it
@@ -73,7 +62,6 @@ export class TelegramStreamingDelivery {
 
   async finish(approval?: ApprovalUIMetadata): Promise<void> {
     this.finished = true;
-    this.pausedForTool = false;
     if (this.editTimer) {
       clearTimeout(this.editTimer);
       this.editTimer = null;
@@ -115,6 +103,18 @@ export class TelegramStreamingDelivery {
         this.finishOk = true;
         return;
       }
+    }
+
+    // Buffer was empty but text was moved to currentMessageText (e.g. by
+    // tool_use_start) before any Telegram message was created. Send it now.
+    if (
+      !this.currentMessageId &&
+      this.currentMessageText.length > 0 &&
+      this.buffer.length === 0
+    ) {
+      await this.sendNewMessage(this.currentMessageText, approval);
+      this.finishOk = true;
+      return;
     }
 
     // Final edit with approval buttons if present.
@@ -183,7 +183,6 @@ export class TelegramStreamingDelivery {
 
   private onTextDelta(text: string): void {
     this.buffer += text;
-    this.pausedForTool = false; // Resume streaming to the same message
     if (
       !this.currentMessageId &&
       !this.initialSendInFlight &&
@@ -197,7 +196,7 @@ export class TelegramStreamingDelivery {
 
   private sendInitialMessage(): void {
     this.initialSendInFlight = true;
-    this.currentMessageText = this.buffer;
+    this.currentMessageText += this.buffer;
     this.buffer = "";
 
     const textSnapshot = this.currentMessageText;
@@ -346,78 +345,6 @@ export class TelegramStreamingDelivery {
         });
     }
     this.lastEditAt = Date.now();
-  }
-
-  private finalizeCurrentMessage(): void {
-    if (this.editTimer) {
-      clearTimeout(this.editTimer);
-      this.editTimer = null;
-    }
-
-    // Flush any remaining buffer into the current message
-    if (this.buffer.length > 0) {
-      this.currentMessageText += this.buffer;
-      this.buffer = "";
-    }
-
-    if (this.currentMessageId && this.currentMessageText) {
-      // Send a final edit for the active message
-      const textSnapshot = this.currentMessageText;
-      deliverChannelReply(
-        this.opts.callbackUrl,
-        {
-          chatId: this.opts.chatId,
-          text: this.currentMessageText,
-          messageId: this.currentMessageId,
-          assistantId: this.opts.assistantId,
-        },
-        this.opts.mintBearerToken(),
-      )
-        .then(() => {
-          this.lastSentText = textSnapshot;
-        })
-        .catch((err) => {
-          log.error(
-            { err, chatId: this.opts.chatId },
-            "Failed to finalize streaming message",
-          );
-        });
-    } else if (!this.currentMessageId && this.currentMessageText) {
-      // No Telegram message was created yet (e.g., text was under the
-      // MIN_INITIAL_CHARS threshold when tool_use_start arrived). Send
-      // the buffered text as a new message so it isn't lost.
-      const textSnapshot = this.currentMessageText;
-      deliverChannelReply(
-        this.opts.callbackUrl,
-        {
-          chatId: this.opts.chatId,
-          text: textSnapshot,
-          assistantId: this.opts.assistantId,
-        },
-        this.opts.mintBearerToken(),
-      )
-        .then((result) => {
-          if (result.messageId) {
-            // Message sent successfully; don't set currentMessageId since
-            // we're about to reset for the next segment anyway.
-          }
-          this.textDelivered = true;
-          this.lastSentText = textSnapshot;
-          this.messageCount++;
-        })
-        .catch((err) => {
-          log.error(
-            { err, chatId: this.opts.chatId },
-            "Failed to send pre-tool buffered text",
-          );
-        });
-    }
-
-    // Reset so the next text delta starts a new message
-    this.currentMessageId = null;
-    this.currentMessageText = "";
-    this.lastSentText = "";
-    this.pausedForTool = false;
   }
 
   private async sendNewMessage(


### PR DESCRIPTION
## Summary
- Fix text loss when `tool_use_start` arrives before the initial Telegram message is sent (text below MIN_INITIAL_CHARS threshold)
- Fix dead `flushEdit()` call in tool_use_start handler by rearranging to call it before buffer drain
- Remove write-only `pausedForTool` field, dead `tool_result` handler, and dead `finalizeCurrentMessage()` method
- Add test coverage for below-threshold text preservation across tool calls
- Fix pre-existing broken test expectation for no-messageId case

Fixes gaps found during plan review for tg-duplicate-msg-fix.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
