### PR TITLE
fix: align macOS session info tests with correlation ID requirement

### DIFF
--- a/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
+++ b/clients/macos/vellum-assistantTests/ChatViewModelTests.swift
@@ -163,7 +163,8 @@ final class ChatViewModelTests: XCTestCase {
     // MARK: - Session Info
 
     func testSessionInfoStoresSessionId() {
-        let info = SessionInfoMessage(sessionId: "test-123", title: "Test")
+        viewModel.bootstrapCorrelationId = "corr-1"
+        let info = SessionInfoMessage(sessionId: "test-123", title: "Test", correlationId: "corr-1")
         viewModel.handleServerMessage(.sessionInfo(info))
         XCTAssertEqual(viewModel.sessionId, "test-123")
     }
@@ -1303,15 +1304,13 @@ final class ChatViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.sessionId, "Should not claim session_info without correlationId when bootstrapping with one")
     }
 
-    func testSessionInfoWithoutCorrelationIdAcceptedWhenNoBootstrap() {
-        // When a ChatViewModel has no bootstrap correlationId (e.g., backwards compat),
-        // it should still accept session_info without a correlationId.
-        // Simulate the old behavior: directly set up state without going through
-        // bootstrapSession (which would generate a correlationId)
+    func testSessionInfoWithoutCorrelationIdRejectedWhenNoBootstrap() {
+        // After removing backwards compat, session_info without a correlationId
+        // is rejected even when there is no bootstrap correlationId set.
         let info = SessionInfoMessage(sessionId: "test-session", title: "Test")
         viewModel.handleServerMessage(.sessionInfo(info))
 
-        XCTAssertEqual(viewModel.sessionId, "test-session", "Should accept session_info when no correlationId was set")
+        XCTAssertNil(viewModel.sessionId, "Should reject session_info when no bootstrapCorrelationId is set")
     }
 
     // MARK: - Session Error (Typed Error State)


### PR DESCRIPTION
Apply the same correlation ID fix from PR #14069 (iOS tests) to the macOS test counterparts.

- `testSessionInfoStoresSessionId`: Add `bootstrapCorrelationId` and `correlationId` parameter to match the post-#14039 requirement
- `testSessionInfoWithoutCorrelationIdAcceptedWhenNoBootstrap`: Renamed to `testSessionInfoWithoutCorrelationIdRejectedWhenNoBootstrap` and updated assertion to expect rejection since backward compat was removed in #14039
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
