### PR TITLE
feat: add POST /v1/workspace/write endpoint for creating and updating files

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -267,6 +267,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "workspace/tree", scopes: ["settings.read"] },
   { endpoint: "workspace/file", scopes: ["settings.read"] },
   { endpoint: "workspace/file/content", scopes: ["settings.read"] },
+  { endpoint: "workspace/write", scopes: ["settings.write"] },
 
   // Browser relay
   { endpoint: "browser-relay/status", scopes: ["settings.read"] },

--- a/assistant/src/runtime/routes/workspace-routes.test.ts
+++ b/assistant/src/runtime/routes/workspace-routes.test.ts
@@ -5,8 +5,10 @@
  * directory listing, file metadata, and raw content serving with range support.
  */
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   realpathSync,
   rmSync,
   writeFileSync,
@@ -94,6 +96,22 @@ function getHandler(endpoint: string) {
   const route = routes.find((r) => r.endpoint === endpoint);
   if (!route) throw new Error(`No route found for endpoint: ${endpoint}`);
   return route.handler;
+}
+
+/** Build a RouteContext-like object for POST handler testing with a JSON body. */
+function makePostCtx(body: unknown) {
+  const url = new URL("http://localhost/v1/workspace/write");
+  return {
+    url,
+    req: new Request(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    server: {} as ReturnType<typeof Bun.serve>,
+    authContext: {} as never,
+    params: {},
+  };
 }
 
 // ===========================================================================
@@ -426,5 +444,99 @@ describe("GET /v1/workspace/file/content", () => {
     const ctx = makeCtx({ path: "hello.txt" });
     const res = await handler(ctx);
     expect(res.headers.get("Accept-Ranges")).toBe("bytes");
+  });
+});
+
+// ===========================================================================
+// POST /v1/workspace/write
+// ===========================================================================
+
+describe("POST /v1/workspace/write", () => {
+  const handler = getHandler("workspace/write");
+
+  test("creates a new text file with UTF-8 content", async () => {
+    const ctx = makePostCtx({ path: "new-file.txt", content: "hello world" });
+    const res = await handler(ctx);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { path: string; size: number };
+    expect(body.path).toBe("new-file.txt");
+    expect(body.size).toBe(11);
+    const written = readFileSync(join(testWorkspaceDir, "new-file.txt"), "utf-8");
+    expect(written).toBe("hello world");
+  });
+
+  test("overwrites an existing file", async () => {
+    writeFileSync(join(testWorkspaceDir, "overwrite-me.txt"), "old content");
+    const ctx = makePostCtx({
+      path: "overwrite-me.txt",
+      content: "new content",
+    });
+    const res = await handler(ctx);
+    expect(res.status).toBe(201);
+    const written = readFileSync(
+      join(testWorkspaceDir, "overwrite-me.txt"),
+      "utf-8",
+    );
+    expect(written).toBe("new content");
+  });
+
+  test("auto-creates parent directories for nested paths", async () => {
+    const ctx = makePostCtx({
+      path: "new-dir/sub/file.txt",
+      content: "deep content",
+    });
+    const res = await handler(ctx);
+    expect(res.status).toBe(201);
+    const fullPath = join(testWorkspaceDir, "new-dir", "sub", "file.txt");
+    expect(existsSync(fullPath)).toBe(true);
+    const written = readFileSync(fullPath, "utf-8");
+    expect(written).toBe("deep content");
+  });
+
+  test("handles base64 encoding", async () => {
+    const original = "binary\x00data";
+    const encoded = Buffer.from(original).toString("base64");
+    const ctx = makePostCtx({
+      path: "img.bin",
+      content: encoded,
+      encoding: "base64",
+    });
+    const res = await handler(ctx);
+    expect(res.status).toBe(201);
+    const written = readFileSync(join(testWorkspaceDir, "img.bin"));
+    expect(written.toString("binary")).toBe(original);
+  });
+
+  test("rejects path traversal", async () => {
+    const ctx = makePostCtx({
+      path: "../../etc/passwd",
+      content: "malicious",
+    });
+    const res = await handler(ctx);
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects missing path", async () => {
+    const ctx = makePostCtx({ content: "no path" });
+    const res = await handler(ctx);
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects dotfile segments", async () => {
+    const ctx = makePostCtx({
+      path: ".hidden/file.txt",
+      content: "sneaky",
+    });
+    const res = await handler(ctx);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 201 with path and size in response", async () => {
+    const ctx = makePostCtx({ path: "response-check.txt", content: "abc" });
+    const res = await handler(ctx);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { path: string; size: number };
+    expect(body.path).toBe("response-check.txt");
+    expect(body.size).toBe(3);
   });
 });

--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -1,8 +1,15 @@
 /**
  * Route handlers for workspace file browsing and content serving.
  */
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { basename, join } from "node:path";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
 
 import { getWorkspaceDir } from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
@@ -219,6 +226,39 @@ function handleWorkspaceFileContent(ctx: RouteContext): Response {
 }
 
 // ---------------------------------------------------------------------------
+// POST /v1/workspace/write — create or overwrite a file
+// ---------------------------------------------------------------------------
+
+async function handleWorkspaceWrite(ctx: RouteContext): Promise<Response> {
+  const body = (await ctx.req.json()) as {
+    path?: string;
+    content?: string;
+    encoding?: string;
+  };
+
+  const { path, content, encoding } = body;
+
+  if (!path || typeof path !== "string") {
+    return httpError("BAD_REQUEST", "path is required", 400);
+  }
+
+  const resolved = resolveWorkspacePath(path);
+  if (resolved === undefined) {
+    return httpError("BAD_REQUEST", "Invalid path", 400);
+  }
+
+  const buffer =
+    encoding === "base64"
+      ? Buffer.from(content ?? "", "base64")
+      : Buffer.from(content ?? "", "utf-8");
+
+  mkdirSync(dirname(resolved), { recursive: true });
+  writeFileSync(resolved, buffer);
+
+  return Response.json({ path, size: buffer.byteLength }, { status: 201 });
+}
+
+// ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
 
@@ -238,6 +278,11 @@ export function workspaceRouteDefinitions(): RouteDefinition[] {
       endpoint: "workspace/file",
       method: "GET",
       handler: (ctx) => handleWorkspaceFile(ctx),
+    },
+    {
+      endpoint: "workspace/write",
+      method: "POST",
+      handler: (ctx) => handleWorkspaceWrite(ctx),
     },
   ];
 }


### PR DESCRIPTION
## Summary
- Add POST /v1/workspace/write endpoint with UTF-8 and base64 content support
- Auto-create parent directories, validate paths (block traversal and dotfiles)
- Add route policy for settings.write scope and comprehensive tests

Part of plan: workspace-edit.md (PR 1 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
