### PR TITLE
fix: accept URL-backed drops and read files off main thread

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -285,22 +285,34 @@ private struct WorkspaceTreeSidebar: View {
 private func handleDrop(providers: [NSItemProvider], targetDir: String, state: WorkspaceBrowserState, daemonClient: DaemonClient) {
     for provider in providers {
         provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
-            guard let data = item as? Data,
-                  let url = URL(dataRepresentation: data, relativeTo: nil) else { return }
+            guard let url = fileURLFromDropItem(item) else { return }
             let fileName = url.lastPathComponent
             let targetPath = targetDir.isEmpty ? fileName : "\(targetDir)/\(fileName)"
-            Task { @MainActor in
-                state.uploadingCount += 1
+            Task {
+                await MainActor.run { state.uploadingCount += 1 }
                 if let fileData = try? Data(contentsOf: url) {
                     let success = await daemonClient.writeWorkspaceFile(path: targetPath, content: fileData)
                     if success {
                         await state.refreshDirectory(targetDir, using: daemonClient)
                     }
                 }
-                state.uploadingCount -= 1
+                await MainActor.run { state.uploadingCount -= 1 }
             }
         }
     }
+}
+
+private func fileURLFromDropItem(_ item: NSSecureCoding?) -> URL? {
+    if let data = item as? Data {
+        return URL(dataRepresentation: data, relativeTo: nil)
+    }
+    if let url = item as? URL {
+        return url
+    }
+    if let str = item as? String, let url = URL(string: str), url.isFileURL {
+        return url
+    }
+    return nil
 }
 
 // MARK: - Tree Row


### PR DESCRIPTION
Fix workspace drag-and-drop: handle URL-backed drop items (not just Data) and move synchronous file reads off the main actor to prevent UI blocking on large files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
