### PR TITLE
feat: parse keyFingerprint from daemon_status and store on DaemonClient

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -340,6 +340,10 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// The daemon version string, populated via `daemon_status` on connect.
     @Published public internal(set) var daemonVersion: String?
 
+    /// Signing key fingerprint from the connected daemon, populated via `daemon_status`.
+    /// Used to detect instance switches — if this changes, the stored actor token is stale.
+    @Published public internal(set) var keyFingerprint: String?
+
     /// Latest memory health payload from daemon `memory_status` events.
     @Published public var latestMemoryStatus: MemoryStatusMessage?
 
@@ -774,6 +778,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         isBlobTransportAvailable = false
         httpPort = nil
         daemonVersion = nil
+        keyFingerprint = nil
         latestMemoryStatus = nil
         currentModel = nil
         cuObservationSequenceBySession.removeAll()

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -21,6 +21,7 @@ extension DaemonClient {
             if let version = status.version {
                 daemonVersion = version
             }
+            keyFingerprint = status.keyFingerprint
         }
 
         // Handle blob probe result internally.


### PR DESCRIPTION
## Summary
- Add `@Published keyFingerprint: String?` property to `DaemonClient`
- Parse `keyFingerprint` from `daemon_status` IPC messages in `DaemonMessageRouter`
- Enables PR 6 to detect instance switches by observing fingerprint changes

Part of plan: fix-auth-token-lifecycle.md (PR 4 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
