### PR TITLE
M3: Swift client for platform Twitter OAuth endpoints

### DIFF
--- a/clients/shared/App/Auth/PlatformTwitterOAuthService.swift
+++ b/clients/shared/App/Auth/PlatformTwitterOAuthService.swift
@@ -1,0 +1,271 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "PlatformTwitterOAuth")
+
+/// Protocol abstracting URLSession for testability.
+public protocol URLSessionProtocol: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: URLSessionProtocol {}
+
+/// A Twitter OAuth connection returned by the platform.
+public struct TwitterOAuthConnection: Codable, Sendable {
+    public let id: String
+    public let provider: String
+    public let accountInfo: String?
+    public let createdAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case provider
+        case accountInfo = "account_info"
+        case createdAt = "created_at"
+    }
+
+    public init(id: String, provider: String, accountInfo: String? = nil, createdAt: String? = nil) {
+        self.id = id
+        self.provider = provider
+        self.accountInfo = accountInfo
+        self.createdAt = createdAt
+    }
+}
+
+/// Response from listing Twitter OAuth connections.
+public struct ListTwitterOAuthConnectionsResponse: Codable, Sendable {
+    public let connections: [TwitterOAuthConnection]
+
+    public init(connections: [TwitterOAuthConnection]) {
+        self.connections = connections
+    }
+}
+
+/// Response from starting a Twitter OAuth connect flow.
+public struct StartTwitterConnectResponse: Codable, Sendable {
+    public let authorizationUrl: String
+
+    enum CodingKeys: String, CodingKey {
+        case authorizationUrl = "authorization_url"
+    }
+
+    public init(authorizationUrl: String) {
+        self.authorizationUrl = authorizationUrl
+    }
+}
+
+/// Response from disconnecting Twitter.
+public struct DisconnectTwitterResponse: Codable, Sendable {
+    public let success: Bool
+
+    public init(success: Bool) {
+        self.success = success
+    }
+}
+
+/// Service for communicating with the platform's Twitter OAuth endpoints.
+///
+/// Provides methods to list connections, initiate OAuth flows, and disconnect Twitter
+/// for a given platform assistant. Uses `PlatformAssistantIdResolver` to resolve the
+/// platform assistant ID, and follows the same auth patterns as `AuthService`
+/// (`X-Session-Token`, `Vellum-Organization-Id`).
+public final class PlatformTwitterOAuthService: @unchecked Sendable {
+
+    private let baseURL: String
+    private let session: URLSessionProtocol
+    private let sessionTokenProvider: @Sendable () async -> String?
+
+    /// The OAuth scopes requested when starting a Twitter connect flow.
+    public static let requestedScopes: [String] = [
+        "tweet.read",
+        "tweet.write",
+        "users.read",
+        "offline.access",
+    ]
+
+    /// The redirect URL the platform navigates to after OAuth completes.
+    /// Points to a desktop completion page served by the platform.
+    public static let redirectAfterConnect = "vellum://oauth/twitter/complete"
+
+    /// Creates a new service instance.
+    ///
+    /// - Parameters:
+    ///   - baseURL: The platform base URL (e.g., `https://platform.vellum.ai`).
+    ///   - session: The URLSession (or mock) to use for HTTP requests.
+    ///   - sessionTokenProvider: Closure that returns the current session token, or nil if unauthenticated.
+    public init(
+        baseURL: String,
+        session: URLSessionProtocol = URLSession.shared,
+        sessionTokenProvider: @escaping @Sendable () async -> String? = { await SessionTokenManager.getTokenAsync() }
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+        self.sessionTokenProvider = sessionTokenProvider
+    }
+
+    // MARK: - List Connections
+
+    /// Lists Twitter OAuth connections for the given platform assistant.
+    ///
+    /// - Parameters:
+    ///   - platformAssistantId: The platform assistant UUID.
+    ///   - organizationId: The organization ID.
+    /// - Returns: The list of Twitter OAuth connections.
+    public func listConnections(
+        platformAssistantId: String,
+        organizationId: String
+    ) async throws -> ListTwitterOAuthConnectionsResponse {
+        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/twitter/connections/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        try await applySessionToken(to: &request)
+
+        let (data, response) = try await performRequest(request)
+        let statusCode = httpStatusCode(response)
+
+        log.debug("Platform request GET assistants/\(platformAssistantId, privacy: .public)/twitter/connections/ -> \(statusCode)")
+
+        try checkAuthErrors(statusCode: statusCode)
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(ListTwitterOAuthConnectionsResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Start Twitter Connect
+
+    /// Initiates the Twitter OAuth connect flow for the given platform assistant.
+    ///
+    /// - Parameters:
+    ///   - platformAssistantId: The platform assistant UUID.
+    ///   - organizationId: The organization ID.
+    /// - Returns: A response containing the authorization URL to open in a browser.
+    public func startTwitterConnect(
+        platformAssistantId: String,
+        organizationId: String
+    ) async throws -> StartTwitterConnectResponse {
+        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/twitter/connect/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        try await applySessionToken(to: &request)
+
+        let body: [String: Any] = [
+            "requested_scopes": Self.requestedScopes,
+            "redirect_after_connect": Self.redirectAfterConnect,
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await performRequest(request)
+        let statusCode = httpStatusCode(response)
+
+        log.debug("Platform request POST assistants/\(platformAssistantId, privacy: .public)/twitter/connect/ -> \(statusCode)")
+
+        try checkAuthErrors(statusCode: statusCode)
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(StartTwitterConnectResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Disconnect Twitter
+
+    /// Disconnects (revokes) a Twitter connection for the given platform assistant.
+    ///
+    /// - Parameters:
+    ///   - platformAssistantId: The platform assistant UUID.
+    ///   - organizationId: The organization ID.
+    /// - Returns: A response indicating whether the disconnect succeeded.
+    public func disconnectTwitter(
+        platformAssistantId: String,
+        organizationId: String
+    ) async throws -> DisconnectTwitterResponse {
+        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/twitter/disconnect/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        try await applySessionToken(to: &request)
+
+        let (data, response) = try await performRequest(request)
+        let statusCode = httpStatusCode(response)
+
+        log.debug("Platform request POST assistants/\(platformAssistantId, privacy: .public)/twitter/disconnect/ -> \(statusCode)")
+
+        try checkAuthErrors(statusCode: statusCode)
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(DisconnectTwitterResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func applySessionToken(to request: inout URLRequest) async throws {
+        if let token = await sessionTokenProvider() {
+            request.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+    }
+
+    private func performRequest(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        do {
+            return try await session.data(for: request)
+        } catch let error as PlatformAPIError {
+            throw error
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+    }
+
+    private func httpStatusCode(_ response: URLResponse) -> Int {
+        (response as? HTTPURLResponse)?.statusCode ?? 0
+    }
+
+    private func checkAuthErrors(statusCode: Int) throws {
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+    }
+}

--- a/clients/shared/Tests/PlatformTwitterOAuthServiceTests.swift
+++ b/clients/shared/Tests/PlatformTwitterOAuthServiceTests.swift
@@ -1,0 +1,342 @@
+import XCTest
+@testable import VellumAssistantShared
+
+/// Mock URLSession that returns pre-configured responses for testing.
+private final class MockURLSession: URLSessionProtocol, @unchecked Sendable {
+    var responseData: Data = Data()
+    var responseStatusCode: Int = 200
+    var responseError: Error?
+    var capturedRequests: [URLRequest] = []
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        capturedRequests.append(request)
+
+        if let error = responseError {
+            throw error
+        }
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: responseStatusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+
+        return (responseData, response)
+    }
+}
+
+final class PlatformTwitterOAuthServiceTests: XCTestCase {
+
+    private var mockSession: MockURLSession!
+    private var service: PlatformTwitterOAuthService!
+
+    private let testBaseURL = "https://platform.example.com"
+    private let testPlatformAssistantId = "asst-uuid-1234"
+    private let testOrganizationId = "org-uuid-5678"
+    private let testSessionToken = "test-session-token"
+
+    override func setUp() {
+        super.setUp()
+        mockSession = MockURLSession()
+        service = PlatformTwitterOAuthService(
+            baseURL: testBaseURL,
+            session: mockSession,
+            sessionTokenProvider: { [testSessionToken] in testSessionToken }
+        )
+    }
+
+    // MARK: - listConnections
+
+    func testListConnectionsSendsCorrectRequest() async throws {
+        let connections = [
+            TwitterOAuthConnection(id: "conn-1", provider: "twitter", accountInfo: "@testuser")
+        ]
+        let responseBody = ListTwitterOAuthConnectionsResponse(connections: connections)
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        _ = try await service.listConnections(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        XCTAssertEqual(mockSession.capturedRequests.count, 1)
+        let request = mockSession.capturedRequests[0]
+
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(
+            request.url?.absoluteString,
+            "\(testBaseURL)/v1/assistants/\(testPlatformAssistantId)/twitter/connections/"
+        )
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Session-Token"), testSessionToken)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Vellum-Organization-Id"), testOrganizationId)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
+    }
+
+    func testListConnectionsDecodesResponse() async throws {
+        let connections = [
+            TwitterOAuthConnection(id: "conn-1", provider: "twitter", accountInfo: "@user1"),
+            TwitterOAuthConnection(id: "conn-2", provider: "twitter", accountInfo: "@user2"),
+        ]
+        let responseBody = ListTwitterOAuthConnectionsResponse(connections: connections)
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        let result = try await service.listConnections(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        XCTAssertEqual(result.connections.count, 2)
+        XCTAssertEqual(result.connections[0].id, "conn-1")
+        XCTAssertEqual(result.connections[0].accountInfo, "@user1")
+        XCTAssertEqual(result.connections[1].id, "conn-2")
+    }
+
+    func testListConnectionsReturnsEmptyList() async throws {
+        let responseBody = ListTwitterOAuthConnectionsResponse(connections: [])
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        let result = try await service.listConnections(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        XCTAssertTrue(result.connections.isEmpty)
+    }
+
+    func testListConnectionsThrowsOnAuthError() async throws {
+        mockSession.responseStatusCode = 401
+
+        do {
+            _ = try await service.listConnections(
+                platformAssistantId: testPlatformAssistantId,
+                organizationId: testOrganizationId
+            )
+            XCTFail("Expected authenticationRequired error")
+        } catch let error as PlatformAPIError {
+            if case .authenticationRequired = error {
+                // Expected
+            } else {
+                XCTFail("Expected authenticationRequired, got \(error)")
+            }
+        }
+    }
+
+    func testListConnectionsThrowsOnServerError() async throws {
+        mockSession.responseStatusCode = 500
+        mockSession.responseData = Data("Internal Server Error".utf8)
+
+        do {
+            _ = try await service.listConnections(
+                platformAssistantId: testPlatformAssistantId,
+                organizationId: testOrganizationId
+            )
+            XCTFail("Expected serverError")
+        } catch let error as PlatformAPIError {
+            if case .serverError(let statusCode, _) = error {
+                XCTAssertEqual(statusCode, 500)
+            } else {
+                XCTFail("Expected serverError, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - startTwitterConnect
+
+    func testStartConnectSendsCorrectRequest() async throws {
+        let responseBody = StartTwitterConnectResponse(authorizationUrl: "https://twitter.com/oauth/authorize?token=abc")
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        _ = try await service.startTwitterConnect(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        XCTAssertEqual(mockSession.capturedRequests.count, 1)
+        let request = mockSession.capturedRequests[0]
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(
+            request.url?.absoluteString,
+            "\(testBaseURL)/v1/assistants/\(testPlatformAssistantId)/twitter/connect/"
+        )
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Session-Token"), testSessionToken)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Vellum-Organization-Id"), testOrganizationId)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+
+    func testStartConnectSendsRequestedScopes() async throws {
+        let responseBody = StartTwitterConnectResponse(authorizationUrl: "https://twitter.com/oauth/authorize")
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        _ = try await service.startTwitterConnect(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        let request = mockSession.capturedRequests[0]
+        let body = try JSONSerialization.jsonObject(with: request.httpBody!) as! [String: Any]
+
+        let scopes = body["requested_scopes"] as? [String]
+        XCTAssertEqual(scopes, ["tweet.read", "tweet.write", "users.read", "offline.access"])
+    }
+
+    func testStartConnectSendsRedirectAfterConnect() async throws {
+        let responseBody = StartTwitterConnectResponse(authorizationUrl: "https://twitter.com/oauth/authorize")
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        _ = try await service.startTwitterConnect(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        let request = mockSession.capturedRequests[0]
+        let body = try JSONSerialization.jsonObject(with: request.httpBody!) as! [String: Any]
+
+        let redirect = body["redirect_after_connect"] as? String
+        XCTAssertEqual(redirect, "vellum://oauth/twitter/complete")
+    }
+
+    func testStartConnectDecodesAuthorizationUrl() async throws {
+        let expectedUrl = "https://twitter.com/i/oauth2/authorize?client_id=abc&scope=tweet.read"
+        let responseBody = StartTwitterConnectResponse(authorizationUrl: expectedUrl)
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        let result = try await service.startTwitterConnect(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        XCTAssertEqual(result.authorizationUrl, expectedUrl)
+    }
+
+    func testStartConnectThrowsOn403() async throws {
+        mockSession.responseStatusCode = 403
+
+        do {
+            _ = try await service.startTwitterConnect(
+                platformAssistantId: testPlatformAssistantId,
+                organizationId: testOrganizationId
+            )
+            XCTFail("Expected authenticationRequired error")
+        } catch let error as PlatformAPIError {
+            if case .authenticationRequired = error {
+                // Expected
+            } else {
+                XCTFail("Expected authenticationRequired, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - disconnectTwitter
+
+    func testDisconnectSendsCorrectRequest() async throws {
+        let responseBody = DisconnectTwitterResponse(success: true)
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        _ = try await service.disconnectTwitter(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        XCTAssertEqual(mockSession.capturedRequests.count, 1)
+        let request = mockSession.capturedRequests[0]
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(
+            request.url?.absoluteString,
+            "\(testBaseURL)/v1/assistants/\(testPlatformAssistantId)/twitter/disconnect/"
+        )
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Session-Token"), testSessionToken)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Vellum-Organization-Id"), testOrganizationId)
+    }
+
+    func testDisconnectDecodesSuccessResponse() async throws {
+        let responseBody = DisconnectTwitterResponse(success: true)
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        let result = try await service.disconnectTwitter(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        XCTAssertTrue(result.success)
+    }
+
+    func testDisconnectThrowsOnServerError() async throws {
+        mockSession.responseStatusCode = 502
+        mockSession.responseData = Data("Bad Gateway".utf8)
+
+        do {
+            _ = try await service.disconnectTwitter(
+                platformAssistantId: testPlatformAssistantId,
+                organizationId: testOrganizationId
+            )
+            XCTFail("Expected serverError")
+        } catch let error as PlatformAPIError {
+            if case .serverError(let statusCode, _) = error {
+                XCTAssertEqual(statusCode, 502)
+            } else {
+                XCTFail("Expected serverError, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Authentication
+
+    func testThrowsWhenNoSessionToken() async throws {
+        let unauthService = PlatformTwitterOAuthService(
+            baseURL: testBaseURL,
+            session: mockSession,
+            sessionTokenProvider: { nil }
+        )
+
+        do {
+            _ = try await unauthService.listConnections(
+                platformAssistantId: testPlatformAssistantId,
+                organizationId: testOrganizationId
+            )
+            XCTFail("Expected authenticationRequired error")
+        } catch let error as PlatformAPIError {
+            if case .authenticationRequired = error {
+                // Expected — no request should have been sent
+                XCTAssertTrue(mockSession.capturedRequests.isEmpty)
+            } else {
+                XCTFail("Expected authenticationRequired, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Network errors
+
+    func testNetworkErrorWrappedAsPlatformAPIError() async throws {
+        let networkError = URLError(.notConnectedToInternet)
+        mockSession.responseError = networkError
+
+        do {
+            _ = try await service.listConnections(
+                platformAssistantId: testPlatformAssistantId,
+                organizationId: testOrganizationId
+            )
+            XCTFail("Expected networkError")
+        } catch let error as PlatformAPIError {
+            if case .networkError = error {
+                // Expected
+            } else {
+                XCTFail("Expected networkError, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Static properties
+
+    func testRequestedScopesContainsExpectedValues() {
+        let scopes = PlatformTwitterOAuthService.requestedScopes
+        XCTAssertEqual(scopes, ["tweet.read", "tweet.write", "users.read", "offline.access"])
+    }
+
+    func testRedirectAfterConnectIsDesktopScheme() {
+        let redirect = PlatformTwitterOAuthService.redirectAfterConnect
+        XCTAssertTrue(redirect.hasPrefix("vellum://"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add `PlatformTwitterOAuthService` with methods for listing connections, starting OAuth connect flow, and disconnecting Twitter
- Introduce `URLSessionProtocol` abstraction for testability with mocked URLSession
- Include comprehensive tests covering request construction, response decoding, auth errors, and network errors

Part of #14191.

## Test plan
- [ ] Verify `PlatformTwitterOAuthServiceTests` pass in Xcode
- [ ] Verify the service integrates correctly with `PlatformAssistantIdResolver` from M1
- [ ] Verify OAuth flow works end-to-end with platform endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
