### PR TITLE
fix: add cancellation guard to video player and use task(id:) for URL changes

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -452,8 +452,7 @@ private struct WorkspaceVideoPlayer: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .task { await loadVideo() }
-        .onChange(of: url) { _, _ in
+        .task(id: url) {
             player?.pause()
             player = nil
             failed = false
@@ -461,7 +460,7 @@ private struct WorkspaceVideoPlayer: View {
                 try? FileManager.default.removeItem(at: tempFileURL)
             }
             tempFileURL = nil
-            Task { await loadVideo() }
+            await loadVideo()
         }
         .onDisappear {
             player?.pause()
@@ -475,6 +474,13 @@ private struct WorkspaceVideoPlayer: View {
     private func loadVideo() async {
         do {
             let result = try await downloadVideo(url: url)
+            guard !Task.isCancelled else {
+                // Clean up downloaded file if task was cancelled during download
+                if let localURL = result {
+                    try? FileManager.default.removeItem(at: localURL)
+                }
+                return
+            }
             guard let localURL = result else {
                 failed = true
                 return
@@ -482,7 +488,9 @@ private struct WorkspaceVideoPlayer: View {
             tempFileURL = localURL
             player = AVPlayer(url: localURL)
         } catch {
-            failed = true
+            if !Task.isCancelled {
+                failed = true
+            }
         }
     }
 


### PR DESCRIPTION
Addresses remaining review feedback from PR #14372 (issue #5: no cancellation guard in loadVideo).

Changes:
- Replace .task + .onChange pattern with .task(id: url) in WorkspaceVideoPlayer, matching AuthenticatedImageView's pattern. This ensures SwiftUI automatically cancels the previous task when the URL changes.
- Add Task.isCancelled guard after the async downloadVideo() call to prevent races where a cancelled task sets state after a new one starts.
- Clean up downloaded temp file if the task is cancelled mid-download.
- Skip setting failed state if the task was cancelled (avoids flashing error UI during URL transitions).

Issues 1-4 from the original feedback were already addressed in follow-up PRs #14379, #14384, #14385.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
