### PR TITLE
fix: skip 401 retry in executeLocalRequest when tokenOverride is set

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1732,6 +1732,12 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
             }
 
             if http.statusCode == 401 {
+                // If caller provided an explicit token override, 401 recovery via
+                // actor-token re-bootstrap won't help — it's a different credential.
+                if tokenOverride != nil {
+                    log.warning("Local HTTP 401 for \(path, privacy: .public) — tokenOverride set, skipping retry")
+                    return nil
+                }
                 guard let platform = recoveryPlatform, let deviceId = recoveryDeviceId else {
                     log.warning("Local HTTP 401 for \(path, privacy: .public) — no recovery credentials configured")
                     return nil


### PR DESCRIPTION
Addresses feedback on PR #14375. When a caller provides a tokenOverride, 401 recovery via actor token re-bootstrap won't help (it's a different credential), so we skip the retry path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
