### PR TITLE
fix: sync file detail metadata when renaming the active file

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -437,11 +437,28 @@ private struct WorkspaceTreeRow: View {
             if success {
                 await state.refreshDirectory(parentPath, using: daemonClient)
 
-                // Update selectedFilePath for exact match or descendants
+                // Update selectedFilePath and selectedFileDetail for exact match or descendants
                 if state.selectedFilePath == oldPath {
                     state.selectedFilePath = newPath
+                    if let detail = state.selectedFileDetail {
+                        let newName = String(newPath.split(separator: "/").last ?? Substring(newPath))
+                        state.selectedFileDetail = WorkspaceFileResponse(
+                            path: newPath, name: newName, size: detail.size,
+                            mimeType: detail.mimeType, modifiedAt: detail.modifiedAt,
+                            content: detail.content, isBinary: detail.isBinary
+                        )
+                    }
                 } else if let selected = state.selectedFilePath, selected.hasPrefix(oldPath + "/") {
-                    state.selectedFilePath = newPath + selected.dropFirst(oldPath.count)
+                    let updatedPath = newPath + selected.dropFirst(oldPath.count)
+                    state.selectedFilePath = updatedPath
+                    if let detail = state.selectedFileDetail {
+                        let newName = String(updatedPath.split(separator: "/").last ?? Substring(updatedPath))
+                        state.selectedFileDetail = WorkspaceFileResponse(
+                            path: updatedPath, name: newName, size: detail.size,
+                            mimeType: detail.mimeType, modifiedAt: detail.modifiedAt,
+                            content: detail.content, isBinary: detail.isBinary
+                        )
+                    }
                 }
 
                 // Migrate expandedDirs and directoryCache for renamed directories


### PR DESCRIPTION
When renaming the currently open file, update selectedFileDetail's path to match the new name so the editor shows correct metadata instead of stale old-path information.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
