### PR TITLE
Owner-Bound Managed Twitter OAuth for Desktop

### DIFF
--- a/assistant/src/__tests__/managed-twitter-guardrails.test.ts
+++ b/assistant/src/__tests__/managed-twitter-guardrails.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Regression tests for managed Twitter OAuth guardrails.
+ *
+ * Verifies three critical invariants:
+ * 1. Managed mode never falls back to local BYO connect flow
+ * 2. Non-owner users are blocked from managed Twitter UI and control-plane calls
+ * 3. Runtime never supplies a user selector for managed Twitter (uses assistant API key)
+ */
+
+import { mkdtempSync } from "node:fs";
+import * as net from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const testDir = mkdtempSync(join(tmpdir(), "managed-twitter-guardrails-"));
+
+// ---------------------------------------------------------------------------
+// Shared mock state
+// ---------------------------------------------------------------------------
+
+let rawConfigStore: Record<string, unknown> = {};
+let secureKeyStore: Record<string, string> = {};
+let orchestratorCalled = false;
+
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  const keys = path.split(".");
+  let current: unknown = obj;
+  for (const key of keys) {
+    if (current == null || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+function setNestedValue(
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): void {
+  const keys = path.split(".");
+  let current = obj;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i]!;
+    if (current[key] == null || typeof current[key] !== "object") {
+      current[key] = {};
+    }
+    current = current[key] as Record<string, unknown>;
+  }
+  current[keys[keys.length - 1]!] = value;
+}
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be before importing the module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ ui: {}, platform: { baseUrl: "" } }),
+  loadConfig: () => ({
+    ingress: { publicBaseUrl: "https://test.example.com" },
+  }),
+  loadRawConfig: () => structuredClone(rawConfigStore),
+  saveRawConfig: (cfg: Record<string, unknown>) => {
+    rawConfigStore = structuredClone(cfg);
+  },
+  saveConfig: () => {},
+  invalidateConfigCache: () => {},
+  getNestedValue,
+  setNestedValue,
+}));
+
+mock.module("../inbound/public-ingress-urls.js", () => ({
+  getPublicBaseUrl: () => "https://test.example.com",
+  getOAuthCallbackUrl: () => "https://test.example.com/webhooks/oauth/callback",
+}));
+
+mock.module("../util/platform.js", () => ({
+  getRootDir: () => testDir,
+  getDataDir: () => testDir,
+  getIpcBlobDir: () => join(testDir, "ipc-blobs"),
+  isMacOS: () => process.platform === "darwin",
+  isLinux: () => process.platform === "linux",
+  isWindows: () => process.platform === "win32",
+  getSocketPath: () => join(testDir, "test.sock"),
+  getPidPath: () => join(testDir, "test.pid"),
+  getDbPath: () => join(testDir, "test.db"),
+  getLogPath: () => join(testDir, "test.log"),
+  ensureDataDir: () => {},
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKey: (account: string) => secureKeyStore[account] ?? undefined,
+  setSecureKey: (account: string, value: string) => {
+    secureKeyStore[account] = value;
+    return true;
+  },
+  deleteSecureKey: () => "not-found",
+  listSecureKeys: () => Object.keys(secureKeyStore),
+  getBackendType: () => "encrypted",
+  isDowngradedFromKeychain: () => false,
+  _resetBackend: () => {},
+  _setBackend: () => {},
+}));
+
+mock.module("../oauth/connect-orchestrator.js", () => ({
+  orchestrateOAuthConnect: async () => {
+    orchestratorCalled = true;
+    return {
+      success: true,
+      deferred: false,
+      grantedScopes: [],
+      accountInfo: "@test",
+    };
+  },
+}));
+
+mock.module("../tools/credentials/metadata-store.js", () => ({
+  getCredentialMetadata: () => undefined,
+  upsertCredentialMetadata: () => ({}),
+  deleteCredentialMetadata: () => false,
+  listCredentialMetadata: () => [],
+  assertMetadataWritable: () => {},
+  _setMetadataPath: () => {},
+}));
+
+mock.module("../config/env.js", () => ({
+  getPlatformBaseUrl: () => "https://platform.vellum.ai",
+  getPlatformAssistantId: () => "ast_test123",
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { handleMessage } from "../daemon/handlers/index.js";
+import type { HandlerContext } from "../daemon/handlers/shared.js";
+import type {
+  ServerMessage,
+  TwitterAuthStartRequest,
+} from "../daemon/ipc-protocol.js";
+import {
+  mapProxyError,
+  resolvePrerequisites,
+  TwitterProxyError,
+} from "../twitter/platform-proxy-client.js";
+import { DebouncerMap } from "../util/debounce.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
+  const sent: ServerMessage[] = [];
+  const ctx: HandlerContext = {
+    sessions: new Map(),
+    socketToSession: new Map(),
+    cuSessions: new Map(),
+    socketToCuSession: new Map(),
+    cuObservationParseSequence: new Map(),
+    socketSandboxOverride: new Map(),
+    sharedRequestTimestamps: [],
+    debounceTimers: new DebouncerMap({ defaultDelayMs: 200 }),
+    suppressConfigReload: false,
+    setSuppressConfigReload: () => {},
+    updateConfigFingerprint: () => {},
+    send: (_socket, msg) => {
+      sent.push(msg);
+    },
+    broadcast: () => {},
+    clearAllSessions: () => 0,
+    getOrCreateSession: () => {
+      throw new Error("not implemented");
+    },
+    touchSession: () => {},
+  };
+  return { ctx, sent };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Managed Twitter guardrails", () => {
+  beforeEach(() => {
+    rawConfigStore = {};
+    secureKeyStore = {};
+    orchestratorCalled = false;
+  });
+
+  // =========================================================================
+  // Guardrail 1: Managed mode never falls back to local BYO connect flow
+  // =========================================================================
+
+  describe("managed mode never falls back to local BYO connect flow", () => {
+    test("returns managed-specific error code, not OAuth flow, when API key is missing", async () => {
+      rawConfigStore = { twitter: { integrationMode: "managed" } };
+      // No API key configured — should NOT start OAuth
+
+      const msg: TwitterAuthStartRequest = { type: "twitter_auth_start" };
+      const { ctx, sent } = createTestContext();
+      await handleMessage(msg, {} as net.Socket, ctx);
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(orchestratorCalled).toBe(false);
+      const result = sent.find((m) => m.type === "twitter_auth_result") as {
+        type: string;
+        success: boolean;
+        error?: string;
+        errorCode?: string;
+      };
+      expect(result).toBeDefined();
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe("managed_missing_api_key");
+    });
+
+    test("returns managed-specific error code when prerequisites are met but auth is platform-handled", async () => {
+      rawConfigStore = { twitter: { integrationMode: "managed" } };
+      secureKeyStore["credential:vellum:assistant_api_key"] = "test-key";
+
+      const msg: TwitterAuthStartRequest = { type: "twitter_auth_start" };
+      const { ctx, sent } = createTestContext();
+      await handleMessage(msg, {} as net.Socket, ctx);
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(orchestratorCalled).toBe(false);
+      const result = sent.find((m) => m.type === "twitter_auth_result") as {
+        type: string;
+        success: boolean;
+        error?: string;
+        errorCode?: string;
+      };
+      expect(result).toBeDefined();
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe("managed_auth_via_platform");
+      expect(result.error).toContain("platform");
+    });
+
+    test("never calls orchestrateOAuthConnect in managed mode regardless of config", async () => {
+      rawConfigStore = { twitter: { integrationMode: "managed" } };
+      // Even with local BYO credentials present, managed mode must not start OAuth
+      secureKeyStore["credential:vellum:assistant_api_key"] = "test-key";
+      secureKeyStore["credential:integration:twitter:client_id"] =
+        "test-client-id";
+      secureKeyStore["credential:integration:twitter:client_secret"] =
+        "test-secret";
+
+      const msg: TwitterAuthStartRequest = { type: "twitter_auth_start" };
+      const { ctx } = createTestContext();
+      await handleMessage(msg, {} as net.Socket, ctx);
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(orchestratorCalled).toBe(false);
+    });
+
+    test("never sends open_url message in managed mode", async () => {
+      rawConfigStore = { twitter: { integrationMode: "managed" } };
+      secureKeyStore["credential:vellum:assistant_api_key"] = "test-key";
+
+      const msg: TwitterAuthStartRequest = { type: "twitter_auth_start" };
+      const { ctx, sent } = createTestContext();
+      await handleMessage(msg, {} as net.Socket, ctx);
+      await new Promise((r) => setTimeout(r, 20));
+
+      const openUrlMsg = sent.find((m) => m.type === "open_url");
+      expect(openUrlMsg).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // Guardrail 2: Non-owner users are blocked from managed Twitter operations
+  // =========================================================================
+
+  describe("non-owner users are blocked from managed Twitter UI and control-plane calls", () => {
+    test("proxy client surfaces owner_only error for non-owner 403", () => {
+      // Exercise the production mapProxyError path with a 403 containing
+      // "owner" in the detail — must yield an actionable owner_only error.
+      const error = mapProxyError(403, {
+        detail: "Only the owner can perform this action",
+      });
+
+      expect(error).toBeInstanceOf(TwitterProxyError);
+      expect(error.code).toBe("owner_only");
+      expect(error.message).toBe("Sign in as the assistant owner");
+      expect(error.retryable).toBe(false);
+      expect(error.statusCode).toBe(403);
+    });
+
+    test("proxy client surfaces owner_credential_required for missing credential 403", () => {
+      // Exercise the production mapProxyError path with a 403 containing
+      // both "owner" and "credential" — must yield owner_credential_required.
+      const error = mapProxyError(403, {
+        detail: "Owner credential required to access this resource",
+      });
+
+      expect(error).toBeInstanceOf(TwitterProxyError);
+      expect(error.code).toBe("owner_credential_required");
+      expect(error.message).toBe(
+        "Connect Twitter in Settings as the assistant owner",
+      );
+      expect(error.retryable).toBe(false);
+      expect(error.statusCode).toBe(403);
+    });
+  });
+
+  // =========================================================================
+  // Guardrail 3: Runtime never supplies a user selector for managed Twitter
+  // =========================================================================
+
+  describe("runtime uses assistant API key, not user tokens, for managed Twitter", () => {
+    test("resolvePrerequisites returns assistant_api_key as the auth token", () => {
+      secureKeyStore["credential:vellum:assistant_api_key"] = "ast-key-xyz";
+
+      const prereqs = resolvePrerequisites();
+
+      // The auth token must be the assistant API key, not a user-specific
+      // session token or OAuth token
+      expect(prereqs.authToken).toBe("ast-key-xyz");
+    });
+
+    test("resolvePrerequisites never uses user session tokens for auth", () => {
+      // Even if user-specific tokens exist in the store, the proxy must
+      // use the assistant API key
+      secureKeyStore["credential:vellum:assistant_api_key"] = "ast-key-xyz";
+      secureKeyStore["credential:vellum:session_token"] = "user-session-token";
+      secureKeyStore["credential:integration:twitter:access_token"] =
+        "user-oauth-token";
+
+      const prereqs = resolvePrerequisites();
+
+      expect(prereqs.authToken).toBe("ast-key-xyz");
+      expect(prereqs.authToken).not.toBe("user-session-token");
+      expect(prereqs.authToken).not.toBe("user-oauth-token");
+    });
+
+    test("resolvePrerequisites errors when assistant API key is absent", () => {
+      // No assistant API key — should error, not fall back to user tokens
+      secureKeyStore["credential:vellum:session_token"] = "user-session-token";
+
+      expect(() => resolvePrerequisites()).toThrow(TwitterProxyError);
+      try {
+        resolvePrerequisites();
+      } catch (err) {
+        const tpe = err as TwitterProxyError;
+        expect(tpe.code).toBe("missing_assistant_api_key");
+      }
+    });
+  });
+});

--- a/assistant/src/__tests__/managed-twitter-guardrails.test.ts
+++ b/assistant/src/__tests__/managed-twitter-guardrails.test.ts
@@ -8,7 +8,6 @@
  */
 
 import { mkdtempSync } from "node:fs";
-import * as net from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -77,6 +76,7 @@ mock.module("../inbound/public-ingress-urls.js", () => ({
 mock.module("../util/platform.js", () => ({
   getRootDir: () => testDir,
   getDataDir: () => testDir,
+  getWorkspaceDir: () => testDir,
   getIpcBlobDir: () => join(testDir, "ipc-blobs"),
   isMacOS: () => process.platform === "darwin",
   isLinux: () => process.platform === "linux",
@@ -149,48 +149,56 @@ mock.module("../config/env.js", () => ({
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
-import { handleMessage } from "../daemon/handlers/index.js";
-import type { HandlerContext } from "../daemon/handlers/shared.js";
-import type {
-  ServerMessage,
-  TwitterAuthStartRequest,
-} from "../daemon/ipc-protocol.js";
+import type { RouteContext } from "../runtime/http-router.js";
+import { settingsRouteDefinitions } from "../runtime/routes/settings-routes.js";
 import {
   mapProxyError,
   resolvePrerequisites,
   TwitterProxyError,
 } from "../twitter/platform-proxy-client.js";
-import { DebouncerMap } from "../util/debounce.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
 
-function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
-  const sent: ServerMessage[] = [];
-  const ctx: HandlerContext = {
-    sessions: new Map(),
-    socketToSession: new Map(),
-    cuSessions: new Map(),
-    socketToCuSession: new Map(),
-    cuObservationParseSequence: new Map(),
-    socketSandboxOverride: new Map(),
-    sharedRequestTimestamps: [],
-    debounceTimers: new DebouncerMap({ defaultDelayMs: 200 }),
-    suppressConfigReload: false,
-    setSuppressConfigReload: () => {},
-    updateConfigFingerprint: () => {},
-    send: (_socket, msg) => {
-      sent.push(msg);
-    },
-    broadcast: () => {},
-    clearAllSessions: () => 0,
-    getOrCreateSession: () => {
-      throw new Error("not implemented");
-    },
-    touchSession: () => {},
-  };
-  return { ctx, sent };
+/**
+ * Find a route definition by endpoint from the settings route table.
+ */
+function findRoute(endpoint: string) {
+  const routes = settingsRouteDefinitions();
+  const route = routes.find((r) => r.endpoint === endpoint);
+  if (!route) {
+    throw new Error(`Route not found: ${endpoint}`);
+  }
+  return route;
+}
+
+/**
+ * Call a route handler with a minimal RouteContext.
+ */
+function callRoute(
+  endpoint: string,
+  options?: { method?: string; body?: unknown },
+): Promise<Response> | Response {
+  const route = findRoute(endpoint);
+  const url = new URL(`http://localhost/v1/${endpoint}`);
+  const req = new Request(url.toString(), {
+    method: options?.method ?? route.method,
+    ...(options?.body
+      ? {
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(options.body),
+        }
+      : {}),
+  });
+  const ctx = {
+    req,
+    url,
+    server: {} as RouteContext["server"],
+    authContext: {} as RouteContext["authContext"],
+    params: {},
+  } satisfies RouteContext;
+  return route.handler(ctx);
 }
 
 // ---------------------------------------------------------------------------
@@ -213,20 +221,18 @@ describe("Managed Twitter guardrails", () => {
       rawConfigStore = { twitter: { integrationMode: "managed" } };
       // No API key configured — should NOT start OAuth
 
-      const msg: TwitterAuthStartRequest = { type: "twitter_auth_start" };
-      const { ctx, sent } = createTestContext();
-      await handleMessage(msg, {} as net.Socket, ctx);
-      await new Promise((r) => setTimeout(r, 20));
+      const response = await callRoute("integrations/twitter/auth/start", {
+        method: "POST",
+      });
 
       expect(orchestratorCalled).toBe(false);
-      const result = sent.find((m) => m.type === "twitter_auth_result") as {
-        type: string;
-        success: boolean;
+      expect(response.status).toBe(400);
+      const result = (await response.json()) as {
+        ok: boolean;
         error?: string;
         errorCode?: string;
       };
-      expect(result).toBeDefined();
-      expect(result.success).toBe(false);
+      expect(result.ok).toBe(false);
       expect(result.errorCode).toBe("managed_missing_api_key");
     });
 
@@ -234,20 +240,18 @@ describe("Managed Twitter guardrails", () => {
       rawConfigStore = { twitter: { integrationMode: "managed" } };
       secureKeyStore["credential:vellum:assistant_api_key"] = "test-key";
 
-      const msg: TwitterAuthStartRequest = { type: "twitter_auth_start" };
-      const { ctx, sent } = createTestContext();
-      await handleMessage(msg, {} as net.Socket, ctx);
-      await new Promise((r) => setTimeout(r, 20));
+      const response = await callRoute("integrations/twitter/auth/start", {
+        method: "POST",
+      });
 
       expect(orchestratorCalled).toBe(false);
-      const result = sent.find((m) => m.type === "twitter_auth_result") as {
-        type: string;
-        success: boolean;
+      expect(response.status).toBe(400);
+      const result = (await response.json()) as {
+        ok: boolean;
         error?: string;
         errorCode?: string;
       };
-      expect(result).toBeDefined();
-      expect(result.success).toBe(false);
+      expect(result.ok).toBe(false);
       expect(result.errorCode).toBe("managed_auth_via_platform");
       expect(result.error).toContain("platform");
     });
@@ -261,25 +265,9 @@ describe("Managed Twitter guardrails", () => {
       secureKeyStore["credential:integration:twitter:client_secret"] =
         "test-secret";
 
-      const msg: TwitterAuthStartRequest = { type: "twitter_auth_start" };
-      const { ctx } = createTestContext();
-      await handleMessage(msg, {} as net.Socket, ctx);
-      await new Promise((r) => setTimeout(r, 20));
+      await callRoute("integrations/twitter/auth/start", { method: "POST" });
 
       expect(orchestratorCalled).toBe(false);
-    });
-
-    test("never sends open_url message in managed mode", async () => {
-      rawConfigStore = { twitter: { integrationMode: "managed" } };
-      secureKeyStore["credential:vellum:assistant_api_key"] = "test-key";
-
-      const msg: TwitterAuthStartRequest = { type: "twitter_auth_start" };
-      const { ctx, sent } = createTestContext();
-      await handleMessage(msg, {} as net.Socket, ctx);
-      await new Promise((r) => setTimeout(r, 20));
-
-      const openUrlMsg = sent.find((m) => m.type === "open_url");
-      expect(openUrlMsg).toBeUndefined();
     });
   });
 

--- a/assistant/src/__tests__/twitter-platform-proxy-client.test.ts
+++ b/assistant/src/__tests__/twitter-platform-proxy-client.test.ts
@@ -1,0 +1,450 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock dependencies — must be before importing the module under test
+// ---------------------------------------------------------------------------
+
+let mockApiKey: string | undefined = "test-api-key-123";
+let mockPlatformEnvUrl = "https://platform.vellum.ai";
+let mockPlatformAssistantId = "ast_abc123";
+let mockConfigBaseUrl = "";
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKey: (account: string) => {
+    if (account === "credential:vellum:assistant_api_key") return mockApiKey;
+    return undefined;
+  },
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    platform: { baseUrl: mockConfigBaseUrl },
+  }),
+}));
+
+mock.module("../config/env.js", () => ({
+  getPlatformBaseUrl: () => mockPlatformEnvUrl,
+  getPlatformAssistantId: () => mockPlatformAssistantId,
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  }),
+}));
+
+// Mock global fetch
+let lastFetchArgs: [string, RequestInit] | null = null;
+let fetchResponse: {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+} = {
+  ok: true,
+  status: 200,
+  json: async () => ({}),
+};
+
+globalThis.fetch = (async (url: string, init: RequestInit) => {
+  lastFetchArgs = [url, init];
+  return fetchResponse;
+}) as typeof globalThis.fetch;
+
+// Import after mocking
+import {
+  getMe,
+  postTweet,
+  proxyTwitterCall,
+  resolveAuthToken,
+  resolvePlatformAssistantId,
+  resolvePlatformBaseUrl,
+  resolvePrerequisites,
+  TwitterProxyError,
+} from "../twitter/platform-proxy-client.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockApiKey = "test-api-key-123";
+  mockPlatformEnvUrl = "https://platform.vellum.ai";
+  mockPlatformAssistantId = "ast_abc123";
+  mockConfigBaseUrl = "";
+  lastFetchArgs = null;
+  fetchResponse = {
+    ok: true,
+    status: 200,
+    json: async () => ({ data: { id: "12345", text: "Hello world" } }),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Prerequisite resolution
+// ---------------------------------------------------------------------------
+
+describe("prerequisite resolution", () => {
+  test("resolvePlatformBaseUrl prefers config over env", () => {
+    mockConfigBaseUrl = "https://config.vellum.ai";
+    mockPlatformEnvUrl = "https://env.vellum.ai";
+    expect(resolvePlatformBaseUrl()).toBe("https://config.vellum.ai");
+  });
+
+  test("resolvePlatformBaseUrl falls back to env when config is empty", () => {
+    mockConfigBaseUrl = "";
+    mockPlatformEnvUrl = "https://env.vellum.ai";
+    expect(resolvePlatformBaseUrl()).toBe("https://env.vellum.ai");
+  });
+
+  test("resolvePlatformBaseUrl strips trailing slashes", () => {
+    mockPlatformEnvUrl = "https://platform.vellum.ai///";
+    expect(resolvePlatformBaseUrl()).toBe("https://platform.vellum.ai");
+  });
+
+  test("resolveAuthToken returns the token from secure storage", () => {
+    expect(resolveAuthToken()).toBe("test-api-key-123");
+  });
+
+  test("resolveAuthToken returns undefined when token is missing", () => {
+    mockApiKey = undefined;
+    expect(resolveAuthToken()).toBeUndefined();
+  });
+
+  test("resolvePlatformAssistantId returns the env value", () => {
+    expect(resolvePlatformAssistantId()).toBe("ast_abc123");
+  });
+
+  test("resolvePrerequisites returns all values when present", () => {
+    const prereqs = resolvePrerequisites();
+    expect(prereqs.platformBaseUrl).toBe("https://platform.vellum.ai");
+    expect(prereqs.authToken).toBe("test-api-key-123");
+    expect(prereqs.platformAssistantId).toBe("ast_abc123");
+  });
+
+  test("resolvePrerequisites throws when platform assistant ID is missing", () => {
+    mockPlatformAssistantId = "";
+    try {
+      resolvePrerequisites();
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("missing_platform_assistant_id");
+      expect(tpe.message).toBe("Local assistant not registered with platform");
+      expect(tpe.retryable).toBe(false);
+    }
+  });
+
+  test("resolvePrerequisites throws when assistant API key is missing", () => {
+    mockApiKey = undefined;
+    try {
+      resolvePrerequisites();
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("missing_assistant_api_key");
+      expect(tpe.message).toBe("Assistant not bootstrapped — run setup");
+    }
+  });
+
+  test("resolvePrerequisites throws when platform base URL is missing", () => {
+    mockPlatformEnvUrl = "";
+    mockConfigBaseUrl = "";
+    try {
+      resolvePrerequisites();
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("missing_platform_base_url");
+      expect(tpe.message).toBe("Platform base URL is not configured");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Proxy calls
+// ---------------------------------------------------------------------------
+
+describe("proxyTwitterCall", () => {
+  test("sends POST to the correct proxy endpoint", async () => {
+    await proxyTwitterCall({
+      method: "POST",
+      path: "/2/tweets",
+      body: { text: "Hello" },
+    });
+
+    expect(lastFetchArgs).not.toBeNull();
+    expect(lastFetchArgs![0]).toBe(
+      "https://platform.vellum.ai/v1/assistants/ast_abc123/external-provider-proxy/twitter/",
+    );
+    expect(lastFetchArgs![1].method).toBe("POST");
+  });
+
+  test("sends Api-Key authorization header with assistant API key", async () => {
+    await proxyTwitterCall({
+      method: "GET",
+      path: "/2/users/me",
+    });
+
+    expect(lastFetchArgs).not.toBeNull();
+    const headers = lastFetchArgs![1].headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Api-Key test-api-key-123");
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  test("request body contains the Twitter API call description", async () => {
+    await proxyTwitterCall({
+      method: "POST",
+      path: "/2/tweets",
+      body: { text: "Hello world" },
+    });
+
+    const parsed = JSON.parse(lastFetchArgs![1].body as string);
+    expect(parsed.method).toBe("POST");
+    expect(parsed.path).toBe("/2/tweets");
+    expect(parsed.body).toEqual({ text: "Hello world" });
+  });
+
+  test("GET-style request includes query parameters", async () => {
+    await proxyTwitterCall({
+      method: "GET",
+      path: "/2/users/me",
+      query: { "user.fields": "name,username" },
+    });
+
+    const parsed = JSON.parse(lastFetchArgs![1].body as string);
+    expect(parsed.method).toBe("GET");
+    expect(parsed.path).toBe("/2/users/me");
+    expect(parsed.query).toEqual({ "user.fields": "name,username" });
+  });
+
+  test("returns parsed response data on success", async () => {
+    fetchResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { id: "99", text: "ok" } }),
+    };
+
+    const result = await proxyTwitterCall({
+      method: "POST",
+      path: "/2/tweets",
+      body: { text: "ok" },
+    });
+
+    expect(result.data).toEqual({ data: { id: "99", text: "ok" } });
+    expect(result.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+describe("error mapping", () => {
+  test("403 with owner credential message maps to owner_credential_required", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 403,
+      json: async () => ({
+        detail: "Owner credential required to access this resource",
+      }),
+    };
+
+    try {
+      await proxyTwitterCall({ method: "GET", path: "/2/users/me" });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("owner_credential_required");
+      expect(tpe.message).toBe(
+        "Connect Twitter in Settings as the assistant owner",
+      );
+      expect(tpe.retryable).toBe(false);
+      expect(tpe.statusCode).toBe(403);
+    }
+  });
+
+  test("403 with owner-only message maps to owner_only", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 403,
+      json: async () => ({
+        detail: "Only the owner can perform this action",
+      }),
+    };
+
+    try {
+      await proxyTwitterCall({ method: "POST", path: "/2/tweets", body: {} });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("owner_only");
+      expect(tpe.message).toBe("Sign in as the assistant owner");
+    }
+  });
+
+  test("403 without owner keyword maps to generic forbidden", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 403,
+      json: async () => ({ detail: "Access denied" }),
+    };
+
+    try {
+      await proxyTwitterCall({ method: "GET", path: "/2/users/me" });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("forbidden");
+      expect(tpe.statusCode).toBe(403);
+    }
+  });
+
+  test("401 maps to auth_failure with retryable true", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 401,
+      json: async () => ({ detail: "Token expired" }),
+    };
+
+    try {
+      await proxyTwitterCall({ method: "GET", path: "/2/users/me" });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("auth_failure");
+      expect(tpe.message).toBe("Reconnect Twitter or retry");
+      expect(tpe.retryable).toBe(true);
+    }
+  });
+
+  test("502 maps to upstream_failure with retryable true", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 502,
+      json: async () => ({}),
+    };
+
+    try {
+      await proxyTwitterCall({ method: "GET", path: "/2/users/me" });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("upstream_failure");
+      expect(tpe.retryable).toBe(true);
+    }
+  });
+
+  test("429 maps to rate_limit with retryable true", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 429,
+      json: async () => ({ detail: "Too many requests" }),
+    };
+
+    try {
+      await proxyTwitterCall({ method: "POST", path: "/2/tweets", body: {} });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("rate_limit");
+      expect(tpe.retryable).toBe(true);
+      expect(tpe.statusCode).toBe(429);
+    }
+  });
+
+  test("500 maps to platform_error with retryable true", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: "Internal server error" }),
+    };
+
+    try {
+      await proxyTwitterCall({ method: "GET", path: "/2/users/me" });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("platform_error");
+      expect(tpe.retryable).toBe(true);
+    }
+  });
+
+  test("unparseable error response falls back to status code", async () => {
+    fetchResponse = {
+      ok: false,
+      status: 400,
+      json: async () => {
+        throw new Error("not json");
+      },
+    };
+
+    try {
+      await proxyTwitterCall({ method: "GET", path: "/2/users/me" });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwitterProxyError);
+      const tpe = err as TwitterProxyError;
+      expect(tpe.code).toBe("proxy_error");
+      expect(tpe.message).toContain("HTTP 400");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Convenience helpers
+// ---------------------------------------------------------------------------
+
+describe("postTweet", () => {
+  test("sends a tweet through the proxy", async () => {
+    await postTweet("Hello from proxy");
+
+    const parsed = JSON.parse(lastFetchArgs![1].body as string);
+    expect(parsed.method).toBe("POST");
+    expect(parsed.path).toBe("/2/tweets");
+    expect(parsed.body.text).toBe("Hello from proxy");
+  });
+
+  test("includes reply metadata when replyToId is provided", async () => {
+    await postTweet("This is a reply", { replyToId: "tweet_789" });
+
+    const parsed = JSON.parse(lastFetchArgs![1].body as string);
+    expect(parsed.body.reply).toEqual({
+      in_reply_to_tweet_id: "tweet_789",
+    });
+  });
+});
+
+describe("getMe", () => {
+  test("sends a GET request for the authenticated user", async () => {
+    await getMe({ "user.fields": "name,username,profile_image_url" });
+
+    const parsed = JSON.parse(lastFetchArgs![1].body as string);
+    expect(parsed.method).toBe("GET");
+    expect(parsed.path).toBe("/2/users/me");
+    expect(parsed.query).toEqual({
+      "user.fields": "name,username,profile_image_url",
+    });
+  });
+
+  test("sends without query when none provided", async () => {
+    await getMe();
+
+    const parsed = JSON.parse(lastFetchArgs![1].body as string);
+    expect(parsed.method).toBe("GET");
+    expect(parsed.path).toBe("/2/users/me");
+    expect(parsed.query).toBeUndefined();
+  });
+});

--- a/assistant/src/cli/commands/twitter/__tests__/cli-error-shaping.test.ts
+++ b/assistant/src/cli/commands/twitter/__tests__/cli-error-shaping.test.ts
@@ -45,7 +45,8 @@ function buildErrorPayload(err: unknown): Record<string, unknown> | null {
     err instanceof Error &&
     (meta.pathUsed !== undefined ||
       meta.suggestAlternative !== undefined ||
-      meta.oauthError !== undefined)
+      meta.oauthError !== undefined ||
+      meta.proxyErrorCode !== undefined)
   ) {
     const payload: Record<string, unknown> = {
       ok: false,
@@ -55,6 +56,9 @@ function buildErrorPayload(err: unknown): Record<string, unknown> | null {
     if (meta.suggestAlternative !== undefined)
       payload.suggestAlternative = meta.suggestAlternative;
     if (meta.oauthError !== undefined) payload.oauthError = meta.oauthError;
+    if (meta.proxyErrorCode !== undefined)
+      payload.proxyErrorCode = meta.proxyErrorCode;
+    if (meta.retryable !== undefined) payload.retryable = meta.retryable;
     return payload;
   }
 
@@ -203,6 +207,43 @@ describe("CLI error shaping", () => {
     expect(payload).toEqual({
       ok: false,
       error: "some string error",
+    });
+  });
+
+  test("managed proxy error preserves proxyErrorCode and retryable metadata", () => {
+    const err = Object.assign(
+      new Error("Connect Twitter in Settings as the assistant owner"),
+      {
+        pathUsed: "managed" as const,
+        proxyErrorCode: "owner_credential_required",
+        retryable: false,
+      },
+    );
+    const payload = buildErrorPayload(err);
+
+    expect(payload).toEqual({
+      ok: false,
+      error: "Connect Twitter in Settings as the assistant owner",
+      pathUsed: "managed",
+      proxyErrorCode: "owner_credential_required",
+      retryable: false,
+    });
+  });
+
+  test("managed proxy retryable error preserves metadata", () => {
+    const err = Object.assign(new Error("Reconnect Twitter or retry"), {
+      pathUsed: "managed" as const,
+      proxyErrorCode: "auth_failure",
+      retryable: true,
+    });
+    const payload = buildErrorPayload(err);
+
+    expect(payload).toEqual({
+      ok: false,
+      error: "Reconnect Twitter or retry",
+      pathUsed: "managed",
+      proxyErrorCode: "auth_failure",
+      retryable: true,
     });
   });
 

--- a/assistant/src/cli/commands/twitter/__tests__/cli-read-routing.test.ts
+++ b/assistant/src/cli/commands/twitter/__tests__/cli-read-routing.test.ts
@@ -1,0 +1,483 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// --- Mock state ---
+
+let mockManagedGetUserByUsernameResult: {
+  data: unknown;
+  status: number;
+} | null = null;
+let mockManagedGetUserByUsernameError: Error | null = null;
+
+let mockManagedGetUserTweetsResult: {
+  data: unknown;
+  status: number;
+} | null = null;
+let mockManagedGetUserTweetsError: Error | null = null;
+
+let mockManagedGetTweetResult: { data: unknown; status: number } | null = null;
+let mockManagedGetTweetError: Error | null = null;
+
+let mockManagedSearchRecentTweetsResult: {
+  data: unknown;
+  status: number;
+} | null = null;
+let mockManagedSearchRecentTweetsError: Error | null = null;
+
+let mockBrowserGetUserByScreenNameResult: {
+  userId: string;
+  screenName: string;
+  name: string;
+} | null = null;
+let mockBrowserGetUserByScreenNameError: Error | null = null;
+
+let mockBrowserGetUserTweetsResult: Array<{
+  tweetId: string;
+  text: string;
+  url: string;
+  createdAt: string;
+}> | null = null;
+let mockBrowserGetUserTweetsError: Error | null = null;
+
+let mockBrowserGetTweetDetailResult: Array<{
+  tweetId: string;
+  text: string;
+  url: string;
+  createdAt: string;
+}> | null = null;
+let mockBrowserGetTweetDetailError: Error | null = null;
+
+let mockBrowserSearchTweetsResult: Array<{
+  tweetId: string;
+  text: string;
+  url: string;
+  createdAt: string;
+}> | null = null;
+let mockBrowserSearchTweetsError: Error | null = null;
+
+// --- Mock TwitterProxyError ---
+
+class MockTwitterProxyError extends Error {
+  public readonly code: string;
+  public readonly retryable: boolean;
+  public readonly statusCode: number;
+  constructor(
+    message: string,
+    code: string,
+    retryable: boolean,
+    statusCode = 0,
+  ) {
+    super(message);
+    this.name = "TwitterProxyError";
+    this.code = code;
+    this.retryable = retryable;
+    this.statusCode = statusCode;
+  }
+}
+
+// --- Mocks ---
+
+mock.module("../../../../twitter/platform-proxy-client.js", () => ({
+  postTweet: async () => {
+    throw new Error("Not used in read tests");
+  },
+  getUserByUsername: async () => {
+    if (mockManagedGetUserByUsernameError)
+      throw mockManagedGetUserByUsernameError;
+    if (mockManagedGetUserByUsernameResult)
+      return mockManagedGetUserByUsernameResult;
+    throw new Error("Managed getUserByUsername mock not configured");
+  },
+  getUserTweets: async () => {
+    if (mockManagedGetUserTweetsError) throw mockManagedGetUserTweetsError;
+    if (mockManagedGetUserTweetsResult) return mockManagedGetUserTweetsResult;
+    throw new Error("Managed getUserTweets mock not configured");
+  },
+  getTweet: async () => {
+    if (mockManagedGetTweetError) throw mockManagedGetTweetError;
+    if (mockManagedGetTweetResult) return mockManagedGetTweetResult;
+    throw new Error("Managed getTweet mock not configured");
+  },
+  searchRecentTweets: async () => {
+    if (mockManagedSearchRecentTweetsError)
+      throw mockManagedSearchRecentTweetsError;
+    if (mockManagedSearchRecentTweetsResult)
+      return mockManagedSearchRecentTweetsResult;
+    throw new Error("Managed searchRecentTweets mock not configured");
+  },
+  TwitterProxyError: MockTwitterProxyError,
+}));
+
+class MockSessionExpiredError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "SessionExpiredError";
+  }
+}
+
+mock.module("../client.js", () => ({
+  postTweet: async () => {
+    throw new Error("Not used in read tests");
+  },
+  getUserByScreenName: async () => {
+    if (mockBrowserGetUserByScreenNameError)
+      throw mockBrowserGetUserByScreenNameError;
+    if (mockBrowserGetUserByScreenNameResult)
+      return mockBrowserGetUserByScreenNameResult;
+    throw new Error("Browser getUserByScreenName mock not configured");
+  },
+  getUserTweets: async () => {
+    if (mockBrowserGetUserTweetsError) throw mockBrowserGetUserTweetsError;
+    if (mockBrowserGetUserTweetsResult) return mockBrowserGetUserTweetsResult;
+    throw new Error("Browser getUserTweets mock not configured");
+  },
+  getTweetDetail: async () => {
+    if (mockBrowserGetTweetDetailError) throw mockBrowserGetTweetDetailError;
+    if (mockBrowserGetTweetDetailResult) return mockBrowserGetTweetDetailResult;
+    throw new Error("Browser getTweetDetail mock not configured");
+  },
+  searchTweets: async () => {
+    if (mockBrowserSearchTweetsError) throw mockBrowserSearchTweetsError;
+    if (mockBrowserSearchTweetsResult) return mockBrowserSearchTweetsResult;
+    throw new Error("Browser searchTweets mock not configured");
+  },
+  SessionExpiredError: MockSessionExpiredError,
+}));
+
+mock.module("../oauth-client.js", () => ({
+  oauthIsAvailable: () => false,
+  oauthSupportsOperation: () => false,
+  oauthPostTweet: async () => {
+    throw new Error("Not used in read tests");
+  },
+}));
+
+mock.module("../../../../util/logger.js", () => ({
+  getLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+    fatal: () => {},
+    child: () => ({
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    }),
+  }),
+}));
+
+import {
+  routedGetTweetDetail,
+  routedGetUserByScreenName,
+  routedGetUserTweets,
+  routedSearchTweets,
+} from "../router.js";
+
+beforeEach(() => {
+  mockManagedGetUserByUsernameResult = null;
+  mockManagedGetUserByUsernameError = null;
+  mockManagedGetUserTweetsResult = null;
+  mockManagedGetUserTweetsError = null;
+  mockManagedGetTweetResult = null;
+  mockManagedGetTweetError = null;
+  mockManagedSearchRecentTweetsResult = null;
+  mockManagedSearchRecentTweetsError = null;
+  mockBrowserGetUserByScreenNameResult = null;
+  mockBrowserGetUserByScreenNameError = null;
+  mockBrowserGetUserTweetsResult = null;
+  mockBrowserGetUserTweetsError = null;
+  mockBrowserGetTweetDetailResult = null;
+  mockBrowserGetTweetDetailError = null;
+  mockBrowserSearchTweetsResult = null;
+  mockBrowserSearchTweetsError = null;
+});
+
+describe("Twitter read routing", () => {
+  // =========================================================================
+  // User lookup
+  // =========================================================================
+  describe("routedGetUserByScreenName", () => {
+    test("managed strategy routes through proxy", async () => {
+      mockManagedGetUserByUsernameResult = {
+        data: { data: { id: "123", username: "testuser", name: "Test User" } },
+        status: 200,
+      };
+
+      const { result, pathUsed } = await routedGetUserByScreenName("testuser", {
+        strategy: "managed",
+      });
+
+      expect(pathUsed).toBe("managed");
+      expect(result.userId).toBe("123");
+      expect(result.screenName).toBe("testuser");
+      expect(result.name).toBe("Test User");
+    });
+
+    test("browser strategy uses browser path", async () => {
+      mockBrowserGetUserByScreenNameResult = {
+        userId: "456",
+        screenName: "browseruser",
+        name: "Browser User",
+      };
+
+      const { result, pathUsed } = await routedGetUserByScreenName(
+        "browseruser",
+        { strategy: "browser" },
+      );
+
+      expect(pathUsed).toBe("browser");
+      expect(result.userId).toBe("456");
+      expect(result.screenName).toBe("browseruser");
+    });
+
+    test("auto strategy falls through to browser", async () => {
+      mockBrowserGetUserByScreenNameResult = {
+        userId: "789",
+        screenName: "autouser",
+        name: "Auto User",
+      };
+
+      const { result, pathUsed } = await routedGetUserByScreenName("autouser", {
+        strategy: "auto",
+      });
+
+      expect(pathUsed).toBe("browser");
+      expect(result.userId).toBe("789");
+    });
+
+    test("managed strategy surfaces proxy errors with metadata", async () => {
+      mockManagedGetUserByUsernameError = new MockTwitterProxyError(
+        "Rate limit exceeded — retry later",
+        "rate_limit",
+        true,
+        429,
+      );
+
+      try {
+        await routedGetUserByScreenName("testuser", { strategy: "managed" });
+        expect(true).toBe(false);
+      } catch (err) {
+        const e = err as Error & {
+          pathUsed: string;
+          proxyErrorCode: string;
+          retryable: boolean;
+        };
+        expect(e.message).toBe("Rate limit exceeded — retry later");
+        expect(e.pathUsed).toBe("managed");
+        expect(e.proxyErrorCode).toBe("rate_limit");
+        expect(e.retryable).toBe(true);
+      }
+    });
+  });
+
+  // =========================================================================
+  // User tweets
+  // =========================================================================
+  describe("routedGetUserTweets", () => {
+    test("managed strategy routes through proxy", async () => {
+      mockManagedGetUserTweetsResult = {
+        data: {
+          data: [
+            {
+              id: "t1",
+              text: "Hello world",
+              created_at: "2025-01-01T00:00:00Z",
+            },
+            {
+              id: "t2",
+              text: "Second tweet",
+              created_at: "2025-01-02T00:00:00Z",
+            },
+          ],
+        },
+        status: 200,
+      };
+
+      const { result, pathUsed } = await routedGetUserTweets("123", 20, {
+        strategy: "managed",
+      });
+
+      expect(pathUsed).toBe("managed");
+      expect(result).toHaveLength(2);
+      expect(result[0].tweetId).toBe("t1");
+      expect(result[0].text).toBe("Hello world");
+      expect(result[0].url).toBe("https://x.com/i/status/t1");
+      expect(result[1].tweetId).toBe("t2");
+    });
+
+    test("browser strategy uses browser path", async () => {
+      mockBrowserGetUserTweetsResult = [
+        {
+          tweetId: "bt1",
+          text: "Browser tweet",
+          url: "https://x.com/user/status/bt1",
+          createdAt: "2025-01-01",
+        },
+      ];
+
+      const { result, pathUsed } = await routedGetUserTweets("456", 20, {
+        strategy: "browser",
+      });
+
+      expect(pathUsed).toBe("browser");
+      expect(result).toHaveLength(1);
+      expect(result[0].tweetId).toBe("bt1");
+    });
+  });
+
+  // =========================================================================
+  // Tweet detail
+  // =========================================================================
+  describe("routedGetTweetDetail", () => {
+    test("managed strategy routes through proxy", async () => {
+      mockManagedGetTweetResult = {
+        data: {
+          data: {
+            id: "tweet-123",
+            text: "A specific tweet",
+            created_at: "2025-01-01T00:00:00Z",
+          },
+        },
+        status: 200,
+      };
+
+      const { result, pathUsed } = await routedGetTweetDetail("tweet-123", {
+        strategy: "managed",
+      });
+
+      expect(pathUsed).toBe("managed");
+      expect(result).toHaveLength(1);
+      expect(result[0].tweetId).toBe("tweet-123");
+      expect(result[0].text).toBe("A specific tweet");
+    });
+
+    test("browser strategy uses browser path", async () => {
+      mockBrowserGetTweetDetailResult = [
+        {
+          tweetId: "detail-1",
+          text: "Thread tweet 1",
+          url: "https://x.com/user/status/detail-1",
+          createdAt: "2025-01-01",
+        },
+        {
+          tweetId: "detail-2",
+          text: "Reply tweet",
+          url: "https://x.com/user/status/detail-2",
+          createdAt: "2025-01-01",
+        },
+      ];
+
+      const { result, pathUsed } = await routedGetTweetDetail("detail-1", {
+        strategy: "browser",
+      });
+
+      expect(pathUsed).toBe("browser");
+      expect(result).toHaveLength(2);
+    });
+
+    test("managed strategy surfaces proxy errors", async () => {
+      mockManagedGetTweetError = new MockTwitterProxyError(
+        "Forbidden: insufficient permissions",
+        "forbidden",
+        false,
+        403,
+      );
+
+      try {
+        await routedGetTweetDetail("tweet-123", { strategy: "managed" });
+        expect(true).toBe(false);
+      } catch (err) {
+        const e = err as Error & {
+          pathUsed: string;
+          proxyErrorCode: string;
+        };
+        expect(e.pathUsed).toBe("managed");
+        expect(e.proxyErrorCode).toBe("forbidden");
+      }
+    });
+  });
+
+  // =========================================================================
+  // Search
+  // =========================================================================
+  describe("routedSearchTweets", () => {
+    test("managed strategy routes through proxy", async () => {
+      mockManagedSearchRecentTweetsResult = {
+        data: {
+          data: [
+            {
+              id: "s1",
+              text: "Search result 1",
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+        status: 200,
+      };
+
+      const { result, pathUsed } = await routedSearchTweets(
+        "AI agents",
+        "Top",
+        { strategy: "managed" },
+      );
+
+      expect(pathUsed).toBe("managed");
+      expect(result).toHaveLength(1);
+      expect(result[0].tweetId).toBe("s1");
+      expect(result[0].text).toBe("Search result 1");
+    });
+
+    test("browser strategy uses browser path", async () => {
+      mockBrowserSearchTweetsResult = [
+        {
+          tweetId: "bs1",
+          text: "Browser search result",
+          url: "https://x.com/user/status/bs1",
+          createdAt: "2025-01-01",
+        },
+      ];
+
+      const { result, pathUsed } = await routedSearchTweets(
+        "test query",
+        "Latest",
+        { strategy: "browser" },
+      );
+
+      expect(pathUsed).toBe("browser");
+      expect(result).toHaveLength(1);
+      expect(result[0].tweetId).toBe("bs1");
+    });
+
+    test("auto strategy falls through to browser for search", async () => {
+      mockBrowserSearchTweetsResult = [
+        {
+          tweetId: "auto-s1",
+          text: "Auto search result",
+          url: "https://x.com/user/status/auto-s1",
+          createdAt: "2025-01-01",
+        },
+      ];
+
+      const { result, pathUsed } = await routedSearchTweets("test", "Top", {
+        strategy: "auto",
+      });
+
+      expect(pathUsed).toBe("browser");
+      expect(result[0].tweetId).toBe("auto-s1");
+    });
+
+    test("managed strategy re-throws non-proxy errors", async () => {
+      mockManagedSearchRecentTweetsError = new Error("Network failure");
+
+      try {
+        await routedSearchTweets("test", "Top", { strategy: "managed" });
+        expect(true).toBe(false);
+      } catch (err) {
+        expect((err as Error).message).toBe("Network failure");
+        expect((err as Record<string, unknown>).pathUsed).toBeUndefined();
+      }
+    });
+  });
+});

--- a/assistant/src/cli/commands/twitter/__tests__/cli-routing.test.ts
+++ b/assistant/src/cli/commands/twitter/__tests__/cli-routing.test.ts
@@ -14,6 +14,8 @@ let mockBrowserPostResult: {
   url: string;
 } | null = null;
 let mockBrowserPostError: Error | null = null;
+let mockManagedPostResult: { data: unknown; status: number } | null = null;
+let mockManagedPostError: Error | null = null;
 
 // Mock the OAuth client
 mock.module("../oauth-client.js", () => ({
@@ -37,6 +39,35 @@ mock.module("../oauth-client.js", () => ({
       this.operation = operation;
     }
   },
+}));
+
+// Mock TwitterProxyError for managed path tests
+class MockTwitterProxyError extends Error {
+  public readonly code: string;
+  public readonly retryable: boolean;
+  public readonly statusCode: number;
+  constructor(
+    message: string,
+    code: string,
+    retryable: boolean,
+    statusCode = 0,
+  ) {
+    super(message);
+    this.name = "TwitterProxyError";
+    this.code = code;
+    this.retryable = retryable;
+    this.statusCode = statusCode;
+  }
+}
+
+// Mock the platform proxy client
+mock.module("../../../../twitter/platform-proxy-client.js", () => ({
+  postTweet: async (_text: string, _opts?: { replyToId?: string }) => {
+    if (mockManagedPostError) throw mockManagedPostError;
+    if (mockManagedPostResult) return mockManagedPostResult;
+    throw new Error("Managed mock not configured");
+  },
+  TwitterProxyError: MockTwitterProxyError,
 }));
 
 // Create a SessionExpiredError class that matches the real one
@@ -82,6 +113,8 @@ beforeEach(() => {
   mockOauthPostError = null;
   mockBrowserPostResult = null;
   mockBrowserPostError = null;
+  mockManagedPostResult = null;
+  mockManagedPostError = null;
 });
 
 describe("Twitter strategy router", () => {
@@ -245,6 +278,99 @@ describe("Twitter strategy router", () => {
         expect(true).toBe(false); // should not reach
       } catch (err) {
         expect((err as Error).message).toBe("Network failure");
+      }
+    });
+  });
+
+  describe("managed strategy", () => {
+    test("routes post through platform proxy", async () => {
+      mockManagedPostResult = {
+        data: { data: { id: "managed-1" } },
+        status: 200,
+      };
+
+      const { result, pathUsed } = await routedPostTweet("managed post", {
+        strategy: "managed",
+      });
+
+      expect(pathUsed).toBe("managed");
+      expect(result.tweetId).toBe("managed-1");
+      expect(result.url).toBe("https://x.com/i/status/managed-1");
+    });
+
+    test("routes reply through platform proxy", async () => {
+      mockManagedPostResult = {
+        data: { data: { id: "managed-reply-1" } },
+        status: 200,
+      };
+
+      const { result, pathUsed } = await routedPostTweet("reply text", {
+        strategy: "managed",
+        inReplyToTweetId: "original-tweet-123",
+      });
+
+      expect(pathUsed).toBe("managed");
+      expect(result.tweetId).toBe("managed-reply-1");
+    });
+
+    test("surfaces proxy errors with actionable metadata", async () => {
+      mockManagedPostError = new MockTwitterProxyError(
+        "Connect Twitter in Settings as the assistant owner",
+        "owner_credential_required",
+        false,
+        403,
+      );
+
+      try {
+        await routedPostTweet("will fail", { strategy: "managed" });
+        expect(true).toBe(false); // should not reach
+      } catch (err) {
+        const e = err as Error & {
+          pathUsed: string;
+          proxyErrorCode: string;
+          retryable: boolean;
+        };
+        expect(e.message).toBe(
+          "Connect Twitter in Settings as the assistant owner",
+        );
+        expect(e.pathUsed).toBe("managed");
+        expect(e.proxyErrorCode).toBe("owner_credential_required");
+        expect(e.retryable).toBe(false);
+      }
+    });
+
+    test("surfaces retryable proxy errors", async () => {
+      mockManagedPostError = new MockTwitterProxyError(
+        "Reconnect Twitter or retry",
+        "auth_failure",
+        true,
+        401,
+      );
+
+      try {
+        await routedPostTweet("will fail", { strategy: "managed" });
+        expect(true).toBe(false);
+      } catch (err) {
+        const e = err as Error & {
+          pathUsed: string;
+          proxyErrorCode: string;
+          retryable: boolean;
+        };
+        expect(e.pathUsed).toBe("managed");
+        expect(e.proxyErrorCode).toBe("auth_failure");
+        expect(e.retryable).toBe(true);
+      }
+    });
+
+    test("re-throws non-proxy errors without wrapping", async () => {
+      mockManagedPostError = new Error("Network failure");
+
+      try {
+        await routedPostTweet("will fail", { strategy: "managed" });
+        expect(true).toBe(false);
+      } catch (err) {
+        expect((err as Error).message).toBe("Network failure");
+        expect((err as Record<string, unknown>).pathUsed).toBeUndefined();
       }
     });
   });

--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -86,7 +86,8 @@ async function run(cmd: Command, fn: () => Promise<unknown>): Promise<void> {
       err instanceof Error &&
       (meta.pathUsed !== undefined ||
         meta.suggestAlternative !== undefined ||
-        meta.oauthError !== undefined)
+        meta.oauthError !== undefined ||
+        meta.proxyErrorCode !== undefined)
     ) {
       const payload: Record<string, unknown> = {
         ok: false,
@@ -96,6 +97,9 @@ async function run(cmd: Command, fn: () => Promise<unknown>): Promise<void> {
       if (meta.suggestAlternative !== undefined)
         payload.suggestAlternative = meta.suggestAlternative;
       if (meta.oauthError !== undefined) payload.oauthError = meta.oauthError;
+      if (meta.proxyErrorCode !== undefined)
+        payload.proxyErrorCode = meta.proxyErrorCode;
+      if (meta.retryable !== undefined) payload.retryable = meta.retryable;
       output(payload, getJson(cmd));
       process.exitCode = 1;
       return;
@@ -113,22 +117,25 @@ export function registerTwitterCommand(program: Command): void {
     .command("x")
     .alias("twitter")
     .description(
-      "Post on X and manage connections. Supports OAuth (official API) and browser session paths.",
+      "Post on X and manage connections. Supports managed (platform proxy), OAuth (official API), and browser session paths.",
     )
     .option("--json", "Machine-readable JSON output");
 
   tw.addHelpText(
     "after",
     `
-Twitter (X) uses a dual-path architecture for interacting with the platform:
+Twitter (X) supports multiple paths for interacting with the platform:
 
-  1. OAuth (official API) — uses an authenticated Twitter OAuth application for
+  1. Managed (platform proxy) — routes Twitter API calls through the platform,
+     which holds the OAuth credentials. Used when integrationMode is "managed".
+  2. OAuth (official API) — uses an authenticated Twitter OAuth application for
      posting and replying. Requires a connected OAuth credential.
-  2. Browser session (Ride Shotgun) — uses cookies captured from a real Chrome
+  3. Browser session (Ride Shotgun) — uses cookies captured from a real Chrome
      session to call Twitter's internal GraphQL API. Supports all read operations
      and posting as a fallback.
 
-The strategy system controls which path is used for operations that support both:
+The strategy system controls which path is used for operations that support multiple:
+  managed  — route through the platform proxy (platform holds credentials)
   oauth    — always use the OAuth API; fail if unavailable
   browser  — always use the browser session; fail if unavailable
   auto     — try OAuth first, fall back to browser session (default)
@@ -142,6 +149,7 @@ Session management:
 
 Examples:
   $ assistant x status
+  $ assistant x post "Hello world" --strategy managed
   $ assistant x post "Hello world" --strategy auto
   $ assistant x timeline elonmusk --count 10
   $ assistant x search "from:vaborsh AI agents" --product Latest
@@ -331,7 +339,7 @@ Examples:
   const strategyCli = tw
     .command("strategy")
     .description(
-      "Get or set the Twitter operation strategy (oauth, browser, auto)",
+      "Get or set the Twitter operation strategy (managed, oauth, browser, auto)",
     )
     .addHelpText(
       "after",
@@ -339,6 +347,7 @@ Examples:
 The strategy controls which authentication path is used for operations that
 support both OAuth and browser session:
 
+  managed  — route through the platform proxy (platform holds OAuth credentials).
   oauth    — always use the official Twitter OAuth API. Fails if no OAuth
              credential is connected. Best for reliable posting.
   browser  — always use the browser session (captured cookies). Fails if no
@@ -375,7 +384,8 @@ Arguments:
 
 Sets the preferred strategy for Twitter operations that support dual-path
 routing. The setting is persisted by the assistant and applies to all subsequent
-operations until changed.
+operations until changed. Note: "managed" is determined by integration mode
+and cannot be set manually.
 
 Examples:
   $ assistant x strategy set oauth
@@ -410,7 +420,7 @@ Examples:
     .argument("<text>", "Tweet text")
     .requiredOption(
       "--strategy <strategy>",
-      "Operation strategy: oauth, browser, or auto",
+      "Operation strategy: oauth, browser, auto, or managed",
     )
     .option(
       "--oauth-token <token>",
@@ -422,14 +432,20 @@ Examples:
 Arguments:
   text   The tweet text to post (max 280 characters)
 
-Posts a new tweet using the routed dual-path system. The --strategy flag
-controls which path is used. The response includes the tweet ID, URL, and
-which path was used.
+Posts a new tweet using the routed system. The --strategy flag controls which
+path is used. The response includes the tweet ID, URL, and which path was used.
+
+Strategies:
+  oauth    — use the local OAuth token directly
+  browser  — use the browser session (CDP)
+  auto     — try OAuth first, fall back to browser
+  managed  — route through the platform proxy (platform holds OAuth credentials)
 
 Examples:
   $ assistant x post "Hello world" --strategy browser
   $ assistant x post "Hello world" --strategy oauth --oauth-token "$TOKEN"
-  $ assistant x post "Hello world" --strategy auto --oauth-token "$TOKEN"`,
+  $ assistant x post "Hello world" --strategy auto --oauth-token "$TOKEN"
+  $ assistant x post "Hello world" --strategy managed`,
     )
     .action(
       async (
@@ -442,10 +458,11 @@ Examples:
           if (
             strategy !== "oauth" &&
             strategy !== "browser" &&
-            strategy !== "auto"
+            strategy !== "auto" &&
+            strategy !== "managed"
           ) {
             throw new Error(
-              `Invalid strategy "${opts.strategy}". Must be oauth, browser, or auto.`,
+              `Invalid strategy "${opts.strategy}". Must be oauth, browser, auto, or managed.`,
             );
           }
           const { result, pathUsed } = await routedPostTweet(text, {
@@ -471,7 +488,7 @@ Examples:
     .argument("<text>", "Reply text")
     .requiredOption(
       "--strategy <strategy>",
-      "Operation strategy: oauth, browser, or auto",
+      "Operation strategy: oauth, browser, auto, or managed",
     )
     .option(
       "--oauth-token <token>",
@@ -490,7 +507,8 @@ URL. The --strategy flag controls which path is used.
 
 Examples:
   $ assistant x reply https://x.com/elonmusk/status/1234567890 "Great point!" --strategy browser
-  $ assistant x reply 1234567890 "Interesting thread" --strategy oauth --oauth-token "$TOKEN"`,
+  $ assistant x reply 1234567890 "Interesting thread" --strategy oauth --oauth-token "$TOKEN"
+  $ assistant x reply 1234567890 "Nice!" --strategy managed`,
     )
     .action(
       async (
@@ -504,10 +522,11 @@ Examples:
           if (
             strategy !== "oauth" &&
             strategy !== "browser" &&
-            strategy !== "auto"
+            strategy !== "auto" &&
+            strategy !== "managed"
           ) {
             throw new Error(
-              `Invalid strategy "${opts.strategy}". Must be oauth, browser, or auto.`,
+              `Invalid strategy "${opts.strategy}". Must be oauth, browser, auto, or managed.`,
             );
           }
           // Extract tweet ID: either a bare numeric ID or the last numeric segment of a URL

--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -976,6 +976,9 @@ async function sendTwitterConfigRequest(
       strategy: data.strategy ?? "auto",
       strategyConfigured: data.strategyConfigured ?? false,
       mode: data.mode,
+      managedAvailable: data.managedAvailable ?? false,
+      managedPrerequisites: data.managedPrerequisites,
+      localClientConfigured: data.localClientConfigured ?? false,
     };
   }
 
@@ -1127,9 +1130,7 @@ async function startLearnSession(
 
         if (status.bootstrapFailureReason) {
           reject(
-            new Error(
-              `Learn session failed: ${status.bootstrapFailureReason}`,
-            ),
+            new Error(`Learn session failed: ${status.bootstrapFailureReason}`),
           );
           return;
         }
@@ -1142,9 +1143,7 @@ async function startLearnSession(
             });
           } else {
             reject(
-              new Error(
-                "Learn session completed but no recording was saved.",
-              ),
+              new Error("Learn session completed but no recording was saved."),
             );
           }
           return;

--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -20,15 +20,18 @@ import {
   getHomeTimeline,
   getLikes,
   getNotifications,
-  getTweetDetail,
   getUserByScreenName,
   getUserMedia,
-  getUserTweets,
-  searchTweets,
   SessionExpiredError,
 } from "./client.js";
 import type { TwitterStrategy } from "./router.js";
-import { routedPostTweet } from "./router.js";
+import {
+  routedGetTweetDetail,
+  routedGetUserByScreenName,
+  routedGetUserTweets,
+  routedPostTweet,
+  routedSearchTweets,
+} from "./router.js";
 import { clearSession, importFromRecording, loadSession } from "./session.js";
 
 // ---------------------------------------------------------------------------
@@ -557,30 +560,54 @@ Examples:
     .description("Fetch a user's recent tweets")
     .argument("<screenName>", "Twitter screen name (without @)")
     .option("--count <n>", "Number of tweets to fetch", "20")
+    .option(
+      "--strategy <strategy>",
+      "Operation strategy: managed or browser (default: browser)",
+    )
     .addHelpText(
       "after",
       `
 Arguments:
   screenName   Twitter screen name without the @ prefix (e.g. "elonmusk", not "@elonmusk")
 
-Fetches a user's recent tweets via the browser session. Resolves the screen name
-to a user ID first, then retrieves their tweet timeline. The --count flag controls
-how many tweets to return (default: 20).
+Fetches a user's recent tweets. Resolves the screen name to a user ID first,
+then retrieves their tweet timeline. The --count flag controls how many tweets
+to return (default: 20). Use --strategy managed to route through the platform proxy.
 
 Examples:
   $ assistant x timeline elonmusk
   $ assistant x timeline vaborsh --count 50
-  $ assistant x timeline openai --count 10 --json`,
+  $ assistant x timeline openai --count 10 --json
+  $ assistant x timeline elonmusk --strategy managed`,
     )
     .action(
-      async (screenName: string, opts: { count: string }, cmd: Command) => {
+      async (
+        screenName: string,
+        opts: { count: string; strategy?: string },
+        cmd: Command,
+      ) => {
         await run(cmd, async () => {
-          const user = await getUserByScreenName(screenName.replace(/^@/, ""));
-          const tweets = await getUserTweets(
+          const strategy = (opts.strategy ?? "browser") as TwitterStrategy;
+          if (
+            strategy !== "oauth" &&
+            strategy !== "browser" &&
+            strategy !== "auto" &&
+            strategy !== "managed"
+          ) {
+            throw new Error(
+              `Invalid strategy "${opts.strategy}". Must be oauth, browser, auto, or managed.`,
+            );
+          }
+          const { result: user, pathUsed } = await routedGetUserByScreenName(
+            screenName.replace(/^@/, ""),
+            { strategy },
+          );
+          const { result: tweets } = await routedGetUserTweets(
             user.userId,
             parseInt(opts.count, 10),
+            { strategy },
           );
-          return { user, tweets };
+          return { user, tweets, pathUsed };
         });
       },
     );
@@ -591,6 +618,10 @@ Examples:
   tw.command("tweet")
     .description("Fetch a tweet and its reply thread")
     .argument("<tweetIdOrUrl>", "Tweet ID or URL")
+    .option(
+      "--strategy <strategy>",
+      "Operation strategy: managed or browser (default: browser)",
+    )
     .addHelpText(
       "after",
       `
@@ -598,24 +629,45 @@ Arguments:
   tweetIdOrUrl   A bare tweet ID (e.g. 1234567890) or a full tweet URL
                  (e.g. https://x.com/user/status/1234567890)
 
-Fetches a single tweet and its reply thread via the browser session. The tweet
-ID is extracted from the last numeric segment of the input. Returns an array of
-tweets representing the conversation thread.
+Fetches a single tweet and its reply thread. The tweet ID is extracted from the
+last numeric segment of the input. Returns an array of tweets representing the
+conversation thread. Use --strategy managed to route through the platform proxy.
 
 Examples:
   $ assistant x tweet 1234567890
   $ assistant x tweet https://x.com/elonmusk/status/1234567890
-  $ assistant x tweet https://x.com/openai/status/9876543210 --json`,
+  $ assistant x tweet https://x.com/openai/status/9876543210 --json
+  $ assistant x tweet 1234567890 --strategy managed`,
     )
-    .action(async (tweetIdOrUrl: string, _opts: unknown, cmd: Command) => {
-      await run(cmd, async () => {
-        const idMatch = tweetIdOrUrl.match(/(\d+)\s*$/);
-        if (!idMatch)
-          throw new Error(`Could not extract tweet ID from: ${tweetIdOrUrl}`);
-        const tweets = await getTweetDetail(idMatch[1]);
-        return { tweets };
-      });
-    });
+    .action(
+      async (
+        tweetIdOrUrl: string,
+        opts: { strategy?: string },
+        cmd: Command,
+      ) => {
+        await run(cmd, async () => {
+          const idMatch = tweetIdOrUrl.match(/(\d+)\s*$/);
+          if (!idMatch)
+            throw new Error(`Could not extract tweet ID from: ${tweetIdOrUrl}`);
+          const strategy = (opts.strategy ?? "browser") as TwitterStrategy;
+          if (
+            strategy !== "oauth" &&
+            strategy !== "browser" &&
+            strategy !== "auto" &&
+            strategy !== "managed"
+          ) {
+            throw new Error(
+              `Invalid strategy "${opts.strategy}". Must be oauth, browser, auto, or managed.`,
+            );
+          }
+          const { result: tweets, pathUsed } = await routedGetTweetDetail(
+            idMatch[1],
+            { strategy },
+          );
+          return { tweets, pathUsed };
+        });
+      },
+    );
 
   // =========================================================================
   // search — search tweets
@@ -624,6 +676,10 @@ Examples:
     .description("Search tweets")
     .argument("<query>", "Search query")
     .option("--product <type>", "Top, Latest, People, or Media", "Top")
+    .option(
+      "--strategy <strategy>",
+      "Operation strategy: managed or browser (default: browser)",
+    )
     .addHelpText(
       "after",
       `
@@ -637,22 +693,43 @@ The --product flag selects the search result type:
   People   — user accounts matching the query
   Media    — tweets containing images or video
 
-Uses the browser session path. Requires an active browser session.
+Use --strategy managed to route through the platform proxy (uses Twitter's
+recent search API).
 
 Examples:
   $ assistant x search "AI agents"
   $ assistant x search "from:elonmusk SpaceX" --product Latest
-  $ assistant x search "machine learning" --product Media --json`,
+  $ assistant x search "machine learning" --product Media --json
+  $ assistant x search "AI agents" --strategy managed`,
     )
-    .action(async (query: string, opts: { product: string }, cmd: Command) => {
-      await run(cmd, async () => {
-        const tweets = await searchTweets(
-          query,
-          opts.product as "Top" | "Latest" | "People" | "Media",
-        );
-        return { query, tweets };
-      });
-    });
+    .action(
+      async (
+        query: string,
+        opts: { product: string; strategy?: string },
+        cmd: Command,
+      ) => {
+        await run(cmd, async () => {
+          const strategy = (opts.strategy ?? "browser") as TwitterStrategy;
+          if (
+            strategy !== "oauth" &&
+            strategy !== "browser" &&
+            strategy !== "auto" &&
+            strategy !== "managed"
+          ) {
+            throw new Error(
+              `Invalid strategy "${opts.strategy}". Must be oauth, browser, auto, or managed.`,
+            );
+          }
+          const product = opts.product as "Top" | "Latest" | "People" | "Media";
+          const { result: tweets, pathUsed } = await routedSearchTweets(
+            query,
+            product,
+            { strategy },
+          );
+          return { query, tweets, pathUsed };
+        });
+      },
+    );
 
   // =========================================================================
   // bookmarks — fetch bookmarks

--- a/assistant/src/cli/commands/twitter/router.ts
+++ b/assistant/src/cli/commands/twitter/router.ts
@@ -1,8 +1,12 @@
 /**
  * Strategy router for Twitter operations.
- * Selects OAuth or browser path based on the caller-provided strategy.
+ * Selects managed proxy, OAuth, or browser path based on the caller-provided strategy.
  */
 
+import {
+  postTweet as managedPostTweet,
+  TwitterProxyError,
+} from "../../../twitter/platform-proxy-client.js";
 import type { PostTweetResult } from "./client.js";
 import {
   postTweet as browserPostTweet,
@@ -14,7 +18,7 @@ import {
   oauthSupportsOperation,
 } from "./oauth-client.js";
 
-export type TwitterStrategy = "oauth" | "browser" | "auto";
+export type TwitterStrategy = "oauth" | "browser" | "auto" | "managed";
 
 export interface RoutedResult<T> {
   result: T;
@@ -38,6 +42,46 @@ export async function routedPostTweet(
 ): Promise<RoutedResult<PostTweetResult>> {
   const strategy = opts.strategy;
   const operation = opts.inReplyToTweetId ? "reply" : "post";
+
+  if (strategy === "managed") {
+    // Route through platform proxy — the platform holds the OAuth credentials
+    try {
+      const response = await managedPostTweet(text, {
+        replyToId: opts.inReplyToTweetId,
+      });
+      const data = response.data as Record<string, unknown>;
+      const tweetData = (data?.data ?? data) as Record<string, unknown>;
+      const tweetId = String(tweetData.id ?? "");
+      if (!tweetId) {
+        throw Object.assign(
+          new Error(
+            "Managed post succeeded but the proxy response did not include a tweet ID",
+          ),
+          {
+            pathUsed: "managed" as const,
+          },
+        );
+      }
+      return {
+        result: {
+          tweetId,
+          text,
+          url: `https://x.com/i/status/${tweetId}`,
+        },
+        pathUsed: "managed",
+      };
+    } catch (err) {
+      if (err instanceof TwitterProxyError) {
+        // Surface actionable error messages from the proxy
+        throw Object.assign(new Error(err.message), {
+          pathUsed: "managed" as const,
+          proxyErrorCode: err.code,
+          retryable: err.retryable,
+        });
+      }
+      throw err;
+    }
+  }
 
   if (strategy === "oauth") {
     // User explicitly wants OAuth

--- a/assistant/src/cli/commands/twitter/router.ts
+++ b/assistant/src/cli/commands/twitter/router.ts
@@ -4,12 +4,20 @@
  */
 
 import {
+  getTweet as managedGetTweet,
+  getUserByUsername as managedGetUserByUsername,
+  getUserTweets as managedGetUserTweets,
   postTweet as managedPostTweet,
+  searchRecentTweets as managedSearchRecentTweets,
   TwitterProxyError,
 } from "../../../twitter/platform-proxy-client.js";
-import type { PostTweetResult } from "./client.js";
+import type { PostTweetResult, TweetEntry, UserInfo } from "./client.js";
 import {
+  getTweetDetail as browserGetTweetDetail,
+  getUserByScreenName as browserGetUserByScreenName,
+  getUserTweets as browserGetUserTweets,
   postTweet as browserPostTweet,
+  searchTweets as browserSearchTweets,
   SessionExpiredError,
 } from "./client.js";
 import {
@@ -172,4 +180,217 @@ export async function routedPostTweet(
     }
     throw err;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Routed read operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up a user by screen name.
+ * Managed mode uses GET /2/users/by/username/:username; browser mode uses GraphQL.
+ */
+export async function routedGetUserByScreenName(
+  screenName: string,
+  opts: { strategy: TwitterStrategy },
+): Promise<RoutedResult<UserInfo>> {
+  if (opts.strategy === "managed") {
+    try {
+      const response = await managedGetUserByUsername(screenName, {
+        "user.fields": "id,name,username",
+      });
+      const data = response.data as Record<string, unknown>;
+      const userData = (data?.data ?? data) as Record<string, unknown>;
+      if (!userData.id) {
+        throw Object.assign(new Error(`User not found: @${screenName}`), {
+          pathUsed: "managed" as const,
+        });
+      }
+      return {
+        result: {
+          userId: String(userData.id),
+          screenName: String(
+            userData.username ?? userData.screen_name ?? screenName,
+          ),
+          name: String(userData.name ?? screenName),
+        },
+        pathUsed: "managed",
+      };
+    } catch (err) {
+      if (err instanceof TwitterProxyError) {
+        throw Object.assign(new Error(err.message), {
+          pathUsed: "managed" as const,
+          proxyErrorCode: err.code,
+          retryable: err.retryable,
+        });
+      }
+      throw err;
+    }
+  }
+
+  // Browser path (used for browser, oauth, auto — read operations always go through browser)
+  const result = await browserGetUserByScreenName(screenName);
+  return { result, pathUsed: "browser" };
+}
+
+/**
+ * Fetch a user's recent tweets.
+ * Managed mode uses GET /2/users/:id/tweets; browser mode uses GraphQL.
+ */
+export async function routedGetUserTweets(
+  userId: string,
+  count: number,
+  opts: { strategy: TwitterStrategy },
+): Promise<RoutedResult<TweetEntry[]>> {
+  if (opts.strategy === "managed") {
+    try {
+      const response = await managedGetUserTweets(userId, {
+        max_results: String(Math.min(count, 100)),
+        "tweet.fields": "id,text,created_at,author_id",
+      });
+      const data = response.data as Record<string, unknown>;
+      const tweetsArray = (data?.data ?? []) as Array<Record<string, unknown>>;
+      const tweets: TweetEntry[] = tweetsArray.map((t) => ({
+        tweetId: String(t.id ?? ""),
+        text: String(t.text ?? ""),
+        url: `https://x.com/i/status/${t.id}`,
+        createdAt: String(t.created_at ?? ""),
+      }));
+      return { result: tweets, pathUsed: "managed" };
+    } catch (err) {
+      if (err instanceof TwitterProxyError) {
+        throw Object.assign(new Error(err.message), {
+          pathUsed: "managed" as const,
+          proxyErrorCode: err.code,
+          retryable: err.retryable,
+        });
+      }
+      throw err;
+    }
+  }
+
+  const result = await browserGetUserTweets(userId, count);
+  return { result, pathUsed: "browser" };
+}
+
+/**
+ * Fetch a single tweet by ID.
+ * Managed mode uses GET /2/tweets/:id; browser mode uses GraphQL TweetDetail.
+ */
+export async function routedGetTweetDetail(
+  tweetId: string,
+  opts: { strategy: TwitterStrategy },
+): Promise<RoutedResult<TweetEntry[]>> {
+  if (opts.strategy === "managed") {
+    try {
+      const response = await managedGetTweet(tweetId, {
+        "tweet.fields": "id,text,created_at,author_id,conversation_id",
+      });
+      const data = response.data as Record<string, unknown>;
+      const tweetData = (data?.data ?? data) as Record<string, unknown>;
+      const primaryTweet: TweetEntry = {
+        tweetId: String(tweetData.id ?? ""),
+        text: String(tweetData.text ?? ""),
+        url: `https://x.com/i/status/${tweetData.id}`,
+        createdAt: String(tweetData.created_at ?? ""),
+      };
+
+      // If the tweet has a conversation_id, fetch the thread via search
+      const conversationId = tweetData.conversation_id as string | undefined;
+      if (conversationId) {
+        try {
+          const threadResponse = await managedSearchRecentTweets(
+            `conversation_id:${conversationId}`,
+            {
+              "tweet.fields": "id,text,created_at,author_id",
+              max_results: "100",
+            },
+          );
+          const threadData = threadResponse.data as Record<string, unknown>;
+          const threadArray = (threadData?.data ?? []) as Array<
+            Record<string, unknown>
+          >;
+          const threadTweets: TweetEntry[] = threadArray.map((t) => ({
+            tweetId: String(t.id ?? ""),
+            text: String(t.text ?? ""),
+            url: `https://x.com/i/status/${t.id}`,
+            createdAt: String(t.created_at ?? ""),
+          }));
+          // Deduplicate: the primary tweet may already be in the search results
+          const seen = new Set(threadTweets.map((t) => t.tweetId));
+          if (!seen.has(primaryTweet.tweetId)) {
+            threadTweets.unshift(primaryTweet);
+          }
+          return { result: threadTweets, pathUsed: "managed" };
+        } catch {
+          // If thread search fails, fall back to returning just the single tweet
+        }
+      }
+
+      return { result: [primaryTweet], pathUsed: "managed" };
+    } catch (err) {
+      if (err instanceof TwitterProxyError) {
+        throw Object.assign(new Error(err.message), {
+          pathUsed: "managed" as const,
+          proxyErrorCode: err.code,
+          retryable: err.retryable,
+        });
+      }
+      throw err;
+    }
+  }
+
+  const result = await browserGetTweetDetail(tweetId);
+  return { result, pathUsed: "browser" };
+}
+
+/**
+ * Search tweets.
+ * Managed mode uses GET /2/tweets/search/recent; browser mode uses GraphQL SearchTimeline.
+ */
+export async function routedSearchTweets(
+  query: string,
+  product: "Top" | "Latest" | "People" | "Media",
+  opts: { strategy: TwitterStrategy },
+): Promise<RoutedResult<TweetEntry[]>> {
+  if (opts.strategy === "managed") {
+    if (product === "People" || product === "Media") {
+      throw Object.assign(
+        new Error(
+          `Product type "${product}" is not supported in managed mode. Only "Top" and "Latest" are supported.`,
+        ),
+        { pathUsed: "managed" as const },
+      );
+    }
+    try {
+      const queryParams: Record<string, string> = {
+        "tweet.fields": "id,text,created_at,author_id",
+      };
+      if (product === "Latest") {
+        queryParams.sort_order = "recency";
+      }
+      const response = await managedSearchRecentTweets(query, queryParams);
+      const data = response.data as Record<string, unknown>;
+      const tweetsArray = (data?.data ?? []) as Array<Record<string, unknown>>;
+      const tweets: TweetEntry[] = tweetsArray.map((t) => ({
+        tweetId: String(t.id ?? ""),
+        text: String(t.text ?? ""),
+        url: `https://x.com/i/status/${t.id}`,
+        createdAt: String(t.created_at ?? ""),
+      }));
+      return { result: tweets, pathUsed: "managed" };
+    } catch (err) {
+      if (err instanceof TwitterProxyError) {
+        throw Object.assign(new Error(err.message), {
+          pathUsed: "managed" as const,
+          proxyErrorCode: err.code,
+          retryable: err.retryable,
+        });
+      }
+      throw err;
+    }
+  }
+
+  const result = await browserSearchTweets(query, product);
+  return { result, pathUsed: "browser" };
 }

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -27,6 +27,15 @@ When `twitter.integrationMode` is set to `managed`, the platform holds the OAuth
 - *"Sign in as the assistant owner"* — The current user is not the assistant owner.
 - *"Reconnect Twitter or retry"* — The platform's OAuth token may have expired. Reconnect on the platform.
 
+**Architecture notes for managed mode:**
+
+- **Assistant hosting mode and Twitter credential mode are separate concepts.** An assistant can be self-hosted (local daemon) yet use managed Twitter credentials, or platform-hosted yet use local BYO OAuth. The `twitter.integrationMode` config controls credential mode; the assistant's hosting mode is determined by its lockfile entry.
+- **Managed Twitter is bound to the assistant owner.** Only the owner of the assistant (as determined by the platform) can connect or disconnect the Twitter account. Non-owner users receive a `403` with an `owner_only` or `owner_credential_required` error code.
+- **Connect/disconnect/status uses desktop session authentication.** The macOS Settings UI calls the platform's Twitter OAuth endpoints using the user's `X-Session-Token` header (obtained during managed sign-in via WorkOS). This authenticates the human user, not the assistant.
+- **Actual Twitter API calls use assistant-level API key authentication.** At runtime, the proxy client sends `Authorization: Api-Key {assistant_api_key}` — it never includes user-level session tokens or OAuth tokens. This ensures the assistant's identity is what the platform uses for token lookup and rate limiting.
+- **The platform proxy handles token storage and refresh.** OAuth tokens are stored server-side by the platform. The assistant never sees or stores the Twitter OAuth access/refresh tokens in managed mode. Token refresh is handled transparently by the proxy.
+- **The daemon auth handler never starts local OAuth in managed mode.** When `integrationMode` is `managed`, `handleTwitterAuthStart` returns a managed-specific error code (`managed_auth_via_platform` or `managed_missing_api_key`) and never calls `orchestrateOAuthConnect`. This is a critical guardrail to prevent credential confusion.
+
 ### OAuth (recommended with X developer credentials)
 
 OAuth uses the official X API v2. It is the most reliable connection method and does not depend on browser sessions.

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -9,7 +9,23 @@ You are an X (formerly Twitter) assistant. Use the `bash` tool to run `assistant
 
 ## Connection Options
 
-There are two supported ways to connect to X. Both are fully functional; choose whichever fits the user's situation.
+There are three supported ways to connect to X. Choose whichever fits the user's situation.
+
+### Managed mode (platform-hosted credentials)
+
+When `twitter.integrationMode` is set to `managed`, the platform holds the OAuth credentials and proxies Twitter API calls on behalf of the assistant. No local OAuth setup or browser session is needed.
+
+- Supports: **post** and **reply** (routed through the platform proxy)
+- Read-only operations still use the browser path when available.
+- Prerequisites: The assistant must be registered with the platform (`PLATFORM_ASSISTANT_ID`), have an API key (`credential:vellum:assistant_api_key`), and the assistant owner must have connected their Twitter account on the platform.
+- The strategy is automatically set to `managed` when `integrationMode` is `managed` and prerequisites are satisfied.
+
+**Error scenarios in managed mode:**
+- *"Assistant not bootstrapped"* — The assistant API key is missing. Run setup.
+- *"Local assistant not registered with platform"* — `PLATFORM_ASSISTANT_ID` is not set.
+- *"Connect Twitter in Settings as the assistant owner"* — The owner hasn't connected their X account on the platform yet.
+- *"Sign in as the assistant owner"* — The current user is not the assistant owner.
+- *"Reconnect Twitter or retry"* — The platform's OAuth token may have expired. Reconnect on the platform.
 
 ### OAuth (recommended with X developer credentials)
 
@@ -95,6 +111,11 @@ When a Twitter operation fails, follow these steps:
    - `Twitter API error (401)` — OAuth token may be expired or revoked.
    - `UnsupportedOAuthOperationError` — the requested write operation is not available via OAuth.
    - `Cannot connect to assistant` — the Vellum assistant is not running.
+   - `proxyErrorCode: "owner_credential_required"` — managed mode: the assistant owner has not connected their X account on the platform.
+   - `proxyErrorCode: "owner_only"` — managed mode: the current user is not the assistant owner.
+   - `proxyErrorCode: "auth_failure"` or `"upstream_failure"` — managed mode: platform token issue, reconnect Twitter on the platform.
+   - `proxyErrorCode: "missing_assistant_api_key"` — managed mode: the assistant is not bootstrapped.
+   - `proxyErrorCode: "missing_platform_assistant_id"` — managed mode: the assistant is not registered with the platform.
 
 2. **Explain the likely cause clearly** to the user.
 
@@ -102,6 +123,7 @@ When a Twitter operation fails, follow these steps:
    - If the browser session expired: suggest setting up OAuth for post/reply operations, or refresh the browser session with `assistant x refresh`.
    - If OAuth failed or is not configured: suggest using the browser path with `assistant config set twitter.operationStrategy browser` and `assistant x refresh`.
    - If the operation is unsupported via OAuth: explain that this write operation is not yet supported via OAuth, and suggest using the browser path with `assistant config set twitter.operationStrategy browser`.
+   - If managed mode failed with a credential or ownership error: explain the specific issue and guide the user to resolve it on the platform (connect Twitter, sign in as owner, etc.).
 
 4. **Offer concrete steps to switch:**
 
@@ -130,34 +152,44 @@ assistant x status --json
 
 ## Posting
 
-Before posting, fetch the current strategy and OAuth token:
+Before posting, check the integration mode and fetch the current strategy:
 
 ```bash
-# 1. Get the configured strategy
+# 1. Check integration mode
+MODE=$(assistant config get twitter.integrationMode)
+
+# 2. Get the configured strategy
 STRATEGY=$(assistant config get twitter.operationStrategy)
 # If not set, default to "auto"
-
-# 2. If strategy is "oauth" or "auto", get a valid OAuth token
-TOKEN=$(assistant oauth token twitter)
 ```
 
-Then post with the fetched values:
+Then post based on the mode and strategy:
 
 ```bash
+# Managed mode — route through platform proxy (no local token needed):
+assistant x post "The post text here" --strategy managed
+
 # With OAuth token (strategy is oauth or auto):
+TOKEN=$(assistant oauth token twitter)
 assistant x post "The post text here" --strategy "$STRATEGY" --oauth-token "$TOKEN"
 
 # With browser-only strategy:
 assistant x post "The post text here" --strategy browser
 ```
 
-Returns JSON with `ok`, `tweetId`, `text`, `url`, and `pathUsed` fields. Share the URL with the user so they can verify the post.
+When `twitter.integrationMode` is `managed`, always use `--strategy managed`. The platform proxy handles authentication.
+
+Returns JSON with `ok`, `tweetId`, `text`, `url`, and `pathUsed` fields. Share the URL with the user so they can verify the post. For managed mode errors, the response includes `proxyErrorCode` and `retryable` fields.
 
 ## Replying
 
-Same setup as posting — fetch strategy and token first, then:
+Same setup as posting — check integration mode and fetch strategy first, then:
 
 ```bash
+# Managed mode:
+assistant x reply <tweetUrl> "The reply text here" --strategy managed
+
+# Local OAuth or auto:
 assistant x reply <tweetUrl> "The reply text here" --strategy "$STRATEGY" --oauth-token "$TOKEN"
 ```
 

--- a/assistant/src/daemon/message-types/integrations.ts
+++ b/assistant/src/daemon/message-types/integrations.ts
@@ -140,11 +140,22 @@ export interface VercelApiConfigResponse {
   error?: string;
 }
 
+export interface ManagedPrerequisites {
+  /** Whether twitter.integrationMode is set to "managed" in config. */
+  integrationModeManaged: boolean;
+  /** Whether the assistant API key credential exists in secure storage. */
+  assistantApiKeyPresent: boolean;
+  /** Whether the platform base URL is configured (platform registration resolvable). */
+  platformAssistantIdResolvable: boolean;
+}
+
 export interface TwitterIntegrationConfigResponse {
   type: "twitter_integration_config_response";
   success: boolean;
   mode?: "local_byo" | "managed";
   managedAvailable: boolean;
+  /** Detailed prerequisite status for managed Twitter availability. */
+  managedPrerequisites?: ManagedPrerequisites;
   localClientConfigured: boolean;
   connected: boolean;
   accountInfo?: string;
@@ -210,6 +221,8 @@ export interface TwitterAuthResult {
   type: "twitter_auth_result";
   success: boolean;
   accountInfo?: string;
+  /** Machine-readable error code for programmatic handling (e.g. "managed_missing_api_key", "managed_auth_via_platform"). */
+  errorCode?: string;
   error?: string;
 }
 

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -16,6 +16,10 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import {
+  getPlatformAssistantId,
+  getPlatformBaseUrl,
+} from "../../config/env.js";
+import {
   getNestedValue,
   invalidateConfigCache,
   loadConfig,
@@ -298,6 +302,29 @@ async function handleTwitterAuthStart(): Promise<Response> {
     const mode =
       (getNestedValue(raw, "twitter.integrationMode") as string | undefined) ??
       "local_byo";
+    if (mode === "managed") {
+      const apiKey = getSecureKey("credential:vellum:assistant_api_key");
+      if (!apiKey) {
+        return Response.json(
+          {
+            ok: false,
+            error:
+              "An AssistantAPIKey is required for managed Twitter. Run assistant setup.",
+            errorCode: "managed_missing_api_key",
+          },
+          { status: 400 },
+        );
+      }
+      return Response.json(
+        {
+          ok: false,
+          error:
+            "Managed Twitter authentication is handled through the Vellum platform. Open Settings to connect.",
+          errorCode: "managed_auth_via_platform",
+        },
+        { status: 400 },
+      );
+    }
     if (mode !== "local_byo") {
       return httpError(
         "BAD_REQUEST",
@@ -395,11 +422,7 @@ async function handleTwitterAuthStart(): Promise<Response> {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Twitter OAuth flow failed");
-    return httpError(
-      "INTERNAL_ERROR",
-      sanitizeTwitterAuthError(message),
-      500,
-    );
+    return httpError("INTERNAL_ERROR", sanitizeTwitterAuthError(message), 500);
   }
 }
 
@@ -418,10 +441,54 @@ function handleTwitterAuthStatus(): Response {
       | string
       | undefined;
 
+    // Managed prerequisites
+    const integrationModeManaged = mode === "managed";
+    const assistantApiKeyPresent = !!getSecureKey(
+      "credential:vellum:assistant_api_key",
+    );
+    const platformBaseUrlFromEnv = getPlatformBaseUrl();
+    const platformBaseUrlFromConfig = (
+      raw?.platform as Record<string, unknown> | undefined
+    )?.baseUrl as string | undefined;
+    const platformAssistantIdResolvable = !!(
+      (platformBaseUrlFromEnv || platformBaseUrlFromConfig) &&
+      getPlatformAssistantId()
+    );
+
+    const managedPrerequisites = {
+      integrationModeManaged,
+      assistantApiKeyPresent,
+      platformAssistantIdResolvable,
+    };
+    const managedAvailable =
+      integrationModeManaged &&
+      assistantApiKeyPresent &&
+      platformAssistantIdResolvable;
+
+    // Local client configured
+    const localClientConfigured = !!getSecureKey(
+      "credential:integration:twitter:client_id",
+    );
+
+    // Strategy
+    const strategyRaw = getNestedValue(raw, "twitter.strategy") as
+      | string
+      | undefined;
+    const strategy = strategyRaw ?? "auto";
+    const strategyConfigured = strategyRaw !== undefined;
+
+    // In managed mode, connected is always false (auth goes through platform)
+    const connected = mode === "managed" ? false : !!accessToken;
+
     return Response.json({
-      connected: !!accessToken,
+      connected,
       accountInfo: accountInfo ?? undefined,
       mode,
+      managedAvailable,
+      managedPrerequisites,
+      localClientConfigured,
+      strategy,
+      strategyConfigured,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -589,7 +656,8 @@ function handleToolNamesList(): Response {
         for (const entry of manifest.tools) {
           if (nameSet.has(entry.name)) continue;
           nameSet.add(entry.name);
-          schemas[entry.name] = entry.input_schema as unknown as (typeof schemas)[string];
+          schemas[entry.name] =
+            entry.input_schema as unknown as (typeof schemas)[string];
         }
       } catch {
         // Skip skills whose manifests can't be parsed
@@ -779,11 +847,7 @@ export function settingsRouteDefinitions(): RouteDefinition[] {
       handler: async ({ req }) => {
         const body = (await req.json()) as { activationKey?: string };
         if (!body.activationKey) {
-          return httpError(
-            "BAD_REQUEST",
-            "activationKey is required",
-            400,
-          );
+          return httpError("BAD_REQUEST", "activationKey is required", 400);
         }
         return handleVoiceConfigUpdate(body.activationKey);
       },
@@ -808,11 +872,7 @@ export function settingsRouteDefinitions(): RouteDefinition[] {
       handler: async ({ req }) => {
         const body = (await req.json()) as { key?: string; value?: string };
         if (!body.key || body.value === undefined) {
-          return httpError(
-            "BAD_REQUEST",
-            "key and value are required",
-            400,
-          );
+          return httpError("BAD_REQUEST", "key and value are required", 400);
         }
         return handleClientSettingsUpdate(body.key, body.value);
       },
@@ -871,7 +931,11 @@ export function settingsRouteDefinitions(): RouteDefinition[] {
       handler: ({ url }) => {
         const filePath = url.searchParams.get("path") ?? "";
         if (!filePath) {
-          return httpError("BAD_REQUEST", "path query parameter is required", 400);
+          return httpError(
+            "BAD_REQUEST",
+            "path query parameter is required",
+            400,
+          );
         }
         return handleWorkspaceFileRead(filePath);
       },

--- a/assistant/src/twitter/platform-proxy-client.ts
+++ b/assistant/src/twitter/platform-proxy-client.ts
@@ -131,7 +131,10 @@ export interface TwitterProxyResponse<T = unknown> {
 // Error mapping
 // ---------------------------------------------------------------------------
 
-function mapProxyError(status: number, body: unknown): TwitterProxyError {
+export function mapProxyError(
+  status: number,
+  body: unknown,
+): TwitterProxyError {
   const obj =
     typeof body === "object" && body
       ? (body as Record<string, unknown>)

--- a/assistant/src/twitter/platform-proxy-client.ts
+++ b/assistant/src/twitter/platform-proxy-client.ts
@@ -322,3 +322,59 @@ export async function getMe(
     query,
   });
 }
+
+/**
+ * Look up a user by screen name through the platform proxy.
+ */
+export async function getUserByUsername(
+  username: string,
+  query?: Record<string, string>,
+): Promise<TwitterProxyResponse> {
+  return proxyTwitterCall({
+    method: "GET",
+    path: `/2/users/by/username/${encodeURIComponent(username)}`,
+    query,
+  });
+}
+
+/**
+ * Fetch a user's tweets through the platform proxy.
+ */
+export async function getUserTweets(
+  userId: string,
+  query?: Record<string, string>,
+): Promise<TwitterProxyResponse> {
+  return proxyTwitterCall({
+    method: "GET",
+    path: `/2/users/${encodeURIComponent(userId)}/tweets`,
+    query,
+  });
+}
+
+/**
+ * Fetch a single tweet by ID through the platform proxy.
+ */
+export async function getTweet(
+  tweetId: string,
+  query?: Record<string, string>,
+): Promise<TwitterProxyResponse> {
+  return proxyTwitterCall({
+    method: "GET",
+    path: `/2/tweets/${encodeURIComponent(tweetId)}`,
+    query,
+  });
+}
+
+/**
+ * Search recent tweets through the platform proxy.
+ */
+export async function searchRecentTweets(
+  queryStr: string,
+  query?: Record<string, string>,
+): Promise<TwitterProxyResponse> {
+  return proxyTwitterCall({
+    method: "GET",
+    path: "/2/tweets/search/recent",
+    query: { ...query, query: queryStr },
+  });
+}

--- a/assistant/src/twitter/platform-proxy-client.ts
+++ b/assistant/src/twitter/platform-proxy-client.ts
@@ -1,0 +1,324 @@
+/**
+ * Platform-managed Twitter proxy client.
+ *
+ * Proxies Twitter API calls through the platform instead of calling the
+ * Twitter API directly. Used when the Twitter integration is in "managed"
+ * mode — the platform holds the OAuth credentials and forwards requests
+ * on behalf of the assistant.
+ *
+ * Prerequisites:
+ * - Platform base URL (env `PLATFORM_BASE_URL` or config `platform.baseUrl`)
+ * - Auth token (secure key `credential:vellum:assistant_api_key`)
+ * - Platform assistant ID (env `PLATFORM_ASSISTANT_ID`)
+ */
+
+import { getPlatformAssistantId, getPlatformBaseUrl } from "../config/env.js";
+import { getConfig } from "../config/loader.js";
+import { getSecureKey } from "../security/secure-keys.js";
+import { BackendError } from "../util/errors.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("twitter-proxy");
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+export class TwitterProxyError extends BackendError {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly retryable: boolean,
+    public readonly statusCode: number = 0,
+  ) {
+    super(message);
+    this.name = "TwitterProxyError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Prerequisite resolution
+// ---------------------------------------------------------------------------
+
+export interface TwitterProxyPrerequisites {
+  platformBaseUrl: string;
+  authToken: string;
+  platformAssistantId: string;
+}
+
+/**
+ * Resolve the platform base URL from config or environment.
+ * Config `platform.baseUrl` takes precedence over `PLATFORM_BASE_URL` env.
+ */
+export function resolvePlatformBaseUrl(): string {
+  const configUrl = getConfig().platform.baseUrl;
+  const envUrl = getPlatformBaseUrl();
+  return (configUrl || envUrl).replace(/\/+$/, "");
+}
+
+/**
+ * Resolve the assistant auth token from secure storage.
+ */
+export function resolveAuthToken(): string | undefined {
+  return getSecureKey("credential:vellum:assistant_api_key");
+}
+
+/**
+ * Resolve the platform assistant ID from environment.
+ */
+export function resolvePlatformAssistantId(): string {
+  return getPlatformAssistantId();
+}
+
+/**
+ * Resolve all prerequisites for managed Twitter proxy calls.
+ * Throws a descriptive `TwitterProxyError` if any prerequisite is missing.
+ */
+export function resolvePrerequisites(): TwitterProxyPrerequisites {
+  const platformAssistantId = resolvePlatformAssistantId();
+  if (!platformAssistantId) {
+    throw new TwitterProxyError(
+      "Local assistant not registered with platform",
+      "missing_platform_assistant_id",
+      false,
+    );
+  }
+
+  const authToken = resolveAuthToken();
+  if (!authToken) {
+    throw new TwitterProxyError(
+      "Assistant not bootstrapped — run setup",
+      "missing_assistant_api_key",
+      false,
+    );
+  }
+
+  const platformBaseUrl = resolvePlatformBaseUrl();
+  if (!platformBaseUrl) {
+    throw new TwitterProxyError(
+      "Platform base URL is not configured",
+      "missing_platform_base_url",
+      false,
+    );
+  }
+
+  return { platformBaseUrl, authToken, platformAssistantId };
+}
+
+// ---------------------------------------------------------------------------
+// Proxy request/response types
+// ---------------------------------------------------------------------------
+
+export interface TwitterProxyRequest {
+  /** HTTP method for the underlying Twitter API call. */
+  method: "GET" | "POST" | "PUT" | "DELETE";
+  /** Twitter API path (e.g. "/2/tweets", "/2/users/me"). */
+  path: string;
+  /** JSON body for POST/PUT requests. */
+  body?: Record<string, unknown>;
+  /** Query parameters for GET-style requests. */
+  query?: Record<string, string>;
+}
+
+export interface TwitterProxyResponse<T = unknown> {
+  /** Parsed response data from the Twitter API. */
+  data: T;
+  /** HTTP status code from the proxy response. */
+  status: number;
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+function mapProxyError(status: number, body: unknown): TwitterProxyError {
+  const obj =
+    typeof body === "object" && body
+      ? (body as Record<string, unknown>)
+      : undefined;
+  const detail = obj?.detail ?? obj?.message ?? obj?.error;
+  const detailStr = detail ? String(detail) : `HTTP ${status}`;
+
+  if (status === 403) {
+    const msg = String(detailStr).toLowerCase();
+    if (msg.includes("owner") && msg.includes("credential")) {
+      return new TwitterProxyError(
+        "Connect Twitter in Settings as the assistant owner",
+        "owner_credential_required",
+        false,
+        status,
+      );
+    }
+    if (msg.includes("owner")) {
+      return new TwitterProxyError(
+        "Sign in as the assistant owner",
+        "owner_only",
+        false,
+        status,
+      );
+    }
+    return new TwitterProxyError(
+      `Forbidden: ${detailStr}`,
+      "forbidden",
+      false,
+      status,
+    );
+  }
+
+  if (status === 401) {
+    return new TwitterProxyError(
+      "Reconnect Twitter or retry",
+      "auth_failure",
+      true,
+      status,
+    );
+  }
+
+  if (status === 502 || status === 503 || status === 504) {
+    return new TwitterProxyError(
+      "Reconnect Twitter or retry",
+      "upstream_failure",
+      true,
+      status,
+    );
+  }
+
+  if (status === 429) {
+    return new TwitterProxyError(
+      "Rate limit exceeded — retry later",
+      "rate_limit",
+      true,
+      status,
+    );
+  }
+
+  if (status >= 500) {
+    return new TwitterProxyError(
+      `Platform error: ${detailStr}`,
+      "platform_error",
+      true,
+      status,
+    );
+  }
+
+  return new TwitterProxyError(
+    `Proxy request failed: ${detailStr}`,
+    "proxy_error",
+    false,
+    status,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Proxy call
+// ---------------------------------------------------------------------------
+
+/**
+ * Send a Twitter API call through the platform proxy.
+ *
+ * The proxy endpoint is:
+ *   POST {platformBaseURL}/v1/assistants/{platform_assistant_id}/external-provider-proxy/twitter/
+ *
+ * The request body describes the Twitter API call to make:
+ *   { method, path, body?, query? }
+ *
+ * Auth uses `Authorization: Api-Key {auth_token}` (the assistant API key).
+ */
+export async function proxyTwitterCall<T = unknown>(
+  request: TwitterProxyRequest,
+): Promise<TwitterProxyResponse<T>> {
+  const { platformBaseUrl, authToken, platformAssistantId } =
+    resolvePrerequisites();
+
+  const url = `${platformBaseUrl}/v1/assistants/${platformAssistantId}/external-provider-proxy/twitter/`;
+
+  const headers: Record<string, string> = {
+    Authorization: `Api-Key ${authToken}`,
+    "Content-Type": "application/json",
+  };
+
+  log.debug(
+    { method: request.method, path: request.path },
+    "Proxying Twitter API call through platform",
+  );
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(request),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    const isTimeout =
+      err instanceof DOMException && err.name === "TimeoutError";
+    throw new TwitterProxyError(
+      isTimeout
+        ? "Platform proxy request timed out"
+        : `Network error: ${err instanceof Error ? err.message : String(err)}`,
+      isTimeout ? "timeout" : "network_error",
+      true,
+    );
+  }
+
+  if (!response.ok) {
+    let errorBody: unknown;
+    try {
+      errorBody = await response.json();
+    } catch {
+      errorBody = undefined;
+    }
+    throw mapProxyError(response.status, errorBody);
+  }
+
+  let data: T;
+  try {
+    data = (await response.json()) as T;
+  } catch (err) {
+    throw new TwitterProxyError(
+      `Failed to parse proxy response: ${err instanceof Error ? err.message : String(err)}`,
+      "unparseable_response",
+      false,
+      response.status,
+    );
+  }
+
+  return { data, status: response.status };
+}
+
+// ---------------------------------------------------------------------------
+// Convenience helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Post a tweet through the platform proxy.
+ */
+export async function postTweet(
+  text: string,
+  options?: { replyToId?: string },
+): Promise<TwitterProxyResponse> {
+  const body: Record<string, unknown> = { text };
+  if (options?.replyToId) {
+    body.reply = { in_reply_to_tweet_id: options.replyToId };
+  }
+
+  return proxyTwitterCall({
+    method: "POST",
+    path: "/2/tweets",
+    body,
+  });
+}
+
+/**
+ * Read the authenticated user's profile through the platform proxy.
+ */
+export async function getMe(
+  query?: Record<string, string>,
+): Promise<TwitterProxyResponse> {
+  return proxyTwitterCall({
+    method: "GET",
+    path: "/2/users/me",
+    query,
+  });
+}

--- a/assistant/src/twitter/platform-proxy-client.ts
+++ b/assistant/src/twitter/platform-proxy-client.ts
@@ -142,6 +142,15 @@ export function mapProxyError(
   const detail = obj?.detail ?? obj?.message ?? obj?.error;
   const detailStr = detail ? String(detail) : `HTTP ${status}`;
 
+  if (status === 424) {
+    return new TwitterProxyError(
+      "Connect Twitter in Settings — no active credential",
+      "credential_required",
+      false,
+      status,
+    );
+  }
+
   if (status === 403) {
     const msg = String(detailStr).toLowerCase();
     if (msg.includes("owner") && msg.includes("credential")) {
@@ -222,8 +231,10 @@ export function mapProxyError(
  * The proxy endpoint is:
  *   POST {platformBaseURL}/v1/assistants/{platform_assistant_id}/external-provider-proxy/twitter/
  *
- * The request body describes the Twitter API call to make:
- *   { method, path, body?, query? }
+ * The request body wraps the Twitter API call in an envelope:
+ *   { request: { method, path, body?, query?, headers? }, on_behalf_of_user_id? }
+ *
+ * The response is an envelope: { status, headers, body } where body is the Twitter payload.
  *
  * Auth uses `Authorization: Api-Key {auth_token}` (the assistant API key).
  */
@@ -250,7 +261,7 @@ export async function proxyTwitterCall<T = unknown>(
     response = await fetch(url, {
       method: "POST",
       headers,
-      body: JSON.stringify(request),
+      body: JSON.stringify({ request }),
       signal: AbortSignal.timeout(30_000),
     });
   } catch (err) {
@@ -265,6 +276,7 @@ export async function proxyTwitterCall<T = unknown>(
     );
   }
 
+  // Platform-level errors (proxy endpoint itself returned non-200)
   if (!response.ok) {
     let errorBody: unknown;
     try {
@@ -275,9 +287,14 @@ export async function proxyTwitterCall<T = unknown>(
     throw mapProxyError(response.status, errorBody);
   }
 
-  let data: T;
+  // Parse the proxy envelope
+  let envelope: {
+    status: number;
+    headers: Record<string, string>;
+    body: unknown;
+  };
   try {
-    data = (await response.json()) as T;
+    envelope = (await response.json()) as typeof envelope;
   } catch (err) {
     throw new TwitterProxyError(
       `Failed to parse proxy response: ${err instanceof Error ? err.message : String(err)}`,
@@ -287,7 +304,12 @@ export async function proxyTwitterCall<T = unknown>(
     );
   }
 
-  return { data, status: response.status };
+  // Check upstream status from the envelope
+  if (envelope.status >= 400) {
+    throw mapProxyError(envelope.status, envelope.body);
+  }
+
+  return { data: envelope.body as T, status: envelope.status };
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -766,3 +766,50 @@ Guardian approval prompts are rendered as structured card UIs in the chat timeli
 | `clients/shared/Features/Chat/ToolConfirmationBubble.swift` | Tool confirmation card (shares `ApprovalActionButton`) |
 
 ---
+
+## Managed Twitter OAuth (macOS)
+
+When `twitter.integrationMode` is `managed`, the macOS Settings UI enables the assistant owner to connect their Twitter/X account through the platform rather than using local BYO OAuth credentials.
+
+### Key Concepts
+
+- **Hosting mode vs. credential mode are independent.** An assistant can be self-hosted (local daemon) yet use platform-managed Twitter credentials. The `twitter.integrationMode` config controls credential mode; the assistant's hosting mode is determined by its lockfile entry.
+- **Owner-only binding.** Only the assistant owner can connect or disconnect the managed Twitter account. Non-owner users see a disabled state and cannot trigger connect/disconnect. The platform enforces this via 403 responses with `owner_only` or `owner_credential_required` error codes.
+
+### Authentication Layers
+
+| Flow | Header | Token Source | Purpose |
+|------|--------|-------------|---------|
+| Connect/disconnect/status (Settings UI) | `X-Session-Token` | WorkOS session (via `SessionTokenManager`) | Authenticates the human user to the platform |
+| Runtime Twitter API calls (proxy client) | `Authorization: Api-Key {key}` | `credential:vellum:assistant_api_key` (secure storage) | Authenticates the assistant to the platform proxy |
+
+The proxy client (`platform-proxy-client.ts`) never includes user-level session tokens or user OAuth tokens. Token storage and refresh are handled server-side by the platform.
+
+### Connect Flow
+
+```
+Owner clicks "Connect Twitter" in Settings
+  --> PlatformTwitterOAuthService.connect(assistantId:)
+  --> POST /v1/assistants/{id}/twitter-oauth/connect/
+      (with X-Session-Token header)
+  --> Platform redirects to Twitter OAuth
+  --> Callback to platform, token stored server-side
+  --> Settings UI polls status until connected
+```
+
+### Daemon Guardrail
+
+When `integrationMode` is `managed`, the daemon's `handleTwitterAuthStart` handler returns a managed-specific error code (`managed_auth_via_platform` or `managed_missing_api_key`) and never calls `orchestrateOAuthConnect`. This prevents credential confusion between managed and local BYO flows.
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `clients/shared/App/Auth/PlatformTwitterOAuthService.swift` | Swift client for platform Twitter OAuth connect/disconnect/status |
+| `clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift` | Settings state including managed Twitter connection UI |
+| `assistant/src/daemon/handlers/twitter-auth.ts` | Daemon auth handler with managed mode guardrail |
+| `assistant/src/twitter/platform-proxy-client.ts` | Runtime proxy client (Api-Key auth, no user tokens) |
+| `assistant/src/cli/commands/twitter/router.ts` | Strategy router dispatching to managed/oauth/browser paths |
+| `assistant/src/config/bundled-skills/twitter/SKILL.md` | Skill documentation including managed mode architecture |
+
+---

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -617,14 +617,24 @@ struct SettingsPanel: View {
                 }
             }
 
-            // Managed mode "coming soon"
+            // Managed mode status
             if store.twitterMode == "managed" {
-                HStack(spacing: VSpacing.sm) {
-                    VIconView(.info, size: 14)
-                        .foregroundStyle(VColor.textSecondary)
-                    Text("Managed mode is coming soon. Switch to Local (BYO App) to connect now.")
-                        .font(VFont.caption)
-                        .foregroundStyle(VColor.textSecondary)
+                if store.isManagedTwitterEligible {
+                    HStack(spacing: VSpacing.sm) {
+                        VIconView(.circleCheck, size: 14)
+                            .foregroundStyle(VColor.textSecondary)
+                        Text("Managed Twitter is ready. Authentication is handled by the platform.")
+                            .font(VFont.caption)
+                            .foregroundStyle(VColor.textSecondary)
+                    }
+                } else if let reason = store.managedTwitterBlockReason {
+                    HStack(spacing: VSpacing.sm) {
+                        VIconView(.info, size: 14)
+                            .foregroundStyle(VColor.textSecondary)
+                        Text(reason)
+                            .font(VFont.caption)
+                            .foregroundStyle(VColor.textSecondary)
+                    }
                 }
             }
 

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -148,6 +148,7 @@ struct SettingsPanel: View {
         .onAppear {
             store.refreshAPIKeyState()
             store.refreshTwitterStatus()
+            store.refreshManagedTwitterStatus()
             store.refreshTelegramStatus()
             store.refreshTwilioStatus()
             store.refreshIngressConfig()
@@ -194,6 +195,9 @@ struct SettingsPanel: View {
             Task { @MainActor in
                 await refreshPermissionStatus()
             }
+            // Refresh managed Twitter status when app regains focus (e.g. after
+            // completing the OAuth flow in the browser).
+            store.refreshManagedTwitterStatus()
         }
         .sheet(isPresented: $showingTrustRules) {
             if let daemonClient {
@@ -619,21 +623,72 @@ struct SettingsPanel: View {
 
             // Managed mode status
             if store.twitterMode == "managed" {
-                if store.isManagedTwitterEligible {
+                if !authManager.isAuthenticated {
+                    // State 1: Not signed in
                     HStack(spacing: VSpacing.sm) {
-                        VIconView(.circleCheck, size: 14)
-                            .foregroundStyle(VColor.textSecondary)
-                        Text("Managed Twitter is ready. Authentication is handled by the platform.")
-                            .font(VFont.caption)
-                            .foregroundStyle(VColor.textSecondary)
+                        VButton(label: "Connect", style: .primary) {}
+                            .disabled(true)
                     }
-                } else if let reason = store.managedTwitterBlockReason {
                     HStack(spacing: VSpacing.sm) {
                         VIconView(.info, size: 14)
                             .foregroundStyle(VColor.textSecondary)
-                        Text(reason)
+                        Text("Sign in to Vellum to use Managed")
                             .font(VFont.caption)
                             .foregroundStyle(VColor.textSecondary)
+                    }
+                } else if !store.isManagedTwitterEligible {
+                    // State 2/3: Signed in but prerequisites not met
+                    HStack(spacing: VSpacing.sm) {
+                        VButton(label: "Connect", style: .primary) {}
+                            .disabled(true)
+                    }
+                    if let reason = store.managedTwitterBlockReason {
+                        HStack(spacing: VSpacing.sm) {
+                            VIconView(.info, size: 14)
+                                .foregroundStyle(VColor.textSecondary)
+                            Text(reason)
+                                .font(VFont.caption)
+                                .foregroundStyle(VColor.textSecondary)
+                        }
+                    }
+                } else if store.managedTwitterConnected {
+                    // State 5: Connected
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        HStack(spacing: VSpacing.sm) {
+                            VButton(label: "Connected", leftIcon: VIcon.circleCheck.rawValue, style: .success) {}
+                            VButton(label: "Disconnect", style: .danger) {
+                                store.disconnectManagedTwitter()
+                            }
+                            .disabled(store.managedTwitterConnectInProgress)
+                        }
+                        if let account = store.managedTwitterAccountInfo {
+                            Text(account)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.textMuted)
+                        }
+                    }
+                } else if store.managedTwitterConnectInProgress {
+                    // State 6: In progress
+                    HStack(spacing: VSpacing.sm) {
+                        VButton(label: "Connect", style: .primary) {}
+                            .disabled(true)
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Opening browser...")
+                            .font(VFont.caption)
+                            .foregroundColor(VColor.textSecondary)
+                    }
+                } else {
+                    // State 4: Eligible + disconnected
+                    VStack(alignment: .leading, spacing: VSpacing.sm) {
+                        VButton(label: "Connect", style: .primary) {
+                            store.connectManagedTwitter()
+                        }
+                        if let error = store.managedTwitterError {
+                            Text(error)
+                                .font(VFont.caption)
+                                .foregroundColor(VColor.error)
+                        }
                     }
                 }
             }

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1031,13 +1031,13 @@ public final class SettingsStore: ObservableObject {
 
             let service = PlatformTwitterOAuthService(baseURL: ctx.baseURL)
             do {
-                let response = try await service.listConnections(
+                let connections = try await service.listConnections(
                     platformAssistantId: ctx.platformAssistantId,
                     organizationId: ctx.organizationId
                 )
-                if let connection = response.connections.first {
+                if let connection = connections.first(where: { $0.provider == "twitter" }), connection.connected {
                     managedTwitterConnected = true
-                    managedTwitterAccountInfo = connection.accountInfo
+                    managedTwitterAccountInfo = connection.accountLabel
                 } else {
                     managedTwitterConnected = false
                     managedTwitterAccountInfo = nil
@@ -1069,7 +1069,7 @@ public final class SettingsStore: ObservableObject {
                     platformAssistantId: ctx.platformAssistantId,
                     organizationId: ctx.organizationId
                 )
-                if let url = URL(string: response.authorizationUrl) {
+                if let url = URL(string: response.connectUrl) {
                     NSWorkspace.shared.open(url)
                 } else {
                     managedTwitterError = "Invalid authorization URL received."

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Carbon.HIToolbox
 import Combine
 import Foundation
@@ -90,6 +91,12 @@ public final class SettingsStore: ObservableObject {
     @Published var twitterAuthInProgress: Bool = false
     @Published var twitterAuthErrorCode: String?
     @Published var twitterAuthError: String?
+
+    // Managed Twitter connection state (populated via PlatformTwitterOAuthService)
+    @Published var managedTwitterConnected: Bool = false
+    @Published var managedTwitterAccountInfo: String?
+    @Published var managedTwitterConnectInProgress: Bool = false
+    @Published var managedTwitterError: String?
 
     /// Whether all managed Twitter prerequisites are met.
     var isManagedTwitterEligible: Bool {
@@ -977,6 +984,127 @@ public final class SettingsStore: ObservableObject {
             try daemonClient?.send(TwitterIntegrationConfigRequestMessage(action: "disconnect"))
         } catch {
             log.error("Failed to send Twitter disconnect: \(error)")
+        }
+    }
+
+    // MARK: - Managed Twitter Actions
+
+    /// Resolves the platform assistant ID and organization ID for managed Twitter calls.
+    /// Returns nil if the required context is unavailable.
+    private func resolveManagedTwitterContext() async -> (platformAssistantId: String, organizationId: String, baseURL: String)? {
+        let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId")
+        let assistant = connectedId.flatMap { LockfileAssistant.loadByName($0) }
+            ?? LockfileAssistant.loadLatest()
+        guard let assistant else { return nil }
+
+        guard let orgId = UserDefaults.standard.string(forKey: "connectedOrganizationId"),
+              !orgId.isEmpty else { return nil }
+
+        // Resolve the current user ID from the auth session so self-hosted local
+        // assistants can look up their persisted platform assistant ID.
+        let userId: String? = try? await AuthService.shared.getSession().data?.user?.id
+
+        let platformId = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: assistant.assistantId,
+            isManaged: assistant.isManaged,
+            organizationId: orgId,
+            userId: userId,
+            credentialStorage: KeychainCredentialStorage()
+        )
+        guard let platformId else { return nil }
+
+        let baseURL = assistant.runtimeUrl ?? AuthService.shared.baseURL
+        return (platformAssistantId: platformId, organizationId: orgId, baseURL: baseURL)
+    }
+
+    /// Fetches managed Twitter connection status from the platform.
+    func refreshManagedTwitterStatus() {
+        Task { @MainActor in
+            guard let ctx = await resolveManagedTwitterContext() else {
+                managedTwitterConnected = false
+                managedTwitterAccountInfo = nil
+                return
+            }
+
+            let service = PlatformTwitterOAuthService(baseURL: ctx.baseURL)
+            do {
+                let response = try await service.listConnections(
+                    platformAssistantId: ctx.platformAssistantId,
+                    organizationId: ctx.organizationId
+                )
+                if let connection = response.connections.first {
+                    managedTwitterConnected = true
+                    managedTwitterAccountInfo = connection.accountInfo
+                } else {
+                    managedTwitterConnected = false
+                    managedTwitterAccountInfo = nil
+                }
+                managedTwitterError = nil
+            } catch {
+                log.error("Failed to fetch managed Twitter status: \(error)")
+                managedTwitterError = error.localizedDescription
+            }
+        }
+    }
+
+    /// Starts the managed Twitter OAuth connect flow: calls the platform to get
+    /// an authorization URL and opens it in the default browser.
+    func connectManagedTwitter() {
+        managedTwitterConnectInProgress = true
+        managedTwitterError = nil
+        Task { @MainActor in
+            defer { managedTwitterConnectInProgress = false }
+
+            guard let ctx = await resolveManagedTwitterContext() else {
+                managedTwitterError = "Unable to resolve platform assistant. Check your account settings."
+                return
+            }
+
+            let service = PlatformTwitterOAuthService(baseURL: ctx.baseURL)
+            do {
+                let response = try await service.startTwitterConnect(
+                    platformAssistantId: ctx.platformAssistantId,
+                    organizationId: ctx.organizationId
+                )
+                if let url = URL(string: response.authorizationUrl) {
+                    NSWorkspace.shared.open(url)
+                } else {
+                    managedTwitterError = "Invalid authorization URL received."
+                }
+            } catch {
+                log.error("Failed to start managed Twitter connect: \(error)")
+                managedTwitterError = error.localizedDescription
+            }
+        }
+    }
+
+    /// Disconnects the managed Twitter connection via the platform API.
+    func disconnectManagedTwitter() {
+        managedTwitterConnectInProgress = true
+        managedTwitterError = nil
+        Task { @MainActor in
+            defer { managedTwitterConnectInProgress = false }
+
+            guard let ctx = await resolveManagedTwitterContext() else {
+                managedTwitterError = "Unable to resolve platform assistant. Check your account settings."
+                return
+            }
+
+            let service = PlatformTwitterOAuthService(baseURL: ctx.baseURL)
+            do {
+                _ = try await service.disconnectTwitter(
+                    platformAssistantId: ctx.platformAssistantId,
+                    organizationId: ctx.organizationId
+                )
+                managedTwitterConnected = false
+                managedTwitterAccountInfo = nil
+                managedTwitterError = nil
+                // Refresh to confirm
+                refreshManagedTwitterStatus()
+            } catch {
+                log.error("Failed to disconnect managed Twitter: \(error)")
+                managedTwitterError = error.localizedDescription
+            }
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1013,7 +1013,10 @@ public final class SettingsStore: ObservableObject {
         )
         guard let platformId else { return nil }
 
-        let baseURL = assistant.runtimeUrl ?? AuthService.shared.baseURL
+        // Always use the platform base URL for managed Twitter OAuth API calls.
+        // The assistant's runtimeUrl points to the local daemon endpoint for
+        // self-hosted assistants, which is not the platform API.
+        let baseURL = AuthService.shared.baseURL
         return (platformAssistantId: platformId, organizationId: orgId, baseURL: baseURL)
     }
 

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -83,11 +83,35 @@ public final class SettingsStore: ObservableObject {
 
     @Published var twitterMode: String = "local_byo"
     @Published var twitterManagedAvailable: Bool = false
+    @Published var twitterManagedPrerequisites: IPCManagedPrerequisites?
     @Published var twitterLocalClientConfigured: Bool = false
     @Published var twitterConnected: Bool = false
     @Published var twitterAccountInfo: String?
     @Published var twitterAuthInProgress: Bool = false
+    @Published var twitterAuthErrorCode: String?
     @Published var twitterAuthError: String?
+
+    /// Whether all managed Twitter prerequisites are met.
+    var isManagedTwitterEligible: Bool {
+        twitterManagedAvailable
+    }
+
+    /// Human-readable reason why managed Twitter is not available, or nil if eligible.
+    var managedTwitterBlockReason: String? {
+        guard let prereqs = twitterManagedPrerequisites else {
+            return "Managed Twitter status is unavailable."
+        }
+        if !prereqs.integrationModeManaged {
+            return "Switch to Managed mode to use platform-managed Twitter."
+        }
+        if !prereqs.assistantApiKeyPresent {
+            return "Assistant API key is not configured. Set up your API key in settings."
+        }
+        if !prereqs.platformAssistantIdResolvable {
+            return "Platform connection is not configured. Set up your platform URL."
+        }
+        return nil
+    }
 
     // MARK: - Telegram Integration State
 
@@ -471,6 +495,7 @@ public final class SettingsStore: ObservableObject {
             if response.success {
                 self.twitterMode = response.mode ?? "local_byo"
                 self.twitterManagedAvailable = response.managedAvailable
+                self.twitterManagedPrerequisites = response.managedPrerequisites
                 self.twitterLocalClientConfigured = response.localClientConfigured
                 self.twitterConnected = response.connected
                 self.twitterAccountInfo = response.accountInfo
@@ -544,8 +569,10 @@ public final class SettingsStore: ObservableObject {
             if response.success {
                 self.twitterConnected = true
                 self.twitterAccountInfo = response.accountInfo
+                self.twitterAuthErrorCode = nil
                 self.twitterAuthError = nil
             } else {
+                self.twitterAuthErrorCode = response.errorCode
                 self.twitterAuthError = response.error
             }
             self.refreshTwitterStatus()
@@ -931,6 +958,7 @@ public final class SettingsStore: ObservableObject {
 
     func connectTwitter() {
         twitterAuthInProgress = true
+        twitterAuthErrorCode = nil
         twitterAuthError = nil
         do {
             guard let daemonClient else {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1035,7 +1035,7 @@ public final class SettingsStore: ObservableObject {
                     platformAssistantId: ctx.platformAssistantId,
                     organizationId: ctx.organizationId
                 )
-                if let connection = connections.first(where: { $0.provider == "twitter" }), connection.connected {
+                if let connection = connections.first(where: { $0.provider == "twitter" && $0.connected }) {
                     managedTwitterConnected = true
                     managedTwitterAccountInfo = connection.accountLabel
                 } else {

--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -123,6 +123,27 @@ public final class LocalAssistantBootstrapService {
         let platformAssistantId = registration.assistant.id
         log.info("Registered local assistant: \(platformAssistantId, privacy: .public)")
 
+        // Persist the platform assistant ID mapping so other services can resolve it.
+        if let storage = credentialStorage {
+            let userId = try? await resolveUserId()
+            if let uid = userId {
+                let persisted = PlatformAssistantIdResolver.persist(
+                    platformAssistantId: platformAssistantId,
+                    runtimeAssistantId: runtimeAssistantId,
+                    organizationId: organizationId,
+                    userId: uid,
+                    credentialStorage: storage
+                )
+                if persisted {
+                    log.info("Persisted platform assistant ID mapping for runtime assistant: \(runtimeAssistantId, privacy: .public)")
+                } else {
+                    log.warning("Failed to persist platform assistant ID mapping for runtime assistant: \(runtimeAssistantId, privacy: .public)")
+                }
+            } else {
+                log.warning("Could not resolve user ID — platform assistant ID mapping not persisted")
+            }
+        }
+
         let credentialAccount = Self.credentialAccount(for: runtimeAssistantId)
 
         // Step 2: Check if we already have the key stored locally
@@ -207,6 +228,12 @@ public final class LocalAssistantBootstrapService {
               (200...299).contains(httpResponse.statusCode) else {
             throw LocalBootstrapError.daemonInjectionFailed
         }
+    }
+
+    /// Resolves the current user ID from the auth session.
+    private func resolveUserId() async throws -> String? {
+        let session = try await authService.getSession()
+        return session.data?.user?.id
     }
 
     private enum ErrorContext {

--- a/clients/shared/App/Auth/PlatformAssistantIdResolver.swift
+++ b/clients/shared/App/Auth/PlatformAssistantIdResolver.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Resolves the platform assistant ID for the current assistant, regardless of hosting mode.
+///
+/// - **Managed (cloud = "vellum")**: The lockfile `assistantId` IS the platform UUID — return it directly.
+/// - **Self-hosted local**: The lockfile `assistantId` is a runtime slug (e.g., `vellum-cool-heron`),
+///   not the platform UUID. The platform ID is persisted during bootstrap via `persist()` and looked
+///   up by `(runtimeAssistantId, organizationId, userId)`.
+///
+/// Callers don't need to know the hosting mode — `resolve()` handles both cases.
+public enum PlatformAssistantIdResolver {
+
+    // MARK: - Key format
+
+    /// Keychain account name for the persisted platform assistant ID mapping.
+    static func keychainAccount(
+        runtimeAssistantId: String,
+        organizationId: String,
+        userId: String
+    ) -> String {
+        "vellum_platform_id_\(runtimeAssistantId)_\(organizationId)_\(userId)"
+    }
+
+    // MARK: - Persist
+
+    /// Persists the platform assistant ID for a self-hosted local assistant.
+    ///
+    /// Call this after `ensureSelfHostedLocalRegistration` returns the platform assistant ID
+    /// during bootstrap. The mapping is scoped by runtime assistant ID, org ID, and user ID
+    /// so switching accounts or orgs doesn't return stale IDs.
+    @discardableResult
+    public static func persist(
+        platformAssistantId: String,
+        runtimeAssistantId: String,
+        organizationId: String,
+        userId: String,
+        credentialStorage: CredentialStorage
+    ) -> Bool {
+        let account = keychainAccount(
+            runtimeAssistantId: runtimeAssistantId,
+            organizationId: organizationId,
+            userId: userId
+        )
+        return credentialStorage.set(account: account, value: platformAssistantId)
+    }
+
+    // MARK: - Resolve
+
+    /// Resolves the platform assistant ID for the current assistant.
+    ///
+    /// - For managed assistants (`isManaged == true`): returns the lockfile `assistantId` directly.
+    /// - For self-hosted local assistants: looks up the persisted mapping in credential storage.
+    /// - Returns `nil` if the assistant is local and no mapping has been persisted yet.
+    public static func resolve(
+        lockfileAssistantId: String,
+        isManaged: Bool,
+        organizationId: String?,
+        userId: String?,
+        credentialStorage: CredentialStorage
+    ) -> String? {
+        if isManaged {
+            return lockfileAssistantId
+        }
+
+        guard let orgId = organizationId, let uid = userId else {
+            return nil
+        }
+
+        let account = keychainAccount(
+            runtimeAssistantId: lockfileAssistantId,
+            organizationId: orgId,
+            userId: uid
+        )
+        return credentialStorage.get(account: account)
+    }
+
+    // MARK: - Clear
+
+    /// Removes the persisted platform assistant ID mapping for a specific scope.
+    ///
+    /// Call this when an account switch or logout invalidates the cached mapping.
+    @discardableResult
+    public static func clear(
+        runtimeAssistantId: String,
+        organizationId: String,
+        userId: String,
+        credentialStorage: CredentialStorage
+    ) -> Bool {
+        let account = keychainAccount(
+            runtimeAssistantId: runtimeAssistantId,
+            organizationId: organizationId,
+            userId: userId
+        )
+        return credentialStorage.delete(account: account)
+    }
+}

--- a/clients/shared/App/Auth/PlatformTwitterOAuthService.swift
+++ b/clients/shared/App/Auth/PlatformTwitterOAuthService.swift
@@ -1,0 +1,271 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "PlatformTwitterOAuth")
+
+/// Protocol abstracting URLSession for testability.
+public protocol URLSessionProtocol: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: URLSessionProtocol {}
+
+/// A Twitter OAuth connection returned by the platform.
+public struct TwitterOAuthConnection: Codable, Sendable {
+    public let id: String
+    public let provider: String
+    public let accountInfo: String?
+    public let createdAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case provider
+        case accountInfo = "account_info"
+        case createdAt = "created_at"
+    }
+
+    public init(id: String, provider: String, accountInfo: String? = nil, createdAt: String? = nil) {
+        self.id = id
+        self.provider = provider
+        self.accountInfo = accountInfo
+        self.createdAt = createdAt
+    }
+}
+
+/// Response from listing Twitter OAuth connections.
+public struct ListTwitterOAuthConnectionsResponse: Codable, Sendable {
+    public let connections: [TwitterOAuthConnection]
+
+    public init(connections: [TwitterOAuthConnection]) {
+        self.connections = connections
+    }
+}
+
+/// Response from starting a Twitter OAuth connect flow.
+public struct StartTwitterConnectResponse: Codable, Sendable {
+    public let authorizationUrl: String
+
+    enum CodingKeys: String, CodingKey {
+        case authorizationUrl = "authorization_url"
+    }
+
+    public init(authorizationUrl: String) {
+        self.authorizationUrl = authorizationUrl
+    }
+}
+
+/// Response from disconnecting Twitter.
+public struct DisconnectTwitterResponse: Codable, Sendable {
+    public let success: Bool
+
+    public init(success: Bool) {
+        self.success = success
+    }
+}
+
+/// Service for communicating with the platform's Twitter OAuth endpoints.
+///
+/// Provides methods to list connections, initiate OAuth flows, and disconnect Twitter
+/// for a given platform assistant. Uses `PlatformAssistantIdResolver` to resolve the
+/// platform assistant ID, and follows the same auth patterns as `AuthService`
+/// (`X-Session-Token`, `Vellum-Organization-Id`).
+public final class PlatformTwitterOAuthService: @unchecked Sendable {
+
+    private let baseURL: String
+    private let session: URLSessionProtocol
+    private let sessionTokenProvider: @Sendable () async -> String?
+
+    /// The OAuth scopes requested when starting a Twitter connect flow.
+    public static let requestedScopes: [String] = [
+        "tweet.read",
+        "tweet.write",
+        "users.read",
+        "offline.access",
+    ]
+
+    /// The redirect URL the platform navigates to after OAuth completes.
+    /// Points to a desktop completion page served by the platform.
+    public static let redirectAfterConnect = "vellum://oauth/twitter/complete"
+
+    /// Creates a new service instance.
+    ///
+    /// - Parameters:
+    ///   - baseURL: The platform base URL (e.g., `https://platform.vellum.ai`).
+    ///   - session: The URLSession (or mock) to use for HTTP requests.
+    ///   - sessionTokenProvider: Closure that returns the current session token, or nil if unauthenticated.
+    public init(
+        baseURL: String,
+        session: URLSessionProtocol = URLSession.shared,
+        sessionTokenProvider: @escaping @Sendable () async -> String? = { await SessionTokenManager.getTokenAsync() }
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+        self.sessionTokenProvider = sessionTokenProvider
+    }
+
+    // MARK: - List Connections
+
+    /// Lists Twitter OAuth connections for the given platform assistant.
+    ///
+    /// - Parameters:
+    ///   - platformAssistantId: The platform assistant UUID.
+    ///   - organizationId: The organization ID.
+    /// - Returns: The list of Twitter OAuth connections.
+    public func listConnections(
+        platformAssistantId: String,
+        organizationId: String
+    ) async throws -> ListTwitterOAuthConnectionsResponse {
+        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/twitter/connections/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        try await applySessionToken(to: &request)
+
+        let (data, response) = try await performRequest(request)
+        let statusCode = httpStatusCode(response)
+
+        log.debug("Platform request GET assistants/\(platformAssistantId, privacy: .public)/twitter/connections/ -> \(statusCode)")
+
+        try checkAuthErrors(statusCode: statusCode)
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(ListTwitterOAuthConnectionsResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Start Twitter Connect
+
+    /// Initiates the Twitter OAuth connect flow for the given platform assistant.
+    ///
+    /// - Parameters:
+    ///   - platformAssistantId: The platform assistant UUID.
+    ///   - organizationId: The organization ID.
+    /// - Returns: A response containing the authorization URL to open in a browser.
+    public func startTwitterConnect(
+        platformAssistantId: String,
+        organizationId: String
+    ) async throws -> StartTwitterConnectResponse {
+        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/twitter/connect/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        try await applySessionToken(to: &request)
+
+        let body: [String: Any] = [
+            "requested_scopes": Self.requestedScopes,
+            "redirect_after_connect": Self.redirectAfterConnect,
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await performRequest(request)
+        let statusCode = httpStatusCode(response)
+
+        log.debug("Platform request POST assistants/\(platformAssistantId, privacy: .public)/twitter/connect/ -> \(statusCode)")
+
+        try checkAuthErrors(statusCode: statusCode)
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(StartTwitterConnectResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Disconnect Twitter
+
+    /// Disconnects (revokes) a Twitter connection for the given platform assistant.
+    ///
+    /// - Parameters:
+    ///   - platformAssistantId: The platform assistant UUID.
+    ///   - organizationId: The organization ID.
+    /// - Returns: A response indicating whether the disconnect succeeded.
+    public func disconnectTwitter(
+        platformAssistantId: String,
+        organizationId: String
+    ) async throws -> DisconnectTwitterResponse {
+        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/twitter/disconnect/"
+        guard let url = URL(string: urlString) else {
+            throw PlatformAPIError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(organizationId, forHTTPHeaderField: "Vellum-Organization-Id")
+
+        try await applySessionToken(to: &request)
+
+        let (data, response) = try await performRequest(request)
+        let statusCode = httpStatusCode(response)
+
+        log.debug("Platform request POST assistants/\(platformAssistantId, privacy: .public)/twitter/disconnect/ -> \(statusCode)")
+
+        try checkAuthErrors(statusCode: statusCode)
+
+        guard (200..<300).contains(statusCode) else {
+            let detail = String(data: data, encoding: .utf8)
+            throw PlatformAPIError.serverError(statusCode: statusCode, detail: detail)
+        }
+
+        do {
+            return try JSONDecoder().decode(DisconnectTwitterResponse.self, from: data)
+        } catch {
+            throw PlatformAPIError.decodingError(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func applySessionToken(to request: inout URLRequest) async throws {
+        if let token = await sessionTokenProvider() {
+            request.setValue(token, forHTTPHeaderField: "X-Session-Token")
+        } else {
+            throw PlatformAPIError.authenticationRequired
+        }
+    }
+
+    private func performRequest(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        do {
+            return try await session.data(for: request)
+        } catch let error as PlatformAPIError {
+            throw error
+        } catch {
+            throw PlatformAPIError.networkError(error.localizedDescription)
+        }
+    }
+
+    private func httpStatusCode(_ response: URLResponse) -> Int {
+        (response as? HTTPURLResponse)?.statusCode ?? 0
+    }
+
+    private func checkAuthErrors(statusCode: Int) throws {
+        if statusCode == 401 || statusCode == 403 {
+            throw PlatformAPIError.authenticationRequired
+        }
+    }
+}

--- a/clients/shared/App/Auth/PlatformTwitterOAuthService.swift
+++ b/clients/shared/App/Auth/PlatformTwitterOAuthService.swift
@@ -12,45 +12,54 @@ extension URLSession: URLSessionProtocol {}
 
 /// A Twitter OAuth connection returned by the platform.
 public struct TwitterOAuthConnection: Codable, Sendable {
-    public let id: String
     public let provider: String
-    public let accountInfo: String?
-    public let createdAt: String?
+    public let status: String           // "ACTIVE", "REVOKED", "EXPIRED"
+    public let connected: Bool
+    public let accountLabel: String?
+    public let scopesGranted: [String]?
+    public let expiresAt: String?
 
     enum CodingKeys: String, CodingKey {
-        case id
         case provider
-        case accountInfo = "account_info"
-        case createdAt = "created_at"
+        case status
+        case connected
+        case accountLabel = "account_label"
+        case scopesGranted = "scopes_granted"
+        case expiresAt = "expires_at"
     }
 
-    public init(id: String, provider: String, accountInfo: String? = nil, createdAt: String? = nil) {
-        self.id = id
+    public init(provider: String, status: String, connected: Bool, accountLabel: String? = nil, scopesGranted: [String]? = nil, expiresAt: String? = nil) {
         self.provider = provider
-        self.accountInfo = accountInfo
-        self.createdAt = createdAt
-    }
-}
-
-/// Response from listing Twitter OAuth connections.
-public struct ListTwitterOAuthConnectionsResponse: Codable, Sendable {
-    public let connections: [TwitterOAuthConnection]
-
-    public init(connections: [TwitterOAuthConnection]) {
-        self.connections = connections
+        self.status = status
+        self.connected = connected
+        self.accountLabel = accountLabel
+        self.scopesGranted = scopesGranted
+        self.expiresAt = expiresAt
     }
 }
 
 /// Response from starting a Twitter OAuth connect flow.
 public struct StartTwitterConnectResponse: Codable, Sendable {
-    public let authorizationUrl: String
+    public let success: Bool
+    public let deferred: Bool
+    public let provider: String
+    public let connectUrl: String
+    public let stateId: String
 
     enum CodingKeys: String, CodingKey {
-        case authorizationUrl = "authorization_url"
+        case success
+        case deferred
+        case provider
+        case connectUrl = "connect_url"
+        case stateId = "state_id"
     }
 
-    public init(authorizationUrl: String) {
-        self.authorizationUrl = authorizationUrl
+    public init(success: Bool, deferred: Bool, provider: String, connectUrl: String, stateId: String) {
+        self.success = success
+        self.deferred = deferred
+        self.provider = provider
+        self.connectUrl = connectUrl
+        self.stateId = stateId
     }
 }
 
@@ -83,9 +92,8 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
         "offline.access",
     ]
 
-    /// The redirect URL the platform navigates to after OAuth completes.
-    /// Points to a desktop completion page served by the platform.
-    public static let redirectAfterConnect = "vellum://oauth/twitter/complete"
+    /// The redirect path the platform navigates to after OAuth completes.
+    public static let redirectAfterConnect = "/"
 
     /// Creates a new service instance.
     ///
@@ -114,8 +122,8 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
     public func listConnections(
         platformAssistantId: String,
         organizationId: String
-    ) async throws -> ListTwitterOAuthConnectionsResponse {
-        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/twitter/connections/"
+    ) async throws -> [TwitterOAuthConnection] {
+        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/oauth/connections/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
         }
@@ -130,7 +138,7 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
         let (data, response) = try await performRequest(request)
         let statusCode = httpStatusCode(response)
 
-        log.debug("Platform request GET assistants/\(platformAssistantId, privacy: .public)/twitter/connections/ -> \(statusCode)")
+        log.debug("Platform request GET assistants/\(platformAssistantId, privacy: .public)/oauth/connections/ -> \(statusCode)")
 
         try checkAuthErrors(statusCode: statusCode)
 
@@ -140,7 +148,7 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
         }
 
         do {
-            return try JSONDecoder().decode(ListTwitterOAuthConnectionsResponse.self, from: data)
+            return try JSONDecoder().decode([TwitterOAuthConnection].self, from: data)
         } catch {
             throw PlatformAPIError.decodingError(error.localizedDescription)
         }
@@ -158,7 +166,7 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
         platformAssistantId: String,
         organizationId: String
     ) async throws -> StartTwitterConnectResponse {
-        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/twitter/connect/"
+        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/oauth/twitter/start/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
         }
@@ -180,7 +188,7 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
         let (data, response) = try await performRequest(request)
         let statusCode = httpStatusCode(response)
 
-        log.debug("Platform request POST assistants/\(platformAssistantId, privacy: .public)/twitter/connect/ -> \(statusCode)")
+        log.debug("Platform request POST assistants/\(platformAssistantId, privacy: .public)/oauth/twitter/start/ -> \(statusCode)")
 
         try checkAuthErrors(statusCode: statusCode)
 
@@ -208,7 +216,7 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
         platformAssistantId: String,
         organizationId: String
     ) async throws -> DisconnectTwitterResponse {
-        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/twitter/disconnect/"
+        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/oauth/twitter/disconnect/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
         }
@@ -223,7 +231,7 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
         let (data, response) = try await performRequest(request)
         let statusCode = httpStatusCode(response)
 
-        log.debug("Platform request POST assistants/\(platformAssistantId, privacy: .public)/twitter/disconnect/ -> \(statusCode)")
+        log.debug("Platform request POST assistants/\(platformAssistantId, privacy: .public)/oauth/twitter/disconnect/ -> \(statusCode)")
 
         try checkAuthErrors(statusCode: statusCode)
 

--- a/clients/shared/IPC/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/IPC/Generated/GeneratedAPITypes.swift
@@ -2736,6 +2736,21 @@ public struct IPCListSurfaceData: Codable, Sendable {
     }
 }
 
+public struct IPCManagedPrerequisites: Codable, Sendable {
+    /// Whether twitter.integrationMode is set to "managed" in config.
+    public let integrationModeManaged: Bool
+    /// Whether the assistant API key credential exists in secure storage.
+    public let assistantApiKeyPresent: Bool
+    /// Whether the platform base URL is configured (platform registration resolvable).
+    public let platformAssistantIdResolvable: Bool
+
+    public init(integrationModeManaged: Bool, assistantApiKeyPresent: Bool, platformAssistantIdResolvable: Bool) {
+        self.integrationModeManaged = integrationModeManaged
+        self.assistantApiKeyPresent = assistantApiKeyPresent
+        self.platformAssistantIdResolvable = platformAssistantIdResolvable
+    }
+}
+
 public struct IPCMemoryRecalled: Codable, Sendable {
     public let type: String
     public let provider: String
@@ -5012,12 +5027,15 @@ public struct IPCTwitterAuthResult: Codable, Sendable {
     public let type: String
     public let success: Bool
     public let accountInfo: String?
+    /// Machine-readable error code for programmatic handling (e.g. "managed_missing_api_key", "managed_auth_via_platform").
+    public let errorCode: String?
     public let error: String?
 
-    public init(type: String, success: Bool, accountInfo: String? = nil, error: String? = nil) {
+    public init(type: String, success: Bool, accountInfo: String? = nil, errorCode: String? = nil, error: String? = nil) {
         self.type = type
         self.success = success
         self.accountInfo = accountInfo
+        self.errorCode = errorCode
         self.error = error
     }
 }
@@ -5077,6 +5095,8 @@ public struct IPCTwitterIntegrationConfigResponse: Codable, Sendable {
     public let success: Bool
     public let mode: String?
     public let managedAvailable: Bool
+    /// Detailed prerequisite status for managed Twitter availability.
+    public let managedPrerequisites: IPCManagedPrerequisites?
     public let localClientConfigured: Bool
     public let connected: Bool
     public let accountInfo: String?
@@ -5085,11 +5105,12 @@ public struct IPCTwitterIntegrationConfigResponse: Codable, Sendable {
     public let strategyConfigured: Bool?
     public let error: String?
 
-    public init(type: String, success: Bool, mode: String? = nil, managedAvailable: Bool, localClientConfigured: Bool, connected: Bool, accountInfo: String? = nil, strategy: String? = nil, strategyConfigured: Bool? = nil, error: String? = nil) {
+    public init(type: String, success: Bool, mode: String? = nil, managedAvailable: Bool, managedPrerequisites: IPCManagedPrerequisites? = nil, localClientConfigured: Bool, connected: Bool, accountInfo: String? = nil, strategy: String? = nil, strategyConfigured: Bool? = nil, error: String? = nil) {
         self.type = type
         self.success = success
         self.mode = mode
         self.managedAvailable = managedAvailable
+        self.managedPrerequisites = managedPrerequisites
         self.localClientConfigured = localClientConfigured
         self.connected = connected
         self.accountInfo = accountInfo

--- a/clients/shared/Tests/PlatformAssistantIdResolverTests.swift
+++ b/clients/shared/Tests/PlatformAssistantIdResolverTests.swift
@@ -1,0 +1,307 @@
+import XCTest
+@testable import VellumAssistantShared
+
+/// In-memory credential storage for testing.
+private final class MockCredentialStorage: CredentialStorage {
+    private var store: [String: String] = [:]
+
+    func get(account: String) -> String? {
+        store[account]
+    }
+
+    func set(account: String, value: String) -> Bool {
+        store[account] = value
+        return true
+    }
+
+    func delete(account: String) -> Bool {
+        store.removeValue(forKey: account) != nil
+    }
+}
+
+final class PlatformAssistantIdResolverTests: XCTestCase {
+
+    private var storage: MockCredentialStorage!
+
+    override func setUp() {
+        super.setUp()
+        storage = MockCredentialStorage()
+    }
+
+    // MARK: - Managed assistants
+
+    func testResolveManagedAssistantReturnsLockfileIdDirectly() {
+        let platformId = "platform-uuid-1234"
+        let result = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: platformId,
+            isManaged: true,
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+        XCTAssertEqual(result, platformId)
+    }
+
+    func testResolveManagedAssistantIgnoresPersistedMapping() {
+        // Even if a mapping is persisted, managed mode should return the lockfile ID directly.
+        PlatformAssistantIdResolver.persist(
+            platformAssistantId: "stale-platform-id",
+            runtimeAssistantId: "managed-uuid",
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+
+        let result = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: "managed-uuid",
+            isManaged: true,
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+        XCTAssertEqual(result, "managed-uuid")
+    }
+
+    func testResolveManagedAssistantWorksWithoutOrgOrUserId() {
+        let result = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: "managed-uuid",
+            isManaged: true,
+            organizationId: nil,
+            userId: nil,
+            credentialStorage: storage
+        )
+        XCTAssertEqual(result, "managed-uuid")
+    }
+
+    // MARK: - Self-hosted local assistants
+
+    func testResolveLocalAssistantReturnsPersistedMapping() {
+        PlatformAssistantIdResolver.persist(
+            platformAssistantId: "platform-uuid-5678",
+            runtimeAssistantId: "vellum-cool-heron",
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+
+        let result = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: "vellum-cool-heron",
+            isManaged: false,
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+        XCTAssertEqual(result, "platform-uuid-5678")
+    }
+
+    func testResolveLocalAssistantReturnsNilWhenNotPersisted() {
+        let result = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: "vellum-cool-heron",
+            isManaged: false,
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+        XCTAssertNil(result)
+    }
+
+    func testResolveLocalAssistantReturnsNilWithoutOrgId() {
+        PlatformAssistantIdResolver.persist(
+            platformAssistantId: "platform-uuid-5678",
+            runtimeAssistantId: "vellum-cool-heron",
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+
+        let result = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: "vellum-cool-heron",
+            isManaged: false,
+            organizationId: nil,
+            userId: "user-1",
+            credentialStorage: storage
+        )
+        XCTAssertNil(result)
+    }
+
+    func testResolveLocalAssistantReturnsNilWithoutUserId() {
+        PlatformAssistantIdResolver.persist(
+            platformAssistantId: "platform-uuid-5678",
+            runtimeAssistantId: "vellum-cool-heron",
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+
+        let result = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: "vellum-cool-heron",
+            isManaged: false,
+            organizationId: "org-1",
+            userId: nil,
+            credentialStorage: storage
+        )
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Account switch isolation
+
+    func testDifferentOrgIdReturnsDifferentMapping() {
+        PlatformAssistantIdResolver.persist(
+            platformAssistantId: "platform-org-A",
+            runtimeAssistantId: "vellum-cool-heron",
+            organizationId: "org-A",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+        PlatformAssistantIdResolver.persist(
+            platformAssistantId: "platform-org-B",
+            runtimeAssistantId: "vellum-cool-heron",
+            organizationId: "org-B",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+
+        let resultA = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: "vellum-cool-heron",
+            isManaged: false,
+            organizationId: "org-A",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+        let resultB = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: "vellum-cool-heron",
+            isManaged: false,
+            organizationId: "org-B",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+
+        XCTAssertEqual(resultA, "platform-org-A")
+        XCTAssertEqual(resultB, "platform-org-B")
+    }
+
+    func testDifferentUserIdReturnsDifferentMapping() {
+        PlatformAssistantIdResolver.persist(
+            platformAssistantId: "platform-user-1",
+            runtimeAssistantId: "vellum-cool-heron",
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+        PlatformAssistantIdResolver.persist(
+            platformAssistantId: "platform-user-2",
+            runtimeAssistantId: "vellum-cool-heron",
+            organizationId: "org-1",
+            userId: "user-2",
+            credentialStorage: storage
+        )
+
+        let result1 = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: "vellum-cool-heron",
+            isManaged: false,
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+        let result2 = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: "vellum-cool-heron",
+            isManaged: false,
+            organizationId: "org-1",
+            userId: "user-2",
+            credentialStorage: storage
+        )
+
+        XCTAssertEqual(result1, "platform-user-1")
+        XCTAssertEqual(result2, "platform-user-2")
+    }
+
+    // MARK: - Clear
+
+    func testClearRemovesPersistedMapping() {
+        PlatformAssistantIdResolver.persist(
+            platformAssistantId: "platform-uuid-5678",
+            runtimeAssistantId: "vellum-cool-heron",
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+
+        PlatformAssistantIdResolver.clear(
+            runtimeAssistantId: "vellum-cool-heron",
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+
+        let result = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: "vellum-cool-heron",
+            isManaged: false,
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+        XCTAssertNil(result)
+    }
+
+    func testClearDoesNotAffectOtherScopes() {
+        PlatformAssistantIdResolver.persist(
+            platformAssistantId: "platform-A",
+            runtimeAssistantId: "vellum-cool-heron",
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+        PlatformAssistantIdResolver.persist(
+            platformAssistantId: "platform-B",
+            runtimeAssistantId: "vellum-cool-heron",
+            organizationId: "org-2",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+
+        PlatformAssistantIdResolver.clear(
+            runtimeAssistantId: "vellum-cool-heron",
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+
+        // org-2 mapping should still be present
+        let result = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: "vellum-cool-heron",
+            isManaged: false,
+            organizationId: "org-2",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+        XCTAssertEqual(result, "platform-B")
+    }
+
+    // MARK: - Persist overwrites
+
+    func testPersistOverwritesExistingMapping() {
+        PlatformAssistantIdResolver.persist(
+            platformAssistantId: "old-platform-id",
+            runtimeAssistantId: "vellum-cool-heron",
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+        PlatformAssistantIdResolver.persist(
+            platformAssistantId: "new-platform-id",
+            runtimeAssistantId: "vellum-cool-heron",
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+
+        let result = PlatformAssistantIdResolver.resolve(
+            lockfileAssistantId: "vellum-cool-heron",
+            isManaged: false,
+            organizationId: "org-1",
+            userId: "user-1",
+            credentialStorage: storage
+        )
+        XCTAssertEqual(result, "new-platform-id")
+    }
+}

--- a/clients/shared/Tests/PlatformTwitterOAuthServiceTests.swift
+++ b/clients/shared/Tests/PlatformTwitterOAuthServiceTests.swift
@@ -1,0 +1,342 @@
+import XCTest
+@testable import VellumAssistantShared
+
+/// Mock URLSession that returns pre-configured responses for testing.
+private final class MockURLSession: URLSessionProtocol, @unchecked Sendable {
+    var responseData: Data = Data()
+    var responseStatusCode: Int = 200
+    var responseError: Error?
+    var capturedRequests: [URLRequest] = []
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        capturedRequests.append(request)
+
+        if let error = responseError {
+            throw error
+        }
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: responseStatusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        )!
+
+        return (responseData, response)
+    }
+}
+
+final class PlatformTwitterOAuthServiceTests: XCTestCase {
+
+    private var mockSession: MockURLSession!
+    private var service: PlatformTwitterOAuthService!
+
+    private let testBaseURL = "https://platform.example.com"
+    private let testPlatformAssistantId = "asst-uuid-1234"
+    private let testOrganizationId = "org-uuid-5678"
+    private let testSessionToken = "test-session-token"
+
+    override func setUp() {
+        super.setUp()
+        mockSession = MockURLSession()
+        service = PlatformTwitterOAuthService(
+            baseURL: testBaseURL,
+            session: mockSession,
+            sessionTokenProvider: { [testSessionToken] in testSessionToken }
+        )
+    }
+
+    // MARK: - listConnections
+
+    func testListConnectionsSendsCorrectRequest() async throws {
+        let connections = [
+            TwitterOAuthConnection(id: "conn-1", provider: "twitter", accountInfo: "@testuser")
+        ]
+        let responseBody = ListTwitterOAuthConnectionsResponse(connections: connections)
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        _ = try await service.listConnections(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        XCTAssertEqual(mockSession.capturedRequests.count, 1)
+        let request = mockSession.capturedRequests[0]
+
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(
+            request.url?.absoluteString,
+            "\(testBaseURL)/v1/assistants/\(testPlatformAssistantId)/twitter/connections/"
+        )
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Session-Token"), testSessionToken)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Vellum-Organization-Id"), testOrganizationId)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
+    }
+
+    func testListConnectionsDecodesResponse() async throws {
+        let connections = [
+            TwitterOAuthConnection(id: "conn-1", provider: "twitter", accountInfo: "@user1"),
+            TwitterOAuthConnection(id: "conn-2", provider: "twitter", accountInfo: "@user2"),
+        ]
+        let responseBody = ListTwitterOAuthConnectionsResponse(connections: connections)
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        let result = try await service.listConnections(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        XCTAssertEqual(result.connections.count, 2)
+        XCTAssertEqual(result.connections[0].id, "conn-1")
+        XCTAssertEqual(result.connections[0].accountInfo, "@user1")
+        XCTAssertEqual(result.connections[1].id, "conn-2")
+    }
+
+    func testListConnectionsReturnsEmptyList() async throws {
+        let responseBody = ListTwitterOAuthConnectionsResponse(connections: [])
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        let result = try await service.listConnections(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        XCTAssertTrue(result.connections.isEmpty)
+    }
+
+    func testListConnectionsThrowsOnAuthError() async throws {
+        mockSession.responseStatusCode = 401
+
+        do {
+            _ = try await service.listConnections(
+                platformAssistantId: testPlatformAssistantId,
+                organizationId: testOrganizationId
+            )
+            XCTFail("Expected authenticationRequired error")
+        } catch let error as PlatformAPIError {
+            if case .authenticationRequired = error {
+                // Expected
+            } else {
+                XCTFail("Expected authenticationRequired, got \(error)")
+            }
+        }
+    }
+
+    func testListConnectionsThrowsOnServerError() async throws {
+        mockSession.responseStatusCode = 500
+        mockSession.responseData = Data("Internal Server Error".utf8)
+
+        do {
+            _ = try await service.listConnections(
+                platformAssistantId: testPlatformAssistantId,
+                organizationId: testOrganizationId
+            )
+            XCTFail("Expected serverError")
+        } catch let error as PlatformAPIError {
+            if case .serverError(let statusCode, _) = error {
+                XCTAssertEqual(statusCode, 500)
+            } else {
+                XCTFail("Expected serverError, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - startTwitterConnect
+
+    func testStartConnectSendsCorrectRequest() async throws {
+        let responseBody = StartTwitterConnectResponse(authorizationUrl: "https://twitter.com/oauth/authorize?token=abc")
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        _ = try await service.startTwitterConnect(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        XCTAssertEqual(mockSession.capturedRequests.count, 1)
+        let request = mockSession.capturedRequests[0]
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(
+            request.url?.absoluteString,
+            "\(testBaseURL)/v1/assistants/\(testPlatformAssistantId)/twitter/connect/"
+        )
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Session-Token"), testSessionToken)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Vellum-Organization-Id"), testOrganizationId)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+
+    func testStartConnectSendsRequestedScopes() async throws {
+        let responseBody = StartTwitterConnectResponse(authorizationUrl: "https://twitter.com/oauth/authorize")
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        _ = try await service.startTwitterConnect(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        let request = mockSession.capturedRequests[0]
+        let body = try JSONSerialization.jsonObject(with: request.httpBody!) as! [String: Any]
+
+        let scopes = body["requested_scopes"] as? [String]
+        XCTAssertEqual(scopes, ["tweet.read", "tweet.write", "users.read", "offline.access"])
+    }
+
+    func testStartConnectSendsRedirectAfterConnect() async throws {
+        let responseBody = StartTwitterConnectResponse(authorizationUrl: "https://twitter.com/oauth/authorize")
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        _ = try await service.startTwitterConnect(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        let request = mockSession.capturedRequests[0]
+        let body = try JSONSerialization.jsonObject(with: request.httpBody!) as! [String: Any]
+
+        let redirect = body["redirect_after_connect"] as? String
+        XCTAssertEqual(redirect, "vellum://oauth/twitter/complete")
+    }
+
+    func testStartConnectDecodesAuthorizationUrl() async throws {
+        let expectedUrl = "https://twitter.com/i/oauth2/authorize?client_id=abc&scope=tweet.read"
+        let responseBody = StartTwitterConnectResponse(authorizationUrl: expectedUrl)
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        let result = try await service.startTwitterConnect(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        XCTAssertEqual(result.authorizationUrl, expectedUrl)
+    }
+
+    func testStartConnectThrowsOn403() async throws {
+        mockSession.responseStatusCode = 403
+
+        do {
+            _ = try await service.startTwitterConnect(
+                platformAssistantId: testPlatformAssistantId,
+                organizationId: testOrganizationId
+            )
+            XCTFail("Expected authenticationRequired error")
+        } catch let error as PlatformAPIError {
+            if case .authenticationRequired = error {
+                // Expected
+            } else {
+                XCTFail("Expected authenticationRequired, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - disconnectTwitter
+
+    func testDisconnectSendsCorrectRequest() async throws {
+        let responseBody = DisconnectTwitterResponse(success: true)
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        _ = try await service.disconnectTwitter(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        XCTAssertEqual(mockSession.capturedRequests.count, 1)
+        let request = mockSession.capturedRequests[0]
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(
+            request.url?.absoluteString,
+            "\(testBaseURL)/v1/assistants/\(testPlatformAssistantId)/twitter/disconnect/"
+        )
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Session-Token"), testSessionToken)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Vellum-Organization-Id"), testOrganizationId)
+    }
+
+    func testDisconnectDecodesSuccessResponse() async throws {
+        let responseBody = DisconnectTwitterResponse(success: true)
+        mockSession.responseData = try JSONEncoder().encode(responseBody)
+
+        let result = try await service.disconnectTwitter(
+            platformAssistantId: testPlatformAssistantId,
+            organizationId: testOrganizationId
+        )
+
+        XCTAssertTrue(result.success)
+    }
+
+    func testDisconnectThrowsOnServerError() async throws {
+        mockSession.responseStatusCode = 502
+        mockSession.responseData = Data("Bad Gateway".utf8)
+
+        do {
+            _ = try await service.disconnectTwitter(
+                platformAssistantId: testPlatformAssistantId,
+                organizationId: testOrganizationId
+            )
+            XCTFail("Expected serverError")
+        } catch let error as PlatformAPIError {
+            if case .serverError(let statusCode, _) = error {
+                XCTAssertEqual(statusCode, 502)
+            } else {
+                XCTFail("Expected serverError, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Authentication
+
+    func testThrowsWhenNoSessionToken() async throws {
+        let unauthService = PlatformTwitterOAuthService(
+            baseURL: testBaseURL,
+            session: mockSession,
+            sessionTokenProvider: { nil }
+        )
+
+        do {
+            _ = try await unauthService.listConnections(
+                platformAssistantId: testPlatformAssistantId,
+                organizationId: testOrganizationId
+            )
+            XCTFail("Expected authenticationRequired error")
+        } catch let error as PlatformAPIError {
+            if case .authenticationRequired = error {
+                // Expected — no request should have been sent
+                XCTAssertTrue(mockSession.capturedRequests.isEmpty)
+            } else {
+                XCTFail("Expected authenticationRequired, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Network errors
+
+    func testNetworkErrorWrappedAsPlatformAPIError() async throws {
+        let networkError = URLError(.notConnectedToInternet)
+        mockSession.responseError = networkError
+
+        do {
+            _ = try await service.listConnections(
+                platformAssistantId: testPlatformAssistantId,
+                organizationId: testOrganizationId
+            )
+            XCTFail("Expected networkError")
+        } catch let error as PlatformAPIError {
+            if case .networkError = error {
+                // Expected
+            } else {
+                XCTFail("Expected networkError, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Static properties
+
+    func testRequestedScopesContainsExpectedValues() {
+        let scopes = PlatformTwitterOAuthService.requestedScopes
+        XCTAssertEqual(scopes, ["tweet.read", "tweet.write", "users.read", "offline.access"])
+    }
+
+    func testRedirectAfterConnectIsDesktopScheme() {
+        let redirect = PlatformTwitterOAuthService.redirectAfterConnect
+        XCTAssertTrue(redirect.hasPrefix("vellum://"))
+    }
+}


### PR DESCRIPTION
## Summary
Add managed Twitter OAuth support for desktop assistants. When `integrationMode` is set to `managed`, Twitter API calls are proxied through the Vellum platform using the assistant's API key, with OAuth tokens stored and refreshed server-side. Only the assistant owner can connect/disconnect Twitter, enforced both client-side (macOS UI) and server-side (platform proxy).

## Changes
- **M1**: `PlatformAssistantIdResolver` for resolving platform assistant IDs in both managed and self-hosted local modes
- **M2**: Real managed Twitter availability checks based on prerequisites (API key, platform URL, integration mode)
- **M3**: Swift `PlatformTwitterOAuthService` client for platform OAuth endpoints (list connections, connect, disconnect)
- **M4**: Full managed Twitter UI in macOS Settings (connect/disconnect/status with auto-refresh, sign-in gates, owner checks)
- **M5**: TypeScript `platform-proxy-client` for proxying Twitter API calls through the platform
- **M6**: Routing managed Twitter posts through the proxy client
- **M7**: Managed Twitter reads for official-API-compatible endpoints (user lookup, tweets, search)
- **M8**: Guardrail regression tests, architecture docs, cleanup

## Milestone PRs (merged into feature branch)
- #14312: M1 — Persist and resolve platform assistant ID
- #14313: M2 — Expose real managed Twitter availability
- #14314: M3 — Swift client for platform Twitter OAuth endpoints
- #14315: M4 — Enable managed Twitter connect/disconnect/status in macOS Settings
- #14324: M5 — Assistant-side platform-managed Twitter proxy client
- #14333: M6 — Route managed Twitter posts through proxy client
- #14342: M7 — Add managed Twitter reads for official-API-compatible endpoints
- #14343: M8 — Cleanup, guardrails, and docs

## Project issue
Closes #14191

## Test plan
- [ ] Verify managed Twitter connect flow works end-to-end with platform
- [ ] Verify owner-only enforcement (non-owner can't connect/disconnect)
- [ ] Verify managed post/reply routes through platform proxy
- [ ] Verify managed reads (user lookup, tweets, search) work
- [ ] Verify local BYO mode is unaffected
- [ ] Run `bun test` to verify all new tests pass

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
