### PR TITLE
fix: replace magic numbers in drawer positioning with named constants

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -522,7 +522,8 @@ struct MainWindowView: View {
                         let drawerWidth = sidebarExpandedWidth - VSpacing.sm * 2
                         let bottomPad: CGFloat = 16 + (sidebarExpanded ? VSpacing.md : VSpacing.sm)
                         // Position above the PreferencesRow: clear the row height + divider + gap
-                        let drawerY = bottomPad + 28 + 9 + VSpacing.xs
+                        let dividerHeight: CGFloat = 1 + SidebarLayoutMetrics.dividerVerticalPadding * 2
+                        let drawerY = bottomPad + SidebarLayoutMetrics.rowMinHeight + dividerHeight + VSpacing.xs
                         DrawerMenuView(
                             onSettings: {
                                 sidebar.showPreferencesDrawer = false


### PR DESCRIPTION
Addresses feedback on PR #14371. Replaces hardcoded 28 and 9 in the preferences drawer Y-offset calculation with SidebarLayoutMetrics.rowMinHeight and a computed divider height constant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
