### PR TITLE
feat: add Swift client methods for workspace write operations

### DIFF
--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -1113,6 +1113,175 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
         return URL(string: "http://localhost:\(port)/v1/workspace/file/content?path=\(encoded)")
     }
 
+    // MARK: - Workspace Write Operations
+
+    /// Write (create or overwrite) a file in the workspace.
+    /// Delegates to HTTPTransport for remote connections, or calls the local daemon HTTP server.
+    /// Automatically detects text vs binary content and uses base64 encoding when needed.
+    public func writeWorkspaceFile(path: String, content: Data) async -> Bool {
+        if let httpTransport {
+            return await httpTransport.writeWorkspaceFile(path: path, content: content)
+        }
+
+        guard var request = buildLocalRequest(target: .daemon, path: "v1/workspace/write", method: "POST") else { return false }
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        var body: [String: Any] = ["path": path]
+        if let text = String(data: content, encoding: .utf8), !content.isEmpty {
+            body["content"] = text
+        } else {
+            body["content"] = content.base64EncodedString()
+            body["encoding"] = "base64"
+        }
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return false }
+
+            if http.statusCode == 401 {
+                guard let platform = recoveryPlatform, let deviceId = recoveryDeviceId else {
+                    log.warning("Local HTTP 401 for v1/workspace/write — no recovery credentials configured")
+                    return false
+                }
+                let success = await bootstrapActorToken(platform: platform, deviceId: deviceId)
+                guard success else { return false }
+
+                guard var retryRequest = buildLocalRequest(target: .daemon, path: "v1/workspace/write", method: "POST") else { return false }
+                retryRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                retryRequest.httpBody = request.httpBody
+                let (_, retryResponse) = try await URLSession.shared.data(for: retryRequest)
+                guard let retryHttp = retryResponse as? HTTPURLResponse else { return false }
+                return (200...299).contains(retryHttp.statusCode)
+            }
+
+            return (200...299).contains(http.statusCode)
+        } catch {
+            log.warning("writeWorkspaceFile failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    /// Create a directory in the workspace.
+    /// Delegates to HTTPTransport for remote connections, or calls the local daemon HTTP server.
+    public func createWorkspaceDirectory(path: String) async -> Bool {
+        if let httpTransport {
+            return await httpTransport.createWorkspaceDirectory(path: path)
+        }
+
+        guard var request = buildLocalRequest(target: .daemon, path: "v1/workspace/mkdir", method: "POST") else { return false }
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = ["path": path]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return false }
+
+            if http.statusCode == 401 {
+                guard let platform = recoveryPlatform, let deviceId = recoveryDeviceId else {
+                    log.warning("Local HTTP 401 for v1/workspace/mkdir — no recovery credentials configured")
+                    return false
+                }
+                let success = await bootstrapActorToken(platform: platform, deviceId: deviceId)
+                guard success else { return false }
+
+                guard var retryRequest = buildLocalRequest(target: .daemon, path: "v1/workspace/mkdir", method: "POST") else { return false }
+                retryRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                retryRequest.httpBody = request.httpBody
+                let (_, retryResponse) = try await URLSession.shared.data(for: retryRequest)
+                guard let retryHttp = retryResponse as? HTTPURLResponse else { return false }
+                return (200...299).contains(retryHttp.statusCode)
+            }
+
+            return (200...299).contains(http.statusCode)
+        } catch {
+            log.warning("createWorkspaceDirectory failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    /// Rename or move a file/directory in the workspace.
+    /// Delegates to HTTPTransport for remote connections, or calls the local daemon HTTP server.
+    public func renameWorkspaceItem(oldPath: String, newPath: String) async -> Bool {
+        if let httpTransport {
+            return await httpTransport.renameWorkspaceItem(oldPath: oldPath, newPath: newPath)
+        }
+
+        guard var request = buildLocalRequest(target: .daemon, path: "v1/workspace/rename", method: "POST") else { return false }
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = ["oldPath": oldPath, "newPath": newPath]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return false }
+
+            if http.statusCode == 401 {
+                guard let platform = recoveryPlatform, let deviceId = recoveryDeviceId else {
+                    log.warning("Local HTTP 401 for v1/workspace/rename — no recovery credentials configured")
+                    return false
+                }
+                let success = await bootstrapActorToken(platform: platform, deviceId: deviceId)
+                guard success else { return false }
+
+                guard var retryRequest = buildLocalRequest(target: .daemon, path: "v1/workspace/rename", method: "POST") else { return false }
+                retryRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                retryRequest.httpBody = request.httpBody
+                let (_, retryResponse) = try await URLSession.shared.data(for: retryRequest)
+                guard let retryHttp = retryResponse as? HTTPURLResponse else { return false }
+                return (200...299).contains(retryHttp.statusCode)
+            }
+
+            return (200...299).contains(http.statusCode)
+        } catch {
+            log.warning("renameWorkspaceItem failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    /// Delete a file or directory in the workspace.
+    /// Delegates to HTTPTransport for remote connections, or calls the local daemon HTTP server.
+    public func deleteWorkspaceItem(path: String) async -> Bool {
+        if let httpTransport {
+            return await httpTransport.deleteWorkspaceItem(path: path)
+        }
+
+        guard var request = buildLocalRequest(target: .daemon, path: "v1/workspace/delete", method: "POST") else { return false }
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = ["path": path]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return false }
+
+            if http.statusCode == 401 {
+                guard let platform = recoveryPlatform, let deviceId = recoveryDeviceId else {
+                    log.warning("Local HTTP 401 for v1/workspace/delete — no recovery credentials configured")
+                    return false
+                }
+                let success = await bootstrapActorToken(platform: platform, deviceId: deviceId)
+                guard success else { return false }
+
+                guard var retryRequest = buildLocalRequest(target: .daemon, path: "v1/workspace/delete", method: "POST") else { return false }
+                retryRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                retryRequest.httpBody = request.httpBody
+                let (_, retryResponse) = try await URLSession.shared.data(for: retryRequest)
+                guard let retryHttp = retryResponse as? HTTPURLResponse else { return false }
+                return (200...299).contains(retryHttp.statusCode)
+            }
+
+            return (200...299).contains(http.statusCode)
+        } catch {
+            log.warning("deleteWorkspaceItem failed: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
     // MARK: - Surface Undo
 
     /// Send a surface undo request to revert the last refinement on a workspace surface.

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -233,6 +233,10 @@ public final class HTTPTransport {
         case workspaceTree(path: String)
         case workspaceFile(path: String)
         case workspaceFileContent(path: String)
+        case workspaceWrite
+        case workspaceMkdir
+        case workspaceRename
+        case workspaceDelete
     }
 
     /// Build a URL for the given endpoint using the current route mode.
@@ -352,6 +356,14 @@ public final class HTTPTransport {
         case .workspaceFileContent(let path):
             let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
             return ("/v1/workspace/file/content", "path=\(encoded)")
+        case .workspaceWrite:
+            return ("/v1/workspace/write", nil)
+        case .workspaceMkdir:
+            return ("/v1/workspace/mkdir", nil)
+        case .workspaceRename:
+            return ("/v1/workspace/rename", nil)
+        case .workspaceDelete:
+            return ("/v1/workspace/delete", nil)
         }
     }
 
@@ -452,6 +464,14 @@ public final class HTTPTransport {
         case .workspaceFileContent(let path):
             let encoded = path.addingPercentEncoding(withAllowedCharacters: Self.queryValueAllowed) ?? path
             return ("\(prefix)/workspace/file/content/", "path=\(encoded)")
+        case .workspaceWrite:
+            return ("\(prefix)/workspace/write/", nil)
+        case .workspaceMkdir:
+            return ("\(prefix)/workspace/mkdir/", nil)
+        case .workspaceRename:
+            return ("\(prefix)/workspace/rename/", nil)
+        case .workspaceDelete:
+            return ("\(prefix)/workspace/delete/", nil)
         }
     }
 
@@ -2159,6 +2179,138 @@ public final class HTTPTransport {
     /// Build a URL for streaming/downloading workspace file content.
     func workspaceFileContentURL(path: String) -> URL? {
         return buildURL(for: .workspaceFileContent(path: path))
+    }
+
+    /// Write (create or overwrite) a file in the workspace via `POST /v1/workspace/write`.
+    /// Automatically detects text vs binary content — text is sent as a plain string,
+    /// binary content is base64-encoded with an `encoding` field.
+    func writeWorkspaceFile(path: String, content: Data, isRetry: Bool = false) async -> Bool {
+        guard let url = buildURL(for: .workspaceWrite) else { return false }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        var body: [String: Any] = ["path": path]
+        if let text = String(data: content, encoding: .utf8), !content.isEmpty {
+            body["content"] = text
+        } else {
+            body["content"] = content.base64EncodedString()
+            body["encoding"] = "base64"
+        }
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await writeWorkspaceFile(path: path, content: content, isRetry: true)
+                    }
+                    return false
+                }
+                return (200...299).contains(http.statusCode)
+            }
+            return false
+        } catch {
+            log.error("writeWorkspaceFile failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    /// Create a directory in the workspace via `POST /v1/workspace/mkdir`.
+    func createWorkspaceDirectory(path: String, isRetry: Bool = false) async -> Bool {
+        guard let url = buildURL(for: .workspaceMkdir) else { return false }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        let body: [String: Any] = ["path": path]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await createWorkspaceDirectory(path: path, isRetry: true)
+                    }
+                    return false
+                }
+                return (200...299).contains(http.statusCode)
+            }
+            return false
+        } catch {
+            log.error("createWorkspaceDirectory failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    /// Rename or move a file/directory in the workspace via `POST /v1/workspace/rename`.
+    func renameWorkspaceItem(oldPath: String, newPath: String, isRetry: Bool = false) async -> Bool {
+        guard let url = buildURL(for: .workspaceRename) else { return false }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        let body: [String: Any] = ["oldPath": oldPath, "newPath": newPath]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await renameWorkspaceItem(oldPath: oldPath, newPath: newPath, isRetry: true)
+                    }
+                    return false
+                }
+                return (200...299).contains(http.statusCode)
+            }
+            return false
+        } catch {
+            log.error("renameWorkspaceItem failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    /// Delete a file or directory in the workspace via `POST /v1/workspace/delete`.
+    func deleteWorkspaceItem(path: String, isRetry: Bool = false) async -> Bool {
+        guard let url = buildURL(for: .workspaceDelete) else { return false }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        let body: [String: Any] = ["path": path]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let refreshResult = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = refreshResult {
+                        return await deleteWorkspaceItem(path: path, isRetry: true)
+                    }
+                    return false
+                }
+                return (200...299).contains(http.statusCode)
+            }
+            return false
+        } catch {
+            log.error("deleteWorkspaceItem failed: \(error.localizedDescription)")
+            return false
+        }
     }
 
     // MARK: - Disconnect


### PR DESCRIPTION
## Summary
- Add workspaceWrite, workspaceMkdir, workspaceRename, workspaceDelete endpoints to HTTPDaemonClient
- Implement transport methods with 401 retry and JSON body encoding (auto text/base64 detection)
- Add public DaemonClient methods with both remote (HTTPTransport) and local HTTP code paths

Part of plan: workspace-edit.md (PR 4 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
