### PR TITLE
fix: remove unsafe non-null assertion on approvalConversationGenerator

### DIFF
--- a/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
@@ -51,7 +51,7 @@ export interface GuardianCallbackDecisionParams {
   bearerToken?: string;
   assistantId: string;
   approvalCopyGenerator?: ApprovalCopyGenerator;
-  approvalConversationGenerator: ApprovalConversationGenerator;
+  approvalConversationGenerator?: ApprovalConversationGenerator;
 }
 
 export interface ApprovalInterceptionResult {
@@ -211,7 +211,7 @@ export async function handleGuardianCallbackDecision(
   const effectivePending =
     senderPending.length > 0 ? senderPending : allGuardianPending;
 
-  if (effectivePending.length > 0 && content) {
+  if (effectivePending.length > 0 && content && approvalConversationGenerator) {
     return handleConversationalDecision({
       guardianApproval,
       allGuardianPending,

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -108,7 +108,7 @@ export async function handleApprovalInterception(
       bearerToken,
       assistantId,
       approvalCopyGenerator,
-      approvalConversationGenerator: approvalConversationGenerator!,
+      approvalConversationGenerator,
     });
     if (guardianResult) {
       return guardianResult;


### PR DESCRIPTION
Fix type inconsistency in approvalConversationGenerator: make the field optional in GuardianCallbackDecisionParams (matching the rest of the chain), add a guard in the conversational path, and remove the ! non-null assertion in guardian-approval-interception.ts, following up on PR #14068.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
