### PR TITLE
fix: correct misleading recover error message about re-hatching

### DIFF
--- a/cli/src/commands/recover.ts
+++ b/cli/src/commands/recover.ts
@@ -60,7 +60,9 @@ export async function recover(): Promise<void> {
   // 6. Start daemon + gateway (same as wake)
   if (!entry.resources) {
     throw new Error(
-      `Recovered assistant '${name}' is missing resource configuration. Re-hatch to fix.`,
+      `Recovered assistant '${name}' is missing resource configuration. ` +
+        `Data has been restored to ~/.vellum but the assistant cannot start without allocated ports. ` +
+        `Run 'vellum retire ${name}' then 'vellum hatch' to re-provision with proper resource allocation.`,
     );
   }
   await startLocalDaemon(false, entry.resources);


### PR DESCRIPTION
Fix error message in recover.ts that incorrectly suggested re-hatching when metadata is missing resources. Re-hatching would lose recovered data. Updated to explain that data has been restored and suggest the correct retire-then-hatch remediation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
