### PR TITLE
fix: restrict GET app-data to query-only and wire sign-bundle completion

### DIFF
--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -566,9 +566,33 @@ export function appManagementRouteDefinitions(): RouteDefinition[] {
           if (!body.payload) {
             return httpError("BAD_REQUEST", "payload is required", 400);
           }
-          // For HTTP-based signing, the client provides the signature
-          // directly rather than using the IPC round-trip pattern.
-          // Return the payload hash for the client to sign.
+
+          // When all signature fields are present, complete the signing step.
+          if (body.signature && body.keyId && body.publicKey) {
+            // Extract content_hashes from the canonical payload the client signed.
+            let contentHashes: Record<string, string> = {};
+            try {
+              const parsed = JSON.parse(body.payload) as {
+                content_hashes?: Record<string, string>;
+              };
+              contentHashes = parsed.content_hashes ?? {};
+            } catch {
+              // If payload isn't valid JSON, proceed with empty hashes.
+            }
+
+            const signatureJson: import("../../bundler/bundle-signer.js").SignatureJson = {
+              algorithm: "ed25519",
+              signer: {
+                key_id: body.keyId,
+                display_name: "HTTP Signer",
+              },
+              content_hashes: contentHashes,
+              signature: body.signature,
+            };
+            return Response.json({ signed: true, signatureJson });
+          }
+
+          // Otherwise return the payload for the client to sign.
           return Response.json({
             payload: body.payload,
             message:
@@ -614,8 +638,14 @@ export function appManagementRouteDefinitions(): RouteDefinition[] {
       handler: ({ params, url }) => {
         try {
           const method = url.searchParams.get("method") ?? "query";
-          const recordId = url.searchParams.get("recordId") ?? undefined;
-          const result = getAppDataResult(method, params.id, recordId);
+          if (method !== "query") {
+            return httpError(
+              "BAD_REQUEST",
+              "GET app-data only supports method=query; use POST for mutations",
+              400,
+            );
+          }
+          const result = getAppDataResult(method, params.id);
           return Response.json({ success: true, result });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Limits the GET app-data endpoint to query operations only (preventing delete via read scope), and wires up the sign-bundle route to process signature data when provided.

Addresses feedback from PR #14417.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
