### PR TITLE
fix: trim tts_voice_id value before broadcasting to other clients

### DIFF
--- a/assistant/src/daemon/tool-side-effects.ts
+++ b/assistant/src/daemon/tool-side-effects.ts
@@ -237,6 +237,8 @@ registerHook(
       coerced = typeof raw === "number" ? raw : Number(raw);
     } else if (setting === "wake_word_keyword" && typeof raw === "string") {
       coerced = raw.trim();
+    } else if (setting === "tts_voice_id" && typeof raw === "string") {
+      coerced = raw.trim();
     }
     broadcastToAllClients?.({
       type: "client_settings_update",


### PR DESCRIPTION
The tts_voice_id setting was added to the SETTING_TO_KEY broadcast map but the broadcast value was not trimmed, causing inconsistency with the validated/trimmed value stored by the requesting client. Add trim() normalization to match validateSetting() behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
