### PR TITLE
fix: exclude reaction callbacks from plain-text fallback and route through message composer

### DIFF
--- a/assistant/src/runtime/approval-message-composer.ts
+++ b/assistant/src/runtime/approval-message-composer.ts
@@ -35,7 +35,8 @@ export type ApprovalMessageScenario =
   | "guardian_deny_no_identity"
   | "guardian_deny_no_binding"
   | "requester_cancel"
-  | "approval_already_resolved";
+  | "approval_already_resolved"
+  | "guardian_text_unavailable";
 
 export interface ApprovalMessageContext {
   scenario: ApprovalMessageScenario;
@@ -288,6 +289,9 @@ export function getFallbackMessage(context: ApprovalMessageContext): string {
 
     case "approval_already_resolved":
       return "This approval request has already been resolved.";
+
+    case "guardian_text_unavailable":
+      return "I can't process text replies for approvals right now. Please use the approve/deny buttons above to respond.";
 
     default: {
       // Exhaustive check — TypeScript will flag if a scenario is missing.

--- a/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-callback-strategy.ts
@@ -230,15 +230,27 @@ export async function handleGuardianCallbackDecision(
 
   // Guardian sent a plain-text message with pending approvals but the
   // conversational engine is unavailable. Return a handled result with a
-  // static reply so the guardian gets feedback instead of the message being
+  // generative reply so the guardian gets feedback instead of the message being
   // silently swallowed by the standard approval flow.
-  if (effectivePending.length > 0 && content) {
+  //
+  // Exclude callback/reaction payloads (e.g. `reaction:+1`) — these carry
+  // `callbackData` and must fall through so `handleApprovalInterception` can
+  // route them to the deterministic reaction handler.
+  if (effectivePending.length > 0 && content && !callbackData) {
     try {
+      const text = await composeApprovalMessageGenerative(
+        {
+          scenario: "guardian_text_unavailable",
+          channel: sourceChannel,
+        },
+        {},
+        approvalCopyGenerator,
+      );
       await deliverChannelReply(
         replyCallbackUrl,
         {
           chatId: conversationExternalId,
-          text: "I can't process text replies for approvals right now. Please use the approve/deny buttons above to respond.",
+          text,
           assistantId,
         },
         bearerToken,


### PR DESCRIPTION
Two fixes for PR #14331 feedback:

1. **Reaction callback exclusion (P1)**: The plain-text fallback added in #14331 checks `content` but reaction events have non-empty content like `reaction:+1` along with `callbackData`. When `approvalConversationGenerator` is unavailable, reactions hit this fallback and return early, preventing `handleApprovalInterception` from reaching its deterministic reaction handler. Fix: add `&& !callbackData` guard so reaction/callback payloads fall through.

2. **Hardcoded string removal**: The hardcoded user-facing string violates AGENTS.md daemon-driven UX rule. Fix: add `guardian_text_unavailable` scenario to `ApprovalMessageScenario` and route through `composeApprovalMessageGenerative()` using the existing `approvalCopyGenerator`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
