### PR TITLE
fix: wire model-set context into RuntimeHttpServer for model mutation routes

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -420,6 +420,7 @@ export async function runDaemon(): Promise<void> {
       },
       findSession: (sessionId) => server.findSession(sessionId),
       getSkillContext: () => server.getSkillContext(),
+      modelSetContext: server.getHandlerContext(),
       sessionManagementDeps: {
         switchSession: (sessionId) =>
           switchSession(sessionId, server.getHandlerContext()),


### PR DESCRIPTION
Passes the daemon's model-set context into RuntimeHttpServerOptions so PUT /v1/model and image-gen routes work in the normal daemon startup path instead of always returning 500.

Addresses feedback from PR #14418.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
