### PR TITLE
fix: distinguish skill inspect errors and validate description in create

### DIFF
--- a/assistant/src/runtime/routes/skills-routes.ts
+++ b/assistant/src/runtime/routes/skills-routes.ts
@@ -191,10 +191,15 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       policyKey: "skills",
       handler: async ({ req }) => {
         const body = (await req.json()) as CreateSkillParams;
-        if (!body.skillId || !body.name || !body.bodyMarkdown) {
+        if (
+          !body.skillId ||
+          !body.name ||
+          !body.description ||
+          !body.bodyMarkdown
+        ) {
           return httpError(
             "BAD_REQUEST",
-            "skillId, name, and bodyMarkdown are required",
+            "skillId, name, description, and bodyMarkdown are required",
             400,
           );
         }
@@ -228,7 +233,17 @@ export function skillRouteDefinitions(deps: SkillRouteDeps): RouteDefinition[] {
       handler: async ({ params }) => {
         const result = await inspectSkill(params.id, ctx());
         if (result.error && !result.data) {
-          return httpError("NOT_FOUND", result.error, 404);
+          if (result.error.startsWith("Invalid skill slug:")) {
+            return httpError("BAD_REQUEST", result.error, 400);
+          }
+          if (
+            /not found|does not exist|no such skill|unknown skill/i.test(
+              result.error,
+            )
+          ) {
+            return httpError("NOT_FOUND", result.error, 404);
+          }
+          return httpError("INTERNAL_ERROR", result.error, 500);
         }
         return Response.json(result);
       },


### PR DESCRIPTION
Maps only confirmed missing-skill errors to 404 (other failures get appropriate status codes), and adds description to the create-skill validation guard.

Addresses feedback from PR #14423.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
