### PR TITLE
fix: clear stale actor token when assistant changes

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -48,6 +48,16 @@ extension AppDelegate {
 
         guard let assistant else { return nil }
 
+        // If the assistant changed (e.g. user hatched a new one via CLI),
+        // clear the stale actor token so ensureActorCredentials() triggers
+        // a fresh bootstrap against the new daemon's JWT secret.
+        if let storedId, storedId != assistant.assistantId, ActorTokenManager.hasToken {
+            log.info("Assistant changed from \(storedId, privacy: .public) to \(assistant.assistantId, privacy: .public) — clearing stale actor token")
+            actorTokenBootstrapTask?.cancel()
+            actorTokenBootstrapTask = nil
+            ActorTokenManager.deleteToken()
+        }
+
         UserDefaults.standard.set(assistant.assistantId, forKey: "connectedAssistantId")
         assistant.writeToWorkspaceConfig()
         return assistant


### PR DESCRIPTION
## Summary
- When switching to a new self-hosted assistant (e.g. via `vellum hatch`), the app retained the old actor token signed by the previous daemon's JWT secret
- All authenticated local HTTP requests (usage panel, etc.) failed with 401 `invalid_signature` because `ensureActorCredentials()` saw a token existed and skipped bootstrap
- Detect assistant ID change in `loadAssistantFromLockfile()` and clear stale credentials so a fresh bootstrap runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
