### PR TITLE
feat: add GET /v1/workspace/tree endpoint for lazy directory listing

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -139,6 +139,7 @@ import { surfaceActionRouteDefinitions } from "./routes/surface-action-routes.js
 import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.js";
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";
 import { usageRouteDefinitions } from "./routes/usage-routes.js";
+import { workspaceRouteDefinitions } from "./routes/workspace-routes.js";
 
 // Re-export for consumers
 export { isPrivateAddress } from "./middleware/auth.js";
@@ -960,6 +961,7 @@ export class RuntimeHttpServer {
       ...brainGraphRouteDefinitions({ mintUiPageToken }),
       ...eventsRouteDefinitions(),
       ...migrationRouteDefinitions(),
+      ...workspaceRouteDefinitions(),
 
       // Internal OAuth callback (gateway -> runtime)
       {

--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -1,0 +1,67 @@
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { getWorkspaceDir } from "../../util/platform.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+import { resolveWorkspacePath } from "./workspace-utils.js";
+
+interface TreeEntry {
+  name: string;
+  path: string;
+  type: "file" | "directory";
+  size: number | undefined;
+  mimeType: string | undefined;
+  modifiedAt: string;
+}
+
+function handleWorkspaceTree(ctx: { url: URL }): Response {
+  const requestedPath = ctx.url.searchParams.get("path") ?? "";
+  const resolved = resolveWorkspacePath(requestedPath);
+  if (resolved === undefined) {
+    return httpError("BAD_REQUEST", "Invalid path", 400);
+  }
+
+  try {
+    const dirents = readdirSync(resolved, { withFileTypes: true });
+    const workspaceDir = getWorkspaceDir();
+
+    const entries: TreeEntry[] = dirents.map((entry) => {
+      const fullPath = join(resolved, entry.name);
+      const isDir = entry.isDirectory();
+      const stats = statSync(fullPath);
+      const relativePath = fullPath.slice(workspaceDir.length + 1);
+
+      return {
+        name: entry.name,
+        path: relativePath,
+        type: isDir ? "directory" : "file",
+        size: isDir ? undefined : stats.size,
+        mimeType: isDir ? undefined : Bun.file(fullPath).type,
+        modifiedAt: stats.mtime.toISOString(),
+      };
+    });
+
+    // Sort: directories first, then files, alphabetically within each group
+    entries.sort((a, b) => {
+      if (a.type !== b.type) {
+        return a.type === "directory" ? -1 : 1;
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+    return Response.json({ path: requestedPath, entries });
+  } catch {
+    return httpError("NOT_FOUND", "Directory not found", 404);
+  }
+}
+
+export function workspaceRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "workspace/tree",
+      method: "GET",
+      handler: (ctx) => handleWorkspaceTree(ctx),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add `workspace-routes.ts` with `GET /v1/workspace/tree` endpoint for lazy directory listing
- Returns sorted entries (directories first) with name, path, type, size, mimeType, modifiedAt
- Register workspace routes in http-server.ts

Part of plan: workspace-tab.md (PR 2 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
