### PR TITLE
feat: add DaemonClient fetch methods for workspace tree, file, and content URL

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1061,6 +1061,63 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         }
     }
 
+    // MARK: - Workspace API
+
+    /// Fetch the workspace directory tree.
+    /// Delegates to HTTPTransport for remote connections, or calls the local daemon HTTP server.
+    public func fetchWorkspaceTree(path: String = "") async -> WorkspaceTreeResponse? {
+        if let httpTransport {
+            return await httpTransport.fetchWorkspaceTree(path: path)
+        }
+
+        let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? path
+        let queryPath = path.isEmpty ? "v1/workspace/tree" : "v1/workspace/tree?path=\(encoded)"
+        guard let request = buildLocalRequest(target: .daemon, path: queryPath, timeout: 10) else { return nil }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else { return nil }
+            return try JSONDecoder().decode(WorkspaceTreeResponse.self, from: data)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Fetch a single workspace file's metadata and optional content.
+    /// Delegates to HTTPTransport for remote connections, or calls the local daemon HTTP server.
+    public func fetchWorkspaceFile(path: String) async -> WorkspaceFileResponse? {
+        if let httpTransport {
+            return await httpTransport.fetchWorkspaceFile(path: path)
+        }
+
+        let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? path
+        guard let request = buildLocalRequest(
+            target: .daemon,
+            path: "v1/workspace/file?path=\(encoded)",
+            timeout: 10
+        ) else { return nil }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else { return nil }
+            return try JSONDecoder().decode(WorkspaceFileResponse.self, from: data)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Build a URL for streaming/downloading workspace file content.
+    /// For remote connections, delegates to HTTPTransport. For local, builds against daemon HTTP port.
+    public func workspaceFileContentURL(path: String) -> URL? {
+        if let httpTransport {
+            return httpTransport.workspaceFileContentURL(path: path)
+        }
+
+        let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? path
+        guard let port = httpPort else { return nil }
+        return URL(string: "http://localhost:\(port)/v1/workspace/file/content?path=\(encoded)")
+    }
+
     // MARK: - Surface Undo
 
     /// Send a surface undo request to revert the last refinement on a workspace surface.

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -51,31 +51,31 @@ private struct HTTPErrorEnvelope: Decodable {
 
 // MARK: - Workspace API Response Types
 
-struct WorkspaceTreeEntry: Codable, Identifiable, Hashable {
-    let name: String
-    let path: String
-    let type: String  // "file" or "directory"
-    let size: Int?
-    let mimeType: String?
-    let modifiedAt: String
+public struct WorkspaceTreeEntry: Codable, Identifiable, Hashable, Sendable {
+    public let name: String
+    public let path: String
+    public let type: String  // "file" or "directory"
+    public let size: Int?
+    public let mimeType: String?
+    public let modifiedAt: String
 
-    var id: String { path }
-    var isDirectory: Bool { type == "directory" }
+    public var id: String { path }
+    public var isDirectory: Bool { type == "directory" }
 }
 
-struct WorkspaceTreeResponse: Codable {
-    let path: String
-    let entries: [WorkspaceTreeEntry]
+public struct WorkspaceTreeResponse: Codable, Sendable {
+    public let path: String
+    public let entries: [WorkspaceTreeEntry]
 }
 
-struct WorkspaceFileResponse: Codable {
-    let path: String
-    let name: String
-    let size: Int
-    let mimeType: String
-    let modifiedAt: String
-    let content: String?
-    let isBinary: Bool
+public struct WorkspaceFileResponse: Codable, Sendable {
+    public let path: String
+    public let name: String
+    public let size: Int
+    public let mimeType: String
+    public let modifiedAt: String
+    public let content: String?
+    public let isBinary: Bool
 }
 
 // MARK: - HTTP Transport
@@ -2088,6 +2088,67 @@ public final class HTTPTransport {
             log.error("fetchUsageBreakdown failed: \(error.localizedDescription)")
             return nil
         }
+    }
+
+    // MARK: - Workspace API
+
+    /// Fetch the workspace directory tree from `GET /v1/workspace/tree`.
+    func fetchWorkspaceTree(path: String, isRetry: Bool = false) async -> WorkspaceTreeResponse? {
+        guard let url = buildURL(for: .workspaceTree(path: path)) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await fetchWorkspaceTree(path: path, isRetry: true)
+                    }
+                    return nil
+                }
+                guard (200...299).contains(http.statusCode) else { return nil }
+            }
+            return try decoder.decode(WorkspaceTreeResponse.self, from: data)
+        } catch {
+            log.error("fetchWorkspaceTree failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// Fetch a single workspace file's metadata from `GET /v1/workspace/file`.
+    func fetchWorkspaceFile(path: String, isRetry: Bool = false) async -> WorkspaceFileResponse? {
+        guard let url = buildURL(for: .workspaceFile(path: path)) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await fetchWorkspaceFile(path: path, isRetry: true)
+                    }
+                    return nil
+                }
+                guard (200...299).contains(http.statusCode) else { return nil }
+            }
+            return try decoder.decode(WorkspaceFileResponse.self, from: data)
+        } catch {
+            log.error("fetchWorkspaceFile failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// Build a URL for streaming/downloading workspace file content.
+    func workspaceFileContentURL(path: String) -> URL? {
+        return buildURL(for: .workspaceFileContent(path: path))
     }
 
     // MARK: - Disconnect


### PR DESCRIPTION
## Summary
- Add `fetchWorkspaceTree`, `fetchWorkspaceFile`, `workspaceFileContentURL` to HTTPTransport
- Add corresponding public methods to DaemonClient with local/remote mode support
- Follow existing auth retry and URL construction patterns
- Make `WorkspaceTreeEntry`, `WorkspaceTreeResponse`, `WorkspaceFileResponse` public and Sendable for cross-module use

Part of plan: workspace-tab.md (PR 7 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
