### PR TITLE
feat: add delete to workspace sidebar context menu

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -26,6 +26,8 @@ final class WorkspaceBrowserState {
     var showingNewFolderAlert = false
     var newItemName: String = ""
     var newItemParentPath: String = ""
+    var deleteConfirmPath: String?
+    var deleteConfirmName: String = ""
 
     func refreshDirectory(_ dirPath: String, using daemonClient: DaemonClient) async {
         if let response = await daemonClient.fetchWorkspaceTree(path: dirPath) {
@@ -53,6 +55,34 @@ struct WorkspacePanel: View {
             state.fileLoadTask = nil
             state.isLoadingFile = false
         }
+        .alert(
+            "Delete \"\(state.deleteConfirmName)\"?",
+            isPresented: Binding(
+                get: { state.deleteConfirmPath != nil },
+                set: { if !$0 { state.deleteConfirmPath = nil } }
+            )
+        ) {
+            Button("Delete", role: .destructive) {
+                guard let path = state.deleteConfirmPath else { return }
+                let parentPath = parentDirectory(of: path)
+                Task {
+                    let success = await daemonClient.deleteWorkspaceItem(path: path)
+                    if success {
+                        await state.refreshDirectory(parentPath, using: daemonClient)
+                        if state.selectedFilePath == path {
+                            state.selectedFilePath = nil
+                            state.selectedFileDetail = nil
+                            state.editableContent = ""
+                            state.originalContent = ""
+                            state.isDirty = false
+                        }
+                    }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This cannot be undone.")
+        }
     }
 
     private func loadRoot() async {
@@ -61,6 +91,12 @@ struct WorkspacePanel: View {
             state.directoryCache[""] = response.entries
         }
         state.isLoadingTree = false
+    }
+
+    private func parentDirectory(of path: String) -> String {
+        let components = path.split(separator: "/")
+        guard components.count > 1 else { return "" }
+        return components.dropLast().joined(separator: "/")
     }
 }
 
@@ -303,6 +339,13 @@ private struct WorkspaceTreeRow: View {
                 } label: {
                     Label { Text("New Folder") } icon: { VIconView(.folder, size: 12) }
                 }
+                Divider()
+            }
+            Button(role: .destructive) {
+                state.deleteConfirmPath = entry.path
+                state.deleteConfirmName = entry.name
+            } label: {
+                Label { Text("Delete") } icon: { VIconView(.trash, size: 12) }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add Delete option to context menu on both files and directories
- Show confirmation alert before deletion with item name
- Refresh sidebar after delete, clear selection if deleted item was selected

Part of plan: workspace-edit.md (PR 6 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
