### PR TITLE
fix: preserve existing core.hooksPath in postinstall

### DIFF
--- a/assistant/package.json
+++ b/assistant/package.json
@@ -24,7 +24,7 @@
     "test:stable": "EXCLUDE_EXPERIMENTAL=true bash scripts/test.sh",
     "test:bench": "find src/__tests__ -maxdepth 1 -type f -name '*.benchmark.test.ts' -print0 | xargs -0 -P 1 -I {} bun test {}",
     "test:filesystem-tools": "bash scripts/test-filesystem-tools.sh",
-    "postinstall": "cd .. && git config core.hooksPath .githooks 2>/dev/null || true"
+    "postinstall": "cd .. && git config core.hooksPath || git config core.hooksPath .githooks 2>/dev/null || true"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.42",

--- a/clients/.build
+++ b/clients/.build
@@ -1,0 +1,1 @@
+/Users/sidd/vocify/vellum-assistant/clients/.build

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -17,7 +17,7 @@
     "format:check": "prettier --check .",
     "lint": "eslint",
     "typecheck": "bunx tsc --noEmit",
-    "postinstall": "cd .. && git config core.hooksPath .githooks 2>/dev/null || true"
+    "postinstall": "cd .. && git config core.hooksPath || git config core.hooksPath .githooks 2>/dev/null || true"
   },
   "dependencies": {
     "file-type": "^21.3.0",


### PR DESCRIPTION
## Summary
- The postinstall scripts in `assistant/` and `gateway/` unconditionally set `core.hooksPath = .githooks`, overwriting any local override (e.g. `/dev/null` to disable hooks)
- Changed both postinstall scripts to only set `core.hooksPath` if it's not already configured, so developers who opt out of local hooks aren't reset on every `bun install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
