### PR TITLE
fix: pre-download workspace images/video with auth headers instead of bare URLs

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -284,32 +284,8 @@ private struct WorkspaceFileViewer: View {
 
     private func imageViewer(_ detail: WorkspaceFileResponse) -> some View {
         Group {
-            // TODO: Add auth headers for remote/cloud support — bare URLs work for local daemon only
             if let url = daemonClient.workspaceFileContentURL(path: detail.path) {
-                AsyncImage(url: url) { phase in
-                    switch phase {
-                    case .success(let image):
-                        image
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            .padding(VSpacing.md)
-                    case .failure:
-                        VStack {
-                            VIconView(.triangleAlert, size: 24)
-                                .foregroundColor(VColor.warning)
-                            Text("Failed to load image")
-                                .font(VFont.body)
-                                .foregroundColor(VColor.textMuted)
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    case .empty:
-                        ProgressView()
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    @unknown default:
-                        EmptyView()
-                    }
-                }
+                AuthenticatedImageView(url: url)
             } else {
                 Text("Unable to load image URL")
                     .font(VFont.body)
@@ -321,7 +297,6 @@ private struct WorkspaceFileViewer: View {
 
     private func videoViewer(_ detail: WorkspaceFileResponse) -> some View {
         Group {
-            // TODO: Add auth headers for remote/cloud support — bare URLs work for local daemon only
             if let url = daemonClient.workspaceFileContentURL(path: detail.path) {
                 WorkspaceVideoPlayer(url: url)
             } else {
@@ -371,11 +346,62 @@ private struct WorkspaceFileViewer: View {
     }
 }
 
+// MARK: - Authenticated Image View
+
+private struct AuthenticatedImageView: View {
+    let url: URL
+    @State private var image: NSImage?
+    @State private var failed = false
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .padding(VSpacing.md)
+            } else if failed {
+                VStack {
+                    VIconView(.triangleAlert, size: 24)
+                        .foregroundColor(VColor.warning)
+                    Text("Failed to load image")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textMuted)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .task {
+            var request = URLRequest(url: url)
+            if let token = ActorTokenManager.getToken(), !token.isEmpty {
+                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            }
+            do {
+                let (data, response) = try await URLSession.shared.data(for: request)
+                guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+                    failed = true
+                    return
+                }
+                image = NSImage(data: data)
+                if image == nil { failed = true }
+            } catch {
+                failed = true
+            }
+        }
+    }
+}
+
 // MARK: - Video Player
 
 private struct WorkspaceVideoPlayer: View {
     let url: URL
     @State private var player: AVPlayer?
+    @State private var tempFileURL: URL?
+    @State private var failed = false
 
     var body: some View {
         Group {
@@ -383,21 +409,53 @@ private struct WorkspaceVideoPlayer: View {
                 VideoPlayer(player: player)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .padding(VSpacing.md)
+            } else if failed {
+                VStack {
+                    VIconView(.triangleAlert, size: 24)
+                        .foregroundColor(VColor.warning)
+                    Text("Failed to load video")
+                        .font(VFont.body)
+                        .foregroundColor(VColor.textMuted)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .onAppear {
-            player = AVPlayer(url: url)
-        }
-        .onChange(of: url) { _, newURL in
+        .task { await loadVideo() }
+        .onChange(of: url) { _, _ in
             player?.pause()
-            player = AVPlayer(url: newURL)
+            player = nil
+            Task { await loadVideo() }
         }
         .onDisappear {
             player?.pause()
             player = nil
+            if let tempFileURL {
+                try? FileManager.default.removeItem(at: tempFileURL)
+            }
+        }
+    }
+
+    private func loadVideo() async {
+        var request = URLRequest(url: url)
+        if let token = ActorTokenManager.getToken(), !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+                failed = true
+                return
+            }
+            let tmpDir = FileManager.default.temporaryDirectory
+            let tmpFile = tmpDir.appendingPathComponent(UUID().uuidString + ".mp4")
+            try data.write(to: tmpFile)
+            tempFileURL = tmpFile
+            player = AVPlayer(url: tmpFile)
+        } catch {
+            failed = true
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace bare URL image loading with `AuthenticatedImageView` that downloads via URLSession with Bearer token auth
- Replace bare URL video loading with authenticated `WorkspaceVideoPlayer` that downloads to temp file with auth headers
- Remove TODO comments about auth headers — now properly implemented

Part of plan: fix-auth-token-lifecycle.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
