### PR TITLE
feat: add inline rename to workspace sidebar

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -26,6 +26,8 @@ final class WorkspaceBrowserState {
     var showingNewFolderAlert = false
     var newItemName: String = ""
     var newItemParentPath: String = ""
+    var renamingPath: String? = nil
+    var renamingText: String = ""
 
     func refreshDirectory(_ dirPath: String, using daemonClient: DaemonClient) async {
         if let response = await daemonClient.fetchWorkspaceTree(path: dirPath) {
@@ -252,11 +254,23 @@ private struct WorkspaceTreeRow: View {
                     VIconView(entry.isDirectory ? .folder : .fileText, size: 12)
                         .foregroundColor(entry.isDirectory ? VColor.iconAccent : VColor.textSecondary)
 
-                    Text(entry.name)
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
+                    if state.renamingPath == entry.path {
+                        TextField("Name", text: $state.renamingText)
+                            .textFieldStyle(.plain)
+                            .font(VFont.body)
+                            .onSubmit {
+                                submitRename()
+                            }
+                            .onExitCommand {
+                                state.renamingPath = nil
+                            }
+                    } else {
+                        Text(entry.name)
+                            .font(VFont.body)
+                            .foregroundColor(VColor.textPrimary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
 
                     Spacer()
                 }
@@ -304,7 +318,35 @@ private struct WorkspaceTreeRow: View {
                     Label { Text("New Folder") } icon: { VIconView(.folder, size: 12) }
                 }
             }
+            Button {
+                state.renamingPath = entry.path
+                state.renamingText = entry.name
+            } label: {
+                Label { Text("Rename") } icon: { VIconView(.pencil, size: 12) }
+            }
         }
+    }
+
+    private func submitRename() {
+        let oldPath = entry.path
+        let parentPath = parentDirectory(of: oldPath)
+        let newPath = parentPath.isEmpty ? state.renamingText : "\(parentPath)/\(state.renamingText)"
+        Task {
+            let success = await daemonClient.renameWorkspaceItem(oldPath: oldPath, newPath: newPath)
+            if success {
+                await state.refreshDirectory(parentPath, using: daemonClient)
+                if state.selectedFilePath == oldPath {
+                    state.selectedFilePath = newPath
+                }
+            }
+            state.renamingPath = nil
+        }
+    }
+
+    private func parentDirectory(of path: String) -> String {
+        let components = path.split(separator: "/")
+        guard components.count > 1 else { return "" }
+        return components.dropLast().joined(separator: "/")
     }
 
     private func handleTap() async {


### PR DESCRIPTION
## Summary
- Add Rename option to context menu on all files and directories
- Replace name label with inline TextField when renaming (Enter to submit, Escape to cancel)
- Update file selection to new path if the renamed item was selected

Part of plan: workspace-edit.md (PR 7 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
