### PR TITLE
feat: add text file editing and file import to iOS workspace

### DIFF
--- a/clients/ios/Views/WorkspaceBrowserView.swift
+++ b/clients/ios/Views/WorkspaceBrowserView.swift
@@ -1,5 +1,6 @@
 #if canImport(UIKit)
 import SwiftUI
+import UniformTypeIdentifiers
 import VellumAssistantShared
 
 struct WorkspaceBrowserView: View {
@@ -15,6 +16,7 @@ struct WorkspaceBrowserView: View {
     @State private var deletingEntry: WorkspaceTreeEntry?
     @State private var renamingEntry: WorkspaceTreeEntry?
     @State private var renameText: String = ""
+    @State private var showDocumentPicker = false
 
     var body: some View {
         Group {
@@ -38,24 +40,38 @@ struct WorkspaceBrowserView: View {
         .navigationTitle(initialPath.isEmpty ? "Workspace" : lastPathComponent(initialPath))
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Menu {
-                    Button {
-                        newItemName = ""
-                        showingNewFileAlert = true
-                    } label: {
-                        Label { Text("New File") } icon: { VIconView(.filePlus, size: 14) }
+                HStack(spacing: VSpacing.md) {
+                    Button { showDocumentPicker = true } label: {
+                        VIconView(.upload, size: 16)
+                            .accessibilityLabel("Import files")
                     }
-                    Button {
-                        newItemName = ""
-                        showingNewFolderAlert = true
+
+                    Menu {
+                        Button {
+                            newItemName = ""
+                            showingNewFileAlert = true
+                        } label: {
+                            Label { Text("New File") } icon: { VIconView(.filePlus, size: 14) }
+                        }
+                        Button {
+                            newItemName = ""
+                            showingNewFolderAlert = true
+                        } label: {
+                            Label { Text("New Folder") } icon: { VIconView(.folder, size: 14) }
+                        }
                     } label: {
-                        Label { Text("New Folder") } icon: { VIconView(.folder, size: 14) }
+                        VIconView(.plus, size: 16)
+                            .accessibilityLabel("Add item")
                     }
-                } label: {
-                    VIconView(.plus, size: 16)
-                        .accessibilityLabel("Add item")
                 }
             }
+        }
+        .fileImporter(
+            isPresented: $showDocumentPicker,
+            allowedContentTypes: [.item],
+            allowsMultipleSelection: true
+        ) { result in
+            handleFileImport(result)
         }
         .sheet(item: $selectedFile) { file in
             WorkspaceFileSheet(filePath: file.path, mimeType: file.mimeType, client: client)
@@ -287,6 +303,23 @@ struct WorkspaceBrowserView: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(entry.name)
         .accessibilityHint("Opens file viewer")
+    }
+
+    // MARK: - File Import
+
+    private func handleFileImport(_ result: Result<[URL], Error>) {
+        guard case .success(let urls) = result else { return }
+        for url in urls {
+            let didAccess = url.startAccessingSecurityScopedResource()
+            defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+            guard let data = try? Data(contentsOf: url) else { continue }
+            let fileName = url.lastPathComponent
+            let targetPath = initialPath.isEmpty ? fileName : "\(initialPath)/\(fileName)"
+            Task {
+                let success = await client?.writeWorkspaceFile(path: targetPath, content: data) ?? false
+                if success { await reloadDirectory() }
+            }
+        }
     }
 
     // MARK: - Helpers

--- a/clients/ios/Views/WorkspaceFileSheet.swift
+++ b/clients/ios/Views/WorkspaceFileSheet.swift
@@ -11,6 +11,9 @@ struct WorkspaceFileSheet: View {
     @State private var fileResponse: WorkspaceFileResponse?
     @State private var isLoading = true
     @State private var error: String?
+    @State private var editableContent: String = ""
+    @State private var isDirty = false
+    @State private var isSaving = false
 
     var displayName: String {
         let trimmed = filePath.hasSuffix("/") ? String(filePath.dropLast()) : filePath
@@ -47,6 +50,14 @@ struct WorkspaceFileSheet: View {
             .navigationTitle(displayName)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    if isDirty {
+                        Button("Save") {
+                            Task { await saveFile() }
+                        }
+                        .disabled(isSaving)
+                    }
+                }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") { dismiss() }
                 }
@@ -54,6 +65,9 @@ struct WorkspaceFileSheet: View {
         }
         .task {
             await loadContent()
+            if let content = fileResponse?.content {
+                editableContent = content
+            }
         }
     }
 
@@ -67,11 +81,13 @@ struct WorkspaceFileSheet: View {
             AuthenticatedImageView(url: contentURL, client: client)
         } else if resolvedMime.hasPrefix("video/"), let contentURL = client?.workspaceFileContentURL(path: filePath) {
             WorkspaceVideoPlayer(url: contentURL, client: client)
-        } else if let response = fileResponse, !response.isBinary, let content = response.content {
-            ScrollView {
-                markdownContent(content)
-                    .padding(VSpacing.lg)
-            }
+        } else if let response = fileResponse, !response.isBinary, response.content != nil {
+            TextEditor(text: $editableContent)
+                .font(VFont.mono)
+                .padding(VSpacing.sm)
+                .onChange(of: editableContent) { _, newValue in
+                    isDirty = newValue != (fileResponse?.content ?? "")
+                }
         } else if let response = fileResponse {
             metadataView(response)
         } else {
@@ -120,25 +136,6 @@ struct WorkspaceFileSheet: View {
         }
     }
 
-    // MARK: - Markdown Rendering
-
-    @ViewBuilder
-    private func markdownContent(_ raw: String) -> some View {
-        if let attributed = try? AttributedString(markdown: raw, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)) {
-            Text(attributed)
-                .font(VFont.body)
-                .foregroundColor(VColor.textPrimary)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        } else {
-            Text(raw)
-                .font(VFont.body)
-                .foregroundColor(VColor.textPrimary)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-    }
-
     // MARK: - Loading
 
     private func loadContent() async {
@@ -154,6 +151,15 @@ struct WorkspaceFileSheet: View {
             error = "Unable to read file."
         }
         isLoading = false
+    }
+
+    private func saveFile() async {
+        guard let path = fileResponse?.path else { return }
+        isSaving = true
+        let data = Data(editableContent.utf8)
+        let success = await client?.writeWorkspaceFile(path: path, content: data) ?? false
+        if success { isDirty = false }
+        isSaving = false
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
- Replace read-only text view with editable TextEditor in WorkspaceFileSheet
- Add Save toolbar button with dirty state tracking
- Add file import button with iOS document picker and security-scoped resource handling

Part of plan: workspace-edit.md (PR 11 of 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
