### PR TITLE
fix: normalize contractions before splitting in FTS query expansion

### DIFF
--- a/assistant/src/memory/search/query-expansion.test.ts
+++ b/assistant/src/memory/search/query-expansion.test.ts
@@ -41,6 +41,11 @@ describe("expandQueryForFTS", () => {
     const result = expandQueryForFTS("error-handling config.yaml");
     expect(result).toEqual(["error", "handling", "config", "yaml"]);
   });
+
+  test("normalizes contractions instead of splitting on apostrophes", () => {
+    const result = expandQueryForFTS("can't we discuss what's happening?");
+    expect(result).toEqual(["cant", "discuss", "whats", "happening"]);
+  });
 });
 
 describe("buildFTSQuery", () => {

--- a/assistant/src/memory/search/query-expansion.ts
+++ b/assistant/src/memory/search/query-expansion.ts
@@ -84,7 +84,8 @@ export function expandQueryForFTS(query: string): string[] {
     return [];
   }
 
-  const tokens = trimmed.split(/[^\w]+/).filter((token) => token.length > 0);
+  const normalized = trimmed.replace(/(\w)'(\w)/g, "$1$2");
+  const tokens = normalized.split(/[^\w]+/).filter((token) => token.length > 0);
 
   if (tokens.length === 0) {
     return [];


### PR DESCRIPTION
Splitting on [^\w]+ broke contractions like "can't" into ["can", "t"], leaving meaningless single-letter tokens in FTS queries. Normalize apostrophes between word characters first (e.g. "can't" → "cant") before splitting. Adds test coverage for contractions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
