### PR TITLE
fix: guard against renaming workspace root directory

### DIFF
--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -319,6 +319,11 @@ async function handleWorkspaceRename(ctx: RouteContext): Promise<Response> {
     return httpError("BAD_REQUEST", "Invalid newPath", 400);
   }
 
+  const workspaceDir = getWorkspaceDir();
+  if (resolvedOld === workspaceDir || resolvedNew === workspaceDir) {
+    return httpError("BAD_REQUEST", "Cannot rename workspace root", 400);
+  }
+
   if (!existsSync(resolvedOld)) {
     return httpError("NOT_FOUND", "Source path not found", 404);
   }


### PR DESCRIPTION
Add a guard to handleWorkspaceRename that rejects attempts to rename the workspace root directory, matching the existing guard in handleWorkspaceDelete.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
