### PR TITLE
fix: extract snappy animation into VAnimation design token

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView+Sidebar.swift
@@ -447,7 +447,7 @@ extension MainWindowView {
                 isActive: sidebar.showPreferencesDrawer,
                 isExpanded: true,
                 onToggle: {
-                    withAnimation(.easeOut(duration: 0.12)) {
+                    withAnimation(VAnimation.snappy) {
                         sidebar.showPreferencesDrawer.toggle()
                     }
                 }
@@ -543,7 +543,7 @@ extension MainWindowView {
                 isActive: sidebar.showPreferencesDrawer,
                 isExpanded: false,
                 onToggle: {
-                    withAnimation(.easeOut(duration: 0.12)) {
+                    withAnimation(VAnimation.snappy) {
                         sidebar.showPreferencesDrawer.toggle()
                     }
                 }

--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -475,7 +475,7 @@ struct MainWindowView: View {
                         Color.clear
                             .contentShape(Rectangle())
                             .onTapGesture {
-                                withAnimation(.easeOut(duration: 0.12)) {
+                                withAnimation(VAnimation.snappy) {
                                     sidebar.showPreferencesDrawer = false
                                 }
                             }

--- a/clients/shared/DesignSystem/Tokens/AnimationTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/AnimationTokens.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 /// Animation presets. Use instead of raw Animation values.
 public enum VAnimation {
+    public static let snappy   = Animation.easeOut(duration: 0.12)
     public static let fast     = Animation.easeOut(duration: 0.15)
     public static let standard = Animation.easeInOut(duration: 0.25)
     public static let slow     = Animation.easeInOut(duration: 0.4)


### PR DESCRIPTION
Addresses feedback on PR #14373. Adds VAnimation.snappy token and replaces 3 hardcoded .easeOut(duration: 0.12) literals with the new token.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
