### PR TITLE
fix: don't show error state on image load cancellation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -740,7 +740,9 @@ private struct AuthenticatedImageView: View {
                 image = loadedImage
                 if image == nil { failed = true }
             } catch {
-                failed = true
+                if !Task.isCancelled {
+                    failed = true
+                }
             }
         }
     }


### PR DESCRIPTION
When an image loading task is cancelled (e.g., user switches files), return early without setting failed=true to avoid briefly flashing an error state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
