### PR TITLE
fix: validate resources before archive deletion in recover command

### DIFF
--- a/cli/src/commands/recover.ts
+++ b/cli/src/commands/recover.ts
@@ -53,18 +53,19 @@ export async function recover(): Promise<void> {
   const entry: AssistantEntry = JSON.parse(readFileSync(metadataPath, "utf-8"));
   saveAssistantEntry(entry);
 
-  // 5. Clean up archive
+  // 5. Validate resources before cleaning up the archive
+  if (!entry.resources) {
+    throw new Error(
+      `Recovery archive entry for '${name}' is missing resource configuration. ` +
+        `The archive has been preserved — fix the archive and retry 'vellum recover'.`,
+    );
+  }
+
+  // 6. Clean up archive
   unlinkSync(archivePath);
   unlinkSync(metadataPath);
 
-  // 6. Start daemon + gateway (same as wake)
-  if (!entry.resources) {
-    throw new Error(
-      `Recovered assistant '${name}' is missing resource configuration. ` +
-        `Data has been restored to ~/.vellum but the assistant cannot start without allocated ports. ` +
-        `Run 'vellum retire ${name}' then 'vellum hatch' to re-provision with proper resource allocation.`,
-    );
-  }
+  // 7. Start daemon + gateway (same as wake)
   await startLocalDaemon(false, entry.resources);
   if (!process.env.VELLUM_DESKTOP_APP) {
     await startGateway(undefined, false, entry.resources);


### PR DESCRIPTION
The recover command deleted the archive before checking entry.resources, creating an unrecoverable state if resources were missing. The error message also suggested running vellum retire which would also fail. Move resources validation before archive cleanup so the archive is preserved on failure, and update the error message with actionable guidance.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
