### PR TITLE
M6: Route managed Twitter posts through proxy client

### DIFF
--- a/assistant/src/cli/commands/twitter/__tests__/cli-error-shaping.test.ts
+++ b/assistant/src/cli/commands/twitter/__tests__/cli-error-shaping.test.ts
@@ -45,7 +45,8 @@ function buildErrorPayload(err: unknown): Record<string, unknown> | null {
     err instanceof Error &&
     (meta.pathUsed !== undefined ||
       meta.suggestAlternative !== undefined ||
-      meta.oauthError !== undefined)
+      meta.oauthError !== undefined ||
+      meta.proxyErrorCode !== undefined)
   ) {
     const payload: Record<string, unknown> = {
       ok: false,
@@ -55,6 +56,9 @@ function buildErrorPayload(err: unknown): Record<string, unknown> | null {
     if (meta.suggestAlternative !== undefined)
       payload.suggestAlternative = meta.suggestAlternative;
     if (meta.oauthError !== undefined) payload.oauthError = meta.oauthError;
+    if (meta.proxyErrorCode !== undefined)
+      payload.proxyErrorCode = meta.proxyErrorCode;
+    if (meta.retryable !== undefined) payload.retryable = meta.retryable;
     return payload;
   }
 
@@ -203,6 +207,43 @@ describe("CLI error shaping", () => {
     expect(payload).toEqual({
       ok: false,
       error: "some string error",
+    });
+  });
+
+  test("managed proxy error preserves proxyErrorCode and retryable metadata", () => {
+    const err = Object.assign(
+      new Error("Connect Twitter in Settings as the assistant owner"),
+      {
+        pathUsed: "managed" as const,
+        proxyErrorCode: "owner_credential_required",
+        retryable: false,
+      },
+    );
+    const payload = buildErrorPayload(err);
+
+    expect(payload).toEqual({
+      ok: false,
+      error: "Connect Twitter in Settings as the assistant owner",
+      pathUsed: "managed",
+      proxyErrorCode: "owner_credential_required",
+      retryable: false,
+    });
+  });
+
+  test("managed proxy retryable error preserves metadata", () => {
+    const err = Object.assign(new Error("Reconnect Twitter or retry"), {
+      pathUsed: "managed" as const,
+      proxyErrorCode: "auth_failure",
+      retryable: true,
+    });
+    const payload = buildErrorPayload(err);
+
+    expect(payload).toEqual({
+      ok: false,
+      error: "Reconnect Twitter or retry",
+      pathUsed: "managed",
+      proxyErrorCode: "auth_failure",
+      retryable: true,
     });
   });
 

--- a/assistant/src/cli/commands/twitter/__tests__/cli-routing.test.ts
+++ b/assistant/src/cli/commands/twitter/__tests__/cli-routing.test.ts
@@ -14,6 +14,8 @@ let mockBrowserPostResult: {
   url: string;
 } | null = null;
 let mockBrowserPostError: Error | null = null;
+let mockManagedPostResult: { data: unknown; status: number } | null = null;
+let mockManagedPostError: Error | null = null;
 
 // Mock the OAuth client
 mock.module("../oauth-client.js", () => ({
@@ -37,6 +39,35 @@ mock.module("../oauth-client.js", () => ({
       this.operation = operation;
     }
   },
+}));
+
+// Mock TwitterProxyError for managed path tests
+class MockTwitterProxyError extends Error {
+  public readonly code: string;
+  public readonly retryable: boolean;
+  public readonly statusCode: number;
+  constructor(
+    message: string,
+    code: string,
+    retryable: boolean,
+    statusCode = 0,
+  ) {
+    super(message);
+    this.name = "TwitterProxyError";
+    this.code = code;
+    this.retryable = retryable;
+    this.statusCode = statusCode;
+  }
+}
+
+// Mock the platform proxy client
+mock.module("../../../../twitter/platform-proxy-client.js", () => ({
+  postTweet: async (_text: string, _opts?: { replyToId?: string }) => {
+    if (mockManagedPostError) throw mockManagedPostError;
+    if (mockManagedPostResult) return mockManagedPostResult;
+    throw new Error("Managed mock not configured");
+  },
+  TwitterProxyError: MockTwitterProxyError,
 }));
 
 // Create a SessionExpiredError class that matches the real one
@@ -82,6 +113,8 @@ beforeEach(() => {
   mockOauthPostError = null;
   mockBrowserPostResult = null;
   mockBrowserPostError = null;
+  mockManagedPostResult = null;
+  mockManagedPostError = null;
 });
 
 describe("Twitter strategy router", () => {
@@ -245,6 +278,99 @@ describe("Twitter strategy router", () => {
         expect(true).toBe(false); // should not reach
       } catch (err) {
         expect((err as Error).message).toBe("Network failure");
+      }
+    });
+  });
+
+  describe("managed strategy", () => {
+    test("routes post through platform proxy", async () => {
+      mockManagedPostResult = {
+        data: { data: { id: "managed-1" } },
+        status: 200,
+      };
+
+      const { result, pathUsed } = await routedPostTweet("managed post", {
+        strategy: "managed",
+      });
+
+      expect(pathUsed).toBe("managed");
+      expect(result.tweetId).toBe("managed-1");
+      expect(result.url).toBe("https://x.com/i/status/managed-1");
+    });
+
+    test("routes reply through platform proxy", async () => {
+      mockManagedPostResult = {
+        data: { data: { id: "managed-reply-1" } },
+        status: 200,
+      };
+
+      const { result, pathUsed } = await routedPostTweet("reply text", {
+        strategy: "managed",
+        inReplyToTweetId: "original-tweet-123",
+      });
+
+      expect(pathUsed).toBe("managed");
+      expect(result.tweetId).toBe("managed-reply-1");
+    });
+
+    test("surfaces proxy errors with actionable metadata", async () => {
+      mockManagedPostError = new MockTwitterProxyError(
+        "Connect Twitter in Settings as the assistant owner",
+        "owner_credential_required",
+        false,
+        403,
+      );
+
+      try {
+        await routedPostTweet("will fail", { strategy: "managed" });
+        expect(true).toBe(false); // should not reach
+      } catch (err) {
+        const e = err as Error & {
+          pathUsed: string;
+          proxyErrorCode: string;
+          retryable: boolean;
+        };
+        expect(e.message).toBe(
+          "Connect Twitter in Settings as the assistant owner",
+        );
+        expect(e.pathUsed).toBe("managed");
+        expect(e.proxyErrorCode).toBe("owner_credential_required");
+        expect(e.retryable).toBe(false);
+      }
+    });
+
+    test("surfaces retryable proxy errors", async () => {
+      mockManagedPostError = new MockTwitterProxyError(
+        "Reconnect Twitter or retry",
+        "auth_failure",
+        true,
+        401,
+      );
+
+      try {
+        await routedPostTweet("will fail", { strategy: "managed" });
+        expect(true).toBe(false);
+      } catch (err) {
+        const e = err as Error & {
+          pathUsed: string;
+          proxyErrorCode: string;
+          retryable: boolean;
+        };
+        expect(e.pathUsed).toBe("managed");
+        expect(e.proxyErrorCode).toBe("auth_failure");
+        expect(e.retryable).toBe(true);
+      }
+    });
+
+    test("re-throws non-proxy errors without wrapping", async () => {
+      mockManagedPostError = new Error("Network failure");
+
+      try {
+        await routedPostTweet("will fail", { strategy: "managed" });
+        expect(true).toBe(false);
+      } catch (err) {
+        expect((err as Error).message).toBe("Network failure");
+        expect((err as Record<string, unknown>).pathUsed).toBeUndefined();
       }
     });
   });

--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -357,7 +357,7 @@ Examples:
   const strategyCli = tw
     .command("strategy")
     .description(
-      "Get or set the Twitter operation strategy (oauth, browser, auto)",
+      "Get or set the Twitter operation strategy (managed, oauth, browser, auto)",
     )
     .addHelpText(
       "after",
@@ -365,6 +365,7 @@ Examples:
 The strategy controls which authentication path is used for operations that
 support both OAuth and browser session:
 
+  managed  — route through the platform proxy (platform holds OAuth credentials).
   oauth    — always use the official Twitter OAuth API. Fails if no OAuth
              credential is connected. Best for reliable posting.
   browser  — always use the browser session (captured cookies). Fails if no
@@ -376,6 +377,7 @@ Run without a subcommand to display the current strategy. Use "set" to change it
 
 Examples:
   $ assistant x strategy
+  $ assistant x strategy set managed
   $ assistant x strategy set oauth
   $ assistant x strategy set auto`,
     )
@@ -399,18 +401,19 @@ Examples:
   strategyCli
     .command("set")
     .description("Set the Twitter operation strategy")
-    .argument("<value>", "Strategy value: oauth, browser, or auto")
+    .argument("<value>", "Strategy value: managed, oauth, browser, or auto")
     .addHelpText(
       "after",
       `
 Arguments:
-  value   Strategy to use: "oauth", "browser", or "auto"
+  value   Strategy to use: "managed", "oauth", "browser", or "auto"
 
 Sets the preferred strategy for Twitter operations that support dual-path
 routing. The setting is persisted by the assistant and applies to all subsequent
 operations until changed.
 
 Examples:
+  $ assistant x strategy set managed
   $ assistant x strategy set oauth
   $ assistant x strategy set browser
   $ assistant x strategy set auto`,

--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -91,7 +91,8 @@ async function run(cmd: Command, fn: () => Promise<unknown>): Promise<void> {
       err instanceof Error &&
       (meta.pathUsed !== undefined ||
         meta.suggestAlternative !== undefined ||
-        meta.oauthError !== undefined)
+        meta.oauthError !== undefined ||
+        meta.proxyErrorCode !== undefined)
     ) {
       const payload: Record<string, unknown> = {
         ok: false,
@@ -101,6 +102,9 @@ async function run(cmd: Command, fn: () => Promise<unknown>): Promise<void> {
       if (meta.suggestAlternative !== undefined)
         payload.suggestAlternative = meta.suggestAlternative;
       if (meta.oauthError !== undefined) payload.oauthError = meta.oauthError;
+      if (meta.proxyErrorCode !== undefined)
+        payload.proxyErrorCode = meta.proxyErrorCode;
+      if (meta.retryable !== undefined) payload.retryable = meta.retryable;
       output(payload, getJson(cmd));
       process.exitCode = 1;
       return;
@@ -118,22 +122,25 @@ export function registerTwitterCommand(program: Command): void {
     .command("x")
     .alias("twitter")
     .description(
-      "Post on X and manage connections. Supports OAuth (official API) and browser session paths.",
+      "Post on X and manage connections. Supports managed (platform proxy), OAuth (official API), and browser session paths.",
     )
     .option("--json", "Machine-readable JSON output");
 
   tw.addHelpText(
     "after",
     `
-Twitter (X) uses a dual-path architecture for interacting with the platform:
+Twitter (X) supports multiple paths for interacting with the platform:
 
-  1. OAuth (official API) — uses an authenticated Twitter OAuth application for
+  1. Managed (platform proxy) — routes Twitter API calls through the platform,
+     which holds the OAuth credentials. Used when integrationMode is "managed".
+  2. OAuth (official API) — uses an authenticated Twitter OAuth application for
      posting and replying. Requires a connected OAuth credential.
-  2. Browser session (Ride Shotgun) — uses cookies captured from a real Chrome
+  3. Browser session (Ride Shotgun) — uses cookies captured from a real Chrome
      session to call Twitter's internal GraphQL API. Supports all read operations
      and posting as a fallback.
 
-The strategy system controls which path is used for operations that support both:
+The strategy system controls which path is used for operations that support multiple:
+  managed  — route through the platform proxy (platform holds credentials)
   oauth    — always use the OAuth API; fail if unavailable
   browser  — always use the browser session; fail if unavailable
   auto     — try OAuth first, fall back to browser session (default)
@@ -147,6 +154,7 @@ Session management:
 
 Examples:
   $ assistant x status
+  $ assistant x post "Hello world" --strategy managed
   $ assistant x post "Hello world" --strategy auto
   $ assistant x timeline elonmusk --count 10
   $ assistant x search "from:vaborsh AI agents" --product Latest
@@ -441,7 +449,7 @@ Examples:
     .argument("<text>", "Tweet text")
     .requiredOption(
       "--strategy <strategy>",
-      "Operation strategy: oauth, browser, or auto",
+      "Operation strategy: oauth, browser, auto, or managed",
     )
     .option(
       "--oauth-token <token>",
@@ -453,14 +461,20 @@ Examples:
 Arguments:
   text   The tweet text to post (max 280 characters)
 
-Posts a new tweet using the routed dual-path system. The --strategy flag
-controls which path is used. The response includes the tweet ID, URL, and
-which path was used.
+Posts a new tweet using the routed system. The --strategy flag controls which
+path is used. The response includes the tweet ID, URL, and which path was used.
+
+Strategies:
+  oauth    — use the local OAuth token directly
+  browser  — use the browser session (CDP)
+  auto     — try OAuth first, fall back to browser
+  managed  — route through the platform proxy (platform holds OAuth credentials)
 
 Examples:
   $ assistant x post "Hello world" --strategy browser
   $ assistant x post "Hello world" --strategy oauth --oauth-token "$TOKEN"
-  $ assistant x post "Hello world" --strategy auto --oauth-token "$TOKEN"`,
+  $ assistant x post "Hello world" --strategy auto --oauth-token "$TOKEN"
+  $ assistant x post "Hello world" --strategy managed`,
     )
     .action(
       async (
@@ -473,10 +487,11 @@ Examples:
           if (
             strategy !== "oauth" &&
             strategy !== "browser" &&
-            strategy !== "auto"
+            strategy !== "auto" &&
+            strategy !== "managed"
           ) {
             throw new Error(
-              `Invalid strategy "${opts.strategy}". Must be oauth, browser, or auto.`,
+              `Invalid strategy "${opts.strategy}". Must be oauth, browser, auto, or managed.`,
             );
           }
           const { result, pathUsed } = await routedPostTweet(text, {
@@ -502,7 +517,7 @@ Examples:
     .argument("<text>", "Reply text")
     .requiredOption(
       "--strategy <strategy>",
-      "Operation strategy: oauth, browser, or auto",
+      "Operation strategy: oauth, browser, auto, or managed",
     )
     .option(
       "--oauth-token <token>",
@@ -521,7 +536,8 @@ URL. The --strategy flag controls which path is used.
 
 Examples:
   $ assistant x reply https://x.com/elonmusk/status/1234567890 "Great point!" --strategy browser
-  $ assistant x reply 1234567890 "Interesting thread" --strategy oauth --oauth-token "$TOKEN"`,
+  $ assistant x reply 1234567890 "Interesting thread" --strategy oauth --oauth-token "$TOKEN"
+  $ assistant x reply 1234567890 "Nice!" --strategy managed`,
     )
     .action(
       async (
@@ -535,10 +551,11 @@ Examples:
           if (
             strategy !== "oauth" &&
             strategy !== "browser" &&
-            strategy !== "auto"
+            strategy !== "auto" &&
+            strategy !== "managed"
           ) {
             throw new Error(
-              `Invalid strategy "${opts.strategy}". Must be oauth, browser, or auto.`,
+              `Invalid strategy "${opts.strategy}". Must be oauth, browser, auto, or managed.`,
             );
           }
           // Extract tweet ID: either a bare numeric ID or the last numeric segment of a URL

--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -377,7 +377,6 @@ Run without a subcommand to display the current strategy. Use "set" to change it
 
 Examples:
   $ assistant x strategy
-  $ assistant x strategy set managed
   $ assistant x strategy set oauth
   $ assistant x strategy set auto`,
     )
@@ -401,19 +400,19 @@ Examples:
   strategyCli
     .command("set")
     .description("Set the Twitter operation strategy")
-    .argument("<value>", "Strategy value: managed, oauth, browser, or auto")
+    .argument("<value>", "Strategy value: oauth, browser, or auto")
     .addHelpText(
       "after",
       `
 Arguments:
-  value   Strategy to use: "managed", "oauth", "browser", or "auto"
+  value   Strategy to use: "oauth", "browser", or "auto"
 
 Sets the preferred strategy for Twitter operations that support dual-path
 routing. The setting is persisted by the assistant and applies to all subsequent
-operations until changed.
+operations until changed. Note: "managed" is determined by integration mode
+and cannot be set manually.
 
 Examples:
-  $ assistant x strategy set managed
   $ assistant x strategy set oauth
   $ assistant x strategy set browser
   $ assistant x strategy set auto`,

--- a/assistant/src/cli/commands/twitter/router.ts
+++ b/assistant/src/cli/commands/twitter/router.ts
@@ -52,11 +52,21 @@ export async function routedPostTweet(
       const data = response.data as Record<string, unknown>;
       const tweetData = (data?.data ?? data) as Record<string, unknown>;
       const tweetId = String(tweetData.id ?? "");
+      if (!tweetId) {
+        throw Object.assign(
+          new Error(
+            "Managed post succeeded but the proxy response did not include a tweet ID",
+          ),
+          {
+            pathUsed: "managed" as const,
+          },
+        );
+      }
       return {
         result: {
           tweetId,
           text,
-          url: tweetId ? `https://x.com/i/status/${tweetId}` : "",
+          url: `https://x.com/i/status/${tweetId}`,
         },
         pathUsed: "managed",
       };

--- a/assistant/src/cli/commands/twitter/router.ts
+++ b/assistant/src/cli/commands/twitter/router.ts
@@ -1,8 +1,12 @@
 /**
  * Strategy router for Twitter operations.
- * Selects OAuth or browser path based on the caller-provided strategy.
+ * Selects managed proxy, OAuth, or browser path based on the caller-provided strategy.
  */
 
+import {
+  postTweet as managedPostTweet,
+  TwitterProxyError,
+} from "../../../twitter/platform-proxy-client.js";
 import type { PostTweetResult } from "./client.js";
 import {
   postTweet as browserPostTweet,
@@ -14,7 +18,7 @@ import {
   oauthSupportsOperation,
 } from "./oauth-client.js";
 
-export type TwitterStrategy = "oauth" | "browser" | "auto";
+export type TwitterStrategy = "oauth" | "browser" | "auto" | "managed";
 
 export interface RoutedResult<T> {
   result: T;
@@ -38,6 +42,36 @@ export async function routedPostTweet(
 ): Promise<RoutedResult<PostTweetResult>> {
   const strategy = opts.strategy;
   const operation = opts.inReplyToTweetId ? "reply" : "post";
+
+  if (strategy === "managed") {
+    // Route through platform proxy — the platform holds the OAuth credentials
+    try {
+      const response = await managedPostTweet(text, {
+        replyToId: opts.inReplyToTweetId,
+      });
+      const data = response.data as Record<string, unknown>;
+      const tweetData = (data?.data ?? data) as Record<string, unknown>;
+      const tweetId = String(tweetData.id ?? "");
+      return {
+        result: {
+          tweetId,
+          text,
+          url: tweetId ? `https://x.com/i/status/${tweetId}` : "",
+        },
+        pathUsed: "managed",
+      };
+    } catch (err) {
+      if (err instanceof TwitterProxyError) {
+        // Surface actionable error messages from the proxy
+        throw Object.assign(new Error(err.message), {
+          pathUsed: "managed" as const,
+          proxyErrorCode: err.code,
+          retryable: err.retryable,
+        });
+      }
+      throw err;
+    }
+  }
 
   if (strategy === "oauth") {
     // User explicitly wants OAuth

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -9,7 +9,23 @@ You are an X (formerly Twitter) assistant. Use the `bash` tool to run `assistant
 
 ## Connection Options
 
-There are two supported ways to connect to X. Both are fully functional; choose whichever fits the user's situation.
+There are three supported ways to connect to X. Choose whichever fits the user's situation.
+
+### Managed mode (platform-hosted credentials)
+
+When `twitter.integrationMode` is set to `managed`, the platform holds the OAuth credentials and proxies Twitter API calls on behalf of the assistant. No local OAuth setup or browser session is needed.
+
+- Supports: **post** and **reply** (routed through the platform proxy)
+- Read-only operations still use the browser path when available.
+- Prerequisites: The assistant must be registered with the platform (`PLATFORM_ASSISTANT_ID`), have an API key (`credential:vellum:assistant_api_key`), and the assistant owner must have connected their Twitter account on the platform.
+- The strategy is automatically set to `managed` when `integrationMode` is `managed` and prerequisites are satisfied.
+
+**Error scenarios in managed mode:**
+- *"Assistant not bootstrapped"* — The assistant API key is missing. Run setup.
+- *"Local assistant not registered with platform"* — `PLATFORM_ASSISTANT_ID` is not set.
+- *"Connect Twitter in Settings as the assistant owner"* — The owner hasn't connected their X account on the platform yet.
+- *"Sign in as the assistant owner"* — The current user is not the assistant owner.
+- *"Reconnect Twitter or retry"* — The platform's OAuth token may have expired. Reconnect on the platform.
 
 ### OAuth (recommended with X developer credentials)
 
@@ -94,6 +110,11 @@ When a Twitter operation fails, follow these steps:
    - `Twitter API error (401)` — OAuth token may be expired or revoked.
    - `UnsupportedOAuthOperationError` — the requested write operation is not available via OAuth.
    - `Cannot connect to assistant` — the Vellum assistant is not running.
+   - `proxyErrorCode: "owner_credential_required"` — managed mode: the assistant owner has not connected their X account on the platform.
+   - `proxyErrorCode: "owner_only"` — managed mode: the current user is not the assistant owner.
+   - `proxyErrorCode: "auth_failure"` or `"upstream_failure"` — managed mode: platform token issue, reconnect Twitter on the platform.
+   - `proxyErrorCode: "missing_assistant_api_key"` — managed mode: the assistant is not bootstrapped.
+   - `proxyErrorCode: "missing_platform_assistant_id"` — managed mode: the assistant is not registered with the platform.
 
 2. **Explain the likely cause clearly** to the user.
 
@@ -101,6 +122,7 @@ When a Twitter operation fails, follow these steps:
    - If the browser session expired: suggest setting up OAuth for post/reply operations, or refresh the browser session with `assistant x refresh`.
    - If OAuth failed or is not configured: suggest using the browser path with `assistant config set twitter.operationStrategy browser` and `assistant x refresh`.
    - If the operation is unsupported via OAuth: explain that this write operation is not yet supported via OAuth, and suggest using the browser path with `assistant config set twitter.operationStrategy browser`.
+   - If managed mode failed with a credential or ownership error: explain the specific issue and guide the user to resolve it on the platform (connect Twitter, sign in as owner, etc.).
 
 4. **Offer concrete steps to switch:**
 
@@ -129,34 +151,44 @@ assistant x status --json
 
 ## Posting
 
-Before posting, fetch the current strategy and OAuth token:
+Before posting, check the integration mode and fetch the current strategy:
 
 ```bash
-# 1. Get the configured strategy
+# 1. Check integration mode
+MODE=$(assistant config get twitter.integrationMode)
+
+# 2. Get the configured strategy
 STRATEGY=$(assistant config get twitter.operationStrategy)
 # If not set, default to "auto"
-
-# 2. If strategy is "oauth" or "auto", get a valid OAuth token
-TOKEN=$(assistant oauth token twitter)
 ```
 
-Then post with the fetched values:
+Then post based on the mode and strategy:
 
 ```bash
+# Managed mode — route through platform proxy (no local token needed):
+assistant x post "The post text here" --strategy managed
+
 # With OAuth token (strategy is oauth or auto):
+TOKEN=$(assistant oauth token twitter)
 assistant x post "The post text here" --strategy "$STRATEGY" --oauth-token "$TOKEN"
 
 # With browser-only strategy:
 assistant x post "The post text here" --strategy browser
 ```
 
-Returns JSON with `ok`, `tweetId`, `text`, `url`, and `pathUsed` fields. Share the URL with the user so they can verify the post.
+When `twitter.integrationMode` is `managed`, always use `--strategy managed`. The platform proxy handles authentication.
+
+Returns JSON with `ok`, `tweetId`, `text`, `url`, and `pathUsed` fields. Share the URL with the user so they can verify the post. For managed mode errors, the response includes `proxyErrorCode` and `retryable` fields.
 
 ## Replying
 
-Same setup as posting — fetch strategy and token first, then:
+Same setup as posting — check integration mode and fetch strategy first, then:
 
 ```bash
+# Managed mode:
+assistant x reply <tweetUrl> "The reply text here" --strategy managed
+
+# Local OAuth or auto:
 assistant x reply <tweetUrl> "The reply text here" --strategy "$STRATEGY" --oauth-token "$TOKEN"
 ```
 


### PR DESCRIPTION
## Summary
- Add "managed" strategy to the Twitter post/reply router that routes operations through the platform proxy client (`platform-proxy-client.ts`) when `integrationMode` is `managed`
- Surface actionable error messages from the proxy (auth failures, ownership issues, missing credentials) with structured `proxyErrorCode` and `retryable` metadata in CLI output
- Update SKILL.md with managed mode documentation, error scenarios, and usage examples

## Test plan
- [ ] Verify `assistant x post "test" --strategy managed` routes through the platform proxy
- [ ] Verify `assistant x reply <url> "test" --strategy managed` routes through the platform proxy
- [ ] Verify existing `oauth`, `browser`, and `auto` strategies are unaffected
- [ ] Verify proxy errors surface with actionable messages and structured metadata
- [ ] Run `cli-routing.test.ts` and `cli-error-shaping.test.ts` to validate routing and error shaping

Part of #14191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
