### PR TITLE
fix: fall through to URL mode when active assistant is stale in client command

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -66,16 +66,17 @@ function parseArgs(): ParsedArgs {
     const active = getActiveAssistant();
     if (active) {
       entry = findAssistantByName(active);
-      if (!entry) {
+      if (!entry && !hasExplicitUrl) {
         console.error(
           `Active assistant '${active}' not found in lockfile. Set an active assistant with 'vellum use <name>'.`,
         );
         process.exit(1);
       }
-    } else if (hasExplicitUrl) {
-      // URL provided but no active assistant — use latest for remaining defaults
+    }
+    if (!entry && hasExplicitUrl) {
+      // URL provided but active assistant missing or unset — use latest for remaining defaults
       entry = loadLatestAssistant();
-    } else {
+    } else if (!entry) {
       console.error(
         "No active assistant set. Set one with 'vellum use <name>' or specify a name: 'vellum client <name>'.",
       );


### PR DESCRIPTION
When activeAssistant was set but missing from the lockfile, the client command hard-exited even when the user provided an explicit --url. Now falls through to loadLatestAssistant() when hasExplicitUrl is true, matching the pre-#14326 behavior for the URL override path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
