### PR TITLE
feat: add executeLocalRequest helper with 401 retry, re-bootstrap, and logging

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -42,9 +42,16 @@ final class ClientProvider: ObservableObject {
     /// Call this after QR pairing, cloud provisioning, or Settings changes so the
     /// new transport configuration takes effect without an app restart.
     func rebuildClient() {
+        // Preserve recovery credentials across client replacement
+        let prevPlatform = (client as? DaemonClient)?.recoveryPlatform
+        let prevDeviceId = (client as? DaemonClient)?.recoveryDeviceId
+
         // Tear down the old client's connection, timers, and monitors before replacing.
         client.disconnect()
-        self.client = DaemonClient(config: .fromUserDefaults())
+        let newClient = DaemonClient(config: .fromUserDefaults())
+        newClient.recoveryPlatform = prevPlatform
+        newClient.recoveryDeviceId = prevDeviceId
+        self.client = newClient
         self.clientGeneration &+= 1
         self.isConnected = false
         bindCombineBridge()
@@ -94,6 +101,12 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // v4 upgrade migration — clear legacy pairing state so users re-pair through
         // the new approval flow. Runs once; the flag persists across future launches.
         migrateToPairingV4IfNeeded()
+
+        // Set recovery credentials for automatic 401 re-bootstrap
+        if let daemon = clientProvider.client as? DaemonClient {
+            daemon.recoveryPlatform = "ios"
+            daemon.recoveryDeviceId = Self.getOrCreateDeviceId()
+        }
 
         // Initial connect is handled by SceneDelegate.sceneWillEnterForeground, which fires
         // during launch and on every background→foreground transition. Calling connect() here

--- a/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+DaemonSetup.swift
@@ -158,6 +158,10 @@ extension AppDelegate {
 
         configureDaemonTransport(for: assistant)
 
+        // Set recovery credentials for automatic 401 re-bootstrap
+        daemonClient.recoveryPlatform = "macos"
+        daemonClient.recoveryDeviceId = PairingQRCodeSheet.computeHostId()
+
         // Rebind the menu bar icon observer after transport reconfiguration
         // so connection status changes continue to update the icon.
         rebindConnectionStatusObserver()

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -321,6 +321,14 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// `nil` means the HTTP server is not running.
     @Published public var httpPort: Int?
 
+    /// Platform identifier for automatic 401 re-bootstrap (e.g. "macos", "ios").
+    /// Set by the app delegate after creating the client.
+    public var recoveryPlatform: String?
+
+    /// Device identifier for automatic 401 re-bootstrap.
+    /// Set by the app delegate after creating the client.
+    public var recoveryDeviceId: String?
+
     /// Returns a closure that resolves the current HTTP port at call time.
     /// Use this instead of reading `httpPort` directly when the value must
     /// reflect the latest daemon state (e.g. after a daemon restart). The
@@ -1716,6 +1724,70 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
         return request
+    }
+
+    /// Execute a local HTTP request with automatic 401 recovery.
+    ///
+    /// On 401, attempts to re-bootstrap the actor token via `guardian/init`
+    /// and retries the request once. Logs all failure paths for diagnostics.
+    private func executeLocalRequest<T: Decodable>(
+        target: LocalHTTPTarget = .daemon,
+        path: String,
+        method: String = "GET",
+        body: Data? = nil,
+        timeout: TimeInterval = 10,
+        tokenOverride: String? = nil
+    ) async -> T? {
+        guard var request = buildLocalRequest(target: target, path: path, method: method, timeout: timeout, tokenOverride: tokenOverride) else {
+            log.warning("Local HTTP: no port available for \(path, privacy: .public)")
+            return nil
+        }
+        if let body {
+            request.httpBody = body
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                log.warning("Local HTTP: no HTTPURLResponse for \(path, privacy: .public)")
+                return nil
+            }
+
+            if http.statusCode == 401 {
+                guard let platform = recoveryPlatform, let deviceId = recoveryDeviceId else {
+                    log.warning("Local HTTP 401 for \(path, privacy: .public) — no recovery credentials configured")
+                    return nil
+                }
+                log.info("Local HTTP 401 for \(path, privacy: .public) — attempting re-bootstrap")
+                let success = await bootstrapActorToken(platform: platform, deviceId: deviceId)
+                guard success else {
+                    log.warning("Local HTTP re-bootstrap failed for \(path, privacy: .public)")
+                    return nil
+                }
+                // Retry with fresh token
+                guard var retryRequest = buildLocalRequest(target: target, path: path, method: method, timeout: timeout) else { return nil }
+                if let body {
+                    retryRequest.httpBody = body
+                    retryRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                }
+                let (retryData, retryResponse) = try await URLSession.shared.data(for: retryRequest)
+                guard let retryHttp = retryResponse as? HTTPURLResponse, (200...299).contains(retryHttp.statusCode) else {
+                    log.warning("Local HTTP retry failed for \(path, privacy: .public) status=\((retryResponse as? HTTPURLResponse)?.statusCode ?? -1)")
+                    return nil
+                }
+                return try JSONDecoder().decode(T.self, from: retryData)
+            }
+
+            guard (200...299).contains(http.statusCode) else {
+                log.warning("Local HTTP \(http.statusCode) for \(path, privacy: .public)")
+                return nil
+            }
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            log.warning("Local HTTP error for \(path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
     }
 
     // MARK: - Integrations Status


### PR DESCRIPTION
## Summary
- Add `executeLocalRequest<T>` generic helper to DaemonClient with automatic 401 detection, re-bootstrap via `guardian/init`, and single retry
- Add `recoveryPlatform` and `recoveryDeviceId` stored properties for bootstrap recovery context
- Set recovery properties during app startup on both macOS and iOS
- Preserve recovery properties across iOS `rebuildClient()` calls

Part of plan: fix-auth-token-lifecycle.md (PR 2 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
