### PR TITLE
feat: add GET /v1/workspace/file endpoint for reading file metadata and text content

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -139,6 +139,7 @@ import { surfaceActionRouteDefinitions } from "./routes/surface-action-routes.js
 import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.js";
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";
 import { usageRouteDefinitions } from "./routes/usage-routes.js";
+import { workspaceRouteDefinitions } from "./routes/workspace-routes.js";
 
 // Re-export for consumers
 export { isPrivateAddress } from "./middleware/auth.js";
@@ -688,6 +689,7 @@ export class RuntimeHttpServer {
       ...identityRouteDefinitions(),
       ...debugRouteDefinitions(),
       ...usageRouteDefinitions(),
+      ...workspaceRouteDefinitions(),
 
       // Browser relay — not extracted into a domain module because
       // these two routes depend on the in-process extensionRelayServer

--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -1,0 +1,126 @@
+/**
+ * Route handlers for workspace file browsing.
+ *
+ * Provides lazy directory listing and file metadata/content endpoints
+ * for the Workspace tab in the Intelligence panel.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+
+import { getWorkspaceDir } from "../../util/platform.js";
+import { httpError } from "../http-errors.js";
+import type { RouteContext, RouteDefinition } from "../http-router.js";
+import {
+  isTextMimeType,
+  MAX_INLINE_TEXT_SIZE,
+  resolveWorkspacePath,
+} from "./workspace-utils.js";
+
+// ---------------------------------------------------------------------------
+// GET /v1/workspace/tree — lazy directory listing
+// ---------------------------------------------------------------------------
+
+function handleWorkspaceTree(ctx: RouteContext): Response {
+  const requestedPath = ctx.url.searchParams.get("path") ?? "";
+  const resolved = resolveWorkspacePath(requestedPath);
+  if (resolved === undefined) {
+    return httpError("BAD_REQUEST", "Invalid path", 400);
+  }
+
+  try {
+    const dirEntries = readdirSync(resolved, { withFileTypes: true });
+    const workspaceRoot = getWorkspaceDir();
+
+    const entries = dirEntries
+      .map((entry) => {
+        const fullPath = join(resolved, entry.name);
+        const stat = statSync(fullPath);
+        const relativePath = fullPath.slice(workspaceRoot.length + 1);
+        const isDir = entry.isDirectory();
+        return {
+          name: entry.name,
+          path: relativePath,
+          type: isDir ? ("directory" as const) : ("file" as const),
+          size: isDir ? undefined : stat.size,
+          mimeType: isDir ? undefined : Bun.file(fullPath).type,
+          modifiedAt: stat.mtime.toISOString(),
+        };
+      })
+      .sort((a, b) => {
+        if (a.type !== b.type) {
+          return a.type === "directory" ? -1 : 1;
+        }
+        return a.name.localeCompare(b.name);
+      });
+
+    return Response.json({ path: requestedPath, entries });
+  } catch {
+    return httpError("NOT_FOUND", "Directory not found", 404);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/workspace/file — file metadata + inline text content
+// ---------------------------------------------------------------------------
+
+function handleWorkspaceFile(ctx: RouteContext): Response {
+  const path = ctx.url.searchParams.get("path");
+  if (!path) {
+    return httpError("BAD_REQUEST", "path query parameter is required", 400);
+  }
+
+  const resolved = resolveWorkspacePath(path);
+  if (resolved === undefined) {
+    return httpError("BAD_REQUEST", "Invalid path", 400);
+  }
+
+  let stat: ReturnType<typeof statSync>;
+  try {
+    stat = statSync(resolved);
+  } catch {
+    return httpError("NOT_FOUND", "File not found", 404);
+  }
+
+  if (!stat.isFile()) {
+    return httpError("NOT_FOUND", "File not found", 404);
+  }
+
+  const mimeType = Bun.file(resolved).type;
+  const isText = isTextMimeType(mimeType);
+  const isBinary = !isText;
+
+  let content: string | undefined = undefined;
+  if (isText && stat.size <= MAX_INLINE_TEXT_SIZE) {
+    content = readFileSync(resolved, "utf-8");
+  }
+
+  return Response.json({
+    path,
+    name: basename(resolved),
+    size: stat.size,
+    mimeType,
+    modifiedAt: stat.mtime.toISOString(),
+    content: content ?? null,
+    isBinary,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function workspaceRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "workspace/tree",
+      method: "GET",
+      handler: (ctx) => handleWorkspaceTree(ctx),
+    },
+    {
+      endpoint: "workspace/file",
+      method: "GET",
+      handler: (ctx) => handleWorkspaceFile(ctx),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add `handleWorkspaceFile` handler for GET /v1/workspace/file endpoint
- Returns file metadata (name, size, mimeType, modifiedAt) and inline text content for text files
- Binary files return `isBinary: true` with `content: null`
- Also includes `handleWorkspaceTree` handler from PR 2 (workspace tree listing) since both share the same file

Part of plan: workspace-tab.md (PR 3 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
