### PR TITLE
feat: add HTTP routes for computer use sessions and recordings

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -285,6 +285,22 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "trust-rules/manage:DELETE", scopes: ["settings.write"] },
   { endpoint: "trust-rules/manage:PATCH", scopes: ["settings.write"] },
 
+  // Computer use
+  { endpoint: "computer-use/sessions", scopes: ["chat.write"] },
+  { endpoint: "computer-use/sessions/abort", scopes: ["chat.write"] },
+  { endpoint: "computer-use/observations", scopes: ["chat.write"] },
+  { endpoint: "computer-use/tasks", scopes: ["chat.write"] },
+  { endpoint: "computer-use/ride-shotgun/start", scopes: ["chat.write"] },
+  { endpoint: "computer-use/ride-shotgun/stop", scopes: ["chat.write"] },
+  { endpoint: "computer-use/watch", scopes: ["chat.write"] },
+
+  // Recordings
+  { endpoint: "recordings/start", scopes: ["settings.write"] },
+  { endpoint: "recordings/stop", scopes: ["settings.write"] },
+  { endpoint: "recordings/pause", scopes: ["settings.write"] },
+  { endpoint: "recordings/resume", scopes: ["settings.write"] },
+  { endpoint: "recordings/status", scopes: ["settings.read"] },
+
   // Surface actions
   { endpoint: "surface-actions", scopes: ["chat.write"] },
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -140,6 +140,14 @@ import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";
 import { usageRouteDefinitions } from "./routes/usage-routes.js";
 import { workspaceRouteDefinitions } from "./routes/workspace-routes.js";
+import {
+  computerUseRouteDefinitions,
+  type ComputerUseDeps,
+} from "./routes/computer-use-routes.js";
+import {
+  recordingRouteDefinitions,
+  type RecordingDeps,
+} from "./routes/recording-routes.js";
 
 // Re-export for consumers
 export { isPrivateAddress } from "./middleware/auth.js";
@@ -195,6 +203,8 @@ export class RuntimeHttpServer {
   private pairingBroadcast?: (msg: ServerMessage) => void;
   private sendMessageDeps?: SendMessageDeps;
   private findSession?: RuntimeHttpServerOptions["findSession"];
+  private getComputerUseDeps?: RuntimeHttpServerOptions["getComputerUseDeps"];
+  private getRecordingDeps?: RuntimeHttpServerOptions["getRecordingDeps"];
   private router: HttpRouter;
 
   constructor(options: RuntimeHttpServerOptions = {}) {
@@ -210,6 +220,8 @@ export class RuntimeHttpServer {
     this.interfacesDir = options.interfacesDir ?? null;
     this.sendMessageDeps = options.sendMessageDeps;
     this.findSession = options.findSession;
+    this.getComputerUseDeps = options.getComputerUseDeps;
+    this.getRecordingDeps = options.getRecordingDeps;
     this.router = new HttpRouter(this.buildRouteTable());
   }
 
@@ -886,6 +898,13 @@ export class RuntimeHttpServer {
       ...twilioRouteDefinitions(),
       ...channelReadinessRouteDefinitions(),
       ...attachmentRouteDefinitions(),
+
+      ...computerUseRouteDefinitions({
+        getComputerUseDeps: this.getComputerUseDeps,
+      }),
+      ...recordingRouteDefinitions({
+        getRecordingDeps: this.getRecordingDeps,
+      }),
 
       {
         endpoint: "interfaces/:path*",

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -197,6 +197,10 @@ export interface RuntimeHttpServerOptions {
         }>;
       }
     | undefined;
+  /** Provider for computer-use session dependencies (CU routes). */
+  getComputerUseDeps?: () => import("./routes/computer-use-routes.js").ComputerUseDeps;
+  /** Provider for recording dependencies (recording routes). */
+  getRecordingDeps?: () => import("./routes/recording-routes.js").RecordingDeps;
 }
 
 export interface RuntimeAttachmentMetadata {

--- a/assistant/src/runtime/routes/computer-use-routes.ts
+++ b/assistant/src/runtime/routes/computer-use-routes.ts
@@ -1,0 +1,570 @@
+/**
+ * HTTP route handlers for computer use session lifecycle.
+ *
+ * These endpoints expose CU session management, ride-shotgun, and watch
+ * observation functionality over HTTP. The existing IPC handlers remain
+ * as the primary transport; these routes provide the HTTP-first API
+ * surface for the phase-out-ipc migration.
+ *
+ * All CU write operations require the `chat.write` scope.
+ */
+
+import type { ComputerUseSession } from "../../daemon/computer-use-session.js";
+import type { CuObservation } from "../../daemon/ipc-protocol.js";
+import { getConfig } from "../../config/loader.js";
+import { RateLimitProvider } from "../../providers/ratelimit.js";
+import { getFailoverProvider } from "../../providers/registry.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+import { buildAssistantEvent } from "../assistant-event.js";
+import { assistantEventHub } from "../assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
+import type { ServerMessage } from "../../daemon/ipc-protocol.js";
+
+const log = getLogger("computer-use-routes");
+
+// ---------------------------------------------------------------------------
+// Dependency injection interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface for CU session management.
+ * The daemon wires a concrete implementation at startup.
+ */
+export interface ComputerUseDeps {
+  /** Active CU sessions keyed by session ID. */
+  cuSessions: Map<string, ComputerUseSession>;
+  /** Shared rate-limiter timestamps across the daemon. */
+  sharedRequestTimestamps: number[];
+  /** Sequence tracker for CU observations (per session). */
+  cuObservationParseSequence: Map<string, number>;
+  /** Handle a ride-shotgun start request. Returns watchId and sessionId. */
+  handleRideShotgunStart: (params: {
+    durationSeconds: number;
+    intervalSeconds: number;
+    mode?: "observe" | "learn";
+    targetDomain?: string;
+    navigateDomain?: string;
+    autoNavigate?: boolean;
+  }) => Promise<{ watchId: string; sessionId: string }>;
+  /** Handle a ride-shotgun stop request. */
+  handleRideShotgunStop: (watchId: string) => Promise<void>;
+  /** Handle a watch observation. */
+  handleWatchObservation: (params: {
+    watchId: string;
+    sessionId: string;
+    ocrText: string;
+    appName?: string;
+    windowTitle?: string;
+    bundleIdentifier?: string;
+    timestamp: number;
+    captureIndex: number;
+    totalExpected: number;
+  }) => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level state (mirrors IPC handler)
+// ---------------------------------------------------------------------------
+
+const cuObservationSequenceBySession = new Map<string, number>();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Publish a server message to the SSE event hub for HTTP clients. */
+function publishEvent(msg: ServerMessage): void {
+  void assistantEventHub.publish(
+    buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg),
+  );
+}
+
+function removeCuSessionReferences(
+  deps: ComputerUseDeps,
+  sessionId: string,
+  expectedSession?: ComputerUseSession,
+): void {
+  const current = deps.cuSessions.get(sessionId);
+  if (expectedSession && current && current !== expectedSession) {
+    return;
+  }
+  deps.cuSessions.delete(sessionId);
+  cuObservationSequenceBySession.delete(sessionId);
+  deps.cuObservationParseSequence.delete(sessionId);
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /v1/computer-use/sessions — create a CU session.
+ *
+ * Body: { sessionId, task, screenWidth, screenHeight, interactionType? }
+ */
+async function handleCreateSession(
+  req: Request,
+  deps: ComputerUseDeps,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    sessionId?: string;
+    task?: string;
+    screenWidth?: number;
+    screenHeight?: number;
+    interactionType?: "computer_use" | "text_qa";
+  };
+
+  const { sessionId, task, screenWidth, screenHeight, interactionType } = body;
+
+  if (!sessionId || typeof sessionId !== "string") {
+    return httpError("BAD_REQUEST", "sessionId is required", 400);
+  }
+  if (!task || typeof task !== "string") {
+    return httpError("BAD_REQUEST", "task is required", 400);
+  }
+  if (typeof screenWidth !== "number" || screenWidth <= 0) {
+    return httpError("BAD_REQUEST", "screenWidth must be a positive number", 400);
+  }
+  if (typeof screenHeight !== "number" || screenHeight <= 0) {
+    return httpError("BAD_REQUEST", "screenHeight must be a positive number", 400);
+  }
+
+  // Abort any existing session with the same ID to prevent zombies
+  const existingSession = deps.cuSessions.get(sessionId);
+  if (existingSession) {
+    existingSession.abort();
+    removeCuSessionReferences(deps, sessionId, existingSession);
+  }
+
+  const config = getConfig();
+  let provider = getFailoverProvider(config.provider, config.providerOrder);
+  const { rateLimit } = config;
+  if (rateLimit.maxRequestsPerMinute > 0 || rateLimit.maxTokensPerSession > 0) {
+    provider = new RateLimitProvider(
+      provider,
+      rateLimit,
+      deps.sharedRequestTimestamps,
+    );
+  }
+
+  const sendToClient = (serverMsg: ServerMessage) => {
+    publishEvent(serverMsg);
+  };
+
+  const sessionRef: { current?: ComputerUseSession } = {};
+  const onTerminal = (sid: string) => {
+    removeCuSessionReferences(deps, sid, sessionRef.current);
+    log.info({ sessionId: sid }, "Computer-use session cleaned up after terminal state");
+  };
+
+  // Dynamic import to avoid circular dependency
+  const { ComputerUseSession: CUSession } = await import(
+    "../../daemon/computer-use-session.js"
+  );
+
+  const session = new CUSession(
+    sessionId,
+    task,
+    screenWidth,
+    screenHeight,
+    provider,
+    sendToClient,
+    interactionType,
+    onTerminal,
+  );
+  sessionRef.current = session;
+
+  deps.cuSessions.set(sessionId, session);
+
+  log.info(
+    { sessionId, taskLength: task.length },
+    "Computer-use session created via HTTP",
+  );
+
+  return Response.json({ sessionId }, { status: 201 });
+}
+
+/**
+ * POST /v1/computer-use/sessions/:id/abort — abort a CU session.
+ */
+function handleAbortSession(
+  sessionId: string,
+  deps: ComputerUseDeps,
+): Response {
+  const session = deps.cuSessions.get(sessionId);
+  if (!session) {
+    log.debug(
+      { sessionId },
+      "CU session abort via HTTP: session not found (already finished?)",
+    );
+    return httpError("NOT_FOUND", "Session not found", 404);
+  }
+
+  session.abort();
+  removeCuSessionReferences(deps, sessionId, session);
+
+  log.info({ sessionId }, "Computer-use session aborted via HTTP");
+  return Response.json({ ok: true });
+}
+
+/**
+ * POST /v1/computer-use/observations — send a CU observation.
+ *
+ * Body: { sessionId, axTree?, axDiff?, secondaryWindows?, screenshot?,
+ *         screenshotWidthPx?, screenshotHeightPx?, screenWidthPt?,
+ *         screenHeightPt?, coordinateOrigin?, captureDisplayId?,
+ *         executionResult?, executionError?, userGuidance? }
+ */
+async function handleObservation(
+  req: Request,
+  deps: ComputerUseDeps,
+): Promise<Response> {
+  const receiveTimestampMs = Date.now();
+  const msg = (await req.json()) as CuObservation;
+
+  if (!msg.sessionId || typeof msg.sessionId !== "string") {
+    return httpError("BAD_REQUEST", "sessionId is required", 400);
+  }
+
+  // HTTP observations arrive with inline data (no blob refs to hydrate).
+  const previousSequence =
+    cuObservationSequenceBySession.get(msg.sessionId) ?? 0;
+  const sequence = previousSequence + 1;
+  cuObservationSequenceBySession.set(msg.sessionId, sequence);
+
+  const axTreeBytes = msg.axTree ? Buffer.byteLength(msg.axTree, "utf8") : 0;
+  const axDiffBytes = msg.axDiff ? Buffer.byteLength(msg.axDiff, "utf8") : 0;
+  const secondaryWindowsBytes = msg.secondaryWindows
+    ? Buffer.byteLength(msg.secondaryWindows, "utf8")
+    : 0;
+  const screenshotBase64Bytes = msg.screenshot
+    ? Buffer.byteLength(msg.screenshot, "utf8")
+    : 0;
+  const screenshotApproxRawBytes = msg.screenshot
+    ? Math.floor((msg.screenshot.length / 4) * 3)
+    : 0;
+
+  log.info(
+    {
+      sessionId: msg.sessionId,
+      sequence,
+      receiveTimestampMs,
+      axTreeBytes,
+      axDiffBytes,
+      secondaryWindowsBytes,
+      screenshotBase64Bytes,
+      screenshotApproxRawBytes,
+    },
+    "HTTP_METRIC cu_observation_http_receive",
+  );
+
+  const session = deps.cuSessions.get(msg.sessionId);
+  if (!session) {
+    publishEvent({
+      type: "cu_error",
+      sessionId: msg.sessionId,
+      message: `No computer-use session found for id ${msg.sessionId}`,
+    });
+    return httpError(
+      "NOT_FOUND",
+      `No computer-use session found for id ${msg.sessionId}`,
+      404,
+    );
+  }
+
+  // Fire-and-forget: the session sends messages via its sendToClient callback
+  session.handleObservation(msg).catch((err) => {
+    log.error(
+      { err, sessionId: msg.sessionId },
+      "Error handling CU observation (HTTP)",
+    );
+  });
+
+  return Response.json({ ok: true, sequence });
+}
+
+/**
+ * POST /v1/computer-use/tasks — submit a task.
+ *
+ * This is a simplified HTTP version of task_submit that creates a CU session.
+ * The full task_submit flow (with routing, recording intents, etc.) remains
+ * IPC-only for now; this endpoint provides direct CU session creation.
+ *
+ * Body: { task, screenWidth, screenHeight, interactionType? }
+ */
+async function handleTaskSubmit(
+  req: Request,
+  deps: ComputerUseDeps,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    task?: string;
+    screenWidth?: number;
+    screenHeight?: number;
+    interactionType?: "computer_use" | "text_qa";
+  };
+
+  const { task, screenWidth, screenHeight, interactionType } = body;
+
+  if (!task || typeof task !== "string") {
+    return httpError("BAD_REQUEST", "task is required", 400);
+  }
+  if (typeof screenWidth !== "number" || screenWidth <= 0) {
+    return httpError("BAD_REQUEST", "screenWidth must be a positive number", 400);
+  }
+  if (typeof screenHeight !== "number" || screenHeight <= 0) {
+    return httpError("BAD_REQUEST", "screenHeight must be a positive number", 400);
+  }
+
+  const sessionId = crypto.randomUUID();
+
+  // Reuse session creation logic
+  const config = getConfig();
+  let provider = getFailoverProvider(config.provider, config.providerOrder);
+  const { rateLimit } = config;
+  if (rateLimit.maxRequestsPerMinute > 0 || rateLimit.maxTokensPerSession > 0) {
+    provider = new RateLimitProvider(
+      provider,
+      rateLimit,
+      deps.sharedRequestTimestamps,
+    );
+  }
+
+  const sendToClient = (serverMsg: ServerMessage) => {
+    publishEvent(serverMsg);
+  };
+
+  const sessionRef: { current?: ComputerUseSession } = {};
+  const onTerminal = (sid: string) => {
+    removeCuSessionReferences(deps, sid, sessionRef.current);
+    log.info({ sessionId: sid }, "Computer-use session cleaned up after terminal state");
+  };
+
+  const { ComputerUseSession: CUSession } = await import(
+    "../../daemon/computer-use-session.js"
+  );
+
+  const session = new CUSession(
+    sessionId,
+    task,
+    screenWidth,
+    screenHeight,
+    provider,
+    sendToClient,
+    interactionType,
+    onTerminal,
+  );
+  sessionRef.current = session;
+
+  deps.cuSessions.set(sessionId, session);
+
+  log.info(
+    { sessionId, taskLength: task.length },
+    "Task submitted via HTTP — CU session created",
+  );
+
+  return Response.json(
+    { sessionId, interactionType: interactionType ?? "computer_use" },
+    { status: 201 },
+  );
+}
+
+/**
+ * POST /v1/computer-use/ride-shotgun/start — start a ride-shotgun session.
+ *
+ * Body: { durationSeconds, intervalSeconds, mode?, targetDomain?, navigateDomain?, autoNavigate? }
+ */
+async function handleRideShotgunStartRoute(
+  req: Request,
+  deps: ComputerUseDeps,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    durationSeconds?: number;
+    intervalSeconds?: number;
+    mode?: "observe" | "learn";
+    targetDomain?: string;
+    navigateDomain?: string;
+    autoNavigate?: boolean;
+  };
+
+  const { durationSeconds, intervalSeconds, mode, targetDomain, navigateDomain, autoNavigate } = body;
+
+  if (typeof durationSeconds !== "number" || durationSeconds <= 0) {
+    return httpError("BAD_REQUEST", "durationSeconds must be a positive number", 400);
+  }
+  if (typeof intervalSeconds !== "number" || intervalSeconds <= 0) {
+    return httpError("BAD_REQUEST", "intervalSeconds must be a positive number", 400);
+  }
+
+  try {
+    const result = await deps.handleRideShotgunStart({
+      durationSeconds,
+      intervalSeconds,
+      mode,
+      targetDomain,
+      navigateDomain,
+      autoNavigate,
+    });
+
+    log.info(
+      { watchId: result.watchId, sessionId: result.sessionId, durationSeconds, mode },
+      "Ride shotgun started via HTTP",
+    );
+
+    return Response.json(result, { status: 201 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Failed to start ride shotgun via HTTP");
+    return httpError("INTERNAL_ERROR", message, 500);
+  }
+}
+
+/**
+ * POST /v1/computer-use/ride-shotgun/stop — stop a ride-shotgun session.
+ *
+ * Body: { watchId }
+ */
+async function handleRideShotgunStopRoute(
+  req: Request,
+  deps: ComputerUseDeps,
+): Promise<Response> {
+  const body = (await req.json()) as { watchId?: string };
+
+  if (!body.watchId || typeof body.watchId !== "string") {
+    return httpError("BAD_REQUEST", "watchId is required", 400);
+  }
+
+  try {
+    await deps.handleRideShotgunStop(body.watchId);
+
+    log.info({ watchId: body.watchId }, "Ride shotgun stopped via HTTP");
+    return Response.json({ ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, watchId: body.watchId }, "Failed to stop ride shotgun via HTTP");
+    return httpError("INTERNAL_ERROR", message, 500);
+  }
+}
+
+/**
+ * POST /v1/computer-use/watch — send a watch observation.
+ *
+ * Body: { watchId, sessionId, ocrText, appName?, windowTitle?,
+ *         bundleIdentifier?, timestamp, captureIndex, totalExpected }
+ */
+async function handleWatchObservationRoute(
+  req: Request,
+  deps: ComputerUseDeps,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    watchId?: string;
+    sessionId?: string;
+    ocrText?: string;
+    appName?: string;
+    windowTitle?: string;
+    bundleIdentifier?: string;
+    timestamp?: number;
+    captureIndex?: number;
+    totalExpected?: number;
+  };
+
+  if (!body.watchId || typeof body.watchId !== "string") {
+    return httpError("BAD_REQUEST", "watchId is required", 400);
+  }
+  if (!body.sessionId || typeof body.sessionId !== "string") {
+    return httpError("BAD_REQUEST", "sessionId is required", 400);
+  }
+  if (!body.ocrText || typeof body.ocrText !== "string") {
+    return httpError("BAD_REQUEST", "ocrText is required", 400);
+  }
+  if (typeof body.timestamp !== "number") {
+    return httpError("BAD_REQUEST", "timestamp is required", 400);
+  }
+  if (typeof body.captureIndex !== "number") {
+    return httpError("BAD_REQUEST", "captureIndex is required", 400);
+  }
+  if (typeof body.totalExpected !== "number") {
+    return httpError("BAD_REQUEST", "totalExpected is required", 400);
+  }
+
+  try {
+    await deps.handleWatchObservation({
+      watchId: body.watchId,
+      sessionId: body.sessionId,
+      ocrText: body.ocrText,
+      appName: body.appName,
+      windowTitle: body.windowTitle,
+      bundleIdentifier: body.bundleIdentifier,
+      timestamp: body.timestamp,
+      captureIndex: body.captureIndex,
+      totalExpected: body.totalExpected,
+    });
+
+    return Response.json({ ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, watchId: body.watchId }, "Failed to handle watch observation via HTTP");
+    return httpError("INTERNAL_ERROR", message, 500);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function computerUseRouteDefinitions(deps: {
+  getComputerUseDeps?: () => ComputerUseDeps;
+}): RouteDefinition[] {
+  const getDeps = (): ComputerUseDeps => {
+    if (!deps.getComputerUseDeps) {
+      throw new Error("Computer use deps not available");
+    }
+    return deps.getComputerUseDeps();
+  };
+
+  return [
+    {
+      endpoint: "computer-use/sessions",
+      method: "POST",
+      policyKey: "computer-use/sessions",
+      handler: async ({ req }) => handleCreateSession(req, getDeps()),
+    },
+    {
+      endpoint: "computer-use/sessions/:id/abort",
+      method: "POST",
+      policyKey: "computer-use/sessions/abort",
+      handler: ({ params }) => handleAbortSession(params.id, getDeps()),
+    },
+    {
+      endpoint: "computer-use/observations",
+      method: "POST",
+      policyKey: "computer-use/observations",
+      handler: async ({ req }) => handleObservation(req, getDeps()),
+    },
+    {
+      endpoint: "computer-use/tasks",
+      method: "POST",
+      policyKey: "computer-use/tasks",
+      handler: async ({ req }) => handleTaskSubmit(req, getDeps()),
+    },
+    {
+      endpoint: "computer-use/ride-shotgun/start",
+      method: "POST",
+      policyKey: "computer-use/ride-shotgun/start",
+      handler: async ({ req }) => handleRideShotgunStartRoute(req, getDeps()),
+    },
+    {
+      endpoint: "computer-use/ride-shotgun/stop",
+      method: "POST",
+      policyKey: "computer-use/ride-shotgun/stop",
+      handler: async ({ req }) => handleRideShotgunStopRoute(req, getDeps()),
+    },
+    {
+      endpoint: "computer-use/watch",
+      method: "POST",
+      policyKey: "computer-use/watch",
+      handler: async ({ req }) => handleWatchObservationRoute(req, getDeps()),
+    },
+  ];
+}

--- a/assistant/src/runtime/routes/recording-routes.ts
+++ b/assistant/src/runtime/routes/recording-routes.ts
@@ -1,0 +1,271 @@
+/**
+ * HTTP route handlers for screen recording lifecycle.
+ *
+ * These endpoints expose recording start/stop/pause/resume/status
+ * functionality over HTTP. The existing IPC handlers remain as the
+ * primary transport; these routes provide the HTTP-first API surface
+ * for the phase-out-ipc migration.
+ *
+ * Recording write operations require `settings.write`; status queries
+ * require `settings.read`.
+ */
+
+import type { RecordingOptions } from "../../daemon/ipc-protocol.js";
+import {
+  handleRecordingStart,
+  handleRecordingStop,
+  handleRecordingPause,
+  handleRecordingResume,
+  isRecordingIdle,
+  getActiveRestartToken,
+} from "../../daemon/handlers/recording.js";
+import type { HandlerContext } from "../../daemon/handlers/shared.js";
+import { findSocketForSession } from "../../daemon/handlers/shared.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+const log = getLogger("recording-routes");
+
+// ---------------------------------------------------------------------------
+// Dependency injection interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface for recording operations.
+ * The daemon wires a concrete HandlerContext at startup.
+ */
+export interface RecordingDeps {
+  /** The daemon's handler context for IPC message dispatch. */
+  getHandlerContext: () => HandlerContext;
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /v1/recordings/start — start a screen recording.
+ *
+ * Body: { conversationId, options? }
+ * options: { captureScope?, displayId?, windowId?, includeAudio?,
+ *            includeMicrophone?, promptForSource? }
+ */
+async function handleStartRecording(
+  req: Request,
+  deps: RecordingDeps,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    conversationId?: string;
+    options?: RecordingOptions;
+  };
+
+  if (!body.conversationId || typeof body.conversationId !== "string") {
+    return httpError("BAD_REQUEST", "conversationId is required", 400);
+  }
+
+  const ctx = deps.getHandlerContext();
+  const socket = findSocketForSession(body.conversationId, ctx);
+  if (!socket) {
+    return httpError(
+      "UNPROCESSABLE_ENTITY",
+      "No active client connection for this conversation — recording requires a connected client",
+      422,
+    );
+  }
+
+  const recordingId = handleRecordingStart(
+    body.conversationId,
+    body.options,
+    socket,
+    ctx,
+  );
+
+  if (!recordingId) {
+    const isIdle = isRecordingIdle();
+    const reason = isIdle
+      ? "unknown"
+      : "A recording is already active";
+    log.warn(
+      { conversationId: body.conversationId, isIdle },
+      "Recording start failed via HTTP",
+    );
+    return httpError("CONFLICT", reason, 409);
+  }
+
+  log.info(
+    { recordingId, conversationId: body.conversationId },
+    "Recording started via HTTP",
+  );
+
+  return Response.json({ recordingId }, { status: 201 });
+}
+
+/**
+ * POST /v1/recordings/stop — stop the active recording.
+ *
+ * Body: { conversationId }
+ */
+async function handleStopRecording(
+  req: Request,
+  deps: RecordingDeps,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    conversationId?: string;
+  };
+
+  if (!body.conversationId || typeof body.conversationId !== "string") {
+    return httpError("BAD_REQUEST", "conversationId is required", 400);
+  }
+
+  const ctx = deps.getHandlerContext();
+  const recordingId = handleRecordingStop(body.conversationId, ctx);
+
+  if (!recordingId) {
+    log.debug(
+      { conversationId: body.conversationId },
+      "No active recording to stop via HTTP",
+    );
+    return httpError("NOT_FOUND", "No active recording to stop", 404);
+  }
+
+  log.info(
+    { recordingId, conversationId: body.conversationId },
+    "Recording stop sent via HTTP",
+  );
+
+  return Response.json({ recordingId, stopped: true });
+}
+
+/**
+ * POST /v1/recordings/pause — pause the active recording.
+ *
+ * Body: { conversationId }
+ */
+async function handlePauseRecording(
+  req: Request,
+  deps: RecordingDeps,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    conversationId?: string;
+  };
+
+  if (!body.conversationId || typeof body.conversationId !== "string") {
+    return httpError("BAD_REQUEST", "conversationId is required", 400);
+  }
+
+  const ctx = deps.getHandlerContext();
+  const recordingId = handleRecordingPause(body.conversationId, ctx);
+
+  if (!recordingId) {
+    log.debug(
+      { conversationId: body.conversationId },
+      "No active recording to pause via HTTP",
+    );
+    return httpError("NOT_FOUND", "No active recording to pause", 404);
+  }
+
+  log.info(
+    { recordingId, conversationId: body.conversationId },
+    "Recording pause sent via HTTP",
+  );
+
+  return Response.json({ recordingId, paused: true });
+}
+
+/**
+ * POST /v1/recordings/resume — resume a paused recording.
+ *
+ * Body: { conversationId }
+ */
+async function handleResumeRecording(
+  req: Request,
+  deps: RecordingDeps,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    conversationId?: string;
+  };
+
+  if (!body.conversationId || typeof body.conversationId !== "string") {
+    return httpError("BAD_REQUEST", "conversationId is required", 400);
+  }
+
+  const ctx = deps.getHandlerContext();
+  const recordingId = handleRecordingResume(body.conversationId, ctx);
+
+  if (!recordingId) {
+    log.debug(
+      { conversationId: body.conversationId },
+      "No active recording to resume via HTTP",
+    );
+    return httpError("NOT_FOUND", "No active recording to resume", 404);
+  }
+
+  log.info(
+    { recordingId, conversationId: body.conversationId },
+    "Recording resume sent via HTTP",
+  );
+
+  return Response.json({ recordingId, resumed: true });
+}
+
+/**
+ * GET /v1/recordings/status — get current recording status.
+ */
+function handleRecordingStatus(): Response {
+  const idle = isRecordingIdle();
+  const activeRestartToken = getActiveRestartToken();
+
+  return Response.json({
+    idle,
+    restartInProgress: activeRestartToken !== null,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function recordingRouteDefinitions(deps: {
+  getRecordingDeps?: () => RecordingDeps;
+}): RouteDefinition[] {
+  const getDeps = (): RecordingDeps => {
+    if (!deps.getRecordingDeps) {
+      throw new Error("Recording deps not available");
+    }
+    return deps.getRecordingDeps();
+  };
+
+  return [
+    {
+      endpoint: "recordings/start",
+      method: "POST",
+      policyKey: "recordings/start",
+      handler: async ({ req }) => handleStartRecording(req, getDeps()),
+    },
+    {
+      endpoint: "recordings/stop",
+      method: "POST",
+      policyKey: "recordings/stop",
+      handler: async ({ req }) => handleStopRecording(req, getDeps()),
+    },
+    {
+      endpoint: "recordings/pause",
+      method: "POST",
+      policyKey: "recordings/pause",
+      handler: async ({ req }) => handlePauseRecording(req, getDeps()),
+    },
+    {
+      endpoint: "recordings/resume",
+      method: "POST",
+      policyKey: "recordings/resume",
+      handler: async ({ req }) => handleResumeRecording(req, getDeps()),
+    },
+    {
+      endpoint: "recordings/status",
+      method: "GET",
+      policyKey: "recordings/status",
+      handler: () => handleRecordingStatus(),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Create `computer-use-routes.ts` with 7 HTTP endpoints for CU session lifecycle (create, abort, observation, task submit), ride-shotgun (start, stop), and watch observation
- Create `recording-routes.ts` with 5 HTTP endpoints for recording lifecycle (start, stop, pause, resume) and status query
- Register route policies: CU endpoints use `chat.write` scope, recording write endpoints use `settings.write`, recording status uses `settings.read`
- Wire both route modules into `http-server.ts` `buildRouteTable()` with dependency injection via `RuntimeHttpServerOptions`
- CU routes publish events via SSE event hub for HTTP clients; recording routes delegate to existing shared handler functions

Part of plan: phase-out-ipc.md (PR 6 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
