### PR TITLE
feat: add drag & drop file import to workspace panel

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 import VellumAssistantShared
 #if os(macOS)
 import AVKit
@@ -15,6 +16,14 @@ final class WorkspaceBrowserState {
     var isLoadingTree = false
     var isLoadingFile = false
     var fileLoadTask: Task<Void, Never>?
+    var isDropTargeted: Bool = false
+    var uploadingCount: Int = 0
+
+    func refreshDirectory(_ dirPath: String, using daemonClient: DaemonClient) async {
+        if let response = await daemonClient.fetchWorkspaceTree(path: dirPath) {
+            directoryCache[dirPath] = response.entries
+        }
+    }
 }
 
 // MARK: - Workspace Panel
@@ -87,8 +96,53 @@ private struct WorkspaceTreeSidebar: View {
                     .padding(.vertical, VSpacing.xs)
                 }
             }
+
+            if state.uploadingCount > 0 {
+                HStack(spacing: VSpacing.xs) {
+                    ProgressView().controlSize(.small)
+                    Text("Uploading \(state.uploadingCount) file\(state.uploadingCount == 1 ? "" : "s")...")
+                        .font(VFont.caption)
+                        .foregroundColor(VColor.textMuted)
+                }
+                .padding(.horizontal, VSpacing.md)
+                .padding(.vertical, VSpacing.xs)
+            }
+        }
+        .overlay {
+            if state.isDropTargeted {
+                RoundedRectangle(cornerRadius: VRadius.md)
+                    .strokeBorder(VColor.accent, style: StrokeStyle(lineWidth: 2, dash: [6, 3]))
+                    .padding(4)
+            }
+        }
+        .onDrop(of: [.fileURL], isTargeted: $state.isDropTargeted) { providers in
+            handleDrop(providers: providers, targetDir: "", state: state, daemonClient: daemonClient)
+            return true
         }
         .background(VColor.backgroundSubtle)
+    }
+}
+
+// MARK: - Drop Handler
+
+private func handleDrop(providers: [NSItemProvider], targetDir: String, state: WorkspaceBrowserState, daemonClient: DaemonClient) {
+    for provider in providers {
+        provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
+            guard let data = item as? Data,
+                  let url = URL(dataRepresentation: data, relativeTo: nil) else { return }
+            let fileName = url.lastPathComponent
+            let targetPath = targetDir.isEmpty ? fileName : "\(targetDir)/\(fileName)"
+            Task { @MainActor in
+                state.uploadingCount += 1
+                if let fileData = try? Data(contentsOf: url) {
+                    let success = await daemonClient.writeWorkspaceFile(path: targetPath, content: fileData)
+                    if success {
+                        await state.refreshDirectory(targetDir, using: daemonClient)
+                    }
+                }
+                state.uploadingCount -= 1
+            }
+        }
     }
 }
 
@@ -140,6 +194,11 @@ private struct WorkspaceTreeRow: View {
                 .background(isSelected ? VColor.navActive : Color.clear)
             }
             .buttonStyle(.plain)
+            .onDrop(of: entry.isDirectory ? [.fileURL] : [], isTargeted: .none) { providers in
+                guard entry.isDirectory else { return false }
+                handleDrop(providers: providers, targetDir: entry.path, state: state, daemonClient: daemonClient)
+                return true
+            }
 
             // Expanded children
             if entry.isDirectory && isExpanded {


### PR DESCRIPTION
## Summary
- Add drag & drop support for importing files from Finder into workspace
- Drop onto sidebar imports to root, drop onto folder imports into that folder
- Visual dashed border indicator during drag and upload progress counter

Part of plan: workspace-edit.md (PR 9 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
