### PR TITLE
fix: use bootstrapActorToken instead of deleteAllCredentials in iOS content viewers

### DIFF
--- a/clients/ios/Views/WorkspaceFileSheet.swift
+++ b/clients/ios/Views/WorkspaceFileSheet.swift
@@ -64,9 +64,9 @@ struct WorkspaceFileSheet: View {
         let resolvedMime = fileResponse?.mimeType ?? mimeType ?? ""
 
         if resolvedMime.hasPrefix("image/"), let contentURL = client?.workspaceFileContentURL(path: filePath) {
-            AuthenticatedImageView(url: contentURL)
+            AuthenticatedImageView(url: contentURL, client: client)
         } else if resolvedMime.hasPrefix("video/"), let contentURL = client?.workspaceFileContentURL(path: filePath) {
-            WorkspaceVideoPlayer(url: contentURL)
+            WorkspaceVideoPlayer(url: contentURL, client: client)
         } else if let response = fileResponse, !response.isBinary, let content = response.content {
             ScrollView {
                 markdownContent(content)
@@ -193,6 +193,7 @@ struct WorkspaceFileSheet: View {
 
 private struct AuthenticatedImageView: View {
     let url: URL
+    let client: DaemonClient?
     @State private var image: UIImage?
     @State private var failed = false
 
@@ -239,9 +240,19 @@ private struct AuthenticatedImageView: View {
                 failed = true
                 return
             }
-            // 401 retry: clear stale credentials and retry once with refreshed token
+            // 401 retry: re-bootstrap actor token via DaemonClient then retry once
             if http.statusCode == 401 {
-                ActorTokenManager.deleteAllCredentials()
+                guard let client,
+                      let platform = client.recoveryPlatform,
+                      let deviceId = client.recoveryDeviceId else {
+                    failed = true
+                    return
+                }
+                let success = await client.bootstrapActorToken(platform: platform, deviceId: deviceId)
+                guard success else {
+                    failed = true
+                    return
+                }
                 var retryRequest = URLRequest(url: url)
                 if let freshToken = ActorTokenManager.getToken(), !freshToken.isEmpty {
                     retryRequest.setValue("Bearer \(freshToken)", forHTTPHeaderField: "Authorization")
@@ -271,6 +282,7 @@ private struct AuthenticatedImageView: View {
 
 private struct WorkspaceVideoPlayer: View {
     let url: URL
+    let client: DaemonClient?
     @State private var player: AVPlayer?
     @State private var tempFileURL: URL?
     @State private var failed = false
@@ -320,10 +332,20 @@ private struct WorkspaceVideoPlayer: View {
                 failed = true
                 return
             }
-            // 401 retry: clear stale credentials and retry once with refreshed token
+            // 401 retry: re-bootstrap actor token via DaemonClient then retry once
             if http.statusCode == 401 {
                 try? FileManager.default.removeItem(at: localURL)
-                ActorTokenManager.deleteAllCredentials()
+                guard let client,
+                      let platform = client.recoveryPlatform,
+                      let deviceId = client.recoveryDeviceId else {
+                    failed = true
+                    return
+                }
+                let success = await client.bootstrapActorToken(platform: platform, deviceId: deviceId)
+                guard success else {
+                    failed = true
+                    return
+                }
                 var retryRequest = URLRequest(url: url)
                 if let freshToken = ActorTokenManager.getToken(), !freshToken.isEmpty {
                     retryRequest.setValue("Bearer \(freshToken)", forHTTPHeaderField: "Authorization")


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for fix-auth-token-lifecycle.md (round 2).

**Gap:** iOS content viewer 401 retry calls deleteAllCredentials() then retries with nil token
**What was expected:** Proper re-bootstrap on 401 like executeLocalRequest does
**What was found:** deleteAllCredentials() wipes all tokens, retry gets nil, request fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
