### PR TITLE
feat: add HTTP routes for settings, schedules, diagnostics, and remaining IPC-only operations

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -287,6 +287,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
 
   // Surface actions
   { endpoint: "surface-actions", scopes: ["chat.write"] },
+  { endpoint: "surfaces/undo", scopes: ["chat.write"] },
 
   // Conversation deletion (channel-facing)
   { endpoint: "channels/conversation:DELETE", scopes: ["chat.write"] },
@@ -299,6 +300,40 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "migrations/export", scopes: ["settings.write"] },
   { endpoint: "migrations/import-preflight", scopes: ["settings.write"] },
   { endpoint: "migrations/import", scopes: ["settings.write"] },
+
+  // Settings (voice, avatar, client settings)
+  { endpoint: "settings/voice", scopes: ["settings.write"] },
+  { endpoint: "settings/avatar/generate", scopes: ["settings.write"] },
+  { endpoint: "settings/client", scopes: ["settings.write"] },
+
+  // Schedules
+  { endpoint: "schedules", scopes: ["settings.read"] },
+  { endpoint: "schedules:DELETE", scopes: ["settings.write"] },
+  { endpoint: "schedules/toggle", scopes: ["settings.write"] },
+  { endpoint: "schedules/run", scopes: ["settings.write"] },
+
+  // Diagnostics
+  { endpoint: "diagnostics/export", scopes: ["settings.read"] },
+  { endpoint: "diagnostics/env-vars", scopes: ["settings.read"] },
+
+  // Dictation
+  { endpoint: "dictation", scopes: ["chat.write"] },
+
+  // OAuth / integrations
+  { endpoint: "integrations/oauth/start", scopes: ["settings.write"] },
+  { endpoint: "integrations/twitter/auth/start", scopes: ["settings.write"] },
+  { endpoint: "integrations/twitter/auth/status", scopes: ["settings.read"] },
+
+  // Home base
+  { endpoint: "home-base", scopes: ["settings.read"] },
+
+  // Workspace files (IPC-migrated)
+  { endpoint: "workspace-files", scopes: ["settings.read"] },
+  { endpoint: "workspace-files/read", scopes: ["settings.read"] },
+
+  // Tools
+  { endpoint: "tools", scopes: ["settings.read"] },
+  { endpoint: "tools/simulate-permission", scopes: ["settings.read"] },
 ];
 
 for (const { endpoint, scopes } of ACTOR_ENDPOINTS) {

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -140,6 +140,9 @@ import { surfaceContentRouteDefinitions } from "./routes/surface-content-routes.
 import { trustRulesRouteDefinitions } from "./routes/trust-rules-routes.js";
 import { usageRouteDefinitions } from "./routes/usage-routes.js";
 import { workspaceRouteDefinitions } from "./routes/workspace-routes.js";
+import { diagnosticsRouteDefinitions } from "./routes/diagnostics-routes.js";
+import { scheduleRouteDefinitions } from "./routes/schedule-routes.js";
+import { settingsRouteDefinitions } from "./routes/settings-routes.js";
 
 // Re-export for consumers
 export { isPrivateAddress } from "./middleware/auth.js";
@@ -690,6 +693,11 @@ export class RuntimeHttpServer {
       ...debugRouteDefinitions(),
       ...usageRouteDefinitions(),
       ...workspaceRouteDefinitions(),
+      ...settingsRouteDefinitions(),
+      ...scheduleRouteDefinitions({
+        sendMessageDeps: this.sendMessageDeps,
+      }),
+      ...diagnosticsRouteDefinitions(),
 
       // Browser relay — not extracted into a domain module because
       // these two routes depend on the in-process extensionRelayServer

--- a/assistant/src/runtime/routes/diagnostics-routes.ts
+++ b/assistant/src/runtime/routes/diagnostics-routes.ts
@@ -1,0 +1,813 @@
+/**
+ * HTTP route handlers for diagnostics export and dictation processing.
+ *
+ * Migrated from IPC handlers:
+ *   - handlers/diagnostics.ts (diagnostics_export_request)
+ *   - handlers/dictation.ts (dictation_request)
+ */
+
+import { randomBytes } from "node:crypto";
+import { createWriteStream, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+import archiver from "archiver";
+import { and, desc, eq, gte, lte } from "drizzle-orm";
+
+import { getDb } from "../../memory/db.js";
+import {
+  llmRequestLogs,
+  llmUsageEvents,
+  messages,
+  toolInvocations,
+} from "../../memory/schema.js";
+import {
+  createTimeout,
+  extractToolUse,
+  getConfiguredProvider,
+  userMessage,
+} from "../../providers/provider-send-message.js";
+import {
+  type ProfileResolution,
+  resolveProfile,
+} from "../../daemon/dictation-profile-store.js";
+import {
+  applyDictionary,
+  expandSnippets,
+} from "../../daemon/dictation-text-processing.js";
+import { detectDictationModeHeuristic } from "../../daemon/handlers/dictation.js";
+import type { DictationRequest } from "../../daemon/ipc-contract/diagnostics.js";
+import type { DictationContext } from "../../daemon/ipc-contract/shared.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+
+const log = getLogger("diagnostics-routes");
+
+// ---------------------------------------------------------------------------
+// Diagnostics export — redaction helpers (shared with IPC handler)
+// ---------------------------------------------------------------------------
+
+const MAX_CONTENT_LENGTH = 500;
+
+const REDACT_PATTERNS = [
+  /\b(sk|key|api[_-]?key|token|secret|password|passwd|credential)[_\-]?[a-zA-Z0-9]{16,}\b/gi,
+  /Bearer\s+[A-Za-z0-9\-._~+\/]+=*/gi,
+  /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g,
+  /\b(AKIA|ASIA)[A-Z0-9]{16}\b/g,
+  /\b[A-Fa-f0-9]{32,}\b/g,
+];
+
+function redact(text: string): string {
+  let result = text;
+  for (const pattern of REDACT_PATTERNS) {
+    result = result.replace(pattern, "[REDACTED]");
+  }
+  return result;
+}
+
+function truncateAndRedact(text: string): string {
+  const truncated =
+    text.length > MAX_CONTENT_LENGTH
+      ? text.slice(0, MAX_CONTENT_LENGTH) + "...[truncated]"
+      : text;
+  return redact(truncated);
+}
+
+const SENSITIVE_KEYS = new Set([
+  "api_key",
+  "apikey",
+  "api-key",
+  "authorization",
+  "x-api-key",
+  "secret",
+  "password",
+  "token",
+  "credential",
+  "credentials",
+]);
+
+function redactDeep(value: unknown): unknown {
+  if (typeof value === "string") return redact(value);
+  if (Array.isArray(value)) return value.map(redactDeep);
+  if (value != null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (SENSITIVE_KEYS.has(k.toLowerCase())) {
+        out[k] = "[REDACTED]";
+      } else {
+        out[k] = redactDeep(v);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostics export handler
+// ---------------------------------------------------------------------------
+
+async function handleDiagnosticsExport(body: {
+  conversationId?: string;
+  anchorMessageId?: string;
+}): Promise<Response> {
+  if (!body.conversationId) {
+    return httpError("BAD_REQUEST", "conversationId is required", 400);
+  }
+
+  const { conversationId, anchorMessageId } = body;
+
+  try {
+    const db = getDb();
+
+    // 1. Find the anchor message
+    let anchorMessage;
+    if (anchorMessageId) {
+      anchorMessage = db
+        .select()
+        .from(messages)
+        .where(
+          and(
+            eq(messages.id, anchorMessageId),
+            eq(messages.conversationId, conversationId),
+          ),
+        )
+        .get();
+    } else {
+      anchorMessage = db
+        .select()
+        .from(messages)
+        .where(
+          and(
+            eq(messages.conversationId, conversationId),
+            eq(messages.role, "assistant"),
+          ),
+        )
+        .orderBy(desc(messages.createdAt))
+        .limit(1)
+        .get();
+    }
+
+    if (!anchorMessage) {
+      return httpError("NOT_FOUND", "Anchor message not found", 404);
+    }
+
+    // 2. Find the preceding user message
+    const precedingUserMessage = db
+      .select()
+      .from(messages)
+      .where(
+        and(
+          eq(messages.conversationId, conversationId),
+          eq(messages.role, "user"),
+          lte(messages.createdAt, anchorMessage.createdAt),
+        ),
+      )
+      .orderBy(desc(messages.createdAt))
+      .limit(1)
+      .get();
+
+    const rangeStart =
+      precedingUserMessage?.createdAt ?? anchorMessage.createdAt - 2000;
+    const rangeEnd = anchorMessage.createdAt;
+    const usageRangeEnd = anchorMessage.createdAt + 5000;
+
+    // 3. Query all messages in the range
+    const rangeMessages = db
+      .select()
+      .from(messages)
+      .where(
+        and(
+          eq(messages.conversationId, conversationId),
+          gte(messages.createdAt, rangeStart),
+          lte(messages.createdAt, rangeEnd),
+        ),
+      )
+      .orderBy(messages.createdAt)
+      .all();
+
+    // 4. Query tool invocations in the range
+    const rangeToolInvocations = db
+      .select()
+      .from(toolInvocations)
+      .where(
+        and(
+          eq(toolInvocations.conversationId, conversationId),
+          gte(toolInvocations.createdAt, rangeStart),
+          lte(toolInvocations.createdAt, rangeEnd),
+        ),
+      )
+      .orderBy(toolInvocations.createdAt)
+      .all();
+
+    // 5. Query LLM usage events
+    const rangeUsageEvents = db
+      .select()
+      .from(llmUsageEvents)
+      .where(
+        and(
+          eq(llmUsageEvents.conversationId, conversationId),
+          gte(llmUsageEvents.createdAt, rangeStart),
+          lte(llmUsageEvents.createdAt, usageRangeEnd),
+        ),
+      )
+      .orderBy(llmUsageEvents.createdAt)
+      .all();
+
+    // 5b. Query raw LLM request/response logs
+    const rangeRequestLogs = db
+      .select()
+      .from(llmRequestLogs)
+      .where(
+        and(
+          eq(llmRequestLogs.conversationId, conversationId),
+          gte(llmRequestLogs.createdAt, rangeStart),
+          lte(llmRequestLogs.createdAt, usageRangeEnd),
+        ),
+      )
+      .orderBy(llmRequestLogs.createdAt)
+      .all();
+
+    // 6. Write export files to a temp directory
+    const exportId = `diagnostics-${new Date().toISOString().replace(/[:.]/g, "-")}-${randomBytes(4).toString("hex")}`;
+    const tempDir = join(tmpdir(), exportId);
+    mkdirSync(tempDir, { recursive: true });
+
+    try {
+      const manifest = {
+        version: "1.1",
+        exportedAt: new Date().toISOString(),
+        conversationId,
+        messageId: anchorMessage.id,
+      };
+      writeFileSync(
+        join(tempDir, "manifest.json"),
+        JSON.stringify(manifest, null, 2),
+      );
+
+      const messagesLines = rangeMessages.map((m) =>
+        JSON.stringify({
+          id: m.id,
+          conversationId: m.conversationId,
+          role: m.role,
+          content: truncateAndRedact(m.content),
+          createdAt: m.createdAt,
+        }),
+      );
+      writeFileSync(
+        join(tempDir, "messages.jsonl"),
+        messagesLines.join("\n") + (messagesLines.length > 0 ? "\n" : ""),
+      );
+
+      const toolLines = rangeToolInvocations.map((t) =>
+        JSON.stringify({
+          id: t.id,
+          conversationId: t.conversationId,
+          toolName: t.toolName,
+          input: truncateAndRedact(t.input),
+          result: truncateAndRedact(t.result),
+          decision: t.decision,
+          riskLevel: t.riskLevel,
+          durationMs: t.durationMs,
+          createdAt: t.createdAt,
+        }),
+      );
+      writeFileSync(
+        join(tempDir, "tool_invocations.jsonl"),
+        toolLines.join("\n") + (toolLines.length > 0 ? "\n" : ""),
+      );
+
+      const usageLines = rangeUsageEvents.map((u) =>
+        JSON.stringify({
+          id: u.id,
+          conversationId: u.conversationId,
+          actor: u.actor,
+          provider: u.provider,
+          model: u.model,
+          inputTokens: u.inputTokens,
+          outputTokens: u.outputTokens,
+          cacheCreationInputTokens: u.cacheCreationInputTokens,
+          cacheReadInputTokens: u.cacheReadInputTokens,
+          estimatedCostUsd: u.estimatedCostUsd,
+          pricingStatus: u.pricingStatus,
+          createdAt: u.createdAt,
+        }),
+      );
+      writeFileSync(
+        join(tempDir, "usage.jsonl"),
+        usageLines.join("\n") + (usageLines.length > 0 ? "\n" : ""),
+      );
+
+      const requestLogLines = rangeRequestLogs.map((r) => {
+        let request: unknown;
+        let response: unknown;
+        try {
+          request = JSON.parse(r.requestPayload);
+        } catch {
+          request = r.requestPayload;
+        }
+        try {
+          response = JSON.parse(r.responsePayload);
+        } catch {
+          response = r.responsePayload;
+        }
+        return JSON.stringify({
+          id: r.id,
+          conversationId: r.conversationId,
+          request: redactDeep(request),
+          response: redactDeep(response),
+          createdAt: r.createdAt,
+        });
+      });
+      writeFileSync(
+        join(tempDir, "llm_requests.jsonl"),
+        requestLogLines.join("\n") + (requestLogLines.length > 0 ? "\n" : ""),
+      );
+
+      // 7. Zip the temp directory
+      const downloadsDir = join(homedir(), "Downloads");
+      mkdirSync(downloadsDir, { recursive: true });
+      const zipFilename = `${exportId}.zip`;
+      const zipPath = join(downloadsDir, zipFilename);
+
+      await new Promise<void>((resolve, reject) => {
+        const output = createWriteStream(zipPath);
+        const archive = archiver("zip", { zlib: { level: 9 } });
+
+        output.on("close", () => resolve());
+        output.on("error", (err: Error) => reject(err));
+        archive.on("error", (err: Error) => reject(err));
+        archive.on("warning", (err: Error) => {
+          log.warn({ err }, "Archiver warning during diagnostics export");
+        });
+
+        archive.pipe(output);
+        archive.directory(tempDir, false);
+        archive.finalize();
+      });
+
+      log.info(
+        { conversationId, zipPath, messageCount: rangeMessages.length },
+        "Diagnostics export completed via HTTP",
+      );
+
+      return Response.json({ ok: true, filePath: zipPath });
+    } finally {
+      try {
+        rmSync(tempDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup
+      }
+    }
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    log.error({ err, conversationId }, "Failed to export diagnostics");
+    return httpError(
+      "INTERNAL_ERROR",
+      `Failed to export diagnostics: ${errorMessage}`,
+      500,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dictation
+// ---------------------------------------------------------------------------
+
+type DictationMode = "dictation" | "command" | "action";
+
+const DICTATION_CLASSIFICATION_TIMEOUT_MS = 5000;
+const MAX_WINDOW_TITLE_LENGTH = 100;
+
+function sanitizeWindowTitle(title: string | undefined): string {
+  if (!title) return "";
+  return title
+    .replace(/[<>]/g, "")
+    .slice(0, MAX_WINDOW_TITLE_LENGTH);
+}
+
+interface DictationBody {
+  transcription: string;
+  context: DictationContext;
+  profileId?: string;
+}
+
+function buildAppMetadataBlock(context: DictationContext): string {
+  const windowTitle = sanitizeWindowTitle(context.windowTitle);
+  return [
+    "<app_metadata>",
+    `App: ${context.appName} (${context.bundleIdentifier})`,
+    `Window: ${windowTitle}`,
+    "</app_metadata>",
+  ].join("\n");
+}
+
+function buildCombinedDictationPrompt(
+  body: DictationBody,
+  stylePrompt?: string,
+): string {
+  const sections = [
+    "You are a voice input assistant. You will receive a speech transcription and must:",
+    '1. Classify it as "dictation" (text to insert) or "action" (task for an assistant to execute)',
+    "2. If dictation, clean up the text. If action, return the raw transcription.",
+    "",
+    "## Classification",
+    'DICTATION examples: "Hey how are you doing", "I think we should move forward with the proposal", "Dear team comma please review the attached document"',
+    'ACTION examples: "Message Aaron on Slack saying hey what\'s up", "Send an email to the team about the meeting", "Open Spotify and play my playlist", "Search for flights to Denver", "Create a new document in Google Docs"',
+    "",
+    "Key signals for ACTION: the user is addressing an assistant and asking it to DO something (send, message, open, search, create, schedule, etc.)",
+    "Key signals for DICTATION: the user is composing text content that should be typed out as-is",
+    `Cursor in text field: ${body.context.cursorInTextField ? "yes" : "no"} -- if yes, lean toward dictation unless the intent to command is clear.`,
+    "",
+    "## Cleanup Rules (for dictation mode only)",
+    "- Fix grammar, punctuation, and capitalization",
+    "- Remove filler words (um, uh, like, you know)",
+    '- Rewrite vague or hedging language ("so yeah probably", "I guess maybe") into clear, confident statements',
+    "- Maintain the speaker's intent and meaning",
+  ];
+
+  if (stylePrompt) {
+    sections.push(
+      "",
+      "## User Style (HIGHEST PRIORITY)",
+      "The user has configured these style preferences. They OVERRIDE the default tone adaptation below.",
+      "Follow these instructions precisely -- they reflect the user's personal writing voice and preferences.",
+      "",
+      stylePrompt,
+    );
+  }
+
+  sections.push("", "## Tone Adaptation");
+
+  if (stylePrompt) {
+    sections.push(
+      "Use these as fallback guidance only when the User Style above does not cover a specific aspect:",
+    );
+  } else {
+    sections.push("Adapt your output tone based on the active application:");
+  }
+
+  sections.push(
+    "- Email apps (Gmail, Mail): Professional but warm. Use proper greetings and sign-offs if appropriate.",
+    "- Slack: Casual and conversational. Match typical chat style.",
+    "- Code editors (VS Code, Xcode): Technical and concise. Code comments style.",
+    "- Terminal: Command-like, terse.",
+    "- Messages/iMessage: Very casual, texting style. Short sentences.",
+    "- Notes/Docs: Neutral, clear writing.",
+    "- Default: Match the user's natural voice.",
+    "",
+    "## Context Clues",
+    "- Window title may contain recipient name (Slack DMs, email compose)",
+    "- If you can identify a recipient, adapt formality to the apparent relationship",
+    "- Maintain the user's natural voice -- don't over-formalize casual speech",
+    "- The user's writing patterns and preferences may be available from memory context -- follow those when present",
+    "",
+    buildAppMetadataBlock(body.context),
+  );
+
+  return sections.join("\n");
+}
+
+function buildCommandPrompt(
+  body: DictationBody,
+  stylePrompt?: string,
+): string {
+  const sections = [
+    "You are a text transformation assistant. The user has selected text and given a voice command to transform it.",
+    "",
+    "## Rules",
+    "- Apply the instruction to the selected text",
+    "- Return ONLY the transformed text, nothing else",
+    "- Do NOT add explanations or commentary",
+  ];
+
+  if (stylePrompt) {
+    sections.push(
+      "",
+      "## User Style (HIGHEST PRIORITY)",
+      "The user has configured these style preferences. They OVERRIDE the default tone adaptation below.",
+      "Follow these instructions precisely -- they reflect the user's personal writing voice and preferences.",
+      "",
+      stylePrompt,
+    );
+  }
+
+  sections.push("", "## Tone Adaptation");
+
+  if (stylePrompt) {
+    sections.push(
+      "Use these as fallback guidance only when the User Style above does not cover a specific aspect:",
+    );
+  } else {
+    sections.push("Match the tone to the active application context:");
+  }
+
+  sections.push(
+    "- Email apps (Gmail, Mail): Professional but warm.",
+    "- Slack: Casual and conversational.",
+    "- Code editors (VS Code, Xcode): Technical and concise.",
+    "- Terminal: Command-like, terse.",
+    "- Messages/iMessage: Very casual, texting style.",
+    "- Notes/Docs: Neutral, clear writing.",
+    "- Default: Match the user's natural voice.",
+    "",
+    "## Context Clues",
+    "- Window title may contain recipient name (Slack DMs, email compose)",
+    "- If you can identify a recipient, adapt formality to the apparent relationship",
+    "- Maintain the user's natural voice -- don't over-formalize casual speech",
+    "- The user's writing patterns and preferences may be available from memory context -- follow those when present",
+    "",
+    buildAppMetadataBlock(body.context),
+    "",
+    "Selected text:",
+    body.context.selectedText ?? "",
+    "",
+    `Instruction: ${body.transcription}`,
+  );
+
+  return sections.join("\n");
+}
+
+function computeMaxTokens(inputLength: number): number {
+  const estimatedInputTokens = Math.ceil(inputLength / 3);
+  return Math.max(256, estimatedInputTokens + 128);
+}
+
+async function handleDictation(body: DictationBody): Promise<Response> {
+  log.info(
+    { transcriptionLength: body.transcription.length },
+    "Dictation request received via HTTP",
+  );
+
+  const resolution = resolveProfile(
+    body.context.bundleIdentifier,
+    body.context.appName,
+    body.profileId,
+  );
+  const { profile, source: profileSource } = resolution;
+  log.info(
+    { profileId: profile.id, profileSource },
+    "Resolved dictation profile",
+  );
+
+  const profileMeta = {
+    resolvedProfileId: profile.id,
+    profileSource,
+  };
+
+  const stylePrompt = profile.stylePrompt || undefined;
+
+  // Command mode: selected text present
+  if (body.context.selectedText && body.context.selectedText.trim().length > 0) {
+    log.info({ mode: "command" }, "Command mode (selected text present)");
+    return handleCommandMode(body, profile, profileMeta, stylePrompt);
+  }
+
+  // Non-command: single LLM call that classifies AND cleans in one shot
+  const transcription = expandSnippets(body.transcription, profile.snippets);
+
+  try {
+    const provider = getConfiguredProvider();
+    if (!provider) {
+      log.warn(
+        "Dictation: no provider available, using heuristic + raw transcription",
+      );
+      // Build an IPC-compatible msg for the heuristic
+      const mode = detectDictationModeHeuristic({
+        type: "dictation_request",
+        transcription: body.transcription,
+        context: body.context,
+      } as DictationRequest);
+      const normalizedText = applyDictionary(transcription, profile.dictionary);
+      if (mode === "action") {
+        return Response.json({
+          text: body.transcription,
+          mode: "action",
+          actionPlan: `User wants to: ${body.transcription}`,
+          ...profileMeta,
+        });
+      }
+      return Response.json({
+        text: normalizedText,
+        mode,
+        ...profileMeta,
+      });
+    }
+
+    const systemPrompt = buildCombinedDictationPrompt(body, stylePrompt);
+    const maxTokens = computeMaxTokens(transcription.length);
+    const { signal, cleanup } = createTimeout(
+      DICTATION_CLASSIFICATION_TIMEOUT_MS,
+    );
+
+    try {
+      const response = await provider.sendMessage(
+        [userMessage(`Transcription: "${transcription}"`)],
+        [
+          {
+            name: "process_dictation",
+            description: "Classify the voice input and return cleaned text",
+            input_schema: {
+              type: "object" as const,
+              properties: {
+                mode: {
+                  type: "string",
+                  enum: ["dictation", "action"],
+                  description:
+                    "dictation = user wants text inserted/cleaned up for typing. action = user wants the assistant to perform a task.",
+                },
+                text: {
+                  type: "string",
+                  description:
+                    "If dictation: the cleaned/formatted text ready for insertion. If action: the raw transcription unchanged.",
+                },
+                reasoning: {
+                  type: "string",
+                  description: "Brief reasoning for the classification",
+                },
+              },
+              required: ["mode", "text", "reasoning"],
+            },
+          },
+        ],
+        systemPrompt,
+        {
+          config: {
+            modelIntent: "latency-optimized",
+            max_tokens: maxTokens,
+            tool_choice: {
+              type: "tool" as const,
+              name: "process_dictation",
+            },
+          },
+          signal,
+        },
+      );
+      cleanup();
+
+      const toolBlock = extractToolUse(response);
+      if (toolBlock) {
+        const input = toolBlock.input as {
+          mode?: string;
+          text?: string;
+          reasoning?: string;
+        };
+        const mode: DictationMode =
+          input.mode === "action" ? "action" : "dictation";
+        log.info(
+          { mode, reasoning: input.reasoning },
+          "LLM dictation classify+clean",
+        );
+
+        if (mode === "action") {
+          return Response.json({
+            text: body.transcription,
+            mode: "action",
+            actionPlan: `User wants to: ${body.transcription}`,
+            ...profileMeta,
+          });
+        }
+        const cleanedText = input.text?.trim() || transcription;
+        const normalizedText = applyDictionary(
+          cleanedText,
+          profile.dictionary,
+        );
+        return Response.json({
+          text: normalizedText,
+          mode: "dictation",
+          ...profileMeta,
+        });
+      }
+
+      log.warn("No tool_use block in combined dictation call, using heuristic");
+    } finally {
+      cleanup();
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(
+      { err: message },
+      "Combined dictation LLM call failed, using heuristic",
+    );
+  }
+
+  // Heuristic fallback
+  const fallbackMode = detectDictationModeHeuristic({
+    type: "dictation_request",
+    transcription: body.transcription,
+    context: body.context,
+  } as DictationRequest);
+  log.info({ mode: fallbackMode }, "Using heuristic fallback");
+  if (fallbackMode === "action") {
+    return Response.json({
+      text: body.transcription,
+      mode: "action",
+      actionPlan: `User wants to: ${body.transcription}`,
+      ...profileMeta,
+    });
+  }
+  const normalizedText = applyDictionary(transcription, profile.dictionary);
+  return Response.json({
+    text: normalizedText,
+    mode: fallbackMode,
+    ...profileMeta,
+  });
+}
+
+async function handleCommandMode(
+  body: DictationBody,
+  profile: ReturnType<typeof resolveProfile>["profile"],
+  profileMeta: {
+    resolvedProfileId: string;
+    profileSource: ProfileResolution["source"];
+  },
+  stylePrompt: string | undefined,
+): Promise<Response> {
+  const systemPrompt = buildCommandPrompt(body, stylePrompt);
+  const inputLength =
+    (body.context.selectedText ?? "").length + body.transcription.length;
+  const maxTokens = Math.max(1024, computeMaxTokens(inputLength));
+
+  try {
+    const provider = getConfiguredProvider();
+    if (!provider) {
+      log.warn("Command mode: no provider available, returning selected text");
+      const normalizedText = applyDictionary(
+        body.context.selectedText ?? body.transcription,
+        profile.dictionary,
+      );
+      return Response.json({
+        text: normalizedText,
+        mode: "command",
+        ...profileMeta,
+      });
+    }
+
+    const response = await provider.sendMessage(
+      [userMessage(body.transcription)],
+      [],
+      systemPrompt,
+      { config: { modelIntent: "latency-optimized", max_tokens: maxTokens } },
+    );
+
+    const textBlock = response.content.find((b) => b.type === "text");
+    const cleanedText =
+      textBlock && "text" in textBlock
+        ? textBlock.text.trim()
+        : (body.context.selectedText ?? body.transcription);
+    const normalizedText = applyDictionary(cleanedText, profile.dictionary);
+    return Response.json({
+      text: normalizedText,
+      mode: "command",
+      ...profileMeta,
+    });
+  } catch (err) {
+    log.error({ err }, "Command mode LLM call failed, returning selected text");
+    const normalizedText = applyDictionary(
+      body.context.selectedText ?? body.transcription,
+      profile.dictionary,
+    );
+    return Response.json({
+      text: normalizedText,
+      mode: "command",
+      ...profileMeta,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function diagnosticsRouteDefinitions(): RouteDefinition[] {
+  return [
+    {
+      endpoint: "diagnostics/export",
+      method: "POST",
+      policyKey: "diagnostics/export",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as {
+          conversationId?: string;
+          anchorMessageId?: string;
+        };
+        return handleDiagnosticsExport(body);
+      },
+    },
+    {
+      endpoint: "dictation",
+      method: "POST",
+      policyKey: "dictation",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as DictationBody;
+        if (!body.transcription) {
+          return httpError("BAD_REQUEST", "transcription is required", 400);
+        }
+        if (!body.context) {
+          return httpError("BAD_REQUEST", "context is required", 400);
+        }
+        return handleDictation(body);
+      },
+    },
+  ];
+}

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -1,0 +1,225 @@
+/**
+ * HTTP route handlers for schedule management.
+ *
+ * Migrated from IPC handler: handlers/config-scheduling.ts
+ */
+
+import { bootstrapConversation } from "../../memory/conversation-bootstrap.js";
+import {
+  completeScheduleRun,
+  createScheduleRun,
+  deleteSchedule,
+  describeCronExpression,
+  getSchedule,
+  listSchedules,
+  updateSchedule,
+} from "../../schedule/schedule-store.js";
+import { getLogger } from "../../util/logger.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+import type { SendMessageDeps } from "../http-types.js";
+
+const log = getLogger("schedule-routes");
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+function handleListSchedules(): Response {
+  const jobs = listSchedules();
+  return Response.json({
+    schedules: jobs.map((j) => ({
+      id: j.id,
+      name: j.name,
+      enabled: j.enabled,
+      syntax: j.syntax,
+      expression: j.expression,
+      cronExpression: j.cronExpression,
+      timezone: j.timezone,
+      message: j.message,
+      nextRunAt: j.nextRunAt,
+      lastRunAt: j.lastRunAt,
+      lastStatus: j.lastStatus,
+      description:
+        j.syntax === "cron"
+          ? describeCronExpression(j.cronExpression)
+          : j.expression,
+    })),
+  });
+}
+
+function handleToggleSchedule(id: string, enabled: boolean): Response {
+  try {
+    updateSchedule(id, { enabled });
+    log.info({ id, enabled }, "Schedule toggled via HTTP");
+  } catch (err) {
+    log.error({ err }, "Failed to toggle schedule");
+    return httpError("INTERNAL_ERROR", "Failed to toggle schedule", 500);
+  }
+  return handleListSchedules();
+}
+
+function handleDeleteSchedule(id: string): Response {
+  try {
+    const removed = deleteSchedule(id);
+    if (!removed) {
+      return httpError("NOT_FOUND", "Schedule not found", 404);
+    }
+    log.info({ id }, "Schedule removed via HTTP");
+  } catch (err) {
+    log.error({ err }, "Failed to remove schedule");
+    return httpError("INTERNAL_ERROR", "Failed to remove schedule", 500);
+  }
+  return handleListSchedules();
+}
+
+async function handleRunScheduleNow(
+  id: string,
+  sendMessageDeps?: SendMessageDeps,
+): Promise<Response> {
+  const schedule = getSchedule(id);
+  if (!schedule) {
+    return httpError("NOT_FOUND", "Schedule not found", 404);
+  }
+
+  // Check if message is a task invocation (run_task:<task_id>)
+  const taskMatch = schedule.message.match(/^run_task:(\S+)$/);
+  if (taskMatch) {
+    const taskId = taskMatch[1];
+    try {
+      log.info(
+        { jobId: schedule.id, name: schedule.name, taskId },
+        "Executing scheduled task manually via HTTP (run now)",
+      );
+      const { runTask } = await import("../../tasks/task-runner.js");
+      const result = await runTask(
+        { taskId, workingDir: process.cwd(), source: "schedule" },
+        async (conversationId, message, taskRunId) => {
+          if (!sendMessageDeps) {
+            throw new Error("sendMessageDeps not available for schedule execution");
+          }
+          const session = await sendMessageDeps.getOrCreateSession(
+            conversationId,
+          );
+          session.taskRunId = taskRunId;
+          await session.processMessage(
+            message,
+            [],
+            () => {}, // no event callback for HTTP mode
+            undefined,
+            undefined,
+            undefined,
+            { isInteractive: false },
+          );
+        },
+      );
+
+      const runId = createScheduleRun(schedule.id, result.conversationId);
+      if (result.status === "failed") {
+        completeScheduleRun(runId, {
+          status: "error",
+          error: result.error ?? "Task run failed",
+        });
+      } else {
+        completeScheduleRun(runId, { status: "ok" });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(
+        { err, jobId: schedule.id, name: schedule.name, taskId },
+        "Manual scheduled task execution failed",
+      );
+      const fallbackConversation = bootstrapConversation({
+        source: "schedule",
+        origin: "schedule",
+        systemHint: `Schedule (manual): ${schedule.name}`,
+      });
+      const runId = createScheduleRun(schedule.id, fallbackConversation.id);
+      completeScheduleRun(runId, { status: "error", error: message });
+    }
+    return handleListSchedules();
+  }
+
+  // Regular message-based schedule
+  const conversation = bootstrapConversation({
+    source: "schedule",
+    origin: "schedule",
+    systemHint: `Schedule (manual): ${schedule.name}`,
+  });
+  const runId = createScheduleRun(schedule.id, conversation.id);
+
+  try {
+    log.info(
+      {
+        jobId: schedule.id,
+        name: schedule.name,
+        conversationId: conversation.id,
+      },
+      "Executing schedule manually via HTTP (run now)",
+    );
+    if (!sendMessageDeps) {
+      throw new Error("sendMessageDeps not available for schedule execution");
+    }
+    const session = await sendMessageDeps.getOrCreateSession(conversation.id);
+    await session.processMessage(
+      schedule.message,
+      [],
+      () => {}, // no event callback for HTTP mode
+      undefined,
+      undefined,
+      undefined,
+      { isInteractive: false },
+    );
+    completeScheduleRun(runId, { status: "ok" });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(
+      { err, jobId: schedule.id, name: schedule.name },
+      "Manual schedule execution failed",
+    );
+    completeScheduleRun(runId, { status: "error", error: message });
+  }
+  return handleListSchedules();
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function scheduleRouteDefinitions(deps: {
+  sendMessageDeps?: SendMessageDeps;
+}): RouteDefinition[] {
+  return [
+    {
+      endpoint: "schedules",
+      method: "GET",
+      policyKey: "schedules",
+      handler: () => handleListSchedules(),
+    },
+    {
+      endpoint: "schedules/:id/toggle",
+      method: "POST",
+      policyKey: "schedules/toggle",
+      handler: async ({ req, params }) => {
+        const body = (await req.json()) as { enabled?: boolean };
+        if (body.enabled === undefined) {
+          return httpError("BAD_REQUEST", "enabled is required", 400);
+        }
+        return handleToggleSchedule(params.id, body.enabled);
+      },
+    },
+    {
+      endpoint: "schedules/:id",
+      method: "DELETE",
+      policyKey: "schedules",
+      handler: ({ params }) => handleDeleteSchedule(params.id),
+    },
+    {
+      endpoint: "schedules/:id/run",
+      method: "POST",
+      policyKey: "schedules/run",
+      handler: async ({ params }) =>
+        handleRunScheduleNow(params.id, deps.sendMessageDeps),
+    },
+  ];
+}

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -1,0 +1,861 @@
+/**
+ * HTTP route handlers for settings, identity/avatar, voice config,
+ * OAuth connect, Twitter auth, home base, and workspace files.
+ *
+ * Migrated from IPC handlers:
+ *   - handlers/config-voice.ts (voice_config_update)
+ *   - handlers/avatar.ts (generate_avatar)
+ *   - handlers/oauth-connect.ts (oauth_connect_start)
+ *   - handlers/twitter-auth.ts (twitter_auth_start, twitter_auth_status)
+ *   - handlers/home-base.ts (home_base_get)
+ *   - handlers/workspace-files.ts (workspace_files_list, workspace_file_read)
+ *   - handlers/config-tools.ts (tool_names_list, tool_permission_simulate, env_vars_request)
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  getNestedValue,
+  invalidateConfigCache,
+  loadConfig,
+  loadRawConfig,
+  saveRawConfig,
+  setNestedValue,
+} from "../../config/loader.js";
+import { loadSkillCatalog } from "../../config/skills.js";
+import { getHomeBaseAppLink } from "../../home-base/app-link-store.js";
+import {
+  bootstrapHomeBaseAppLink,
+  resolveHomeBaseAppId,
+} from "../../home-base/bootstrap.js";
+import {
+  getPrebuiltHomeBasePreview,
+  getPrebuiltHomeBaseTaskPayload,
+} from "../../home-base/prebuilt/seed.js";
+import { getPublicBaseUrl } from "../../inbound/public-ingress-urls.js";
+import { getApp } from "../../memory/app-store.js";
+import { orchestrateOAuthConnect } from "../../oauth/connect-orchestrator.js";
+import {
+  getProviderProfile,
+  resolveService,
+} from "../../oauth/provider-profiles.js";
+import {
+  check,
+  classifyRisk,
+  generateAllowlistOptions,
+  generateScopeOptions,
+} from "../../permissions/checker.js";
+import { getSecureKey } from "../../security/secure-keys.js";
+import { parseToolManifestFile } from "../../skills/tool-manifest.js";
+import { assertMetadataWritable } from "../../tools/credentials/metadata-store.js";
+import {
+  type ManifestOverride,
+  resolveExecutionTarget,
+} from "../../tools/execution-target.js";
+import { getAllTools, getTool } from "../../tools/registry.js";
+import { isSideEffectTool } from "../../tools/side-effects.js";
+import { setAvatarTool } from "../../tools/system/avatar-generator.js";
+import { ConfigError } from "../../util/errors.js";
+import { pathExists } from "../../util/fs.js";
+import { getLogger } from "../../util/logger.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import { normalizeActivationKey } from "../../daemon/handlers/config-voice.js";
+import { httpError } from "../http-errors.js";
+import type { RouteDefinition } from "../http-router.js";
+import { resolveWorkspacePath } from "./workspace-utils.js";
+
+const log = getLogger("settings-routes");
+
+// ---------------------------------------------------------------------------
+// Voice config
+// ---------------------------------------------------------------------------
+
+function handleVoiceConfigUpdate(activationKey: string): Response {
+  const result = normalizeActivationKey(activationKey);
+  if (!result.ok) {
+    return httpError("BAD_REQUEST", result.reason, 400);
+  }
+  // The broadcast to IPC clients happens via the IPC handler. The HTTP
+  // route validates and returns the canonical value; the caller (client)
+  // applies the setting locally.
+  return Response.json({ ok: true, activationKey: result.value });
+}
+
+// ---------------------------------------------------------------------------
+// Avatar generation
+// ---------------------------------------------------------------------------
+
+async function handleGenerateAvatar(description: string): Promise<Response> {
+  if (!description.trim()) {
+    return httpError("BAD_REQUEST", "Description is required.", 400);
+  }
+
+  log.info({ description }, "Generating avatar via HTTP request");
+
+  try {
+    const result = await setAvatarTool.execute(
+      { description },
+      // Minimal tool context -- avatar generation needs no session context
+      {} as Parameters<typeof setAvatarTool.execute>[1],
+    );
+
+    if (result.isError) {
+      return httpError("INTERNAL_ERROR", result.content, 500);
+    }
+
+    const avatarPath = join(
+      getWorkspaceDir(),
+      "data",
+      "avatar",
+      "custom-avatar.png",
+    );
+    return Response.json({ ok: true, avatarPath });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ error: message }, "Avatar generation failed unexpectedly");
+    return httpError("INTERNAL_ERROR", message, 500);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Client settings update (generic)
+// ---------------------------------------------------------------------------
+
+function handleClientSettingsUpdate(key: string, value: string): Response {
+  // The HTTP route accepts key/value pairs for client settings.
+  // Validation is key-specific.
+  if (key === "activationKey") {
+    return handleVoiceConfigUpdate(value);
+  }
+  // For other keys, accept as-is
+  return Response.json({ ok: true, key, value });
+}
+
+// ---------------------------------------------------------------------------
+// OAuth connect
+// ---------------------------------------------------------------------------
+
+/** Map raw orchestrator/provider error messages to user-friendly strings. */
+function sanitizeOAuthError(message: string): string {
+  const lower = message.toLowerCase();
+  if (lower.includes("timed out")) {
+    return "OAuth authentication timed out. Please try again.";
+  }
+  if (lower.includes("user_cancelled") || lower.includes("cancelled")) {
+    return "OAuth authentication was cancelled.";
+  }
+  if (lower.includes("denied") || lower.includes("invalid_grant")) {
+    return "The authorization request was denied. Please try again.";
+  }
+  return "OAuth authentication failed. Please try again.";
+}
+
+/** Resolve client_secret from the keychain, checking canonical then alias service name. */
+function getClientSecret(
+  resolvedService: string,
+  rawService: string,
+): string | undefined {
+  return (
+    getSecureKey(`credential:${resolvedService}:client_secret`) ??
+    (resolvedService !== rawService
+      ? getSecureKey(`credential:${rawService}:client_secret`)
+      : undefined) ??
+    undefined
+  );
+}
+
+async function handleOAuthConnectStart(body: {
+  service?: string;
+  requestedScopes?: string[];
+}): Promise<Response> {
+  try {
+    assertMetadataWritable();
+  } catch {
+    return httpError(
+      "UNPROCESSABLE_ENTITY",
+      "Credential metadata file has an unrecognized version. Cannot store OAuth credentials.",
+      422,
+    );
+  }
+
+  if (!body.service) {
+    return httpError("BAD_REQUEST", "Missing required field: service", 400);
+  }
+
+  const resolvedService = resolveService(body.service);
+
+  let clientId = getSecureKey(`credential:${resolvedService}:client_id`);
+  if (!clientId && resolvedService !== body.service) {
+    clientId = getSecureKey(`credential:${body.service}:client_id`);
+  }
+
+  if (!clientId) {
+    return httpError(
+      "BAD_REQUEST",
+      `No client_id found for "${body.service}". Store it first via the credential vault.`,
+      400,
+    );
+  }
+
+  const clientSecret = getClientSecret(resolvedService, body.service);
+
+  const profile = getProviderProfile(resolvedService);
+  const requiresSecret =
+    profile?.setup?.requiresClientSecret ??
+    !!(profile?.tokenEndpointAuthMethod || profile?.extraParams);
+  if (requiresSecret && !clientSecret) {
+    return httpError(
+      "BAD_REQUEST",
+      `client_secret is required for "${body.service}" but not found in the keychain. Store it first via the credential vault.`,
+      400,
+    );
+  }
+
+  try {
+    // For HTTP, we cannot send `open_url` mid-request. The auth URL is
+    // returned to the client to open.
+    let authUrl: string | undefined;
+
+    const result = await orchestrateOAuthConnect({
+      service: body.service,
+      requestedScopes: body.requestedScopes,
+      clientId,
+      clientSecret,
+      isInteractive: true,
+      openUrl: (url: string) => {
+        authUrl = url;
+      },
+    });
+
+    if (!result.success) {
+      log.error(
+        { err: result.error, service: body.service },
+        "OAuth connect orchestrator returned error",
+      );
+      return httpError(
+        "INTERNAL_ERROR",
+        result.safeError ? result.error : sanitizeOAuthError(result.error),
+        500,
+      );
+    }
+
+    if (result.deferred) {
+      return Response.json({
+        ok: true,
+        deferred: true,
+        authUrl: result.authUrl,
+      });
+    }
+
+    return Response.json({
+      ok: true,
+      grantedScopes: result.grantedScopes,
+      accountInfo: result.accountInfo,
+      ...(authUrl ? { authUrl } : {}),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, service: body.service }, "OAuth connect flow failed");
+    return httpError("INTERNAL_ERROR", sanitizeOAuthError(message), 500);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Twitter auth
+// ---------------------------------------------------------------------------
+
+function sanitizeTwitterAuthError(message: string): string {
+  const lower = message.toLowerCase();
+  if (lower.includes("timed out")) {
+    return "Twitter authentication timed out. Please try again.";
+  }
+  if (lower.includes("user_cancelled") || lower.includes("cancelled")) {
+    return "Twitter authentication was cancelled.";
+  }
+  if (lower.includes("denied") || lower.includes("invalid_grant")) {
+    return "Twitter denied the authorization request. Please try again.";
+  }
+  return "Twitter authentication failed. Please try again.";
+}
+
+async function handleTwitterAuthStart(): Promise<Response> {
+  try {
+    assertMetadataWritable();
+  } catch {
+    return httpError(
+      "UNPROCESSABLE_ENTITY",
+      "Credential metadata file has an unrecognized version. Cannot store OAuth credentials.",
+      422,
+    );
+  }
+
+  try {
+    const raw = loadRawConfig();
+    const mode =
+      (getNestedValue(raw, "twitter.integrationMode") as string | undefined) ??
+      "local_byo";
+    if (mode !== "local_byo") {
+      return httpError(
+        "BAD_REQUEST",
+        'Twitter integration mode must be "local_byo" to use this flow.',
+        400,
+      );
+    }
+
+    const clientId = getSecureKey("credential:integration:twitter:client_id");
+    if (!clientId) {
+      return httpError(
+        "BAD_REQUEST",
+        "No Twitter client credentials configured. Please set up your Client ID first.",
+        400,
+      );
+    }
+
+    const clientSecret =
+      getSecureKey("credential:integration:twitter:client_secret") || undefined;
+
+    let config;
+    try {
+      config = loadConfig();
+    } catch (err) {
+      const detail = err instanceof ConfigError ? err.message : String(err);
+      return httpError(
+        "INTERNAL_ERROR",
+        `Unable to load config: ${detail}`,
+        500,
+      );
+    }
+
+    try {
+      getPublicBaseUrl(config);
+    } catch {
+      return httpError(
+        "BAD_REQUEST",
+        "Set ingress.publicBaseUrl (or INGRESS_PUBLIC_BASE_URL) so OAuth callbacks can route through /webhooks/oauth/callback on the gateway.",
+        400,
+      );
+    }
+
+    let authUrl: string | undefined;
+
+    const result = await orchestrateOAuthConnect({
+      service: "integration:twitter",
+      clientId,
+      clientSecret,
+      isInteractive: true,
+      openUrl: (url: string) => {
+        authUrl = url;
+      },
+      allowedTools: ["twitter_post"],
+    });
+
+    if (!result.success) {
+      log.error(
+        { err: result.error },
+        "Twitter OAuth orchestrator returned error",
+      );
+      return httpError(
+        "INTERNAL_ERROR",
+        result.safeError
+          ? result.error
+          : sanitizeTwitterAuthError(result.error),
+        500,
+      );
+    }
+
+    if (result.deferred) {
+      return Response.json({
+        ok: true,
+        deferred: true,
+        authUrl: result.authUrl,
+      });
+    }
+
+    // Persist accountInfo to config
+    if (result.accountInfo) {
+      try {
+        const raw2 = loadRawConfig();
+        setNestedValue(raw2, "twitter.accountInfo", result.accountInfo);
+        saveRawConfig(raw2);
+        invalidateConfigCache();
+      } catch {
+        // Non-fatal
+      }
+    }
+
+    return Response.json({
+      ok: true,
+      accountInfo: result.accountInfo,
+      ...(authUrl ? { authUrl } : {}),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Twitter OAuth flow failed");
+    return httpError(
+      "INTERNAL_ERROR",
+      sanitizeTwitterAuthError(message),
+      500,
+    );
+  }
+}
+
+function handleTwitterAuthStatus(): Response {
+  try {
+    const accessToken = getSecureKey(
+      "credential:integration:twitter:access_token",
+    );
+    const raw = loadRawConfig();
+    const mode =
+      (getNestedValue(raw, "twitter.integrationMode") as
+        | "local_byo"
+        | "managed"
+        | undefined) ?? "local_byo";
+    const accountInfo = getNestedValue(raw, "twitter.accountInfo") as
+      | string
+      | undefined;
+
+    return Response.json({
+      connected: !!accessToken,
+      accountInfo: accountInfo ?? undefined,
+      mode,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Failed to get Twitter auth status");
+    return httpError("INTERNAL_ERROR", message, 500);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Home base
+// ---------------------------------------------------------------------------
+
+function handleHomeBaseGet(ensureLinked: boolean): Response {
+  try {
+    if (ensureLinked !== false) {
+      bootstrapHomeBaseAppLink();
+    }
+
+    const appId = resolveHomeBaseAppId();
+    if (!appId) {
+      return Response.json({ homeBase: null });
+    }
+
+    const link = getHomeBaseAppLink();
+    const source = link?.source ?? "prebuilt_seed";
+
+    let preview: {
+      title: string;
+      subtitle: string;
+      description: string;
+      icon: string;
+      metrics: Array<{ label: string; value: string }>;
+    };
+
+    if (source === "personalized") {
+      const app = getApp(appId);
+      if (app) {
+        preview = {
+          title: app.name,
+          subtitle: "Dashboard",
+          description: app.description ?? "",
+          icon: app.icon ?? "",
+          metrics: [],
+        };
+      } else {
+        preview = getPrebuiltHomeBasePreview();
+      }
+    } else {
+      preview = getPrebuiltHomeBasePreview();
+    }
+
+    const tasks = getPrebuiltHomeBaseTaskPayload();
+
+    return Response.json({
+      homeBase: {
+        appId,
+        source,
+        starterTasks: tasks.starterTasks,
+        onboardingTasks: tasks.onboardingTasks,
+        preview,
+      },
+    });
+  } catch (err) {
+    log.error({ err }, "Failed to resolve home base metadata");
+    return Response.json({ homeBase: null });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Workspace files (IPC-style list/read)
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_FILES = ["IDENTITY.md", "SOUL.md", "USER.md", "skills/"];
+
+function handleWorkspaceFilesList(): Response {
+  const base = getWorkspaceDir();
+  const files = WORKSPACE_FILES.map((name) => ({
+    path: name,
+    name,
+    exists: pathExists(join(base, name)),
+  }));
+  return Response.json({ files });
+}
+
+function handleWorkspaceFileRead(requestedPath: string): Response {
+  const resolved = resolveWorkspacePath(requestedPath);
+  if (resolved === undefined) {
+    return httpError("BAD_REQUEST", "Invalid path", 400);
+  }
+
+  try {
+    if (!pathExists(resolved)) {
+      return httpError("NOT_FOUND", "File not found", 404);
+    }
+    const content = readFileSync(resolved, "utf-8");
+    return Response.json({ path: requestedPath, content });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err, path: requestedPath }, "Failed to read workspace file");
+    return httpError("INTERNAL_ERROR", message, 500);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tools
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up manifest metadata for a tool that isn't in the live registry.
+ */
+function resolveManifestOverride(
+  toolName: string,
+): ManifestOverride | undefined {
+  if (getTool(toolName)) return undefined;
+  try {
+    const catalog = loadSkillCatalog();
+    for (const skill of catalog) {
+      if (!skill.toolManifest?.present || !skill.toolManifest.valid) continue;
+      try {
+        const manifest = parseToolManifestFile(
+          join(skill.directoryPath, "TOOLS.json"),
+        );
+        const entry = manifest.tools.find((t) => t.name === toolName);
+        if (entry) {
+          return { risk: entry.risk, execution_target: entry.execution_target };
+        }
+      } catch {
+        // Skip unparseable manifests
+      }
+    }
+  } catch {
+    // Non-fatal
+  }
+  return undefined;
+}
+
+function handleToolNamesList(): Response {
+  const tools = getAllTools();
+  const nameSet = new Set(tools.map((t) => t.name));
+  const schemas: Record<
+    string,
+    {
+      type: string;
+      properties?: Record<string, unknown>;
+      required?: string[];
+    }
+  > = {};
+  for (const tool of tools) {
+    try {
+      const def = tool.getDefinition();
+      schemas[tool.name] = def.input_schema as (typeof schemas)[string];
+    } catch {
+      // Skip tools whose definitions can't be resolved
+    }
+  }
+
+  try {
+    const catalog = loadSkillCatalog();
+    for (const skill of catalog) {
+      if (!skill.toolManifest?.present || !skill.toolManifest.valid) continue;
+      try {
+        const manifest = parseToolManifestFile(
+          join(skill.directoryPath, "TOOLS.json"),
+        );
+        for (const entry of manifest.tools) {
+          if (nameSet.has(entry.name)) continue;
+          nameSet.add(entry.name);
+          schemas[entry.name] = entry.input_schema as unknown as (typeof schemas)[string];
+        }
+      } catch {
+        // Skip skills whose manifests can't be parsed
+      }
+    }
+  } catch {
+    // Non-fatal
+  }
+
+  const names = Array.from(nameSet).sort((a, b) => a.localeCompare(b));
+  return Response.json({ names, schemas });
+}
+
+async function handleToolPermissionSimulate(body: {
+  toolName?: string;
+  input?: Record<string, unknown>;
+  workingDir?: string;
+  forcePromptSideEffects?: boolean;
+  isInteractive?: boolean;
+}): Promise<Response> {
+  if (!body.toolName || typeof body.toolName !== "string") {
+    return httpError("BAD_REQUEST", "toolName is required", 400);
+  }
+  if (!body.input || typeof body.input !== "object") {
+    return httpError(
+      "BAD_REQUEST",
+      "input is required and must be an object",
+      400,
+    );
+  }
+
+  const workingDir = body.workingDir ?? process.cwd();
+
+  try {
+    const manifestOverride = resolveManifestOverride(body.toolName);
+    const executionTarget = resolveExecutionTarget(
+      body.toolName,
+      manifestOverride,
+    );
+    const policyContext = { executionTarget };
+
+    const riskLevel = await classifyRisk(
+      body.toolName,
+      body.input,
+      workingDir,
+      undefined,
+      manifestOverride,
+    );
+    const result = await check(
+      body.toolName,
+      body.input,
+      workingDir,
+      policyContext,
+      manifestOverride,
+    );
+
+    // Private-thread override
+    if (
+      body.forcePromptSideEffects &&
+      result.decision === "allow" &&
+      isSideEffectTool(body.toolName, body.input)
+    ) {
+      result.decision = "prompt";
+      result.reason =
+        "Private thread: side-effect tools require explicit approval";
+    }
+
+    // Non-interactive override
+    if (body.isInteractive === false && result.decision === "prompt") {
+      result.decision = "deny";
+      result.reason = "Non-interactive session: no client to approve prompt";
+    }
+
+    let promptPayload:
+      | {
+          allowlistOptions: Array<{
+            label: string;
+            description: string;
+            pattern: string;
+          }>;
+          scopeOptions: Array<{ label: string; scope: string }>;
+          persistentDecisionsAllowed: boolean;
+        }
+      | undefined;
+
+    if (result.decision === "prompt") {
+      const allowlistOptions = await generateAllowlistOptions(
+        body.toolName,
+        body.input,
+      );
+      const scopeOptions = generateScopeOptions(workingDir, body.toolName);
+      promptPayload = {
+        allowlistOptions,
+        scopeOptions,
+        persistentDecisionsAllowed: true,
+      };
+    }
+
+    return Response.json({
+      ok: true,
+      decision: result.decision,
+      riskLevel,
+      reason: result.reason,
+      executionTarget,
+      matchedRuleId: result.matchedRule?.id,
+      promptPayload,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error({ err }, "Failed to simulate tool permission");
+    return httpError("INTERNAL_ERROR", message, 500);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Environment variables
+// ---------------------------------------------------------------------------
+
+function handleEnvVars(): Response {
+  const vars: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) vars[key] = value;
+  }
+  return Response.json({ vars });
+}
+
+// ---------------------------------------------------------------------------
+// Route definitions
+// ---------------------------------------------------------------------------
+
+export function settingsRouteDefinitions(): RouteDefinition[] {
+  return [
+    // Voice config
+    {
+      endpoint: "settings/voice",
+      method: "PUT",
+      policyKey: "settings/voice",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as { activationKey?: string };
+        if (!body.activationKey) {
+          return httpError(
+            "BAD_REQUEST",
+            "activationKey is required",
+            400,
+          );
+        }
+        return handleVoiceConfigUpdate(body.activationKey);
+      },
+    },
+
+    // Avatar generation
+    {
+      endpoint: "settings/avatar/generate",
+      method: "POST",
+      policyKey: "settings/avatar/generate",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as { description?: string };
+        return handleGenerateAvatar(body.description ?? "");
+      },
+    },
+
+    // Client settings update
+    {
+      endpoint: "settings/client",
+      method: "PUT",
+      policyKey: "settings/client",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as { key?: string; value?: string };
+        if (!body.key || body.value === undefined) {
+          return httpError(
+            "BAD_REQUEST",
+            "key and value are required",
+            400,
+          );
+        }
+        return handleClientSettingsUpdate(body.key, body.value);
+      },
+    },
+
+    // OAuth connect
+    {
+      endpoint: "integrations/oauth/start",
+      method: "POST",
+      policyKey: "integrations/oauth/start",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as {
+          service?: string;
+          requestedScopes?: string[];
+        };
+        return handleOAuthConnectStart(body);
+      },
+    },
+
+    // Twitter auth
+    {
+      endpoint: "integrations/twitter/auth/start",
+      method: "POST",
+      policyKey: "integrations/twitter/auth/start",
+      handler: async () => handleTwitterAuthStart(),
+    },
+    {
+      endpoint: "integrations/twitter/auth/status",
+      method: "GET",
+      policyKey: "integrations/twitter/auth/status",
+      handler: () => handleTwitterAuthStatus(),
+    },
+
+    // Home base
+    {
+      endpoint: "home-base",
+      method: "GET",
+      policyKey: "home-base",
+      handler: ({ url }) => {
+        const ensureLinked = url.searchParams.get("ensureLinked") !== "false";
+        return handleHomeBaseGet(ensureLinked);
+      },
+    },
+
+    // Workspace files (IPC-style list/read -- distinct from workspace-routes.ts tree/file)
+    {
+      endpoint: "workspace-files",
+      method: "GET",
+      policyKey: "workspace-files",
+      handler: () => handleWorkspaceFilesList(),
+    },
+    {
+      endpoint: "workspace-files/read",
+      method: "GET",
+      policyKey: "workspace-files/read",
+      handler: ({ url }) => {
+        const filePath = url.searchParams.get("path") ?? "";
+        if (!filePath) {
+          return httpError("BAD_REQUEST", "path query parameter is required", 400);
+        }
+        return handleWorkspaceFileRead(filePath);
+      },
+    },
+
+    // Tool names list
+    {
+      endpoint: "tools",
+      method: "GET",
+      policyKey: "tools",
+      handler: () => handleToolNamesList(),
+    },
+
+    // Tool permission simulate
+    {
+      endpoint: "tools/simulate-permission",
+      method: "POST",
+      policyKey: "tools/simulate-permission",
+      handler: async ({ req }) => {
+        const body = (await req.json()) as {
+          toolName?: string;
+          input?: Record<string, unknown>;
+          workingDir?: string;
+          forcePromptSideEffects?: boolean;
+          isInteractive?: boolean;
+        };
+        return handleToolPermissionSimulate(body);
+      },
+    },
+
+    // Environment variables
+    {
+      endpoint: "diagnostics/env-vars",
+      method: "GET",
+      policyKey: "diagnostics/env-vars",
+      handler: () => handleEnvVars(),
+    },
+  ];
+}

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -17,6 +17,7 @@ interface SurfaceActionTarget {
     actionId: string,
     data?: Record<string, unknown>,
   ): void;
+  handleSurfaceUndo?(surfaceId: string): void;
 }
 
 export type SessionLookup = (
@@ -80,6 +81,59 @@ export async function handleSurfaceAction(
 // Route definitions
 // ---------------------------------------------------------------------------
 
+/**
+ * POST /v1/surfaces/:id/undo — undo the last surface action.
+ *
+ * Body: { sessionId }
+ */
+export async function handleSurfaceUndo(
+  req: Request,
+  surfaceId: string,
+  findSession: SessionLookup,
+): Promise<Response> {
+  const body = (await req.json()) as {
+    sessionId?: string;
+  };
+
+  const { sessionId } = body;
+
+  if (!sessionId || typeof sessionId !== "string") {
+    return httpError("BAD_REQUEST", "sessionId is required", 400);
+  }
+
+  const session = findSession(sessionId);
+  if (!session) {
+    return httpError(
+      "NOT_FOUND",
+      "No active session found for this sessionId",
+      404,
+    );
+  }
+
+  if (!session.handleSurfaceUndo) {
+    return httpError(
+      "NOT_IMPLEMENTED",
+      "Surface undo not supported for this session type",
+      501,
+    );
+  }
+
+  try {
+    session.handleSurfaceUndo(surfaceId);
+    log.info(
+      { sessionId, surfaceId },
+      "Surface undo handled via HTTP",
+    );
+    return Response.json({ ok: true });
+  } catch (err) {
+    log.error(
+      { err, sessionId, surfaceId },
+      "Failed to handle surface undo via HTTP",
+    );
+    return httpError("INTERNAL_ERROR", "Failed to handle surface undo", 500);
+  }
+}
+
 export function surfaceActionRouteDefinitions(deps: {
   findSession?: SessionLookup;
 }): RouteDefinition[] {
@@ -96,6 +150,20 @@ export function surfaceActionRouteDefinitions(deps: {
           );
         }
         return handleSurfaceAction(req, deps.findSession);
+      },
+    },
+    {
+      endpoint: "surfaces/:id/undo",
+      method: "POST",
+      handler: async ({ req, params }) => {
+        if (!deps.findSession) {
+          return httpError(
+            "NOT_IMPLEMENTED",
+            "Surface undo not available",
+            501,
+          );
+        }
+        return handleSurfaceUndo(req, params.id, deps.findSession);
       },
     },
   ];


### PR DESCRIPTION
## Summary
- Extract settings, identity, avatar, schedule, diagnostic, dictation, and miscellaneous logic from IPC handlers
- Create settings-routes.ts, schedule-routes.ts, and diagnostics-routes.ts with HTTP route definitions
- Add surface undo route to surface-action-routes.ts
- Skip no-op/stub handlers (integration_list, etc.) per plan instructions
- Register all routes in http-server.ts buildRouteTable() and add policies in route-policy.ts

Part of plan: phase-out-ipc.md (PR 7 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
