### PR TITLE
fix: gate CU/recording routes on deps and include sessionId in SSE events

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -953,12 +953,16 @@ export class RuntimeHttpServer {
       ...channelReadinessRouteDefinitions(),
       ...attachmentRouteDefinitions(),
 
-      ...computerUseRouteDefinitions({
-        getComputerUseDeps: this.getComputerUseDeps,
-      }),
-      ...recordingRouteDefinitions({
-        getRecordingDeps: this.getRecordingDeps,
-      }),
+      ...(this.getComputerUseDeps
+        ? computerUseRouteDefinitions({
+            getComputerUseDeps: this.getComputerUseDeps,
+          })
+        : []),
+      ...(this.getRecordingDeps
+        ? recordingRouteDefinitions({
+            getRecordingDeps: this.getRecordingDeps,
+          })
+        : []),
 
       {
         endpoint: "interfaces/:path*",

--- a/assistant/src/runtime/routes/computer-use-routes.ts
+++ b/assistant/src/runtime/routes/computer-use-routes.ts
@@ -75,9 +75,9 @@ const cuObservationSequenceBySession = new Map<string, number>();
 // ---------------------------------------------------------------------------
 
 /** Publish a server message to the SSE event hub for HTTP clients. */
-function publishEvent(msg: ServerMessage): void {
+function publishEvent(msg: ServerMessage, sessionId?: string): void {
   void assistantEventHub.publish(
-    buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg),
+    buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg, sessionId),
   );
 }
 
@@ -150,7 +150,7 @@ async function handleCreateSession(
   }
 
   const sendToClient = (serverMsg: ServerMessage) => {
-    publishEvent(serverMsg);
+    publishEvent(serverMsg, sessionId);
   };
 
   const sessionRef: { current?: ComputerUseSession } = {};
@@ -262,11 +262,14 @@ async function handleObservation(
 
   const session = deps.cuSessions.get(msg.sessionId);
   if (!session) {
-    publishEvent({
-      type: "cu_error",
-      sessionId: msg.sessionId,
-      message: `No computer-use session found for id ${msg.sessionId}`,
-    });
+    publishEvent(
+      {
+        type: "cu_error",
+        sessionId: msg.sessionId,
+        message: `No computer-use session found for id ${msg.sessionId}`,
+      },
+      msg.sessionId,
+    );
     return httpError(
       "NOT_FOUND",
       `No computer-use session found for id ${msg.sessionId}`,
@@ -332,7 +335,7 @@ async function handleTaskSubmit(
   }
 
   const sendToClient = (serverMsg: ServerMessage) => {
-    publishEvent(serverMsg);
+    publishEvent(serverMsg, sessionId);
   };
 
   const sessionRef: { current?: ComputerUseSession } = {};


### PR DESCRIPTION
Only registers computer-use and recording routes when their dependencies are available, and passes sessionId through buildAssistantEvent to scope SSE events to the correct conversation.

Addresses feedback from PR #14420.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
