### PR TITLE
M4: Enable managed Twitter connect/disconnect/status in macOS Settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -153,6 +153,7 @@ struct SettingsPanel: View {
         .onAppear {
             store.refreshAPIKeyState()
             store.refreshTwitterStatus()
+            store.refreshManagedTwitterStatus()
             store.refreshTelegramStatus()
             store.refreshTwilioStatus()
             store.refreshIngressConfig()
@@ -203,6 +204,9 @@ struct SettingsPanel: View {
             Task { @MainActor in
                 await refreshPermissionStatus()
             }
+            // Refresh managed Twitter status when app regains focus (e.g. after
+            // completing the OAuth flow in the browser).
+            store.refreshManagedTwitterStatus()
         }
         .sheet(isPresented: $showingTrustRules) {
             if let daemonClient {
@@ -644,21 +648,72 @@ struct SettingsPanel: View {
 
             // Managed mode status
             if store.twitterMode == "managed" {
-                if store.isManagedTwitterEligible {
+                if !authManager.isAuthenticated {
+                    // State 1: Not signed in
                     HStack(spacing: VSpacing.sm) {
-                        VIconView(.circleCheck, size: 14)
-                            .foregroundStyle(VColor.textSecondary)
-                        Text("Managed Twitter is ready. Authentication is handled by the platform.")
-                            .font(VFont.caption)
-                            .foregroundStyle(VColor.textSecondary)
+                        VButton(label: "Connect", style: .primary) {}
+                            .disabled(true)
                     }
-                } else if let reason = store.managedTwitterBlockReason {
                     HStack(spacing: VSpacing.sm) {
                         VIconView(.info, size: 14)
                             .foregroundStyle(VColor.textSecondary)
-                        Text(reason)
+                        Text("Sign in to Vellum to use Managed")
                             .font(VFont.caption)
                             .foregroundStyle(VColor.textSecondary)
+                    }
+                } else if !store.isManagedTwitterEligible {
+                    // State 2/3: Signed in but prerequisites not met
+                    HStack(spacing: VSpacing.sm) {
+                        VButton(label: "Connect", style: .primary) {}
+                            .disabled(true)
+                    }
+                    if let reason = store.managedTwitterBlockReason {
+                        HStack(spacing: VSpacing.sm) {
+                            VIconView(.info, size: 14)
+                                .foregroundStyle(VColor.textSecondary)
+                            Text(reason)
+                                .font(VFont.caption)
+                                .foregroundStyle(VColor.textSecondary)
+                        }
+                    }
+                } else if store.managedTwitterConnected {
+                    // State 5: Connected
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        HStack(spacing: VSpacing.sm) {
+                            VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success) {}
+                            VButton(label: "Disconnect", style: .danger) {
+                                store.disconnectManagedTwitter()
+                            }
+                            .disabled(store.managedTwitterConnectInProgress)
+                        }
+                        if let account = store.managedTwitterAccountInfo {
+                            Text(account)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                    }
+                } else if store.managedTwitterConnectInProgress {
+                    // State 6: In progress
+                    HStack(spacing: VSpacing.sm) {
+                        VButton(label: "Connect", style: .primary) {}
+                            .disabled(true)
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Opening browser...")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                } else {
+                    // State 4: Eligible + disconnected
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        VButton(label: "Connect", style: .primary) {
+                            store.connectManagedTwitter()
+                        }
+                        if let error = store.managedTwitterError {
+                            Text(error)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.error)
+                        }
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -991,7 +991,7 @@ public final class SettingsStore: ObservableObject {
 
     /// Resolves the platform assistant ID and organization ID for managed Twitter calls.
     /// Returns nil if the required context is unavailable.
-    private func resolveManagedTwitterContext(userId: String? = nil) -> (platformAssistantId: String, organizationId: String, baseURL: String)? {
+    private func resolveManagedTwitterContext() async -> (platformAssistantId: String, organizationId: String, baseURL: String)? {
         let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
         let assistant = connectedId.flatMap { LockfileAssistant.loadByName($0) }
             ?? LockfileAssistant.loadLatest()
@@ -999,6 +999,10 @@ public final class SettingsStore: ObservableObject {
 
         guard let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId"),
               !orgId.isEmpty else { return nil }
+
+        // Resolve the current user ID from the auth session so self-hosted local
+        // assistants can look up their persisted platform assistant ID.
+        let userId: String? = try? await AuthService.shared.getSession().data?.user?.id
 
         let platformId = PlatformAssistantIdResolver.resolve(
             lockfileAssistantId: assistant.assistantId,
@@ -1016,7 +1020,7 @@ public final class SettingsStore: ObservableObject {
     /// Fetches managed Twitter connection status from the platform.
     func refreshManagedTwitterStatus() {
         Task { @MainActor in
-            guard let ctx = resolveManagedTwitterContext() else {
+            guard let ctx = await resolveManagedTwitterContext() else {
                 managedTwitterConnected = false
                 managedTwitterAccountInfo = nil
                 return
@@ -1051,7 +1055,7 @@ public final class SettingsStore: ObservableObject {
         Task { @MainActor in
             defer { managedTwitterConnectInProgress = false }
 
-            guard let ctx = resolveManagedTwitterContext() else {
+            guard let ctx = await resolveManagedTwitterContext() else {
                 managedTwitterError = "Unable to resolve platform assistant. Check your account settings."
                 return
             }
@@ -1081,7 +1085,7 @@ public final class SettingsStore: ObservableObject {
         Task { @MainActor in
             defer { managedTwitterConnectInProgress = false }
 
-            guard let ctx = resolveManagedTwitterContext() else {
+            guard let ctx = await resolveManagedTwitterContext() else {
                 managedTwitterError = "Unable to resolve platform assistant. Check your account settings."
                 return
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Carbon.HIToolbox
 import Combine
 import Foundation
@@ -90,6 +91,12 @@ public final class SettingsStore: ObservableObject {
     @Published var twitterAuthInProgress: Bool = false
     @Published var twitterAuthErrorCode: String?
     @Published var twitterAuthError: String?
+
+    // Managed Twitter connection state (populated via PlatformTwitterOAuthService)
+    @Published var managedTwitterConnected: Bool = false
+    @Published var managedTwitterAccountInfo: String?
+    @Published var managedTwitterConnectInProgress: Bool = false
+    @Published var managedTwitterError: String?
 
     /// Whether all managed Twitter prerequisites are met.
     var isManagedTwitterEligible: Bool {
@@ -977,6 +984,123 @@ public final class SettingsStore: ObservableObject {
             try daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "disconnect"))
         } catch {
             log.error("Failed to send Twitter disconnect: \(error)")
+        }
+    }
+
+    // MARK: - Managed Twitter Actions
+
+    /// Resolves the platform assistant ID and organization ID for managed Twitter calls.
+    /// Returns nil if the required context is unavailable.
+    private func resolveManagedTwitterContext(userId: String? = nil) -> (platformAssistantId: String, organizationId: String, baseURL: String)? {
+        let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+        let assistant = connectedId.flatMap { LockfileAssistant.loadByName($0) }
+            ?? LockfileAssistant.loadLatest()
+        guard let assistant else { return nil }
+
+        guard let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId"),
+              !orgId.isEmpty else { return nil }
+
+        let platformId = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: assistant.assistantId,
+            isManaged: assistant.isManaged,
+            organizationId: orgId,
+            userId: userId,
+            credentialStorage: KeychainCredentialStorage()
+        )
+        guard let platformId else { return nil }
+
+        let baseURL = assistant.runtimeUrl ?? AuthService.shared.baseURL
+        return (platformAssistantId: platformId, organizationId: orgId, baseURL: baseURL)
+    }
+
+    /// Fetches managed Twitter connection status from the platform.
+    func refreshManagedTwitterStatus() {
+        Task { @MainActor in
+            guard let ctx = resolveManagedTwitterContext() else {
+                managedTwitterConnected = false
+                managedTwitterAccountInfo = nil
+                return
+            }
+
+            let service = PlatformTwitterOAuthService(baseURL: ctx.baseURL)
+            do {
+                let response = try await service.listConnections(
+                    platformAssistantId: ctx.platformAssistantId,
+                    organizationId: ctx.organizationId
+                )
+                if let connection = response.connections.first {
+                    managedTwitterConnected = true
+                    managedTwitterAccountInfo = connection.accountInfo
+                } else {
+                    managedTwitterConnected = false
+                    managedTwitterAccountInfo = nil
+                }
+                managedTwitterError = nil
+            } catch {
+                log.error("Failed to fetch managed Twitter status: \(error)")
+                managedTwitterError = error.localizedDescription
+            }
+        }
+    }
+
+    /// Starts the managed Twitter OAuth connect flow: calls the platform to get
+    /// an authorization URL and opens it in the default browser.
+    func connectManagedTwitter() {
+        managedTwitterConnectInProgress = true
+        managedTwitterError = nil
+        Task { @MainActor in
+            defer { managedTwitterConnectInProgress = false }
+
+            guard let ctx = resolveManagedTwitterContext() else {
+                managedTwitterError = "Unable to resolve platform assistant. Check your account settings."
+                return
+            }
+
+            let service = PlatformTwitterOAuthService(baseURL: ctx.baseURL)
+            do {
+                let response = try await service.startTwitterConnect(
+                    platformAssistantId: ctx.platformAssistantId,
+                    organizationId: ctx.organizationId
+                )
+                if let url = URL(string: response.authorizationUrl) {
+                    NSWorkspace.shared.open(url)
+                } else {
+                    managedTwitterError = "Invalid authorization URL received."
+                }
+            } catch {
+                log.error("Failed to start managed Twitter connect: \(error)")
+                managedTwitterError = error.localizedDescription
+            }
+        }
+    }
+
+    /// Disconnects the managed Twitter connection via the platform API.
+    func disconnectManagedTwitter() {
+        managedTwitterConnectInProgress = true
+        managedTwitterError = nil
+        Task { @MainActor in
+            defer { managedTwitterConnectInProgress = false }
+
+            guard let ctx = resolveManagedTwitterContext() else {
+                managedTwitterError = "Unable to resolve platform assistant. Check your account settings."
+                return
+            }
+
+            let service = PlatformTwitterOAuthService(baseURL: ctx.baseURL)
+            do {
+                _ = try await service.disconnectTwitter(
+                    platformAssistantId: ctx.platformAssistantId,
+                    organizationId: ctx.organizationId
+                )
+                managedTwitterConnected = false
+                managedTwitterAccountInfo = nil
+                managedTwitterError = nil
+                // Refresh to confirm
+                refreshManagedTwitterStatus()
+            } catch {
+                log.error("Failed to disconnect managed Twitter: \(error)")
+                managedTwitterError = error.localizedDescription
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace the "coming soon" managed Twitter block in SettingsPanel.swift with full managed-mode UI states: sign-in gate, owner/prerequisite checks, connect/disconnect buttons, connection status display
- Add managed Twitter connect/disconnect/refresh methods to SettingsStore.swift using PlatformTwitterOAuthService and PlatformAssistantIdResolver
- Auto-refresh managed Twitter status on settings panel open and when app becomes active (for OAuth flow completion detection)

## Test plan
- [ ] Verify managed mode shows "Sign in to Vellum to use Managed" when not authenticated
- [ ] Verify managed mode shows prerequisite block reason when signed in but not eligible
- [ ] Verify Connect button appears when eligible and disconnected
- [ ] Verify Connect opens browser with OAuth authorization URL
- [ ] Verify Connected badge and Disconnect button appear after successful OAuth
- [ ] Verify Disconnect removes the connection and refreshes status
- [ ] Verify local BYO mode UI is unchanged

Part of #14191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
