### PR TITLE
fix: adapt HTTP response shapes for app data, app open, and documents in Swift client

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient+Apps.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Apps.swift
@@ -92,6 +92,13 @@ extension HTTPTransport {
         }
     }
 
+    /// REST shape returned by `/v1/apps/:id/data`.
+    private struct RESTAppDataResponse: Decodable {
+        let success: Bool
+        let result: AnyCodable?
+        let error: String?
+    }
+
     private func fetchAppData(_ msg: AppDataRequestMessage, isRetry: Bool = false) async {
         guard let url = buildURL(for: .appData(id: msg.appId)) else { return }
 
@@ -142,11 +149,27 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCAppDataResponse.self, from: data)
-            onMessage?(.appDataResponse(decoded))
+            // REST returns { success, result, error? } — wrap into IPC envelope
+            let rest = try decoder.decode(RESTAppDataResponse.self, from: data)
+            let ipcResponse = IPCAppDataResponse(
+                type: "app_data_response",
+                surfaceId: msg.surfaceId,
+                callId: msg.callId,
+                success: rest.success,
+                result: rest.result,
+                error: rest.error
+            )
+            onMessage?(.appDataResponse(ipcResponse))
         } catch {
             log.error("App data request error: \(error.localizedDescription)")
         }
+    }
+
+    /// REST shape returned by `/v1/apps/:id/open`.
+    private struct RESTAppOpenResponse: Decodable {
+        let appId: String
+        let name: String
+        let html: String
     }
 
     private func handleAppOpen(appId: String, isRetry: Bool = false) async {
@@ -172,8 +195,20 @@ extension HTTPTransport {
                 }
             }
 
-            // App open response is handled by the daemon via SSE events
-            log.info("App open request sent for \(appId)")
+            // REST returns { appId, name, html } — translate into ui_surface_show event
+            let rest = try decoder.decode(RESTAppOpenResponse.self, from: data)
+            let surfaceId = "app-\(rest.appId)"
+            let surfaceMessage = UiSurfaceShowMessage(
+                sessionId: "",
+                surfaceId: surfaceId,
+                surfaceType: "dynamic_page",
+                title: rest.name,
+                data: AnyCodable(["html": rest.html, "appId": rest.appId]),
+                actions: nil,
+                display: "panel",
+                messageId: nil
+            )
+            onMessage?(.uiSurfaceShow(surfaceMessage))
         } catch {
             log.error("App open error: \(error.localizedDescription)")
         }

--- a/clients/shared/IPC/HTTPDaemonClient+Documents.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Documents.swift
@@ -34,6 +34,42 @@ extension HTTPTransport {
         }
     }
 
+    // MARK: - REST Response Shapes
+
+    /// REST shape returned by `GET /v1/documents`.
+    private struct RESTDocumentListResponse: Decodable {
+        let documents: [RESTDocumentListItem]
+    }
+
+    private struct RESTDocumentListItem: Decodable {
+        let surfaceId: String
+        let conversationId: String
+        let title: String
+        let wordCount: Int
+        let createdAt: Int
+        let updatedAt: Int
+    }
+
+    /// REST shape returned by `GET /v1/documents/:id`.
+    private struct RESTDocumentLoadResponse: Decodable {
+        let success: Bool
+        let surfaceId: String
+        let conversationId: String
+        let title: String
+        let content: String
+        let wordCount: Int
+        let createdAt: Int
+        let updatedAt: Int
+        let error: String?
+    }
+
+    /// REST shape returned by `POST /v1/documents`.
+    private struct RESTDocumentSaveResponse: Decodable {
+        let success: Bool
+        let surfaceId: String
+        let error: String?
+    }
+
     // MARK: - Documents HTTP Endpoints
 
     private func fetchDocumentList(conversationId: String?, isRetry: Bool = false) async {
@@ -65,8 +101,23 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCDocumentListResponse.self, from: data)
-            onMessage?(.documentListResponse(decoded))
+            // REST returns { documents: [...] } without `type` — wrap into IPC envelope
+            let rest = try decoder.decode(RESTDocumentListResponse.self, from: data)
+            let ipcDocs = rest.documents.map { doc in
+                IPCDocumentListResponseDocument(
+                    surfaceId: doc.surfaceId,
+                    conversationId: doc.conversationId,
+                    title: doc.title,
+                    wordCount: doc.wordCount,
+                    createdAt: doc.createdAt,
+                    updatedAt: doc.updatedAt
+                )
+            }
+            let ipcResponse = IPCDocumentListResponse(
+                type: "document_list_response",
+                documents: ipcDocs
+            )
+            onMessage?(.documentListResponse(ipcResponse))
         } catch {
             log.error("Fetch document list error: \(error.localizedDescription)")
         }
@@ -93,8 +144,21 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCDocumentLoadResponse.self, from: data)
-            onMessage?(.documentLoadResponse(decoded))
+            // REST returns { success, surfaceId, conversationId, ... } without `type` — wrap into IPC envelope
+            let rest = try decoder.decode(RESTDocumentLoadResponse.self, from: data)
+            let ipcResponse = IPCDocumentLoadResponse(
+                type: "document_load_response",
+                surfaceId: rest.surfaceId,
+                conversationId: rest.conversationId,
+                title: rest.title,
+                content: rest.content,
+                wordCount: rest.wordCount,
+                createdAt: rest.createdAt,
+                updatedAt: rest.updatedAt,
+                success: rest.success,
+                error: rest.error
+            )
+            onMessage?(.documentLoadResponse(ipcResponse))
         } catch {
             log.error("Fetch document load error: \(error.localizedDescription)")
         }
@@ -148,8 +212,15 @@ extension HTTPTransport {
                 }
             }
 
-            let decoded = try decoder.decode(IPCDocumentSaveResponse.self, from: data)
-            onMessage?(.documentSaveResponse(decoded))
+            // REST returns { success, surfaceId, error? } without `type` — wrap into IPC envelope
+            let rest = try decoder.decode(RESTDocumentSaveResponse.self, from: data)
+            let ipcResponse = IPCDocumentSaveResponse(
+                type: "document_save_response",
+                surfaceId: rest.surfaceId,
+                success: rest.success,
+                error: rest.error
+            )
+            onMessage?(.documentSaveResponse(ipcResponse))
         } catch {
             log.error("Document save error: \(error.localizedDescription)")
         }


### PR DESCRIPTION
Decodes REST response shapes and wraps them into IPC envelopes for app data responses, app-open surface messages, and document operations so the Swift client correctly processes HTTP responses.

- **App data**: REST returns `{ success, result }` — now wrapped with `surfaceId`/`callId` from the original request into `IPCAppDataResponse`
- **App open**: REST returns `{ appId, name, html }` — now translated into a `UiSurfaceShowMessage` so the UI receives the surface to display
- **Documents**: REST returns plain JSON without `type` discriminator — now wrapped into `IPCDocumentListResponse`, `IPCDocumentLoadResponse`, and `IPCDocumentSaveResponse` with the correct `type` field

Addresses feedback from PR #14426.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
