### PR TITLE
fix: remove dead legacy channel ID references after alias removal

### DIFF
--- a/assistant/src/calls/guardian-action-sweep.ts
+++ b/assistant/src/calls/guardian-action-sweep.ts
@@ -67,9 +67,7 @@ export async function sendGuardianExpiryNotices(
       );
 
       if (
-        (delivery.destinationChannel === "vellum" ||
-          delivery.destinationChannel === "macos" ||
-          delivery.destinationChannel === "mac") &&
+        delivery.destinationChannel === "vellum" &&
         delivery.destinationConversationId
       ) {
         // Add expiry message to vellum guardian thread.

--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -304,9 +304,6 @@ export function resolveChannelCapabilities(
     case undefined:
     case "dashboard":
     case "http-api":
-    case "mac":
-    case "macos":
-    case "ios":
       channel = "vellum";
       break;
     default:


### PR DESCRIPTION
Clean up dead code that still referenced legacy macos/ios channel aliases after PR #14010 removed the aliases themselves. Removes dead checks in guardian-action-sweep.ts and legacy normalization in session-runtime-assembly.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
