### PR TITLE
fix: re-add deleted-status filter to handleMemoryUpdate collision detection

### DIFF
--- a/assistant/src/tools/memory/handlers.ts
+++ b/assistant/src/tools/memory/handlers.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import type { AssistantConfig } from "../../config/types.js";
@@ -208,6 +208,7 @@ export async function handleMemoryUpdate(
         and(
           eq(memoryItems.fingerprint, fingerprint),
           eq(memoryItems.scopeId, scopeId),
+          ne(memoryItems.status, "deleted"),
         ),
       )
       .get();


### PR DESCRIPTION
The collision-detection query in handleMemoryUpdate was incorrectly matching soft-deleted items after the filter was removed in #13999. This caused legitimate updates to be blocked by ghost rows the user cannot interact with via memory_recall. Re-add the ne(status, deleted) filter to handleMemoryUpdate only — handleMemorySave correctly omits it for consistency with other dedup sites.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
