### PR TITLE
fix: iOS workspace browser AVPlayer lifecycle and accessibility

### DIFF
--- a/clients/ios/Views/IdentityView.swift
+++ b/clients/ios/Views/IdentityView.swift
@@ -299,6 +299,8 @@ struct IdentityView: View {
             RoundedRectangle(cornerRadius: VRadius.lg)
                 .stroke(VColor.surfaceBorder, lineWidth: 1)
         )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Workspace files")
     }
 
     // MARK: - Shared Section Header

--- a/clients/ios/Views/WorkspaceFileSheet.swift
+++ b/clients/ios/Views/WorkspaceFileSheet.swift
@@ -11,6 +11,7 @@ struct WorkspaceFileSheet: View {
     @State private var fileResponse: WorkspaceFileResponse?
     @State private var isLoading = true
     @State private var error: String?
+    @State private var videoPlayer: AVPlayer?
 
     var displayName: String {
         let trimmed = filePath.hasSuffix("/") ? String(filePath.dropLast()) : filePath
@@ -64,6 +65,7 @@ struct WorkspaceFileSheet: View {
         let resolvedMime = fileResponse?.mimeType ?? mimeType ?? ""
 
         if resolvedMime.hasPrefix("image/"), let contentURL = client?.workspaceFileContentURL(path: filePath) {
+            // TODO: AsyncImage uses bare URL without auth headers. Acceptable for local daemon; add auth for remote/cloud support.
             ScrollView {
                 AsyncImage(url: contentURL) { phase in
                     switch phase {
@@ -91,8 +93,9 @@ struct WorkspaceFileSheet: View {
                 }
                 .padding(VSpacing.lg)
             }
-        } else if resolvedMime.hasPrefix("video/"), let contentURL = client?.workspaceFileContentURL(path: filePath) {
-            VideoPlayer(player: AVPlayer(url: contentURL))
+        } else if resolvedMime.hasPrefix("video/"), let player = videoPlayer {
+            // TODO: VideoPlayer uses bare URL without auth headers. Acceptable for local daemon; add auth for remote/cloud support.
+            VideoPlayer(player: player)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let response = fileResponse, !response.isBinary, let content = response.content {
             ScrollView {
@@ -177,6 +180,11 @@ struct WorkspaceFileSheet: View {
 
         if let response = await client.fetchWorkspaceFile(path: filePath) {
             fileResponse = response
+
+            let resolvedMime = response.mimeType ?? mimeType ?? ""
+            if resolvedMime.hasPrefix("video/"), let contentURL = client.workspaceFileContentURL(path: filePath) {
+                videoPlayer = AVPlayer(url: contentURL)
+            }
         } else {
             error = "Unable to read file."
         }


### PR DESCRIPTION
## Summary
- Move AVPlayer creation out of view body into @State property, initialized once in loadContent() when MIME is video
- Add accessibility attributes (.accessibilityElement and .accessibilityLabel) to workspace section in IdentityView for consistency with other sections
- Add TODO comments for auth on media content URLs (AsyncImage and VideoPlayer) for future remote/cloud support

## Test plan
- [ ] Verify workspace file sheet displays video files correctly
- [ ] Verify video doesn't restart on view re-renders
- [ ] Verify VoiceOver reads workspace section label

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
