### PR TITLE
fix: prevent duplicate Telegram messages when gateway omits messageId

### DIFF
--- a/assistant/src/runtime/telegram-streaming-delivery.test.ts
+++ b/assistant/src/runtime/telegram-streaming-delivery.test.ts
@@ -412,6 +412,88 @@ describe("TelegramStreamingDelivery", () => {
     expect(delivery.finishSucceeded).toBe(true);
   });
 
+  // ── Test 5h: no-messageId response doesn't cause duplicate messages on continued deltas ─
+  test("no-messageId response doesn't cause duplicate messages on continued deltas", async () => {
+    // Simulate the exact bug from the screenshot: initial send succeeds
+    // without messageId, then more deltas create overlapping new messages
+    mockDeliverChannelReply.mockReset();
+    mockDeliverChannelReply.mockImplementation(
+      async (): Promise<ChannelDeliveryResult> => {
+        // All sends return no messageId (simulates gateway omitting it)
+        return { ok: true };
+      },
+    );
+
+    const delivery = createDelivery();
+
+    // First batch: triggers sendInitialMessage (>= 20 chars)
+    delivery.onEvent({
+      type: "assistant_text_delta",
+      text: "Alright, hit me with something",
+    });
+    await flushPromises();
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(1);
+    expect(callPayload(0).text).toBe("Alright, hit me with something");
+
+    // More deltas arrive — should NOT trigger another sendInitialMessage
+    delivery.onEvent({
+      type: "assistant_text_delta",
+      text: " longer and let's see if it comes through as one",
+    });
+    await flushPromises();
+    // Still only 1 call — text accumulates in buffer
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(1);
+
+    delivery.onEvent({
+      type: "assistant_text_delta",
+      text: " message now!",
+    });
+    await delivery.finish();
+
+    // finish() should send the remainder as a single new message
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(2);
+    const finishPayload = callPayload(1);
+    expect(finishPayload.text).toBe(
+      " longer and let's see if it comes through as one message now!",
+    );
+    expect(finishPayload.messageId).toBeUndefined();
+    expect(delivery.finishSucceeded).toBe(true);
+  });
+
+  // ── Test 5i: combined threshold accounts for pre-tool currentMessageText ─
+  test("combined threshold accounts for pre-tool currentMessageText", async () => {
+    const delivery = createDelivery();
+
+    // Send 15 chars (below 20 threshold)
+    delivery.onEvent({
+      type: "assistant_text_delta",
+      text: "Hello, world!! ", // 15 chars
+    });
+    await flushPromises();
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(0);
+
+    // tool_use_start moves 15 chars to currentMessageText
+    delivery.onEvent({
+      type: "tool_use_start",
+      toolName: "lookup",
+      input: {},
+    });
+
+    // Send only 6 more chars — buffer alone (6) < 20, but combined (21) >= 20
+    delivery.onEvent({
+      type: "assistant_text_delta",
+      text: "Great!",
+    });
+    await flushPromises();
+
+    // Should have triggered initial send with combined text
+    expect(mockDeliverChannelReply).toHaveBeenCalledTimes(1);
+    expect(callPayload(0).text).toBe("Hello, world!! Great!");
+
+    await delivery.finish();
+    expect(delivery.finishSucceeded).toBe(true);
+  });
+
   // ── Test 6: skips final edit when text hasn't changed ───────────────
   test("skips final edit when text hasn't changed", async () => {
     const delivery = createDelivery();

--- a/assistant/src/runtime/telegram-streaming-delivery.ts
+++ b/assistant/src/runtime/telegram-streaming-delivery.ts
@@ -109,6 +109,7 @@ export class TelegramStreamingDelivery {
     // tool_use_start) before any Telegram message was created. Send it now.
     if (
       !this.currentMessageId &&
+      !this.textDelivered &&
       this.currentMessageText.length > 0 &&
       this.buffer.length === 0
     ) {
@@ -186,7 +187,8 @@ export class TelegramStreamingDelivery {
     if (
       !this.currentMessageId &&
       !this.initialSendInFlight &&
-      this.buffer.length >= MIN_INITIAL_CHARS
+      !this.textDelivered &&
+      this.buffer.length + this.currentMessageText.length >= MIN_INITIAL_CHARS
     ) {
       this.sendInitialMessage();
     } else if (this.currentMessageId) {


### PR DESCRIPTION
## Summary
- Add `textDelivered` guard to `onTextDelta` to prevent re-calling `sendInitialMessage()` when text was already sent but no messageId was returned, which caused duplicate overlapping messages
- Add `textDelivered` guard to `finish()` fallback to prevent re-sending already-delivered text
- Use combined `buffer + currentMessageText` length for initial-send threshold so pre-tool text counts toward the minimum
- Add tests for no-messageId streaming scenario and combined threshold behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
