### PR TITLE
fix: wire regenerate events to SSE and hydrate sessions for socketless callers

### DIFF
--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -482,12 +482,12 @@ export async function switchSession(
     return null;
   }
 
-  if (socket) {
-    // If the target session is headless-locked (actively executing a task run),
-    // skip rebinding the socket so tool confirmations stay suppressed.
-    const existingSession = ctx.sessions.get(sessionId);
-    const isHeadlessLocked = existingSession?.headlessLock;
+  // If the target session is headless-locked (actively executing a task run),
+  // skip rebinding the socket so tool confirmations stay suppressed.
+  const existingSession = ctx.sessions.get(sessionId);
+  const isHeadlessLocked = existingSession?.headlessLock;
 
+  if (socket) {
     ctx.socketToSession.set(socket, sessionId);
 
     if (isHeadlessLocked) {
@@ -501,6 +501,12 @@ export async function switchSession(
       if (!session.hasEscalationHandler()) {
         wireEscalationHandler(session, socket, ctx);
       }
+    }
+  } else {
+    // Socketless callers (HTTP) still need the session hydrated in memory so
+    // follow-up operations (undo, regenerate, cancel) find an active session.
+    if (!existingSession) {
+      await ctx.getOrCreateSession(sessionId);
     }
   }
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -40,6 +40,7 @@ import {
 } from "../notifications/emit-signal.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { syncUpdateBulletinOnStartup } from "../prompts/update-bulletin.js";
+import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import {
   initAuthSigningKey,
@@ -429,12 +430,32 @@ export async function runDaemon(): Promise<void> {
           cancelGeneration(sessionId, server.getHandlerContext()),
         undoLastMessage: (sessionId) =>
           undoLastMessage(sessionId, server.getHandlerContext()),
-        regenerateResponse: (sessionId) =>
-          regenerateResponse(
+        regenerateResponse: (sessionId) => {
+          let hubChain: Promise<void> = Promise.resolve();
+          const sendEvent = (event: ServerMessage) => {
+            const ae = buildAssistantEvent(
+              "self",
+              event,
+              sessionId,
+            );
+            hubChain = (async () => {
+              await hubChain;
+              try {
+                await assistantEventHub.publish(ae);
+              } catch (err) {
+                log.warn(
+                  { err },
+                  "assistant-events hub subscriber threw during regenerate",
+                );
+              }
+            })();
+          };
+          return regenerateResponse(
             sessionId,
             server.getHandlerContext(),
-            () => {},
-          ),
+            sendEvent,
+          );
+        },
       },
     });
 


### PR DESCRIPTION
Routes regenerate callback events through the assistant event hub for SSE delivery, and ensures switchSession loads/binds sessions even without an IPC socket so HTTP callers get active sessions.

Addresses feedback from PR #14419.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
