### PR TITLE
fix: restore queryVector null check in isQdrantIssue classification

### DIFF
--- a/assistant/src/memory/retriever.ts
+++ b/assistant/src/memory/retriever.ts
@@ -839,6 +839,7 @@ export async function buildMemoryRecall(
         : "memory.semantic_search_failure");
     if (!embeddingResult.degradation) {
       const isQdrantIssue =
+        embeddingResult.queryVector != null ||
         isQdrantConnectionError(collected.semanticSearchError) ||
         collected.semanticSearchError instanceof QdrantCircuitOpenError;
       const reason: DegradationReason = isQdrantIssue


### PR DESCRIPTION
Restores the `embeddingResult.queryVector != null` condition in the `isQdrantIssue` check that was incorrectly removed in #14339.

Without this check, when the Qdrant breaker races from open to closed and embeddings succeed, the degradation reason is misclassified as `embedding_generation_failed` instead of `qdrant_unavailable`. The `queryVector != null` guard correctly infers that if embeddings worked, the degradation must be Qdrant-related.

This also restores consistency with the `reason` string assignment a few lines above, which still uses the same `queryVector != null` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
