### PR TITLE
fix: harden workspace route handlers

### DIFF
--- a/assistant/src/runtime/routes/workspace-routes.test.ts
+++ b/assistant/src/runtime/routes/workspace-routes.test.ts
@@ -45,12 +45,17 @@ const textFile = join(testWorkspaceDir, "hello.txt");
 const jsonFile = join(testWorkspaceDir, "data.json");
 const nestedFile = join(subDir, "nested.txt");
 const binaryFile = join(testWorkspaceDir, "image.png");
+const dotenvFile = join(testWorkspaceDir, ".env");
+const dotDir = join(testWorkspaceDir, ".hidden");
 
 beforeAll(() => {
   mkdirSync(subDir, { recursive: true });
+  mkdirSync(dotDir, { recursive: true });
   writeFileSync(textFile, "Hello, world!");
   writeFileSync(jsonFile, '{"key":"value"}');
   writeFileSync(nestedFile, "nested content");
+  writeFileSync(dotenvFile, "SECRET=hunter2");
+  writeFileSync(join(dotDir, "secret.txt"), "hidden content");
   // Write a minimal PNG (8-byte signature + IHDR + IEND)
   const pngSignature = Buffer.from([
     0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
@@ -228,6 +233,36 @@ describe("GET /v1/workspace/tree", () => {
     expect(fileEntry?.type).toBe("file");
   });
 
+  test("dotfiles and dot-directories are excluded", async () => {
+    const ctx = makeCtx({});
+    const res = await handler(ctx);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      entries: Array<{ name: string }>;
+    };
+    const names = body.entries.map((e) => e.name);
+    expect(names).not.toContain(".env");
+    expect(names).not.toContain(".hidden");
+  });
+
+  test("directory entries have null size and mimeType", async () => {
+    const ctx = makeCtx({});
+    const res = await handler(ctx);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      entries: Array<{
+        name: string;
+        type: string;
+        size: number | null;
+        mimeType: string | null;
+      }>;
+    };
+    const dirEntry = body.entries.find((e) => e.type === "directory");
+    expect(dirEntry).toBeDefined();
+    expect(dirEntry!.size).toBeNull();
+    expect(dirEntry!.mimeType).toBeNull();
+  });
+
   test("directories sorted before files", async () => {
     const ctx = makeCtx({});
     const res = await handler(ctx);
@@ -379,6 +414,12 @@ describe("GET /v1/workspace/file/content", () => {
     expect(res.status).toBe(206);
     const text = await res.text();
     expect(text).toBe("orld!");
+  });
+
+  test("directory path returns 400", async () => {
+    const ctx = makeCtx({ path: "subdir" });
+    const res = await handler(ctx);
+    expect(res.status).toBe(400);
   });
 
   test("Accept-Ranges header is present", async () => {

--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -1,7 +1,13 @@
 /**
  * Route handlers for workspace file browsing and content serving.
  */
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
 import { basename, join } from "node:path";
 
 import { getWorkspaceDir } from "../../util/platform.js";
@@ -17,12 +23,12 @@ interface TreeEntry {
   name: string;
   path: string;
   type: "file" | "directory";
-  size: number | undefined;
-  mimeType: string | undefined;
+  size: number | null;
+  mimeType: string | null;
   modifiedAt: string;
 }
 
-function handleWorkspaceTree(ctx: { url: URL }): Response {
+function handleWorkspaceTree(ctx: RouteContext): Response {
   const requestedPath = ctx.url.searchParams.get("path") ?? "";
   const resolved = resolveWorkspacePath(requestedPath);
   if (resolved === undefined) {
@@ -33,21 +39,33 @@ function handleWorkspaceTree(ctx: { url: URL }): Response {
     const dirents = readdirSync(resolved, { withFileTypes: true });
     const workspaceDir = getWorkspaceDir();
 
-    const entries: TreeEntry[] = dirents.map((entry) => {
+    const entries: TreeEntry[] = [];
+    for (const entry of dirents) {
+      // Filter out dotfiles/directories (.env, .git, .private, etc.)
+      if (entry.name.startsWith(".")) continue;
+
       const fullPath = join(resolved, entry.name);
       const isDir = entry.isDirectory();
-      const stats = statSync(fullPath);
+
+      let stats: ReturnType<typeof lstatSync>;
+      try {
+        stats = lstatSync(fullPath);
+      } catch {
+        // Skip entries that can't be stat'd (broken symlinks, permission denied, etc.)
+        continue;
+      }
+
       const relativePath = fullPath.slice(workspaceDir.length + 1);
 
-      return {
+      entries.push({
         name: entry.name,
         path: relativePath,
         type: isDir ? "directory" : "file",
-        size: isDir ? undefined : stats.size,
-        mimeType: isDir ? undefined : Bun.file(fullPath).type,
+        size: isDir ? null : stats.size,
+        mimeType: isDir ? null : Bun.file(fullPath).type,
         modifiedAt: stats.mtime.toISOString(),
-      };
-    });
+      });
+    }
 
     // Sort: directories first, then files, alphabetically within each group
     entries.sort((a, b) => {
@@ -129,6 +147,14 @@ function handleWorkspaceFileContent(ctx: RouteContext): Response {
   }
 
   if (!existsSync(resolved)) {
+    return httpError("NOT_FOUND", "File not found", 404);
+  }
+
+  try {
+    if (!statSync(resolved).isFile()) {
+      return httpError("BAD_REQUEST", "Path is not a file", 400);
+    }
+  } catch {
     return httpError("NOT_FOUND", "File not found", 404);
   }
 


### PR DESCRIPTION
## Summary
Fixes multiple gaps identified during plan review for workspace-tab.md.

- Add isFile() check to handleWorkspaceFileContent (prevents streaming directories)
- Wrap per-entry statSync in try/catch with lstatSync (prevents single entry failures from crashing listing)
- Use null instead of undefined for directory size/mimeType (proper JSON serialization)
- Use RouteContext type for handleWorkspaceTree consistency
- Filter dotfiles/directories from tree listing (.env, .git, .private)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
