### PR TITLE
fix: add public memberwise init to WorkspaceFileResponse

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -76,6 +76,16 @@ public struct WorkspaceFileResponse: Codable, Sendable {
     public let modifiedAt: String
     public let content: String?
     public let isBinary: Bool
+
+    public init(path: String, name: String, size: Int, mimeType: String, modifiedAt: String, content: String?, isBinary: Bool) {
+        self.path = path
+        self.name = name
+        self.size = size
+        self.mimeType = mimeType
+        self.modifiedAt = modifiedAt
+        self.content = content
+        self.isBinary = isBinary
+    }
 }
 
 // MARK: - HTTP Transport


### PR DESCRIPTION
## Summary
- `WorkspaceFileResponse` is a `public struct` in `VellumAssistantShared` but had no explicit `public` initializer
- Swift only generates an internal memberwise initializer for structs; external modules could only see the `Codable` `init(from:)`
- Fixes build error in `WorkspacePanel.swift` where it constructs `WorkspaceFileResponse` during rename operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
