### PR TITLE
fix: preserve active assistant defaults when --url is set in client command

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -58,14 +58,11 @@ function parseArgs(): ParsedArgs {
       );
       process.exit(1);
     }
-  } else if (
-    process.env.RUNTIME_URL ||
-    flagArgs.includes("--url") ||
-    flagArgs.includes("-u")
-  ) {
-    // Explicit URL provided via env var or flag — skip assistant resolution
-    entry = loadLatestAssistant();
   } else {
+    const hasExplicitUrl =
+      process.env.RUNTIME_URL ||
+      flagArgs.includes("--url") ||
+      flagArgs.includes("-u");
     const active = getActiveAssistant();
     if (active) {
       entry = findAssistantByName(active);
@@ -75,6 +72,9 @@ function parseArgs(): ParsedArgs {
         );
         process.exit(1);
       }
+    } else if (hasExplicitUrl) {
+      // URL provided but no active assistant — use latest for remaining defaults
+      entry = loadLatestAssistant();
     } else {
       console.error(
         "No active assistant set. Set one with 'vellum use <name>' or specify a name: 'vellum client <name>'.",


### PR DESCRIPTION
When --url was provided, the client command skipped getActiveAssistant() entirely and fell back to loadLatestAssistant(), potentially using wrong defaults (assistantId, token, species) in multi-assistant setups. Now --url still tries the active assistant first and only falls back when none is active.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
