### PR TITLE
fix: capture save snapshot to prevent dirty state race

### DIFF
--- a/clients/ios/Views/WorkspaceFileSheet.swift
+++ b/clients/ios/Views/WorkspaceFileSheet.swift
@@ -158,11 +158,12 @@ struct WorkspaceFileSheet: View {
     private func saveFile() async {
         guard let path = fileResponse?.path else { return }
         isSaving = true
-        let data = Data(editableContent.utf8)
+        let snapshot = editableContent
+        let data = Data(snapshot.utf8)
         let success = await client?.writeWorkspaceFile(path: path, content: data) ?? false
         if success {
-            originalContent = editableContent
-            isDirty = false
+            originalContent = snapshot
+            isDirty = editableContent != snapshot
         }
         isSaving = false
     }

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -603,11 +603,12 @@ private struct WorkspaceFileViewer: View {
 
     private func saveFile(path: String) async {
         state.isSaving = true
-        let data = Data(state.editableContent.utf8)
+        let snapshot = state.editableContent
+        let data = Data(snapshot.utf8)
         let success = await daemonClient.writeWorkspaceFile(path: path, content: data)
         if success {
-            state.originalContent = state.editableContent
-            state.isDirty = false
+            state.originalContent = snapshot
+            state.isDirty = state.editableContent != snapshot
         }
         state.isSaving = false
     }


### PR DESCRIPTION
Fix save race condition in workspace file editor: capture editableContent at submission time and use that snapshot (not the potentially-changed current value) when updating originalContent after the save completes. Applies to both macOS and iOS.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
