### PR TITLE
M5: Assistant-side platform-managed Twitter proxy client

### DIFF
--- a/assistant/src/__tests__/twitter-platform-proxy-client.test.ts
+++ b/assistant/src/__tests__/twitter-platform-proxy-client.test.ts
@@ -1,0 +1,450 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock dependencies — must be before importing the module under test
+// ---------------------------------------------------------------------------
+
+let mockApiKey: string | undefined = "test-api-key-123";
+let mockPlatformEnvUrl = "https://platform.vellum.ai";
+let mockPlatformAssistantId = "ast_abc123";
+let mockConfigBaseUrl = "";
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKey: (account: string) => {
+    if (account === "credential:vellum:assistant_api_key") return mockApiKey;
+    return undefined;
+  },
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    platform: { baseUrl: mockConfigBaseUrl },
+  }),
+}));
+
+mock.module("../config/env.js", () => ({
+  getPlatformBaseUrl: () => mockPlatformEnvUrl,
+  getPlatformAssistantId: () => mockPlatformAssistantId,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+// Mock global fetch
+let lastFetchArgs: [string, RequestInit] | null = null;
+let fetchResponse: {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+} = {
+  ok: true,
+  status: 200,
+  json: async () => ({}),
+};
+
+globalThis.fetch = (async (url: string, init: RequestInit) => {
+  lastFetchArgs = [url, init];
+  return fetchResponse;
+}) as typeof globalThis.fetch;
+
+// Import after mocking
+import {
+  getMe,
+  postTweet,
+  proxyTwitterCall,
+  resolveAuthToken,
+  resolvePlatformAssistantId,
+  resolvePlatformBaseUrl,
+  resolvePrerequisites,
+  TwitterProxyError,
+} from "../twitter/platform-proxy-client.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockApiKey = "test-api-key-123";
+  mockPlatformEnvUrl = "https://platform.vellum.ai";
+  mockPlatformAssistantId = "ast_abc123";
+  mockConfigBaseUrl = "";
+  lastFetchArgs = null;
+  fetchResponse = {
+    ok: true,
+    status: 200,
+    json: async () => ({ data: { id: "12345", text: "Hello world" } }),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Prerequisite resolution
+// ---------------------------------------------------------------------------
+
+describe("prerequisite resolution", () => {
+  test("resolvePlatformBaseUrl prefers config over env", () => {
+    mockConfigBaseUrl = "https://config.vellum.ai";
+    mockPlatformEnvUrl = "https://env.vellum.ai";
+    expect(resolvePlatformBaseUrl()).toBe("https://config.vellum.ai");
+  });
+
+  test("resolvePlatformBaseUrl falls back to env when config is empty", () => {
+    mockConfigBaseUrl = "";
+    mockPlatformEnvUrl = "https://env.vellum.ai";
+    expect(resolvePlatformBaseUrl()).toBe("https://env.vellum.ai");
+  });
+
+  test("resolvePlatformBaseUrl strips trailing slashes", () => {
+    mockPlatformEnvUrl = "https://platform.vellum.ai///";
+    expect(resolvePlatformBaseUrl()).toBe("https://platform.vellum.ai");
+  });
+
+  test("resolveAuthToken returns the token from secure storage", () => {
+    expect(resolveAuthToken()).toBe("test-api-key-123");
+  });
+
+  test("resolveAuthToken returns undefined when token is missing", () => {
+    mockApiKey = undefined;
+    expect(resolveAuthToken()).toBeUndefined();
+  });
+
+  test("resolvePlatformAssistantId returns the env value", () => {
+    expect(resolvePlatformAssistantId()).toBe("ast_abc123");
+  });
+
+  test("resolvePrerequisites returns all values when present", () => {
+    const prereqs = resolvePrerequisites();
+    expect(prereqs.platformBaseUrl).toBe("https://platform.vellum.ai");
+    expect(prereqs.authToken).toBe("test-api-key-123");
+    expect(prereqs.platformAssistantId).toBe("ast_abc123");
+  });
+
+  test("resolvePrerequisites throws when platform assistant ID is missing", () => {
+    mockPlatformAssistantId = "";
+    try {
+      resolvePrerequisites();
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("missing_platform_assistant_id");
+      expect(tpe.message).toBe("Local assistant not registered with platform");
+      expect(tpe.retryable).toBe(false);
+    }
+  });
+
+  test("resolvePrerequisites throws when assistant API key is missing", () => {
+    mockApiKey = undefined;
+    try {
+      resolvePrerequisites();
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("missing_assistant_api_key");
+      expect(tpe.message).toBe("Assistant not bootstrapped — run setup");
+    }
+  });
+
+  test("resolvePrerequisites throws when platform base URL is missing", () => {
+    mockPlatformEnvUrl = "";
+    mockConfigBaseUrl = "";
+    try {
+      resolvePrerequisites();
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("missing_platform_base_url");
+      expect(tpe.message).toBe("Platform base URL is not configured");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Proxy calls
+// ---------------------------------------------------------------------------
+
+describe("proxyTwitterCall", () => {
+  test("sends POST to the correct proxy endpoint", async () => {
+    await proxyTwitterCall({
+      method: "POST",
+      path: "/2/tweets",
+      body: { text: "Hello" },
+    });
+
+    expect(lastFetchArgs).not.toBeNull();
+    expect(lastFetchArgs![0]).toBe(
+      "https://platform.vellum.ai/v1/assistants/ast_abc123/external-provider-proxy/twitter/",
+    );
+    expect(lastFetchArgs![1].method).toBe("POST");
+  });
+
+  test("sends Bearer authorization header with assistant API key", async () => {
+    await proxyTwitterCall({
+      method: "GET",
+      path: "/2/users/me",
+    });
+
+    expect(lastFetchArgs).not.toBeNull();
+    const headers = lastFetchArgs![1].headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer test-api-key-123");
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  test("request body contains the Twitter API call description", async () => {
+    await proxyTwitterCall({
+      method: "POST",
+      path: "/2/tweets",
+      body: { text: "Hello world" },
+    });
+
+    const parsed = JSON.parse(lastFetchArgs![1].body as string);
+    expect(parsed.method).toBe("POST");
+    expect(parsed.path).toBe("/2/tweets");
+    expect(parsed.body).toEqual({ text: "Hello world" });
+  });
+
+  test("GET-style request includes query parameters", async () => {
+    await proxyTwitterCall({
+      method: "GET",
+      path: "/2/users/me",
+      query: { "user.fields": "name,username" },
+    });
+
+    const parsed = JSON.parse(lastFetchArgs![1].body as string);
+    expect(parsed.method).toBe("GET");
+    expect(parsed.path).toBe("/2/users/me");
+    expect(parsed.query).toEqual({ "user.fields": "name,username" });
+  });
+
+  test("returns parsed response data on success", async () => {
+    fetchResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { id: "99", text: "ok" } }),
+    };
+
+    const result = await proxyTwitterCall({
+      method: "POST",
+      path: "/2/tweets",
+      body: { text: "ok" },
+    });
+
+    expect(result.data).toEqual({ data: { id: "99", text: "ok" } });
+    expect(result.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+describe("error mapping", () => {
+  test("403 with owner credential message maps to owner_credential_required", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 403,
+      json: async () => ({
+        detail: "Owner credential required to access this resource",
+      }),
+    };
+
+    try {
+      await proxyTwitterCall({ method: "GET", path: "/2/users/me" });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("owner_credential_required");
+      expect(tpe.message).toBe(
+        "Connect Twitter in Settings as the assistant owner",
+      );
+      expect(tpe.retryable).toBe(false);
+      expect(tpe.statusCode).toBe(403);
+    }
+  });
+
+  test("403 with owner-only message maps to owner_only", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 403,
+      json: async () => ({
+        detail: "Only the owner can perform this action",
+      }),
+    };
+
+    try {
+      await proxyTwitterCall({ method: "POST", path: "/2/tweets", body: {} });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("owner_only");
+      expect(tpe.message).toBe("Sign in as the assistant owner");
+    }
+  });
+
+  test("403 without owner keyword maps to generic forbidden", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 403,
+      json: async () => ({ detail: "Access denied" }),
+    };
+
+    try {
+      await proxyTwitterCall({ method: "GET", path: "/2/users/me" });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("forbidden");
+      expect(tpe.statusCode).toBe(403);
+    }
+  });
+
+  test("401 maps to auth_failure with retryable true", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 401,
+      json: async () => ({ detail: "Token expired" }),
+    };
+
+    try {
+      await proxyTwitterCall({ method: "GET", path: "/2/users/me" });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("auth_failure");
+      expect(tpe.message).toBe("Reconnect Twitter or retry");
+      expect(tpe.retryable).toBe(true);
+    }
+  });
+
+  test("502 maps to upstream_failure with retryable true", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 502,
+      json: async () => ({}),
+    };
+
+    try {
+      await proxyTwitterCall({ method: "GET", path: "/2/users/me" });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("upstream_failure");
+      expect(tpe.retryable).toBe(true);
+    }
+  });
+
+  test("429 maps to rate_limit with retryable true", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 429,
+      json: async () => ({ detail: "Too many requests" }),
+    };
+
+    try {
+      await proxyTwitterCall({ method: "POST", path: "/2/tweets", body: {} });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("rate_limit");
+      expect(tpe.retryable).toBe(true);
+      expect(tpe.statusCode).toBe(429);
+    }
+  });
+
+  test("500 maps to platform_error with retryable true", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: "Internal server error" }),
+    };
+
+    try {
+      await proxyTwitterCall({ method: "GET", path: "/2/users/me" });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("platform_error");
+      expect(tpe.retryable).toBe(true);
+    }
+  });
+
+  test("unparseable error response falls back to status code", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 400,
+      json: async () => {
+        throw new Error("not json");
+      },
+    };
+
+    try {
+      await proxyTwitterCall({ method: "GET", path: "/2/users/me" });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("proxy_error");
+      expect(tpe.message).toContain("HTTP 400");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Convenience helpers
+// ---------------------------------------------------------------------------
+
+describe("postTweet", () => {
+  test("sends a tweet through the proxy", async () => {
+    await postTweet("Hello from proxy");
+
+    const parsed = JSON.parse(lastFetchArgs![1].body as string);
+    expect(parsed.method).toBe("POST");
+    expect(parsed.path).toBe("/2/tweets");
+    expect(parsed.body.text).toBe("Hello from proxy");
+  });
+
+  test("includes reply metadata when replyToId is provided", async () => {
+    await postTweet("This is a reply", { replyToId: "tweet_789" });
+
+    const parsed = JSON.parse(lastFetchArgs![1].body as string);
+    expect(parsed.body.reply).toEqual({
+      in_reply_to_tweet_id: "tweet_789",
+    });
+  });
+});
+
+describe("getMe", () => {
+  test("sends a GET request for the authenticated user", async () => {
+    await getMe({ "user.fields": "name,username,profile_image_url" });
+
+    const parsed = JSON.parse(lastFetchArgs![1].body as string);
+    expect(parsed.method).toBe("GET");
+    expect(parsed.path).toBe("/2/users/me");
+    expect(parsed.query).toEqual({
+      "user.fields": "name,username,profile_image_url",
+    });
+  });
+
+  test("sends without query when none provided", async () => {
+    await getMe();
+
+    const parsed = JSON.parse(lastFetchArgs![1].body as string);
+    expect(parsed.method).toBe("GET");
+    expect(parsed.path).toBe("/2/users/me");
+    expect(parsed.query).toBeUndefined();
+  });
+});

--- a/assistant/src/__tests__/twitter-platform-proxy-client.test.ts
+++ b/assistant/src/__tests__/twitter-platform-proxy-client.test.ts
@@ -185,7 +185,7 @@ describe("proxyTwitterCall", () => {
     expect(lastFetchArgs![1].method).toBe("POST");
   });
 
-  test("sends Bearer authorization header with assistant API key", async () => {
+  test("sends Api-Key authorization header with assistant API key", async () => {
     await proxyTwitterCall({
       method: "GET",
       path: "/2/users/me",
@@ -193,7 +193,7 @@ describe("proxyTwitterCall", () => {
 
     expect(lastFetchArgs).not.toBeNull();
     const headers = lastFetchArgs![1].headers as Record<string, string>;
-    expect(headers.Authorization).toBe("Bearer test-api-key-123");
+    expect(headers.Authorization).toBe("Api-Key test-api-key-123");
     expect(headers["Content-Type"]).toBe("application/json");
   });
 

--- a/assistant/src/twitter/platform-proxy-client.ts
+++ b/assistant/src/twitter/platform-proxy-client.ts
@@ -1,0 +1,323 @@
+/**
+ * Platform-managed Twitter proxy client.
+ *
+ * Proxies Twitter API calls through the platform instead of calling the
+ * Twitter API directly. Used when the Twitter integration is in "managed"
+ * mode — the platform holds the OAuth credentials and forwards requests
+ * on behalf of the assistant.
+ *
+ * Prerequisites:
+ * - Platform base URL (env `PLATFORM_BASE_URL` or config `platform.baseUrl`)
+ * - Auth token (secure key `credential:vellum:assistant_api_key`)
+ * - Platform assistant ID (env `PLATFORM_ASSISTANT_ID`)
+ */
+
+import { getPlatformAssistantId, getPlatformBaseUrl } from "../config/env.js";
+import { getConfig } from "../config/loader.js";
+import { getSecureKey } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("twitter-proxy");
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+export class TwitterProxyError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly retryable: boolean,
+    public readonly statusCode: number = 0,
+  ) {
+    super(message);
+    this.name = "TwitterProxyError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Prerequisite resolution
+// ---------------------------------------------------------------------------
+
+export interface TwitterProxyPrerequisites {
+  platformBaseUrl: string;
+  authToken: string;
+  platformAssistantId: string;
+}
+
+/**
+ * Resolve the platform base URL from config or environment.
+ * Config `platform.baseUrl` takes precedence over `PLATFORM_BASE_URL` env.
+ */
+export function resolvePlatformBaseUrl(): string {
+  const configUrl = getConfig().platform.baseUrl;
+  const envUrl = getPlatformBaseUrl();
+  return (configUrl || envUrl).replace(/\/+$/, "");
+}
+
+/**
+ * Resolve the assistant auth token from secure storage.
+ */
+export function resolveAuthToken(): string | undefined {
+  return getSecureKey("credential:vellum:assistant_api_key");
+}
+
+/**
+ * Resolve the platform assistant ID from environment.
+ */
+export function resolvePlatformAssistantId(): string {
+  return getPlatformAssistantId();
+}
+
+/**
+ * Resolve all prerequisites for managed Twitter proxy calls.
+ * Throws a descriptive `TwitterProxyError` if any prerequisite is missing.
+ */
+export function resolvePrerequisites(): TwitterProxyPrerequisites {
+  const platformAssistantId = resolvePlatformAssistantId();
+  if (!platformAssistantId) {
+    throw new TwitterProxyError(
+      "Local assistant not registered with platform",
+      "missing_platform_assistant_id",
+      false,
+    );
+  }
+
+  const authToken = resolveAuthToken();
+  if (!authToken) {
+    throw new TwitterProxyError(
+      "Assistant not bootstrapped — run setup",
+      "missing_assistant_api_key",
+      false,
+    );
+  }
+
+  const platformBaseUrl = resolvePlatformBaseUrl();
+  if (!platformBaseUrl) {
+    throw new TwitterProxyError(
+      "Platform base URL is not configured",
+      "missing_platform_base_url",
+      false,
+    );
+  }
+
+  return { platformBaseUrl, authToken, platformAssistantId };
+}
+
+// ---------------------------------------------------------------------------
+// Proxy request/response types
+// ---------------------------------------------------------------------------
+
+export interface TwitterProxyRequest {
+  /** HTTP method for the underlying Twitter API call. */
+  method: "GET" | "POST" | "PUT" | "DELETE";
+  /** Twitter API path (e.g. "/2/tweets", "/2/users/me"). */
+  path: string;
+  /** JSON body for POST/PUT requests. */
+  body?: Record<string, unknown>;
+  /** Query parameters for GET-style requests. */
+  query?: Record<string, string>;
+}
+
+export interface TwitterProxyResponse<T = unknown> {
+  /** Parsed response data from the Twitter API. */
+  data: T;
+  /** HTTP status code from the proxy response. */
+  status: number;
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+function mapProxyError(status: number, body: unknown): TwitterProxyError {
+  const obj =
+    typeof body === "object" && body
+      ? (body as Record<string, unknown>)
+      : undefined;
+  const detail = obj?.detail ?? obj?.message ?? obj?.error;
+  const detailStr = detail ? String(detail) : `HTTP ${status}`;
+
+  if (status === 403) {
+    const msg = String(detailStr).toLowerCase();
+    if (msg.includes("owner") && msg.includes("credential")) {
+      return new TwitterProxyError(
+        "Connect Twitter in Settings as the assistant owner",
+        "owner_credential_required",
+        false,
+        status,
+      );
+    }
+    if (msg.includes("owner")) {
+      return new TwitterProxyError(
+        "Sign in as the assistant owner",
+        "owner_only",
+        false,
+        status,
+      );
+    }
+    return new TwitterProxyError(
+      `Forbidden: ${detailStr}`,
+      "forbidden",
+      false,
+      status,
+    );
+  }
+
+  if (status === 401) {
+    return new TwitterProxyError(
+      "Reconnect Twitter or retry",
+      "auth_failure",
+      true,
+      status,
+    );
+  }
+
+  if (status === 502 || status === 503 || status === 504) {
+    return new TwitterProxyError(
+      "Reconnect Twitter or retry",
+      "upstream_failure",
+      true,
+      status,
+    );
+  }
+
+  if (status === 429) {
+    return new TwitterProxyError(
+      "Rate limit exceeded — retry later",
+      "rate_limit",
+      true,
+      status,
+    );
+  }
+
+  if (status >= 500) {
+    return new TwitterProxyError(
+      `Platform error: ${detailStr}`,
+      "platform_error",
+      true,
+      status,
+    );
+  }
+
+  return new TwitterProxyError(
+    `Proxy request failed: ${detailStr}`,
+    "proxy_error",
+    false,
+    status,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Proxy call
+// ---------------------------------------------------------------------------
+
+/**
+ * Send a Twitter API call through the platform proxy.
+ *
+ * The proxy endpoint is:
+ *   POST {platformBaseURL}/v1/assistants/{platform_assistant_id}/external-provider-proxy/twitter/
+ *
+ * The request body describes the Twitter API call to make:
+ *   { method, path, body?, query? }
+ *
+ * Auth uses `Authorization: Bearer {auth_token}` (the assistant API key).
+ */
+export async function proxyTwitterCall<T = unknown>(
+  request: TwitterProxyRequest,
+): Promise<TwitterProxyResponse<T>> {
+  const { platformBaseUrl, authToken, platformAssistantId } =
+    resolvePrerequisites();
+
+  const url = `${platformBaseUrl}/v1/assistants/${platformAssistantId}/external-provider-proxy/twitter/`;
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${authToken}`,
+    "Content-Type": "application/json",
+  };
+
+  log.debug(
+    { method: request.method, path: request.path },
+    "Proxying Twitter API call through platform",
+  );
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(request),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    const isTimeout =
+      err instanceof DOMException && err.name === "TimeoutError";
+    throw new TwitterProxyError(
+      isTimeout
+        ? "Platform proxy request timed out"
+        : `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      isTimeout ? "timeout" : "network_error",
+      true,
+    );
+  }
+
+  if (!response.ok) {
+    let errorBody: unknown;
+    try {
+      errorBody = await response.json();
+    } catch {
+      errorBody = undefined;
+    }
+    throw mapProxyError(response.status, errorBody);
+  }
+
+  let data: T;
+  try {
+    data = (await response.json()) as T;
+  } catch (err) {
+    throw new TwitterProxyError(
+      `Failed to parse proxy response: ${err instanceof Error ? err.message : String(err)}`,
+      "unparseable_response",
+      false,
+      response.status,
+    );
+  }
+
+  return { data, status: response.status };
+}
+
+// ---------------------------------------------------------------------------
+// Convenience helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Post a tweet through the platform proxy.
+ */
+export async function postTweet(
+  text: string,
+  options?: { replyToId?: string },
+): Promise<TwitterProxyResponse> {
+  const body: Record<string, unknown> = { text };
+  if (options?.replyToId) {
+    body.reply = { in_reply_to_tweet_id: options.replyToId };
+  }
+
+  return proxyTwitterCall({
+    method: "POST",
+    path: "/2/tweets",
+    body,
+  });
+}
+
+/**
+ * Read the authenticated user's profile through the platform proxy.
+ */
+export async function getMe(
+  query?: Record<string, string>,
+): Promise<TwitterProxyResponse> {
+  return proxyTwitterCall({
+    method: "GET",
+    path: "/2/users/me",
+    query,
+  });
+}

--- a/assistant/src/twitter/platform-proxy-client.ts
+++ b/assistant/src/twitter/platform-proxy-client.ts
@@ -15,6 +15,7 @@
 import { getPlatformAssistantId, getPlatformBaseUrl } from "../config/env.js";
 import { getConfig } from "../config/loader.js";
 import { getSecureKey } from "../security/secure-keys.js";
+import { BackendError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("twitter-proxy");
@@ -23,7 +24,7 @@ const log = getLogger("twitter-proxy");
 // Error types
 // ---------------------------------------------------------------------------
 
-export class TwitterProxyError extends Error {
+export class TwitterProxyError extends BackendError {
   constructor(
     message: string,
     public readonly code: string,
@@ -221,7 +222,7 @@ function mapProxyError(status: number, body: unknown): TwitterProxyError {
  * The request body describes the Twitter API call to make:
  *   { method, path, body?, query? }
  *
- * Auth uses `Authorization: Bearer {auth_token}` (the assistant API key).
+ * Auth uses `Authorization: Api-Key {auth_token}` (the assistant API key).
  */
 export async function proxyTwitterCall<T = unknown>(
   request: TwitterProxyRequest,
@@ -232,7 +233,7 @@ export async function proxyTwitterCall<T = unknown>(
   const url = `${platformBaseUrl}/v1/assistants/${platformAssistantId}/external-provider-proxy/twitter/`;
 
   const headers: Record<string, string> = {
-    Authorization: `Bearer ${authToken}`,
+    Authorization: `Api-Key ${authToken}`,
     "Content-Type": "application/json",
   };
 


### PR DESCRIPTION
## Summary
- Add `assistant/src/twitter/platform-proxy-client.ts` — a TypeScript client that proxies Twitter API calls through the platform for managed Twitter integration mode
- Resolves prerequisites (platform base URL, auth token, platform assistant ID) with descriptive error messages for each missing prerequisite
- Maps proxy errors (403 owner credential, 401 auth, 502/503/504 upstream, 429 rate limit) to actionable user-facing messages
- Includes convenience helpers for posting tweets and reading user profile
- Add comprehensive tests covering prerequisite resolution, proxy calls, error mapping, and convenience helpers

## Test plan
- [ ] Verify prerequisite resolution (config vs env priority, missing values)
- [ ] Verify proxy call sends correct URL, headers, and body shape
- [ ] Verify error mapping for each HTTP status code scenario
- [ ] Verify convenience helpers (postTweet, getMe) format requests correctly

Part of #14196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
