### PR TITLE
fix: add 401 retry to fetchSurfaceData for auth token recovery

### DIFF
--- a/clients/.build
+++ b/clients/.build
@@ -1,0 +1,1 @@
+/Users/sidd/vocify/vellum-assistant/clients/.build

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -996,15 +996,39 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         // Local daemon path — build request using the daemon HTTP port.
         let sEncoded = surfaceId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? surfaceId
         let qEncoded = sessionId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? sessionId
+        let surfacePath = "v1/surfaces/\(sEncoded)?sessionId=\(qEncoded)"
         guard let request = buildLocalRequest(
             target: .daemon,
-            path: "v1/surfaces/\(sEncoded)?sessionId=\(qEncoded)",
+            path: surfacePath,
             timeout: 10
         ) else { return nil }
 
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
-            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else { return nil }
+            guard let http = response as? HTTPURLResponse else { return nil }
+
+            if http.statusCode == 401 {
+                guard let platform = recoveryPlatform, let deviceId = recoveryDeviceId else {
+                    log.warning("Local HTTP 401 for \(surfacePath, privacy: .public) — no recovery credentials configured")
+                    return nil
+                }
+                log.info("Local HTTP 401 for \(surfacePath, privacy: .public) — attempting re-bootstrap")
+                let success = await bootstrapActorToken(platform: platform, deviceId: deviceId)
+                guard success else {
+                    log.warning("Local HTTP re-bootstrap failed for \(surfacePath, privacy: .public)")
+                    return nil
+                }
+                // Retry with fresh token
+                guard let retryRequest = buildLocalRequest(target: .daemon, path: surfacePath, timeout: 10) else { return nil }
+                let (retryData, retryResponse) = try await URLSession.shared.data(for: retryRequest)
+                guard let retryHttp = retryResponse as? HTTPURLResponse, (200...299).contains(retryHttp.statusCode) else {
+                    log.warning("Local HTTP retry failed for \(surfacePath, privacy: .public) status=\((retryResponse as? HTTPURLResponse)?.statusCode ?? -1)")
+                    return nil
+                }
+                return Surface.parseSurfaceDataFromResponse(retryData)
+            }
+
+            guard (200...299).contains(http.statusCode) else { return nil }
             return Surface.parseSurfaceDataFromResponse(data)
         } catch {
             return nil


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-auth-token-lifecycle.md.

**Gap:** fetchSurfaceData not migrated — no 401 retry
**What was expected:** All local HTTP callers should have 401 recovery
**What was found:** fetchSurfaceData still uses manual buildLocalRequest without 401 handling

Adds inline 401 retry logic directly in fetchSurfaceData, matching the pattern used
by executeLocalRequest: on 401, attempt re-bootstrap using stored recovery credentials,
rebuild the request with the fresh token, and retry once. Preserves the custom
Surface.parseSurfaceDataFromResponse parsing (which is why this method couldn't simply
delegate to executeLocalRequest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
