### PR TITLE
fix: remove orphaned getNextMessage dead code from session-history

### DIFF
--- a/assistant/src/__tests__/recording-intent-handler.test.ts
+++ b/assistant/src/__tests__/recording-intent-handler.test.ts
@@ -285,7 +285,6 @@ mock.module("../memory/conversation-queries.js", () => ({
   countConversations: () => 0,
   searchConversations: () => [],
   getMessagesPaginated: () => ({ messages: [], hasMore: false }),
-  getNextMessage: () => null,
 }));
 
 mock.module("../memory/conversation-title-service.js", () => ({

--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, desc, eq, gte, lt, ne, or, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, lt, or, sql } from "drizzle-orm";
 
 import { getLogger } from "../util/logger.js";
 import type { ConversationRow, MessageRow } from "./conversation-crud.js";
@@ -53,34 +53,6 @@ export function getLatestConversation(): ConversationRow | null {
     .limit(1)
     .get();
   return row ? parseConversation(row) : null;
-}
-
-/**
- * Get the next message in a conversation after a given message.
- * Uses gte + ne(id) instead of gt on timestamp so that messages sharing the
- * same millisecond (common in legacy conversations where an assistant turn and
- * the following user tool_result are saved in the same tick) are not skipped.
- */
-export function getNextMessage(
-  conversationId: string,
-  afterTimestamp: number,
-  excludeMessageId: string,
-): MessageRow | null {
-  const db = getDb();
-  const row = db
-    .select()
-    .from(messages)
-    .where(
-      and(
-        eq(messages.conversationId, conversationId),
-        gte(messages.createdAt, afterTimestamp),
-        ne(messages.id, excludeMessageId),
-      ),
-    )
-    .orderBy(asc(messages.createdAt), asc(messages.id))
-    .limit(1)
-    .get();
-  return row ? parseMessage(row) : null;
 }
 
 export interface PaginatedMessagesResult {


### PR DESCRIPTION
Remove getNextMessage function that became dead code after PR #14028 removed mergeToolResults(). Also removes unused gte/ne imports and the corresponding test mock entry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
