### PR TITLE
fix: store NotificationCenter observer token to prevent observer leak

### DIFF
--- a/clients/ios/App/AppDelegate.swift
+++ b/clients/ios/App/AppDelegate.swift
@@ -89,6 +89,10 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     let authManager = AuthManager()
     let ambientAgentManager = AmbientAgentManager()
     private var actorTokenBootstrapTask: Task<Void, Never>?
+    /// Opaque token returned by `NotificationCenter.addObserver(forName:)` for
+    /// the daemon-instance-changed observer. Stored so we can properly remove
+    /// the closure-based observer before registering a new one.
+    private var instanceChangeObserver: NSObjectProtocol?
     override init() {
         self.clientProvider = ClientProvider(client: DaemonClient(config: .fromUserDefaults()))
         super.init()
@@ -220,9 +224,12 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     func ensureActorCredentials() {
         actorTokenBootstrapTask?.cancel()
 
-        // Re-bootstrap on instance switch
-        NotificationCenter.default.removeObserver(self, name: .daemonInstanceChanged, object: nil)
-        NotificationCenter.default.addObserver(forName: .daemonInstanceChanged, object: nil, queue: .main) { [weak self] _ in
+        // Re-bootstrap on instance switch — remove previous closure-based observer
+        // using the opaque token (removeObserver(self) doesn't work for closure observers).
+        if let prev = instanceChangeObserver {
+            NotificationCenter.default.removeObserver(prev)
+        }
+        instanceChangeObserver = NotificationCenter.default.addObserver(forName: .daemonInstanceChanged, object: nil, queue: .main) { [weak self] _ in
             guard let self else { return }
             log.info("Daemon instance changed — re-running credential bootstrap")
             self.ensureActorCredentials()

--- a/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+Bootstrap.swift
@@ -389,9 +389,12 @@ extension AppDelegate {
     func ensureActorCredentials() {
         actorTokenBootstrapTask?.cancel()
 
-        // Re-bootstrap on instance switch
-        NotificationCenter.default.removeObserver(self, name: .daemonInstanceChanged, object: nil)
-        NotificationCenter.default.addObserver(forName: .daemonInstanceChanged, object: nil, queue: .main) { [weak self] _ in
+        // Re-bootstrap on instance switch — remove previous closure-based observer
+        // using the opaque token (removeObserver(self) doesn't work for closure observers).
+        if let prev = instanceChangeObserver {
+            NotificationCenter.default.removeObserver(prev)
+        }
+        instanceChangeObserver = NotificationCenter.default.addObserver(forName: .daemonInstanceChanged, object: nil, queue: .main) { [weak self] _ in
             guard let self else { return }
             log.info("Daemon instance changed — re-running credential bootstrap")
             self.ensureActorCredentials()

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -84,6 +84,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
     var bootstrapFailureKind: BootstrapFailureKind = .unknown
     /// Background task that retries actor-token bootstrap until success.
     var actorTokenBootstrapTask: Task<Void, Never>?
+    /// Opaque token returned by `NotificationCenter.addObserver(forName:)` for
+    /// the daemon-instance-changed observer. Stored so we can properly remove
+    /// the closure-based observer before registering a new one.
+    var instanceChangeObserver: NSObjectProtocol?
     /// Tracks file paths of .vellum bundles awaiting daemon responses (FIFO).
     /// Each call to sendOpenBundle appends a path; handleOpenBundleResponse
     /// pops the first entry so concurrent opens are correctly paired.


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-auth-token-lifecycle.md.

**Gap:** NotificationCenter observer leak
**What was expected:** Each call to ensureActorCredentials() should replace the previous instance-change observer
**What was found:** removeObserver(self) doesn't remove closure-based observers — the opaque token from addObserver(forName:) was discarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
