### PR TITLE
M2: Expose real platform-managed Twitter availability

### DIFF
--- a/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
+++ b/assistant/src/__tests__/__snapshots__/ipc-snapshot.test.ts.snap
@@ -2282,6 +2282,11 @@ exports[`IPC message snapshots ServerMessage types twitter_integration_config_re
   "connected": false,
   "localClientConfigured": true,
   "managedAvailable": false,
+  "managedPrerequisites": {
+    "assistantApiKeyPresent": false,
+    "integrationModeManaged": false,
+    "platformAssistantIdResolvable": false,
+  },
   "mode": "local_byo",
   "success": true,
   "type": "twitter_integration_config_response",

--- a/assistant/src/__tests__/handlers-twitter-config.test.ts
+++ b/assistant/src/__tests__/handlers-twitter-config.test.ts
@@ -55,6 +55,19 @@ mock.module("../config/loader.js", () => ({
   setNestedValue,
 }));
 
+// Mock platform base URL for managed prerequisites
+let mockPlatformBaseUrl = "";
+
+mock.module("../config/env.js", () => ({
+  getPlatformBaseUrl: () => mockPlatformBaseUrl,
+  getPlatformAssistantId: () => "",
+  getPlatformInternalApiKey: () => "",
+  getGatewayPort: () => 7830,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+  getIngressPublicBaseUrl: () => undefined,
+  setIngressPublicBaseUrl: () => {},
+}));
+
 mock.module("../util/platform.js", () => ({
   getRootDir: () => testDir,
   getDataDir: () => testDir,
@@ -228,6 +241,7 @@ describe("Twitter integration config handler", () => {
     setSecureKeyOverride = null;
     credentialMetadataStore = [];
     deletedMetadata.length = 0;
+    mockPlatformBaseUrl = "";
   });
 
   test("get action returns correct status when not configured", () => {
@@ -245,6 +259,11 @@ describe("Twitter integration config handler", () => {
       success: boolean;
       mode: string;
       managedAvailable: boolean;
+      managedPrerequisites: {
+        integrationModeManaged: boolean;
+        assistantApiKeyPresent: boolean;
+        platformAssistantIdResolvable: boolean;
+      };
       localClientConfigured: boolean;
       connected: boolean;
     };
@@ -252,6 +271,11 @@ describe("Twitter integration config handler", () => {
     expect(res.success).toBe(true);
     expect(res.mode).toBe("local_byo");
     expect(res.managedAvailable).toBe(false);
+    expect(res.managedPrerequisites).toEqual({
+      integrationModeManaged: false,
+      assistantApiKeyPresent: false,
+      platformAssistantIdResolvable: false,
+    });
     expect(res.localClientConfigured).toBe(false);
     expect(res.connected).toBe(false);
   });
@@ -1135,5 +1159,186 @@ describe("Twitter integration config handler", () => {
       expect(res.success).toBe(true);
       expect(res.strategy).toBe(value);
     }
+  });
+
+  // --- Managed prerequisites tests ---
+
+  test("managedAvailable is true when all prerequisites are met", () => {
+    rawConfigStore = { twitter: { integrationMode: "managed" } };
+    secureKeyStore["credential:vellum:assistant_api_key"] = "test-api-key";
+    mockPlatformBaseUrl = "https://platform.example.com";
+
+    const msg: TwitterIntegrationConfigRequest = {
+      type: "twitter_integration_config",
+      action: "get",
+    };
+
+    const { ctx, sent } = createTestContext();
+    handleMessage(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as {
+      type: string;
+      success: boolean;
+      managedAvailable: boolean;
+      managedPrerequisites: {
+        integrationModeManaged: boolean;
+        assistantApiKeyPresent: boolean;
+        platformAssistantIdResolvable: boolean;
+      };
+      connected: boolean;
+    };
+    expect(res.managedAvailable).toBe(true);
+    expect(res.managedPrerequisites).toEqual({
+      integrationModeManaged: true,
+      assistantApiKeyPresent: true,
+      platformAssistantIdResolvable: true,
+    });
+    // In managed mode, connected is conservative (false)
+    expect(res.connected).toBe(false);
+  });
+
+  test("managedAvailable is true regardless of cloud mode when prerequisites are met", () => {
+    // No cloud config set — should still work
+    rawConfigStore = { twitter: { integrationMode: "managed" } };
+    secureKeyStore["credential:vellum:assistant_api_key"] = "test-api-key";
+    mockPlatformBaseUrl = "https://platform.example.com";
+
+    const msg: TwitterIntegrationConfigRequest = {
+      type: "twitter_integration_config",
+      action: "get",
+    };
+
+    const { ctx, sent } = createTestContext();
+    handleMessage(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as {
+      type: string;
+      managedAvailable: boolean;
+    };
+    expect(res.managedAvailable).toBe(true);
+  });
+
+  test("managedAvailable is false when mode is local_byo", () => {
+    rawConfigStore = { twitter: { integrationMode: "local_byo" } };
+    secureKeyStore["credential:vellum:assistant_api_key"] = "test-api-key";
+    mockPlatformBaseUrl = "https://platform.example.com";
+
+    const msg: TwitterIntegrationConfigRequest = {
+      type: "twitter_integration_config",
+      action: "get",
+    };
+
+    const { ctx, sent } = createTestContext();
+    handleMessage(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as {
+      type: string;
+      managedAvailable: boolean;
+      managedPrerequisites: {
+        integrationModeManaged: boolean;
+        assistantApiKeyPresent: boolean;
+        platformAssistantIdResolvable: boolean;
+      };
+    };
+    expect(res.managedAvailable).toBe(false);
+    expect(res.managedPrerequisites.integrationModeManaged).toBe(false);
+    expect(res.managedPrerequisites.assistantApiKeyPresent).toBe(true);
+    expect(res.managedPrerequisites.platformAssistantIdResolvable).toBe(true);
+  });
+
+  test("managedAvailable is false when assistant API key is missing", () => {
+    rawConfigStore = { twitter: { integrationMode: "managed" } };
+    // No assistant API key set
+    mockPlatformBaseUrl = "https://platform.example.com";
+
+    const msg: TwitterIntegrationConfigRequest = {
+      type: "twitter_integration_config",
+      action: "get",
+    };
+
+    const { ctx, sent } = createTestContext();
+    handleMessage(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as {
+      type: string;
+      managedAvailable: boolean;
+      managedPrerequisites: {
+        integrationModeManaged: boolean;
+        assistantApiKeyPresent: boolean;
+        platformAssistantIdResolvable: boolean;
+      };
+    };
+    expect(res.managedAvailable).toBe(false);
+    expect(res.managedPrerequisites.integrationModeManaged).toBe(true);
+    expect(res.managedPrerequisites.assistantApiKeyPresent).toBe(false);
+    expect(res.managedPrerequisites.platformAssistantIdResolvable).toBe(true);
+  });
+
+  test("managedAvailable is false when platform base URL is missing", () => {
+    rawConfigStore = { twitter: { integrationMode: "managed" } };
+    secureKeyStore["credential:vellum:assistant_api_key"] = "test-api-key";
+    mockPlatformBaseUrl = ""; // No platform URL
+
+    const msg: TwitterIntegrationConfigRequest = {
+      type: "twitter_integration_config",
+      action: "get",
+    };
+
+    const { ctx, sent } = createTestContext();
+    handleMessage(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as {
+      type: string;
+      managedAvailable: boolean;
+      managedPrerequisites: {
+        integrationModeManaged: boolean;
+        assistantApiKeyPresent: boolean;
+        platformAssistantIdResolvable: boolean;
+      };
+    };
+    expect(res.managedAvailable).toBe(false);
+    expect(res.managedPrerequisites.integrationModeManaged).toBe(true);
+    expect(res.managedPrerequisites.assistantApiKeyPresent).toBe(true);
+    expect(res.managedPrerequisites.platformAssistantIdResolvable).toBe(false);
+  });
+
+  test("set_mode to managed updates managedAvailable based on real prerequisites", () => {
+    secureKeyStore["credential:vellum:assistant_api_key"] = "test-api-key";
+    mockPlatformBaseUrl = "https://platform.example.com";
+
+    const msg: TwitterIntegrationConfigRequest = {
+      type: "twitter_integration_config",
+      action: "set_mode",
+      mode: "managed",
+    };
+
+    const { ctx, sent } = createTestContext();
+    handleMessage(msg, {} as net.Socket, ctx);
+
+    expect(sent).toHaveLength(1);
+    const res = sent[0] as {
+      type: string;
+      success: boolean;
+      mode: string;
+      managedAvailable: boolean;
+      managedPrerequisites: {
+        integrationModeManaged: boolean;
+        assistantApiKeyPresent: boolean;
+        platformAssistantIdResolvable: boolean;
+      };
+    };
+    expect(res.success).toBe(true);
+    expect(res.mode).toBe("managed");
+    expect(res.managedAvailable).toBe(true);
+    expect(res.managedPrerequisites).toEqual({
+      integrationModeManaged: true,
+      assistantApiKeyPresent: true,
+      platformAssistantIdResolvable: true,
+    });
   });
 });

--- a/assistant/src/__tests__/ipc-snapshot.test.ts
+++ b/assistant/src/__tests__/ipc-snapshot.test.ts
@@ -1484,6 +1484,11 @@ const serverMessages: Record<ServerMessageType, ServerMessage> = {
     success: true,
     mode: "local_byo",
     managedAvailable: false,
+    managedPrerequisites: {
+      integrationModeManaged: false,
+      assistantApiKeyPresent: false,
+      platformAssistantIdResolvable: false,
+    },
     localClientConfigured: true,
     connected: false,
   },

--- a/assistant/src/daemon/handlers/config-integrations.ts
+++ b/assistant/src/daemon/handlers/config-integrations.ts
@@ -112,7 +112,10 @@ function computeManagedPrerequisites(mode: "local_byo" | "managed"): {
   const assistantApiKeyPresent = !!getSecureKey(
     "credential:vellum:assistant_api_key",
   );
-  const platformAssistantIdResolvable = !!getPlatformBaseUrl();
+  const platformAssistantIdResolvable = !!(
+    getPlatformBaseUrl() ||
+    (loadRawConfig()?.platform as Record<string, unknown> | undefined)?.baseUrl
+  );
 
   const managedPrerequisites: ManagedPrerequisites = {
     integrationModeManaged,

--- a/assistant/src/daemon/handlers/config-integrations.ts
+++ b/assistant/src/daemon/handlers/config-integrations.ts
@@ -191,9 +191,10 @@ export async function handleTwitterIntegrationConfig(
         managedAvailable,
         managedPrerequisites,
         localClientConfigured: hasTwitterClientId(),
-        connected: !!getSecureKey(
-          "credential:integration:twitter:access_token",
-        ),
+        connected:
+          currentMode === "managed"
+            ? false
+            : !!getSecureKey("credential:integration:twitter:access_token"),
         strategy,
         strategyConfigured,
       });
@@ -223,9 +224,10 @@ export async function handleTwitterIntegrationConfig(
         managedAvailable,
         managedPrerequisites,
         localClientConfigured: hasTwitterClientId(),
-        connected: !!getSecureKey(
-          "credential:integration:twitter:access_token",
-        ),
+        connected:
+          currentMode === "managed"
+            ? false
+            : !!getSecureKey("credential:integration:twitter:access_token"),
         strategy: value as "oauth" | "browser" | "auto",
         strategyConfigured: true,
       });
@@ -242,9 +244,10 @@ export async function handleTwitterIntegrationConfig(
         managedAvailable,
         managedPrerequisites,
         localClientConfigured: hasTwitterClientId(),
-        connected: !!getSecureKey(
-          "credential:integration:twitter:access_token",
-        ),
+        connected:
+          currentMode === "managed"
+            ? false
+            : !!getSecureKey("credential:integration:twitter:access_token"),
       });
     } else if (msg.action === "set_local_client") {
       const { managedAvailable, managedPrerequisites } = managed();
@@ -321,9 +324,10 @@ export async function handleTwitterIntegrationConfig(
         managedAvailable,
         managedPrerequisites,
         localClientConfigured: true,
-        connected: !!getSecureKey(
-          "credential:integration:twitter:access_token",
-        ),
+        connected:
+          currentMode === "managed"
+            ? false
+            : !!getSecureKey("credential:integration:twitter:access_token"),
       });
     } else if (msg.action === "clear_local_client") {
       // If connected, disconnect first

--- a/assistant/src/daemon/handlers/config-integrations.ts
+++ b/assistant/src/daemon/handlers/config-integrations.ts
@@ -1,5 +1,6 @@
 import * as net from "node:net";
 
+import { getPlatformBaseUrl } from "../../config/env.js";
 import {
   getNestedValue,
   loadRawConfig,
@@ -17,6 +18,7 @@ import {
   upsertCredentialMetadata,
 } from "../../tools/credentials/metadata-store.js";
 import type {
+  ManagedPrerequisites,
   TwitterIntegrationConfigRequest,
   VercelApiConfigRequest,
 } from "../ipc-protocol.js";
@@ -101,19 +103,50 @@ function hasTwitterClientId(): boolean {
   return !!getSecureKey("credential:integration:twitter:client_id");
 }
 
+/** Compute managed Twitter prerequisites from config, secure storage, and environment. */
+function computeManagedPrerequisites(mode: "local_byo" | "managed"): {
+  managedAvailable: boolean;
+  managedPrerequisites: ManagedPrerequisites;
+} {
+  const integrationModeManaged = mode === "managed";
+  const assistantApiKeyPresent = !!getSecureKey(
+    "credential:vellum:assistant_api_key",
+  );
+  const platformAssistantIdResolvable = !!getPlatformBaseUrl();
+
+  const managedPrerequisites: ManagedPrerequisites = {
+    integrationModeManaged,
+    assistantApiKeyPresent,
+    platformAssistantIdResolvable,
+  };
+
+  const managedAvailable =
+    integrationModeManaged &&
+    assistantApiKeyPresent &&
+    platformAssistantIdResolvable;
+
+  return { managedAvailable, managedPrerequisites };
+}
+
 export async function handleTwitterIntegrationConfig(
   msg: TwitterIntegrationConfigRequest,
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   try {
+    // Read the current mode once — individual branches may override after persisting a new mode.
+    const rawForMode = loadRawConfig();
+    let currentMode =
+      (getNestedValue(rawForMode, "twitter.integrationMode") as
+        | "local_byo"
+        | "managed"
+        | undefined) ?? "local_byo";
+
+    /** Helper: compute managed prereqs for the current (possibly updated) mode. */
+    const managed = () => computeManagedPrerequisites(currentMode);
+
     if (msg.action === "get") {
       const raw = loadRawConfig();
-      const mode =
-        (getNestedValue(raw, "twitter.integrationMode") as
-          | "local_byo"
-          | "managed"
-          | undefined) ?? "local_byo";
       const strategy =
         (getNestedValue(raw, "twitter.operationStrategy") as
           | "oauth"
@@ -123,15 +156,18 @@ export async function handleTwitterIntegrationConfig(
       const strategyConfigured =
         getNestedValue(raw, "twitter.operationStrategy") !== undefined;
       const localClientConfigured = hasTwitterClientId();
-      const connected = !!getSecureKey(
-        "credential:integration:twitter:access_token",
-      );
+      const connected =
+        currentMode === "managed"
+          ? false
+          : !!getSecureKey("credential:integration:twitter:access_token");
       const meta = getCredentialMetadata("integration:twitter", "access_token");
+      const { managedAvailable, managedPrerequisites } = managed();
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: true,
-        mode,
-        managedAvailable: false,
+        mode: currentMode,
+        managedAvailable,
+        managedPrerequisites,
         localClientConfigured,
         connected,
         accountInfo: meta?.accountInfo ?? undefined,
@@ -148,10 +184,12 @@ export async function handleTwitterIntegrationConfig(
           | undefined) ?? "auto";
       const strategyConfigured =
         getNestedValue(raw, "twitter.operationStrategy") !== undefined;
+      const { managedAvailable, managedPrerequisites } = managed();
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: true,
-        managedAvailable: false,
+        managedAvailable,
+        managedPrerequisites,
         localClientConfigured: hasTwitterClientId(),
         connected: !!getSecureKey(
           "credential:integration:twitter:access_token",
@@ -163,10 +201,12 @@ export async function handleTwitterIntegrationConfig(
       const valid = ["oauth", "browser", "auto"];
       const value = msg.strategy;
       if (!value || !valid.includes(value)) {
+        const { managedAvailable, managedPrerequisites } = managed();
         ctx.send(socket, {
           type: "twitter_integration_config_response",
           success: false,
-          managedAvailable: false,
+          managedAvailable,
+          managedPrerequisites,
           localClientConfigured: false,
           connected: false,
           error: `Invalid strategy value: ${String(value)}. Must be one of: ${valid.join(", ")}`,
@@ -176,10 +216,12 @@ export async function handleTwitterIntegrationConfig(
       const raw = loadRawConfig();
       setNestedValue(raw, "twitter.operationStrategy", value);
       saveRawConfig(raw);
+      const { managedAvailable, managedPrerequisites } = managed();
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: true,
-        managedAvailable: false,
+        managedAvailable,
+        managedPrerequisites,
         localClientConfigured: hasTwitterClientId(),
         connected: !!getSecureKey(
           "credential:integration:twitter:access_token",
@@ -189,24 +231,29 @@ export async function handleTwitterIntegrationConfig(
       });
     } else if (msg.action === "set_mode") {
       const raw = loadRawConfig();
-      setNestedValue(raw, "twitter.integrationMode", msg.mode ?? "local_byo");
+      currentMode = msg.mode ?? "local_byo";
+      setNestedValue(raw, "twitter.integrationMode", currentMode);
       saveRawConfig(raw);
+      const { managedAvailable, managedPrerequisites } = managed();
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: true,
-        mode: msg.mode ?? "local_byo",
-        managedAvailable: false,
+        mode: currentMode,
+        managedAvailable,
+        managedPrerequisites,
         localClientConfigured: hasTwitterClientId(),
         connected: !!getSecureKey(
           "credential:integration:twitter:access_token",
         ),
       });
     } else if (msg.action === "set_local_client") {
+      const { managedAvailable, managedPrerequisites } = managed();
       if (!msg.clientId) {
         ctx.send(socket, {
           type: "twitter_integration_config_response",
           success: false,
-          managedAvailable: false,
+          managedAvailable,
+          managedPrerequisites,
           localClientConfigured: false,
           connected: false,
           error: "clientId is required for set_local_client action",
@@ -225,7 +272,8 @@ export async function handleTwitterIntegrationConfig(
         ctx.send(socket, {
           type: "twitter_integration_config_response",
           success: false,
-          managedAvailable: false,
+          managedAvailable,
+          managedPrerequisites,
           localClientConfigured: false,
           connected: false,
           error: "Failed to store client ID in secure storage",
@@ -253,7 +301,8 @@ export async function handleTwitterIntegrationConfig(
           ctx.send(socket, {
             type: "twitter_integration_config_response",
             success: false,
-            managedAvailable: false,
+            managedAvailable,
+            managedPrerequisites,
             localClientConfigured: !!previousClientId,
             connected: false,
             error: "Failed to store client secret in secure storage",
@@ -269,7 +318,8 @@ export async function handleTwitterIntegrationConfig(
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: true,
-        managedAvailable: false,
+        managedAvailable,
+        managedPrerequisites,
         localClientConfigured: true,
         connected: !!getSecureKey(
           "credential:integration:twitter:access_token",
@@ -303,10 +353,12 @@ export async function handleTwitterIntegrationConfig(
       if (!hasDeleteError) {
         deleteCredentialMetadata("integration:twitter", "access_token");
       }
+      const { managedAvailable, managedPrerequisites } = managed();
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: !hasDeleteError,
-        managedAvailable: false,
+        managedAvailable,
+        managedPrerequisites,
         localClientConfigured: hasDeleteError ? hasTwitterClientId() : false,
         connected: hasDeleteError
           ? !!getSecureKey("credential:integration:twitter:access_token")
@@ -331,10 +383,12 @@ export async function handleTwitterIntegrationConfig(
       if (!disconnectFailed) {
         deleteCredentialMetadata("integration:twitter", "access_token");
       }
+      const { managedAvailable, managedPrerequisites } = managed();
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: !disconnectFailed,
-        managedAvailable: false,
+        managedAvailable,
+        managedPrerequisites,
         localClientConfigured: hasTwitterClientId(),
         connected: disconnectFailed
           ? !!getSecureKey("credential:integration:twitter:access_token")
@@ -346,10 +400,12 @@ export async function handleTwitterIntegrationConfig(
           : {}),
       });
     } else {
+      const { managedAvailable, managedPrerequisites } = managed();
       ctx.send(socket, {
         type: "twitter_integration_config_response",
         success: false,
-        managedAvailable: false,
+        managedAvailable,
+        managedPrerequisites,
         localClientConfigured: false,
         connected: false,
         error: `Unknown action: ${String(msg.action)}`,

--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -57,6 +57,27 @@ export async function handleTwitterAuthStart(
     const mode =
       (getNestedValue(raw, "twitter.integrationMode") as string | undefined) ??
       "local_byo";
+    if (mode === "managed") {
+      // In managed mode, check prerequisites and return specific guidance
+      const hasApiKey = !!getSecureKey("credential:vellum:assistant_api_key");
+      if (!hasApiKey) {
+        ctx.send(socket, {
+          type: "twitter_auth_result",
+          success: false,
+          error:
+            "managed_missing_api_key: Assistant API key is not configured. Set up your API key to use managed Twitter.",
+        });
+        return;
+      }
+      // Prerequisites met — auth should happen via the platform desktop client
+      ctx.send(socket, {
+        type: "twitter_auth_result",
+        success: false,
+        error:
+          "managed_auth_via_platform: In managed mode, Twitter authentication is handled by the platform. Use the desktop client to connect.",
+      });
+      return;
+    }
     if (mode !== "local_byo") {
       ctx.send(socket, {
         type: "twitter_auth_result",

--- a/assistant/src/daemon/handlers/twitter-auth.ts
+++ b/assistant/src/daemon/handlers/twitter-auth.ts
@@ -64,8 +64,9 @@ export async function handleTwitterAuthStart(
         ctx.send(socket, {
           type: "twitter_auth_result",
           success: false,
+          errorCode: "managed_missing_api_key",
           error:
-            "managed_missing_api_key: Assistant API key is not configured. Set up your API key to use managed Twitter.",
+            "Assistant API key is not configured. Set up your API key to use managed Twitter.",
         });
         return;
       }
@@ -73,8 +74,9 @@ export async function handleTwitterAuthStart(
       ctx.send(socket, {
         type: "twitter_auth_result",
         success: false,
+        errorCode: "managed_auth_via_platform",
         error:
-          "managed_auth_via_platform: In managed mode, Twitter authentication is handled by the platform. Use the desktop client to connect.",
+          "In managed mode, Twitter authentication is handled by the platform. Use the desktop client to connect.",
       });
       return;
     }

--- a/assistant/src/daemon/ipc-contract/integrations.ts
+++ b/assistant/src/daemon/ipc-contract/integrations.ts
@@ -221,6 +221,8 @@ export interface TwitterAuthResult {
   type: "twitter_auth_result";
   success: boolean;
   accountInfo?: string;
+  /** Machine-readable error code for programmatic handling (e.g. "managed_missing_api_key", "managed_auth_via_platform"). */
+  errorCode?: string;
   error?: string;
 }
 

--- a/assistant/src/daemon/ipc-contract/integrations.ts
+++ b/assistant/src/daemon/ipc-contract/integrations.ts
@@ -140,11 +140,22 @@ export interface VercelApiConfigResponse {
   error?: string;
 }
 
+export interface ManagedPrerequisites {
+  /** Whether twitter.integrationMode is set to "managed" in config. */
+  integrationModeManaged: boolean;
+  /** Whether the assistant API key credential exists in secure storage. */
+  assistantApiKeyPresent: boolean;
+  /** Whether the platform base URL is configured (platform registration resolvable). */
+  platformAssistantIdResolvable: boolean;
+}
+
 export interface TwitterIntegrationConfigResponse {
   type: "twitter_integration_config_response";
   success: boolean;
   mode?: "local_byo" | "managed";
   managedAvailable: boolean;
+  /** Detailed prerequisite status for managed Twitter availability. */
+  managedPrerequisites?: ManagedPrerequisites;
   localClientConfigured: boolean;
   connected: boolean;
   accountInfo?: string;

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -642,14 +642,24 @@ struct SettingsPanel: View {
                 }
             }
 
-            // Managed mode "coming soon"
+            // Managed mode status
             if store.twitterMode == "managed" {
-                HStack(spacing: VSpacing.sm) {
-                    VIconView(.info, size: 14)
-                        .foregroundStyle(VColor.textSecondary)
-                    Text("Managed mode is coming soon. Switch to Local (BYO App) to connect now.")
-                        .font(VFont.caption)
-                        .foregroundStyle(VColor.textSecondary)
+                if store.isManagedTwitterEligible {
+                    HStack(spacing: VSpacing.sm) {
+                        VIconView(.circleCheck, size: 14)
+                            .foregroundStyle(VColor.textSecondary)
+                        Text("Managed Twitter is ready. Authentication is handled by the platform.")
+                            .font(VFont.caption)
+                            .foregroundStyle(VColor.textSecondary)
+                    }
+                } else if let reason = store.managedTwitterBlockReason {
+                    HStack(spacing: VSpacing.sm) {
+                        VIconView(.info, size: 14)
+                            .foregroundStyle(VColor.textSecondary)
+                        Text(reason)
+                            .font(VFont.caption)
+                            .foregroundStyle(VColor.textSecondary)
+                    }
                 }
             }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -83,11 +83,34 @@ public final class SettingsStore: ObservableObject {
 
     @Published var twitterMode: String = "local_byo"
     @Published var twitterManagedAvailable: Bool = false
+    @Published var twitterManagedPrerequisites: IPCManagedPrerequisites?
     @Published var twitterLocalClientConfigured: Bool = false
     @Published var twitterConnected: Bool = false
     @Published var twitterAccountInfo: String?
     @Published var twitterAuthInProgress: Bool = false
     @Published var twitterAuthError: String?
+
+    /// Whether all managed Twitter prerequisites are met.
+    var isManagedTwitterEligible: Bool {
+        twitterManagedAvailable
+    }
+
+    /// Human-readable reason why managed Twitter is not available, or nil if eligible.
+    var managedTwitterBlockReason: String? {
+        guard let prereqs = twitterManagedPrerequisites else {
+            return "Managed Twitter status is unavailable."
+        }
+        if !prereqs.integrationModeManaged {
+            return "Switch to Managed mode to use platform-managed Twitter."
+        }
+        if !prereqs.assistantApiKeyPresent {
+            return "Assistant API key is not configured. Set up your API key in settings."
+        }
+        if !prereqs.platformAssistantIdResolvable {
+            return "Platform connection is not configured. Set up your platform URL."
+        }
+        return nil
+    }
 
     // MARK: - Telegram Integration State
 
@@ -471,6 +494,7 @@ public final class SettingsStore: ObservableObject {
             if response.success {
                 self.twitterMode = response.mode ?? "local_byo"
                 self.twitterManagedAvailable = response.managedAvailable
+                self.twitterManagedPrerequisites = response.managedPrerequisites
                 self.twitterLocalClientConfigured = response.localClientConfigured
                 self.twitterConnected = response.connected
                 self.twitterAccountInfo = response.accountInfo

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -88,6 +88,7 @@ public final class SettingsStore: ObservableObject {
     @Published var twitterConnected: Bool = false
     @Published var twitterAccountInfo: String?
     @Published var twitterAuthInProgress: Bool = false
+    @Published var twitterAuthErrorCode: String?
     @Published var twitterAuthError: String?
 
     /// Whether all managed Twitter prerequisites are met.
@@ -568,8 +569,10 @@ public final class SettingsStore: ObservableObject {
             if response.success {
                 self.twitterConnected = true
                 self.twitterAccountInfo = response.accountInfo
+                self.twitterAuthErrorCode = nil
                 self.twitterAuthError = nil
             } else {
+                self.twitterAuthErrorCode = response.errorCode
                 self.twitterAuthError = response.error
             }
             self.refreshTwitterStatus()
@@ -955,6 +958,7 @@ public final class SettingsStore: ObservableObject {
 
     func connectTwitter() {
         twitterAuthInProgress = true
+        twitterAuthErrorCode = nil
         twitterAuthError = nil
         do {
             guard let daemonClient else {

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -5026,12 +5026,15 @@ public struct IPCTwitterAuthResult: Codable, Sendable {
     public let type: String
     public let success: Bool
     public let accountInfo: String?
+    /// Machine-readable error code for programmatic handling (e.g. "managed_missing_api_key", "managed_auth_via_platform").
+    public let errorCode: String?
     public let error: String?
 
-    public init(type: String, success: Bool, accountInfo: String? = nil, error: String? = nil) {
+    public init(type: String, success: Bool, accountInfo: String? = nil, errorCode: String? = nil, error: String? = nil) {
         self.type = type
         self.success = success
         self.accountInfo = accountInfo
+        self.errorCode = errorCode
         self.error = error
     }
 }

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -2735,6 +2735,21 @@ public struct IPCListSurfaceData: Codable, Sendable {
     }
 }
 
+public struct IPCManagedPrerequisites: Codable, Sendable {
+    /// Whether twitter.integrationMode is set to "managed" in config.
+    public let integrationModeManaged: Bool
+    /// Whether the assistant API key credential exists in secure storage.
+    public let assistantApiKeyPresent: Bool
+    /// Whether the platform base URL is configured (platform registration resolvable).
+    public let platformAssistantIdResolvable: Bool
+
+    public init(integrationModeManaged: Bool, assistantApiKeyPresent: Bool, platformAssistantIdResolvable: Bool) {
+        self.integrationModeManaged = integrationModeManaged
+        self.assistantApiKeyPresent = assistantApiKeyPresent
+        self.platformAssistantIdResolvable = platformAssistantIdResolvable
+    }
+}
+
 public struct IPCMemoryRecalled: Codable, Sendable {
     public let type: String
     public let provider: String
@@ -5076,6 +5091,8 @@ public struct IPCTwitterIntegrationConfigResponse: Codable, Sendable {
     public let success: Bool
     public let mode: String?
     public let managedAvailable: Bool
+    /// Detailed prerequisite status for managed Twitter availability.
+    public let managedPrerequisites: IPCManagedPrerequisites?
     public let localClientConfigured: Bool
     public let connected: Bool
     public let accountInfo: String?
@@ -5084,11 +5101,12 @@ public struct IPCTwitterIntegrationConfigResponse: Codable, Sendable {
     public let strategyConfigured: Bool?
     public let error: String?
 
-    public init(type: String, success: Bool, mode: String? = nil, managedAvailable: Bool, localClientConfigured: Bool, connected: Bool, accountInfo: String? = nil, strategy: String? = nil, strategyConfigured: Bool? = nil, error: String? = nil) {
+    public init(type: String, success: Bool, mode: String? = nil, managedAvailable: Bool, managedPrerequisites: IPCManagedPrerequisites? = nil, localClientConfigured: Bool, connected: Bool, accountInfo: String? = nil, strategy: String? = nil, strategyConfigured: Bool? = nil, error: String? = nil) {
         self.type = type
         self.success = success
         self.mode = mode
         self.managedAvailable = managedAvailable
+        self.managedPrerequisites = managedPrerequisites
         self.localClientConfigured = localClientConfigured
         self.connected = connected
         self.accountInfo = accountInfo


### PR DESCRIPTION
## Summary
- Replace hardcoded `twitterManagedAvailable: false` with real prerequisite checks (integration mode, AssistantAPIKey, platform base URL)
- Add `managedPrerequisites` detail object to the IPC response for granular UI feedback
- Update macOS SettingsStore to expose `isManagedTwitterEligible` and `managedTwitterBlockReason` computed properties
- Replace hardcoded "coming soon" text in SettingsPanel with dynamic prerequisite-based messaging
- Add managed-specific error codes in twitter-auth handler for managed mode auth attempts
- Add tests for all prerequisite combinations

## Test plan
- [ ] Verify `managedAvailable` is `true` when mode=managed, API key present, and platform URL set
- [ ] Verify `managedAvailable` is `false` when any single prerequisite is missing
- [ ] Verify managed availability works regardless of cloud mode (no `cloud == "vellum"` gate)
- [ ] Verify SettingsPanel shows appropriate block reason when managed prereqs are not met
- [ ] Verify twitter_auth_start returns `managed_auth_via_platform` error in managed mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
