### PR TITLE
fix: complete chat bubble width token migration to VSpacing.chatBubbleMaxWidth

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AnimatedImageView.swift
@@ -19,7 +19,7 @@ struct AnimatedImageView: View {
     @Environment(\.displayScale) private var displayScale
 
     /// Maximum display dimension in points (matches text bubble maxWidth).
-    private let maxDimension: CGFloat = 520
+    private let maxDimension: CGFloat = VSpacing.chatBubbleMaxWidth
 
     var body: some View {
         Group {

--- a/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatMarkdownParser.swift
@@ -262,7 +262,7 @@ func parseTableCells(_ line: String) -> [String] {
 struct MarkdownTableView: View {
     let headers: [String]
     let rows: [[String]]
-    var maxWidth: CGFloat = 520
+    var maxWidth: CGFloat = VSpacing.chatBubbleMaxWidth
 
     @Environment(\.conversationZoomScale) private var zoomScale
 

--- a/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MarkdownSegmentView.swift
@@ -8,7 +8,7 @@ import VellumAssistantShared
 /// unified Text views so that text selection can span across paragraphs.
 struct MarkdownSegmentView: View {
     let segments: [MarkdownSegment]
-    var maxContentWidth: CGFloat? = 520
+    var maxContentWidth: CGFloat? = VSpacing.chatBubbleMaxWidth
     var textColor: Color = VColor.textPrimary
     var secondaryTextColor: Color = VColor.textSecondary
     var mutedTextColor: Color = VColor.textMuted

--- a/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/MessageListView.swift
@@ -489,7 +489,7 @@ struct MessageListView: View {
                 .padding(.horizontal, VSpacing.xl)
                 .padding(.top, VSpacing.md)
                 .padding(.bottom, VSpacing.md)
-                .frame(maxWidth: 700)
+                .frame(maxWidth: VSpacing.chatColumnMaxWidth)
                 .frame(maxWidth: .infinity)
             }
             .scrollContentBackground(.hidden)

--- a/clients/shared/DesignSystem/Tokens/SpacingTokens.swift
+++ b/clients/shared/DesignSystem/Tokens/SpacingTokens.swift
@@ -42,4 +42,6 @@ public enum VSpacing {
 
     /// Maximum width for chat message bubbles
     public static let chatBubbleMaxWidth: CGFloat = 680
+    /// Maximum width for the chat message column (bubble width + horizontal padding)
+    public static let chatColumnMaxWidth: CGFloat = chatBubbleMaxWidth + 2 * xl
 }


### PR DESCRIPTION
Completes the width token migration from PR #14370. Updates MarkdownSegmentView, MarkdownTableView, and AnimatedImageView defaults from hardcoded 520 to VSpacing.chatBubbleMaxWidth so all content stays in sync with the bubble container width. Also bumps the outer message column from a hardcoded 700 to a derived VSpacing.chatColumnMaxWidth (680 + 2*24 = 728) so the full bubble width is reachable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
