### PR TITLE
fix: normalize mac/macos/ios channel aliases to vellum

### DIFF
--- a/assistant/src/daemon/session-runtime-assembly.ts
+++ b/assistant/src/daemon/session-runtime-assembly.ts
@@ -304,6 +304,9 @@ export function resolveChannelCapabilities(
     case undefined:
     case "dashboard":
     case "http-api":
+    case "mac":
+    case "macos":
+    case "ios":
       channel = "vellum";
       break;
     default:


### PR DESCRIPTION
## Summary
- Add `"mac"`, `"macos"`, and `"ios"` to the channel normalization switch in `resolveChannelCapabilities` so they map to `"vellum"` (matching existing test expectations)
- Fixes 5 failing CI tests: 3 channel alias normalization tests and 2 PTT metadata tests that relied on `"macos"` being routed through the vellum capability branch

## Original prompt
Fix this Ci issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22829555685

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
