### PR TITLE
fix: migrate channel adapters from legacy to scoped conversation key format

### DIFF
--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -128,7 +128,7 @@ export const telegramBotMessagingProvider: MessagingProvider = {
     // conversation key mapping and binding exist for the next inbound.
     try {
       const sourceChannel = "telegram";
-      const conversationKey = `${sourceChannel}:${conversationId}`;
+      const conversationKey = `asst:self:${sourceChannel}:${conversationId}`;
       const { conversationId: internalId } =
         getOrCreateConversation(conversationKey);
       externalConversationStore.upsertOutboundBinding({

--- a/assistant/src/messaging/providers/whatsapp/adapter.ts
+++ b/assistant/src/messaging/providers/whatsapp/adapter.ts
@@ -107,10 +107,7 @@ export const whatsappMessagingProvider: MessagingProvider = {
     // exists for the next inbound WhatsApp message from this number.
     try {
       const sourceChannel = "whatsapp";
-      const conversationKey =
-        assistantId && assistantId !== "self"
-          ? `asst:${assistantId}:${sourceChannel}:${conversationId}`
-          : `${sourceChannel}:${conversationId}`;
+      const conversationKey = `asst:${assistantId ?? "self"}:${sourceChannel}:${conversationId}`;
       const { conversationId: internalId } =
         getOrCreateConversation(conversationKey);
       if (!assistantId || assistantId === "self") {


### PR DESCRIPTION
PR #14053 removed legacy key deletion but adapters still created legacy keys, allowing stale mappings to survive conversation resets. Migrates Telegram and WhatsApp adapters to use scoped key format (asst:self:channel:id), eliminating the legacy key creation entirely per the backwards-compatibility rule.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
