### PR TITLE
fix: make enabled fallback consistent between get/set in config-ingress

### DIFF
--- a/assistant/src/daemon/handlers/config-ingress.ts
+++ b/assistant/src/daemon/handlers/config-ingress.ts
@@ -151,8 +151,7 @@ export async function handleIngressConfig(
       // `pkill -f gateway`).
       // Only export the URL when ingress is enabled; clearing it when
       // disabled ensures the gateway stops accepting inbound webhooks.
-      const isEnabled =
-        (ingress.enabled as boolean | undefined) ?? (value ? true : false);
+      const isEnabled = (ingress.enabled as boolean | undefined) ?? false;
       if (value && isEnabled) {
         setIngressPublicBaseUrl(value);
       } else if (isEnabled && getOriginalIngressEnv() !== undefined) {


### PR DESCRIPTION
Remove the old enabled-inference-from-publicBaseUrl pattern from the set action in config-ingress.ts to match the get action cleanup done in PR #14052.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
