### PR TITLE
feat: add workspace mkdir, rename, and delete HTTP endpoints

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -267,6 +267,9 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "workspace/tree", scopes: ["settings.read"] },
   { endpoint: "workspace/file", scopes: ["settings.read"] },
   { endpoint: "workspace/file/content", scopes: ["settings.read"] },
+  { endpoint: "workspace/mkdir", scopes: ["settings.write"] },
+  { endpoint: "workspace/rename", scopes: ["settings.write"] },
+  { endpoint: "workspace/delete", scopes: ["settings.write"] },
 
   // Browser relay
   { endpoint: "browser-relay/status", scopes: ["settings.read"] },

--- a/assistant/src/runtime/routes/workspace-routes.test.ts
+++ b/assistant/src/runtime/routes/workspace-routes.test.ts
@@ -5,6 +5,7 @@
  * directory listing, file metadata, and raw content serving with range support.
  */
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   realpathSync,
@@ -89,9 +90,27 @@ function makeCtx(
   };
 }
 
-function getHandler(endpoint: string) {
+/** Build a RouteContext-like object for POST handler testing with a JSON body. */
+function makePostCtx(endpoint: string, body: unknown) {
+  const url = new URL(`http://localhost/v1/${endpoint}`);
+  return {
+    url,
+    req: new Request(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    server: {} as ReturnType<typeof Bun.serve>,
+    authContext: {} as never,
+    params: {},
+  };
+}
+
+function getHandler(endpoint: string, method?: string) {
   const routes = workspaceRouteDefinitions();
-  const route = routes.find((r) => r.endpoint === endpoint);
+  const route = routes.find(
+    (r) => r.endpoint === endpoint && (!method || r.method === method),
+  );
   if (!route) throw new Error(`No route found for endpoint: ${endpoint}`);
   return route.handler;
 }
@@ -426,5 +445,211 @@ describe("GET /v1/workspace/file/content", () => {
     const ctx = makeCtx({ path: "hello.txt" });
     const res = await handler(ctx);
     expect(res.headers.get("Accept-Ranges")).toBe("bytes");
+  });
+});
+
+// ===========================================================================
+// POST /v1/workspace/mkdir
+// ===========================================================================
+
+describe("POST /v1/workspace/mkdir", () => {
+  const handler = getHandler("workspace/mkdir", "POST");
+
+  test("creates directory and returns 201", async () => {
+    const ctx = makePostCtx("workspace/mkdir", { path: "new-dir" });
+    const res = await handler(ctx);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { path: string };
+    expect(body.path).toBe("new-dir");
+    expect(existsSync(join(testWorkspaceDir, "new-dir"))).toBe(true);
+  });
+
+  test("nested directory creation works", async () => {
+    const ctx = makePostCtx("workspace/mkdir", {
+      path: "deep/nested/dir",
+    });
+    const res = await handler(ctx);
+    expect(res.status).toBe(201);
+    expect(existsSync(join(testWorkspaceDir, "deep/nested/dir"))).toBe(true);
+  });
+
+  test("idempotent on existing directory returns 200", async () => {
+    // subdir already exists from beforeAll
+    const ctx = makePostCtx("workspace/mkdir", { path: "subdir" });
+    const res = await handler(ctx);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { path: string };
+    expect(body.path).toBe("subdir");
+  });
+
+  test("returns 409 if path exists as a file", async () => {
+    const ctx = makePostCtx("workspace/mkdir", { path: "hello.txt" });
+    const res = await handler(ctx);
+    expect(res.status).toBe(409);
+  });
+
+  test("rejects path traversal", async () => {
+    const ctx = makePostCtx("workspace/mkdir", {
+      path: "../../etc/evil",
+    });
+    const res = await handler(ctx);
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects missing path", async () => {
+    const ctx = makePostCtx("workspace/mkdir", {});
+    const res = await handler(ctx);
+    expect(res.status).toBe(400);
+  });
+});
+
+// ===========================================================================
+// POST /v1/workspace/rename
+// ===========================================================================
+
+describe("POST /v1/workspace/rename", () => {
+  const handler = getHandler("workspace/rename", "POST");
+
+  test("renames file", async () => {
+    // Create a file to rename
+    const srcPath = join(testWorkspaceDir, "rename-me.txt");
+    writeFileSync(srcPath, "rename test");
+
+    const ctx = makePostCtx("workspace/rename", {
+      oldPath: "rename-me.txt",
+      newPath: "renamed.txt",
+    });
+    const res = await handler(ctx);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      oldPath: string;
+      newPath: string;
+    };
+    expect(body.oldPath).toBe("rename-me.txt");
+    expect(body.newPath).toBe("renamed.txt");
+    expect(existsSync(srcPath)).toBe(false);
+    expect(existsSync(join(testWorkspaceDir, "renamed.txt"))).toBe(true);
+  });
+
+  test("renames directory", async () => {
+    const srcDir = join(testWorkspaceDir, "dir-to-rename");
+    mkdirSync(srcDir, { recursive: true });
+    writeFileSync(join(srcDir, "child.txt"), "child");
+
+    const ctx = makePostCtx("workspace/rename", {
+      oldPath: "dir-to-rename",
+      newPath: "dir-renamed",
+    });
+    const res = await handler(ctx);
+    expect(res.status).toBe(200);
+    expect(existsSync(srcDir)).toBe(false);
+    expect(
+      existsSync(join(testWorkspaceDir, "dir-renamed", "child.txt")),
+    ).toBe(true);
+  });
+
+  test("rejects missing source with 404", async () => {
+    const ctx = makePostCtx("workspace/rename", {
+      oldPath: "nonexistent.txt",
+      newPath: "dest.txt",
+    });
+    const res = await handler(ctx);
+    expect(res.status).toBe(404);
+  });
+
+  test("rejects existing destination with 409", async () => {
+    const ctx = makePostCtx("workspace/rename", {
+      oldPath: "hello.txt",
+      newPath: "data.json",
+    });
+    const res = await handler(ctx);
+    expect(res.status).toBe(409);
+  });
+
+  test("rejects path traversal on oldPath", async () => {
+    const ctx = makePostCtx("workspace/rename", {
+      oldPath: "../../etc/passwd",
+      newPath: "dest.txt",
+    });
+    const res = await handler(ctx);
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects path traversal on newPath", async () => {
+    const ctx = makePostCtx("workspace/rename", {
+      oldPath: "hello.txt",
+      newPath: "../../etc/evil",
+    });
+    const res = await handler(ctx);
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects missing fields", async () => {
+    const ctx1 = makePostCtx("workspace/rename", { oldPath: "hello.txt" });
+    const res1 = await handler(ctx1);
+    expect(res1.status).toBe(400);
+
+    const ctx2 = makePostCtx("workspace/rename", { newPath: "dest.txt" });
+    const res2 = await handler(ctx2);
+    expect(res2.status).toBe(400);
+  });
+});
+
+// ===========================================================================
+// POST /v1/workspace/delete
+// ===========================================================================
+
+describe("POST /v1/workspace/delete", () => {
+  const handler = getHandler("workspace/delete", "POST");
+
+  test("deletes file and returns 204", async () => {
+    const filePath = join(testWorkspaceDir, "delete-me.txt");
+    writeFileSync(filePath, "delete me");
+
+    const ctx = makePostCtx("workspace/delete", { path: "delete-me.txt" });
+    const res = await handler(ctx);
+    expect(res.status).toBe(204);
+    expect(existsSync(filePath)).toBe(false);
+  });
+
+  test("deletes directory recursively and returns 204", async () => {
+    const dirPath = join(testWorkspaceDir, "delete-dir");
+    mkdirSync(dirPath, { recursive: true });
+    writeFileSync(join(dirPath, "child.txt"), "child");
+
+    const ctx = makePostCtx("workspace/delete", { path: "delete-dir" });
+    const res = await handler(ctx);
+    expect(res.status).toBe(204);
+    expect(existsSync(dirPath)).toBe(false);
+  });
+
+  test("rejects workspace root deletion with 400", async () => {
+    const ctx = makePostCtx("workspace/delete", { path: "" });
+    const res = await handler(ctx);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toBe("Cannot delete workspace root");
+  });
+
+  test("rejects path traversal", async () => {
+    const ctx = makePostCtx("workspace/delete", {
+      path: "../../etc/passwd",
+    });
+    const res = await handler(ctx);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 404 for missing path", async () => {
+    const ctx = makePostCtx("workspace/delete", {
+      path: "nonexistent.txt",
+    });
+    const res = await handler(ctx);
+    expect(res.status).toBe(404);
+  });
+
+  test("rejects missing path field", async () => {
+    const ctx = makePostCtx("workspace/delete", {});
+    const res = await handler(ctx);
+    expect(res.status).toBe(400);
   });
 });

--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -1,8 +1,16 @@
 /**
  * Route handlers for workspace file browsing and content serving.
  */
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { basename, join } from "node:path";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
 
 import { getWorkspaceDir } from "../../util/platform.js";
 import { httpError } from "../http-errors.js";
@@ -219,6 +227,98 @@ function handleWorkspaceFileContent(ctx: RouteContext): Response {
 }
 
 // ---------------------------------------------------------------------------
+// POST /v1/workspace/mkdir — create directories
+// ---------------------------------------------------------------------------
+
+async function handleWorkspaceMkdir(ctx: RouteContext): Promise<Response> {
+  const body = (await ctx.req.json()) as { path?: string };
+  const path = body.path;
+  if (!path) {
+    return httpError("BAD_REQUEST", "path is required", 400);
+  }
+
+  const resolved = resolveWorkspacePath(path);
+  if (resolved === undefined) {
+    return httpError("BAD_REQUEST", "Invalid path", 400);
+  }
+
+  if (existsSync(resolved)) {
+    if (statSync(resolved).isDirectory()) {
+      return Response.json({ path }, { status: 200 });
+    }
+    return httpError("CONFLICT", "Path exists as a file", 409);
+  }
+
+  mkdirSync(resolved, { recursive: true });
+  return Response.json({ path }, { status: 201 });
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/workspace/rename — rename/move files and directories
+// ---------------------------------------------------------------------------
+
+async function handleWorkspaceRename(ctx: RouteContext): Promise<Response> {
+  const body = (await ctx.req.json()) as {
+    oldPath?: string;
+    newPath?: string;
+  };
+  const { oldPath, newPath } = body;
+  if (!oldPath || !newPath) {
+    return httpError("BAD_REQUEST", "oldPath and newPath are required", 400);
+  }
+
+  const resolvedOld = resolveWorkspacePath(oldPath);
+  if (resolvedOld === undefined) {
+    return httpError("BAD_REQUEST", "Invalid oldPath", 400);
+  }
+
+  const resolvedNew = resolveWorkspacePath(newPath);
+  if (resolvedNew === undefined) {
+    return httpError("BAD_REQUEST", "Invalid newPath", 400);
+  }
+
+  if (!existsSync(resolvedOld)) {
+    return httpError("NOT_FOUND", "Source path not found", 404);
+  }
+
+  if (existsSync(resolvedNew)) {
+    return httpError("CONFLICT", "Destination already exists", 409);
+  }
+
+  mkdirSync(dirname(resolvedNew), { recursive: true });
+  renameSync(resolvedOld, resolvedNew);
+  return Response.json({ oldPath, newPath }, { status: 200 });
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/workspace/delete — delete files and directories
+// ---------------------------------------------------------------------------
+
+async function handleWorkspaceDelete(ctx: RouteContext): Promise<Response> {
+  const body = (await ctx.req.json()) as { path?: string };
+  const path = body.path;
+  if (path == null) {
+    return httpError("BAD_REQUEST", "path is required", 400);
+  }
+
+  const resolved = resolveWorkspacePath(path);
+  if (resolved === undefined) {
+    return httpError("BAD_REQUEST", "Invalid path", 400);
+  }
+
+  if (resolved === getWorkspaceDir()) {
+    return httpError("BAD_REQUEST", "Cannot delete workspace root", 400);
+  }
+
+  if (!existsSync(resolved)) {
+    return httpError("NOT_FOUND", "Path not found", 404);
+  }
+
+  rmSync(resolved, { recursive: true, force: true });
+  return new Response(null, { status: 204 });
+}
+
+// ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
 
@@ -238,6 +338,21 @@ export function workspaceRouteDefinitions(): RouteDefinition[] {
       endpoint: "workspace/file",
       method: "GET",
       handler: (ctx) => handleWorkspaceFile(ctx),
+    },
+    {
+      endpoint: "workspace/mkdir",
+      method: "POST",
+      handler: (ctx) => handleWorkspaceMkdir(ctx),
+    },
+    {
+      endpoint: "workspace/rename",
+      method: "POST",
+      handler: (ctx) => handleWorkspaceRename(ctx),
+    },
+    {
+      endpoint: "workspace/delete",
+      method: "POST",
+      handler: (ctx) => handleWorkspaceDelete(ctx),
     },
   ];
 }


### PR DESCRIPTION
## Summary
- Add POST endpoints for /v1/workspace/mkdir, /v1/workspace/rename, /v1/workspace/delete
- Validate paths, handle edge cases (idempotent mkdir, workspace root protection)
- Add route policies and comprehensive tests for all three endpoints

Part of plan: workspace-edit.md (PR 2 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
