### PR TITLE
feat: add HTTP routes for model config, conversation search, and message content

### DIFF
--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -18,17 +18,154 @@ import {
   log,
 } from "./shared.js";
 
-export function handleModelGet(socket: net.Socket, ctx: HandlerContext): void {
+// ---------------------------------------------------------------------------
+// Shared business logic (transport-agnostic)
+// ---------------------------------------------------------------------------
+
+export interface ModelInfo {
+  model: string;
+  provider: string;
+  configuredProviders?: string[];
+}
+
+/** Return current model configuration. */
+export function getModelInfo(): ModelInfo {
   const config = getConfig();
   const configured = Object.keys(config.apiKeys).filter(
     (k) => !!config.apiKeys[k],
   );
   if (!configured.includes("ollama")) configured.push("ollama");
-  ctx.send(socket, {
-    type: "model_info",
+  return {
     model: config.model,
     provider: config.provider,
     configuredProviders: configured,
+  };
+}
+
+/**
+ * Minimal interface for the side-effects needed by setModel / setImageGenModel.
+ * Keeps the business logic decoupled from IPC-specific HandlerContext.
+ */
+export interface ModelSetContext {
+  sessions: Map<string, { isProcessing(): boolean; dispose(): void; markStale(): void }>;
+  suppressConfigReload: boolean;
+  setSuppressConfigReload(value: boolean): void;
+  updateConfigFingerprint(): void;
+  debounceTimers: { schedule(key: string, fn: () => void, ms: number): void };
+}
+
+/**
+ * Set the active model. Returns the resulting ModelInfo, or throws on failure.
+ * The caller is responsible for sending the response to the client.
+ */
+export function setModel(modelId: string, ctx: ModelSetContext): ModelInfo {
+  // If the requested model is already the current model AND the provider
+  // is already aligned with what MODEL_TO_PROVIDER expects, skip expensive
+  // reinitialization but still return model_info so the client confirms.
+  {
+    const current = getConfig();
+    const expectedProvider = MODEL_TO_PROVIDER[modelId];
+    const providerAligned =
+      !expectedProvider || current.provider === expectedProvider;
+    if (modelId === current.model && providerAligned) {
+      return getModelInfo();
+    }
+  }
+
+  // Validate API key before switching
+  const provider = MODEL_TO_PROVIDER[modelId];
+  if (provider && provider !== "ollama") {
+    const currentConfig = getConfig();
+    if (!currentConfig.apiKeys[provider]) {
+      // Return current model_info so the client resyncs its optimistic state
+      return getModelInfo();
+    }
+  }
+
+  // Use raw config to avoid persisting env-var API keys to disk
+  const raw = loadRawConfig();
+  raw.model = modelId;
+  // Infer provider from model ID to keep provider and model in sync
+  raw.provider = provider ?? raw.provider;
+
+  // Suppress the file watcher callback — setModel already does
+  // the full reload sequence; a redundant watcher-triggered reload
+  // would incorrectly evict sessions created after this method returns.
+  const wasSuppressed = ctx.suppressConfigReload;
+  ctx.setSuppressConfigReload(true);
+  try {
+    saveRawConfig(raw);
+  } catch (err) {
+    ctx.setSuppressConfigReload(wasSuppressed);
+    throw err;
+  }
+  ctx.debounceTimers.schedule(
+    "__suppress_reset__",
+    () => {
+      ctx.setSuppressConfigReload(false);
+    },
+    CONFIG_RELOAD_DEBOUNCE_MS,
+  );
+
+  // Re-initialize provider with the new model so LLM calls use it
+  const config = getConfig();
+  initializeProviders(config);
+
+  // Evict idle sessions immediately; mark busy ones as stale so they
+  // get recreated with the new provider once they finish processing.
+  for (const [id, session] of ctx.sessions) {
+    if (!session.isProcessing()) {
+      session.dispose();
+      ctx.sessions.delete(id);
+    } else {
+      session.markStale();
+    }
+  }
+
+  ctx.updateConfigFingerprint();
+
+  return { model: config.model, provider: config.provider };
+}
+
+/**
+ * Set the image generation model. Throws on failure.
+ */
+export function setImageGenModel(
+  modelId: string,
+  ctx: ModelSetContext,
+): void {
+  const raw = loadRawConfig();
+  raw.imageGenModel = modelId;
+
+  const wasSuppressed = ctx.suppressConfigReload;
+  ctx.setSuppressConfigReload(true);
+  try {
+    saveRawConfig(raw);
+  } catch (err) {
+    ctx.setSuppressConfigReload(wasSuppressed);
+    throw err;
+  }
+  ctx.debounceTimers.schedule(
+    "__suppress_reset__",
+    () => {
+      ctx.setSuppressConfigReload(false);
+    },
+    CONFIG_RELOAD_DEBOUNCE_MS,
+  );
+
+  ctx.updateConfigFingerprint();
+  log.info({ model: modelId }, "Image generation model updated");
+}
+
+// ---------------------------------------------------------------------------
+// IPC handlers (delegate to shared logic)
+// ---------------------------------------------------------------------------
+
+export function handleModelGet(socket: net.Socket, ctx: HandlerContext): void {
+  const info = getModelInfo();
+  ctx.send(socket, {
+    type: "model_info",
+    ...info,
   });
 }
 
@@ -38,99 +175,8 @@ export function handleModelSet(
   ctx: HandlerContext,
 ): void {
   try {
-    // If the requested model is already the current model AND the provider
-    // is already aligned with what MODEL_TO_PROVIDER expects, skip expensive
-    // reinitialization but still send model_info so the client confirms.
-    // If the provider has drifted (e.g. manual config edit), fall through
-    // so the full reinit path can repair it.
-    {
-      const current = getConfig();
-      const expectedProvider = MODEL_TO_PROVIDER[msg.model];
-      const providerAligned =
-        !expectedProvider || current.provider === expectedProvider;
-      if (msg.model === current.model && providerAligned) {
-        const configured = Object.keys(current.apiKeys).filter(
-          (k) => !!current.apiKeys[k],
-        );
-        if (!configured.includes("ollama")) configured.push("ollama");
-        ctx.send(socket, {
-          type: "model_info",
-          model: current.model,
-          provider: current.provider,
-          configuredProviders: configured,
-        });
-        return;
-      }
-    }
-
-    // Validate API key before switching
-    const provider = MODEL_TO_PROVIDER[msg.model];
-    if (provider && provider !== "ollama") {
-      const currentConfig = getConfig();
-      if (!currentConfig.apiKeys[provider]) {
-        // Send current model_info so the client resyncs its optimistic state
-        // (don't use generic 'error' type — it would interrupt in-flight chat)
-        const configured = Object.keys(currentConfig.apiKeys).filter(
-          (k) => !!currentConfig.apiKeys[k],
-        );
-        if (!configured.includes("ollama")) configured.push("ollama");
-        ctx.send(socket, {
-          type: "model_info",
-          model: currentConfig.model,
-          provider: currentConfig.provider,
-          configuredProviders: configured,
-        });
-        return;
-      }
-    }
-
-    // Use raw config to avoid persisting env-var API keys to disk
-    const raw = loadRawConfig();
-    raw.model = msg.model;
-    // Infer provider from model ID to keep provider and model in sync
-    raw.provider = provider ?? raw.provider;
-
-    // Suppress the file watcher callback — handleModelSet already does
-    // the full reload sequence; a redundant watcher-triggered reload
-    // would incorrectly evict sessions created after this method returns.
-    const wasSuppressed = ctx.suppressConfigReload;
-    ctx.setSuppressConfigReload(true);
-    try {
-      saveRawConfig(raw);
-    } catch (err) {
-      ctx.setSuppressConfigReload(wasSuppressed);
-      throw err;
-    }
-    ctx.debounceTimers.schedule(
-      "__suppress_reset__",
-      () => {
-        ctx.setSuppressConfigReload(false);
-      },
-      CONFIG_RELOAD_DEBOUNCE_MS,
-    );
-
-    // Re-initialize provider with the new model so LLM calls use it
-    const config = getConfig();
-    initializeProviders(config);
-
-    // Evict idle sessions immediately; mark busy ones as stale so they
-    // get recreated with the new provider once they finish processing.
-    for (const [id, session] of ctx.sessions) {
-      if (!session.isProcessing()) {
-        session.dispose();
-        ctx.sessions.delete(id);
-      } else {
-        session.markStale();
-      }
-    }
-
-    ctx.updateConfigFingerprint();
-
-    ctx.send(socket, {
-      type: "model_info",
-      model: config.model,
-      provider: config.provider,
-    });
+    const info = setModel(msg.model, ctx);
+    ctx.send(socket, { type: "model_info", ...info });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     ctx.send(socket, {
@@ -146,27 +192,7 @@ export function handleImageGenModelSet(
   ctx: HandlerContext,
 ): void {
   try {
-    const raw = loadRawConfig();
-    raw.imageGenModel = msg.model;
-
-    const wasSuppressed = ctx.suppressConfigReload;
-    ctx.setSuppressConfigReload(true);
-    try {
-      saveRawConfig(raw);
-    } catch (err) {
-      ctx.setSuppressConfigReload(wasSuppressed);
-      throw err;
-    }
-    ctx.debounceTimers.schedule(
-      "__suppress_reset__",
-      () => {
-        ctx.setSuppressConfigReload(false);
-      },
-      CONFIG_RELOAD_DEBOUNCE_MS,
-    );
-
-    ctx.updateConfigFingerprint();
-    log.info({ model: msg.model }, "Image generation model updated");
+    setImageGenModel(msg.model, ctx);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, `Failed to set image gen model: ${message}`);

--- a/assistant/src/daemon/handlers/session-history.ts
+++ b/assistant/src/daemon/handlers/session-history.ts
@@ -290,35 +290,45 @@ export function handleHistoryRequest(
   // so we no longer emit separate ui_surface_show messages during history loading.
 }
 
-export function handleConversationSearch(
-  msg: ConversationSearchRequest,
-  socket: net.Socket,
-  ctx: HandlerContext,
-): void {
-  const results = searchConversations(msg.query, {
-    limit: msg.limit,
-    maxMessagesPerConversation: msg.maxMessagesPerConversation,
-  });
-  ctx.send(socket, {
-    type: "conversation_search_response",
-    query: msg.query,
-    results,
+// ---------------------------------------------------------------------------
+// Shared business logic (transport-agnostic)
+// ---------------------------------------------------------------------------
+
+export interface ConversationSearchParams {
+  query: string;
+  limit?: number;
+  maxMessagesPerConversation?: number;
+}
+
+/** Search conversations and return results (no transport dependency). */
+export function performConversationSearch(params: ConversationSearchParams) {
+  return searchConversations(params.query, {
+    limit: params.limit,
+    maxMessagesPerConversation: params.maxMessagesPerConversation,
   });
 }
 
-export function handleMessageContentRequest(
-  msg: MessageContentRequest,
-  socket: net.Socket,
-  ctx: HandlerContext,
-): void {
-  const dbMessage = getMessageById(msg.messageId, msg.sessionId);
-  if (!dbMessage) {
-    ctx.send(socket, {
-      type: "error",
-      message: `Message ${msg.messageId} not found in session ${msg.sessionId}`,
-    });
-    return;
-  }
+export interface MessageContentResult {
+  sessionId?: string;
+  messageId: string;
+  text?: string;
+  toolCalls?: Array<{
+    name: string;
+    result?: string;
+    input?: Record<string, unknown>;
+  }>;
+}
+
+/**
+ * Get the full content of a single message by ID.
+ * Returns null if the message is not found.
+ */
+export function getMessageContent(
+  messageId: string,
+  sessionId?: string,
+): MessageContentResult | null {
+  const dbMessage = getMessageById(messageId, sessionId);
+  if (!dbMessage) return null;
 
   let text: string | undefined;
   let toolCalls:
@@ -343,11 +353,54 @@ export function handleMessageContentRequest(
     text = dbMessage.content || undefined;
   }
 
+  return {
+    sessionId,
+    messageId,
+    ...(text !== undefined ? { text } : {}),
+    ...(toolCalls ? { toolCalls } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// IPC handlers (delegate to shared logic)
+// ---------------------------------------------------------------------------
+
+export function handleConversationSearch(
+  msg: ConversationSearchRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  const results = performConversationSearch({
+    query: msg.query,
+    limit: msg.limit,
+    maxMessagesPerConversation: msg.maxMessagesPerConversation,
+  });
+  ctx.send(socket, {
+    type: "conversation_search_response",
+    query: msg.query,
+    results,
+  });
+}
+
+export function handleMessageContentRequest(
+  msg: MessageContentRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  const result = getMessageContent(msg.messageId, msg.sessionId);
+  if (!result) {
+    ctx.send(socket, {
+      type: "error",
+      message: `Message ${msg.messageId} not found in session ${msg.sessionId}`,
+    });
+    return;
+  }
+
   ctx.send(socket, {
     type: "message_content_response",
     sessionId: msg.sessionId,
     messageId: msg.messageId,
-    ...(text !== undefined ? { text } : {}),
-    ...(toolCalls ? { toolCalls } : {}),
+    ...(result.text !== undefined ? { text: result.text } : {}),
+    ...(result.toolCalls ? { toolCalls: result.toolCalls } : {}),
   });
 }

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -629,31 +629,58 @@ export function handleUsageRequest(
   });
 }
 
+// ---------------------------------------------------------------------------
+// Shared business logic (transport-agnostic)
+// ---------------------------------------------------------------------------
+
+/**
+ * Delete a queued message from a session.
+ * Returns `{ removed: true }` on success, `{ removed: false, reason }` on failure.
+ */
+export function deleteQueuedMessage(
+  sessionId: string,
+  requestId: string,
+  findSession: (id: string) => { removeQueuedMessage(requestId: string): boolean } | undefined,
+): { removed: true } | { removed: false; reason: "session_not_found" | "message_not_found" } {
+  const session = findSession(sessionId);
+  if (!session) {
+    log.warn(
+      { sessionId, requestId },
+      "No session found for delete_queued_message",
+    );
+    return { removed: false, reason: "session_not_found" };
+  }
+  const removed = session.removeQueuedMessage(requestId);
+  if (removed) {
+    return { removed: true };
+  }
+  log.warn(
+    { sessionId, requestId },
+    "Queued message not found for deletion",
+  );
+  return { removed: false, reason: "message_not_found" };
+}
+
+// ---------------------------------------------------------------------------
+// IPC handler (delegates to shared logic)
+// ---------------------------------------------------------------------------
+
 export function handleDeleteQueuedMessage(
   msg: DeleteQueuedMessage,
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  const session = ctx.sessions.get(msg.sessionId);
-  if (!session) {
-    log.warn(
-      { sessionId: msg.sessionId, requestId: msg.requestId },
-      "No session found for delete_queued_message",
-    );
-    return;
-  }
-  const removed = session.removeQueuedMessage(msg.requestId);
-  if (removed) {
+  const result = deleteQueuedMessage(
+    msg.sessionId,
+    msg.requestId,
+    (id) => ctx.sessions.get(id),
+  );
+  if (result.removed) {
     ctx.send(socket, {
       type: "message_queued_deleted",
       sessionId: msg.sessionId,
       requestId: msg.requestId,
     });
-  } else {
-    log.warn(
-      { sessionId: msg.sessionId, requestId: msg.requestId },
-      "Queued message not found for deletion",
-    );
   }
 }
 

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -272,6 +272,20 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "workspace/rename", scopes: ["settings.write"] },
   { endpoint: "workspace/delete", scopes: ["settings.write"] },
 
+  // Model config
+  { endpoint: "model:GET", scopes: ["settings.read"] },
+  { endpoint: "model:PUT", scopes: ["settings.write"] },
+  { endpoint: "model/image-gen", scopes: ["settings.write"] },
+
+  // Conversation search
+  { endpoint: "conversations/search", scopes: ["chat.read"] },
+
+  // Message content
+  { endpoint: "messages/content", scopes: ["chat.read"] },
+
+  // Queued message deletion
+  { endpoint: "messages/queued", scopes: ["chat.write"] },
+
   // Browser relay
   { endpoint: "browser-relay/status", scopes: ["settings.read"] },
   { endpoint: "browser-relay/command", scopes: ["settings.write"] },

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -135,6 +135,7 @@ import {
   pairingRouteDefinitions,
 } from "./routes/pairing-routes.js";
 import { secretRouteDefinitions } from "./routes/secret-routes.js";
+import { sessionQueryRouteDefinitions } from "./routes/session-query-routes.js";
 import { surfaceActionRouteDefinitions } from "./routes/surface-action-routes.js";
 import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.js";
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";
@@ -195,6 +196,7 @@ export class RuntimeHttpServer {
   private pairingBroadcast?: (msg: ServerMessage) => void;
   private sendMessageDeps?: SendMessageDeps;
   private findSession?: RuntimeHttpServerOptions["findSession"];
+  private modelSetContext?: RuntimeHttpServerOptions["modelSetContext"];
   private router: HttpRouter;
 
   constructor(options: RuntimeHttpServerOptions = {}) {
@@ -210,6 +212,7 @@ export class RuntimeHttpServer {
     this.interfacesDir = options.interfacesDir ?? null;
     this.sendMessageDeps = options.sendMessageDeps;
     this.findSession = options.findSession;
+    this.modelSetContext = options.modelSetContext;
     this.router = new HttpRouter(this.buildRouteTable());
   }
 
@@ -690,6 +693,16 @@ export class RuntimeHttpServer {
       ...debugRouteDefinitions(),
       ...usageRouteDefinitions(),
       ...workspaceRouteDefinitions(),
+      ...sessionQueryRouteDefinitions({
+        modelSetContext: this.modelSetContext,
+        findSessionForQueue: this.findSession
+          ? (id) => {
+              const s = this.findSession!(id);
+              if (!s?.removeQueuedMessage) return undefined;
+              return { removeQueuedMessage: s.removeQueuedMessage.bind(s) };
+            }
+          : undefined,
+      }),
 
       // Browser relay — not extracted into a domain module because
       // these two routes depend on the in-process extensionRelayServer

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -195,8 +195,11 @@ export interface RuntimeHttpServerOptions {
           data: SurfaceData;
           actions?: Array<{ id: string; label: string; style?: string }>;
         }>;
+        removeQueuedMessage?: (requestId: string) => boolean;
       }
     | undefined;
+  /** Context for model config set operations (session eviction, config reload suppression). */
+  modelSetContext?: import("../daemon/handlers/config-model.js").ModelSetContext;
 }
 
 export interface RuntimeAttachmentMetadata {

--- a/assistant/src/runtime/routes/session-query-routes.ts
+++ b/assistant/src/runtime/routes/session-query-routes.ts
@@ -1,0 +1,204 @@
+/**
+ * HTTP route definitions for model configuration, conversation search,
+ * message content, and queued message deletion.
+ *
+ * These routes expose IPC-only functionality over the HTTP API, enabling
+ * clients to migrate from the Unix socket transport to HTTP+SSE.
+ *
+ * GET    /v1/model                   — current model info
+ * PUT    /v1/model                   — set model
+ * PUT    /v1/model/image-gen         — set image-gen model
+ * GET    /v1/conversations/search    — search conversations
+ * GET    /v1/messages/:id/content    — full message content
+ * DELETE /v1/messages/queued/:id     — delete queued message
+ */
+
+import {
+  getModelInfo,
+  setImageGenModel,
+  setModel,
+  type ModelSetContext,
+} from "../../daemon/handlers/config-model.js";
+import {
+  getMessageContent,
+  performConversationSearch,
+} from "../../daemon/handlers/session-history.js";
+import { deleteQueuedMessage } from "../../daemon/handlers/sessions.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+// ---------------------------------------------------------------------------
+// Dependency interfaces
+// ---------------------------------------------------------------------------
+
+export interface SessionQueryRouteDeps {
+  /** Context for model set operations (config reload suppression, session eviction). */
+  modelSetContext?: ModelSetContext;
+  /** Lookup an active session by ID for queued message deletion. */
+  findSessionForQueue?: (
+    id: string,
+  ) => { removeQueuedMessage(requestId: string): boolean } | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function sessionQueryRouteDefinitions(
+  deps: SessionQueryRouteDeps = {},
+): RouteDefinition[] {
+  return [
+    // ── Model config ──────────────────────────────────────────────────
+    {
+      endpoint: "model",
+      method: "GET",
+      policyKey: "model",
+      handler: () => {
+        const info = getModelInfo();
+        return Response.json(info);
+      },
+    },
+    {
+      endpoint: "model",
+      method: "PUT",
+      policyKey: "model",
+      handler: async ({ req }) => {
+        if (!deps.modelSetContext) {
+          return httpError(
+            "INTERNAL_ERROR",
+            "Model set not available",
+            500,
+          );
+        }
+        const body = (await req.json()) as { modelId?: string };
+        if (!body.modelId || typeof body.modelId !== "string") {
+          return httpError("BAD_REQUEST", "Missing required field: modelId", 400);
+        }
+        try {
+          const info = setModel(body.modelId, deps.modelSetContext);
+          return Response.json(info);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return httpError(
+            "INTERNAL_ERROR",
+            `Failed to set model: ${message}`,
+            500,
+          );
+        }
+      },
+    },
+    {
+      endpoint: "model/image-gen",
+      method: "PUT",
+      policyKey: "model/image-gen",
+      handler: async ({ req }) => {
+        if (!deps.modelSetContext) {
+          return httpError(
+            "INTERNAL_ERROR",
+            "Image gen model set not available",
+            500,
+          );
+        }
+        const body = (await req.json()) as { modelId?: string };
+        if (!body.modelId || typeof body.modelId !== "string") {
+          return httpError("BAD_REQUEST", "Missing required field: modelId", 400);
+        }
+        try {
+          setImageGenModel(body.modelId, deps.modelSetContext);
+          return Response.json({ ok: true });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return httpError(
+            "INTERNAL_ERROR",
+            `Failed to set image gen model: ${message}`,
+            500,
+          );
+        }
+      },
+    },
+
+    // ── Conversation search ───────────────────────────────────────────
+    {
+      endpoint: "conversations/search",
+      method: "GET",
+      policyKey: "conversations/search",
+      handler: ({ url }) => {
+        const q = url.searchParams.get("q");
+        if (!q) {
+          return httpError("BAD_REQUEST", "Missing required query parameter: q", 400);
+        }
+        const limit = url.searchParams.has("limit")
+          ? Number(url.searchParams.get("limit"))
+          : undefined;
+        const maxMessages = url.searchParams.has("maxMessagesPerConversation")
+          ? Number(url.searchParams.get("maxMessagesPerConversation"))
+          : undefined;
+        const results = performConversationSearch({
+          query: q,
+          limit,
+          maxMessagesPerConversation: maxMessages,
+        });
+        return Response.json({ query: q, results });
+      },
+    },
+
+    // ── Message content ───────────────────────────────────────────────
+    {
+      endpoint: "messages/:id/content",
+      method: "GET",
+      policyKey: "messages/content",
+      handler: ({ url, params }) => {
+        const sessionId = url.searchParams.get("sessionId");
+        const result = getMessageContent(params.id, sessionId ?? undefined);
+        if (!result) {
+          return httpError(
+            "NOT_FOUND",
+            `Message ${params.id} not found`,
+            404,
+          );
+        }
+        return Response.json(result);
+      },
+    },
+
+    // ── Delete queued message ─────────────────────────────────────────
+    {
+      endpoint: "messages/queued/:id",
+      method: "DELETE",
+      policyKey: "messages/queued",
+      handler: ({ url, params }) => {
+        if (!deps.findSessionForQueue) {
+          return httpError(
+            "INTERNAL_ERROR",
+            "Queued message deletion not available",
+            500,
+          );
+        }
+        const sessionId = url.searchParams.get("sessionId");
+        if (!sessionId) {
+          return httpError(
+            "BAD_REQUEST",
+            "Missing required query parameter: sessionId",
+            400,
+          );
+        }
+        const result = deleteQueuedMessage(
+          sessionId,
+          params.id,
+          deps.findSessionForQueue,
+        );
+        if (result.removed) {
+          return Response.json({
+            ok: true,
+            sessionId,
+            requestId: params.id,
+          });
+        }
+        if (result.reason === "session_not_found") {
+          return httpError("NOT_FOUND", "Session not found", 404);
+        }
+        return httpError("NOT_FOUND", "Queued message not found", 404);
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Extract model config, conversation search, and message content logic from IPC handlers into shared functions
- Create new HTTP route definitions for model get/set, image-gen model set, conversation search, message content, and queued message deletion
- Register routes in http-server.ts buildRouteTable()

Part of plan: phase-out-ipc.md (PR 2 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
