### PR TITLE
fix: add snappy animation token to gallery and docs

### DIFF
--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -193,7 +193,7 @@ All design system types use the `V` prefix (VButton, VColor, VFont, etc.). Alway
 
 **VRadius** — `xs`(2), `sm`(4), `md`(8), `lg`(12), `xl`(16), `pill`(999).
 
-**VAnimation** — `fast` (0.15s easeOut), `standard` (0.25s easeInOut), `slow` (0.4s easeInOut), `spring`, `panel` (gentle spring for panels), `bouncy` (celebratory spring).
+**VAnimation** — `snappy` (0.12s easeOut), `fast` (0.15s easeOut), `standard` (0.25s easeInOut), `slow` (0.4s easeInOut), `spring`, `panel` (gentle spring for panels), `bouncy` (celebratory spring).
 
 **VShadow** — `sm`, `md`, `lg`, `glow` (Amber), `accentGlow` (Violet). Applied via `.vShadow()` modifier.
 

--- a/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
+++ b/clients/shared/DesignSystem/Gallery/Sections/TokensGallerySection.swift
@@ -217,6 +217,7 @@ struct TokensGallerySection: View {
             VCard {
                 VStack(alignment: .leading, spacing: VSpacing.lg) {
                     let animations: [(String, String)] = [
+                        ("snappy", "0.12s easeOut"),
                         ("fast", "0.15s easeOut"),
                         ("standard", "0.25s easeInOut"),
                         ("slow", "0.4s easeInOut"),


### PR DESCRIPTION
Add the snappy VAnimation token to the design system gallery preview and update CLAUDE.md's VAnimation token reference list.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
