### PR TITLE
M7: Add managed Twitter reads for official-API-compatible endpoints

### DIFF
--- a/assistant/src/cli/commands/twitter/__tests__/cli-read-routing.test.ts
+++ b/assistant/src/cli/commands/twitter/__tests__/cli-read-routing.test.ts
@@ -1,0 +1,483 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// --- Mock state ---
+
+let mockManagedGetUserByUsernameResult: {
+  data: unknown;
+  status: number;
+} | null = null;
+let mockManagedGetUserByUsernameError: Error | null = null;
+
+let mockManagedGetUserTweetsResult: {
+  data: unknown;
+  status: number;
+} | null = null;
+let mockManagedGetUserTweetsError: Error | null = null;
+
+let mockManagedGetTweetResult: { data: unknown; status: number } | null = null;
+let mockManagedGetTweetError: Error | null = null;
+
+let mockManagedSearchRecentTweetsResult: {
+  data: unknown;
+  status: number;
+} | null = null;
+let mockManagedSearchRecentTweetsError: Error | null = null;
+
+let mockBrowserGetUserByScreenNameResult: {
+  userId: string;
+  screenName: string;
+  name: string;
+} | null = null;
+let mockBrowserGetUserByScreenNameError: Error | null = null;
+
+let mockBrowserGetUserTweetsResult: Array<{
+  tweetId: string;
+  text: string;
+  url: string;
+  createdAt: string;
+}> | null = null;
+let mockBrowserGetUserTweetsError: Error | null = null;
+
+let mockBrowserGetTweetDetailResult: Array<{
+  tweetId: string;
+  text: string;
+  url: string;
+  createdAt: string;
+}> | null = null;
+let mockBrowserGetTweetDetailError: Error | null = null;
+
+let mockBrowserSearchTweetsResult: Array<{
+  tweetId: string;
+  text: string;
+  url: string;
+  createdAt: string;
+}> | null = null;
+let mockBrowserSearchTweetsError: Error | null = null;
+
+// --- Mock TwitterProxyError ---
+
+class MockTwitterProxyError extends Error {
+  public readonly code: string;
+  public readonly retryable: boolean;
+  public readonly statusCode: number;
+  constructor(
+    message: string,
+    code: string,
+    retryable: boolean,
+    statusCode = 0,
+  ) {
+    super(message);
+    this.name = "TwitterProxyError";
+    this.code = code;
+    this.retryable = retryable;
+    this.statusCode = statusCode;
+  }
+}
+
+// --- Mocks ---
+
+mock.module("../../../../twitter/platform-proxy-client.js", () => ({
+  postTweet: async () => {
+    throw new Error("Not used in read tests");
+  },
+  getUserByUsername: async () => {
+    if (mockManagedGetUserByUsernameError)
+      throw mockManagedGetUserByUsernameError;
+    if (mockManagedGetUserByUsernameResult)
+      return mockManagedGetUserByUsernameResult;
+    throw new Error("Managed getUserByUsername mock not configured");
+  },
+  getUserTweets: async () => {
+    if (mockManagedGetUserTweetsError) throw mockManagedGetUserTweetsError;
+    if (mockManagedGetUserTweetsResult) return mockManagedGetUserTweetsResult;
+    throw new Error("Managed getUserTweets mock not configured");
+  },
+  getTweet: async () => {
+    if (mockManagedGetTweetError) throw mockManagedGetTweetError;
+    if (mockManagedGetTweetResult) return mockManagedGetTweetResult;
+    throw new Error("Managed getTweet mock not configured");
+  },
+  searchRecentTweets: async () => {
+    if (mockManagedSearchRecentTweetsError)
+      throw mockManagedSearchRecentTweetsError;
+    if (mockManagedSearchRecentTweetsResult)
+      return mockManagedSearchRecentTweetsResult;
+    throw new Error("Managed searchRecentTweets mock not configured");
+  },
+  TwitterProxyError: MockTwitterProxyError,
+}));
+
+class MockSessionExpiredError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "SessionExpiredError";
+  }
+}
+
+mock.module("../client.js", () => ({
+  postTweet: async () => {
+    throw new Error("Not used in read tests");
+  },
+  getUserByScreenName: async () => {
+    if (mockBrowserGetUserByScreenNameError)
+      throw mockBrowserGetUserByScreenNameError;
+    if (mockBrowserGetUserByScreenNameResult)
+      return mockBrowserGetUserByScreenNameResult;
+    throw new Error("Browser getUserByScreenName mock not configured");
+  },
+  getUserTweets: async () => {
+    if (mockBrowserGetUserTweetsError) throw mockBrowserGetUserTweetsError;
+    if (mockBrowserGetUserTweetsResult) return mockBrowserGetUserTweetsResult;
+    throw new Error("Browser getUserTweets mock not configured");
+  },
+  getTweetDetail: async () => {
+    if (mockBrowserGetTweetDetailError) throw mockBrowserGetTweetDetailError;
+    if (mockBrowserGetTweetDetailResult) return mockBrowserGetTweetDetailResult;
+    throw new Error("Browser getTweetDetail mock not configured");
+  },
+  searchTweets: async () => {
+    if (mockBrowserSearchTweetsError) throw mockBrowserSearchTweetsError;
+    if (mockBrowserSearchTweetsResult) return mockBrowserSearchTweetsResult;
+    throw new Error("Browser searchTweets mock not configured");
+  },
+  SessionExpiredError: MockSessionExpiredError,
+}));
+
+mock.module("../oauth-client.js", () => ({
+  oauthIsAvailable: () => false,
+  oauthSupportsOperation: () => false,
+  oauthPostTweet: async () => {
+    throw new Error("Not used in read tests");
+  },
+}));
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+import {
+  routedGetTweetDetail,
+  routedGetUserByScreenName,
+  routedGetUserTweets,
+  routedSearchTweets,
+} from "../router.js";
+
+beforeEach(() => {
+  mockManagedGetUserByUsernameResult = null;
+  mockManagedGetUserByUsernameError = null;
+  mockManagedGetUserTweetsResult = null;
+  mockManagedGetUserTweetsError = null;
+  mockManagedGetTweetResult = null;
+  mockManagedGetTweetError = null;
+  mockManagedSearchRecentTweetsResult = null;
+  mockManagedSearchRecentTweetsError = null;
+  mockBrowserGetUserByScreenNameResult = null;
+  mockBrowserGetUserByScreenNameError = null;
+  mockBrowserGetUserTweetsResult = null;
+  mockBrowserGetUserTweetsError = null;
+  mockBrowserGetTweetDetailResult = null;
+  mockBrowserGetTweetDetailError = null;
+  mockBrowserSearchTweetsResult = null;
+  mockBrowserSearchTweetsError = null;
+});
+
+describe("Twitter read routing", () => {
+  // =========================================================================
+  // User lookup
+  // =========================================================================
+  describe("routedGetUserByScreenName", () => {
+    test("managed strategy routes through proxy", async () => {
+      mockManagedGetUserByUsernameResult = {
+        data: { data: { id: "123", username: "testuser", name: "Test User" } },
+        status: 200,
+      };
+
+      const { result, pathUsed } = await routedGetUserByScreenName("testuser", {
+        strategy: "managed",
+      });
+
+      expect(pathUsed).toBe("managed");
+      expect(result.userId).toBe("123");
+      expect(result.screenName).toBe("testuser");
+      expect(result.name).toBe("Test User");
+    });
+
+    test("browser strategy uses browser path", async () => {
+      mockBrowserGetUserByScreenNameResult = {
+        userId: "456",
+        screenName: "browseruser",
+        name: "Browser User",
+      };
+
+      const { result, pathUsed } = await routedGetUserByScreenName(
+        "browseruser",
+        { strategy: "browser" },
+      );
+
+      expect(pathUsed).toBe("browser");
+      expect(result.userId).toBe("456");
+      expect(result.screenName).toBe("browseruser");
+    });
+
+    test("auto strategy falls through to browser", async () => {
+      mockBrowserGetUserByScreenNameResult = {
+        userId: "789",
+        screenName: "autouser",
+        name: "Auto User",
+      };
+
+      const { result, pathUsed } = await routedGetUserByScreenName("autouser", {
+        strategy: "auto",
+      });
+
+      expect(pathUsed).toBe("browser");
+      expect(result.userId).toBe("789");
+    });
+
+    test("managed strategy surfaces proxy errors with metadata", async () => {
+      mockManagedGetUserByUsernameError = new MockTwitterProxyError(
+        "Rate limit exceeded — retry later",
+        "rate_limit",
+        true,
+        429,
+      );
+
+      try {
+        await routedGetUserByScreenName("testuser", { strategy: "managed" });
+        expect(true).toBe(false);
+      } catch (err) {
+        const e = err as Error & {
+          pathUsed: string;
+          proxyErrorCode: string;
+          retryable: boolean;
+        };
+        expect(e.message).toBe("Rate limit exceeded — retry later");
+        expect(e.pathUsed).toBe("managed");
+        expect(e.proxyErrorCode).toBe("rate_limit");
+        expect(e.retryable).toBe(true);
+      }
+    });
+  });
+
+  // =========================================================================
+  // User tweets
+  // =========================================================================
+  describe("routedGetUserTweets", () => {
+    test("managed strategy routes through proxy", async () => {
+      mockManagedGetUserTweetsResult = {
+        data: {
+          data: [
+            {
+              id: "t1",
+              text: "Hello world",
+              created_at: "2025-01-01T00:00:00Z",
+            },
+            {
+              id: "t2",
+              text: "Second tweet",
+              created_at: "2025-01-02T00:00:00Z",
+            },
+          ],
+        },
+        status: 200,
+      };
+
+      const { result, pathUsed } = await routedGetUserTweets("123", 20, {
+        strategy: "managed",
+      });
+
+      expect(pathUsed).toBe("managed");
+      expect(result).toHaveLength(2);
+      expect(result[0].tweetId).toBe("t1");
+      expect(result[0].text).toBe("Hello world");
+      expect(result[0].url).toBe("https://x.com/i/status/t1");
+      expect(result[1].tweetId).toBe("t2");
+    });
+
+    test("browser strategy uses browser path", async () => {
+      mockBrowserGetUserTweetsResult = [
+        {
+          tweetId: "bt1",
+          text: "Browser tweet",
+          url: "https://x.com/user/status/bt1",
+          createdAt: "2025-01-01",
+        },
+      ];
+
+      const { result, pathUsed } = await routedGetUserTweets("456", 20, {
+        strategy: "browser",
+      });
+
+      expect(pathUsed).toBe("browser");
+      expect(result).toHaveLength(1);
+      expect(result[0].tweetId).toBe("bt1");
+    });
+  });
+
+  // =========================================================================
+  // Tweet detail
+  // =========================================================================
+  describe("routedGetTweetDetail", () => {
+    test("managed strategy routes through proxy", async () => {
+      mockManagedGetTweetResult = {
+        data: {
+          data: {
+            id: "tweet-123",
+            text: "A specific tweet",
+            created_at: "2025-01-01T00:00:00Z",
+          },
+        },
+        status: 200,
+      };
+
+      const { result, pathUsed } = await routedGetTweetDetail("tweet-123", {
+        strategy: "managed",
+      });
+
+      expect(pathUsed).toBe("managed");
+      expect(result).toHaveLength(1);
+      expect(result[0].tweetId).toBe("tweet-123");
+      expect(result[0].text).toBe("A specific tweet");
+    });
+
+    test("browser strategy uses browser path", async () => {
+      mockBrowserGetTweetDetailResult = [
+        {
+          tweetId: "detail-1",
+          text: "Thread tweet 1",
+          url: "https://x.com/user/status/detail-1",
+          createdAt: "2025-01-01",
+        },
+        {
+          tweetId: "detail-2",
+          text: "Reply tweet",
+          url: "https://x.com/user/status/detail-2",
+          createdAt: "2025-01-01",
+        },
+      ];
+
+      const { result, pathUsed } = await routedGetTweetDetail("detail-1", {
+        strategy: "browser",
+      });
+
+      expect(pathUsed).toBe("browser");
+      expect(result).toHaveLength(2);
+    });
+
+    test("managed strategy surfaces proxy errors", async () => {
+      mockManagedGetTweetError = new MockTwitterProxyError(
+        "Forbidden: insufficient permissions",
+        "forbidden",
+        false,
+        403,
+      );
+
+      try {
+        await routedGetTweetDetail("tweet-123", { strategy: "managed" });
+        expect(true).toBe(false);
+      } catch (err) {
+        const e = err as Error & {
+          pathUsed: string;
+          proxyErrorCode: string;
+        };
+        expect(e.pathUsed).toBe("managed");
+        expect(e.proxyErrorCode).toBe("forbidden");
+      }
+    });
+  });
+
+  // =========================================================================
+  // Search
+  // =========================================================================
+  describe("routedSearchTweets", () => {
+    test("managed strategy routes through proxy", async () => {
+      mockManagedSearchRecentTweetsResult = {
+        data: {
+          data: [
+            {
+              id: "s1",
+              text: "Search result 1",
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+        status: 200,
+      };
+
+      const { result, pathUsed } = await routedSearchTweets(
+        "AI agents",
+        "Top",
+        { strategy: "managed" },
+      );
+
+      expect(pathUsed).toBe("managed");
+      expect(result).toHaveLength(1);
+      expect(result[0].tweetId).toBe("s1");
+      expect(result[0].text).toBe("Search result 1");
+    });
+
+    test("browser strategy uses browser path", async () => {
+      mockBrowserSearchTweetsResult = [
+        {
+          tweetId: "bs1",
+          text: "Browser search result",
+          url: "https://x.com/user/status/bs1",
+          createdAt: "2025-01-01",
+        },
+      ];
+
+      const { result, pathUsed } = await routedSearchTweets(
+        "test query",
+        "Latest",
+        { strategy: "browser" },
+      );
+
+      expect(pathUsed).toBe("browser");
+      expect(result).toHaveLength(1);
+      expect(result[0].tweetId).toBe("bs1");
+    });
+
+    test("auto strategy falls through to browser for search", async () => {
+      mockBrowserSearchTweetsResult = [
+        {
+          tweetId: "auto-s1",
+          text: "Auto search result",
+          url: "https://x.com/user/status/auto-s1",
+          createdAt: "2025-01-01",
+        },
+      ];
+
+      const { result, pathUsed } = await routedSearchTweets("test", "Top", {
+        strategy: "auto",
+      });
+
+      expect(pathUsed).toBe("browser");
+      expect(result[0].tweetId).toBe("auto-s1");
+    });
+
+    test("managed strategy re-throws non-proxy errors", async () => {
+      mockManagedSearchRecentTweetsError = new Error("Network failure");
+
+      try {
+        await routedSearchTweets("test", "Top", { strategy: "managed" });
+        expect(true).toBe(false);
+      } catch (err) {
+        expect((err as Error).message).toBe("Network failure");
+        expect((err as Record<string, unknown>).pathUsed).toBeUndefined();
+      }
+    });
+  });
+});

--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -619,6 +619,16 @@ Examples:
       ) => {
         await run(cmd, async () => {
           const strategy = (opts.strategy ?? "browser") as TwitterStrategy;
+          if (
+            strategy !== "oauth" &&
+            strategy !== "browser" &&
+            strategy !== "auto" &&
+            strategy !== "managed"
+          ) {
+            throw new Error(
+              `Invalid strategy "${opts.strategy}". Must be oauth, browser, auto, or managed.`,
+            );
+          }
           const { result: user, pathUsed } = await routedGetUserByScreenName(
             screenName.replace(/^@/, ""),
             { strategy },
@@ -671,6 +681,16 @@ Examples:
           if (!idMatch)
             throw new Error(`Could not extract tweet ID from: ${tweetIdOrUrl}`);
           const strategy = (opts.strategy ?? "browser") as TwitterStrategy;
+          if (
+            strategy !== "oauth" &&
+            strategy !== "browser" &&
+            strategy !== "auto" &&
+            strategy !== "managed"
+          ) {
+            throw new Error(
+              `Invalid strategy "${opts.strategy}". Must be oauth, browser, auto, or managed.`,
+            );
+          }
           const { result: tweets, pathUsed } = await routedGetTweetDetail(
             idMatch[1],
             { strategy },
@@ -721,6 +741,16 @@ Examples:
       ) => {
         await run(cmd, async () => {
           const strategy = (opts.strategy ?? "browser") as TwitterStrategy;
+          if (
+            strategy !== "oauth" &&
+            strategy !== "browser" &&
+            strategy !== "auto" &&
+            strategy !== "managed"
+          ) {
+            throw new Error(
+              `Invalid strategy "${opts.strategy}". Must be oauth, browser, auto, or managed.`,
+            );
+          }
           const product = opts.product as "Top" | "Latest" | "People" | "Media";
           const { result: tweets, pathUsed } = await routedSearchTweets(
             query,

--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -25,15 +25,18 @@ import {
   getHomeTimeline,
   getLikes,
   getNotifications,
-  getTweetDetail,
   getUserByScreenName,
   getUserMedia,
-  getUserTweets,
-  searchTweets,
   SessionExpiredError,
 } from "./client.js";
 import type { TwitterStrategy } from "./router.js";
-import { routedPostTweet } from "./router.js";
+import {
+  routedGetTweetDetail,
+  routedGetUserByScreenName,
+  routedGetUserTweets,
+  routedPostTweet,
+  routedSearchTweets,
+} from "./router.js";
 import { clearSession, importFromRecording, loadSession } from "./session.js";
 
 // ---------------------------------------------------------------------------
@@ -588,30 +591,44 @@ Examples:
     .description("Fetch a user's recent tweets")
     .argument("<screenName>", "Twitter screen name (without @)")
     .option("--count <n>", "Number of tweets to fetch", "20")
+    .option(
+      "--strategy <strategy>",
+      "Operation strategy: managed or browser (default: browser)",
+    )
     .addHelpText(
       "after",
       `
 Arguments:
   screenName   Twitter screen name without the @ prefix (e.g. "elonmusk", not "@elonmusk")
 
-Fetches a user's recent tweets via the browser session. Resolves the screen name
-to a user ID first, then retrieves their tweet timeline. The --count flag controls
-how many tweets to return (default: 20).
+Fetches a user's recent tweets. Resolves the screen name to a user ID first,
+then retrieves their tweet timeline. The --count flag controls how many tweets
+to return (default: 20). Use --strategy managed to route through the platform proxy.
 
 Examples:
   $ assistant x timeline elonmusk
   $ assistant x timeline vaborsh --count 50
-  $ assistant x timeline openai --count 10 --json`,
+  $ assistant x timeline openai --count 10 --json
+  $ assistant x timeline elonmusk --strategy managed`,
     )
     .action(
-      async (screenName: string, opts: { count: string }, cmd: Command) => {
+      async (
+        screenName: string,
+        opts: { count: string; strategy?: string },
+        cmd: Command,
+      ) => {
         await run(cmd, async () => {
-          const user = await getUserByScreenName(screenName.replace(/^@/, ""));
-          const tweets = await getUserTweets(
+          const strategy = (opts.strategy ?? "browser") as TwitterStrategy;
+          const { result: user, pathUsed } = await routedGetUserByScreenName(
+            screenName.replace(/^@/, ""),
+            { strategy },
+          );
+          const { result: tweets } = await routedGetUserTweets(
             user.userId,
             parseInt(opts.count, 10),
+            { strategy },
           );
-          return { user, tweets };
+          return { user, tweets, pathUsed };
         });
       },
     );
@@ -622,6 +639,10 @@ Examples:
   tw.command("tweet")
     .description("Fetch a tweet and its reply thread")
     .argument("<tweetIdOrUrl>", "Tweet ID or URL")
+    .option(
+      "--strategy <strategy>",
+      "Operation strategy: managed or browser (default: browser)",
+    )
     .addHelpText(
       "after",
       `
@@ -629,24 +650,35 @@ Arguments:
   tweetIdOrUrl   A bare tweet ID (e.g. 1234567890) or a full tweet URL
                  (e.g. https://x.com/user/status/1234567890)
 
-Fetches a single tweet and its reply thread via the browser session. The tweet
-ID is extracted from the last numeric segment of the input. Returns an array of
-tweets representing the conversation thread.
+Fetches a single tweet and its reply thread. The tweet ID is extracted from the
+last numeric segment of the input. Returns an array of tweets representing the
+conversation thread. Use --strategy managed to route through the platform proxy.
 
 Examples:
   $ assistant x tweet 1234567890
   $ assistant x tweet https://x.com/elonmusk/status/1234567890
-  $ assistant x tweet https://x.com/openai/status/9876543210 --json`,
+  $ assistant x tweet https://x.com/openai/status/9876543210 --json
+  $ assistant x tweet 1234567890 --strategy managed`,
     )
-    .action(async (tweetIdOrUrl: string, _opts: unknown, cmd: Command) => {
-      await run(cmd, async () => {
-        const idMatch = tweetIdOrUrl.match(/(\d+)\s*$/);
-        if (!idMatch)
-          throw new Error(`Could not extract tweet ID from: ${tweetIdOrUrl}`);
-        const tweets = await getTweetDetail(idMatch[1]);
-        return { tweets };
-      });
-    });
+    .action(
+      async (
+        tweetIdOrUrl: string,
+        opts: { strategy?: string },
+        cmd: Command,
+      ) => {
+        await run(cmd, async () => {
+          const idMatch = tweetIdOrUrl.match(/(\d+)\s*$/);
+          if (!idMatch)
+            throw new Error(`Could not extract tweet ID from: ${tweetIdOrUrl}`);
+          const strategy = (opts.strategy ?? "browser") as TwitterStrategy;
+          const { result: tweets, pathUsed } = await routedGetTweetDetail(
+            idMatch[1],
+            { strategy },
+          );
+          return { tweets, pathUsed };
+        });
+      },
+    );
 
   // =========================================================================
   // search — search tweets
@@ -655,6 +687,10 @@ Examples:
     .description("Search tweets")
     .argument("<query>", "Search query")
     .option("--product <type>", "Top, Latest, People, or Media", "Top")
+    .option(
+      "--strategy <strategy>",
+      "Operation strategy: managed or browser (default: browser)",
+    )
     .addHelpText(
       "after",
       `
@@ -668,22 +704,33 @@ The --product flag selects the search result type:
   People   — user accounts matching the query
   Media    — tweets containing images or video
 
-Uses the browser session path. Requires an active browser session.
+Use --strategy managed to route through the platform proxy (uses Twitter's
+recent search API).
 
 Examples:
   $ assistant x search "AI agents"
   $ assistant x search "from:elonmusk SpaceX" --product Latest
-  $ assistant x search "machine learning" --product Media --json`,
+  $ assistant x search "machine learning" --product Media --json
+  $ assistant x search "AI agents" --strategy managed`,
     )
-    .action(async (query: string, opts: { product: string }, cmd: Command) => {
-      await run(cmd, async () => {
-        const tweets = await searchTweets(
-          query,
-          opts.product as "Top" | "Latest" | "People" | "Media",
-        );
-        return { query, tweets };
-      });
-    });
+    .action(
+      async (
+        query: string,
+        opts: { product: string; strategy?: string },
+        cmd: Command,
+      ) => {
+        await run(cmd, async () => {
+          const strategy = (opts.strategy ?? "browser") as TwitterStrategy;
+          const product = opts.product as "Top" | "Latest" | "People" | "Media";
+          const { result: tweets, pathUsed } = await routedSearchTweets(
+            query,
+            product,
+            { strategy },
+          );
+          return { query, tweets, pathUsed };
+        });
+      },
+    );
 
   // =========================================================================
   // bookmarks — fetch bookmarks

--- a/assistant/src/cli/commands/twitter/router.ts
+++ b/assistant/src/cli/commands/twitter/router.ts
@@ -4,12 +4,20 @@
  */
 
 import {
+  getTweet as managedGetTweet,
+  getUserByUsername as managedGetUserByUsername,
+  getUserTweets as managedGetUserTweets,
   postTweet as managedPostTweet,
+  searchRecentTweets as managedSearchRecentTweets,
   TwitterProxyError,
 } from "../../../twitter/platform-proxy-client.js";
-import type { PostTweetResult } from "./client.js";
+import type { PostTweetResult, TweetEntry, UserInfo } from "./client.js";
 import {
+  getTweetDetail as browserGetTweetDetail,
+  getUserByScreenName as browserGetUserByScreenName,
+  getUserTweets as browserGetUserTweets,
   postTweet as browserPostTweet,
+  searchTweets as browserSearchTweets,
   SessionExpiredError,
 } from "./client.js";
 import {
@@ -172,4 +180,174 @@ export async function routedPostTweet(
     }
     throw err;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Routed read operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up a user by screen name.
+ * Managed mode uses GET /2/users/by/username/:username; browser mode uses GraphQL.
+ */
+export async function routedGetUserByScreenName(
+  screenName: string,
+  opts: { strategy: TwitterStrategy },
+): Promise<RoutedResult<UserInfo>> {
+  if (opts.strategy === "managed") {
+    try {
+      const response = await managedGetUserByUsername(screenName, {
+        "user.fields": "id,name,username",
+      });
+      const data = response.data as Record<string, unknown>;
+      const userData = (data?.data ?? data) as Record<string, unknown>;
+      return {
+        result: {
+          userId: String(userData.id ?? ""),
+          screenName: String(
+            userData.username ?? userData.screen_name ?? screenName,
+          ),
+          name: String(userData.name ?? screenName),
+        },
+        pathUsed: "managed",
+      };
+    } catch (err) {
+      if (err instanceof TwitterProxyError) {
+        throw Object.assign(new Error(err.message), {
+          pathUsed: "managed" as const,
+          proxyErrorCode: err.code,
+          retryable: err.retryable,
+        });
+      }
+      throw err;
+    }
+  }
+
+  // Browser path (used for browser, oauth, auto — read operations always go through browser)
+  const result = await browserGetUserByScreenName(screenName);
+  return { result, pathUsed: "browser" };
+}
+
+/**
+ * Fetch a user's recent tweets.
+ * Managed mode uses GET /2/users/:id/tweets; browser mode uses GraphQL.
+ */
+export async function routedGetUserTweets(
+  userId: string,
+  count: number,
+  opts: { strategy: TwitterStrategy },
+): Promise<RoutedResult<TweetEntry[]>> {
+  if (opts.strategy === "managed") {
+    try {
+      const response = await managedGetUserTweets(userId, {
+        max_results: String(Math.min(count, 100)),
+        "tweet.fields": "id,text,created_at,author_id",
+      });
+      const data = response.data as Record<string, unknown>;
+      const tweetsArray = (data?.data ?? []) as Array<Record<string, unknown>>;
+      const tweets: TweetEntry[] = tweetsArray.map((t) => ({
+        tweetId: String(t.id ?? ""),
+        text: String(t.text ?? ""),
+        url: `https://x.com/i/status/${t.id}`,
+        createdAt: String(t.created_at ?? ""),
+      }));
+      return { result: tweets, pathUsed: "managed" };
+    } catch (err) {
+      if (err instanceof TwitterProxyError) {
+        throw Object.assign(new Error(err.message), {
+          pathUsed: "managed" as const,
+          proxyErrorCode: err.code,
+          retryable: err.retryable,
+        });
+      }
+      throw err;
+    }
+  }
+
+  const result = await browserGetUserTweets(userId, count);
+  return { result, pathUsed: "browser" };
+}
+
+/**
+ * Fetch a single tweet by ID.
+ * Managed mode uses GET /2/tweets/:id; browser mode uses GraphQL TweetDetail.
+ */
+export async function routedGetTweetDetail(
+  tweetId: string,
+  opts: { strategy: TwitterStrategy },
+): Promise<RoutedResult<TweetEntry[]>> {
+  if (opts.strategy === "managed") {
+    try {
+      const response = await managedGetTweet(tweetId, {
+        "tweet.fields": "id,text,created_at,author_id",
+      });
+      const data = response.data as Record<string, unknown>;
+      const tweetData = (data?.data ?? data) as Record<string, unknown>;
+      const tweets: TweetEntry[] = [
+        {
+          tweetId: String(tweetData.id ?? ""),
+          text: String(tweetData.text ?? ""),
+          url: `https://x.com/i/status/${tweetData.id}`,
+          createdAt: String(tweetData.created_at ?? ""),
+        },
+      ];
+      return { result: tweets, pathUsed: "managed" };
+    } catch (err) {
+      if (err instanceof TwitterProxyError) {
+        throw Object.assign(new Error(err.message), {
+          pathUsed: "managed" as const,
+          proxyErrorCode: err.code,
+          retryable: err.retryable,
+        });
+      }
+      throw err;
+    }
+  }
+
+  const result = await browserGetTweetDetail(tweetId);
+  return { result, pathUsed: "browser" };
+}
+
+/**
+ * Search tweets.
+ * Managed mode uses GET /2/tweets/search/recent; browser mode uses GraphQL SearchTimeline.
+ */
+export async function routedSearchTweets(
+  query: string,
+  product: "Top" | "Latest" | "People" | "Media",
+  opts: { strategy: TwitterStrategy },
+): Promise<RoutedResult<TweetEntry[]>> {
+  if (opts.strategy === "managed") {
+    try {
+      const queryParams: Record<string, string> = {
+        "tweet.fields": "id,text,created_at,author_id",
+        max_results: "10",
+      };
+      if (product === "Latest") {
+        queryParams.sort_order = "recency";
+      }
+      const response = await managedSearchRecentTweets(query, queryParams);
+      const data = response.data as Record<string, unknown>;
+      const tweetsArray = (data?.data ?? []) as Array<Record<string, unknown>>;
+      const tweets: TweetEntry[] = tweetsArray.map((t) => ({
+        tweetId: String(t.id ?? ""),
+        text: String(t.text ?? ""),
+        url: `https://x.com/i/status/${t.id}`,
+        createdAt: String(t.created_at ?? ""),
+      }));
+      return { result: tweets, pathUsed: "managed" };
+    } catch (err) {
+      if (err instanceof TwitterProxyError) {
+        throw Object.assign(new Error(err.message), {
+          pathUsed: "managed" as const,
+          proxyErrorCode: err.code,
+          retryable: err.retryable,
+        });
+      }
+      throw err;
+    }
+  }
+
+  const result = await browserSearchTweets(query, product);
+  return { result, pathUsed: "browser" };
 }

--- a/assistant/src/cli/commands/twitter/router.ts
+++ b/assistant/src/cli/commands/twitter/router.ts
@@ -201,9 +201,14 @@ export async function routedGetUserByScreenName(
       });
       const data = response.data as Record<string, unknown>;
       const userData = (data?.data ?? data) as Record<string, unknown>;
+      if (!userData.id) {
+        throw Object.assign(new Error(`User not found: @${screenName}`), {
+          pathUsed: "managed" as const,
+        });
+      }
       return {
         result: {
-          userId: String(userData.id ?? ""),
+          userId: String(userData.id),
           screenName: String(
             userData.username ?? userData.screen_name ?? screenName,
           ),
@@ -279,19 +284,50 @@ export async function routedGetTweetDetail(
   if (opts.strategy === "managed") {
     try {
       const response = await managedGetTweet(tweetId, {
-        "tweet.fields": "id,text,created_at,author_id",
+        "tweet.fields": "id,text,created_at,author_id,conversation_id",
       });
       const data = response.data as Record<string, unknown>;
       const tweetData = (data?.data ?? data) as Record<string, unknown>;
-      const tweets: TweetEntry[] = [
-        {
-          tweetId: String(tweetData.id ?? ""),
-          text: String(tweetData.text ?? ""),
-          url: `https://x.com/i/status/${tweetData.id}`,
-          createdAt: String(tweetData.created_at ?? ""),
-        },
-      ];
-      return { result: tweets, pathUsed: "managed" };
+      const primaryTweet: TweetEntry = {
+        tweetId: String(tweetData.id ?? ""),
+        text: String(tweetData.text ?? ""),
+        url: `https://x.com/i/status/${tweetData.id}`,
+        createdAt: String(tweetData.created_at ?? ""),
+      };
+
+      // If the tweet has a conversation_id, fetch the thread via search
+      const conversationId = tweetData.conversation_id as string | undefined;
+      if (conversationId) {
+        try {
+          const threadResponse = await managedSearchRecentTweets(
+            `conversation_id:${conversationId}`,
+            {
+              "tweet.fields": "id,text,created_at,author_id",
+              max_results: "100",
+            },
+          );
+          const threadData = threadResponse.data as Record<string, unknown>;
+          const threadArray = (threadData?.data ?? []) as Array<
+            Record<string, unknown>
+          >;
+          const threadTweets: TweetEntry[] = threadArray.map((t) => ({
+            tweetId: String(t.id ?? ""),
+            text: String(t.text ?? ""),
+            url: `https://x.com/i/status/${t.id}`,
+            createdAt: String(t.created_at ?? ""),
+          }));
+          // Deduplicate: the primary tweet may already be in the search results
+          const seen = new Set(threadTweets.map((t) => t.tweetId));
+          if (!seen.has(primaryTweet.tweetId)) {
+            threadTweets.unshift(primaryTweet);
+          }
+          return { result: threadTweets, pathUsed: "managed" };
+        } catch {
+          // If thread search fails, fall back to returning just the single tweet
+        }
+      }
+
+      return { result: [primaryTweet], pathUsed: "managed" };
     } catch (err) {
       if (err instanceof TwitterProxyError) {
         throw Object.assign(new Error(err.message), {
@@ -318,10 +354,17 @@ export async function routedSearchTweets(
   opts: { strategy: TwitterStrategy },
 ): Promise<RoutedResult<TweetEntry[]>> {
   if (opts.strategy === "managed") {
+    if (product === "People" || product === "Media") {
+      throw Object.assign(
+        new Error(
+          `Product type "${product}" is not supported in managed mode. Only "Top" and "Latest" are supported.`,
+        ),
+        { pathUsed: "managed" as const },
+      );
+    }
     try {
       const queryParams: Record<string, string> = {
         "tweet.fields": "id,text,created_at,author_id",
-        max_results: "10",
       };
       if (product === "Latest") {
         queryParams.sort_order = "recency";

--- a/assistant/src/twitter/platform-proxy-client.ts
+++ b/assistant/src/twitter/platform-proxy-client.ts
@@ -322,3 +322,59 @@ export async function getMe(
     query,
   });
 }
+
+/**
+ * Look up a user by screen name through the platform proxy.
+ */
+export async function getUserByUsername(
+  username: string,
+  query?: Record<string, string>,
+): Promise<TwitterProxyResponse> {
+  return proxyTwitterCall({
+    method: "GET",
+    path: `/2/users/by/username/${encodeURIComponent(username)}`,
+    query,
+  });
+}
+
+/**
+ * Fetch a user's tweets through the platform proxy.
+ */
+export async function getUserTweets(
+  userId: string,
+  query?: Record<string, string>,
+): Promise<TwitterProxyResponse> {
+  return proxyTwitterCall({
+    method: "GET",
+    path: `/2/users/${encodeURIComponent(userId)}/tweets`,
+    query,
+  });
+}
+
+/**
+ * Fetch a single tweet by ID through the platform proxy.
+ */
+export async function getTweet(
+  tweetId: string,
+  query?: Record<string, string>,
+): Promise<TwitterProxyResponse> {
+  return proxyTwitterCall({
+    method: "GET",
+    path: `/2/tweets/${encodeURIComponent(tweetId)}`,
+    query,
+  });
+}
+
+/**
+ * Search recent tweets through the platform proxy.
+ */
+export async function searchRecentTweets(
+  queryStr: string,
+  query?: Record<string, string>,
+): Promise<TwitterProxyResponse> {
+  return proxyTwitterCall({
+    method: "GET",
+    path: "/2/tweets/search/recent",
+    query: { query: queryStr, ...query },
+  });
+}

--- a/assistant/src/twitter/platform-proxy-client.ts
+++ b/assistant/src/twitter/platform-proxy-client.ts
@@ -375,6 +375,6 @@ export async function searchRecentTweets(
   return proxyTwitterCall({
     method: "GET",
     path: "/2/tweets/search/recent",
-    query: { query: queryStr, ...query },
+    query: { ...query, query: queryStr },
   });
 }


### PR DESCRIPTION
## Summary
- Add managed proxy convenience helpers for Twitter read operations: user lookup by username, user tweets, single tweet lookup, and recent search
- Add routed read functions in the strategy router that select managed proxy vs browser path based on strategy
- Update CLI commands (timeline, tweet, search) to accept `--strategy managed` option
- Add comprehensive tests verifying routing split between managed and non-managed modes

## Test plan
- [x] All 13 new read routing tests pass
- [x] All 17 existing routing tests still pass
- [x] Lint and formatting checks pass

Part of #14191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
