### PR TITLE
feat: add create file and folder to workspace sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -15,6 +15,16 @@ final class WorkspaceBrowserState {
     var isLoadingTree = false
     var isLoadingFile = false
     var fileLoadTask: Task<Void, Never>?
+    var showingNewFileAlert = false
+    var showingNewFolderAlert = false
+    var newItemName: String = ""
+    var newItemParentPath: String = ""
+
+    func refreshDirectory(_ dirPath: String, using daemonClient: DaemonClient) async {
+        if let response = await daemonClient.fetchWorkspaceTree(path: dirPath) {
+            directoryCache[dirPath] = response.entries
+        }
+    }
 }
 
 // MARK: - Workspace Panel
@@ -55,11 +65,38 @@ private struct WorkspaceTreeSidebar: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text("Files")
-                .font(VFont.headline)
-                .foregroundColor(VColor.textPrimary)
-                .padding(.horizontal, VSpacing.md)
-                .padding(.vertical, VSpacing.sm)
+            HStack {
+                Text("Files")
+                    .font(VFont.headline)
+                    .foregroundColor(VColor.textPrimary)
+
+                Spacer()
+
+                Menu {
+                    Button {
+                        state.newItemParentPath = ""
+                        state.newItemName = ""
+                        state.showingNewFileAlert = true
+                    } label: {
+                        Label { Text("New File") } icon: { VIconView(.filePlus, size: 12) }
+                    }
+                    Button {
+                        state.newItemParentPath = ""
+                        state.newItemName = ""
+                        state.showingNewFolderAlert = true
+                    } label: {
+                        Label { Text("New Folder") } icon: { VIconView(.folder, size: 12) }
+                    }
+                } label: {
+                    VIconView(.plus, size: 12)
+                        .foregroundColor(VColor.textSecondary)
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+            }
+            .padding(.horizontal, VSpacing.md)
+            .padding(.vertical, VSpacing.sm)
 
             Divider().background(VColor.surfaceBorder)
 
@@ -89,6 +126,44 @@ private struct WorkspaceTreeSidebar: View {
             }
         }
         .background(VColor.backgroundSubtle)
+        .alert("New File", isPresented: $state.showingNewFileAlert) {
+            TextField("Filename", text: $state.newItemName)
+            Button("Cancel", role: .cancel) {}
+            Button("Create") {
+                let parentPath = state.newItemParentPath
+                let name = state.newItemName
+                guard !name.isEmpty else { return }
+                let filePath = parentPath.isEmpty ? name : parentPath + "/" + name
+                Task {
+                    let success = await daemonClient.writeWorkspaceFile(path: filePath, content: Data())
+                    if success {
+                        await state.refreshDirectory(parentPath, using: daemonClient)
+                        if !parentPath.isEmpty {
+                            state.expandedDirs.insert(parentPath)
+                        }
+                    }
+                }
+            }
+        }
+        .alert("New Folder", isPresented: $state.showingNewFolderAlert) {
+            TextField("Folder name", text: $state.newItemName)
+            Button("Cancel", role: .cancel) {}
+            Button("Create") {
+                let parentPath = state.newItemParentPath
+                let name = state.newItemName
+                guard !name.isEmpty else { return }
+                let folderPath = parentPath.isEmpty ? name : parentPath + "/" + name
+                Task {
+                    let success = await daemonClient.createWorkspaceDirectory(path: folderPath)
+                    if success {
+                        await state.refreshDirectory(parentPath, using: daemonClient)
+                        if !parentPath.isEmpty {
+                            state.expandedDirs.insert(parentPath)
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -152,6 +227,24 @@ private struct WorkspaceTreeRow: View {
                             daemonClient: daemonClient
                         )
                     }
+                }
+            }
+        }
+        .contextMenu {
+            if entry.isDirectory {
+                Button {
+                    state.newItemParentPath = entry.path
+                    state.newItemName = ""
+                    state.showingNewFileAlert = true
+                } label: {
+                    Label { Text("New File") } icon: { VIconView(.filePlus, size: 12) }
+                }
+                Button {
+                    state.newItemParentPath = entry.path
+                    state.newItemName = ""
+                    state.showingNewFolderAlert = true
+                } label: {
+                    Label { Text("New Folder") } icon: { VIconView(.folder, size: 12) }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Add + button in sidebar header with New File and New Folder menu items
- Add context menu on directory rows with New File and New Folder options
- Implement create alerts that prompt for name, call API, and refresh tree

Part of plan: workspace-edit.md (PR 5 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
