### PR TITLE
fix: use stats.isDirectory() for symlink-transparent directory classification

### DIFF
--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -39,7 +39,6 @@ function handleWorkspaceTree(ctx: RouteContext): Response {
       if (entry.name.startsWith(".")) continue;
 
       const fullPath = join(resolved, entry.name);
-      const isDir = entry.isDirectory();
 
       let stats: ReturnType<typeof statSync>;
       try {
@@ -48,6 +47,8 @@ function handleWorkspaceTree(ctx: RouteContext): Response {
         // Skip entries that can't be stat'd (broken symlinks, permission denied, etc.)
         continue;
       }
+
+      const isDir = stats.isDirectory();
 
       const relativePath = fullPath.slice(workspaceDir.length + 1);
 


### PR DESCRIPTION
Use stats.isDirectory() instead of entry.isDirectory() so symlinks to directories are correctly classified as directories after the statSync change in #14364.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
