### PR TITLE
feat: add iOS workspace browser with navigation-stack directory browsing and MIME-aware file viewer

### DIFF
--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -8,7 +8,6 @@ import VellumAssistantShared
 final class IdentityViewModel {
     var identity: RemoteIdentityInfo?
     var skills: [SkillInfo] = []
-    var workspaceFiles: [WorkspaceFileInfo] = []
     var isLoading = false
 
     func fetchAll(client: any DaemonClientProtocol) async {
@@ -18,9 +17,8 @@ final class IdentityViewModel {
         identity = await identityResult
         isLoading = false
 
-        // Fetch skills and workspace files via IPC (fire-and-forget subscribe)
+        // Fetch skills via IPC (fire-and-forget subscribe)
         await fetchSkills(daemonClient: daemonClient)
-        await fetchWorkspaceFiles(daemonClient: daemonClient)
     }
 
     private func fetchSkills(daemonClient: DaemonClient) async {
@@ -53,37 +51,6 @@ final class IdentityViewModel {
             skills = response.skills.filter { $0.state == "enabled" }
         }
     }
-
-    private func fetchWorkspaceFiles(daemonClient: DaemonClient) async {
-        let stream = daemonClient.subscribe()
-        do {
-            try daemonClient.sendWorkspaceFilesList()
-        } catch {
-            return
-        }
-
-        let response: WorkspaceFilesListResponseMessage? = await withTaskGroup(of: WorkspaceFilesListResponseMessage?.self) { group in
-            group.addTask {
-                for await message in stream {
-                    if case .workspaceFilesListResponse(let msg) = message {
-                        return msg
-                    }
-                }
-                return nil
-            }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: 10_000_000_000)
-                return nil
-            }
-            let first = await group.next() ?? nil
-            group.cancelAll()
-            return first
-        }
-
-        if let response {
-            workspaceFiles = response.files.filter { $0.exists }
-        }
-    }
 }
 
 // MARK: - View
@@ -91,7 +58,6 @@ final class IdentityViewModel {
 struct IdentityView: View {
     @EnvironmentObject var clientProvider: ClientProvider
     @State private var viewModel = IdentityViewModel()
-    @State private var viewingFile: WorkspaceFileInfo?
     var onConnectTapped: (() -> Void)?
 
     var body: some View {
@@ -113,12 +79,6 @@ struct IdentityView: View {
             guard clientProvider.isConnected else { return }
             await viewModel.fetchAll(client: clientProvider.client)
         }
-        .sheet(item: $viewingFile) { file in
-            WorkspaceFileSheet(
-                file: file,
-                client: clientProvider.client as? DaemonClient
-            )
-        }
     }
 
     // MARK: - ID Card Content
@@ -133,9 +93,7 @@ struct IdentityView: View {
                     skillsSection
                 }
 
-                if !viewModel.workspaceFiles.isEmpty {
-                    workspaceFilesSection
-                }
+                workspaceFilesSection
             }
             .padding(.horizontal, VSpacing.lg)
             .padding(.top, VSpacing.md)
@@ -310,36 +268,18 @@ struct IdentityView: View {
 
     private var workspaceFilesSection: some View {
         VStack(spacing: 0) {
-            sectionHeader(icon: .fileText, title: "Workspace Files")
+            sectionHeader(icon: .fileText, title: "Workspace")
 
-            VStack(spacing: 0) {
-                ForEach(Array(viewModel.workspaceFiles.enumerated()), id: \.element.id) { index, file in
-                    workspaceFileRow(file, isLast: index == viewModel.workspaceFiles.count - 1)
-                }
-            }
-        }
-        .background(VColor.surface)
-        .cornerRadius(VRadius.lg)
-        .overlay(
-            RoundedRectangle(cornerRadius: VRadius.lg)
-                .stroke(VColor.surfaceBorder, lineWidth: 1)
-        )
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Workspace files")
-    }
-
-    private func workspaceFileRow(_ file: WorkspaceFileInfo, isLast: Bool) -> some View {
-        VStack(spacing: 0) {
-            Button {
-                viewingFile = file
+            NavigationLink {
+                WorkspaceBrowserView(client: clientProvider.client as? DaemonClient)
             } label: {
                 HStack(spacing: VSpacing.sm) {
-                    VIconView(file.name.hasSuffix("/") ? .folder : .fileText, size: 16)
+                    VIconView(.folder, size: 16)
                         .foregroundColor(VColor.accent)
                         .frame(width: 24)
                         .accessibilityHidden(true)
 
-                    Text(file.name)
+                    Text("Browse Workspace")
                         .font(VFont.body)
                         .foregroundColor(VColor.textPrimary)
 
@@ -352,15 +292,13 @@ struct IdentityView: View {
                 .padding(.horizontal, VSpacing.lg)
                 .padding(.vertical, VSpacing.sm)
             }
-
-            if !isLast {
-                Divider()
-                    .padding(.leading, VSpacing.lg + 24 + VSpacing.sm)
-            }
         }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(file.name)
-        .accessibilityHint("Opens file viewer")
+        .background(VColor.surface)
+        .cornerRadius(VRadius.lg)
+        .overlay(
+            RoundedRectangle(cornerRadius: VRadius.lg)
+                .stroke(VColor.surfaceBorder, lineWidth: 1)
+        )
     }
 
     // MARK: - Shared Section Header

--- a/clients/ios/Views/WorkspaceBrowserView.swift
+++ b/clients/ios/Views/WorkspaceBrowserView.swift
@@ -1,0 +1,143 @@
+#if canImport(UIKit)
+import SwiftUI
+import VellumAssistantShared
+
+struct WorkspaceBrowserView: View {
+    let client: DaemonClient?
+    var initialPath: String = ""
+
+    @State private var entries: [WorkspaceTreeEntry] = []
+    @State private var isLoading = true
+    @State private var selectedFile: WorkspaceTreeEntry?
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if entries.isEmpty {
+                VStack(spacing: VSpacing.md) {
+                    VIconView(.folder, size: 36)
+                        .foregroundColor(VColor.textMuted)
+                        .accessibilityHidden(true)
+                    Text("Empty directory")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textSecondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List {
+                    ForEach(entries) { entry in
+                        if entry.isDirectory {
+                            NavigationLink(value: entry) {
+                                directoryRow(entry)
+                            }
+                        } else {
+                            Button { selectedFile = entry } label: {
+                                fileRow(entry)
+                            }
+                        }
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+        .navigationTitle(initialPath.isEmpty ? "Workspace" : lastPathComponent(initialPath))
+        .navigationDestination(for: WorkspaceTreeEntry.self) { entry in
+            WorkspaceBrowserView(client: client, initialPath: entry.path)
+        }
+        .sheet(item: $selectedFile) { file in
+            WorkspaceFileSheet(filePath: file.path, mimeType: file.mimeType, client: client)
+        }
+        .task { await loadDirectory() }
+    }
+
+    // MARK: - Row Views
+
+    private func directoryRow(_ entry: WorkspaceTreeEntry) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            VIconView(.folder, size: 16)
+                .foregroundColor(VColor.accent)
+                .frame(width: 24)
+                .accessibilityHidden(true)
+
+            Text(entry.name)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+
+            Spacer()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(entry.name), directory")
+    }
+
+    private func fileRow(_ entry: WorkspaceTreeEntry) -> some View {
+        HStack(spacing: VSpacing.sm) {
+            VIconView(iconForMimeType(entry.mimeType), size: 16)
+                .foregroundColor(VColor.accent)
+                .frame(width: 24)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entry.name)
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textPrimary)
+
+                if let size = entry.size {
+                    Text(formatFileSize(size))
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+            }
+
+            Spacer()
+
+            VIconView(.chevronRight, size: 12)
+                .foregroundColor(VColor.textMuted)
+                .accessibilityHidden(true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(entry.name)
+        .accessibilityHint("Opens file viewer")
+    }
+
+    // MARK: - Helpers
+
+    private func loadDirectory() async {
+        guard let client else {
+            isLoading = false
+            return
+        }
+
+        if let response = await client.fetchWorkspaceTree(path: initialPath) {
+            entries = response.entries
+        }
+        isLoading = false
+    }
+
+    private func lastPathComponent(_ path: String) -> String {
+        let trimmed = path.hasSuffix("/") ? String(path.dropLast()) : path
+        return trimmed.components(separatedBy: "/").last ?? path
+    }
+
+    private func iconForMimeType(_ mimeType: String?) -> VIcon {
+        guard let mimeType else { return .file }
+        if mimeType.hasPrefix("image/") { return .image }
+        if mimeType.hasPrefix("video/") { return .video }
+        if mimeType.hasPrefix("text/") { return .fileText }
+        if mimeType == "application/json" { return .fileCode }
+        if mimeType == "application/pdf" { return .fileText }
+        return .file
+    }
+
+    private func formatFileSize(_ bytes: Int) -> String {
+        if bytes < 1024 { return "\(bytes) B" }
+        let kb = Double(bytes) / 1024.0
+        if kb < 1024 { return String(format: "%.1f KB", kb) }
+        let mb = kb / 1024.0
+        if mb < 1024 { return String(format: "%.1f MB", mb) }
+        let gb = mb / 1024.0
+        return String(format: "%.1f GB", gb)
+    }
+}
+#endif

--- a/clients/ios/Views/WorkspaceFileSheet.swift
+++ b/clients/ios/Views/WorkspaceFileSheet.swift
@@ -1,14 +1,21 @@
 #if canImport(UIKit)
 import SwiftUI
+import AVKit
 import VellumAssistantShared
 
 struct WorkspaceFileSheet: View {
-    let file: WorkspaceFileInfo
+    let filePath: String
+    let mimeType: String?
     let client: DaemonClient?
     @Environment(\.dismiss) private var dismiss
-    @State private var content: String?
+    @State private var fileResponse: WorkspaceFileResponse?
     @State private var isLoading = true
     @State private var error: String?
+
+    var displayName: String {
+        let trimmed = filePath.hasSuffix("/") ? String(filePath.dropLast()) : filePath
+        return trimmed.components(separatedBy: "/").last ?? filePath
+    }
 
     var body: some View {
         NavigationStack {
@@ -33,19 +40,11 @@ struct WorkspaceFileSheet: View {
                     }
                     .padding(VSpacing.xl)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else if let content {
-                    ScrollView {
-                        markdownContent(content)
-                            .padding(VSpacing.lg)
-                    }
                 } else {
-                    Text("No content")
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textMuted)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    contentView
                 }
             }
-            .navigationTitle(file.name)
+            .navigationTitle(displayName)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
@@ -58,6 +57,106 @@ struct WorkspaceFileSheet: View {
         }
     }
 
+    // MARK: - MIME-Aware Content Rendering
+
+    @ViewBuilder
+    private var contentView: some View {
+        let resolvedMime = fileResponse?.mimeType ?? mimeType ?? ""
+
+        if resolvedMime.hasPrefix("image/"), let contentURL = client?.workspaceFileContentURL(path: filePath) {
+            ScrollView {
+                AsyncImage(url: contentURL) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxWidth: .infinity)
+                    case .failure:
+                        VStack(spacing: VSpacing.md) {
+                            VIconView(.image, size: 36)
+                                .foregroundColor(VColor.textMuted)
+                                .accessibilityHidden(true)
+                            Text("Unable to load image")
+                                .font(VFont.body)
+                                .foregroundColor(VColor.textSecondary)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    case .empty:
+                        ProgressView()
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    @unknown default:
+                        EmptyView()
+                    }
+                }
+                .padding(VSpacing.lg)
+            }
+        } else if resolvedMime.hasPrefix("video/"), let contentURL = client?.workspaceFileContentURL(path: filePath) {
+            VideoPlayer(player: AVPlayer(url: contentURL))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if resolvedMime.hasPrefix("text/") || resolvedMime == "application/json",
+                  let content = fileResponse?.content {
+            ScrollView {
+                markdownContent(content)
+                    .padding(VSpacing.lg)
+            }
+        } else if let content = fileResponse?.content, !content.isEmpty {
+            // Fallback: if we got text content regardless of MIME type, show it
+            ScrollView {
+                markdownContent(content)
+                    .padding(VSpacing.lg)
+            }
+        } else if let response = fileResponse {
+            // Binary/unknown file — show metadata
+            metadataView(response)
+        } else {
+            Text("No content")
+                .font(VFont.body)
+                .foregroundColor(VColor.textMuted)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func metadataView(_ response: WorkspaceFileResponse) -> some View {
+        VStack(spacing: VSpacing.lg) {
+            VIconView(.file, size: 48)
+                .foregroundColor(VColor.textMuted)
+                .accessibilityHidden(true)
+
+            VStack(spacing: VSpacing.sm) {
+                metadataRow(label: "Name", value: response.name)
+                metadataRow(label: "Size", value: formatFileSize(response.size))
+                metadataRow(label: "Type", value: response.mimeType)
+                metadataRow(label: "Modified", value: formatDate(response.modifiedAt))
+            }
+            .padding(VSpacing.lg)
+            .background(VColor.surface)
+            .cornerRadius(VRadius.lg)
+            .overlay(
+                RoundedRectangle(cornerRadius: VRadius.lg)
+                    .stroke(VColor.surfaceBorder, lineWidth: 1)
+            )
+        }
+        .padding(VSpacing.xl)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func metadataRow(label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(VFont.caption)
+                .foregroundColor(VColor.textMuted)
+                .frame(width: 80, alignment: .leading)
+            Text(value)
+                .font(VFont.body)
+                .foregroundColor(VColor.textPrimary)
+                .lineLimit(2)
+            Spacer()
+        }
+    }
+
+    // MARK: - Markdown Rendering
+
     @ViewBuilder
     private func markdownContent(_ raw: String) -> some View {
         if let attributed = try? AttributedString(markdown: raw, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)) {
@@ -67,7 +166,6 @@ struct WorkspaceFileSheet: View {
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
         } else {
-            // Fallback to plain text
             Text(raw)
                 .font(VFont.body)
                 .foregroundColor(VColor.textPrimary)
@@ -76,51 +174,53 @@ struct WorkspaceFileSheet: View {
         }
     }
 
+    // MARK: - Loading
+
     private func loadContent() async {
         guard let client else {
-            error = "Not connected to daemon."
+            error = "Not connected to assistant."
             isLoading = false
             return
         }
 
-        let stream = client.subscribe()
-        do {
-            try client.sendWorkspaceFileRead(path: file.path)
-        } catch {
-            self.error = "Failed to request file."
-            isLoading = false
-            return
-        }
-
-        let filePath = file.path
-        let response: WorkspaceFileReadResponseMessage? = await withTaskGroup(of: WorkspaceFileReadResponseMessage?.self) { group in
-            group.addTask {
-                for await message in stream {
-                    if case .workspaceFileReadResponse(let msg) = message, msg.path == filePath {
-                        return msg
-                    }
-                }
-                return nil
-            }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: 10_000_000_000)
-                return nil
-            }
-            let first = await group.next() ?? nil
-            group.cancelAll()
-            return first
-        }
-
-        if let response {
-            if let fileContent = response.content {
-                content = fileContent
-            } else {
-                self.error = response.error ?? "Unable to read file."
-            }
+        if let response = await client.fetchWorkspaceFile(path: filePath) {
+            fileResponse = response
         } else {
-            self.error = "Request timed out."
+            error = "Unable to read file."
         }
         isLoading = false
+    }
+
+    // MARK: - Helpers
+
+    private func formatFileSize(_ bytes: Int) -> String {
+        if bytes < 1024 { return "\(bytes) B" }
+        let kb = Double(bytes) / 1024.0
+        if kb < 1024 { return String(format: "%.1f KB", kb) }
+        let mb = kb / 1024.0
+        if mb < 1024 { return String(format: "%.1f MB", mb) }
+        let gb = mb / 1024.0
+        return String(format: "%.1f GB", gb)
+    }
+
+    private func formatDate(_ isoString: String) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: isoString) {
+            return formatDisplayDate(date)
+        }
+        formatter.formatOptions = [.withInternetDateTime]
+        if let date = formatter.date(from: isoString) {
+            return formatDisplayDate(date)
+        }
+        return isoString
+    }
+
+    private func formatDisplayDate(_ date: Date) -> String {
+        let display = DateFormatter()
+        display.dateStyle = .medium
+        display.timeStyle = .short
+        return display.string(from: date)
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- Add WorkspaceBrowserView with NavigationStack for recursive directory browsing
- Enhance WorkspaceFileSheet with MIME-aware rendering (text, images, video, binary fallback)
- Replace flat workspace file list in IdentityView with "Browse Workspace" navigation link
- Remove unused fetchWorkspaceFiles and workspaceFileRow code

Part of plan: workspace-tab.md (PR 9 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
