### PR TITLE
fix: recognize svc:daemon sub pattern in JWT auth

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -41,12 +41,12 @@ All HTTP API requests use a single `Authorization: Bearer <jwt>` header for auth
 
 **Subject patterns:**
 
-| Pattern                                  | Principal Type | Description                                   |
-| ---------------------------------------- | -------------- | --------------------------------------------- |
-| `actor:<assistantId>:<actorPrincipalId>` | `actor`        | Desktop, iOS, or CLI client                   |
-| `svc:gateway:<assistantId>`              | `svc_gateway`  | Gateway service (ingress, webhooks)           |
-| `ipc:<assistantId>:<sessionId>`          | `ipc`          | Internal IPC connections                      |
-| `svc:daemon:self`                        | n/a            | Daemon self-identification (for internal use) |
+| Pattern                                  | Principal Type | Description                                 |
+| ---------------------------------------- | -------------- | ------------------------------------------- |
+| `actor:<assistantId>:<actorPrincipalId>` | `actor`        | Desktop, iOS, or CLI client                 |
+| `svc:gateway:<assistantId>`              | `svc_gateway`  | Gateway service (ingress, webhooks)         |
+| `ipc:<assistantId>:<sessionId>`          | `ipc`          | Internal IPC connections                    |
+| `svc:daemon:<identifier>`                | `svc_daemon`   | Daemon service token (CLI bootstrap, local) |
 
 **Scope profiles:**
 

--- a/assistant/src/__tests__/conversation-unread-route.test.ts
+++ b/assistant/src/__tests__/conversation-unread-route.test.ts
@@ -85,7 +85,7 @@ describe("POST /v1/conversations/unread", () => {
   test("registers the unread route with chat.write policy", () => {
     expect(getPolicy("conversations/unread")).toEqual({
       requiredScopes: ["chat.write"],
-      allowedPrincipalTypes: ["actor", "svc_gateway", "ipc"],
+      allowedPrincipalTypes: ["actor", "svc_gateway", "svc_daemon", "ipc"],
     });
   });
 

--- a/assistant/src/__tests__/migration-export-http.test.ts
+++ b/assistant/src/__tests__/migration-export-http.test.ts
@@ -493,9 +493,9 @@ describe("auth policy shape", () => {
     expect(policy!.requiredScopes).toEqual(["settings.write"]);
     // Verify only the expected principal types are allowed
     expect(policy!.allowedPrincipalTypes).toEqual(
-      expect.arrayContaining(["actor", "svc_gateway", "ipc"]),
+      expect.arrayContaining(["actor", "svc_gateway", "svc_daemon", "ipc"]),
     );
-    expect(policy!.allowedPrincipalTypes).toHaveLength(3);
+    expect(policy!.allowedPrincipalTypes).toHaveLength(4);
   });
 
   test("export policy matches validate policy shape", async () => {

--- a/assistant/src/runtime/auth/__tests__/subject.test.ts
+++ b/assistant/src/runtime/auth/__tests__/subject.test.ts
@@ -44,6 +44,38 @@ describe("parseSub", () => {
   });
 
   // -------------------------------------------------------------------------
+  // svc:daemon pattern
+  // -------------------------------------------------------------------------
+
+  test("parses svc:daemon:<identifier>", () => {
+    const result = parseSub("svc:daemon:self");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.principalType).toBe("svc_daemon");
+      expect(result.assistantId).toBe("self");
+      expect(result.actorPrincipalId).toBeUndefined();
+      expect(result.sessionId).toBeUndefined();
+    }
+  });
+
+  test("parses svc:daemon with non-self identifier", () => {
+    const result = parseSub("svc:daemon:pairing");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.principalType).toBe("svc_daemon");
+      expect(result.assistantId).toBe("pairing");
+    }
+  });
+
+  test("fails on svc:daemon with empty identifier", () => {
+    const result = parseSub("svc:daemon:");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("empty");
+    }
+  });
+
+  // -------------------------------------------------------------------------
   // ipc pattern
   // -------------------------------------------------------------------------
 

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -295,7 +295,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
 for (const { endpoint, scopes } of ACTOR_ENDPOINTS) {
   registerPolicy(endpoint, {
     requiredScopes: scopes,
-    allowedPrincipalTypes: ["actor", "svc_gateway", "ipc"],
+    allowedPrincipalTypes: ["actor", "svc_gateway", "svc_daemon", "ipc"],
   });
 }
 

--- a/assistant/src/runtime/auth/subject.ts
+++ b/assistant/src/runtime/auth/subject.ts
@@ -31,6 +31,7 @@ export type ParseSubResult =
  * Supported patterns:
  *   actor:<assistantId>:<actorPrincipalId>
  *   svc:gateway:<assistantId>
+ *   svc:daemon:<identifier>
  *   ipc:<assistantId>:<sessionId>
  */
 export function parseSub(sub: string): ParseSubResult {
@@ -57,6 +58,14 @@ export function parseSub(sub: string): ParseSubResult {
       return { ok: false, reason: "svc:gateway sub has empty assistantId" };
     }
     return { ok: true, principalType: "svc_gateway", assistantId };
+  }
+
+  if (parts[0] === "svc" && parts[1] === "daemon" && parts.length === 3) {
+    const identifier = parts[2];
+    if (!identifier) {
+      return { ok: false, reason: "svc:daemon sub has empty identifier" };
+    }
+    return { ok: true, principalType: "svc_daemon", assistantId: identifier };
   }
 
   if (parts[0] === "ipc" && parts.length === 3) {

--- a/assistant/src/runtime/auth/types.ts
+++ b/assistant/src/runtime/auth/types.ts
@@ -41,7 +41,7 @@ export type Scope =
 // Principal types — derived from the sub pattern
 // ---------------------------------------------------------------------------
 
-export type PrincipalType = "actor" | "svc_gateway" | "ipc";
+export type PrincipalType = "actor" | "svc_gateway" | "svc_daemon" | "ipc";
 
 // ---------------------------------------------------------------------------
 // Token audience — which service the JWT is intended for

--- a/gateway/src/auth/subject.ts
+++ b/gateway/src/auth/subject.ts
@@ -31,6 +31,7 @@ export type ParseSubResult =
  * Supported patterns:
  *   actor:<assistantId>:<actorPrincipalId>
  *   svc:gateway:<assistantId>
+ *   svc:daemon:<identifier>
  *   ipc:<assistantId>:<sessionId>
  */
 export function parseSub(sub: string): ParseSubResult {
@@ -57,6 +58,14 @@ export function parseSub(sub: string): ParseSubResult {
       return { ok: false, reason: "svc:gateway sub has empty assistantId" };
     }
     return { ok: true, principalType: "svc_gateway", assistantId };
+  }
+
+  if (parts[0] === "svc" && parts[1] === "daemon" && parts.length === 3) {
+    const identifier = parts[2];
+    if (!identifier) {
+      return { ok: false, reason: "svc:daemon sub has empty identifier" };
+    }
+    return { ok: true, principalType: "svc_daemon", assistantId: identifier };
   }
 
   if (parts[0] === "ipc" && parts.length === 3) {

--- a/gateway/src/auth/types.ts
+++ b/gateway/src/auth/types.ts
@@ -41,7 +41,7 @@ export type Scope =
 // Principal types — derived from the sub pattern
 // ---------------------------------------------------------------------------
 
-export type PrincipalType = "actor" | "svc_gateway" | "ipc";
+export type PrincipalType = "actor" | "svc_gateway" | "svc_daemon" | "ipc";
 
 // ---------------------------------------------------------------------------
 // Token audience — which service the JWT is intended for


### PR DESCRIPTION
## Summary
- The macOS client falls back to the `http-token` file (JWT with `sub: svc:daemon:self`) when no actor token is available yet (before guardian bootstrap completes). `parseSub()` didn't recognize the `svc:daemon:*` pattern, causing 401s on all authenticated endpoints — including usage totals, daily, and breakdown.
- Adds `svc_daemon` as a new `PrincipalType`, teaches `parseSub()` to handle `svc:daemon:<identifier>`, and allows it on actor endpoints so the http-token fallback works during the bootstrap window.
- Mirrors the change in both assistant and gateway auth modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
