### PR TITLE
fix: reset isLoadingFile on WorkspacePanel disappear

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -34,6 +34,7 @@ struct WorkspacePanel: View {
         .onDisappear {
             state.fileLoadTask?.cancel()
             state.fileLoadTask = nil
+            state.isLoadingFile = false
         }
     }
 


### PR DESCRIPTION
Add state.isLoadingFile = false in the .onDisappear handler to prevent a stuck loading spinner when the panel reappears after cancellation. Addresses feedback from #14365.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
