### PR TITLE
feat: detect daemon instance switch via key fingerprint and re-bootstrap credentials

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -220,6 +220,14 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     func ensureActorCredentials() {
         actorTokenBootstrapTask?.cancel()
 
+        // Re-bootstrap on instance switch
+        NotificationCenter.default.removeObserver(self, name: .daemonInstanceChanged, object: nil)
+        NotificationCenter.default.addObserver(forName: .daemonInstanceChanged, object: nil, queue: .main) { [weak self] _ in
+            guard let self else { return }
+            log.info("Daemon instance changed — re-running credential bootstrap")
+            self.ensureActorCredentials()
+        }
+
         actorTokenBootstrapTask = Task { [weak self] in
             guard let self else { return }
 

--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -389,6 +389,14 @@ extension AppDelegate {
     func ensureActorCredentials() {
         actorTokenBootstrapTask?.cancel()
 
+        // Re-bootstrap on instance switch
+        NotificationCenter.default.removeObserver(self, name: .daemonInstanceChanged, object: nil)
+        NotificationCenter.default.addObserver(forName: .daemonInstanceChanged, object: nil, queue: .main) { [weak self] _ in
+            guard let self else { return }
+            log.info("Daemon instance changed — re-running credential bootstrap")
+            self.ensureActorCredentials()
+        }
+
         actorTokenBootstrapTask = Task { [weak self] in
             guard let self else { return }
 

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -292,6 +292,10 @@ extension Notification.Name {
     /// The health monitor observes this to trigger an immediate restart instead of waiting
     /// for the next periodic health check.
     public static let daemonSocketNotFound = Notification.Name("daemonSocketNotFound")
+
+    /// Posted when the daemon's signing key fingerprint changes, indicating an instance switch.
+    /// Observers should trigger credential re-bootstrap.
+    public static let daemonInstanceChanged = Notification.Name("daemonInstanceChanged")
 }
 
 /// Platform-agnostic client for communicating with the Vellum daemon.

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -21,7 +21,21 @@ extension DaemonClient {
             if let version = status.version {
                 daemonVersion = version
             }
-            keyFingerprint = status.keyFingerprint
+            if let newFingerprint = status.keyFingerprint {
+                let oldFingerprint = keyFingerprint
+                keyFingerprint = newFingerprint
+
+                if let oldFingerprint, oldFingerprint != newFingerprint {
+                    // Instance changed mid-connection
+                    log.info("Daemon key fingerprint changed (\(oldFingerprint, privacy: .public) → \(newFingerprint, privacy: .public)) — invalidating credentials")
+                    ActorTokenManager.deleteAllCredentials()
+                    NotificationCenter.default.post(name: .daemonInstanceChanged, object: nil)
+                } else if oldFingerprint == nil, ActorTokenManager.hasToken {
+                    // First daemon_status with a fingerprint, but we already have a stored token.
+                    // The reactive 401 retry (executeLocalRequest) handles re-bootstrap if the
+                    // token is stale. No proactive action needed here.
+                }
+            }
         }
 
         // Handle blob probe result internally.


### PR DESCRIPTION
## Summary
- Detect daemon instance switches by comparing `keyFingerprint` across `daemon_status` messages
- On fingerprint change: delete stored credentials and post `daemonInstanceChanged` notification
- macOS and iOS both observe the notification and re-run credential bootstrap
- First-connect stale token case handled by reactive 401 retry from PR 2/5

Part of plan: fix-auth-token-lifecycle.md (PR 6 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
