### PR TITLE
fix: redact env-vars in diagnostics and restore home-base icon default

### DIFF
--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -460,7 +460,7 @@ function handleHomeBaseGet(ensureLinked: boolean): Response {
           title: app.name,
           subtitle: "Dashboard",
           description: app.description ?? "",
-          icon: app.icon ?? "",
+          icon: app.icon ?? "🏠",
           metrics: [],
         };
       } else {
@@ -705,10 +705,51 @@ async function handleToolPermissionSimulate(body: {
 // Environment variables
 // ---------------------------------------------------------------------------
 
+/**
+ * Allowlist of env-var prefixes/names safe to expose via diagnostics.
+ * Everything else is redacted to prevent secret leakage.
+ */
+const SAFE_ENV_VAR_PREFIXES = [
+  "NODE_",
+  "BUN_",
+  "npm_",
+  "LANG",
+  "LC_",
+  "TERM",
+  "SHELL",
+  "HOME",
+  "USER",
+  "LOGNAME",
+  "PATH",
+  "PWD",
+  "OLDPWD",
+  "HOSTNAME",
+  "DISPLAY",
+  "XDG_",
+  "COLORTERM",
+  "EDITOR",
+  "VISUAL",
+  "TZ",
+  "TMPDIR",
+  "VELLUM_",
+  "BASE_DATA_DIR",
+  "QDRANT_HTTP_PORT",
+  "PORT",
+  "DEBUG",
+];
+
+function isEnvVarSafe(key: string): boolean {
+  return SAFE_ENV_VAR_PREFIXES.some(
+    (prefix) => key === prefix || key.startsWith(prefix),
+  );
+}
+
 function handleEnvVars(): Response {
   const vars: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
-    if (value !== undefined) vars[key] = value;
+    if (value !== undefined && isEnvVarSafe(key)) {
+      vars[key] = value;
+    }
   }
   return Response.json({ vars });
 }


### PR DESCRIPTION
Filters diagnostics env-vars output to a safe allowlist (redacting secrets), and restores the default home-base icon emoji when a personalized app lacks one.

Addresses feedback from PR #14424.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
