### PR TITLE
fix: add symlink resolution and content validation to workspace routes

### DIFF
--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -244,6 +244,10 @@ async function handleWorkspaceWrite(ctx: RouteContext): Promise<Response> {
     return httpError("BAD_REQUEST", "path is required", 400);
   }
 
+  if (content !== undefined && typeof content !== "string") {
+    return httpError("BAD_REQUEST", "content must be a string", 400);
+  }
+
   const resolved = resolveWorkspacePath(path);
   if (resolved === undefined) {
     return httpError("BAD_REQUEST", "Invalid path", 400);

--- a/assistant/src/runtime/routes/workspace-utils.ts
+++ b/assistant/src/runtime/routes/workspace-utils.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import { resolve, sep } from "node:path";
 
 import { getWorkspaceDir } from "../../util/platform.js";
@@ -18,6 +19,41 @@ export function resolveWorkspacePath(relativePath: string): string | undefined {
   if (resolved !== base && !resolved.startsWith(base + sep)) {
     return undefined;
   }
+
+  // Canonicalize via realpath to prevent symlink traversal outside workspace.
+  // For new files, realpath the nearest existing ancestor to catch symlinked
+  // parent directories.
+  try {
+    const real = realpathSync(resolved);
+    const realBase = realpathSync(base);
+    if (real !== realBase && !real.startsWith(realBase + sep)) {
+      return undefined;
+    }
+  } catch {
+    // Path doesn't exist yet — walk up to the nearest existing ancestor and
+    // verify *it* resolves inside the workspace.
+    let ancestor = resolved;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const parent = resolve(ancestor, "..");
+      if (parent === ancestor) break; // reached filesystem root
+      ancestor = parent;
+      try {
+        const realAncestor = realpathSync(ancestor);
+        const realBase = realpathSync(base);
+        if (
+          realAncestor !== realBase &&
+          !realAncestor.startsWith(realBase + sep)
+        ) {
+          return undefined;
+        }
+        break;
+      } catch {
+        // ancestor doesn't exist either — keep walking up
+      }
+    }
+  }
+
   return resolved;
 }
 


### PR DESCRIPTION
Harden workspace write routes: resolve symlinks in resolveWorkspacePath to prevent path traversal via symlinks, and validate that the content field is a string before passing to Buffer.from.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
