### PR TITLE
feat: broadcast signing key fingerprint in daemon_status IPC message

### DIFF
--- a/assistant/src/daemon/ipc-contract/sessions.ts
+++ b/assistant/src/daemon/ipc-contract/sessions.ts
@@ -259,6 +259,7 @@ export interface DaemonStatusMessage {
   type: "daemon_status";
   httpPort?: number;
   version?: string;
+  keyFingerprint?: string;
 }
 
 export interface GenerationCancelled {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -38,6 +38,7 @@ import {
   initializeProviders,
 } from "../providers/registry.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { getSigningKeyFingerprint } from "../runtime/auth/token-service.js";
 import { bridgeConfirmationRequestToGuardian } from "../runtime/confirmation-request-guardian-bridge.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { checkIngressForSecrets } from "../security/secret-ingress.js";
@@ -801,6 +802,7 @@ export class DaemonServer {
       type: "daemon_status",
       httpPort: port,
       version: daemonVersion,
+      keyFingerprint: getSigningKeyFingerprint(),
     });
   }
 
@@ -854,6 +856,7 @@ export class DaemonServer {
         type: "daemon_status",
         httpPort: this.httpPort,
         version: daemonVersion,
+        keyFingerprint: getSigningKeyFingerprint(),
       });
       return;
     }
@@ -871,6 +874,7 @@ export class DaemonServer {
       type: "daemon_status",
       httpPort: this.httpPort,
       version: daemonVersion,
+      keyFingerprint: getSigningKeyFingerprint(),
     });
   }
 

--- a/assistant/src/runtime/auth/token-service.ts
+++ b/assistant/src/runtime/auth/token-service.ts
@@ -111,6 +111,17 @@ export function isSigningKeyInitialized(): boolean {
   return _authSigningKey !== undefined;
 }
 
+/**
+ * Returns a short hex fingerprint of the current signing key.
+ * Used by daemon_status to let clients detect instance switches.
+ */
+export function getSigningKeyFingerprint(): string {
+  return createHash("sha256")
+    .update(getSigningKey())
+    .digest("hex")
+    .slice(0, 16);
+}
+
 // ---------------------------------------------------------------------------
 // Base64url helpers
 // ---------------------------------------------------------------------------

--- a/clients/shared/IPC/Generated/IPCContractGenerated.swift
+++ b/clients/shared/IPC/Generated/IPCContractGenerated.swift
@@ -1385,11 +1385,13 @@ public struct IPCDaemonStatusMessage: Codable, Sendable {
     public let type: String
     public let httpPort: Double?
     public let version: String?
+    public let keyFingerprint: String?
 
-    public init(type: String, httpPort: Double? = nil, version: String? = nil) {
+    public init(type: String, httpPort: Double? = nil, version: String? = nil, keyFingerprint: String? = nil) {
         self.type = type
         self.httpPort = httpPort
         self.version = version
+        self.keyFingerprint = keyFingerprint
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `getSigningKeyFingerprint()` to token-service that returns a short SHA-256 hex fingerprint of the signing key
- Include `keyFingerprint` in all `daemon_status` IPC broadcasts so clients can detect instance switches
- Regenerate Swift IPC contract to include `keyFingerprint` on `IPCDaemonStatusMessage`

Part of plan: fix-auth-token-lifecycle.md (PR 1 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14374" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
