### PR TITLE
fix: complete chat bubble column-width token migration

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/ChatQueueSummaryView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ChatQueueSummaryView.swift
@@ -95,7 +95,7 @@ struct ChatQueueSummaryView: View {
             )
             .padding(.horizontal, VSpacing.lg)
             .padding(.bottom, VSpacing.xs)
-            .frame(maxWidth: 700)
+            .frame(maxWidth: VSpacing.chatColumnMaxWidth)
             .frame(maxWidth: .infinity)
             .transition(.opacity.combined(with: .move(edge: .bottom)))
         }

--- a/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/ComposerView.swift
@@ -121,7 +121,7 @@ struct ComposerView: View {
         .animation(VAnimation.fast, value: showSlashMenu)
         .padding(.horizontal, VSpacing.lg)
         .padding(.top, VSpacing.sm)
-        .frame(maxWidth: 700)
+        .frame(maxWidth: VSpacing.chatColumnMaxWidth)
         .frame(maxWidth: .infinity)
         .animation(VAnimation.fast, value: isComposerFocused)
         .onAppear {


### PR DESCRIPTION
Complete the migration of hardcoded column-width values to VSpacing tokens in ComposerView and ChatQueueSummaryView to fix layout misalignment between user and assistant chat bubbles.

Addresses feedback from #14390.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
