### PR TITLE
feat: migrate CLI from IPC socket client to HTTP transport

### DIFF
--- a/cli/src/lib/http-client.ts
+++ b/cli/src/lib/http-client.ts
@@ -1,0 +1,114 @@
+import { readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+import { DEFAULT_DAEMON_PORT } from "./constants.js";
+
+/**
+ * Resolve the HTTP port for the daemon runtime server.
+ * Uses RUNTIME_HTTP_PORT env var, or the default (7821).
+ */
+export function resolveDaemonPort(overridePort?: number): number {
+  if (overridePort !== undefined) return overridePort;
+  const envPort = process.env.RUNTIME_HTTP_PORT;
+  if (envPort) {
+    const parsed = parseInt(envPort, 10);
+    if (!isNaN(parsed)) return parsed;
+  }
+  return DEFAULT_DAEMON_PORT;
+}
+
+/**
+ * Build the base URL for the daemon HTTP server.
+ */
+export function buildDaemonUrl(port: number): string {
+  return `http://127.0.0.1:${port}`;
+}
+
+/**
+ * Read the HTTP bearer token from `<vellumDir>/http-token`.
+ * Respects BASE_DATA_DIR for named instances.
+ * Returns undefined if the token file doesn't exist or is empty.
+ */
+export function readHttpToken(instanceDir?: string): string | undefined {
+  const baseDataDir =
+    instanceDir ??
+    (process.env.BASE_DATA_DIR?.trim() || homedir());
+  const tokenPath = join(baseDataDir, ".vellum", "http-token");
+  try {
+    const token = readFileSync(tokenPath, "utf-8").trim();
+    return token || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Perform an HTTP health check against the daemon's `/healthz` endpoint.
+ * Returns true if the daemon responds with HTTP 200, false otherwise.
+ *
+ * This replaces the socket-based `isSocketResponsive()` check.
+ */
+export async function httpHealthCheck(
+  port: number,
+  timeoutMs = 1500,
+): Promise<boolean> {
+  try {
+    const url = `${buildDaemonUrl(port)}/healthz`;
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Poll the daemon's `/healthz` endpoint until it responds with 200 or the
+ * timeout is reached. This replaces `waitForSocketFile()`.
+ *
+ * Returns true if the daemon became healthy within the timeout, false otherwise.
+ */
+export async function waitForDaemonReady(
+  port: number,
+  timeoutMs = 60000,
+): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await httpHealthCheck(port)) {
+      return true;
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return false;
+}
+
+/**
+ * Make an authenticated HTTP request to the daemon.
+ *
+ * @param port - The daemon's HTTP port
+ * @param path - The request path (e.g. `/v1/sessions`)
+ * @param options - Fetch options (method, body, etc.)
+ * @param bearerToken - The bearer token for authentication
+ * @returns The fetch Response
+ */
+export async function httpSend(
+  port: number,
+  path: string,
+  options: RequestInit = {},
+  bearerToken?: string,
+): Promise<Response> {
+  const url = `${buildDaemonUrl(port)}${path}`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(options.headers as Record<string, string> | undefined),
+  };
+  if (bearerToken) {
+    headers["Authorization"] = `Bearer ${bearerToken}`;
+  }
+  return fetch(url, {
+    ...options,
+    headers,
+  });
+}

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -8,7 +8,6 @@ import {
   writeFileSync,
 } from "fs";
 import { createRequire } from "module";
-import { createConnection } from "net";
 import { homedir, hostname, networkInterfaces, platform } from "os";
 import { dirname, join } from "path";
 
@@ -17,6 +16,7 @@ import {
   type LocalInstanceResources,
 } from "./assistant-config.js";
 import { GATEWAY_PORT } from "./constants.js";
+import { httpHealthCheck, waitForDaemonReady } from "./http-client.js";
 import { stopProcessByPidFile } from "./process.js";
 import { openLogFile, pipeToLogFile } from "./xdg-log.js";
 
@@ -135,23 +135,6 @@ function resolveAssistantIndexPath(): string | undefined {
   return undefined;
 }
 
-async function waitForSocketFile(
-  socketPath: string,
-  timeoutMs = 60000,
-): Promise<boolean> {
-  if (existsSync(socketPath)) return true;
-
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    if (existsSync(socketPath)) {
-      return true;
-    }
-    await new Promise((r) => setTimeout(r, 100));
-  }
-
-  return existsSync(socketPath);
-}
-
 function ensureBunInstalled(): void {
   const bunBinDir = join(homedir(), ".bun", "bin");
   const pathWithBun = [
@@ -244,15 +227,15 @@ async function startDaemonFromSource(
     } catch {}
   }
 
-  if (await isSocketResponsive(socketFile)) {
-    const ownerPid = findSocketOwnerPid(socketFile);
+  // PID file was stale or missing — check if daemon is responding via HTTP
+  if (await isDaemonResponsive(resources.daemonPort)) {
+    const ownerPid = readPidFromFile(pidFile);
     if (ownerPid) {
-      writeFileSync(pidFile, String(ownerPid), "utf-8");
       console.log(
-        `   Assistant socket is responsive (pid ${ownerPid}) — skipping restart\n`,
+        `   Assistant is responsive (pid ${ownerPid}) — skipping restart\n`,
       );
     } else {
-      console.log("   Assistant socket is responsive — skipping restart\n");
+      console.log("   Assistant is responsive — skipping restart\n");
     }
     return;
   }
@@ -334,22 +317,20 @@ async function startDaemonWatchFromSource(
     } catch {}
   }
 
-  // PID file was stale or missing, but a daemon with a different PID may
-  // still be listening on the socket. Check before starting a new one.
-  if (await isSocketResponsive(socketFile)) {
-    const ownerPid = findSocketOwnerPid(socketFile);
+  // PID file was stale or missing — check if daemon is responding via HTTP
+  if (await isDaemonResponsive(resources.daemonPort)) {
+    const ownerPid = readPidFromFile(pidFile);
     if (ownerPid) {
-      writeFileSync(pidFile, String(ownerPid), "utf-8");
       console.log(
-        `   Assistant socket is responsive (pid ${ownerPid}) — skipping restart\n`,
+        `   Assistant is responsive (pid ${ownerPid}) — skipping restart\n`,
       );
     } else {
-      console.log("   Assistant socket is responsive — skipping restart\n");
+      console.log("   Assistant is responsive — skipping restart\n");
     }
     return;
   }
 
-  // Socket is unresponsive or missing — safe to clean up and start fresh.
+  // Daemon is unresponsive — safe to clean up and start fresh.
   try {
     unlinkSync(socketFile);
   } catch {}
@@ -452,56 +433,24 @@ function readWorkspaceIngressPublicBaseUrl(
   }
 }
 
-/** Use lsof to discover the PID of the process listening on a Unix socket.
- *  Returns the PID if found, undefined otherwise. */
-function findSocketOwnerPid(socketPath: string): number | undefined {
+/** Read the PID from a PID file. Returns the PID if the file exists and
+ *  contains a valid number, undefined otherwise. */
+function readPidFromFile(pidFile: string): number | undefined {
   try {
-    const output = execFileSync(
-      "lsof",
-      ["-U", "-a", "-F", "p", "--", socketPath],
-      {
-        encoding: "utf-8",
-        timeout: 3000,
-        stdio: ["ignore", "pipe", "ignore"],
-      },
-    );
-    // lsof -F p outputs lines like "p1234" — extract the first PID
-    const match = output.match(/^p(\d+)/m);
-    if (match) {
-      const pid = parseInt(match[1], 10);
-      if (!isNaN(pid)) return pid;
-    }
+    const raw = readFileSync(pidFile, "utf-8").trim();
+    const pid = parseInt(raw, 10);
+    return isNaN(pid) ? undefined : pid;
   } catch {
-    // lsof not available or failed — cannot recover PID
+    return undefined;
   }
-  return undefined;
 }
 
-/** Try a TCP connect to the Unix socket. Returns true if the handshake
- *  completes within the timeout — false on connection refused, timeout,
- *  or missing socket file. */
-function isSocketResponsive(
-  socketPath: string,
-  timeoutMs = 1500,
-): Promise<boolean> {
-  if (!existsSync(socketPath)) return Promise.resolve(false);
-  return new Promise((resolve) => {
-    const socket = createConnection(socketPath);
-    const timer = setTimeout(() => {
-      socket.destroy();
-      resolve(false);
-    }, timeoutMs);
-    socket.on("connect", () => {
-      clearTimeout(timer);
-      socket.destroy();
-      resolve(true);
-    });
-    socket.on("error", () => {
-      clearTimeout(timer);
-      socket.destroy();
-      resolve(false);
-    });
-  });
+/**
+ * Check if the daemon is responsive by hitting its HTTP `/healthz` endpoint.
+ * This replaces the socket-based `isSocketResponsive()` check.
+ */
+async function isDaemonResponsive(daemonPort: number): Promise<boolean> {
+  return httpHealthCheck(daemonPort);
 }
 
 export async function discoverPublicUrl(port?: number): Promise<string | undefined> {
@@ -678,19 +627,18 @@ export async function startLocalDaemon(
 
     if (!daemonAlive) {
       // The PID file was stale or missing, but a daemon with a different PID
-      // may still be listening on the socket (e.g. if the PID file was
-      // overwritten by a crashed restart attempt). Check before deleting.
-      if (await isSocketResponsive(socketFile)) {
+      // may still be listening on the HTTP port (e.g. if the PID file was
+      // overwritten by a crashed restart attempt). Check before starting a new one.
+      if (await isDaemonResponsive(resources.daemonPort)) {
         // Restore PID tracking so lifecycle commands (sleep, retire,
         // stopLocalProcesses) can manage this daemon process.
-        const ownerPid = findSocketOwnerPid(socketFile);
+        const ownerPid = readPidFromFile(pidFile);
         if (ownerPid) {
-          writeFileSync(pidFile, String(ownerPid), "utf-8");
           console.log(
-            `   Assistant socket is responsive (pid ${ownerPid}) — skipping restart\n`,
+            `   Assistant is responsive (pid ${ownerPid}) — skipping restart\n`,
           );
         } else {
-          console.log("   Assistant socket is responsive — skipping restart\n");
+          console.log("   Assistant is responsive — skipping restart\n");
         }
         // Ensure bun is available for runtime features (browser, skills install)
         // even when reusing an existing daemon.
@@ -698,7 +646,7 @@ export async function startLocalDaemon(
         return;
       }
 
-      // Socket is unresponsive or missing — safe to clean up and start fresh.
+      // Daemon is unresponsive — safe to clean up and start fresh.
       try {
         unlinkSync(socketFile);
       } catch {}
@@ -784,34 +732,34 @@ export async function startLocalDaemon(
       ensureBunInstalled();
     }
 
-    // Wait for socket at ~/.vellum/vellum.sock (up to 60s — fresh installs
+    // Wait for daemon to respond on HTTP (up to 60s — fresh installs
     // may need 30-60s for Qdrant download, migrations, and first-time init)
-    let socketReady = await waitForSocketFile(socketFile, 60000);
+    let daemonReady = await waitForDaemonReady(resources.daemonPort, 60000);
 
-    // Dev fallback: if the bundled daemon did not create a socket in time,
+    // Dev fallback: if the bundled daemon did not become ready in time,
     // fall back to source daemon startup so local `./build.sh run` still works.
-    if (!socketReady) {
+    if (!daemonReady) {
       const assistantIndex = resolveAssistantIndexPath();
       if (assistantIndex) {
         console.log(
-          "   Bundled assistant socket not ready after 60s — falling back to source assistant...",
+          "   Bundled assistant not ready after 60s — falling back to source assistant...",
         );
-        // Kill the bundled daemon to avoid two processes competing for the same socket/port
+        // Kill the bundled daemon to avoid two processes competing for the same port
         await stopProcessByPidFile(pidFile, "bundled daemon", [socketFile]);
         if (watch) {
           await startDaemonWatchFromSource(assistantIndex, resources);
         } else {
           await startDaemonFromSource(assistantIndex, resources);
         }
-        socketReady = await waitForSocketFile(socketFile, 60000);
+        daemonReady = await waitForDaemonReady(resources.daemonPort, 60000);
       }
     }
 
-    if (socketReady) {
-      console.log("   Assistant socket ready\n");
+    if (daemonReady) {
+      console.log("   Assistant ready\n");
     } else {
       console.log(
-        "   ⚠️  Assistant socket did not appear within 60s — continuing anyway\n",
+        "   ⚠️  Assistant did not become ready within 60s — continuing anyway\n",
       );
     }
   } else {
@@ -827,23 +775,23 @@ export async function startLocalDaemon(
     if (watch) {
       await startDaemonWatchFromSource(assistantIndex, resources);
 
-      const socketReady = await waitForSocketFile(resources.socketPath, 60000);
-      if (socketReady) {
-        console.log("   Assistant socket ready\n");
+      const daemonReady = await waitForDaemonReady(resources.daemonPort, 60000);
+      if (daemonReady) {
+        console.log("   Assistant ready\n");
       } else {
         console.log(
-          "   ⚠️  Assistant socket did not appear within 60s — continuing anyway\n",
+          "   ⚠️  Assistant did not become ready within 60s — continuing anyway\n",
         );
       }
     } else {
       await startDaemonFromSource(assistantIndex, resources);
 
-      const socketReady = await waitForSocketFile(resources.socketPath, 60000);
-      if (socketReady) {
-        console.log("   Assistant socket ready\n");
+      const daemonReady = await waitForDaemonReady(resources.daemonPort, 60000);
+      if (daemonReady) {
+        console.log("   Assistant ready\n");
       } else {
         console.log(
-          "   ⚠️  Assistant socket did not appear within 60s — continuing anyway\n",
+          "   ⚠️  Assistant did not become ready within 60s — continuing anyway\n",
         );
       }
     }


### PR DESCRIPTION
## Summary
- Create http-client.ts with HTTP-based client replacing socket-based sendOneMessage()
- Update local.ts to use HTTP health check polling instead of socket file waiting
- Migrate all CLI commands from ipc-client.ts to http-client.ts
- Mark ipc-client.ts as deprecated

Part of plan: phase-out-ipc.md (PR 12 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
