### PR TITLE
fix: remove dead secure store writes for Twilio phone number

### DIFF
--- a/assistant/README.md
+++ b/assistant/README.md
@@ -209,15 +209,15 @@ Twilio is the telephony provider for voice calls. Configuration is managed throu
 
 The runtime exposes a RESTful HTTP API for Twilio configuration, credential management, and phone number operations:
 
-| Method | Path                                        | Description                                                                                                                                                     |
-| ------ | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| GET    | `/v1/integrations/twilio/config`            | Returns current state: `hasCredentials` (boolean) and `phoneNumber` (if assigned)                                                                               |
-| POST   | `/v1/integrations/twilio/credentials`       | Validates and stores Account SID and Auth Token in secure storage (Keychain / encrypted file)                                                                   |
-| DELETE | `/v1/integrations/twilio/credentials`       | Removes stored credentials. Preserves the phone number in both config and secure key so re-entering credentials resumes working without reassigning the number. |
-| GET    | `/v1/integrations/twilio/numbers`           | Lists all incoming phone numbers on the Twilio account with their capabilities                                                                                  |
-| POST   | `/v1/integrations/twilio/numbers/provision` | Purchases a new phone number. Accepts optional `areaCode` and `country`. Auto-assigns and configures webhooks when ingress is available.                        |
-| POST   | `/v1/integrations/twilio/numbers/assign`    | Assigns an existing Twilio phone number (E.164) and auto-configures webhooks when ingress is available                                                          |
-| POST   | `/v1/integrations/twilio/numbers/release`   | Releases a phone number from the Twilio account and clears local references                                                                                     |
+| Method | Path                                        | Description                                                                                                                                 |
+| ------ | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| GET    | `/v1/integrations/twilio/config`            | Returns current state: `hasCredentials` (boolean) and `phoneNumber` (if assigned)                                                           |
+| POST   | `/v1/integrations/twilio/credentials`       | Validates and stores Account SID and Auth Token in secure storage (Keychain / encrypted file)                                               |
+| DELETE | `/v1/integrations/twilio/credentials`       | Removes stored credentials. Preserves the phone number in config so re-entering credentials resumes working without reassigning the number. |
+| GET    | `/v1/integrations/twilio/numbers`           | Lists all incoming phone numbers on the Twilio account with their capabilities                                                              |
+| POST   | `/v1/integrations/twilio/numbers/provision` | Purchases a new phone number. Accepts optional `areaCode` and `country`. Auto-assigns and configures webhooks when ingress is available.    |
+| POST   | `/v1/integrations/twilio/numbers/assign`    | Assigns an existing Twilio phone number (E.164) and auto-configures webhooks when ingress is available                                      |
+| POST   | `/v1/integrations/twilio/numbers/release`   | Releases a phone number from the Twilio account and clears local references                                                                 |
 
 All endpoints are JWT-authenticated (require a valid JWT with appropriate scopes). Skills and clients should call the gateway URL (default `http://localhost:7830`) rather than the runtime port directly, as the gateway proxies all `/v1/integrations/twilio/*` routes.
 
@@ -249,9 +249,8 @@ At runtime, `getTwilioConfig()` resolves the phone number using this priority ch
 
 1. **`TWILIO_PHONE_NUMBER` env var** — highest priority, explicit override for dev/CI.
 2. **`twilio.phoneNumber` in config** — the primary source of truth, written by `provision_number` and `assign_number`.
-3. **`credential:twilio:phone_number` secure key** — backward-compatible fallback for setups that predate the config-first model.
 
-If no number is found after all three sources, an error is thrown.
+If no number is found after both sources, an error is thrown.
 
 ### Assistant-Scoped Guardian State
 

--- a/assistant/src/__tests__/gateway-only-enforcement.test.ts
+++ b/assistant/src/__tests__/gateway-only-enforcement.test.ts
@@ -116,7 +116,6 @@ mock.module("../calls/twilio-provider.js", () => ({
 const secureKeyStore: Record<string, string | undefined> = {
   "credential:twilio:account_sid": "AC_test",
   "credential:twilio:auth_token": "test_token",
-  "credential:twilio:phone_number": "+15550001111",
 };
 
 mock.module("../security/secure-keys.js", () => ({

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -57,10 +57,7 @@ function readMockTwilioAuthToken(): string | undefined {
 
 function readMockTwilioPhoneNumber(): string | undefined {
   const twilio = (mockRawConfigStore.twilio ?? {}) as Record<string, unknown>;
-  return (
-    mockSecureKeyStore["credential:twilio:phone_number"] ??
-    (twilio.phoneNumber as string | undefined)
-  );
+  return twilio.phoneNumber as string | undefined;
 }
 
 function resolveIngressBaseUrlFromConfig(ingressConfig: unknown): string {
@@ -435,7 +432,6 @@ describe("twilio webhook routes", () => {
     mockSecureKeyStore = {
       "credential:twilio:account_sid": "AC_existing",
       "credential:twilio:auth_token": "test-auth-token",
-      "credential:twilio:phone_number": "+15550001111",
     };
     mockAvailableNumbers = [{ phoneNumber: "+15556667777" }];
     mockProvisionedNumber = { phoneNumber: "+15556667777" };

--- a/assistant/src/runtime/routes/integrations/twilio.ts
+++ b/assistant/src/runtime/routes/integrations/twilio.ts
@@ -23,7 +23,6 @@ import { syncTwilioWebhooks } from "../../../daemon/handlers/config-ingress.js";
 import type { IngressConfig } from "../../../inbound/public-ingress-urls.js";
 import {
   deleteSecureKeyAsync,
-  getSecureKey,
   setSecureKeyAsync,
 } from "../../../security/secure-keys.js";
 import {
@@ -288,19 +287,6 @@ export async function handleProvisionTwilioNumber(
     available[0].phoneNumber,
   );
 
-  const phoneStored = await setSecureKeyAsync(
-    "credential:twilio:phone_number",
-    purchased.phoneNumber,
-  );
-  if (!phoneStored) {
-    return Response.json({
-      success: false,
-      hasCredentials: hasTwilioCredentials(),
-      phoneNumber: purchased.phoneNumber,
-      error: `Phone number ${purchased.phoneNumber} was purchased but could not be saved. Use assign to assign it manually.`,
-    });
-  }
-
   const raw = loadRawConfig();
   const twilio = (raw?.twilio ?? {}) as Record<string, unknown>;
   twilio.phoneNumber = purchased.phoneNumber;
@@ -342,18 +328,6 @@ export async function handleAssignTwilioNumber(
       },
       { status: 400 },
     );
-  }
-
-  const phoneStored = await setSecureKeyAsync(
-    "credential:twilio:phone_number",
-    body.phoneNumber,
-  );
-  if (!phoneStored) {
-    return Response.json({
-      success: false,
-      hasCredentials: hasTwilioCredentials(),
-      error: "Failed to store phone number in secure storage",
-    });
   }
 
   const raw = loadRawConfig();
@@ -423,11 +397,6 @@ export async function handleReleaseTwilioNumber(
   }
   pruneAssistantPhoneNumbers(twilio, phoneNumber, "remove");
   saveRawConfig({ ...raw, twilio });
-
-  const storedPhone = getSecureKey("credential:twilio:phone_number");
-  if (storedPhone === phoneNumber) {
-    await deleteSecureKeyAsync("credential:twilio:phone_number");
-  }
 
   return Response.json({
     success: true,


### PR DESCRIPTION
Remove secure store writes in twilio-routes.ts that became dead code after PR #14016 removed the secure store fallback from resolveTwilioPhoneNumber(). Update README to reflect 2-step resolution chain and clean up test mocks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
