### PR TITLE
fix: reject dangling symlinks in workspace path resolution

### DIFF
--- a/assistant/src/runtime/routes/workspace-utils.ts
+++ b/assistant/src/runtime/routes/workspace-utils.ts
@@ -1,4 +1,4 @@
-import { realpathSync } from "node:fs";
+import { lstatSync, realpathSync } from "node:fs";
 import { resolve, sep } from "node:path";
 
 import { getWorkspaceDir } from "../../util/platform.js";
@@ -32,6 +32,18 @@ export function resolveWorkspacePath(relativePath: string): string | undefined {
   } catch {
     // Path doesn't exist yet — walk up to the nearest existing ancestor and
     // verify *it* resolves inside the workspace.
+
+    // Reject dangling symlinks: if the path itself is a symlink whose target
+    // doesn't exist, a subsequent write would follow the symlink and could
+    // create files outside the workspace boundary.
+    try {
+      if (lstatSync(resolved).isSymbolicLink()) {
+        return undefined;
+      }
+    } catch {
+      // lstat failed — path truly doesn't exist (not a symlink), continue
+    }
+
     let ancestor = resolved;
     // eslint-disable-next-line no-constant-condition
     while (true) {


### PR DESCRIPTION
Adds a symlink check in the ENOENT catch path of resolveWorkspacePath to prevent writes through dangling symlinks that could escape the workspace boundary.

Addresses feedback from PR #14412.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
