### PR TITLE
fix: use statSync for symlink metadata and reject hidden path segments

### DIFF
--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -1,13 +1,7 @@
 /**
  * Route handlers for workspace file browsing and content serving.
  */
-import {
-  existsSync,
-  lstatSync,
-  readdirSync,
-  readFileSync,
-  statSync,
-} from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 
 import { getWorkspaceDir } from "../../util/platform.js";
@@ -47,9 +41,9 @@ function handleWorkspaceTree(ctx: RouteContext): Response {
       const fullPath = join(resolved, entry.name);
       const isDir = entry.isDirectory();
 
-      let stats: ReturnType<typeof lstatSync>;
+      let stats: ReturnType<typeof statSync>;
       try {
-        stats = lstatSync(fullPath);
+        stats = statSync(fullPath);
       } catch {
         // Skip entries that can't be stat'd (broken symlinks, permission denied, etc.)
         continue;

--- a/assistant/src/runtime/routes/workspace-utils.ts
+++ b/assistant/src/runtime/routes/workspace-utils.ts
@@ -7,6 +7,12 @@ import { getWorkspaceDir } from "../../util/platform.js";
  * Returns the resolved absolute path, or undefined if the path escapes the workspace root.
  */
 export function resolveWorkspacePath(relativePath: string): string | undefined {
+  // Reject paths containing hidden (dot-prefixed) segments like .env, .git, .hidden/foo
+  const segments = relativePath.split(/[/\\]/);
+  if (segments.some((s) => s.startsWith(".") && s !== "." && s !== "..")) {
+    return undefined;
+  }
+
   const base = getWorkspaceDir();
   const resolved = resolve(base, relativePath);
   if (resolved !== base && !resolved.startsWith(base + sep)) {


### PR DESCRIPTION
Fix two issues in workspace route handlers: (1) revert lstatSync to statSync so symlink entries report target file size/mtime instead of symlink inode metadata, and (2) add dot-segment validation in resolveWorkspacePath to reject paths containing hidden segments like .env or .hidden/.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
