### PR TITLE
fix: clean up stale expandedDirs and directoryCache on workspace delete

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -95,6 +95,14 @@ struct WorkspacePanel: View {
                             state.originalContent = ""
                             state.isDirty = false
                         }
+                        // Clean up stale expandedDirs and directoryCache for deleted path
+                        state.expandedDirs.remove(path)
+                        let deletedPrefix = path + "/"
+                        state.expandedDirs = state.expandedDirs.filter { !$0.hasPrefix(deletedPrefix) }
+                        state.directoryCache.removeValue(forKey: path)
+                        for key in state.directoryCache.keys where key.hasPrefix(deletedPrefix) {
+                            state.directoryCache.removeValue(forKey: key)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Remove deleted directory (and descendants) from `expandedDirs` and `directoryCache` after a successful delete operation
- Prevents stale state from causing a recreated directory to appear pre-expanded with old cached children
- Matches the cleanup pattern already used by the rename handler

## Original prompt
Resolve the one remaining gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
