### PR TITLE
fix: use queryVector null-check instead of re-querying breaker state for degradation classification

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -833,13 +833,13 @@ export async function buildMemoryRecall(
     embeddingResult.reason =
       embeddingResult.reason ??
       (collected.semanticUnavailable
-        ? isQdrantBreakerOpen()
+        ? embeddingResult.queryVector != null
           ? "memory.qdrant_circuit_open"
           : "memory.embedding_unavailable"
         : "memory.semantic_search_failure");
     if (!embeddingResult.degradation) {
       const isQdrantIssue =
-        isQdrantBreakerOpen() ||
+        embeddingResult.queryVector != null ||
         isQdrantConnectionError(collected.semanticSearchError) ||
         collected.semanticSearchError instanceof QdrantCircuitOpenError;
       const reason: DegradationReason = isQdrantIssue


### PR DESCRIPTION
The degradation classification in the retriever re-queried the mutable isQdrantBreakerOpen() state, creating a TOCTOU race where concurrent operations could change the breaker between candidate collection and classification. Use the already-available queryVector from the embedding result instead: null means embedding failed, non-null means Qdrant was the issue.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
