### PR TITLE
fix: consistent validation in workspace delete and directory-path write guard

### DIFF
--- a/assistant/src/runtime/routes/workspace-routes.test.ts
+++ b/assistant/src/runtime/routes/workspace-routes.test.ts
@@ -550,6 +550,16 @@ describe("POST /v1/workspace/write", () => {
     expect(body.path).toBe("response-check.txt");
     expect(body.size).toBe(3);
   });
+
+  test("returns 409 when writing to an existing directory path", async () => {
+    // subdir already exists as a directory from beforeAll
+    const ctx = makePostCtx("workspace/write", {
+      path: "subdir",
+      content: "should fail",
+    });
+    const res = await handler(ctx);
+    expect(res.status).toBe(409);
+  });
 });
 
 // ===========================================================================
@@ -728,11 +738,14 @@ describe("POST /v1/workspace/delete", () => {
   });
 
   test("rejects workspace root deletion with 400", async () => {
+    // Empty string is now rejected by the !path guard (consistent with other handlers).
+    // The workspace-root guard remains as defense-in-depth for non-empty paths that
+    // resolve to the workspace root (e.g. "." or "subdir/..").
     const ctx = makePostCtx("workspace/delete", { path: "" });
     const res = await handler(ctx);
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: { message: string } };
-    expect(body.error.message).toBe("Cannot delete workspace root");
+    expect(body.error.message).toBe("path is required");
   });
 
   test("rejects path traversal", async () => {
@@ -753,6 +766,12 @@ describe("POST /v1/workspace/delete", () => {
 
   test("rejects missing path field", async () => {
     const ctx = makePostCtx("workspace/delete", {});
+    const res = await handler(ctx);
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects empty string path with 400", async () => {
+    const ctx = makePostCtx("workspace/delete", { path: "" });
     const res = await handler(ctx);
     expect(res.status).toBe(400);
   });

--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -254,6 +254,10 @@ async function handleWorkspaceWrite(ctx: RouteContext): Promise<Response> {
       ? Buffer.from(content ?? "", "base64")
       : Buffer.from(content ?? "", "utf-8");
 
+  if (existsSync(resolved) && statSync(resolved).isDirectory()) {
+    return httpError("CONFLICT", "Path is a directory", 409);
+  }
+
   mkdirSync(dirname(resolved), { recursive: true });
   writeFileSync(resolved, buffer);
 
@@ -331,7 +335,7 @@ async function handleWorkspaceRename(ctx: RouteContext): Promise<Response> {
 async function handleWorkspaceDelete(ctx: RouteContext): Promise<Response> {
   const body = (await ctx.req.json()) as { path?: string };
   const path = body.path;
-  if (path == null) {
+  if (!path) {
     return httpError("BAD_REQUEST", "path is required", 400);
   }
 


### PR DESCRIPTION
## Summary
Fixes two gaps identified during plan review for workspace-edit.md.

**Gap A:** handleWorkspaceDelete now uses `!path` for consistent empty-string rejection
**Gap B:** handleWorkspaceWrite returns 409 when target path is an existing directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
