### PR TITLE
fix: initialize entry to null in client.ts

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -49,7 +49,7 @@ function parseArgs(): ParsedArgs {
     }
   }
 
-  let entry: ReturnType<typeof findAssistantByName>;
+  let entry: ReturnType<typeof findAssistantByName> = null;
   if (positionalName) {
     entry = findAssistantByName(positionalName);
     if (!entry) {


### PR DESCRIPTION
## Summary
- Initialize `entry` to `null` (matching its `AssistantEntry | null` return type) so TypeScript's definite assignment analysis doesn't flag its use on lines 76/79 when the `active` branch is not taken

## Original prompt
Fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22830050430

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
