### PR TITLE
fix: rebuild AVPlayer on URL change and cancel fileLoadTask on disappear

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -31,6 +31,10 @@ struct WorkspacePanel: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .task { await loadRoot() }
+        .onDisappear {
+            state.fileLoadTask?.cancel()
+            state.fileLoadTask = nil
+        }
     }
 
     private func loadRoot() async {
@@ -385,6 +389,10 @@ private struct WorkspaceVideoPlayer: View {
         }
         .onAppear {
             player = AVPlayer(url: url)
+        }
+        .onChange(of: url) { _, newURL in
+            player?.pause()
+            player = AVPlayer(url: newURL)
         }
         .onDisappear {
             player?.pause()


### PR DESCRIPTION
Fix two issues in macOS WorkspacePanel:

1. **AVPlayer rebuild on URL change**: `WorkspaceVideoPlayer` only initialized the player in `onAppear`, so switching between video files while the viewer stayed mounted kept playing the old URL. Added `.onChange(of: url)` to pause the old player and create a new one.

2. **Cancel fileLoadTask on disappear**: The unstructured `fileLoadTask` in `WorkspaceBrowserState` was never cancelled when `WorkspacePanel` disappeared, leaving orphaned async work. Added `.onDisappear` to cancel and nil out the task.

Apple refs checked (2026-03-08): onChange(of:) availability (macOS 14+), AVPlayer lifecycle.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
