### PR TITLE
fix: add route policy registrations for workspace endpoints

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -263,6 +263,11 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Debug
   { endpoint: "debug", scopes: ["settings.read"] },
 
+  // Workspace file browsing
+  { endpoint: "workspace/tree", scopes: ["settings.read"] },
+  { endpoint: "workspace/file", scopes: ["settings.read"] },
+  { endpoint: "workspace/file/content", scopes: ["settings.read"] },
+
   // Browser relay
   { endpoint: "browser-relay/status", scopes: ["settings.read"] },
   { endpoint: "browser-relay/command", scopes: ["settings.write"] },


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for workspace-tab.md.

**Gap:** Missing route policy registrations for workspace endpoints
**What was expected:** All HTTP endpoints should have route policy entries to enforce authentication scope checks
**What was found:** `workspace/tree`, `workspace/file`, and `workspace/file/content` were registered in the HTTP router but had no corresponding policy entries in `route-policy.ts`
**Fix:** Added policy registrations for all three workspace endpoints with `settings.read` scope, matching the pattern used by other read-only endpoints (e.g. `debug`, `identity`, `brain-graph`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
