### PR TITLE
feat: add GET /v1/workspace/file/content endpoint for serving raw file bytes

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -139,6 +139,7 @@ import { surfaceActionRouteDefinitions } from "./routes/surface-action-routes.js
 import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.js";
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";
 import { usageRouteDefinitions } from "./routes/usage-routes.js";
+import { workspaceRouteDefinitions } from "./routes/workspace-routes.js";
 
 // Re-export for consumers
 export { isPrivateAddress } from "./middleware/auth.js";
@@ -688,6 +689,7 @@ export class RuntimeHttpServer {
       ...identityRouteDefinitions(),
       ...debugRouteDefinitions(),
       ...usageRouteDefinitions(),
+      ...workspaceRouteDefinitions(),
 
       // Browser relay — not extracted into a domain module because
       // these two routes depend on the in-process extensionRelayServer

--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -1,0 +1,220 @@
+/**
+ * Route handlers for workspace file browsing and content serving.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+
+import { httpError } from "../http-errors.js";
+import type { RouteContext, RouteDefinition } from "../http-router.js";
+import {
+  isTextMimeType,
+  MAX_INLINE_TEXT_SIZE,
+  resolveWorkspacePath,
+} from "./workspace-utils.js";
+
+// ---------------------------------------------------------------------------
+// GET /v1/workspace/tree — directory listing
+// ---------------------------------------------------------------------------
+
+interface TreeEntry {
+  name: string;
+  type: "file" | "directory";
+  size?: number;
+  mimeType?: string;
+}
+
+function handleWorkspaceTree(ctx: RouteContext): Response {
+  const relativePath = ctx.url.searchParams.get("path") ?? ".";
+
+  const resolved = resolveWorkspacePath(relativePath);
+  if (resolved === undefined) {
+    return httpError("BAD_REQUEST", "Invalid path", 400);
+  }
+
+  if (!existsSync(resolved)) {
+    return httpError("NOT_FOUND", "Directory not found", 404);
+  }
+
+  const stat = statSync(resolved);
+  if (!stat.isDirectory()) {
+    return httpError("BAD_REQUEST", "Path is not a directory", 400);
+  }
+
+  const entries: TreeEntry[] = [];
+  for (const entry of readdirSync(resolved, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+
+    if (entry.isDirectory()) {
+      entries.push({ name: entry.name, type: "directory" });
+    } else if (entry.isFile()) {
+      const filePath = `${resolved}/${entry.name}`;
+      const fileStat = statSync(filePath);
+      const bunFile = Bun.file(filePath);
+      entries.push({
+        name: entry.name,
+        type: "file",
+        size: fileStat.size,
+        mimeType: bunFile.type,
+      });
+    }
+  }
+
+  return Response.json({ entries });
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/workspace/file — file metadata + inline text content
+// ---------------------------------------------------------------------------
+
+function handleWorkspaceFile(ctx: RouteContext): Response {
+  const path = ctx.url.searchParams.get("path");
+  if (!path) {
+    return httpError(
+      "BAD_REQUEST",
+      "Missing required query parameter: path",
+      400,
+    );
+  }
+
+  const resolved = resolveWorkspacePath(path);
+  if (resolved === undefined) {
+    return httpError("BAD_REQUEST", "Invalid path", 400);
+  }
+
+  if (!existsSync(resolved)) {
+    return httpError("NOT_FOUND", "File not found", 404);
+  }
+
+  const stat = statSync(resolved);
+  if (!stat.isFile()) {
+    return httpError("BAD_REQUEST", "Path is not a file", 400);
+  }
+
+  const bunFile = Bun.file(resolved);
+  const mimeType = bunFile.type;
+  const size = stat.size;
+
+  const result: Record<string, unknown> = {
+    path,
+    mimeType,
+    size,
+  };
+
+  // Inline text content for small text files
+  if (isTextMimeType(mimeType) && size <= MAX_INLINE_TEXT_SIZE) {
+    result.content = readFileSync(resolved, "utf-8");
+  }
+
+  return Response.json(result);
+}
+
+// ---------------------------------------------------------------------------
+// GET /v1/workspace/file/content — raw file bytes with range support
+// ---------------------------------------------------------------------------
+
+function handleWorkspaceFileContent(ctx: RouteContext): Response {
+  const path = ctx.url.searchParams.get("path");
+  if (!path) {
+    return httpError(
+      "BAD_REQUEST",
+      "Missing required query parameter: path",
+      400,
+    );
+  }
+
+  const resolved = resolveWorkspacePath(path);
+  if (resolved === undefined) {
+    return httpError("BAD_REQUEST", "Invalid path", 400);
+  }
+
+  if (!existsSync(resolved)) {
+    return httpError("NOT_FOUND", "File not found", 404);
+  }
+
+  const file = Bun.file(resolved);
+  const fileSize = file.size;
+  const mimeType = file.type;
+
+  const rangeHeader = ctx.req.headers.get("Range");
+
+  if (rangeHeader) {
+    let start: number;
+    let end: number;
+
+    // Parse suffix range: bytes=-N (last N bytes)
+    const suffixMatch = rangeHeader.match(/bytes=-(\d+)/);
+    if (suffixMatch) {
+      const suffixLen = parseInt(suffixMatch[1]);
+      start = Math.max(0, fileSize - suffixLen);
+      end = fileSize - 1;
+    } else {
+      // Parse standard range: bytes=start-end
+      const match = rangeHeader.match(/bytes=(\d+)-(\d*)/);
+      if (!match) {
+        // Unparseable range — return full file
+        return new Response(file, {
+          headers: {
+            "Content-Type": mimeType,
+            "Content-Length": String(fileSize),
+            "Accept-Ranges": "bytes",
+          },
+        });
+      }
+      start = parseInt(match[1]);
+      end = match[2] ? parseInt(match[2]) : fileSize - 1;
+    }
+
+    // Clamp end to file size
+    end = Math.min(end, fileSize - 1);
+
+    // Reject invalid ranges
+    if (start > end || start >= fileSize) {
+      return new Response(null, {
+        status: 416,
+        headers: { "Content-Range": `bytes */${fileSize}` },
+      });
+    }
+
+    const slice = file.slice(start, end + 1);
+    return new Response(slice, {
+      status: 206,
+      headers: {
+        "Content-Type": mimeType,
+        "Content-Range": `bytes ${start}-${end}/${fileSize}`,
+        "Accept-Ranges": "bytes",
+        "Content-Length": String(end - start + 1),
+      },
+    });
+  }
+
+  return new Response(file, {
+    headers: {
+      "Content-Type": mimeType,
+      "Content-Length": String(fileSize),
+      "Accept-Ranges": "bytes",
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function workspaceRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "workspace/tree",
+      method: "GET",
+      handler: (ctx) => handleWorkspaceTree(ctx),
+    },
+    {
+      endpoint: "workspace/file/content",
+      method: "GET",
+      handler: (ctx) => handleWorkspaceFileContent(ctx),
+    },
+    {
+      endpoint: "workspace/file",
+      method: "GET",
+      handler: (ctx) => handleWorkspaceFile(ctx),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add `handleWorkspaceFileContent` handler for GET /v1/workspace/file/content endpoint
- Serves raw file bytes with correct Content-Type and Content-Length headers
- Supports HTTP Range requests (206 Partial Content) for streaming
- Accept-Ranges: bytes header advertised
- Also includes workspace/tree and workspace/file handlers (shared file with parallel PRs)

Part of plan: workspace-tab.md (PR 4 of 12)

## Test plan
- [ ] Verify `bunx tsc --noEmit` passes
- [ ] Confirm image files return raw bytes with correct Content-Type (e.g., image/png)
- [ ] Confirm Accept-Ranges: bytes header is present on responses
- [ ] Confirm Range requests return 206 with correct Content-Range header
- [ ] Confirm invalid ranges return 416

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
