### PR TITLE
feat: make HTTP the default transport for local assistants

### DIFF
--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -79,7 +79,7 @@
       "key": "local_http_enabled",
       "label": "Local HTTP Enabled",
       "description": "Enable local HTTP transport mode in macOS app",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "command-palette",

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -79,7 +79,7 @@
       "key": "local_http_enabled",
       "label": "Local HTTP Enabled",
       "description": "Enable local HTTP transport mode in macOS app",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "command-palette",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -79,7 +79,7 @@
       "key": "local_http_enabled",
       "label": "Local HTTP Enabled",
       "description": "Enable local HTTP transport mode in macOS app",
-      "defaultEnabled": false
+      "defaultEnabled": true
     },
     {
       "id": "command-palette",


### PR DESCRIPTION
## Summary
- Flip local-http-enabled feature flag default from false to true in all three registry copies
- New installations now default to HTTP transport for local assistants
- Existing explicit flag overrides are preserved

Part of plan: phase-out-ipc.md (PR 13 of 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
