### PR TITLE
fix: guard save completion against file switches in workspace editor

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -636,6 +636,11 @@ private struct WorkspaceFileViewer: View {
         let snapshot = state.editableContent
         let data = Data(snapshot.utf8)
         let success = await daemonClient.writeWorkspaceFile(path: path, content: data)
+        // Only update editor state if the user is still viewing the file that was saved
+        guard state.selectedFilePath == path else {
+            state.isSaving = false
+            return
+        }
         if success {
             state.originalContent = snapshot
             state.isDirty = state.editableContent != snapshot


### PR DESCRIPTION
Adds a path check before updating originalContent on save completion, preventing out-of-order saves from corrupting dirty state when the user switches files during an in-flight save.

Addresses feedback from PR #14411.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
