### PR TITLE
fix: add settings-routes.ts to credential security invariant allowlist

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -238,6 +238,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "oauth/token-persistence.ts", // OAuth token persistence (set/delete tokens)
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)
       "daemon/session-messaging.ts", // credential storage during session messaging
+      "runtime/routes/settings-routes.ts", // settings routes OAuth credential lookup (client_id/client_secret/access tokens)
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary
- `runtime/routes/settings-routes.ts` imports `getSecureKey` from `secure-keys` for OAuth credential lookups (client IDs, client secrets, access tokens for Twitter/integration flows)
- The `credential-security-invariants.test.ts` guard test was not updated when these HTTP routes were added, causing CI to fail
- Adds `settings-routes.ts` to the `ALLOWED_IMPORTERS` set with an explanatory comment

## Test plan
- [ ] `credential-security-invariants.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
