### PR TITLE
fix: handle guardian plain-text approval when conversation generator is unavailable

### DIFF
--- a/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
@@ -228,6 +228,30 @@ export async function handleGuardianCallbackDecision(
     });
   }
 
+  // Guardian sent a plain-text message with pending approvals but the
+  // conversational engine is unavailable. Return a handled result with a
+  // static reply so the guardian gets feedback instead of the message being
+  // silently swallowed by the standard approval flow.
+  if (effectivePending.length > 0 && content) {
+    try {
+      await deliverChannelReply(
+        replyCallbackUrl,
+        {
+          chatId: conversationExternalId,
+          text: "I can't process text replies for approvals right now. Please use the approve/deny buttons above to respond.",
+          assistantId,
+        },
+        bearerToken,
+      );
+    } catch (err) {
+      log.error(
+        { err, conversationExternalId },
+        "Failed to deliver guardian fallback reply",
+      );
+    }
+    return { handled: true, type: "assistant_turn" };
+  }
+
   // No content — nothing actionable.
   return null;
 }


### PR DESCRIPTION
When approvalConversationGenerator was undefined and a guardian sent a plain-text message with pending approvals, the message was silently dropped to normal processing. Now return a handled result with a static reply guiding the guardian to use callback buttons, preserving the fail-closed behavior from before #14322.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
