### PR TITLE
feat: add HTTP routes for skill management operations

### DIFF
--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -24,6 +24,7 @@ import {
 import {
   clawhubCheckUpdates,
   clawhubInspect,
+  type ClawhubInspectResult,
   clawhubInstall,
   clawhubSearch,
   clawhubUpdate,
@@ -56,6 +57,20 @@ import {
   type HandlerContext,
   log,
 } from "./shared.js";
+
+// ─── Shared context for standalone functions ─────────────────────────────────
+
+/**
+ * Minimal context needed by the standalone skill business-logic functions.
+ * HandlerContext satisfies this interface, but HTTP routes can also provide
+ * a compatible object without coupling to IPC internals.
+ */
+export interface SkillOperationContext {
+  debounceTimers: HandlerContext["debounceTimers"];
+  setSuppressConfigReload(value: boolean): void;
+  updateConfigFingerprint(): void;
+  broadcast: HandlerContext["broadcast"];
+}
 
 // ─── Provenance resolution ──────────────────────────────────────────────────
 
@@ -101,559 +116,6 @@ function resolveProvenance(summary: SkillSummary): SkillProvenance {
   }
 
   return { kind: "local" };
-}
-
-export function handleSkillsList(
-  socket: net.Socket,
-  ctx: HandlerContext,
-): void {
-  const config = getConfig();
-  const catalog = loadSkillCatalog();
-  const resolved = resolveSkillStates(catalog, config);
-
-  const skills = resolved.map((r) => ({
-    id: r.summary.id,
-    name: r.summary.displayName,
-    description: r.summary.description,
-    emoji: r.summary.emoji,
-    homepage: r.summary.homepage,
-    source: r.summary.source,
-    state: (r.state === "degraded" ? "enabled" : r.state) as
-      | "enabled"
-      | "disabled"
-      | "available",
-    degraded: r.degraded,
-    missingRequirements: r.missingRequirements,
-    updateAvailable: false,
-    userInvocable: r.summary.userInvocable,
-    provenance: resolveProvenance(r.summary),
-  }));
-
-  ctx.send(socket, { type: "skills_list_response", skills });
-}
-
-export function handleSkillsEnable(
-  msg: SkillsEnableRequest,
-  socket: net.Socket,
-  ctx: HandlerContext,
-): void {
-  try {
-    const raw = loadRawConfig();
-    ensureSkillEntry(raw, msg.name).enabled = true;
-
-    ctx.setSuppressConfigReload(true);
-    try {
-      saveRawConfig(raw);
-    } catch (err) {
-      ctx.setSuppressConfigReload(false);
-      throw err;
-    }
-    invalidateConfigCache();
-
-    ctx.debounceTimers.schedule(
-      "__suppress_reset__",
-      () => {
-        ctx.setSuppressConfigReload(false);
-      },
-      CONFIG_RELOAD_DEBOUNCE_MS,
-    );
-
-    ctx.updateConfigFingerprint();
-
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "enable",
-      success: true,
-    });
-    ctx.broadcast({
-      type: "skills_state_changed",
-      name: msg.name,
-      state: "enabled",
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error({ err }, "Failed to enable skill");
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "enable",
-      success: false,
-      error: message,
-    });
-  }
-}
-
-export function handleSkillsDisable(
-  msg: SkillsDisableRequest,
-  socket: net.Socket,
-  ctx: HandlerContext,
-): void {
-  try {
-    const raw = loadRawConfig();
-    ensureSkillEntry(raw, msg.name).enabled = false;
-
-    ctx.setSuppressConfigReload(true);
-    try {
-      saveRawConfig(raw);
-    } catch (err) {
-      ctx.setSuppressConfigReload(false);
-      throw err;
-    }
-    invalidateConfigCache();
-
-    ctx.debounceTimers.schedule(
-      "__suppress_reset__",
-      () => {
-        ctx.setSuppressConfigReload(false);
-      },
-      CONFIG_RELOAD_DEBOUNCE_MS,
-    );
-
-    ctx.updateConfigFingerprint();
-
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "disable",
-      success: true,
-    });
-    ctx.broadcast({
-      type: "skills_state_changed",
-      name: msg.name,
-      state: "disabled",
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error({ err }, "Failed to disable skill");
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "disable",
-      success: false,
-      error: message,
-    });
-  }
-}
-
-export function handleSkillsConfigure(
-  msg: SkillsConfigureRequest,
-  socket: net.Socket,
-  ctx: HandlerContext,
-): void {
-  try {
-    const raw = loadRawConfig();
-
-    const entry = ensureSkillEntry(raw, msg.name);
-    if (msg.env) {
-      entry.env = msg.env;
-    }
-    if (msg.apiKey !== undefined) {
-      entry.apiKey = msg.apiKey;
-    }
-    if (msg.config) {
-      entry.config = msg.config;
-    }
-
-    ctx.setSuppressConfigReload(true);
-    try {
-      saveRawConfig(raw);
-    } catch (err) {
-      ctx.setSuppressConfigReload(false);
-      throw err;
-    }
-    invalidateConfigCache();
-
-    ctx.debounceTimers.schedule(
-      "__suppress_reset__",
-      () => {
-        ctx.setSuppressConfigReload(false);
-      },
-      CONFIG_RELOAD_DEBOUNCE_MS,
-    );
-
-    ctx.updateConfigFingerprint();
-
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "configure",
-      success: true,
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error({ err }, "Failed to configure skill");
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "configure",
-      success: false,
-      error: message,
-    });
-  }
-}
-
-export async function handleSkillsInstall(
-  msg: SkillsInstallRequest,
-  socket: net.Socket,
-  ctx: HandlerContext,
-): Promise<void> {
-  try {
-    // Bundled skills are already available — no install needed
-    const catalog = loadSkillCatalog();
-    const bundled = catalog.find(
-      (s) => s.id === msg.slug && s.source === "bundled",
-    );
-    if (bundled) {
-      // Auto-enable the bundled skill so it's immediately usable
-      let autoEnabled = false;
-      try {
-        const raw = loadRawConfig();
-        ensureSkillEntry(raw, msg.slug).enabled = true;
-        ctx.setSuppressConfigReload(true);
-        try {
-          saveRawConfig(raw);
-        } catch (err) {
-          ctx.setSuppressConfigReload(false);
-          throw err;
-        }
-        invalidateConfigCache();
-        ctx.debounceTimers.schedule(
-          "__suppress_reset__",
-          () => {
-            ctx.setSuppressConfigReload(false);
-          },
-          CONFIG_RELOAD_DEBOUNCE_MS,
-        );
-        ctx.updateConfigFingerprint();
-        autoEnabled = true;
-      } catch (err) {
-        log.warn(
-          { err, skillId: msg.slug },
-          "Failed to auto-enable bundled skill",
-        );
-      }
-
-      ctx.send(socket, {
-        type: "skills_operation_response",
-        operation: "install",
-        success: true,
-      });
-      if (autoEnabled) {
-        ctx.broadcast({
-          type: "skills_state_changed",
-          name: msg.slug,
-          state: "enabled",
-        });
-      }
-      return;
-    }
-
-    // Install from clawhub (community)
-    const result = await clawhubInstall(msg.slug, { version: msg.version });
-    if (!result.success) {
-      ctx.send(socket, {
-        type: "skills_operation_response",
-        operation: "install",
-        success: false,
-        error: result.error ?? "Unknown error",
-      });
-      return;
-    }
-    const rawId = result.skillName ?? msg.slug;
-    const skillId = rawId.includes("/") ? rawId.split("/").pop()! : rawId;
-
-    // Reload skill catalog so the newly installed skill is picked up
-    loadSkillCatalog();
-
-    // Auto-enable the newly installed skill so it's immediately usable.
-    let autoEnabled = false;
-    try {
-      const raw = loadRawConfig();
-      ensureSkillEntry(raw, skillId).enabled = true;
-      ctx.setSuppressConfigReload(true);
-      try {
-        saveRawConfig(raw);
-      } catch (err) {
-        ctx.setSuppressConfigReload(false);
-        throw err;
-      }
-      invalidateConfigCache();
-      ctx.debounceTimers.schedule(
-        "__suppress_reset__",
-        () => {
-          ctx.setSuppressConfigReload(false);
-        },
-        CONFIG_RELOAD_DEBOUNCE_MS,
-      );
-      ctx.updateConfigFingerprint();
-      autoEnabled = true;
-    } catch (err) {
-      log.warn({ err, skillId }, "Failed to auto-enable installed skill");
-    }
-
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "install",
-      success: true,
-    });
-    if (autoEnabled) {
-      ctx.broadcast({
-        type: "skills_state_changed",
-        name: skillId,
-        state: "enabled",
-      });
-    }
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error({ err }, "Failed to install skill");
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "install",
-      success: false,
-      error: message,
-    });
-  }
-}
-
-export async function handleSkillsUninstall(
-  msg: SkillsUninstallRequest,
-  socket: net.Socket,
-  ctx: HandlerContext,
-): Promise<void> {
-  // Validate skill name to prevent path traversal while allowing namespaced slugs (org/name)
-  const validNamespacedSlug =
-    /^[a-zA-Z0-9][a-zA-Z0-9._-]*\/[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
-  const validSimpleName = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
-  if (
-    msg.name.includes("..") ||
-    msg.name.includes("\\") ||
-    !(validSimpleName.test(msg.name) || validNamespacedSlug.test(msg.name))
-  ) {
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "uninstall",
-      success: false,
-      error: "Invalid skill name",
-    });
-    return;
-  }
-
-  try {
-    // Use shared managed-store logic for simple managed skill IDs
-    const isManagedId = !validateManagedSkillId(msg.name);
-    if (isManagedId) {
-      const result = deleteManagedSkill(msg.name);
-      if (!result.deleted) {
-        ctx.send(socket, {
-          type: "skills_operation_response",
-          operation: "uninstall",
-          success: false,
-          error: result.error ?? "Failed to delete managed skill",
-        });
-        return;
-      }
-    } else {
-      // Namespaced slug (org/name) — direct filesystem removal
-      const skillDir = join(getWorkspaceSkillsDir(), msg.name);
-      if (!existsSync(skillDir)) {
-        ctx.send(socket, {
-          type: "skills_operation_response",
-          operation: "uninstall",
-          success: false,
-          error: "Skill not found",
-        });
-        return;
-      }
-      rmSync(skillDir, { recursive: true });
-      try {
-        removeSkillsIndexEntry(msg.name);
-      } catch {
-        /* best effort */
-      }
-    }
-
-    // Clean config entry
-    const raw = loadRawConfig();
-    const skills = raw.skills as Record<string, unknown> | undefined;
-    const entries = skills?.entries as Record<string, unknown> | undefined;
-    if (entries?.[msg.name]) {
-      delete entries[msg.name];
-
-      ctx.setSuppressConfigReload(true);
-      try {
-        saveRawConfig(raw);
-      } catch (err) {
-        ctx.setSuppressConfigReload(false);
-        throw err;
-      }
-      invalidateConfigCache();
-
-      ctx.debounceTimers.schedule(
-        "__suppress_reset__",
-        () => {
-          ctx.setSuppressConfigReload(false);
-        },
-        CONFIG_RELOAD_DEBOUNCE_MS,
-      );
-
-      ctx.updateConfigFingerprint();
-    }
-
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "uninstall",
-      success: true,
-    });
-    ctx.broadcast({
-      type: "skills_state_changed",
-      name: msg.name,
-      state: "uninstalled",
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error({ err }, "Failed to uninstall skill");
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "uninstall",
-      success: false,
-      error: message,
-    });
-  }
-}
-
-export async function handleSkillsUpdate(
-  msg: SkillsUpdateRequest,
-  socket: net.Socket,
-  ctx: HandlerContext,
-): Promise<void> {
-  try {
-    const result = await clawhubUpdate(msg.name);
-    if (!result.success) {
-      ctx.send(socket, {
-        type: "skills_operation_response",
-        operation: "update",
-        success: false,
-        error: result.error ?? "Unknown error",
-      });
-      return;
-    }
-
-    // Reload skill catalog to pick up updated skill
-    loadSkillCatalog();
-
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "update",
-      success: true,
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error({ err }, "Failed to update skill");
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "update",
-      success: false,
-      error: message,
-    });
-  }
-}
-
-export async function handleSkillsCheckUpdates(
-  _msg: SkillsCheckUpdatesRequest,
-  socket: net.Socket,
-  ctx: HandlerContext,
-): Promise<void> {
-  try {
-    const updates = await clawhubCheckUpdates();
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "check_updates",
-      success: true,
-      data: updates,
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error({ err }, "Failed to check for skill updates");
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "check_updates",
-      success: false,
-      error: message,
-    });
-  }
-}
-
-export async function handleSkillsSearch(
-  msg: SkillsSearchRequest,
-  socket: net.Socket,
-  ctx: HandlerContext,
-): Promise<void> {
-  try {
-    const result = await clawhubSearch(msg.query);
-
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "search",
-      success: true,
-      data: result,
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error({ err }, "Failed to search skills");
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "search",
-      success: false,
-      error: message,
-    });
-  }
-}
-
-export async function handleSkillsInspect(
-  msg: SkillsInspectRequest,
-  socket: net.Socket,
-  ctx: HandlerContext,
-): Promise<void> {
-  try {
-    const result = await clawhubInspect(msg.slug);
-    ctx.send(socket, {
-      type: "skills_inspect_response",
-      slug: msg.slug,
-      ...(result.data ? { data: result.data } : {}),
-      ...(result.error ? { error: result.error } : {}),
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error({ err }, "Failed to inspect skill");
-    ctx.send(socket, {
-      type: "skills_inspect_response",
-      slug: msg.slug,
-      error: message,
-    });
-  }
-}
-
-export async function handleSkillDetail(
-  msg: SkillDetailRequest,
-  socket: net.Socket,
-  ctx: HandlerContext,
-): Promise<void> {
-  const result = loadSkillBySelector(msg.skillId);
-  if (result.skill) {
-    const icon = await ensureSkillIcon(
-      result.skill.directoryPath,
-      result.skill.displayName,
-      result.skill.description,
-    );
-    ctx.send(socket, {
-      type: "skill_detail_response",
-      skillId: result.skill.id,
-      body: result.skill.body,
-      ...(icon ? { icon } : {}),
-    });
-  } else {
-    ctx.send(socket, {
-      type: "skill_detail_response",
-      skillId: msg.skillId,
-      body: "",
-      error: result.error ?? "Skill not found",
-    });
-  }
 }
 
 // ─── Frontmatter parsing ─────────────────────────────────────────────────────
@@ -740,19 +202,353 @@ function heuristicDraft(body: string): {
   return { skillId, name, description, emoji: "\u{1F4DD}" };
 }
 
-// ─── Draft handler ───────────────────────────────────────────────────────────
-
 const LLM_DRAFT_TIMEOUT_MS = 15_000;
 
-export async function handleSkillsDraft(
-  msg: SkillsDraftRequest,
-  socket: net.Socket,
-  ctx: HandlerContext,
-): Promise<void> {
+// ─── Standalone business-logic functions ─────────────────────────────────────
+// These are consumed by both the IPC handlers below and the HTTP route layer.
+
+/** Helper: suppress config reload, save, debounce, and update fingerprint. */
+function saveConfigWithSuppression(
+  raw: Record<string, unknown>,
+  ctx: SkillOperationContext,
+): void {
+  ctx.setSuppressConfigReload(true);
+  try {
+    saveRawConfig(raw);
+  } catch (err) {
+    ctx.setSuppressConfigReload(false);
+    throw err;
+  }
+  invalidateConfigCache();
+
+  ctx.debounceTimers.schedule(
+    "__suppress_reset__",
+    () => {
+      ctx.setSuppressConfigReload(false);
+    },
+    CONFIG_RELOAD_DEBOUNCE_MS,
+  );
+
+  ctx.updateConfigFingerprint();
+}
+
+export interface SkillListItem {
+  id: string;
+  name: string;
+  description: string;
+  emoji?: string;
+  homepage?: string;
+  source: "bundled" | "managed" | "workspace" | "clawhub" | "extra";
+  state: "enabled" | "disabled" | "available";
+  degraded: boolean;
+  missingRequirements?: {
+    bins?: string[];
+    env?: string[];
+    permissions?: string[];
+  };
+  updateAvailable: boolean;
+  userInvocable: boolean;
+  provenance: SkillProvenance;
+}
+
+export function listSkills(_ctx: SkillOperationContext): SkillListItem[] {
+  const config = getConfig();
+  const catalog = loadSkillCatalog();
+  const resolved = resolveSkillStates(catalog, config);
+
+  return resolved.map((r) => ({
+    id: r.summary.id,
+    name: r.summary.displayName,
+    description: r.summary.description,
+    emoji: r.summary.emoji,
+    homepage: r.summary.homepage,
+    source: r.summary.source,
+    state: (r.state === "degraded" ? "enabled" : r.state) as
+      | "enabled"
+      | "disabled"
+      | "available",
+    degraded: r.degraded,
+    missingRequirements: r.missingRequirements,
+    updateAvailable: false,
+    userInvocable: r.summary.userInvocable,
+    provenance: resolveProvenance(r.summary),
+  }));
+}
+
+export function enableSkill(
+  skillId: string,
+  ctx: SkillOperationContext,
+): { success: true } | { success: false; error: string } {
+  try {
+    const raw = loadRawConfig();
+    ensureSkillEntry(raw, skillId).enabled = true;
+    saveConfigWithSuppression(raw, ctx);
+    ctx.broadcast({
+      type: "skills_state_changed",
+      name: skillId,
+      state: "enabled",
+    });
+    return { success: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Failed to enable skill");
+    return { success: false, error: message };
+  }
+}
+
+export function disableSkill(
+  skillId: string,
+  ctx: SkillOperationContext,
+): { success: true } | { success: false; error: string } {
+  try {
+    const raw = loadRawConfig();
+    ensureSkillEntry(raw, skillId).enabled = false;
+    saveConfigWithSuppression(raw, ctx);
+    ctx.broadcast({
+      type: "skills_state_changed",
+      name: skillId,
+      state: "disabled",
+    });
+    return { success: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Failed to disable skill");
+    return { success: false, error: message };
+  }
+}
+
+export function configureSkill(
+  skillId: string,
+  config: { env?: Record<string, string>; apiKey?: string; config?: Record<string, unknown> },
+  ctx: SkillOperationContext,
+): { success: true } | { success: false; error: string } {
+  try {
+    const raw = loadRawConfig();
+    const entry = ensureSkillEntry(raw, skillId);
+    if (config.env) entry.env = config.env;
+    if (config.apiKey !== undefined) entry.apiKey = config.apiKey;
+    if (config.config) entry.config = config.config;
+    saveConfigWithSuppression(raw, ctx);
+    return { success: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Failed to configure skill");
+    return { success: false, error: message };
+  }
+}
+
+export async function installSkill(
+  spec: { slug: string; version?: string },
+  ctx: SkillOperationContext,
+): Promise<{ success: true } | { success: false; error: string }> {
+  try {
+    // Bundled skills are already available — no install needed
+    const catalog = loadSkillCatalog();
+    const bundled = catalog.find(
+      (s) => s.id === spec.slug && s.source === "bundled",
+    );
+    if (bundled) {
+      // Auto-enable the bundled skill so it's immediately usable
+      try {
+        const raw = loadRawConfig();
+        ensureSkillEntry(raw, spec.slug).enabled = true;
+        saveConfigWithSuppression(raw, ctx);
+        ctx.broadcast({
+          type: "skills_state_changed",
+          name: spec.slug,
+          state: "enabled",
+        });
+      } catch (err) {
+        log.warn(
+          { err, skillId: spec.slug },
+          "Failed to auto-enable bundled skill",
+        );
+      }
+      return { success: true };
+    }
+
+    // Install from clawhub (community)
+    const result = await clawhubInstall(spec.slug, { version: spec.version });
+    if (!result.success) {
+      return { success: false, error: result.error ?? "Unknown error" };
+    }
+    const rawId = result.skillName ?? spec.slug;
+    const skillId = rawId.includes("/") ? rawId.split("/").pop()! : rawId;
+
+    // Reload skill catalog so the newly installed skill is picked up
+    loadSkillCatalog();
+
+    // Auto-enable the newly installed skill
+    try {
+      const raw = loadRawConfig();
+      ensureSkillEntry(raw, skillId).enabled = true;
+      saveConfigWithSuppression(raw, ctx);
+      ctx.broadcast({
+        type: "skills_state_changed",
+        name: skillId,
+        state: "enabled",
+      });
+    } catch (err) {
+      log.warn({ err, skillId }, "Failed to auto-enable installed skill");
+    }
+
+    return { success: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Failed to install skill");
+    return { success: false, error: message };
+  }
+}
+
+export async function uninstallSkill(
+  skillId: string,
+  ctx: SkillOperationContext,
+): Promise<{ success: true } | { success: false; error: string }> {
+  // Validate skill name to prevent path traversal while allowing namespaced slugs (org/name)
+  const validNamespacedSlug =
+    /^[a-zA-Z0-9][a-zA-Z0-9._-]*\/[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+  const validSimpleName = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+  if (
+    skillId.includes("..") ||
+    skillId.includes("\\") ||
+    !(validSimpleName.test(skillId) || validNamespacedSlug.test(skillId))
+  ) {
+    return { success: false, error: "Invalid skill name" };
+  }
+
+  try {
+    // Use shared managed-store logic for simple managed skill IDs
+    const isManagedId = !validateManagedSkillId(skillId);
+    if (isManagedId) {
+      const result = deleteManagedSkill(skillId);
+      if (!result.deleted) {
+        return {
+          success: false,
+          error: result.error ?? "Failed to delete managed skill",
+        };
+      }
+    } else {
+      // Namespaced slug (org/name) — direct filesystem removal
+      const skillDir = join(getWorkspaceSkillsDir(), skillId);
+      if (!existsSync(skillDir)) {
+        return { success: false, error: "Skill not found" };
+      }
+      rmSync(skillDir, { recursive: true });
+      try {
+        removeSkillsIndexEntry(skillId);
+      } catch {
+        /* best effort */
+      }
+    }
+
+    // Clean config entry
+    const raw = loadRawConfig();
+    const skills = raw.skills as Record<string, unknown> | undefined;
+    const entries = skills?.entries as Record<string, unknown> | undefined;
+    if (entries?.[skillId]) {
+      delete entries[skillId];
+      saveConfigWithSuppression(raw, ctx);
+    }
+
+    ctx.broadcast({
+      type: "skills_state_changed",
+      name: skillId,
+      state: "uninstalled",
+    });
+
+    return { success: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Failed to uninstall skill");
+    return { success: false, error: message };
+  }
+}
+
+export async function updateSkill(
+  skillId: string,
+  _ctx: SkillOperationContext,
+): Promise<{ success: true } | { success: false; error: string }> {
+  try {
+    const result = await clawhubUpdate(skillId);
+    if (!result.success) {
+      return { success: false, error: result.error ?? "Unknown error" };
+    }
+    // Reload skill catalog to pick up updated skill
+    loadSkillCatalog();
+    return { success: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Failed to update skill");
+    return { success: false, error: message };
+  }
+}
+
+export async function checkSkillUpdates(
+  _ctx: SkillOperationContext,
+): Promise<{ success: true; data: unknown } | { success: false; error: string }> {
+  try {
+    const updates = await clawhubCheckUpdates();
+    return { success: true, data: updates };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Failed to check for skill updates");
+    return { success: false, error: message };
+  }
+}
+
+export async function searchSkills(
+  query: string,
+  _ctx: SkillOperationContext,
+): Promise<{ success: true; data: unknown } | { success: false; error: string }> {
+  try {
+    const result = await clawhubSearch(query);
+    return { success: true, data: result };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Failed to search skills");
+    return { success: false, error: message };
+  }
+}
+
+export async function inspectSkill(
+  skillId: string,
+  _ctx: SkillOperationContext,
+): Promise<{ slug: string; data?: ClawhubInspectResult; error?: string }> {
+  try {
+    const result = await clawhubInspect(skillId);
+    return {
+      slug: skillId,
+      ...(result.data ? { data: result.data } : {}),
+      ...(result.error ? { error: result.error } : {}),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Failed to inspect skill");
+    return { slug: skillId, error: message };
+  }
+}
+
+export interface DraftResult {
+  success: boolean;
+  draft?: {
+    skillId: string;
+    name: string;
+    description: string;
+    emoji?: string;
+    bodyMarkdown: string;
+  };
+  warnings?: string[];
+  error?: string;
+}
+
+export async function draftSkill(
+  params: { sourceText: string },
+  _ctx: SkillOperationContext,
+): Promise<DraftResult> {
   try {
     const warnings: string[] = [];
-    const parsed = parseFrontmatter(msg.sourceText);
-    const body = parsed.body.trim() || msg.sourceText.trim();
+    const parsed = parseFrontmatter(params.sourceText);
+    const body = parsed.body.trim() || params.sourceText.trim();
 
     let { skillId, name, description, emoji } = parsed;
 
@@ -870,8 +666,7 @@ export async function handleSkillsDraft(
       );
     }
 
-    ctx.send(socket, {
-      type: "skills_draft_response",
+    return {
       success: true,
       draft: {
         skillId: skillId!,
@@ -881,28 +676,251 @@ export async function handleSkillsDraft(
         bodyMarkdown: body,
       },
       ...(warnings.length > 0 ? { warnings } : {}),
-    });
+    };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Failed to generate skill draft");
+    return { success: false, error: message };
+  }
+}
+
+export interface CreateSkillParams {
+  skillId: string;
+  name: string;
+  description: string;
+  emoji?: string;
+  bodyMarkdown: string;
+  userInvocable?: boolean;
+  disableModelInvocation?: boolean;
+  overwrite?: boolean;
+}
+
+export async function createSkill(
+  params: CreateSkillParams,
+  ctx: SkillOperationContext,
+): Promise<{ success: true } | { success: false; error: string }> {
+  try {
+    const result = createManagedSkill({
+      id: params.skillId,
+      name: params.name,
+      description: params.description,
+      emoji: params.emoji,
+      bodyMarkdown: params.bodyMarkdown,
+      userInvocable: params.userInvocable,
+      disableModelInvocation: params.disableModelInvocation,
+      overwrite: params.overwrite,
+    });
+
+    if (!result.created) {
+      return {
+        success: false,
+        error: result.error ?? "Failed to create managed skill",
+      };
+    }
+
+    // Auto-enable the newly created skill
+    try {
+      const raw = loadRawConfig();
+      ensureSkillEntry(raw, params.skillId).enabled = true;
+      saveConfigWithSuppression(raw, ctx);
+      ctx.broadcast({
+        type: "skills_state_changed",
+        name: params.skillId,
+        state: "enabled",
+      });
+    } catch (err) {
+      log.warn(
+        { err, skillId: params.skillId },
+        "Failed to auto-enable created skill",
+      );
+    }
+
+    return { success: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Failed to create skill");
+    return { success: false, error: message };
+  }
+}
+
+// ─── IPC handlers (thin wrappers) ───────────────────────────────────────────
+
+export function handleSkillsList(
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  const skills = listSkills(ctx);
+  ctx.send(socket, { type: "skills_list_response", skills });
+}
+
+export function handleSkillsEnable(
+  msg: SkillsEnableRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  const result = enableSkill(msg.name, ctx);
+  ctx.send(socket, {
+    type: "skills_operation_response",
+    operation: "enable",
+    ...result,
+  });
+}
+
+export function handleSkillsDisable(
+  msg: SkillsDisableRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  const result = disableSkill(msg.name, ctx);
+  ctx.send(socket, {
+    type: "skills_operation_response",
+    operation: "disable",
+    ...result,
+  });
+}
+
+export function handleSkillsConfigure(
+  msg: SkillsConfigureRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): void {
+  const result = configureSkill(
+    msg.name,
+    { env: msg.env, apiKey: msg.apiKey, config: msg.config },
+    ctx,
+  );
+  ctx.send(socket, {
+    type: "skills_operation_response",
+    operation: "configure",
+    ...result,
+  });
+}
+
+export async function handleSkillsInstall(
+  msg: SkillsInstallRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  const result = await installSkill(
+    { slug: msg.slug, version: msg.version },
+    ctx,
+  );
+  ctx.send(socket, {
+    type: "skills_operation_response",
+    operation: "install",
+    ...result,
+  });
+}
+
+export async function handleSkillsUninstall(
+  msg: SkillsUninstallRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  const result = await uninstallSkill(msg.name, ctx);
+  ctx.send(socket, {
+    type: "skills_operation_response",
+    operation: "uninstall",
+    ...result,
+  });
+}
+
+export async function handleSkillsUpdate(
+  msg: SkillsUpdateRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  const result = await updateSkill(msg.name, ctx);
+  ctx.send(socket, {
+    type: "skills_operation_response",
+    operation: "update",
+    ...result,
+  });
+}
+
+export async function handleSkillsCheckUpdates(
+  _msg: SkillsCheckUpdatesRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  const result = await checkSkillUpdates(ctx);
+  ctx.send(socket, {
+    type: "skills_operation_response",
+    operation: "check_updates",
+    ...result,
+  });
+}
+
+export async function handleSkillsSearch(
+  msg: SkillsSearchRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  const result = await searchSkills(msg.query, ctx);
+  ctx.send(socket, {
+    type: "skills_operation_response",
+    operation: "search",
+    ...result,
+  });
+}
+
+export async function handleSkillsInspect(
+  msg: SkillsInspectRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  const result = await inspectSkill(msg.slug, ctx);
+  ctx.send(socket, {
+    type: "skills_inspect_response",
+    ...result,
+  });
+}
+
+export async function handleSkillDetail(
+  msg: SkillDetailRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  const result = loadSkillBySelector(msg.skillId);
+  if (result.skill) {
+    const icon = await ensureSkillIcon(
+      result.skill.directoryPath,
+      result.skill.displayName,
+      result.skill.description,
+    );
     ctx.send(socket, {
-      type: "skills_draft_response",
-      success: false,
-      error: message,
+      type: "skill_detail_response",
+      skillId: result.skill.id,
+      body: result.skill.body,
+      ...(icon ? { icon } : {}),
+    });
+  } else {
+    ctx.send(socket, {
+      type: "skill_detail_response",
+      skillId: msg.skillId,
+      body: "",
+      error: result.error ?? "Skill not found",
     });
   }
 }
 
-// ─── Create handler ──────────────────────────────────────────────────────────
+export async function handleSkillsDraft(
+  msg: SkillsDraftRequest,
+  socket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  const result = await draftSkill({ sourceText: msg.sourceText }, ctx);
+  ctx.send(socket, { type: "skills_draft_response", ...result });
+}
 
 export async function handleSkillsCreate(
   msg: SkillsCreateRequest,
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
-  try {
-    const result = createManagedSkill({
-      id: msg.skillId,
+  const result = await createSkill(
+    {
+      skillId: msg.skillId,
       name: msg.name,
       description: msg.description,
       emoji: msg.emoji,
@@ -910,69 +928,14 @@ export async function handleSkillsCreate(
       userInvocable: msg.userInvocable,
       disableModelInvocation: msg.disableModelInvocation,
       overwrite: msg.overwrite,
-    });
-
-    if (!result.created) {
-      ctx.send(socket, {
-        type: "skills_operation_response",
-        operation: "create",
-        success: false,
-        error: result.error ?? "Failed to create managed skill",
-      });
-      return;
-    }
-
-    // Auto-enable the newly created skill
-    let autoEnabled = false;
-    try {
-      const raw = loadRawConfig();
-      ensureSkillEntry(raw, msg.skillId).enabled = true;
-      ctx.setSuppressConfigReload(true);
-      try {
-        saveRawConfig(raw);
-      } catch (err) {
-        ctx.setSuppressConfigReload(false);
-        throw err;
-      }
-      invalidateConfigCache();
-      ctx.debounceTimers.schedule(
-        "__suppress_reset__",
-        () => {
-          ctx.setSuppressConfigReload(false);
-        },
-        CONFIG_RELOAD_DEBOUNCE_MS,
-      );
-      ctx.updateConfigFingerprint();
-      autoEnabled = true;
-    } catch (err) {
-      log.warn(
-        { err, skillId: msg.skillId },
-        "Failed to auto-enable created skill",
-      );
-    }
-
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "create",
-      success: true,
-    });
-    if (autoEnabled) {
-      ctx.broadcast({
-        type: "skills_state_changed",
-        name: msg.skillId,
-        state: "enabled",
-      });
-    }
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error({ err }, "Failed to create skill");
-    ctx.send(socket, {
-      type: "skills_operation_response",
-      operation: "create",
-      success: false,
-      error: message,
-    });
-  }
+    },
+    ctx,
+  );
+  ctx.send(socket, {
+    type: "skills_operation_response",
+    operation: "create",
+    ...result,
+  });
 }
 
 export const skillHandlers = defineHandlers({

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -434,6 +434,7 @@ export async function runDaemon(): Promise<void> {
           })),
       },
       findSession: (sessionId) => server.findSession(sessionId),
+      getSkillContext: () => server.getSkillContext(),
     });
 
     // Inject voice bridge deps BEFORE attempting to start the HTTP server.

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -63,6 +63,7 @@ import { ConfigWatcher } from "./config-watcher.js";
 import { parseIdentityFields } from "./handlers/identity.js";
 import { handleMessage } from "./handlers/index.js";
 import { cleanupRecordingsOnDisconnect } from "./handlers/recording.js";
+import type { SkillOperationContext } from "./handlers/skills.js";
 import type {
   HandlerContext,
   SessionCreateOptions,
@@ -1004,6 +1005,20 @@ export class DaemonServer {
         this.getOrCreateSession(id, socket, rebind, options),
       touchSession: (id) => this.evictor.touch(id),
       heartbeatService: this._heartbeatService,
+    };
+  }
+
+  /** Public subset of handler context for skill management HTTP routes. */
+  getSkillContext(): SkillOperationContext {
+    return {
+      debounceTimers: this.configWatcher.timers,
+      setSuppressConfigReload: (value: boolean) => {
+        this.configWatcher.suppressConfigReload = value;
+      },
+      updateConfigFingerprint: () => {
+        this.configWatcher.updateFingerprint();
+      },
+      broadcast: (msg) => this.broadcast(msg),
     };
   }
 

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -279,6 +279,12 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   // Interfaces
   { endpoint: "interfaces", scopes: ["settings.read"] },
 
+  // Skills
+  { endpoint: "skills:GET", scopes: ["settings.read"] },
+  { endpoint: "skills:POST", scopes: ["settings.write"] },
+  { endpoint: "skills:DELETE", scopes: ["settings.write"] },
+  { endpoint: "skills:PATCH", scopes: ["settings.write"] },
+
   // Trust rule CRUD management
   { endpoint: "trust-rules/manage:GET", scopes: ["settings.read"] },
   { endpoint: "trust-rules/manage:POST", scopes: ["settings.write"] },

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -135,6 +135,7 @@ import {
   pairingRouteDefinitions,
 } from "./routes/pairing-routes.js";
 import { secretRouteDefinitions } from "./routes/secret-routes.js";
+import { skillRouteDefinitions } from "./routes/skills-routes.js";
 import { surfaceActionRouteDefinitions } from "./routes/surface-action-routes.js";
 import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.js";
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";
@@ -195,6 +196,7 @@ export class RuntimeHttpServer {
   private pairingBroadcast?: (msg: ServerMessage) => void;
   private sendMessageDeps?: SendMessageDeps;
   private findSession?: RuntimeHttpServerOptions["findSession"];
+  private getSkillContext?: RuntimeHttpServerOptions["getSkillContext"];
   private router: HttpRouter;
 
   constructor(options: RuntimeHttpServerOptions = {}) {
@@ -210,6 +212,7 @@ export class RuntimeHttpServer {
     this.interfacesDir = options.interfacesDir ?? null;
     this.sendMessageDeps = options.sendMessageDeps;
     this.findSession = options.findSession;
+    this.getSkillContext = options.getSkillContext;
     this.router = new HttpRouter(this.buildRouteTable());
   }
 
@@ -869,6 +872,11 @@ export class RuntimeHttpServer {
       }),
       ...globalSearchRouteDefinitions(),
       ...approvalRouteDefinitions(),
+      ...(this.getSkillContext
+        ? skillRouteDefinitions({
+            getSkillContext: this.getSkillContext,
+          })
+        : []),
       ...trustRulesRouteDefinitions(),
       ...surfaceActionRouteDefinitions({ findSession: this.findSession }),
       ...surfaceContentRouteDefinitions({ findSession: this.findSession }),

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -6,6 +6,7 @@ import type {
   SurfaceData,
   SurfaceType,
 } from "../daemon/ipc-contract/surfaces.js";
+import type { SkillOperationContext } from "../daemon/handlers/skills.js";
 import type { ServerMessage } from "../daemon/ipc-protocol.js";
 import type { Session } from "../daemon/session.js";
 import type { TrustContext } from "../daemon/session-runtime-assembly.js";
@@ -176,6 +177,8 @@ export interface RuntimeHttpServerOptions {
   guardianFollowUpConversationGenerator?: GuardianFollowUpConversationGenerator;
   /** Dependencies for the POST /v1/messages queue-if-busy handler. */
   sendMessageDeps?: SendMessageDeps;
+  /** Context provider for skill management HTTP routes. */
+  getSkillContext?: () => SkillOperationContext;
   /** Lookup an active session by ID (for surface actions and content fetches). */
   findSession?: (sessionId: string) =>
     | {

--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -1,0 +1,251 @@
+/**
+ * Route handlers for skill management operations.
+ *
+ * These HTTP routes expose the same business logic as the IPC skill handlers,
+ * using the standalone functions extracted in `../../daemon/handlers/skills.ts`.
+ */
+
+import type {
+  CreateSkillParams,
+  SkillOperationContext,
+} from "../../daemon/handlers/skills.js";
+import {
+  checkSkillUpdates,
+  configureSkill,
+  createSkill,
+  disableSkill,
+  draftSkill,
+  enableSkill,
+  inspectSkill,
+  installSkill,
+  listSkills,
+  searchSkills,
+  uninstallSkill,
+  updateSkill,
+} from "../../daemon/handlers/skills.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+/**
+ * Dependencies injected by the HTTP server to provide the
+ * SkillOperationContext that the business-logic functions need.
+ */
+export interface SkillRouteDeps {
+  getSkillContext: () => SkillOperationContext;
+}
+
+export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
+  const ctx = () => deps.getSkillContext();
+
+  return [
+    // GET /v1/skills — list all skills
+    {
+      endpoint: "skills",
+      method: "GET",
+      policyKey: "skills",
+      handler: () => {
+        const skills = listSkills(ctx());
+        return Response.json({ skills });
+      },
+    },
+
+    // POST /v1/skills/:id/enable — enable skill
+    {
+      endpoint: "skills/:id/enable",
+      method: "POST",
+      policyKey: "skills",
+      handler: ({ params }) => {
+        const result = enableSkill(params.id, ctx());
+        if (!result.success) {
+          return httpError("INTERNAL_ERROR", result.error, 500);
+        }
+        return Response.json({ ok: true });
+      },
+    },
+
+    // POST /v1/skills/:id/disable — disable skill
+    {
+      endpoint: "skills/:id/disable",
+      method: "POST",
+      policyKey: "skills",
+      handler: ({ params }) => {
+        const result = disableSkill(params.id, ctx());
+        if (!result.success) {
+          return httpError("INTERNAL_ERROR", result.error, 500);
+        }
+        return Response.json({ ok: true });
+      },
+    },
+
+    // PATCH /v1/skills/:id/config — configure skill
+    {
+      endpoint: "skills/:id/config",
+      method: "PATCH",
+      policyKey: "skills",
+      handler: async ({ req, params }) => {
+        const body = (await req.json()) as {
+          env?: Record<string, string>;
+          apiKey?: string;
+          config?: Record<string, unknown>;
+        };
+        const result = configureSkill(
+          params.id,
+          { env: body.env, apiKey: body.apiKey, config: body.config },
+          ctx(),
+        );
+        if (!result.success) {
+          return httpError("INTERNAL_ERROR", result.error, 500);
+        }
+        return Response.json({ ok: true });
+      },
+    },
+
+    // POST /v1/skills/install — install skill
+    {
+      endpoint: "skills/install",
+      method: "POST",
+      policyKey: "skills",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as {
+          slug?: string;
+          url?: string;
+          spec?: string;
+          version?: string;
+        };
+        const slug = body.slug ?? body.url ?? body.spec;
+        if (!slug || typeof slug !== "string") {
+          return httpError(
+            "BAD_REQUEST",
+            "slug, url, or spec is required",
+            400,
+          );
+        }
+        const result = await installSkill(
+          { slug, version: body.version },
+          ctx(),
+        );
+        if (!result.success) {
+          return httpError("INTERNAL_ERROR", result.error, 500);
+        }
+        return Response.json({ ok: true });
+      },
+    },
+
+    // POST /v1/skills/check-updates — check for updates
+    {
+      endpoint: "skills/check-updates",
+      method: "POST",
+      policyKey: "skills",
+      handler: async () => {
+        const result = await checkSkillUpdates(ctx());
+        if (!result.success) {
+          return httpError("INTERNAL_ERROR", result.error, 500);
+        }
+        return Response.json({ data: result.data });
+      },
+    },
+
+    // GET /v1/skills/search — search catalog
+    {
+      endpoint: "skills/search",
+      method: "GET",
+      policyKey: "skills",
+      handler: async ({ url }) => {
+        const query = url.searchParams.get("q") ?? "";
+        if (!query) {
+          return httpError("BAD_REQUEST", "q query parameter is required", 400);
+        }
+        const result = await searchSkills(query, ctx());
+        if (!result.success) {
+          return httpError("INTERNAL_ERROR", result.error, 500);
+        }
+        return Response.json({ data: result.data });
+      },
+    },
+
+    // POST /v1/skills/draft — draft new skill
+    {
+      endpoint: "skills/draft",
+      method: "POST",
+      policyKey: "skills",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as { sourceText?: string };
+        if (!body.sourceText || typeof body.sourceText !== "string") {
+          return httpError("BAD_REQUEST", "sourceText is required", 400);
+        }
+        const result = await draftSkill(
+          { sourceText: body.sourceText },
+          ctx(),
+        );
+        if (!result.success) {
+          return httpError("INTERNAL_ERROR", result.error ?? "Draft failed", 500);
+        }
+        return Response.json(result);
+      },
+    },
+
+    // POST /v1/skills — create skill
+    {
+      endpoint: "skills",
+      method: "POST",
+      policyKey: "skills",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as CreateSkillParams;
+        if (!body.skillId || !body.name || !body.bodyMarkdown) {
+          return httpError(
+            "BAD_REQUEST",
+            "skillId, name, and bodyMarkdown are required",
+            400,
+          );
+        }
+        const result = await createSkill(body, ctx());
+        if (!result.success) {
+          return httpError("INTERNAL_ERROR", result.error, 500);
+        }
+        return Response.json({ ok: true }, { status: 201 });
+      },
+    },
+
+    // POST /v1/skills/:id/update — update skill
+    {
+      endpoint: "skills/:id/update",
+      method: "POST",
+      policyKey: "skills",
+      handler: async ({ params }) => {
+        const result = await updateSkill(params.id, ctx());
+        if (!result.success) {
+          return httpError("INTERNAL_ERROR", result.error, 500);
+        }
+        return Response.json({ ok: true });
+      },
+    },
+
+    // GET /v1/skills/:id/inspect — inspect skill details
+    {
+      endpoint: "skills/:id/inspect",
+      method: "GET",
+      policyKey: "skills",
+      handler: async ({ params }) => {
+        const result = await inspectSkill(params.id, ctx());
+        if (result.error && !result.data) {
+          return httpError("NOT_FOUND", result.error, 404);
+        }
+        return Response.json(result);
+      },
+    },
+
+    // DELETE /v1/skills/:id — uninstall skill
+    {
+      endpoint: "skills/:id",
+      method: "DELETE",
+      policyKey: "skills",
+      handler: async ({ params }) => {
+        const result = await uninstallSkill(params.id, ctx());
+        if (!result.success) {
+          return httpError("INTERNAL_ERROR", result.error, 500);
+        }
+        return new Response(null, { status: 204 });
+      },
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Extract all 12 skill operation business logic from IPC handlers into standalone shared functions
- Create new HTTP route definitions for skill list, enable, disable, configure, install, uninstall, update, check-updates, search, inspect, draft, and create
- Register routes in http-server.ts buildRouteTable()

Part of plan: phase-out-ipc.md (PR 3 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
