### PR TITLE
fix: widen chat message bubbles (520pt → 680pt)

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubble.swift
@@ -96,7 +96,7 @@ struct ChatBubble: View {
             .overlay {
                 bubbleBorderOverlay
             }
-            .frame(maxWidth: message.isError ? .infinity : 520, alignment: isUser ? .trailing : .leading)
+            .frame(maxWidth: message.isError ? .infinity : VSpacing.chatBubbleMaxWidth, alignment: isUser ? .trailing : .leading)
     }
 
     private var formattedTimestamp: String {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleInterleavedContent.swift
@@ -193,7 +193,7 @@ extension ChatBubble {
                 decidedConfirmations: groupConfirmations,
                 onRehydrate: onRehydrate
             )
-            .frame(maxWidth: 520, alignment: .leading)
+            .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
         }
     }
 

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleTextContent.swift
@@ -30,7 +30,7 @@ extension ChatBubble {
                     // Bound width before fixedSize so vertical measurement is
                     // computed within a finite horizontal space, preventing
                     // unbounded layout passes on long messages during scroll.
-                    .frame(maxWidth: 520, alignment: .leading)
+                    .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatBubbleToolStatusView.swift
@@ -46,7 +46,7 @@ extension ChatBubble {
                 decidedConfirmations: effectiveConfirmations,
                 onRehydrate: onRehydrate
             )
-            .frame(maxWidth: 520, alignment: .leading)
+            .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
         } else if !effectiveConfirmations.isEmpty, !inlineToolProgressRenderedInContent {
             // No tool display needed — only show permission chips.
             VStack(alignment: .leading, spacing: 0) {

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -317,7 +317,7 @@ struct MessageListView: View {
                 showIcon: false
             )
         }
-        .frame(maxWidth: 520, alignment: .leading)
+        .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
         .id("thinking-indicator")
         .transition(.opacity.combined(with: .move(edge: .bottom)))
     }
@@ -455,7 +455,7 @@ struct MessageListView: View {
                             onAbort: { onAbortSubagent?(subagent.id) },
                             onTap: { onSubagentTap?(subagent.id) }
                         )
-                            .frame(maxWidth: 520, alignment: .leading)
+                            .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
                             .padding(.leading, 36)
                             .id("subagent-\(subagent.id)")
                             .transition(.opacity.combined(with: .move(edge: .bottom)))
@@ -961,7 +961,7 @@ private struct MessageCellView: View {
                 showIcon: false
             )
         }
-        .frame(maxWidth: 520, alignment: .leading)
+        .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
         .id("thinking-indicator")
     }
 
@@ -1054,7 +1054,7 @@ private struct MessageCellView: View {
                 onAbort: { onAbortSubagent?(subagent.id) },
                 onTap: { onSubagentTap?(subagent.id) }
             )
-                .frame(maxWidth: 520, alignment: .leading)
+                .frame(maxWidth: VSpacing.chatBubbleMaxWidth, alignment: .leading)
                 .padding(.leading, 36)
                 .id("subagent-\(subagent.id)")
         }

--- a/clients/shared/DesignSystem/Tokens/SpacingTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/SpacingTokens.swift
@@ -37,4 +37,9 @@ public enum VSpacing {
     public static var page: CGFloat { xxl }
     /// Compact vertical padding for buttons
     public static let buttonV: CGFloat = 5.5
+
+    // MARK: - Layout Constraints
+
+    /// Maximum width for chat message bubbles
+    public static let chatBubbleMaxWidth: CGFloat = 680
 }


### PR DESCRIPTION
## Summary
- Widened chat message bubbles from 520pt to 680pt (~30% more reading space) to better use available window width
- Extracted the hardcoded `520` magic number into a `VSpacing.chatBubbleMaxWidth` design token, replacing 8 scattered occurrences across 5 chat files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
