### PR TITLE
feat: add HTTP dispatch for apps, documents, work items, and subagents in HTTPDaemonClient

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient+Apps.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Apps.swift
@@ -1,0 +1,561 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "HTTPTransport")
+
+// MARK: - Apps Domain Dispatcher
+
+extension HTTPTransport {
+
+    func registerAppsRoutes() {
+        registerDomainDispatcher { [weak self] message in
+            guard let self else { return false }
+
+            if message is AppsListRequestMessage {
+                Task { await self.fetchAppsList() }
+                return true
+            } else if let msg = message as? AppDataRequestMessage {
+                Task { await self.fetchAppData(msg) }
+                return true
+            } else if let msg = message as? AppOpenRequestMessage {
+                Task { await self.handleAppOpen(appId: msg.appId) }
+                return true
+            } else if let msg = message as? AppDeleteRequestMessage {
+                Task { await self.handleAppDelete(appId: msg.appId) }
+                return true
+            } else if let msg = message as? AppPreviewRequestMessage {
+                Task { await self.fetchAppPreview(appId: msg.appId) }
+                return true
+            } else if let msg = message as? AppUpdatePreviewRequestMessage {
+                Task { await self.handleAppUpdatePreview(appId: msg.appId, preview: msg.preview) }
+                return true
+            } else if let msg = message as? BundleAppRequestMessage {
+                Task { await self.handleBundleApp(appId: msg.appId) }
+                return true
+            } else if let msg = message as? OpenBundleMessage {
+                Task { await self.handleOpenBundle(filePath: msg.filePath) }
+                return true
+            } else if let msg = message as? IPCAppHistoryRequest {
+                Task { await self.fetchAppHistory(appId: msg.appId, limit: msg.limit) }
+                return true
+            } else if let msg = message as? IPCAppDiffRequest {
+                Task { await self.fetchAppDiff(appId: msg.appId, fromCommit: msg.fromCommit, toCommit: msg.toCommit) }
+                return true
+            } else if let msg = message as? IPCAppRestoreRequest {
+                Task { await self.handleAppRestore(appId: msg.appId, commitHash: msg.commitHash) }
+                return true
+            } else if message is SharedAppsListRequestMessage {
+                Task { await self.fetchSharedAppsList() }
+                return true
+            } else if let msg = message as? SharedAppDeleteRequestMessage {
+                Task { await self.handleSharedAppDelete(uuid: msg.uuid) }
+                return true
+            } else if let msg = message as? ForkSharedAppRequestMessage {
+                Task { await self.handleForkSharedApp(uuid: msg.uuid) }
+                return true
+            } else if let msg = message as? ShareAppCloudRequestMessage {
+                Task { await self.handleShareAppCloud(appId: msg.appId) }
+                return true
+            }
+
+            return false
+        }
+    }
+
+    // MARK: - Apps HTTP Endpoints
+
+    private func fetchAppsList(isRetry: Bool = false) async {
+        guard let url = buildURL(for: .appsList) else { return }
+
+        var request = URLRequest(url: url)
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await fetchAppsList(isRetry: true) }
+                    return
+                }
+                guard http.statusCode == 200 else {
+                    log.error("Fetch apps list failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCAppsListResponse.self, from: data)
+            onMessage?(.appsListResponse(decoded))
+        } catch {
+            log.error("Fetch apps list error: \(error.localizedDescription)")
+        }
+    }
+
+    private func fetchAppData(_ msg: AppDataRequestMessage, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .appData(id: msg.appId)) else { return }
+
+        // For query methods use GET, for mutations use POST
+        let isQuery = msg.method == "query" || msg.method == "get"
+
+        var request: URLRequest
+        if isQuery {
+            // Build URL with query params
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            var queryItems = components?.queryItems ?? []
+            queryItems.append(URLQueryItem(name: "method", value: msg.method))
+            if let recordId = msg.recordId {
+                queryItems.append(URLQueryItem(name: "recordId", value: recordId))
+            }
+            components?.queryItems = queryItems
+            guard let queryURL = components?.url else { return }
+            request = URLRequest(url: queryURL)
+        } else {
+            request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+            var body: [String: Any] = ["method": msg.method]
+            if let recordId = msg.recordId {
+                body["recordId"] = recordId
+            }
+            if let dataDict = msg.data {
+                body["data"] = jsonCompatibleDictionary(dataDict)
+            }
+            request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        }
+
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await fetchAppData(msg, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("App data request failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCAppDataResponse.self, from: data)
+            onMessage?(.appDataResponse(decoded))
+        } catch {
+            log.error("App data request error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleAppOpen(appId: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .appOpen(id: appId)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleAppOpen(appId: appId, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("App open failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            // App open response is handled by the daemon via SSE events
+            log.info("App open request sent for \(appId)")
+        } catch {
+            log.error("App open error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleAppDelete(appId: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .appDelete(id: appId)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleAppDelete(appId: appId, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("App delete failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCAppDeleteResponse.self, from: data)
+            onMessage?(.appDeleteResponse(decoded))
+        } catch {
+            log.error("App delete error: \(error.localizedDescription)")
+        }
+    }
+
+    private func fetchAppPreview(appId: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .appPreview(id: appId)) else { return }
+
+        var request = URLRequest(url: url)
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await fetchAppPreview(appId: appId, isRetry: true) }
+                    return
+                }
+                guard http.statusCode == 200 else {
+                    log.error("Fetch app preview failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCAppPreviewResponse.self, from: data)
+            onMessage?(.appPreviewResponse(decoded))
+        } catch {
+            log.error("Fetch app preview error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleAppUpdatePreview(appId: String, preview: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .appPreview(id: appId)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        let body: [String: Any] = ["preview": preview]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleAppUpdatePreview(appId: appId, preview: preview, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("App update preview failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCAppUpdatePreviewResponse.self, from: data)
+            onMessage?(.appUpdatePreviewResponse(decoded))
+        } catch {
+            log.error("App update preview error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleBundleApp(appId: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .appBundle(id: appId)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleBundleApp(appId: appId, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("Bundle app failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCBundleAppResponse.self, from: data)
+            onMessage?(.bundleAppResponse(decoded))
+        } catch {
+            log.error("Bundle app error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleOpenBundle(filePath: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .appsOpenBundle) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        let body: [String: Any] = ["filePath": filePath]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleOpenBundle(filePath: filePath, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("Open bundle failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCOpenBundleResponse.self, from: data)
+            onMessage?(.openBundleResponse(decoded))
+        } catch {
+            log.error("Open bundle error: \(error.localizedDescription)")
+        }
+    }
+
+    private func fetchAppHistory(appId: String, limit: Double?, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .appHistory(id: appId)) else { return }
+
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        if let limit {
+            var queryItems = components?.queryItems ?? []
+            queryItems.append(URLQueryItem(name: "limit", value: "\(Int(limit))"))
+            components?.queryItems = queryItems
+        }
+        guard let finalURL = components?.url ?? url as URL? else { return }
+
+        var request = URLRequest(url: finalURL)
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await fetchAppHistory(appId: appId, limit: limit, isRetry: true) }
+                    return
+                }
+                guard http.statusCode == 200 else {
+                    log.error("Fetch app history failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCAppHistoryResponse.self, from: data)
+            onMessage?(.appHistoryResponse(decoded))
+        } catch {
+            log.error("Fetch app history error: \(error.localizedDescription)")
+        }
+    }
+
+    private func fetchAppDiff(appId: String, fromCommit: String, toCommit: String?, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .appDiff(id: appId)) else { return }
+
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        var queryItems = components?.queryItems ?? []
+        queryItems.append(URLQueryItem(name: "fromCommit", value: fromCommit))
+        if let toCommit {
+            queryItems.append(URLQueryItem(name: "toCommit", value: toCommit))
+        }
+        components?.queryItems = queryItems
+        guard let finalURL = components?.url else { return }
+
+        var request = URLRequest(url: finalURL)
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await fetchAppDiff(appId: appId, fromCommit: fromCommit, toCommit: toCommit, isRetry: true) }
+                    return
+                }
+                guard http.statusCode == 200 else {
+                    log.error("Fetch app diff failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCAppDiffResponse.self, from: data)
+            onMessage?(.appDiffResponse(decoded))
+        } catch {
+            log.error("Fetch app diff error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleAppRestore(appId: String, commitHash: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .appRestore(id: appId)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        let body: [String: Any] = ["commitHash": commitHash]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleAppRestore(appId: appId, commitHash: commitHash, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("App restore failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCAppRestoreResponse.self, from: data)
+            onMessage?(.appRestoreResponse(decoded))
+        } catch {
+            log.error("App restore error: \(error.localizedDescription)")
+        }
+    }
+
+    private func fetchSharedAppsList(isRetry: Bool = false) async {
+        guard let url = buildURL(for: .appsShared) else { return }
+
+        var request = URLRequest(url: url)
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await fetchSharedAppsList(isRetry: true) }
+                    return
+                }
+                guard http.statusCode == 200 else {
+                    log.error("Fetch shared apps list failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCSharedAppsListResponse.self, from: data)
+            onMessage?(.sharedAppsListResponse(decoded))
+        } catch {
+            log.error("Fetch shared apps list error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleSharedAppDelete(uuid: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .appsSharedDelete(uuid: uuid)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleSharedAppDelete(uuid: uuid, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("Shared app delete failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCSharedAppDeleteResponse.self, from: data)
+            onMessage?(.sharedAppDeleteResponse(decoded))
+        } catch {
+            log.error("Shared app delete error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleForkSharedApp(uuid: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .appsFork) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        let body: [String: Any] = ["uuid": uuid]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleForkSharedApp(uuid: uuid, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("Fork shared app failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(ForkSharedAppResponseMessage.self, from: data)
+            onMessage?(.forkSharedAppResponse(decoded))
+        } catch {
+            log.error("Fork shared app error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleShareAppCloud(appId: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .appsShareCloud(id: appId)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleShareAppCloud(appId: appId, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("Share app cloud failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCShareAppCloudResponse.self, from: data)
+            onMessage?(.shareAppCloudResponse(decoded))
+        } catch {
+            log.error("Share app cloud error: \(error.localizedDescription)")
+        }
+    }
+}

--- a/clients/shared/IPC/HTTPDaemonClient+Documents.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Documents.swift
@@ -1,0 +1,157 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "HTTPTransport")
+
+// MARK: - Documents Domain Dispatcher
+
+extension HTTPTransport {
+
+    func registerDocumentsRoutes() {
+        registerDomainDispatcher { [weak self] message in
+            guard let self else { return false }
+
+            if let msg = message as? DocumentListRequestMessage {
+                Task { await self.fetchDocumentList(conversationId: msg.conversationId) }
+                return true
+            } else if let msg = message as? DocumentLoadRequestMessage {
+                Task { await self.fetchDocumentLoad(surfaceId: msg.surfaceId) }
+                return true
+            } else if let msg = message as? DocumentSaveRequestMessage {
+                Task {
+                    await self.handleDocumentSave(
+                        surfaceId: msg.surfaceId,
+                        conversationId: msg.conversationId,
+                        title: msg.title,
+                        content: msg.content,
+                        wordCount: msg.wordCount
+                    )
+                }
+                return true
+            }
+
+            return false
+        }
+    }
+
+    // MARK: - Documents HTTP Endpoints
+
+    private func fetchDocumentList(conversationId: String?, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .documentsList) else { return }
+
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        if let conversationId {
+            var queryItems = components?.queryItems ?? []
+            queryItems.append(URLQueryItem(name: "conversationId", value: conversationId))
+            components?.queryItems = queryItems
+        }
+        guard let finalURL = components?.url ?? url as URL? else { return }
+
+        var request = URLRequest(url: finalURL)
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await fetchDocumentList(conversationId: conversationId, isRetry: true) }
+                    return
+                }
+                guard http.statusCode == 200 else {
+                    log.error("Fetch document list failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCDocumentListResponse.self, from: data)
+            onMessage?(.documentListResponse(decoded))
+        } catch {
+            log.error("Fetch document list error: \(error.localizedDescription)")
+        }
+    }
+
+    private func fetchDocumentLoad(surfaceId: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .documentLoad(id: surfaceId)) else { return }
+
+        var request = URLRequest(url: url)
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await fetchDocumentLoad(surfaceId: surfaceId, isRetry: true) }
+                    return
+                }
+                guard http.statusCode == 200 else {
+                    log.error("Fetch document load failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCDocumentLoadResponse.self, from: data)
+            onMessage?(.documentLoadResponse(decoded))
+        } catch {
+            log.error("Fetch document load error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleDocumentSave(
+        surfaceId: String,
+        conversationId: String,
+        title: String,
+        content: String,
+        wordCount: Int,
+        isRetry: Bool = false
+    ) async {
+        guard let url = buildURL(for: .documentSave) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        let body: [String: Any] = [
+            "surfaceId": surfaceId,
+            "conversationId": conversationId,
+            "title": title,
+            "content": content,
+            "wordCount": wordCount,
+        ]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result {
+                        await handleDocumentSave(
+                            surfaceId: surfaceId,
+                            conversationId: conversationId,
+                            title: title,
+                            content: content,
+                            wordCount: wordCount,
+                            isRetry: true
+                        )
+                    }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("Document save failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCDocumentSaveResponse.self, from: data)
+            onMessage?(.documentSaveResponse(decoded))
+        } catch {
+            log.error("Document save error: \(error.localizedDescription)")
+        }
+    }
+}

--- a/clients/shared/IPC/HTTPDaemonClient+Subagents.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Subagents.swift
@@ -1,0 +1,135 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "HTTPTransport")
+
+// MARK: - Subagents Domain Dispatcher
+
+extension HTTPTransport {
+
+    func registerSubagentsRoutes() {
+        registerDomainDispatcher { [weak self] message in
+            guard let self else { return false }
+
+            if let msg = message as? SubagentDetailRequestMessage {
+                Task { await self.fetchSubagentDetail(subagentId: msg.subagentId, conversationId: msg.conversationId) }
+                return true
+            } else if let msg = message as? SubagentAbortMessage {
+                Task { await self.handleSubagentAbort(subagentId: msg.subagentId) }
+                return true
+            } else if let msg = message as? IPCSubagentMessageRequest {
+                Task { await self.handleSubagentMessage(subagentId: msg.subagentId, content: msg.content) }
+                return true
+            }
+
+            return false
+        }
+    }
+
+    // MARK: - Subagents HTTP Endpoints
+
+    private func fetchSubagentDetail(subagentId: String, conversationId: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .subagentDetail(id: subagentId)) else { return }
+
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        var queryItems = components?.queryItems ?? []
+        queryItems.append(URLQueryItem(name: "conversationId", value: conversationId))
+        components?.queryItems = queryItems
+        guard let finalURL = components?.url else { return }
+
+        var request = URLRequest(url: finalURL)
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await fetchSubagentDetail(subagentId: subagentId, conversationId: conversationId, isRetry: true) }
+                    return
+                }
+                guard http.statusCode == 200 else {
+                    log.error("Fetch subagent detail failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCSubagentDetailResponse.self, from: data)
+            onMessage?(.subagentDetailResponse(decoded))
+        } catch {
+            log.error("Fetch subagent detail error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleSubagentAbort(subagentId: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .subagentAbort(id: subagentId)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        // The abort endpoint requires a sessionId in the body
+        var body: [String: Any] = [:]
+        if let sessionId = activeLocalSessionId {
+            body["sessionId"] = sessionId
+        }
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleSubagentAbort(subagentId: subagentId, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("Subagent abort failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            log.info("Subagent abort request sent for \(subagentId)")
+        } catch {
+            log.error("Subagent abort error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleSubagentMessage(subagentId: String, content: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .subagentMessage(id: subagentId)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        var body: [String: Any] = ["content": content]
+        if let sessionId = activeLocalSessionId {
+            body["sessionId"] = sessionId
+        }
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleSubagentMessage(subagentId: subagentId, content: content, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("Subagent message failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            log.info("Subagent message sent for \(subagentId)")
+        } catch {
+            log.error("Subagent message error: \(error.localizedDescription)")
+        }
+    }
+}

--- a/clients/shared/IPC/HTTPDaemonClient+WorkItems.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+WorkItems.swift
@@ -1,0 +1,385 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "HTTPTransport")
+
+// MARK: - Work Items Domain Dispatcher
+
+extension HTTPTransport {
+
+    func registerWorkItemsRoutes() {
+        registerDomainDispatcher { [weak self] message in
+            guard let self else { return false }
+
+            if let msg = message as? IPCWorkItemsListRequest {
+                Task { await self.fetchWorkItemsList(status: msg.status) }
+                return true
+            } else if let msg = message as? IPCWorkItemCompleteRequest {
+                Task { await self.handleWorkItemComplete(id: msg.id) }
+                return true
+            } else if let msg = message as? IPCWorkItemDeleteRequest {
+                Task { await self.handleWorkItemDelete(id: msg.id) }
+                return true
+            } else if let msg = message as? IPCWorkItemRunTaskRequest {
+                Task { await self.handleWorkItemRunTask(id: msg.id) }
+                return true
+            } else if let msg = message as? IPCWorkItemOutputRequest {
+                Task { await self.fetchWorkItemOutput(id: msg.id) }
+                return true
+            } else if let msg = message as? IPCWorkItemUpdateRequest {
+                Task {
+                    await self.handleWorkItemUpdate(
+                        id: msg.id,
+                        title: msg.title,
+                        notes: msg.notes,
+                        status: msg.status,
+                        priorityTier: msg.priorityTier,
+                        sortIndex: msg.sortIndex
+                    )
+                }
+                return true
+            } else if let msg = message as? IPCWorkItemPreflightRequest {
+                Task { await self.handleWorkItemPreflight(id: msg.id) }
+                return true
+            } else if let msg = message as? IPCWorkItemApprovePermissionsRequest {
+                Task { await self.handleWorkItemApprovePermissions(id: msg.id, approvedTools: msg.approvedTools) }
+                return true
+            } else if let msg = message as? IPCWorkItemCancelRequest {
+                Task { await self.handleWorkItemCancel(id: msg.id) }
+                return true
+            }
+
+            return false
+        }
+    }
+
+    // MARK: - Work Items HTTP Endpoints
+
+    private func fetchWorkItemsList(status: String?, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .workItemsList) else { return }
+
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        if let status {
+            var queryItems = components?.queryItems ?? []
+            queryItems.append(URLQueryItem(name: "status", value: status))
+            components?.queryItems = queryItems
+        }
+        guard let finalURL = components?.url ?? url as URL? else { return }
+
+        var request = URLRequest(url: finalURL)
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await fetchWorkItemsList(status: status, isRetry: true) }
+                    return
+                }
+                guard http.statusCode == 200 else {
+                    log.error("Fetch work items list failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCWorkItemsListResponse.self, from: data)
+            onMessage?(.workItemsListResponse(decoded))
+        } catch {
+            log.error("Fetch work items list error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleWorkItemComplete(id: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .workItemComplete(id: id)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleWorkItemComplete(id: id, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("Work item complete failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            // The complete endpoint returns the updated item; emit a status changed event
+            log.info("Work item complete request sent for \(id)")
+        } catch {
+            log.error("Work item complete error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleWorkItemDelete(id: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .workItemDelete(id: id)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleWorkItemDelete(id: id, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("Work item delete failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCWorkItemDeleteResponse.self, from: data)
+            onMessage?(.workItemDeleteResponse(decoded))
+        } catch {
+            log.error("Work item delete error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleWorkItemRunTask(id: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .workItemRun(id: id)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleWorkItemRunTask(id: id, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    let errorBody = String(data: data, encoding: .utf8) ?? "unknown"
+                    log.error("Work item run task failed (\(http.statusCode)): \(errorBody)")
+                    // Decode error to emit a response with error info
+                    let errorMsg = (try? JSONDecoder().decode(HTTPErrorEnvelopeLocal.self, from: data))?.error.message ?? "HTTP \(http.statusCode)"
+                    onMessage?(.workItemRunTaskResponse(IPCWorkItemRunTaskResponse(
+                        type: "work_item_run_task_response",
+                        id: id,
+                        lastRunId: "",
+                        success: false,
+                        error: errorMsg,
+                        errorCode: http.statusCode == 403 ? "permissions_required" : nil
+                    )))
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCWorkItemRunTaskResponse.self, from: data)
+            onMessage?(.workItemRunTaskResponse(decoded))
+        } catch {
+            log.error("Work item run task error: \(error.localizedDescription)")
+            onMessage?(.workItemRunTaskResponse(IPCWorkItemRunTaskResponse(
+                type: "work_item_run_task_response",
+                id: id,
+                lastRunId: "",
+                success: false,
+                error: error.localizedDescription
+            )))
+        }
+    }
+
+    private func fetchWorkItemOutput(id: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .workItemOutput(id: id)) else { return }
+
+        var request = URLRequest(url: url)
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await fetchWorkItemOutput(id: id, isRetry: true) }
+                    return
+                }
+                guard http.statusCode == 200 else {
+                    log.error("Fetch work item output failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCWorkItemOutputResponse.self, from: data)
+            onMessage?(.workItemOutputResponse(decoded))
+        } catch {
+            log.error("Fetch work item output error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleWorkItemUpdate(
+        id: String,
+        title: String?,
+        notes: String?,
+        status: String?,
+        priorityTier: Double?,
+        sortIndex: Int?,
+        isRetry: Bool = false
+    ) async {
+        guard let url = buildURL(for: .workItemUpdate(id: id)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PATCH"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        var body: [String: Any] = [:]
+        if let title { body["title"] = title }
+        if let notes { body["notes"] = notes }
+        if let status { body["status"] = status }
+        if let priorityTier { body["priorityTier"] = priorityTier }
+        if let sortIndex { body["sortIndex"] = sortIndex }
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result {
+                        await handleWorkItemUpdate(
+                            id: id,
+                            title: title,
+                            notes: notes,
+                            status: status,
+                            priorityTier: priorityTier,
+                            sortIndex: sortIndex,
+                            isRetry: true
+                        )
+                    }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("Work item update failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCWorkItemUpdateResponse.self, from: data)
+            onMessage?(.workItemUpdateResponse(decoded))
+        } catch {
+            log.error("Work item update error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleWorkItemPreflight(id: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .workItemPreflight(id: id)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleWorkItemPreflight(id: id, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("Work item preflight failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCWorkItemPreflightResponse.self, from: data)
+            onMessage?(.workItemPreflightResponse(decoded))
+        } catch {
+            log.error("Work item preflight error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleWorkItemApprovePermissions(id: String, approvedTools: [String], isRetry: Bool = false) async {
+        guard let url = buildURL(for: .workItemApprovePermissions(id: id)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        let body: [String: Any] = ["approvedTools": approvedTools]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleWorkItemApprovePermissions(id: id, approvedTools: approvedTools, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("Work item approve permissions failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCWorkItemApprovePermissionsResponse.self, from: data)
+            onMessage?(.workItemApprovePermissionsResponse(decoded))
+        } catch {
+            log.error("Work item approve permissions error: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleWorkItemCancel(id: String, isRetry: Bool = false) async {
+        guard let url = buildURL(for: .workItemCancel(id: id)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 && !isRetry {
+                    let result = await handleAuthenticationFailureAsync(responseData: data)
+                    if case .success = result { await handleWorkItemCancel(id: id, isRetry: true) }
+                    return
+                }
+                guard (200..<300).contains(http.statusCode) else {
+                    log.error("Work item cancel failed (\(http.statusCode))")
+                    return
+                }
+            }
+
+            let decoded = try decoder.decode(IPCWorkItemCancelResponse.self, from: data)
+            onMessage?(.workItemCancelResponse(decoded))
+        } catch {
+            log.error("Work item cancel error: \(error.localizedDescription)")
+        }
+    }
+}
+
+/// Local error envelope for decoding HTTP error responses in work items dispatch.
+private struct HTTPErrorEnvelopeLocal: Decodable {
+    struct ErrorBody: Decodable {
+        let message: String
+    }
+    let error: ErrorBody
+}

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -171,8 +171,8 @@ public final class HTTPTransport {
     /// All occurrences are remapped to `activeLocalSessionId` in incoming events.
     var remoteSessionId: String?
 
-    private let decoder = JSONDecoder()
-    private let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    let encoder = JSONEncoder()
 
     /// Registered domain dispatchers. Each handler receives the message as `Any`
     /// and returns `true` if it handled the message, `false` otherwise.
@@ -199,6 +199,10 @@ public final class HTTPTransport {
 
         // Register dispatchers for existing HTTP-transported message types
         registerExistingRoutes()
+        registerAppsRoutes()
+        registerDocumentsRoutes()
+        registerWorkItemsRoutes()
+        registerSubagentsRoutes()
     }
 
     // MARK: - Endpoint Builder
@@ -253,11 +257,49 @@ public final class HTTPTransport {
         case workspaceMkdir
         case workspaceRename
         case workspaceDelete
+        // Apps
+        case appsList
+        case appData(id: String)
+        case appOpen(id: String)
+        case appDelete(id: String)
+        case appPreview(id: String)
+        case appHistory(id: String)
+        case appDiff(id: String)
+        case appRestore(id: String)
+        case appBundle(id: String)
+        case appsOpenBundle
+        case appsShared
+        case appsSharedDelete(uuid: String)
+        case appsFork
+        case appsShareCloud(id: String)
+        case appsGallery
+        case appsGalleryInstall
+        case appsSignBundle
+        case appsSigningIdentity
+        // Documents
+        case documentsList
+        case documentLoad(id: String)
+        case documentSave
+        // Work Items
+        case workItemsList
+        case workItemGet(id: String)
+        case workItemUpdate(id: String)
+        case workItemComplete(id: String)
+        case workItemDelete(id: String)
+        case workItemCancel(id: String)
+        case workItemApprovePermissions(id: String)
+        case workItemPreflight(id: String)
+        case workItemRun(id: String)
+        case workItemOutput(id: String)
+        // Subagents
+        case subagentDetail(id: String)
+        case subagentAbort(id: String)
+        case subagentMessage(id: String)
     }
 
     /// Build a URL for the given endpoint using the current route mode.
     /// Returns nil if the URL string is malformed.
-    private func buildURL(for endpoint: Endpoint) -> URL? {
+    func buildURL(for endpoint: Endpoint) -> URL? {
         let path: String
         let query: String?
 
@@ -380,6 +422,101 @@ public final class HTTPTransport {
             return ("/v1/workspace/rename", nil)
         case .workspaceDelete:
             return ("/v1/workspace/delete", nil)
+        // Apps
+        case .appsList:
+            return ("/v1/apps", nil)
+        case .appData(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/apps/\(encoded)/data", nil)
+        case .appOpen(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/apps/\(encoded)/open", nil)
+        case .appDelete(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/apps/\(encoded)/delete", nil)
+        case .appPreview(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/apps/\(encoded)/preview", nil)
+        case .appHistory(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/apps/\(encoded)/history", nil)
+        case .appDiff(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/apps/\(encoded)/diff", nil)
+        case .appRestore(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/apps/\(encoded)/restore", nil)
+        case .appBundle(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/apps/\(encoded)/bundle", nil)
+        case .appsOpenBundle:
+            return ("/v1/apps/open-bundle", nil)
+        case .appsShared:
+            return ("/v1/apps/shared", nil)
+        case .appsSharedDelete(let uuid):
+            let encoded = uuid.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? uuid
+            return ("/v1/apps/shared/\(encoded)", nil)
+        case .appsFork:
+            return ("/v1/apps/fork", nil)
+        case .appsShareCloud(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/apps/\(encoded)/share-cloud", nil)
+        case .appsGallery:
+            return ("/v1/apps/gallery", nil)
+        case .appsGalleryInstall:
+            return ("/v1/apps/gallery/install", nil)
+        case .appsSignBundle:
+            return ("/v1/apps/sign-bundle", nil)
+        case .appsSigningIdentity:
+            return ("/v1/apps/signing-identity", nil)
+        // Documents
+        case .documentsList:
+            return ("/v1/documents", nil)
+        case .documentLoad(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/documents/\(encoded)", nil)
+        case .documentSave:
+            return ("/v1/documents", nil)
+        // Work Items
+        case .workItemsList:
+            return ("/v1/work-items", nil)
+        case .workItemGet(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/work-items/\(encoded)", nil)
+        case .workItemUpdate(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/work-items/\(encoded)", nil)
+        case .workItemComplete(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/work-items/\(encoded)/complete", nil)
+        case .workItemDelete(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/work-items/\(encoded)", nil)
+        case .workItemCancel(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/work-items/\(encoded)/cancel", nil)
+        case .workItemApprovePermissions(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/work-items/\(encoded)/approve-permissions", nil)
+        case .workItemPreflight(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/work-items/\(encoded)/preflight", nil)
+        case .workItemRun(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/work-items/\(encoded)/run", nil)
+        case .workItemOutput(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/work-items/\(encoded)/output", nil)
+        // Subagents
+        case .subagentDetail(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/subagents/\(encoded)", nil)
+        case .subagentAbort(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/subagents/\(encoded)/abort", nil)
+        case .subagentMessage(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/subagents/\(encoded)/message", nil)
         }
     }
 
@@ -488,6 +625,101 @@ public final class HTTPTransport {
             return ("\(prefix)/workspace/rename/", nil)
         case .workspaceDelete:
             return ("\(prefix)/workspace/delete/", nil)
+        // Apps
+        case .appsList:
+            return ("\(prefix)/apps/", nil)
+        case .appData(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/apps/\(encoded)/data/", nil)
+        case .appOpen(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/apps/\(encoded)/open/", nil)
+        case .appDelete(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/apps/\(encoded)/delete/", nil)
+        case .appPreview(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/apps/\(encoded)/preview/", nil)
+        case .appHistory(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/apps/\(encoded)/history/", nil)
+        case .appDiff(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/apps/\(encoded)/diff/", nil)
+        case .appRestore(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/apps/\(encoded)/restore/", nil)
+        case .appBundle(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/apps/\(encoded)/bundle/", nil)
+        case .appsOpenBundle:
+            return ("\(prefix)/apps/open-bundle/", nil)
+        case .appsShared:
+            return ("\(prefix)/apps/shared/", nil)
+        case .appsSharedDelete(let uuid):
+            let encoded = uuid.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? uuid
+            return ("\(prefix)/apps/shared/\(encoded)/", nil)
+        case .appsFork:
+            return ("\(prefix)/apps/fork/", nil)
+        case .appsShareCloud(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/apps/\(encoded)/share-cloud/", nil)
+        case .appsGallery:
+            return ("\(prefix)/apps/gallery/", nil)
+        case .appsGalleryInstall:
+            return ("\(prefix)/apps/gallery/install/", nil)
+        case .appsSignBundle:
+            return ("\(prefix)/apps/sign-bundle/", nil)
+        case .appsSigningIdentity:
+            return ("\(prefix)/apps/signing-identity/", nil)
+        // Documents
+        case .documentsList:
+            return ("\(prefix)/documents/", nil)
+        case .documentLoad(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/documents/\(encoded)/", nil)
+        case .documentSave:
+            return ("\(prefix)/documents/", nil)
+        // Work Items
+        case .workItemsList:
+            return ("\(prefix)/work-items/", nil)
+        case .workItemGet(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/work-items/\(encoded)/", nil)
+        case .workItemUpdate(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/work-items/\(encoded)/", nil)
+        case .workItemComplete(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/work-items/\(encoded)/complete/", nil)
+        case .workItemDelete(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/work-items/\(encoded)/", nil)
+        case .workItemCancel(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/work-items/\(encoded)/cancel/", nil)
+        case .workItemApprovePermissions(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/work-items/\(encoded)/approve-permissions/", nil)
+        case .workItemPreflight(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/work-items/\(encoded)/preflight/", nil)
+        case .workItemRun(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/work-items/\(encoded)/run/", nil)
+        case .workItemOutput(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/work-items/\(encoded)/output/", nil)
+        // Subagents
+        case .subagentDetail(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/subagents/\(encoded)/", nil)
+        case .subagentAbort(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/subagents/\(encoded)/abort/", nil)
+        case .subagentMessage(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/subagents/\(encoded)/message/", nil)
         }
     }
 
@@ -1010,7 +1242,7 @@ public final class HTTPTransport {
 
     /// JSONSerialization cannot encode AnyCodable wrappers directly, so unwrap
     /// them before inserting arbitrary payloads into request bodies.
-    private func jsonCompatibleDictionary(_ values: [String: AnyCodable]) -> [String: Any] {
+    func jsonCompatibleDictionary(_ values: [String: AnyCodable]) -> [String: Any] {
         var jsonCompatible: [String: Any] = [:]
         for (key, value) in values {
             jsonCompatible[key] = value.value
@@ -2364,7 +2596,7 @@ public final class HTTPTransport {
     /// skip refresh and force re-pairing. All other 401 codes — including
     /// `refresh_required`, `UNAUTHORIZED` (expired JWT), and unknown codes —
     /// are treated as refreshable.
-    private func handleAuthenticationFailureAsync(responseData: Data? = nil) async -> AuthRefreshResult {
+    func handleAuthenticationFailureAsync(responseData: Data? = nil) async -> AuthRefreshResult {
         // Managed mode: no bearer refresh — emit session-expired, disconnect to
         // stop loops, and return terminal so callers don't retry.
         if isManagedMode {
@@ -2490,7 +2722,7 @@ public final class HTTPTransport {
 
     // MARK: - Helpers
 
-    private func applyAuth(_ request: inout URLRequest) {
+    func applyAuth(_ request: inout URLRequest) {
         switch transportMetadata.authMode {
         case .bearerToken:
             // The JWT access token is the sole auth credential — it serves as


### PR DESCRIPTION
## Summary
- Add HTTPDaemonClient+Apps.swift with dispatcher for all app message types (list, data, open, delete, preview, update preview, bundle, open bundle, history, diff, restore, shared apps, fork, share cloud)
- Add HTTPDaemonClient+Documents.swift for document operations (list, load, save)
- Add HTTPDaemonClient+WorkItems.swift for all work item operations (list, complete, delete, run, output, update, preflight, approve permissions, cancel)
- Add HTTPDaemonClient+Subagents.swift for subagent detail/abort/message
- Register all dispatchers in HTTPTransport init
- Widen access on buildURL, applyAuth, handleAuthenticationFailureAsync, decoder/encoder, and jsonCompatibleDictionary from private to internal for cross-file extension access

Part of plan: phase-out-ipc.md (PR 10 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
