### PR TITLE
fix: invalidate stale cache entries on workspace directory rename

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -473,11 +473,11 @@ private struct WorkspaceTreeRow: View {
                         state.expandedDirs.remove(dir)
                         state.expandedDirs.insert(newPath + dir.dropFirst(oldPath.count))
                     }
-                    // Transfer directory cache entries
+                    // Invalidate directory cache for renamed directory and descendants
+                    // (WorkspaceTreeEntry.path is immutable, so entries must be re-fetched)
                     let cacheKeys = state.directoryCache.keys.filter { $0 == oldPath || $0.hasPrefix(oldPrefix) }
                     for key in cacheKeys {
-                        let newKey = key == oldPath ? newPath : newPath + key.dropFirst(oldPath.count)
-                        state.directoryCache[newKey] = state.directoryCache.removeValue(forKey: key)
+                        state.directoryCache.removeValue(forKey: key)
                     }
                 }
             }


### PR DESCRIPTION
Replaces directory cache key migration with cache invalidation on rename. WorkspaceTreeEntry.path is immutable (let), so migrating cache keys without updating the entry paths left stale paths that broke child interactions. Now cache entries for the renamed directory and descendants are removed so they get re-fetched on next expand.

The selectedFileDetail sync issue (P2) was already addressed in the current code — both exact-match and descendant cases reconstruct the detail with the updated path.

Addresses feedback from PR #14403.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
