### PR TITLE
feat: add HTTP dispatch for computer use, recordings, settings, and all remaining message types

### DIFF
--- a/clients/ios/Views/Settings/IntegrationsSection.swift
+++ b/clients/ios/Views/Settings/IntegrationsSection.swift
@@ -56,12 +56,7 @@ struct IntegrationsSection: View {
         .onChange(of: clientProvider.isConnected) { _, connected in
             if connected { loadIntegrations() }
         }
-        .onDisappear {
-            if let daemon = clientProvider.client as? DaemonClient {
-                daemon.onIntegrationListResponse = nil
-                daemon.onIntegrationConnectResult = nil
-            }
-        }
+        .onDisappear {}
     }
 
     private func integrationIcon(_ id: String) -> String {
@@ -78,36 +73,9 @@ struct IntegrationsSection: View {
         }
     }
 
-    private func loadIntegrations() {
-        guard let daemon = clientProvider.client as? DaemonClient else { return }
-        daemon.onIntegrationListResponse = { response in
-            integrations = response.integrations
-        }
-        try? daemon.sendIntegrationList()
-    }
-
-    private func connectIntegration(_ id: String) {
-        guard let daemon = clientProvider.client as? DaemonClient else { return }
-        connectingIntegrationId = id
-        daemon.onIntegrationConnectResult = { result in
-            connectingIntegrationId = nil
-            if result.success {
-                loadIntegrations()
-            }
-        }
-        do {
-            try daemon.sendIntegrationConnect(integrationId: id)
-        } catch {
-            connectingIntegrationId = nil
-        }
-    }
-
-    private func disconnectIntegration(_ id: String) {
-        guard let daemon = clientProvider.client as? DaemonClient else { return }
-        try? daemon.sendIntegrationDisconnect(integrationId: id)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            loadIntegrations()
-        }
-    }
+    // Integration registry was removed server-side; these are no-ops.
+    private func loadIntegrations() {}
+    private func connectIntegration(_ id: String) {}
+    private func disconnectIntegration(_ id: String) {}
 }
 #endif

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/SettingsPanel.swift
@@ -83,11 +83,6 @@ struct SettingsPanel: View {
     @State private var showingHeartbeatRuns = false
     @State private var twitterClientId: String = ""
     @State private var twitterClientSecret: String = ""
-    @State private var integrations: [IPCIntegrationListResponseIntegration] = []
-    @State private var connectingIntegration: String?
-    @State private var integrationError: (id: String, message: String)?
-    /// Tracks integrations that need setup (e.g. missing Google Cloud client ID).
-    @State private var setupRequired: (id: String, skillId: String, hint: String)?
     @State private var accessibilityGranted: Bool = false
     @State private var screenRecordingGranted: Bool = false
     @State private var microphoneGranted: Bool = false
@@ -156,8 +151,6 @@ struct SettingsPanel: View {
             store.refreshTelegramStatus()
             store.refreshTwilioStatus()
             store.refreshIngressConfig()
-            setupIntegrationCallbacks()
-            try? daemonClient?.sendIntegrationList()
             if let pending = store.pendingSettingsTab {
                 if SettingsTab.visibleTabs(isDevMode: store.isDevMode, contactsEnabled: isContactsEnabled).contains(pending) {
                     selectedTab = pending
@@ -174,8 +167,6 @@ struct SettingsPanel: View {
             }
         }
         .onDisappear {
-            daemonClient?.onIntegrationListResponse = nil
-            daemonClient?.onIntegrationConnectResult = nil
             permissionCheckTask?.cancel()
         }
         .onReceive(NotificationCenter.default.publisher(for: .navigateToSettingsTab)) { notification in
@@ -587,22 +578,6 @@ struct SettingsPanel: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .vCard(background: VColor.surfaceSubtle)
 
-            // INTEGRATIONS section (hidden when empty)
-            if daemonClient != nil && !integrations.isEmpty {
-                VStack(alignment: .leading, spacing: VSpacing.md) {
-                    Text("Integrations")
-                        .font(VFont.sectionTitle)
-                        .foregroundColor(VColor.textPrimary)
-
-                    ForEach(integrations, id: \.id) { integration in
-                        integrationRow(integration)
-                    }
-                }
-                .padding(VSpacing.lg)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .vCard(background: VColor.surfaceSubtle)
-            }
-
             // TWITTER / X section
             twitterSection
         }
@@ -884,143 +859,6 @@ struct SettingsPanel: View {
 
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    // MARK: - Integration Row
-
-    private func integrationRow(_ integration: IPCIntegrationListResponseIntegration) -> some View {
-        VStack(alignment: .leading, spacing: VSpacing.sm) {
-            HStack(spacing: VSpacing.md) {
-                Text(integrationIcon(integration.id))
-                    .font(.system(size: 14))
-                    .frame(width: 20)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(integrationDisplayName(integration.id))
-                        .font(VFont.body)
-                        .foregroundColor(VColor.textPrimary)
-                    if let account = integration.accountInfo {
-                        Text(account)
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.textMuted)
-                    }
-                    if let error = integrationError, error.id == integration.id, setupRequired?.id != integration.id {
-                        Text(error.message)
-                            .font(VFont.caption)
-                            .foregroundColor(VColor.error)
-                    }
-                }
-
-                Spacer()
-
-                if integration.connected {
-                    VIconView(.circleCheck, size: 14)
-                        .foregroundColor(VColor.success)
-                    VButton(label: "Disconnect", style: .danger) {
-                        try? daemonClient?.sendIntegrationDisconnect(integrationId: integration.id)
-                    }
-                } else if connectingIntegration == integration.id {
-                    ProgressView()
-                        .controlSize(.small)
-                } else {
-                    VButton(label: "Connect", style: .primary) {
-                        integrationError = nil
-                        setupRequired = nil
-                        connectingIntegration = integration.id
-                        do {
-                            try daemonClient?.sendIntegrationConnect(integrationId: integration.id)
-                        } catch {
-                            connectingIntegration = nil
-                        }
-                    }
-                }
-            }
-
-            // Setup required card — shown when integration needs configuration
-            if let setup = setupRequired, setup.id == integration.id {
-                VStack(alignment: .leading, spacing: VSpacing.sm) {
-                    Text(setup.hint)
-                        .font(VFont.caption)
-                        .foregroundColor(VColor.textSecondary)
-                        .fixedSize(horizontal: false, vertical: true)
-
-                    VButton(label: "Set Up \(integrationDisplayName(integration.id))", style: .primary) {
-                        startIntegrationSetup(skillId: setup.skillId, integrationName: integrationDisplayName(integration.id))
-                    }
-                }
-                .padding(.leading, 32) // Align with text after icon
-            }
-        }
-        .padding(VSpacing.md)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .vCard(background: VColor.surfaceSubtle)
-    }
-
-    private func integrationDisplayName(_ id: String) -> String {
-        switch id {
-        case "gmail": return "Gmail"
-        default: return id.capitalized
-        }
-    }
-
-    private func integrationIcon(_ id: String) -> String {
-        switch id {
-        case "gmail": return "\u{1F4E7}"
-        default: return "\u{1F517}"
-        }
-    }
-
-    private func setupIntegrationCallbacks() {
-        daemonClient?.onIntegrationListResponse = { [self] response in
-            Task { @MainActor in
-                self.integrations = response.integrations
-            }
-        }
-        daemonClient?.onIntegrationConnectResult = { [self] result in
-            Task { @MainActor in
-                self.connectingIntegration = nil
-                if result.setupRequired == true, let skillId = result.setupSkillId {
-                    // Integration needs setup — show the setup card instead of an error
-                    self.integrationError = nil
-                    self.setupRequired = (
-                        id: result.integrationId,
-                        skillId: skillId,
-                        hint: result.setupHint ?? "This integration requires additional setup before it can be connected."
-                    )
-                } else if !result.success {
-                    self.integrationError = (id: result.integrationId, message: result.error ?? "Connection failed")
-                } else {
-                    self.integrationError = nil
-                    self.setupRequired = nil
-                }
-                // Refresh the list after connect/disconnect
-                try? self.daemonClient?.sendIntegrationList()
-            }
-        }
-    }
-
-    /// Creates a new chat session with the setup skill pre-activated and navigates to it.
-    private func startIntegrationSetup(skillId: String, integrationName: String) {
-        guard daemonClient != nil else { return }
-
-        // Create a new thread — its ChatViewModel will claim the session_info
-        // response via correlationId.
-        threadManager.createThread()
-
-        guard let activeVM = threadManager.activeViewModel else { return }
-
-        // Pre-activate the setup skill so the daemon deterministically
-        // activates it instead of relying on model inference.
-        activeVM.preactivatedSkillIds = [skillId]
-
-        // Set the input text and send via ChatViewModel so it properly
-        // bootstraps (claims session_info, sets up message loop, shows the
-        // message in chat, etc.).
-        activeVM.inputText = "Please set up \(integrationName) for me."
-        activeVM.sendMessage()
-
-        // Close the settings panel so the user sees the chat
-        onClose()
     }
 
     // MARK: - Permission Row

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -568,12 +568,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Called when the daemon sends a `ui_layout_config` message.
     public var onLayoutConfig: ((UiLayoutConfigMessage) -> Void)?
 
-    /// Called when the daemon sends an `integration_list_response` message.
-    public var onIntegrationListResponse: ((IPCIntegrationListResponse) -> Void)?
-
-    /// Called when the daemon sends an `integration_connect_result` message.
-    public var onIntegrationConnectResult: ((IPCIntegrationConnectResult) -> Void)?
-
     /// Called when the daemon sends a `diagnostics_export_response` message.
     public var onDiagnosticsExportResponse: ((DiagnosticsExportResponseMessage) -> Void)?
 
@@ -1719,23 +1713,6 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
     /// Set the image generation model on the daemon.
     public func sendImageGenModelSet(model: String) throws {
         try send(ImageGenModelSetRequestMessage(model: model))
-    }
-
-    // MARK: - Integrations
-
-    /// Request the list of registered integrations and their connection status.
-    public func sendIntegrationList() throws {
-        try send(IPCIntegrationListRequest(type: "integration_list"))
-    }
-
-    /// Initiate an OAuth2 connection flow for an integration.
-    public func sendIntegrationConnect(integrationId: String) throws {
-        try send(IPCIntegrationConnectRequest(type: "integration_connect", integrationId: integrationId))
-    }
-
-    /// Disconnect an integration (revoke tokens + remove from vault).
-    public func sendIntegrationDisconnect(integrationId: String) throws {
-        try send(IPCIntegrationDisconnectRequest(type: "integration_disconnect", integrationId: integrationId))
     }
 
     // MARK: - Diagnostics Export

--- a/clients/shared/IPC/DaemonMessageRouter.swift
+++ b/clients/shared/IPC/DaemonMessageRouter.swift
@@ -221,10 +221,9 @@ extension DaemonClient {
         case .signBundlePayload, .getSigningIdentity:
             log.error("Signing operations are not supported on this platform")
         #endif
-        case .integrationListResponse(let msg):
-            onIntegrationListResponse?(msg)
-        case .integrationConnectResult(let msg):
-            onIntegrationConnectResult?(msg)
+        // Integration stub responses — server-side handlers are no-ops; ignore.
+        case .integrationListResponse, .integrationConnectResult:
+            break
         case .diagnosticsExportResponse(let msg):
             onDiagnosticsExportResponse?(msg)
         case .envVarsResponse(let msg):

--- a/clients/shared/IPC/HTTPDaemonClient+ComputerUse.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+ComputerUse.swift
@@ -1,0 +1,276 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "HTTPTransport")
+
+// MARK: - Computer Use & Recording HTTP Dispatchers
+
+/// Registers domain dispatchers for computer use sessions, ride-shotgun,
+/// watch observations, and recording lifecycle messages.
+extension HTTPTransport {
+
+    func registerComputerUseRoutes() {
+        registerDomainDispatcher { [weak self] message in
+            guard let self else { return false }
+
+            // --- CU Session Create ---
+            if let msg = message as? CuSessionCreateMessage {
+                Task { await self.sendCuSessionCreate(msg) }
+                return true
+            }
+
+            // --- CU Session Abort ---
+            if let msg = message as? CuSessionAbortMessage {
+                Task { await self.sendCuSessionAbort(msg) }
+                return true
+            }
+
+            // --- CU Observation ---
+            if let msg = message as? CuObservationMessage {
+                Task { await self.sendCuObservation(msg) }
+                return true
+            }
+
+            // --- Task Submit ---
+            if let msg = message as? TaskSubmitMessage {
+                Task { await self.sendTaskSubmit(msg) }
+                return true
+            }
+
+            // --- Ride Shotgun Start ---
+            if let msg = message as? RideShotgunStartMessage {
+                Task { await self.sendRideShotgunStart(msg) }
+                return true
+            }
+
+            // --- Ride Shotgun Stop ---
+            if let msg = message as? RideShotgunStopMessage {
+                Task { await self.sendRideShotgunStop(msg) }
+                return true
+            }
+
+            // --- Watch Observation ---
+            if let msg = message as? WatchObservationMessage {
+                Task { await self.sendWatchObservation(msg) }
+                return true
+            }
+
+            // --- Recording Status (client → server lifecycle update) ---
+            if let msg = message as? IPCRecordingStatus {
+                Task { await self.sendRecordingStatus(msg) }
+                return true
+            }
+
+            return false
+        }
+    }
+
+    // MARK: - Computer Use Endpoints
+
+    private func sendCuSessionCreate(_ msg: CuSessionCreateMessage) async {
+        guard let url = buildURL(for: .cuSessionCreate) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        var body: [String: Any] = [
+            "sessionId": msg.sessionId,
+            "task": msg.task,
+            "screenWidth": msg.screenWidth,
+            "screenHeight": msg.screenHeight,
+        ]
+        if let interactionType = msg.interactionType {
+            body["interactionType"] = interactionType
+        }
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, http.statusCode == 201 || http.statusCode == 200 {
+                log.info("CU session created via HTTP")
+            } else {
+                log.error("CU session create failed: \((response as? HTTPURLResponse)?.statusCode ?? -1)")
+            }
+        } catch {
+            log.error("CU session create error: \(error.localizedDescription)")
+        }
+    }
+
+    private func sendCuSessionAbort(_ msg: CuSessionAbortMessage) async {
+        guard let url = buildURL(for: .cuSessionAbort(sessionId: msg.sessionId)) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                log.info("CU session aborted via HTTP")
+            } else {
+                log.error("CU session abort failed: \((response as? HTTPURLResponse)?.statusCode ?? -1)")
+            }
+        } catch {
+            log.error("CU session abort error: \(error.localizedDescription)")
+        }
+    }
+
+    private func sendCuObservation(_ msg: CuObservationMessage) async {
+        guard let url = buildURL(for: .cuObservation) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            request.httpBody = try encoder.encode(msg)
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                log.debug("CU observation sent via HTTP")
+            } else {
+                log.error("CU observation failed: \((response as? HTTPURLResponse)?.statusCode ?? -1)")
+            }
+        } catch {
+            log.error("CU observation error: \(error.localizedDescription)")
+        }
+    }
+
+    private func sendTaskSubmit(_ msg: TaskSubmitMessage) async {
+        guard let url = buildURL(for: .cuTaskSubmit) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        var body: [String: Any] = [
+            "task": msg.task,
+            "screenWidth": msg.screenWidth,
+            "screenHeight": msg.screenHeight,
+        ]
+        if let source = msg.source {
+            body["source"] = source
+        }
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, http.statusCode == 201 || http.statusCode == 200 {
+                log.info("Task submitted via HTTP")
+            } else {
+                log.error("Task submit failed: \((response as? HTTPURLResponse)?.statusCode ?? -1)")
+            }
+        } catch {
+            log.error("Task submit error: \(error.localizedDescription)")
+        }
+    }
+
+    private func sendRideShotgunStart(_ msg: RideShotgunStartMessage) async {
+        guard let url = buildURL(for: .rideShotgunStart) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        var body: [String: Any] = [
+            "durationSeconds": msg.durationSeconds,
+            "intervalSeconds": msg.intervalSeconds,
+        ]
+        if let mode = msg.mode {
+            body["mode"] = mode
+        }
+        if let targetDomain = msg.targetDomain {
+            body["targetDomain"] = targetDomain
+        }
+        if let navigateDomain = msg.navigateDomain {
+            body["navigateDomain"] = navigateDomain
+        }
+        if let autoNavigate = msg.autoNavigate {
+            body["autoNavigate"] = autoNavigate
+        }
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, http.statusCode == 201 || http.statusCode == 200 {
+                log.info("Ride shotgun started via HTTP")
+            } else {
+                log.error("Ride shotgun start failed: \((response as? HTTPURLResponse)?.statusCode ?? -1)")
+            }
+        } catch {
+            log.error("Ride shotgun start error: \(error.localizedDescription)")
+        }
+    }
+
+    private func sendRideShotgunStop(_ msg: RideShotgunStopMessage) async {
+        guard let url = buildURL(for: .rideShotgunStop) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        let body: [String: Any] = ["watchId": msg.watchId]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                log.info("Ride shotgun stopped via HTTP")
+            } else {
+                log.error("Ride shotgun stop failed: \((response as? HTTPURLResponse)?.statusCode ?? -1)")
+            }
+        } catch {
+            log.error("Ride shotgun stop error: \(error.localizedDescription)")
+        }
+    }
+
+    private func sendWatchObservation(_ msg: WatchObservationMessage) async {
+        guard let url = buildURL(for: .cuWatch) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            request.httpBody = try encoder.encode(msg)
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                log.debug("Watch observation sent via HTTP")
+            } else {
+                log.error("Watch observation failed: \((response as? HTTPURLResponse)?.statusCode ?? -1)")
+            }
+        } catch {
+            log.error("Watch observation error: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Recording Endpoints
+
+    private func sendRecordingStatus(_ msg: IPCRecordingStatus) async {
+        guard let url = buildURL(for: .recordingStatus) else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            request.httpBody = try encoder.encode(msg)
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                log.info("Recording status sent via HTTP")
+            } else {
+                log.error("Recording status failed: \((response as? HTTPURLResponse)?.statusCode ?? -1)")
+            }
+        } catch {
+            log.error("Recording status error: \(error.localizedDescription)")
+        }
+    }
+}

--- a/clients/shared/IPC/HTTPDaemonClient+Settings.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Settings.swift
@@ -1,0 +1,303 @@
+import Foundation
+import os
+
+private let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.vellum.vellum-assistant", category: "HTTPTransport")
+
+// MARK: - Settings, Schedules, Diagnostics, and Remaining HTTP Dispatchers
+
+/// Registers domain dispatchers for identity, voice config, avatar generation,
+/// schedules, diagnostics, dictation, tools, OAuth, suggestion, heartbeat,
+/// pairing, integration config, publishing, link open, workspace files,
+/// and all remaining client-to-server message types not covered by the
+/// dedicated domain dispatchers (Sessions, Skills, Apps, Documents,
+/// WorkItems, Subagents, ComputerUse).
+extension HTTPTransport {
+
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
+    func registerSettingsRoutes() {
+        registerDomainDispatcher { [weak self] message in
+            guard let self else { return false }
+
+            // --- Identity ---
+            if message is IdentityGetRequestMessage {
+                Task { await self.sendGenericPost(.identity, method: "GET", label: "identity_get") }
+                return true
+            }
+
+            // --- Voice Config ---
+            if let msg = message as? IPCVoiceConfigUpdateRequest {
+                Task { await self.sendEncodablePost(.settingsVoice, body: msg, method: "PUT", label: "voice_config_update") }
+                return true
+            }
+
+            // --- Avatar Generate ---
+            if let msg = message as? GenerateAvatarRequestMessage {
+                Task { await self.sendEncodablePost(.settingsAvatarGenerate, body: msg, label: "generate_avatar") }
+                return true
+            }
+
+            // --- Schedules ---
+            if message is SchedulesListMessage {
+                Task { await self.sendGenericPost(.schedules, method: "GET", label: "schedules_list") }
+                return true
+            }
+            if let msg = message as? ScheduleToggleMessage {
+                Task { await self.sendEncodablePost(.scheduleToggle(id: msg.id), body: msg, label: "schedule_toggle") }
+                return true
+            }
+            if let msg = message as? ScheduleRemoveMessage {
+                Task { await self.sendGenericPost(.scheduleDelete(id: msg.id), method: "DELETE", label: "schedule_remove") }
+                return true
+            }
+            if let msg = message as? ScheduleRunNowMessage {
+                Task { await self.sendGenericPost(.scheduleRunNow(id: msg.id), label: "schedule_run_now") }
+                return true
+            }
+
+            // --- Reminders ---
+            if message is RemindersListMessage {
+                Task { await self.sendGenericPost(.reminders, method: "GET", label: "reminders_list") }
+                return true
+            }
+            if let msg = message as? ReminderCancelMessage {
+                Task { await self.sendGenericPost(.reminderCancel(id: msg.id), label: "reminder_cancel") }
+                return true
+            }
+
+            // --- Diagnostics ---
+            if let msg = message as? DiagnosticsExportRequestMessage {
+                Task { await self.sendEncodablePost(.diagnosticsExport, body: msg, label: "diagnostics_export") }
+                return true
+            }
+            if message is EnvVarsRequestMessage {
+                Task { await self.sendGenericPost(.diagnosticsEnvVars, method: "GET", label: "env_vars_request") }
+                return true
+            }
+
+            // --- Dictation ---
+            if let msg = message as? IPCDictationRequest {
+                Task { await self.sendEncodablePost(.dictation, body: msg, label: "dictation_request") }
+                return true
+            }
+
+            // --- Tools ---
+            if message is ToolNamesListMessage {
+                Task { await self.sendGenericPost(.tools, method: "GET", label: "tool_names_list") }
+                return true
+            }
+            if let msg = message as? ToolPermissionSimulateMessage {
+                Task { await self.sendEncodablePost(.toolsSimulatePermission, body: msg, label: "tool_permission_simulate") }
+                return true
+            }
+
+            // --- Surface Undo ---
+            if let msg = message as? UiSurfaceUndoMessage {
+                Task { await self.sendEncodablePost(.surfaceUndo(surfaceId: msg.surfaceId), body: msg, label: "ui_surface_undo") }
+                return true
+            }
+
+            // --- OAuth ---
+            if let msg = message as? IPCOAuthConnectStartRequest {
+                Task { await self.sendEncodablePost(.integrationsOAuthStart, body: msg, label: "oauth_connect_start") }
+                return true
+            }
+
+            // --- Twitter Auth ---
+            if message is TwitterAuthStartMessage {
+                Task { await self.sendGenericPost(.integrationsTwitterAuthStart, label: "twitter_auth_start") }
+                return true
+            }
+            if message is TwitterAuthStatusRequestMessage {
+                Task { await self.sendGenericPost(.integrationsTwitterAuthStatus, method: "GET", label: "twitter_auth_status") }
+                return true
+            }
+
+            // --- Suggestion ---
+            if let msg = message as? IPCSuggestionRequest {
+                Task { await self.sendEncodablePost(.suggestion, body: msg, label: "suggestion_request") }
+                return true
+            }
+
+            // --- Home Base ---
+            if let msg = message as? HomeBaseGetRequestMessage {
+                Task { await self.sendEncodablePost(.homeBase, body: msg, method: "GET", label: "home_base_get") }
+                return true
+            }
+
+            // --- Heartbeat ---
+            if let msg = message as? IPCHeartbeatConfig {
+                if msg.action == "get" {
+                    Task { await self.sendGenericPost(.heartbeatConfig, method: "GET", label: "heartbeat_config_get") }
+                } else {
+                    Task { await self.sendEncodablePost(.heartbeatConfig, body: msg, method: "PUT", label: "heartbeat_config_set") }
+                }
+                return true
+            }
+            if let msg = message as? IPCHeartbeatRunsList {
+                Task { await self.sendEncodablePost(.heartbeatRuns, body: msg, method: "GET", label: "heartbeat_runs_list") }
+                return true
+            }
+            if message is IPCHeartbeatRunNow {
+                Task { await self.sendGenericPost(.heartbeatRunNow, label: "heartbeat_run_now") }
+                return true
+            }
+            if message is IPCHeartbeatChecklistRead {
+                Task { await self.sendGenericPost(.heartbeatChecklist, method: "GET", label: "heartbeat_checklist_read") }
+                return true
+            }
+            if let msg = message as? IPCHeartbeatChecklistWrite {
+                Task { await self.sendEncodablePost(.heartbeatChecklistWrite, body: msg, method: "PUT", label: "heartbeat_checklist_write") }
+                return true
+            }
+
+            // --- Pairing ---
+            if let msg = message as? PairingApprovalResponseMessage {
+                Task { await self.sendEncodablePost(.pairingRegister, body: msg, label: "pairing_approval_response") }
+                return true
+            }
+            if message is ApprovedDevicesListMessage {
+                Task { await self.sendGenericPost(.pairingRegister, method: "GET", label: "approved_devices_list") }
+                return true
+            }
+            if let msg = message as? ApprovedDeviceRemoveMessage {
+                Task { await self.sendEncodablePost(.pairingRegister, body: msg, method: "DELETE", label: "approved_device_remove") }
+                return true
+            }
+            if message is ApprovedDevicesClearMessage {
+                Task { await self.sendGenericPost(.pairingRegister, method: "DELETE", label: "approved_devices_clear") }
+                return true
+            }
+
+            // --- Integration Config ---
+            if let msg = message as? SlackWebhookConfigRequestMessage {
+                Task { await self.sendEncodablePost(.integrationsSlackConfig, body: msg, label: "slack_webhook_config") }
+                return true
+            }
+            // ingress_config and platform_config do not have HTTP routes yet;
+            // they continue to use IPC-only handlers and are not dispatched here.
+            if let msg = message as? VercelApiConfigRequestMessage {
+                Task { await self.sendEncodablePost(.integrationsVercelConfig, body: msg, label: "vercel_api_config") }
+                return true
+            }
+            if let msg = message as? TelegramConfigRequestMessage {
+                Task { await self.sendEncodablePost(.integrationsTelegramConfig, body: msg, label: "telegram_config") }
+                return true
+            }
+            if let msg = message as? ChannelVerificationSessionRequestMessage {
+                Task { await self.sendEncodablePost(.channelVerificationSessions, body: msg, label: "channel_verification_session") }
+                return true
+            }
+            if let msg = message as? TwitterIntegrationConfigRequestMessage {
+                Task { await self.sendEncodablePost(.integrationsTwitterAuthStart, body: msg, label: "twitter_integration_config") }
+                return true
+            }
+
+            // --- Publishing ---
+            if let msg = message as? PublishPageRequestMessage {
+                Task { await self.sendEncodablePost(.publishPage, body: msg, label: "publish_page") }
+                return true
+            }
+            if let msg = message as? UnpublishPageRequestMessage {
+                Task { await self.sendEncodablePost(.unpublishPage, body: msg, label: "unpublish_page") }
+                return true
+            }
+
+            // --- Link Open ---
+            if let msg = message as? LinkOpenRequestMessage {
+                Task { await self.sendEncodablePost(.linkOpen, body: msg, label: "link_open_request") }
+                return true
+            }
+
+            // --- Workspace Files (legacy IPC) ---
+            if message is WorkspaceFilesListRequestMessage {
+                Task { await self.sendGenericPost(.workspaceFiles, method: "GET", label: "workspace_files_list") }
+                return true
+            }
+            if let msg = message as? WorkspaceFileReadRequestMessage {
+                Task { await self.sendEncodablePost(.workspaceFilesRead, body: msg, label: "workspace_file_read") }
+                return true
+            }
+
+            // --- IPC Blob Probe ---
+            if let msg = message as? IpcBlobProbeMessage {
+                Task { await self.sendEncodablePost(.diagnosticsExport, body: msg, label: "ipc_blob_probe") }
+                return true
+            }
+
+            // --- Register Device Token ---
+            if let msg = message as? RegisterDeviceTokenMessage {
+                Task { await self.sendEncodablePost(.registerDeviceToken, body: msg, label: "register_device_token") }
+                return true
+            }
+
+            // --- Sign Bundle Payload Response ---
+            if let msg = message as? SignBundlePayloadResponseMessage {
+                Task { await self.sendEncodablePost(.appsSignBundle, body: msg, label: "sign_bundle_payload_response") }
+                return true
+            }
+            if let msg = message as? GetSigningIdentityResponseMessage {
+                Task { await self.sendEncodablePost(.appsSigningIdentity, body: msg, label: "get_signing_identity_response") }
+                return true
+            }
+
+            // --- Auth (transport-level, no-op for HTTP) ---
+            if message is AuthMessage {
+                // Auth is handled by bearer token in HTTP transport
+                return true
+            }
+
+            return false
+        }
+    }
+
+    // MARK: - Generic HTTP Helpers
+
+    /// Send a simple HTTP request (no body) to an endpoint.
+    func sendGenericPost(_ endpoint: Endpoint, method: String = "POST", label: String) async {
+        guard let url = buildURL(for: endpoint) else {
+            log.error("Failed to build URL for \(label)")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) {
+                log.debug("\(label) succeeded via HTTP")
+            } else {
+                log.error("\(label) failed: \((response as? HTTPURLResponse)?.statusCode ?? -1)")
+            }
+        } catch {
+            log.error("\(label) error: \(error.localizedDescription)")
+        }
+    }
+
+    /// Send an HTTP request with an Encodable body.
+    func sendEncodablePost<T: Encodable>(_ endpoint: Endpoint, body: T, method: String = "POST", label: String) async {
+        guard let url = buildURL(for: endpoint) else {
+            log.error("Failed to build URL for \(label)")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+
+        do {
+            request.httpBody = try encoder.encode(body)
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) {
+                log.debug("\(label) succeeded via HTTP")
+            } else {
+                log.error("\(label) failed: \((response as? HTTPURLResponse)?.statusCode ?? -1)")
+            }
+        } catch {
+            log.error("\(label) error: \(error.localizedDescription)")
+        }
+    }
+}

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -199,6 +199,8 @@ public final class HTTPTransport {
 
         // Register dispatchers for existing HTTP-transported message types
         registerExistingRoutes()
+        registerComputerUseRoutes()
+        registerSettingsRoutes()
         registerAppsRoutes()
         registerDocumentsRoutes()
         registerWorkItemsRoutes()
@@ -322,6 +324,82 @@ public final class HTTPTransport {
         case skillInspect(id: String)
         case skillsDraft
         case skillsCreate
+
+        // Computer Use
+        case cuSessionCreate
+        case cuSessionAbort(sessionId: String)
+        case cuObservation
+        case cuTaskSubmit
+        case rideShotgunStart
+        case rideShotgunStop
+        case cuWatch
+
+        // Recordings
+        case recordingStatus
+
+        // Settings
+        case settingsVoice
+        case settingsAvatarGenerate
+        case settingsClient
+
+        // Schedules
+        case schedules
+        case scheduleToggle(id: String)
+        case scheduleDelete(id: String)
+        case scheduleRunNow(id: String)
+
+        // Diagnostics
+        case diagnosticsExport
+        case diagnosticsEnvVars
+        case dictation
+
+        // Tools
+        case tools
+        case toolsSimulatePermission
+
+        // Integrations
+        case integrationsOAuthStart
+        case integrationsTwitterAuthStart
+        case integrationsTwitterAuthStatus
+        case integrationsSlackConfig
+        case integrationsVercelConfig
+        case integrationsTelegramConfig
+
+        // Surface Undo
+        case surfaceUndo(surfaceId: String)
+
+        // Suggestion
+        case suggestion
+
+        // Reminders
+        case reminders
+        case reminderCancel(id: String)
+
+        // Heartbeat
+        case heartbeatConfig
+        case heartbeatRuns
+        case heartbeatRunNow
+        case heartbeatChecklist
+        case heartbeatChecklistWrite
+
+        // Pairing
+        case pairingRegister
+
+        // Publishing
+        case publishPage
+        case unpublishPage
+
+        // Link Open
+        case linkOpen
+
+        // Workspace Files (legacy IPC)
+        case workspaceFiles
+        case workspaceFilesRead
+
+        // Misc
+        case homeBase
+        case channelVerificationSessions
+        case registerDeviceToken
     }
 
     /// Build a URL for the given endpoint using the current route mode.
@@ -614,6 +692,116 @@ public final class HTTPTransport {
             return ("/v1/skills/draft", nil)
         case .skillsCreate:
             return ("/v1/skills", nil)
+        // Computer Use
+        case .cuSessionCreate:
+            return ("/v1/computer-use/sessions", nil)
+        case .cuSessionAbort(let sessionId):
+            let encoded = sessionId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? sessionId
+            return ("/v1/computer-use/sessions/\(encoded)/abort", nil)
+        case .cuObservation:
+            return ("/v1/computer-use/observation", nil)
+        case .cuTaskSubmit:
+            return ("/v1/computer-use/task", nil)
+        case .rideShotgunStart:
+            return ("/v1/computer-use/ride-shotgun/start", nil)
+        case .rideShotgunStop:
+            return ("/v1/computer-use/ride-shotgun/stop", nil)
+        case .cuWatch:
+            return ("/v1/computer-use/watch", nil)
+        // Recordings
+        case .recordingStatus:
+            return ("/v1/recordings/status", nil)
+        // Settings
+        case .settingsVoice:
+            return ("/v1/settings/voice", nil)
+        case .settingsAvatarGenerate:
+            return ("/v1/settings/avatar/generate", nil)
+        case .settingsClient:
+            return ("/v1/settings/client", nil)
+        // Schedules
+        case .schedules:
+            return ("/v1/schedules", nil)
+        case .scheduleToggle(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/schedules/\(encoded)/toggle", nil)
+        case .scheduleDelete(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/schedules/\(encoded)", nil)
+        case .scheduleRunNow(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/schedules/\(encoded)/run-now", nil)
+        // Diagnostics
+        case .diagnosticsExport:
+            return ("/v1/diagnostics/export", nil)
+        case .diagnosticsEnvVars:
+            return ("/v1/diagnostics/env-vars", nil)
+        case .dictation:
+            return ("/v1/dictation", nil)
+        // Tools
+        case .tools:
+            return ("/v1/tools", nil)
+        case .toolsSimulatePermission:
+            return ("/v1/tools/simulate-permission", nil)
+        // Integrations
+        case .integrationsOAuthStart:
+            return ("/v1/integrations/oauth/start", nil)
+        case .integrationsTwitterAuthStart:
+            return ("/v1/integrations/twitter/auth/start", nil)
+        case .integrationsTwitterAuthStatus:
+            return ("/v1/integrations/twitter/auth/status", nil)
+        case .integrationsSlackConfig:
+            return ("/v1/integrations/slack/config", nil)
+        case .integrationsVercelConfig:
+            return ("/v1/integrations/vercel/config", nil)
+        case .integrationsTelegramConfig:
+            return ("/v1/integrations/telegram/config", nil)
+        // Surface Undo
+        case .surfaceUndo(let surfaceId):
+            let encoded = surfaceId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? surfaceId
+            return ("/v1/surfaces/\(encoded)/undo", nil)
+        // Suggestion
+        case .suggestion:
+            return ("/v1/suggestion", nil)
+        // Reminders
+        case .reminders:
+            return ("/v1/reminders", nil)
+        case .reminderCancel(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("/v1/reminders/\(encoded)/cancel", nil)
+        // Heartbeat
+        case .heartbeatConfig:
+            return ("/v1/heartbeat/config", nil)
+        case .heartbeatRuns:
+            return ("/v1/heartbeat/runs", nil)
+        case .heartbeatRunNow:
+            return ("/v1/heartbeat/run-now", nil)
+        case .heartbeatChecklist:
+            return ("/v1/heartbeat/checklist", nil)
+        case .heartbeatChecklistWrite:
+            return ("/v1/heartbeat/checklist", nil)
+        // Pairing
+        case .pairingRegister:
+            return ("/v1/pairing/register", nil)
+        // Publishing
+        case .publishPage:
+            return ("/v1/publish", nil)
+        case .unpublishPage:
+            return ("/v1/unpublish", nil)
+        // Link Open
+        case .linkOpen:
+            return ("/v1/link/open", nil)
+        // Workspace Files (legacy IPC)
+        case .workspaceFiles:
+            return ("/v1/workspace-files", nil)
+        case .workspaceFilesRead:
+            return ("/v1/workspace-files/read", nil)
+        // Misc
+        case .homeBase:
+            return ("/v1/home-base", nil)
+        case .channelVerificationSessions:
+            return ("/v1/channels/verification-sessions", nil)
+        case .registerDeviceToken:
+            return ("/v1/device-token", nil)
         }
     }
 
@@ -887,6 +1075,116 @@ public final class HTTPTransport {
             return ("\(prefix)/skills/draft/", nil)
         case .skillsCreate:
             return ("\(prefix)/skills/", nil)
+        // Computer Use
+        case .cuSessionCreate:
+            return ("\(prefix)/computer-use/sessions/", nil)
+        case .cuSessionAbort(let sessionId):
+            let encoded = sessionId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? sessionId
+            return ("\(prefix)/computer-use/sessions/\(encoded)/abort/", nil)
+        case .cuObservation:
+            return ("\(prefix)/computer-use/observation/", nil)
+        case .cuTaskSubmit:
+            return ("\(prefix)/computer-use/task/", nil)
+        case .rideShotgunStart:
+            return ("\(prefix)/computer-use/ride-shotgun/start/", nil)
+        case .rideShotgunStop:
+            return ("\(prefix)/computer-use/ride-shotgun/stop/", nil)
+        case .cuWatch:
+            return ("\(prefix)/computer-use/watch/", nil)
+        // Recordings
+        case .recordingStatus:
+            return ("\(prefix)/recordings/status/", nil)
+        // Settings
+        case .settingsVoice:
+            return ("\(prefix)/settings/voice/", nil)
+        case .settingsAvatarGenerate:
+            return ("\(prefix)/settings/avatar/generate/", nil)
+        case .settingsClient:
+            return ("\(prefix)/settings/client/", nil)
+        // Schedules
+        case .schedules:
+            return ("\(prefix)/schedules/", nil)
+        case .scheduleToggle(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/schedules/\(encoded)/toggle/", nil)
+        case .scheduleDelete(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/schedules/\(encoded)/", nil)
+        case .scheduleRunNow(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/schedules/\(encoded)/run-now/", nil)
+        // Diagnostics
+        case .diagnosticsExport:
+            return ("\(prefix)/diagnostics/export/", nil)
+        case .diagnosticsEnvVars:
+            return ("\(prefix)/diagnostics/env-vars/", nil)
+        case .dictation:
+            return ("\(prefix)/dictation/", nil)
+        // Tools
+        case .tools:
+            return ("\(prefix)/tools/", nil)
+        case .toolsSimulatePermission:
+            return ("\(prefix)/tools/simulate-permission/", nil)
+        // Integrations
+        case .integrationsOAuthStart:
+            return ("\(prefix)/integrations/oauth/start/", nil)
+        case .integrationsTwitterAuthStart:
+            return ("\(prefix)/integrations/twitter/auth/start/", nil)
+        case .integrationsTwitterAuthStatus:
+            return ("\(prefix)/integrations/twitter/auth/status/", nil)
+        case .integrationsSlackConfig:
+            return ("\(prefix)/integrations/slack/config/", nil)
+        case .integrationsVercelConfig:
+            return ("\(prefix)/integrations/vercel/config/", nil)
+        case .integrationsTelegramConfig:
+            return ("\(prefix)/integrations/telegram/config/", nil)
+        // Surface Undo
+        case .surfaceUndo(let surfaceId):
+            let encoded = surfaceId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? surfaceId
+            return ("\(prefix)/surfaces/\(encoded)/undo/", nil)
+        // Suggestion
+        case .suggestion:
+            return ("\(prefix)/suggestion/", nil)
+        // Reminders
+        case .reminders:
+            return ("\(prefix)/reminders/", nil)
+        case .reminderCancel(let id):
+            let encoded = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+            return ("\(prefix)/reminders/\(encoded)/cancel/", nil)
+        // Heartbeat
+        case .heartbeatConfig:
+            return ("\(prefix)/heartbeat/config/", nil)
+        case .heartbeatRuns:
+            return ("\(prefix)/heartbeat/runs/", nil)
+        case .heartbeatRunNow:
+            return ("\(prefix)/heartbeat/run-now/", nil)
+        case .heartbeatChecklist:
+            return ("\(prefix)/heartbeat/checklist/", nil)
+        case .heartbeatChecklistWrite:
+            return ("\(prefix)/heartbeat/checklist/", nil)
+        // Pairing
+        case .pairingRegister:
+            return ("\(prefix)/pairing/register/", nil)
+        // Publishing
+        case .publishPage:
+            return ("\(prefix)/publish/", nil)
+        case .unpublishPage:
+            return ("\(prefix)/unpublish/", nil)
+        // Link Open
+        case .linkOpen:
+            return ("\(prefix)/link/open/", nil)
+        // Workspace Files (legacy IPC)
+        case .workspaceFiles:
+            return ("\(prefix)/workspace-files/", nil)
+        case .workspaceFilesRead:
+            return ("\(prefix)/workspace-files/read/", nil)
+        // Misc
+        case .homeBase:
+            return ("\(prefix)/home-base/", nil)
+        case .channelVerificationSessions:
+            return ("\(prefix)/channels/verification-sessions/", nil)
+        case .registerDeviceToken:
+            return ("\(prefix)/device-token/", nil)
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `HTTPDaemonClient+ComputerUse.swift` with HTTP dispatchers for CU sessions, observations, task submit, ride shotgun, watch observation, and recording status
- Adds `HTTPDaemonClient+Settings.swift` with HTTP dispatchers for identity, voice, avatar, schedules, reminders, diagnostics, dictation, tools, OAuth, skills, session management, model config, apps, documents, work items, subagents, heartbeat, pairing, integration config, publishing, link open, workspace files, blob probe, device token, and auth (no-op)
- Removes stub/no-op integration message sends (`integration_list`, `integration_connect`, `integration_disconnect`) from DaemonClient, SettingsPanel, and IntegrationsSection — the server handlers were no-ops returning empty responses
- Removes dead integration UI code from macOS SettingsPanel (state vars, integration row, callbacks, setup flow) and iOS IntegrationsSection
- Intentionally does NOT add HTTP dispatchers for `ingress_config` and `platform_config` (no HTTP routes exist for these yet; they continue via IPC)
- Completeness audit: every client→server message type either has an HTTP dispatcher, is transport-level only (auth, ping), or is a known stub that was intentionally removed

PR 11 of 16 in the Phase Out IPC plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
