### PR TITLE
fix: preserve onCommit callback when re-arming seen flush timer on rollback

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/ThreadManager.swift
@@ -1359,7 +1359,9 @@ final class ThreadManager: ObservableObject, ThreadRestorerDelegate {
 
         if wasPendingSeen && !pendingSeenSessionIds.contains(sessionId) {
             pendingSeenSessionIds.append(sessionId)
-            schedulePendingSeenSignals()
+            if pendingSeenSignalTask == nil {
+                schedulePendingSeenSignals()
+            }
         }
     }
 


### PR DESCRIPTION
In `rollbackUnreadMutationIfNeeded`, calling `schedulePendingSeenSignals()` unconditionally replaced the existing timer, dropping the `onCommit` callback (toast auto-dismiss). Now only creates a new timer if none exists, so the re-queued sessionId is handled by the existing timer with its original callback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
