### PR TITLE
fix: iOS workspace file dirty tracking uses saved content as baseline

### DIFF
--- a/clients/ios/Views/WorkspaceFileSheet.swift
+++ b/clients/ios/Views/WorkspaceFileSheet.swift
@@ -12,6 +12,7 @@ struct WorkspaceFileSheet: View {
     @State private var isLoading = true
     @State private var error: String?
     @State private var editableContent: String = ""
+    @State private var originalContent: String = ""
     @State private var isDirty = false
     @State private var isSaving = false
 
@@ -67,6 +68,7 @@ struct WorkspaceFileSheet: View {
             await loadContent()
             if let content = fileResponse?.content {
                 editableContent = content
+                originalContent = content
             }
         }
     }
@@ -86,7 +88,7 @@ struct WorkspaceFileSheet: View {
                 .font(VFont.mono)
                 .padding(VSpacing.sm)
                 .onChange(of: editableContent) { _, newValue in
-                    isDirty = newValue != (fileResponse?.content ?? "")
+                    isDirty = newValue != originalContent
                 }
         } else if let response = fileResponse {
             metadataView(response)
@@ -158,7 +160,10 @@ struct WorkspaceFileSheet: View {
         isSaving = true
         let data = Data(editableContent.utf8)
         let success = await client?.writeWorkspaceFile(path: path, content: data) ?? false
-        if success { isDirty = false }
+        if success {
+            originalContent = editableContent
+            isDirty = false
+        }
         isSaving = false
     }
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for workspace-edit.md.

**Gap:** iOS WorkspaceFileSheet dirty tracking breaks after first save
**What was expected:** Dirty indicator should compare against last-saved content
**What was found:** Compared against original file load content, never updated after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
