### PR TITLE
fix: use isBinary field for macOS workspace file viewer MIME routing

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -222,12 +222,14 @@ private struct WorkspaceFileViewer: View {
     private func fileContent(_ detail: WorkspaceFileResponse) -> some View {
         let mime = detail.mimeType.lowercased()
 
-        if mime.hasPrefix("text/") || mime == "application/json" {
+        if !detail.isBinary, detail.content != nil {
             textViewer(detail)
         } else if mime.hasPrefix("image/") {
             imageViewer(detail)
         } else if mime.hasPrefix("video/") {
             videoViewer(detail)
+        } else if !detail.isBinary, detail.content == nil {
+            fileTooLarge(detail)
         } else {
             binaryFallback(detail)
         }
@@ -241,6 +243,33 @@ private struct WorkspaceFileViewer: View {
                 .textSelection(.enabled)
                 .padding(VSpacing.md)
                 .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func fileTooLarge(_ detail: WorkspaceFileResponse) -> some View {
+        VStack(spacing: VSpacing.lg) {
+            Spacer()
+
+            Image(systemName: "doc.text")
+                .font(.system(size: 40))
+                .foregroundColor(VColor.textMuted)
+
+            VStack(spacing: VSpacing.sm) {
+                Text(detail.name)
+                    .font(VFont.bodyMedium)
+                    .foregroundColor(VColor.textPrimary)
+
+                Text("File too large to preview")
+                    .font(VFont.body)
+                    .foregroundColor(VColor.textSecondary)
+
+                Text(formatFileSize(detail.size))
+                    .font(VFont.caption)
+                    .foregroundColor(VColor.textMuted)
+            }
+
+            Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }


### PR DESCRIPTION
## Summary
Fixes MIME type handling gaps in the macOS WorkspacePanel file viewer.

- Use isBinary field from API response as primary routing decision instead of MIME prefix checks
- Handles charset suffixes (application/json;charset=utf-8) correctly
- Shows "File too large to preview" for text files exceeding 2MB
- Future-proof: no client update needed when backend adds new text MIME types

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
