### PR TITLE
fix: correct isQdrantIssue classification in semantic search failure path

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -839,7 +839,6 @@ export async function buildMemoryRecall(
         : "memory.semantic_search_failure");
     if (!embeddingResult.degradation) {
       const isQdrantIssue =
-        embeddingResult.queryVector != null ||
         isQdrantConnectionError(collected.semanticSearchError) ||
         collected.semanticSearchError instanceof QdrantCircuitOpenError;
       const reason: DegradationReason = isQdrantIssue


### PR DESCRIPTION
The queryVector null-check is always true in the semanticSearchFailed branch, misclassifying all post-embedding failures (including SQLite errors) as qdrant_unavailable. Removes the queryVector-based disjunct since the existing isQdrantConnectionError and QdrantCircuitOpenError checks already cover Qdrant-specific failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
