### PR TITLE
fix: use restricted CharacterSet for workspace path URL encoding and remove dead IPC methods

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1063,6 +1063,16 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     // MARK: - Workspace API
 
+    /// A restricted character set for encoding query parameter values.
+    /// `.urlQueryAllowed` permits `&`, `=`, `+`, and `#` which are
+    /// query-string metacharacters. File paths containing these characters
+    /// would break parameter parsing, so we exclude them.
+    private static let queryValueAllowed: CharacterSet = {
+        var cs = CharacterSet.urlQueryAllowed
+        cs.remove(charactersIn: "&=+#")
+        return cs
+    }()
+
     /// Fetch the workspace directory tree.
     /// Delegates to HTTPTransport for remote connections, or calls the local daemon HTTP server.
     public func fetchWorkspaceTree(path: String = "") async -> WorkspaceTreeResponse? {
@@ -1070,7 +1080,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             return await httpTransport.fetchWorkspaceTree(path: path)
         }
 
-        let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? path
+        let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
         let queryPath = path.isEmpty ? "v1/workspace/tree" : "v1/workspace/tree?path=\(encoded)"
         guard let request = buildLocalRequest(target: .daemon, path: queryPath, timeout: 10) else { return nil }
 
@@ -1090,7 +1100,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             return await httpTransport.fetchWorkspaceFile(path: path)
         }
 
-        let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? path
+        let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
         guard let request = buildLocalRequest(
             target: .daemon,
             path: "v1/workspace/file?path=\(encoded)",
@@ -1113,7 +1123,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             return httpTransport.workspaceFileContentURL(path: path)
         }
 
-        let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? path
+        let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
         guard let port = httpPort else { return nil }
         return URL(string: "http://localhost:\(port)/v1/workspace/file/content?path=\(encoded)")
     }
@@ -1781,18 +1791,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         } catch {
             return nil
         }
-    }
-
-    // MARK: - Workspace Files
-
-    /// Request the list of workspace files from the daemon.
-    public func sendWorkspaceFilesList() throws {
-        try send(WorkspaceFilesListRequestMessage())
-    }
-
-    /// Request the content of a workspace file from the daemon.
-    public func sendWorkspaceFileRead(path: String) throws {
-        try send(WorkspaceFileReadRequestMessage(path: path))
     }
 
     // MARK: - Document Persistence

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -187,6 +187,16 @@ public final class HTTPTransport {
 
     // MARK: - Endpoint Builder
 
+    /// A restricted character set for encoding query parameter values.
+    /// `.urlQueryAllowed` permits `&`, `=`, `+`, and `#` which are
+    /// query-string metacharacters. File paths containing these characters
+    /// would break parameter parsing, so we exclude them.
+    private static let queryValueAllowed: CharacterSet = {
+        var cs = CharacterSet.urlQueryAllowed
+        cs.remove(charactersIn: "&=+#")
+        return cs
+    }()
+
     /// All HTTP endpoints used by the transport, centralized for consistent
     /// URL construction. Query parameters that are integral to the endpoint
     /// identity are modelled as associated values.
@@ -334,13 +344,13 @@ public final class HTTPTransport {
             let encoded = groupBy.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? groupBy
             return ("/v1/usage/breakdown", "from=\(from)&to=\(to)&groupBy=\(encoded)")
         case .workspaceTree(let path):
-            let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? path
+            let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
             return ("/v1/workspace/tree", path.isEmpty ? nil : "path=\(encoded)")
         case .workspaceFile(let path):
-            let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? path
+            let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
             return ("/v1/workspace/file", "path=\(encoded)")
         case .workspaceFileContent(let path):
-            let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? path
+            let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
             return ("/v1/workspace/file/content", "path=\(encoded)")
         }
     }
@@ -434,13 +444,13 @@ public final class HTTPTransport {
             let encoded = groupBy.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? groupBy
             return ("\(prefix)/usage/breakdown/", "from=\(from)&to=\(to)&groupBy=\(encoded)")
         case .workspaceTree(let path):
-            let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? path
+            let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
             return ("\(prefix)/workspace/tree/", path.isEmpty ? nil : "path=\(encoded)")
         case .workspaceFile(let path):
-            let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? path
+            let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
             return ("\(prefix)/workspace/file/", "path=\(encoded)")
         case .workspaceFileContent(let path):
-            let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? path
+            let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
             return ("\(prefix)/workspace/file/content/", "path=\(encoded)")
         }
     }


### PR DESCRIPTION
## Summary
- Fix URL query parameter encoding for workspace paths: use restricted CharacterSet that excludes &, =, +, # to prevent query string injection from file paths
- Remove unused sendWorkspaceFileRead and sendWorkspaceFilesList IPC methods (superseded by HTTP API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14360" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
