### PR TITLE
feat: add workspace path validation and MIME detection utilities

### DIFF
--- a/assistant/src/daemon/handlers/workspace-files.ts
+++ b/assistant/src/daemon/handlers/workspace-files.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
 import * as net from "node:net";
-import { join, resolve, sep } from "node:path";
+import { join } from "node:path";
 
+import { resolveWorkspacePath } from "../../runtime/routes/workspace-utils.js";
 import { pathExists } from "../../util/fs.js";
 import { getWorkspaceDir } from "../../util/platform.js";
 import type { WorkspaceFileReadRequest } from "../ipc-protocol.js";
@@ -28,14 +29,10 @@ function handleWorkspaceFileRead(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  const base = getWorkspaceDir();
   const requested = msg.path;
 
-  // Prevent path traversal — reject paths that escape the workspace root.
-  // Use resolve() to canonicalize and check with trailing separator to prevent
-  // sibling directory prefix matches (e.g. "../workspace-evil/secret").
-  const resolved = resolve(base, requested);
-  if (!resolved.startsWith(base + sep) && resolved !== base) {
+  const resolved = resolveWorkspacePath(requested);
+  if (resolved === undefined) {
     log.warn(
       { path: requested },
       "Workspace file read blocked: path traversal attempt",

--- a/assistant/src/runtime/routes/workspace-utils.ts
+++ b/assistant/src/runtime/routes/workspace-utils.ts
@@ -1,0 +1,34 @@
+import { resolve, sep } from "node:path";
+
+import { getWorkspaceDir } from "../../util/platform.js";
+
+/**
+ * Resolves a user-provided relative path to an absolute path within the workspace.
+ * Returns the resolved absolute path, or undefined if the path escapes the workspace root.
+ */
+export function resolveWorkspacePath(relativePath: string): string | undefined {
+  const base = getWorkspaceDir();
+  const resolved = resolve(base, relativePath);
+  if (resolved !== base && !resolved.startsWith(base + sep)) {
+    return undefined;
+  }
+  return resolved;
+}
+
+const TEXT_MIME_PREFIXES = [
+  "text/",
+  "application/json",
+  "application/javascript",
+  "application/typescript",
+  "application/xml",
+  "application/yaml",
+  "application/x-yaml",
+  "application/toml",
+  "application/x-sh",
+];
+
+export function isTextMimeType(mimeType: string): boolean {
+  return TEXT_MIME_PREFIXES.some((prefix) => mimeType.startsWith(prefix));
+}
+
+export const MAX_INLINE_TEXT_SIZE = 2 * 1024 * 1024; // 2 MB


### PR DESCRIPTION
## Summary
- Extract workspace path validation into shared `resolveWorkspacePath()` utility
- Add `isTextMimeType()` and `MAX_INLINE_TEXT_SIZE` for MIME-based content handling
- Refactor existing IPC workspace file read handler to use shared utility

Part of plan: workspace-tab.md (PR 1 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
