### PR TITLE
fix: use NavigationLink(destination:) in iOS workspace browser and fix MIME routing

### DIFF
--- a/clients/ios/Views/WorkspaceBrowserView.swift
+++ b/clients/ios/Views/WorkspaceBrowserView.swift
@@ -29,7 +29,7 @@ struct WorkspaceBrowserView: View {
                 List {
                     ForEach(entries) { entry in
                         if entry.isDirectory {
-                            NavigationLink(value: entry) {
+                            NavigationLink(destination: WorkspaceBrowserView(client: client, initialPath: entry.path)) {
                                 directoryRow(entry)
                             }
                         } else {
@@ -43,9 +43,6 @@ struct WorkspaceBrowserView: View {
             }
         }
         .navigationTitle(initialPath.isEmpty ? "Workspace" : lastPathComponent(initialPath))
-        .navigationDestination(for: WorkspaceTreeEntry.self) { entry in
-            WorkspaceBrowserView(client: client, initialPath: entry.path)
-        }
         .sheet(item: $selectedFile) { file in
             WorkspaceFileSheet(filePath: file.path, mimeType: file.mimeType, client: client)
         }

--- a/clients/ios/Views/WorkspaceFileSheet.swift
+++ b/clients/ios/Views/WorkspaceFileSheet.swift
@@ -94,20 +94,12 @@ struct WorkspaceFileSheet: View {
         } else if resolvedMime.hasPrefix("video/"), let contentURL = client?.workspaceFileContentURL(path: filePath) {
             VideoPlayer(player: AVPlayer(url: contentURL))
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if resolvedMime.hasPrefix("text/") || resolvedMime == "application/json",
-                  let content = fileResponse?.content {
-            ScrollView {
-                markdownContent(content)
-                    .padding(VSpacing.lg)
-            }
-        } else if let content = fileResponse?.content, !content.isEmpty {
-            // Fallback: if we got text content regardless of MIME type, show it
+        } else if let response = fileResponse, !response.isBinary, let content = response.content {
             ScrollView {
                 markdownContent(content)
                     .padding(VSpacing.lg)
             }
         } else if let response = fileResponse {
-            // Binary/unknown file — show metadata
             metadataView(response)
         } else {
             Text("No content")


### PR DESCRIPTION
## Summary
- Replace NavigationLink(value:) + navigationDestination with NavigationLink(destination:) to prevent duplicate destination registration warnings when drilling into nested directories
- Fix MIME type routing in WorkspaceFileSheet to use isBinary field instead of strict equality checks (e.g., `== "application/json"`), correctly handling all text-based formats

## Apple refs checked (2026-03-08)
- NavigationLink(destination:label:) — stable API, avoids navigationDestination registration issues in nested push contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14359" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
