### PR TITLE
fix: snappy preferences drawer animation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -447,7 +447,7 @@ extension MainWindowView {
                 isActive: sidebar.showPreferencesDrawer,
                 isExpanded: true,
                 onToggle: {
-                    withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                    withAnimation(.easeOut(duration: 0.12)) {
                         sidebar.showPreferencesDrawer.toggle()
                     }
                 }
@@ -543,7 +543,7 @@ extension MainWindowView {
                 isActive: sidebar.showPreferencesDrawer,
                 isExpanded: false,
                 onToggle: {
-                    withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                    withAnimation(.easeOut(duration: 0.12)) {
                         sidebar.showPreferencesDrawer.toggle()
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -475,7 +475,7 @@ struct MainWindowView: View {
                         Color.clear
                             .contentShape(Rectangle())
                             .onTapGesture {
-                                withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                                withAnimation(.easeOut(duration: 0.12)) {
                                     sidebar.showPreferencesDrawer = false
                                 }
                             }
@@ -544,7 +544,7 @@ struct MainWindowView: View {
                         .frame(width: drawerWidth)
                         .offset(x: 16 + VSpacing.sm, y: -drawerY)
                         .zIndex(10)
-                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                        .transition(.scale(scale: 0.96, anchor: .bottom).combined(with: .opacity))
                     }
                 }
                 .overlay {


### PR DESCRIPTION
## Summary
- Replace sluggish spring animation (0.35s, 0.7 damping) with fast easeOut (0.12s) for all preferences drawer open/close triggers
- Replace slide-from-bottom transition with subtle scale (0.96→1.0) + opacity anchored at the bottom near the Preferences button

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
