### PR TITLE
fix: wire session lookup for work-item cancel and gate run-session deps

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -719,17 +719,21 @@ export class RuntimeHttpServer {
       }),
       ...diagnosticsRouteDefinitions(),
       ...documentRouteDefinitions(),
-      ...workItemRouteDefinitions({
-        getOrCreateSession: async (conversationId) => {
-          if (!this.sendMessageDeps) {
-            throw new Error("Session management not available");
-          }
-          return this.sendMessageDeps.getOrCreateSession(conversationId);
-        },
-        findSession: this.findSession
-          ? undefined // findSession in http-types returns a different shape; session lookup for cancellation uses sendMessageDeps
+      ...workItemRouteDefinitions(
+        this.sendMessageDeps
+          ? {
+              getOrCreateSession: (conversationId) =>
+                this.sendMessageDeps!.getOrCreateSession(conversationId),
+              findSession: this.findSession
+                ? (conversationId) => {
+                    const s = this.findSession!(conversationId);
+                    if (!s || !("abort" in s)) return undefined;
+                    return s as import("../daemon/session.js").Session;
+                  }
+                : undefined,
+            }
           : undefined,
-      }),
+      ),
       ...subagentRouteDefinitions(),
       ...sessionQueryRouteDefinitions({
         modelSetContext: this.modelSetContext,


### PR DESCRIPTION
Wires the actual session lookup function into work-item route deps so cancellation aborts running sessions, and only provides getOrCreateSession when sendMessageDeps is available so the 501 guard works correctly.

Addresses feedback from PR #14422.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
