### PR TITLE
fix: remove obsolete IPC CI steps after IPC socket removal

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -66,15 +66,6 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Verify IPC generated code is up to date
-        run: bun run check:ipc-generated
-
-      - name: Verify IPC contract inventory is up to date
-        run: bun run ipc:inventory
-
-      - name: Verify Swift decoder is in sync with contract
-        run: bun run ipc:check-swift-drift
-
       - name: Type check
         run: bunx tsc --noEmit
 

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -72,15 +72,6 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Verify IPC generated code is up to date
-        run: bun run check:ipc-generated
-
-      - name: Verify IPC contract inventory is up to date
-        run: bun run ipc:inventory
-
-      - name: Verify Swift decoder is in sync with contract
-        run: bun run ipc:check-swift-drift
-
       - name: Type check
         run: bunx tsc --noEmit
 


### PR DESCRIPTION
## Summary
- Removes three IPC-related CI steps that no longer exist after the IPC socket server was removed (PRs #14429–#14431)
- Affected workflows: `ci-main-assistant.yaml` and `pr-assistant.yaml`
- Scripts removed: `check:ipc-generated`, `ipc:inventory`, `ipc:check-swift-drift`

## Test plan
- CI should pass once these non-existent script references are removed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
