### PR TITLE
refactor: remove generated IPC Swift types and update documentation for HTTP-only transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Follow the [Agent Skills specification](https://agentskills.io/specification) fo
 
 ## Multi-Instance Path Invariant
 
-When the daemon runs with `BASE_DATA_DIR` set to an instance directory (e.g. `~/.vellum/instances/alice/`), `getRootDir()` resolves to `join(BASE_DATA_DIR, ".vellum")`. All CLI and daemon code that references instance-scoped files must use `join(instanceDir, ".vellum", ...)` — never assume the root is `~/.vellum/` directly. This ensures socket paths, PID files, tokens, and config are correctly scoped per instance.
+When the daemon runs with `BASE_DATA_DIR` set to an instance directory (e.g. `~/.vellum/instances/alice/`), `getRootDir()` resolves to `join(BASE_DATA_DIR, ".vellum")`. All CLI and daemon code that references instance-scoped files must use `join(instanceDir, ".vellum", ...)` — never assume the root is `~/.vellum/` directly. This ensures PID files, tokens, and config are correctly scoped per instance.
 
 ## Qdrant Port Override
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,7 +23,7 @@ This file is the cross-system architecture index. Detailed designs live in domai
 - Bundled-skill outbound API calls that require credentials default to proxied execution (`bash` with `network_mode: "proxied"` + `credential_ids`) rather than manual token plumbing.
 - Managed shared-identity channel routing runs in a separate managed-gateway service lane from the per-assistant `gateway/` lane. The deployable managed-gateway runtime is platform-owned; this repo keeps public contracts/fixtures under `gateway-managed/`.
 - Production LLM calls go through the provider abstraction, not provider SDKs in feature code.
-- Notification producers emit through `emitNotificationSignal()` to preserve decisioning and audit invariants. Reminder routing metadata (`routingIntent`, `routingHints`) flows through the signal and is enforced post-decision to control multi-channel fanout. The decision engine produces per-channel thread actions (`start_new` / `reuse_existing`) validated against a candidate set; `notification_thread_created` IPC is emitted only on actual creation, not on reuse.
+- Notification producers emit through `emitNotificationSignal()` to preserve decisioning and audit invariants. Reminder routing metadata (`routingIntent`, `routingHints`) flows through the signal and is enforced post-decision to control multi-channel fanout. The decision engine produces per-channel thread actions (`start_new` / `reuse_existing`) validated against a candidate set; `notification_thread_created` is emitted only on actual creation, not on reuse.
 - Memory extraction/recall must enforce actor-role provenance gates for untrusted actors.
 - Trusted contact ingress ACL is channel-agnostic; identity binding adapts per channel (chat ID, E.164 phone, external user ID) without channel-specific branching.
 - macOS managed sign-in connects the desktop app to a platform-hosted assistant via Django assistant-scoped proxy endpoints (`/v1/assistants/{id}/...`). The `HTTPDaemonClient` operates in `platformAssistantProxy` route mode with `X-Session-Token` auth. Managed lockfile entries have `cloud: "vellum"`. Startup guardrails skip local daemon hatching and actor credential bootstrap. See [`clients/ARCHITECTURE.md`](clients/ARCHITECTURE.md) for the full flow.
@@ -44,7 +44,6 @@ Each named instance gets its own directory tree under `~/.vellum/instances/<name
 ├── instances/
 │   ├── alice/                     # Instance root (= BASE_DATA_DIR for this daemon)
 │   │   └── .vellum/              # Runtime dir (getRootDir() resolves here)
-│   │       ├── vellum.sock       # Unix domain socket
 │   │       ├── vellum.pid        # Daemon PID
 │   │       ├── gateway.pid       # Gateway PID
 │   │       ├── outbound-proxy.pid
@@ -71,7 +70,6 @@ Each instance gets its own:
 - **Daemon port** (`RUNTIME_HTTP_PORT`): Allocated by scanning from base port 7821.
 - **Gateway port** (`GATEWAY_PORT`): Allocated by scanning from base port 7830.
 - **Qdrant port** (`QDRANT_HTTP_PORT`): Allocated by scanning from base port 6333.
-- **Unix socket**: `<instanceDir>/.vellum/vellum.sock`
 - **PID file**: `<instanceDir>/.vellum/vellum.pid`
 - **SQLite database, logs, memory indices**: All under `<instanceDir>/.vellum/workspace/data/`
 
@@ -102,7 +100,6 @@ The global lockfile (`~/.vellum.lock.json`) tracks all instances:
         "daemonPort": 7821,
         "gatewayPort": 7830,
         "qdrantPort": 6333,
-        "socketPath": "~/.vellum/instances/alice/.vellum/vellum.sock",
         "pidFile": "~/.vellum/instances/alice/.vellum/vellum.pid"
       }
     },
@@ -117,7 +114,7 @@ The global lockfile (`~/.vellum.lock.json`) tracks all instances:
 }
 ```
 
-- `resources` (`LocalInstanceResources`): Present on all local entries. Contains per-instance ports, paths, and socket locations.
+- `resources` (`LocalInstanceResources`): Present on all local entries. Contains per-instance ports and paths.
 - `activeAssistant`: Determines which instance CLI commands target by default.
 - Remote assistants (`cloud: "gcp"`, `"aws"`, etc.) are unaffected and have no `resources` field.
 
@@ -161,7 +158,7 @@ graph TB
 
         subgraph "Ride Shotgun (Ambient Agent)"
             RS_TRIGGER["RideShotgunTrigger<br/>timer-based auto-invitation<br/>eligibility checks"]
-            RS_SESSION["RideShotgunSession<br/>time-boxed observation<br/>daemon IPC + WatchSession"]
+            RS_SESSION["RideShotgunSession<br/>time-boxed observation<br/>HTTP + WatchSession"]
             RS_INVITE["RideShotgunInvitationWindow"]
             RS_PROGRESS["RideShotgunProgressWindow"]
             RS_SUMMARY["RideShotgunSummaryWindow"]
@@ -199,8 +196,8 @@ graph TB
     end
 
     subgraph "Daemon (Bun + TypeScript)"
-        IPC_SERVER["DaemonServer<br/>Unix socket IPC<br/>~/.vellum/vellum.sock"]
-        HANDLERS["Message Handlers<br/>session routing"]
+        HTTP_RT["RuntimeHttpServer<br/>HTTP + SSE"]
+        HANDLERS["Route Handlers<br/>session routing"]
         SESSION_MGR["Session Manager<br/>in-memory pool<br/>stale eviction"]
 
         subgraph "Onboarding Control Plane"
@@ -305,7 +302,6 @@ graph TB
             VISIBILITY_POLICY["MediaVisibilityPolicy<br/>private thread gate"]
         end
 
-        HTTP_SERVER["RuntimeHttpServer<br/>(optional, RUNTIME_HTTP_PORT)"]
     end
 
     subgraph "Gateway (Bun + TypeScript)"
@@ -345,7 +341,6 @@ graph TB
             PG_APIKEYS["api_keys"]
         end
 
-        LOCAL_IPC["LocalDaemonClient<br/>Unix socket proxy"]
         RUNTIME_CLIENT["RuntimeClient<br/>HTTP proxy"]
     end
 
@@ -368,8 +363,8 @@ graph TB
     TEXT_SESS -.->|"computer_use_request_control<br/>(explicit user request)"| PERCEIVE
 
     %% Computer Use loop
-    PERCEIVE -->|"CuObservationMessage"| IPC_SERVER
-    IPC_SERVER -->|"CuActionMessage"| VERIFY
+    PERCEIVE -->|"CuObservationMessage<br/>(HTTP POST)"| HTTP_RT
+    HTTP_RT -->|"CuActionMessage<br/>(SSE)"| VERIFY
     VERIFY -->|"allowed"| EXECUTE
     VERIFY -->|"needsConfirmation"| UI
     UI -->|"approved"| EXECUTE
@@ -378,14 +373,14 @@ graph TB
     WAIT --> PERCEIVE
 
     %% Text Q&A flow
-    TEXT_SESS -->|"SessionCreate +<br/>UserMessage"| IPC_SERVER
-    IPC_SERVER -->|"AssistantTextDelta<br/>stream"| TEXT_WIN
+    TEXT_SESS -->|"SessionCreate +<br/>UserMessage<br/>(HTTP POST)"| HTTP_RT
+    HTTP_RT -->|"AssistantTextDelta<br/>(SSE stream)"| TEXT_WIN
 
     %% Main Window Chat flow
-    CHAT_VM -->|"session_create +<br/>user_message +<br/>cancel"| IPC_SERVER
-    IPC_SERVER -->|"session_info +<br/>session_title_updated +<br/>text deltas +<br/>message_complete +<br/>session_error +<br/>message_queued +<br/>message_dequeued +<br/>generation_handoff"| CHAT_VM
+    CHAT_VM -->|"session_create +<br/>user_message +<br/>cancel<br/>(HTTP POST)"| HTTP_RT
+    HTTP_RT -->|"session_info +<br/>session_title_updated +<br/>text deltas +<br/>message_complete +<br/>session_error +<br/>message_queued +<br/>message_dequeued +<br/>generation_handoff<br/>(SSE)"| CHAT_VM
     CHAT_VIEW --> CHAT_VM
-    MW_STATE -->|"home_base_get + app_open_request<br/>(dashboard-first bootstrap)"| IPC_SERVER
+    MW_STATE -->|"home_base_get + app_open_request<br/>(dashboard-first bootstrap)"| HTTP_RT
 
     %% Ride Shotgun flow
     RS_TRIGGER -->|"shouldShowInvitation"| AMBIENT
@@ -394,18 +389,18 @@ graph TB
     RS_SESSION --> WATCH
     WATCH --> AX_CAP
     WATCH -.->|"fallback"| OCR_CAP
-    RS_SESSION -->|"observations via<br/>daemon IPC"| IPC_SERVER
+    RS_SESSION -->|"observations via<br/>HTTP POST"| HTTP_RT
     RS_SESSION -->|"progress"| RS_PROGRESS
     RS_SESSION -->|"summary"| RS_SUMMARY
 
     %% Dynamic Workspace flow
-    IPC_SERVER -->|"ui_surface_show"| SURFACE_MGR
+    HTTP_RT -->|"ui_surface_show"| SURFACE_MGR
     SURFACE_MGR -->|"display != inline<br/>.openDynamicWorkspace"| WORKSPACE
     WORKSPACE --> DYN_PAGE
-    DYN_PAGE -->|"vellumBridge<br/>actions + data RPC"| IPC_SERVER
+    DYN_PAGE -->|"vellumBridge<br/>actions + data RPC<br/>(HTTP)"| HTTP_RT
 
     %% Daemon internals
-    IPC_SERVER --> HANDLERS
+    HTTP_RT --> HANDLERS
     HANDLERS --> SESSION_MGR
     SESSION_MGR --> ANTHROPIC
     SESSION_MGR --> OPENAI
@@ -418,7 +413,7 @@ graph TB
     PLAYBOOK_MGR -->|"inject <channel_onboarding_playbook><br/>runtime context"| SESSION_MGR
     PLAYBOOK_MGR --> ONBOARD_ORCH
     ONBOARD_ORCH -->|"inject <onboarding_mode><br/>runtime context"| SESSION_MGR
-    IPC_SERVER -.->|"daemon startup bootstrap + home_base_get"| HOME_BASE_BOOT
+    HTTP_RT -.->|"daemon startup bootstrap + home_base_get"| HOME_BASE_BOOT
     HOME_BASE_BOOT --> HOME_BASE_SEED
     HOME_BASE_BOOT --> HOME_BASE_LINK
     HOME_BASE_LINK --> DB_HOME
@@ -447,45 +442,43 @@ graph TB
     GW_VERIFY --> GW_NORMALIZE
     GW_NORMALIZE --> GW_ROUTE
     GW_ROUTE --> GW_FORWARD
-    GW_FORWARD -->|"HTTP + replyCallbackUrl"| HTTP_SERVER
-    HTTP_SERVER -->|"channels/inbound transport<br/>channelId + hints + uxBrief"| PLAYBOOK_MGR
+    GW_FORWARD -->|"HTTP + replyCallbackUrl"| HTTP_RT
+    HTTP_RT -->|"channels/inbound transport<br/>channelId + hints + uxBrief"| PLAYBOOK_MGR
     GW_REPLY -->|"Telegram API"| GW_WEBHOOK
     GW_ATTACH -->|"download from runtime<br/>+ upload to Telegram"| GW_WEBHOOK
 
     %% Gateway flow — Telegram deliver (runtime → gateway → Telegram)
     %% replyCallbackUrl is built from gatewayInternalBaseUrl (GATEWAY_INTERNAL_BASE_URL env var)
-    HTTP_SERVER -->|"POST /deliver/telegram<br/>(via gatewayInternalBaseUrl)"| GW_TG_DELIVER
+    HTTP_RT -->|"POST /deliver/telegram<br/>(via gatewayInternalBaseUrl)"| GW_TG_DELIVER
     GW_TG_DELIVER --> GW_REPLY
     GW_TG_DELIVER --> GW_ATTACH
 
     %% Gateway flow — Twilio voice webhooks
-    GW_TWILIO_VOICE -->|"HTTP"| HTTP_SERVER
-    GW_TWILIO_STATUS -->|"HTTP"| HTTP_SERVER
-    GW_TWILIO_CONNECT -->|"HTTP"| HTTP_SERVER
-    GW_TWILIO_RELAY -->|"WebSocket proxy"| HTTP_SERVER
+    GW_TWILIO_VOICE -->|"HTTP"| HTTP_RT
+    GW_TWILIO_STATUS -->|"HTTP"| HTTP_RT
+    GW_TWILIO_CONNECT -->|"HTTP"| HTTP_RT
+    GW_TWILIO_RELAY -->|"WebSocket proxy"| HTTP_RT
 
     %% Gateway flow — WhatsApp channel (Meta Cloud API)
     GW_WA_WEBHOOK -->|"HMAC-SHA256 verify<br/>+ normalize + dedup<br/>+ route resolver"| GW_FORWARD
-    HTTP_SERVER -->|"POST /deliver/whatsapp<br/>(via gatewayInternalBaseUrl)"| GW_WA_DELIVER
+    HTTP_RT -->|"POST /deliver/whatsapp<br/>(via gatewayInternalBaseUrl)"| GW_WA_DELIVER
     GW_WA_DELIVER -->|"Meta Cloud API<br/>/{phoneNumberId}/messages"| GW_WA_WEBHOOK
 
     %% Gateway flow — Slack channel (Socket Mode WebSocket)
     GW_SLACK_SOCKET -->|"app_mention events<br/>ACK + dedup"| GW_SLACK_NORMALIZE
     GW_SLACK_NORMALIZE -->|"normalize + route resolver"| GW_FORWARD
-    HTTP_SERVER -->|"POST /deliver/slack<br/>(via gatewayInternalBaseUrl)"| GW_SLACK_DELIVER
+    HTTP_RT -->|"POST /deliver/slack<br/>(via gatewayInternalBaseUrl)"| GW_SLACK_DELIVER
     GW_SLACK_DELIVER -->|"Slack API<br/>chat.postMessage"| GW_SLACK_SOCKET
 
     %% Gateway flow — OAuth callback
-    GW_OAUTH -->|"forward code + state"| HTTP_SERVER
+    GW_OAUTH -->|"forward code + state"| HTTP_RT
 
     %% Gateway flow — Runtime proxy path (optional)
-    GW_PROXY -->|"HTTP (forwarded)"| HTTP_SERVER
+    GW_PROXY -->|"HTTP (forwarded)"| HTTP_RT
 
     %% Web server
-    WEB_API -->|"local mode"| LOCAL_IPC
-    LOCAL_IPC -->|"Unix socket"| IPC_SERVER
-    WEB_API -->|"cloud mode"| RUNTIME_CLIENT
-    RUNTIME_CLIENT -->|"HTTP"| HTTP_SERVER
+    WEB_API -->|"HTTP"| RUNTIME_CLIENT
+    RUNTIME_CLIENT -->|"HTTP"| HTTP_RT
 
     %% Swarm data flow
     SESSION_MGR -->|"swarm_delegate<br/>tool_use"| SWARM_TOOL
@@ -500,14 +493,13 @@ graph TB
     SESSION_MGR --> TRACE_EMITTER
     EVENT_BUS --> TOOL_TRACE
     TOOL_TRACE --> TRACE_EMITTER
-    TRACE_EMITTER -->|"trace_event"| IPC_SERVER
-    IPC_SERVER -->|"trace_event"| TRACE_STORE
+    TRACE_EMITTER -->|"trace_event<br/>(SSE)"| TRACE_STORE
     TRACE_STORE --> DEBUG_PANEL
 
     %% Integration data flow
     HANDLERS -->|"integration_connect"| INT_REGISTRY
     INT_REGISTRY --> INT_OAUTH
-    INT_OAUTH -->|"open_url"| IPC_SERVER
+    INT_OAUTH -->|"open_url<br/>(SSE event)"| UI
     INT_OAUTH -->|"store tokens"| ENC_STORE
     GMAIL_TOOLS --> INT_TOKEN
     INT_TOKEN -->|"auto-refresh"| ENC_STORE

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Vellum integrates with third-party services via OAuth2. Each integration is expo
 
 The unified messaging layer provides platform-agnostic tools (`messaging_send`, `messaging_read`, `messaging_search`, etc.) that delegate to provider adapters. Gmail and Slack each implement the `MessagingProvider` interface. Telegram is also supported as a messaging provider, though with limited capabilities compared to Slack and Gmail: bots can send messages to known chat IDs but cannot list conversations, retrieve message history, or search messages (Bot API limitations). Bots can only message users or groups that have previously interacted with the bot. SMS is supported via Twilio as a send-only provider — it can send outbound SMS messages but does not support listing conversations, reading history, or searching (SMS is stateless). **Note:** SMS only — MMS (media messages) is not currently supported. Platform-specific tools (e.g. `gmail_archive`, `slack_add_reaction`) extend beyond the generic interface where needed.
 
-Connect Gmail and Slack via the Settings UI or `integration_connect` IPC message. OAuth2 tokens are stored in the credential vault — the LLM never sees raw tokens. Telegram uses a bot token (not OAuth) — see the `telegram-setup` skill for setup instructions. SMS uses Twilio credentials (Account SID + Auth Token) — see the `twilio-setup` skill for setup instructions.
+Connect Gmail and Slack via the Settings UI or the `integration_connect` HTTP endpoint. OAuth2 tokens are stored in the credential vault — the LLM never sees raw tokens. Telegram uses a bot token (not OAuth) — see the `telegram-setup` skill for setup instructions. SMS uses Twilio credentials (Account SID + Auth Token) — see the `twilio-setup` skill for setup instructions.
 
 #### Per-assistant phone number mapping (SMS)
 
@@ -315,7 +315,7 @@ Twitter integration supports two operation paths: **OAuth** (X API v2) and **Bro
 
 - **Strategy selection**: `vellum x strategy set <oauth|browser|auto>` controls which path is used. Default is `auto`, which prefers OAuth when credentials are available and the operation is supported, then falls back to browser. The strategy is persisted in config as `twitter.operationStrategy`.
 
-**OAuth2 PKCE setup** (`local_byo` mode): The user provides their own Twitter OAuth2 Client ID (and optional Client Secret). The assistant runs a standard OAuth2 PKCE flow against `twitter.com/i/oauth2/authorize` and `api.x.com/2/oauth2/token`. The flow verifies the user's identity (`GET /2/users/me`) and stores tokens in the vault for use by both identity verification and the OAuth operation path. Connect via the Settings UI or `twitter_auth_start` IPC message.
+**OAuth2 PKCE setup** (`local_byo` mode): The user provides their own Twitter OAuth2 Client ID (and optional Client Secret). The assistant runs a standard OAuth2 PKCE flow against `twitter.com/i/oauth2/authorize` and `api.x.com/2/oauth2/token`. The flow verifies the user's identity (`GET /2/users/me`) and stores tokens in the vault for use by both identity verification and the OAuth operation path. Connect via the Settings UI or the `twitter_auth_start` HTTP endpoint.
 
 **Available tools**: `twitter_post` — posts a tweet via the strategy router (OAuth or CDP depending on configuration). Read operations (timeline, search, etc.) use the browser path.
 
@@ -411,9 +411,9 @@ All `browser_*` tools are declared as low-risk. The system seeds default trust r
 
 The assistant can attach files and images to its replies. Attachments flow through three delivery channels:
 
-### Desktop (IPC)
+### Desktop (HTTP+SSE)
 
-Attachments are sent inline (base64) in `message_complete`, `generation_handoff`, and `history_response` IPC messages. The macOS app renders thumbnails for images and displays file metadata for documents.
+Attachments are sent inline (base64) in `message_complete`, `generation_handoff`, and `history_response` SSE events. The macOS app renders thumbnails for images and displays file metadata for documents.
 
 ### Runtime HTTP API
 
@@ -486,7 +486,7 @@ Media embeds are controlled by settings under `ui.mediaEmbeds` in `~/.vellum/wor
 <details>
 <summary><b>Assistant Events SSE Stream</b></summary>
 
-The runtime HTTP server exposes a Server-Sent Events (SSE) endpoint that streams real-time assistant events for a specific conversation. This provides a transport-agnostic alternative to the Unix socket IPC for HTTP clients (web apps, remote integrations, etc.).
+The runtime HTTP server exposes a Server-Sent Events (SSE) endpoint that streams real-time assistant events for a specific conversation.
 
 ### Endpoint
 
@@ -536,7 +536,7 @@ Each `data` field is a JSON-serialized `AssistantEvent`:
 }
 ```
 
-The `message` field is the unchanged IPC `ServerMessage` payload — the same types sent over the Unix socket to native clients. All delta semantics are preserved:
+The `message` field is the `ServerMessage` payload. All delta semantics are preserved:
 
 | Message type | Description |
 |---|---|
@@ -597,42 +597,36 @@ while (true) {
 
 Access a remote assistant from your local machine via SSH.
 
-### CLI (socket forwarding)
+### CLI (SSH port forwarding)
 
-The CLI connects via Unix socket. Forward the socket with SSH:
-
-```bash
-ssh -L ~/.vellum/remote.sock:/home/user/.vellum/vellum.sock user@remote-host -N &
-VELLUM_DAEMON_SOCKET=~/.vellum/remote.sock vellum
-```
-
-When `VELLUM_DAEMON_SOCKET` is set, autostart is disabled by default. Set `VELLUM_DAEMON_AUTOSTART=1` to override.
-
-### macOS app (socket forwarding)
-
-The macOS app also supports `VELLUM_DAEMON_SOCKET`. Launch it from the terminal:
+The CLI connects via HTTP. Forward the assistant's HTTP port with SSH:
 
 ```bash
-ssh -L ~/.vellum/remote.sock:/home/user/.vellum/vellum.sock user@remote-host -N &
-VELLUM_DAEMON_SOCKET=~/.vellum/remote.sock open -a Vellum
+ssh -L 8741:localhost:8741 user@remote-host -N &
+VELLUM_DAEMON_URL=http://localhost:8741 vellum
 ```
 
-### Blob Transport Behavior
+When connecting to a remote assistant, autostart is disabled by default. Set `VELLUM_DAEMON_AUTOSTART=1` to override.
 
-When the macOS client connects to a local assistant, large CU observation payloads (screenshots, AX trees) are offloaded to file-based blobs at `~/.vellum/workspace/data/ipc-blobs/` instead of being embedded inline in IPC JSON. On connect, the client probes whether client and assistant share the same blob directory. If the probe succeeds, large payloads are written as blob files and only lightweight references travel over the socket.
+### macOS app (SSH port forwarding)
 
-Over SSH-forwarded sockets, the probe fails automatically (the filesystems don't overlap), so the client falls back to inline base64/text payloads transparently. On iOS (TCP connections), the probe is skipped entirely and inline payloads are always used. No configuration is needed.
+The macOS app also supports remote connections. Launch it from the terminal:
+
+```bash
+ssh -L 8741:localhost:8741 user@remote-host -N &
+VELLUM_DAEMON_URL=http://localhost:8741 open -a Vellum
+```
 
 ### Troubleshooting
 
 | Symptom | Check |
 |---|---|
-| CLI: "could not connect to assistant socket" | Is the SSH socket tunnel active? Check `VELLUM_DAEMON_SOCKET` path |
-| CLI: assistant starts locally despite socket override | Check that `VELLUM_DAEMON_AUTOSTART` is not set to `1` |
-| macOS: not connecting | Verify socket path in `VELLUM_DAEMON_SOCKET` exists and is writable |
+| CLI: "could not connect to assistant" | Is the SSH port tunnel active? Check `VELLUM_DAEMON_URL` |
+| CLI: assistant starts locally despite remote override | Check that `VELLUM_DAEMON_AUTOSTART` is not set to `1` |
+| macOS: not connecting | Verify the assistant URL is reachable |
 | Any: "connection refused" | Is the remote assistant running? (`vellum ps` on remote) |
 
-Run `vellum doctor` for a full diagnostic check including socket path and autostart policy.
+Run `vellum doctor` for a full diagnostic check.
 
 </details>
 

--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document owns assistant-runtime architecture details. The repo-level archit
 
 ### Channel Onboarding Playbook Bootstrap
 
-- Transport metadata arrives via `session_create.transport` (IPC) or `/channels/inbound` (`channelId`, optional `hints`, optional `uxBrief`).
+- Transport metadata arrives via `session_create.transport` (HTTP) or `/channels/inbound` (`channelId`, optional `hints`, optional `uxBrief`).
 - Telegram webhook ingress now injects deterministic channel-safe transport metadata (`hints` + `uxBrief`) so non-dashboard channels defer Home Base-only UI tasks cleanly.
 - `OnboardingPlaybookManager` resolves `<channel>_onboarding.md`, checks `onboarding/playbooks/registry.json`, and applies per-channel first-time fast-path onboarding.
 - `OnboardingOrchestrator` derives onboarding-mode guidance (post-hatch sequence, USER.md capture, Home Base handoff) from playbook + transport context.
@@ -45,7 +45,7 @@ All HTTP API requests use a single `Authorization: Bearer <jwt>` header for auth
 | ---------------------------------------- | -------------- | ------------------------------------------- |
 | `actor:<assistantId>:<actorPrincipalId>` | `actor`        | Desktop, iOS, or CLI client                 |
 | `svc:gateway:<assistantId>`              | `svc_gateway`  | Gateway service (ingress, webhooks)         |
-| `ipc:<assistantId>:<sessionId>`          | `ipc`          | Internal IPC connections                    |
+| `svc:internal:<assistantId>:<sessionId>` | `svc_internal` | Internal service connections                |
 | `svc:daemon:<identifier>`                | `svc_daemon`   | Daemon service token (CLI bootstrap, local) |
 
 **Scope profiles:**
@@ -55,7 +55,7 @@ All HTTP API requests use a single `Authorization: Bearer <jwt>` header for auth
 | `actor_client_v1`    | `chat.{read,write}`, `approval.{read,write}`, `settings.{read,write}`, `attachments.{read,write}`, `calls.{read,write}`, `feature_flags.{read,write}` | Desktop, iOS, CLI clients                    |
 | `gateway_ingress_v1` | `ingress.write`, `internal.write`                                                                                                                     | Gateway channel inbound + webhook forwarding |
 | `gateway_service_v1` | `settings.read`, `settings.write`, `internal.write`                                                                                                   | Gateway service-to-daemon calls              |
-| `ipc_v1`             | `ipc.all`                                                                                                                                             | Internal IPC connections                     |
+| `internal_v1`        | `internal.all`                                                                                                                                        | Internal service connections                 |
 
 **Identity lifecycle:**
 
@@ -65,7 +65,7 @@ All HTTP API requests use a single `Authorization: Bearer <jwt>` header for auth
 
 3. **Refresh** — `POST /v1/guardian/refresh` accepts `{ refreshToken }` and returns a new access/refresh token pair. Single-use rotation with replay detection and family-based revocation.
 
-4. **IPC identity** — Local IPC connections use `resolveLocalIpcGuardianContext()` for deterministic identity without tokens.
+4. **Local identity** — Local connections use deterministic identity resolution without tokens.
 
 **Route policy enforcement:** Every protected endpoint declares required scopes and allowed principal types in `src/runtime/auth/route-policy.ts`. The `enforcePolicy()` function checks the AuthContext against these requirements and returns 403 when access is denied. A guard test ensures every dispatched endpoint has a corresponding policy entry.
 
@@ -88,7 +88,7 @@ All HTTP API requests use a single `Authorization: Bearer <jwt>` header for auth
 | `src/runtime/routes/guardian-bootstrap-routes.ts` | `POST /v1/guardian/init` (initial JWT issuance)                                               |
 | `src/runtime/routes/guardian-refresh-routes.ts`   | `POST /v1/guardian/refresh` (token rotation)                                                  |
 | `src/runtime/routes/pairing-routes.ts`            | JWT credential issuance in pairing flow                                                       |
-| `src/runtime/local-actor-identity.ts`             | `resolveLocalIpcGuardianContext` — deterministic IPC identity                                 |
+| `src/runtime/local-actor-identity.ts`             | `resolveLocalGuardianContext` — deterministic local identity                                  |
 | `src/memory/channel-verification-sessions.ts`     | Guardian binding types, verification session management                                       |
 
 ### Channel-Agnostic Scoped Approval Grants
@@ -118,7 +118,7 @@ All guardian approval decisions — regardless of how they arrive — route thro
 **Button-first path (deterministic):**
 
 - Desktop clients (macOS/iOS) render `GuardianDecisionPrompt` objects as tappable card UIs with kind-aware headers and action buttons. The `GuardianDecisionBubble` renders distinct headers for each kind: "Tool Approval Required", "Question Pending", or "Access Request".
-- Desktop clients submit decisions via HTTP (`POST /v1/guardian-actions/decision`) or IPC (`guardian_action_decision`). Both route through `applyCanonicalGuardianDecision`.
+- Desktop clients submit decisions via HTTP (`POST /v1/guardian-actions/decision`), routed through `applyCanonicalGuardianDecision`.
 - Channel adapters (Telegram inline keyboards, WhatsApp) encode actions as callback data (`apr:<requestId>:<action>`).
 
 **Text fallback path (always available):**
@@ -137,8 +137,6 @@ All guardian approval decisions — regardless of how they arrive — route thro
 | `src/approvals/guardian-decision-primitive.ts` | Unified decision application: downgrade, approval info capture, `handleChannelDecision`, record update, grant minting                             |
 | `src/runtime/guardian-decision-types.ts`       | Shared types: `GuardianDecisionPrompt`, `GuardianDecisionAction`, `buildDecisionActions`, `buildPlainTextFallback`, `ApplyGuardianDecisionResult` |
 | `src/runtime/routes/guardian-action-routes.ts` | HTTP route handlers for `GET /v1/guardian-actions/pending` and `POST /v1/guardian-actions/decision`                                               |
-| `src/daemon/handlers/guardian-actions.ts`      | IPC handlers wrapping the same logic for desktop socket clients                                                                                   |
-| `src/daemon/ipc-contract/guardian-actions.ts`  | IPC message type definitions for guardian action requests/responses                                                                               |
 | `src/runtime/channel-approval-types.ts`        | Channel-facing approval action types and `toApprovalActionOptions` bridge                                                                         |
 
 ### Temporary Approval Modes (Session-Scoped Overrides)
@@ -173,11 +171,11 @@ The canonical guardian request system provides a channel-agnostic, unified domai
 
 1. **Canonical domain (single source of truth):** All guardian requests — tool approvals, pending questions, access requests — are persisted in the `canonical_guardian_requests` table (`src/memory/canonical-guardian-store.js`). Each request has a unique ID, a short human-readable request code, and a status that follows a CAS (compare-and-swap) lifecycle: `pending` -> `approved` | `denied` | `expired` | `cancelled`. Deliveries (notifications sent to guardians) are tracked in `canonical_guardian_deliveries`.
 
-2. **Unified apply primitive (single write path):** `applyCanonicalGuardianDecision()` in `src/approvals/guardian-decision-primitive.ts` is the single write path for all guardian decisions. It enforces identity validation, expiry checks, CAS resolution, `approve_always` downgrade (guardian-on-behalf invariant), kind-specific resolver dispatch via the resolver registry, and scoped grant minting. All callers — HTTP API, IPC handlers, inbound channel router, desktop session — route decisions through this function.
+2. **Unified apply primitive (single write path):** `applyCanonicalGuardianDecision()` in `src/approvals/guardian-decision-primitive.ts` is the single write path for all guardian decisions. It enforces identity validation, expiry checks, CAS resolution, `approve_always` downgrade (guardian-on-behalf invariant), kind-specific resolver dispatch via the resolver registry, and scoped grant minting. All callers — HTTP API, inbound channel router, desktop session — route decisions through this function.
 
 3. **Shared reply router (priority-ordered routing):** `routeGuardianReply()` in `src/runtime/guardian-reply-router.ts` provides a single entry point for all inbound guardian reply processing across channels. It routes through a priority-ordered pipeline: (a) deterministic callback parsing (button presses with `apr:<requestId>:<action>`), (b) request code parsing (6-char alphanumeric prefix), (c) NL classification via the conversational approval engine. All decisions flow through `applyCanonicalGuardianDecision`.
 
-4. **Deterministic API (prompt listing and decision endpoints):** Desktop clients and API consumers use `GET /v1/guardian-actions/pending` and `POST /v1/guardian-actions/decision` (HTTP) or the equivalent IPC messages. These endpoints surface canonical requests alongside legacy pending interactions and channel approval records, with deduplication to avoid double-rendering.
+4. **Deterministic API (prompt listing and decision endpoints):** Desktop clients and API consumers use `GET /v1/guardian-actions/pending` and `POST /v1/guardian-actions/decision` (HTTP). These endpoints surface canonical requests alongside legacy pending interactions and channel approval records, with deduplication to avoid double-rendering.
 
 5. **Buttons first, text fallback:** All request kinds (`tool_approval`, `pending_question`, `access_request`) are rendered as structured button cards when displayed in macOS/iOS guardian threads. Each prompt also embeds deterministic text fallback instructions (request-code-based approve/reject directives, and for `access_request` the "open invite flow" phrase) so text-based channels and manual fallback always work. Code-only messages (just a request code without decision text) return clarification instead of auto-approving. Disambiguation with multiple pending requests stays fail-closed — no auto-resolve when the target is ambiguous.
 
@@ -198,12 +196,11 @@ The canonical guardian request system provides a channel-agnostic, unified domai
 | `src/approvals/guardian-request-resolvers.ts`           | Resolver registry: kind-specific side-effect dispatch after CAS resolution                                    |
 | `src/runtime/guardian-reply-router.ts`                  | Shared inbound router: callback -> code -> NL classification pipeline                                         |
 | `src/runtime/routes/guardian-action-routes.ts`          | HTTP endpoints for prompt listing and decision submission                                                     |
-| `src/daemon/handlers/guardian-actions.ts`               | IPC handlers for desktop socket clients                                                                       |
 | `src/runtime/routes/canonical-guardian-expiry-sweep.ts` | Canonical request expiry sweep                                                                                |
 
 ### Outbound Channel Verification (HTTP Endpoints)
 
-Channel verification can be initiated through gateway HTTP endpoints (which forward to runtime handlers) as an alternative to the legacy IPC-only flow. This enables chat-first verification where the assistant guides the user through channel verification setup via normal conversation.
+Channel verification is initiated through gateway HTTP endpoints (which forward to runtime handlers). This enables chat-first verification where the assistant guides the user through channel verification setup via normal conversation.
 
 **HTTP Endpoints:**
 
@@ -219,7 +216,7 @@ All endpoints are JWT-authenticated via `Authorization: Bearer <jwt>`. Skills an
 
 **Shared Business Logic:**
 
-The HTTP route handlers (`channel-verification-routes.ts`) and the legacy IPC handlers (`config-channels.ts`) both delegate to the same action functions in `verification-outbound-actions.ts`. This module contains transport-agnostic business logic for starting, resending, and cancelling outbound verification flows across Telegram and voice channels. It returns `OutboundActionResult` objects that the transport layer (gateway-forwarded HTTP or IPC) maps to its respective response format.
+The HTTP route handlers (`channel-verification-routes.ts`) delegate to action functions in `verification-outbound-actions.ts`. This module contains transport-agnostic business logic for starting, resending, and cancelling outbound verification flows across Telegram and voice channels. It returns `OutboundActionResult` objects that the transport layer maps to the HTTP response format.
 
 **Chat-First Orchestration Flow:**
 
@@ -235,7 +232,6 @@ The HTTP route handlers (`channel-verification-routes.ts`) and the legacy IPC ha
 | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `src/runtime/verification-outbound-actions.ts`             | Shared business logic for start/resend/cancel outbound verification                                                  |
 | `src/runtime/routes/channel-verification-routes.ts`        | HTTP route handlers for unified verification session API (`/v1/channel-verification-sessions`, `/revoke`, `/status`) |
-| `src/daemon/handlers/config-channels.ts`                   | IPC handler that delegates to the same shared actions                                                                |
 | `src/config/bundled-skills/guardian-verify-setup/SKILL.md` | Skill that teaches the assistant how to orchestrate channel verification via chat                                    |
 
 **Guardian-Only Tool Invocation Gate:**
@@ -293,7 +289,7 @@ When a voice call's ASK_GUARDIAN consultation times out before the guardian resp
 | `src/daemon/guardian-action-generators.ts`              | Daemon-injected generator factories: `createGuardianActionCopyGenerator` (latency-optimized text rewriting) and `createGuardianFollowUpConversationGenerator` (tool-calling intent classification) |
 | `src/calls/call-controller.ts`                          | Voice timeout handling: marks requests as timed out, sends expiry notices, injects `[GUARDIAN_TIMEOUT]` instruction for generated voice response                                                   |
 | `src/runtime/routes/inbound-message-handler.ts`         | Late reply interception for Telegram channels: matches late answers to expired requests, routes follow-up conversation turns, dispatches actions                                                   |
-| `src/daemon/session-process.ts`                         | Late reply interception for mac/IPC channel: same logic as inbound-message-handler but using conversation-ID-based delivery lookup                                                                 |
+| `src/daemon/session-process.ts`                         | Late reply interception for mac channel: same logic as inbound-message-handler but using conversation-ID-based delivery lookup                                                                     |
 | `src/calls/guardian-action-sweep.ts`                    | Periodic sweep for stale pending requests; sends expiry notices to guardian destinations                                                                                                           |
 | `src/memory/migrations/030-guardian-action-followup.ts` | Schema migration adding follow-up columns (`followup_state`, `late_answer_text`, `late_answered_at`, `followup_action`, `followup_completed_at`)                                                   |
 
@@ -513,7 +509,7 @@ Voice invites use a short numeric code (4-10 digits, default 6) instead of a URL
 | `src/runtime/channel-invite-transports/telegram.ts` | Telegram adapter — `t.me/<bot>?start=iv_<token>` deep links, `/start iv_<token>` extraction                        |
 | `src/runtime/channel-invite-transports/voice.ts`    | Voice transport adapter — code-based redemption metadata                                                           |
 | `src/daemon/guardian-invite-intent.ts`              | Intent detection — routes create/list/revoke requests into the contacts skill                                      |
-| `src/runtime/invite-service.ts`                     | Shared business logic for invite operations (used by both HTTP routes and IPC)                                     |
+| `src/runtime/invite-service.ts`                     | Shared business logic for invite operations (used by HTTP routes)                                                  |
 | `src/runtime/routes/invite-routes.ts`               | HTTP API handlers for invite management including voice invite creation and redemption                             |
 | `src/runtime/routes/inbound-message-handler.ts`     | Invite token intercept in the inbound flow (unknown-contact and inactive-contact branches)                         |
 | `src/calls/relay-server.ts`                         | Voice relay state machine — `invite_redemption_pending` subflow (always-on canonical behavior)                     |
@@ -641,7 +637,7 @@ The assistant feature-flag resolver (`src/config/assistant-feature-flags.ts`) is
 
 | Enforcement Point                  | Module                                                   | Effect                                                                                                                                                                                                      |
 | ---------------------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **1. Client skill list**           | `resolveSkillStates()` in `config/skill-state.ts`        | Skills with flag OFF are excluded from the resolved list returned to IPC clients (macOS skill list, settings UI). The skill never appears in the client.                                                    |
+| **1. Client skill list**           | `resolveSkillStates()` in `config/skill-state.ts`        | Skills with flag OFF are excluded from the resolved list returned to clients (macOS skill list, settings UI). The skill never appears in the client.                                                        |
 | **2. System prompt skill catalog** | `appendSkillsCatalog()` in `prompts/system-prompt.ts`    | The model-visible `## Skills Catalog` section in the system prompt filters out flagged-off skills. The model cannot see or reference them.                                                                  |
 | **3. `skill_load` tool**           | `executeSkillLoad()` in `tools/skills/load.ts`           | If the model attempts to load a flagged-off skill by name, the tool returns an error: `"skill is currently unavailable (disabled by feature flag)"`.                                                        |
 | **4. Runtime tool projection**     | `projectSkillTools()` in `daemon/session-skill-tools.ts` | Even if a skill was previously active in a session (has `<loaded_skill>` markers in history), the per-turn projection drops it when the flag is OFF. Already-registered tools are unregistered.             |
@@ -661,7 +657,7 @@ All five enforcement points use `isAssistantFeatureFlagEnabled(skillFlagKey(skil
 | `src/tools/skills/load.ts`                      | `executeSkillLoad()` — enforcement points 3 and 5                                                                  |
 | `src/daemon/session-skill-tools.ts`             | `projectSkillTools()` — enforcement point 4                                                                        |
 | `src/config/schema.ts`                          | `assistantFeatureFlagValues` field definition in `AssistantConfig` (Zod schema)                                    |
-| `src/daemon/handlers/skills.ts`                 | `handleSkillsList()` — uses `resolveSkillStates()` for IPC client responses                                        |
+| `src/daemon/handlers/skills.ts`                 | `handleSkillsList()` — uses `resolveSkillStates()` for client responses                                            |
 | `meta/feature-flags/feature-flag-registry.json` | Unified feature flag registry (repo root) — all declared flags with scope, label, default values, and descriptions |
 | `src/config/feature-flag-registry.json`         | Bundled copy of the unified registry for compiled binary resolution                                                |
 
@@ -714,12 +710,7 @@ graph LR
         WORK_ITEMS["work_items<br/>───────────────<br/>Task Queue entries<br/>taskId (FK → tasks)<br/>title, notes, status<br/>priority_tier (0-3), sort_index<br/>last_run_id, last_run_status<br/>source_type, source_id"]
     end
 
-    subgraph "~/.vellum/workspace/data/ipc-blobs/"
-        BLOBS["*.blob<br/>───────────────<br/>Ephemeral blob files<br/>UUID filenames<br/>Atomic temp+rename writes<br/>Consumed after daemon hydration<br/>Stale sweep every 5min (30min max age)"]
-    end
-
     subgraph "~/.vellum/ (Root Files)"
-        SOCK["vellum.sock<br/>Unix domain socket"]
         TRUST["protected/trust.json<br/>Tool permission rules"]
         FF_TOKEN["feature-flag-token<br/>Client token for feature-flag API"]
     end
@@ -753,8 +744,8 @@ graph TB
     end
 
     subgraph "Local Mode"
-        LOCAL_CLIENT["LocalDaemonClient"]
-        LOCAL_SOCK["Unix Socket<br/>~/.vellum/vellum.sock"]
+        LOCAL_CLIENT["RuntimeClient"]
+        LOCAL_HTTP["HTTP API<br/>localhost:RUNTIME_HTTP_PORT"]
         LOCAL_DAEMON["Local Daemon<br/>(same machine)"]
         LOCAL_DB["~/.vellum/workspace/data/db/assistant.db"]
     end
@@ -771,8 +762,8 @@ graph TB
     AUTH --> PG
 
     ROUTES -->|"ASSISTANT_CONNECTION_MODE=local"| LOCAL_CLIENT
-    LOCAL_CLIENT --> LOCAL_SOCK
-    LOCAL_SOCK --> LOCAL_DAEMON
+    LOCAL_CLIENT --> LOCAL_HTTP
+    LOCAL_HTTP --> LOCAL_DAEMON
     LOCAL_DAEMON --> LOCAL_DB
 
     ROUTES -->|"ASSISTANT_CONNECTION_MODE=cloud"| RUNTIME_CLIENT
@@ -783,228 +774,19 @@ graph TB
 
 ---
 
-## IPC Contract — Source of Truth and Code Generation
+## Client-Server Communication — HTTP + SSE
 
-The TypeScript file `assistant/src/daemon/ipc-protocol.ts` is the **single source of truth** for all IPC message types. Swift client models are auto-generated from it.
+All client-server communication uses HTTP for request/response operations and Server-Sent Events (SSE) for streaming server-to-client events. The runtime HTTP server (`RUNTIME_HTTP_PORT`, default 7821) is the sole transport.
 
-```mermaid
-graph LR
-    subgraph "Source of Truth"
-        CONTRACT["ipc-protocol.ts<br/>───────────────<br/>All message interfaces<br/>ClientMessage union<br/>ServerMessage union<br/>Serialization / parsing"]
-    end
+**Client → Server (HTTP POST):** Clients send messages, session operations, configuration changes, and approval decisions via HTTP endpoints (e.g., `POST /v1/messages`, `POST /v1/confirm`, `POST /v1/sessions`).
 
-    subgraph "Generation Pipeline"
-        TJS["typescript-json-schema<br/>───────────────<br/>TS → JSON Schema"]
-        GEN["generate-swift.ts<br/>───────────────<br/>JSON Schema → Swift<br/>Codable structs"]
-    end
-
-    subgraph "Generated Output"
-        SWIFT["IPCContractGenerated.swift<br/>───────────────<br/>clients/shared/IPC/Generated/<br/>IPC-prefixed Codable structs"]
-    end
-
-    subgraph "Hand-Written Swift"
-        ENUMS["IPCMessages.swift<br/>───────────────<br/>ClientMessage / ServerMessage<br/>discriminated union enums<br/>(custom Decodable init)"]
-    end
-
-    subgraph "Inventory Tracking"
-        INV_SRC["ipc-contract-inventory.ts<br/>───────────────<br/>AST parser for union members"]
-        INV_SNAP["ipc-contract-inventory.json<br/>───────────────<br/>Checked-in snapshot"]
-    end
-
-    subgraph "Enforcement"
-        CI["CI (GitHub Actions)<br/>bun run check:ipc-generated<br/>bun run ipc:inventory<br/>bun run ipc:check-swift-drift"]
-        HOOK["Pre-commit hook<br/>same 3 checks on staged<br/>IPC files"]
-    end
-
-    CONTRACT --> TJS
-    TJS --> GEN
-    GEN --> SWIFT
-    SWIFT --> ENUMS
-
-    CONTRACT --> INV_SRC
-    INV_SRC --> INV_SNAP
-
-    CONTRACT --> CI
-    CONTRACT --> HOOK
-```
-
----
-
-## IPC Protocol — Message Types
-
-```mermaid
-graph LR
-    subgraph "Client → Server"
-        direction TB
-        C0["task_submit<br/>task, screenWidth, screenHeight,<br/>attachments, source?:'voice'|'text'"]
-        C1["cu_session_create<br/>task, attachments"]
-        C2["cu_observation<br/>axTree, axDiff, screenshot,<br/>secondaryWindows, result/error,<br/>axTreeBlob?, screenshotBlob?"]
-        C3["ambient_observation<br/>screenContent, requestId"]
-        C4["session_create<br/>title, threadType?"]
-        C5["user_message<br/>text, attachments"]
-        C6["confirmation_response<br/>decision"]
-        C7["cancel / undo"]
-        C8["model_get / model_set"]
-        C9["ping"]
-        C10["ipc_blob_probe<br/>probeId, nonceSha256"]
-        C11["work_items_list / work_item_get<br/>work_item_create / work_item_update<br/>work_item_complete / work_item_run_task<br/>(planned)"]
-        C12["tool_permission_simulate<br/>toolName, input, workingDir?,<br/>isInteractive?, forcePromptSideEffects?,<br/>executionTarget?"]
-        C13["conversation_search<br/>query, limit?,<br/>maxMessagesPerConversation?"]
-        C14["ingress_invite<br/>create / list / revoke / redeem"]
-        C15["contacts<br/>list / get / update_channel"]
-    end
-
-    SOCKET["Unix Socket<br/>~/.vellum/vellum.sock<br/>───────────────<br/>Newline-delimited JSON<br/>Max 96MB per message<br/>Ping/pong every 30s<br/>Auto-reconnect<br/>1s → 30s backoff"]
-
-    subgraph "Server → Client"
-        direction TB
-        S0["task_routed<br/>interactionType, sessionId"]
-        S1["cu_action<br/>tool, input dict"]
-        S2["cu_complete<br/>summary"]
-        S3["cu_error<br/>message"]
-        S4["assistant_text_delta<br/>streaming text"]
-        S5["assistant_thinking_delta<br/>streaming thinking"]
-        S6["message_complete<br/>usage stats, attachments?"]
-        S7["ambient_result<br/>decision, summary/suggestion"]
-        S8["confirmation_request<br/>tool, risk_level,<br/>executionTarget"]
-        S9["memory_recalled<br/>source hits + relation counters<br/>ranking/debug telemetry"]
-        S10["usage_update / error"]
-        S11["generation_cancelled"]
-        S12["message_queued<br/>position in queue"]
-        S13["message_dequeued<br/>queue drained"]
-        S14["generation_handoff<br/>sessionId, requestId?,<br/>queuedCount, attachments?"]
-        S15["trace_event<br/>eventId, sessionId, requestId?,<br/>timestampMs, sequence, kind,<br/>status?, summary, attributes?"]
-        S16["session_error<br/>sessionId, code,<br/>userMessage, retryable,<br/>debugDetails?"]
-        S17["ipc_blob_probe_result<br/>probeId, ok,<br/>observedNonceSha256?, reason?"]
-        S18["session_info<br/>sessionId, title,<br/>correlationId?, threadType?"]
-        S19["session_title_updated<br/>sessionId, title"]
-        S20["session_list_response<br/>sessions[]: id, title,<br/>updatedAt, threadType?"]
-        S21["work_item_status_changed<br/>workItemId, newStatus<br/>(planned push)"]
-        S22["tool_permission_simulate_response<br/>decision, riskLevel, reason?,<br/>promptPayload?, matchedRuleId?"]
-        S23["conversation_search_response<br/>query, results[]: conversationId,<br/>title, updatedAt, matchingMessages[]"]
-        S24["ingress_invite_response<br/>invite / invites"]
-        S25["contacts_response<br/>contact / contacts"]
-    end
-
-    C0 --> SOCKET
-    C1 --> SOCKET
-    C2 --> SOCKET
-    C3 --> SOCKET
-    C4 --> SOCKET
-    C5 --> SOCKET
-    C6 --> SOCKET
-    C7 --> SOCKET
-    C8 --> SOCKET
-    C9 --> SOCKET
-    C10 --> SOCKET
-    C11 --> SOCKET
-    C12 --> SOCKET
-    C13 --> SOCKET
-    C14 --> SOCKET
-    C15 --> SOCKET
-
-    SOCKET --> S0
-    SOCKET --> S1
-    SOCKET --> S2
-    SOCKET --> S3
-    SOCKET --> S4
-    SOCKET --> S5
-    SOCKET --> S6
-    SOCKET --> S7
-    SOCKET --> S8
-    SOCKET --> S9
-    SOCKET --> S10
-    SOCKET --> S11
-    SOCKET --> S12
-    SOCKET --> S13
-    SOCKET --> S14
-    SOCKET --> S15
-    SOCKET --> S16
-    SOCKET --> S17
-    SOCKET --> S18
-    SOCKET --> S19
-    SOCKET --> S20
-    SOCKET --> S21
-    SOCKET --> S22
-    SOCKET --> S24
-    SOCKET --> S25
-```
-
----
-
-## Blob Transport — Large Payload Side-Channel
-
-CU observations can carry large payloads (screenshots as JPEG, AX trees as UTF-8 text). Instead of embedding these inline as base64/text in newline-delimited JSON IPC messages, the blob transport offloads them to local files and sends only lightweight references over the socket.
-
-### Probe Mechanism
-
-Blob transport is opt-in per connection. On every macOS socket connect, the client writes a random nonce file to the blob directory and sends an `ipc_blob_probe` message with the SHA-256 of the nonce. The daemon reads the file, computes the hash, and responds with `ipc_blob_probe_result`. If hashes match, the client sets `isBlobTransportAvailable = true` for that connection. The flag resets to `false` on disconnect or reconnect.
-
-On iOS (HTTP+SSE connections via the gateway), blob transport is not applicable — `isBlobTransportAvailable` stays `false` and inline payloads are always used. Over SSH-forwarded Unix sockets on macOS, the probe runs but fails because the client and daemon don't share a filesystem, so blob transport stays disabled and inline payloads are used transparently.
-
-### Blob Directory
-
-All blobs live at `~/.vellum/workspace/data/ipc-blobs/`. Filenames are `${uuid}.blob`. The daemon ensures this directory exists on startup. Both client and daemon use atomic writes (temp file + rename) to prevent partial reads.
-
-### Blob Reference
-
-```
-IpcBlobRef {
-  id: string              // UUID v4
-  kind: "ax_tree" | "screenshot_jpeg"
-  encoding: "utf8" | "binary"
-  byteLength: number
-  sha256?: string         // SHA-256 hex digest for integrity check
-}
-```
-
-### Transport Decision Flow
-
-```mermaid
-graph TB
-    HAS_DATA{"Has large payload?"}
-    BLOB_AVAIL{"isBlobTransportAvailable?"}
-    THRESHOLD{"Above threshold?<br/>(screenshots: always,<br/>AX trees: >8KB)"}
-    WRITE_BLOB["Write blob file<br/>atomic temp+rename"]
-    WRITE_OK{"Write succeeded?"}
-    SEND_REF["Send IpcBlobRef<br/>(inline field = nil)"]
-    SEND_INLINE["Send inline<br/>(base64 / text)"]
-
-    HAS_DATA -->|Yes| BLOB_AVAIL
-    HAS_DATA -->|No| SEND_INLINE
-    BLOB_AVAIL -->|Yes| THRESHOLD
-    BLOB_AVAIL -->|No| SEND_INLINE
-    THRESHOLD -->|Yes| WRITE_BLOB
-    THRESHOLD -->|No| SEND_INLINE
-    WRITE_BLOB --> WRITE_OK
-    WRITE_OK -->|Yes| SEND_REF
-    WRITE_OK -->|No| SEND_INLINE
-```
-
-### Daemon Hydration
-
-When the daemon receives a CU observation with blob refs, it attempts blob-first hydration before the CU session processes the observation:
-
-1. Validate the blob ref's `kind` and `encoding` match the expected field (`axTreeBlob` must be `kind=ax_tree, encoding=utf8`; `screenshotBlob` must be `kind=screenshot_jpeg, encoding=binary`).
-2. Verify the blob file is a regular file (not a symlink) and its realpath stays within the blob directory.
-3. Read the blob file, verify actual size matches `byteLength`, and check optional `sha256`.
-4. For screenshots: base64-encode the bytes into the `screenshot` field.
-5. For AX trees: decode UTF-8 bytes into the `axTree` field.
-6. Delete the consumed blob file.
-
-**Fallback behavior**: If both a blob ref and an inline field are present and blob hydration succeeds, the blob value takes precedence. If blob hydration fails and an inline fallback exists, the inline value is used. If blob hydration fails and no inline fallback exists, the daemon sends a `cu_error` and does not forward the observation to the session.
-
-### Cleanup
-
-- **Consumed blobs**: Deleted immediately after successful hydration.
-- **Stale sweep**: The daemon runs a periodic sweep (every 5 minutes) to delete blob files older than 30 minutes, catching orphans from failed sends or crashes.
-- **Size limits**: Screenshot blobs are capped at 10MB, AX tree blobs at 2MB. Oversized blobs are rejected.
+**Server → Client (SSE):** The daemon streams events to clients via `GET /v1/events`. All agent events (text deltas, tool execution, confirmations, session state changes) are published through the `assistantEventHub` and delivered as SSE events.
 
 ---
 
 ## Session Errors vs Global Errors
 
-The daemon emits two distinct error message types over IPC:
+The daemon emits two distinct error message types via SSE:
 
 | Message type    | Scope          | Purpose                                                                                                        | Payload                                                                       |
 | --------------- | -------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
@@ -1034,7 +816,7 @@ Classification uses a two-tier strategy:
 1. **Structured provider errors**: If the error is a `ProviderError` with a `statusCode`, the status code determines the category deterministically — `429` maps to `PROVIDER_RATE_LIMIT` (retryable), `5xx` to `PROVIDER_API` (retryable), other `4xx` to `PROVIDER_API` (not retryable).
 2. **Regex fallback**: For non-provider errors or `ProviderError` without a status code, regex pattern matching against the error message detects network failures, rate limits, and API errors. Phase-specific overrides handle queue and regeneration contexts.
 
-Debug details are capped at 4,000 characters to prevent oversized IPC payloads.
+Debug details are capped at 4,000 characters to prevent oversized payloads.
 
 ### Error → Toast → Recovery Flow
 
@@ -1059,14 +841,14 @@ sequenceDiagram
         UI->>VM: retryAfterSessionError()
         VM->>VM: dismissSessionError()<br/>+ regenerateLastMessage()
         VM->>DC: regenerate {sessionId}
-        DC->>Daemon: IPC
+        DC->>Daemon: HTTP POST /v1/messages
     else User taps Dismiss
         UI->>VM: dismissSessionError()
         VM->>VM: clear sessionError + errorText
     end
 ```
 
-1. **Daemon** encounters a session-scoped failure, classifies it via `classifySessionError()`, and sends a `session_error` IPC message with the session ID, typed error code, user-facing message, retryable flag, and optional debug details. Session-scoped failures emit _only_ `session_error` (never the generic `error` type) to prevent cross-session bleed.
+1. **Daemon** encounters a session-scoped failure, classifies it via `classifySessionError()`, and sends a `session_error` SSE event with the session ID, typed error code, user-facing message, retryable flag, and optional debug details. Session-scoped failures emit _only_ `session_error` (never the generic `error` type) to prevent cross-session bleed.
 2. **ChatViewModel** receives the error via DaemonClient's `subscribe()` stream (each view model gets an independent stream), sets the `sessionError` property, and transitions out of the streaming/loading state so the UI is interactive. If the error arrives during an active cancel (`wasCancelling == true`), it is suppressed — cancel only shows `generation_cancelled` behavior.
 3. **ChatView** observes the published `sessionError` and displays an actionable toast with a category-specific icon and accent color:
    - **Retry** (shown when `retryable` is true): calls `retryAfterSessionError()`, which clears the error and sends a `regenerate` message to the daemon.
@@ -1325,9 +1107,9 @@ graph TB
 - macOS UI shows Inspect and Delete controls for managed skills only (source = "managed").
 - `skill_load` validates the recursive include graph (via `include-graph.ts`) before emitting output. Missing children and cycles produce `isError: true` with no `<loaded_skill>` marker. Valid includes produce an "Included Skills (immediate)" metadata section showing child ID, name, description, and path.
 
-### Skills Authoring via IPC
+### Skills Authoring via HTTP
 
-The Skills page in the macOS client can author managed skills through daemon IPC without going through the agent loop:
+The Skills page in the macOS client can author managed skills through the daemon HTTP API without going through the agent loop:
 
 1. **Draft** (`skills_draft`): The client sends source text (with optional YAML frontmatter). The daemon parses frontmatter for metadata fields (skillId, name, description, emoji), fills missing fields via a latency-optimized LLM call, and falls back to deterministic heuristics if the provider is unavailable. Returns `skills_draft_response` with the complete draft.
 2. **Create** (`skills_create`): The client sends finalized skill metadata and body. The daemon calls `createManagedSkill()` from `managed-store.ts`, auto-enables the skill in config, and broadcasts `skills_state_changed`.
@@ -1660,7 +1442,7 @@ For `bash` and `host_bash` tool invocations, the permission system uses parser-d
 
 ### Prompt UX
 
-When a permission prompt is sent to the client (via `confirmation_request` IPC message), it includes:
+When a permission prompt is sent to the client (via `confirmation_request` SSE event), it includes:
 
 | Field              | Content                                             |
 | ------------------ | --------------------------------------------------- |
@@ -1685,7 +1467,7 @@ File tool candidates include canonical (symlink-resolved) absolute paths via `no
 | `assistant/src/permissions/checker.ts`        | `classifyRisk()`, `check()`, `buildCommandCandidates()`, allowlist/scope generation                                                                                                 |
 | `assistant/src/permissions/shell-identity.ts` | `analyzeShellCommand()`, `deriveShellActionKeys()`, `buildShellCommandCandidates()`, `buildShellAllowlistOptions()` — parser-based shell command identity and action key derivation |
 | `assistant/src/permissions/trust-store.ts`    | Rule persistence, `findHighestPriorityRule()`, execution-target matching, starter bundle                                                                                            |
-| `assistant/src/permissions/prompter.ts`       | IPC prompt flow: `confirmation_request` → `confirmation_response`                                                                                                                   |
+| `assistant/src/permissions/prompter.ts`       | Prompt flow: `confirmation_request` (SSE) → `confirmation_response` (HTTP POST)                                                                                                     |
 | `assistant/src/permissions/defaults.ts`       | Default rule templates (system ask rules for host tools, CU, etc.)                                                                                                                  |
 | `assistant/src/skills/version-hash.ts`        | `computeSkillVersionHash()` — deterministic SHA-256 of skill source files                                                                                                           |
 | `assistant/src/skills/path-classifier.ts`     | `isSkillSourcePath()`, `normalizeFilePath()`, skill root detection                                                                                                                  |
@@ -1695,7 +1477,7 @@ File tool candidates include canonical (symlink-resolved) absolute paths via `no
 
 ### Permission Simulation (Tool Permission Tester)
 
-The `tool_permission_simulate` IPC message lets clients dry-run a tool invocation through the full permission evaluation pipeline without actually executing the tool or mutating daemon state. The macOS Settings panel exposes this as a "Tool Permission Tester" UI.
+The `tool_permission_simulate` HTTP endpoint lets clients dry-run a tool invocation through the full permission evaluation pipeline without actually executing the tool or mutating daemon state. The macOS Settings panel exposes this as a "Tool Permission Tester" UI.
 
 **Simulation semantics:**
 
@@ -1791,7 +1573,7 @@ sequenceDiagram
     User->>Chat: send message while busy
     Chat->>VM: enqueue message
     VM->>DC: user_message
-    DC->>Daemon: IPC
+    DC->>Daemon: HTTP
     Daemon-->>DC: message_queued (position)
     DC-->>VM: show queue status
 
@@ -1814,7 +1596,7 @@ sequenceDiagram
 
 ## Trace System — Debug Panel Data Flow
 
-The trace system provides real-time observability of daemon session internals. Each session creates a `TraceEmitter` that emits structured `trace_event` IPC messages as the session processes requests, makes LLM calls, and executes tools.
+The trace system provides real-time observability of daemon session internals. Each session creates a `TraceEmitter` that emits structured `trace_event` SSE events as the session processes requests, makes LLM calls, and executes tools.
 
 ```mermaid
 sequenceDiagram
@@ -1831,7 +1613,7 @@ sequenceDiagram
 
     User->>Chat: send message
     Chat->>DC: user_message
-    DC->>Daemon: IPC
+    DC->>Daemon: HTTP
 
     Daemon->>TE: emit(request_received)
     TE-->>DC: trace_event (request_received)
@@ -1896,9 +1678,9 @@ Events emitted during a session lifecycle:
 
 ### Architecture
 
-- **TraceEmitter** (daemon, per-session): Constructed with a `sessionId` and a `sendToClient` callback. Maintains a monotonic sequence counter for stable ordering. Truncates summaries to 200 chars and attribute values to 500 chars. Each call to `emit()` sends a `trace_event` IPC message to the connected client.
+- **TraceEmitter** (daemon, per-session): Constructed with a `sessionId` and a `sendToClient` callback. Maintains a monotonic sequence counter for stable ordering. Truncates summaries to 200 chars and attribute values to 500 chars. Each call to `emit()` sends a `trace_event` SSE event to connected clients.
 - **ToolTraceListener** (daemon): Subscribes to the session's `EventBus` via `onAny()` and translates tool domain events (`tool.execution.started`, `tool.execution.finished`, `tool.execution.failed`, `tool.permission.requested`, `tool.permission.decided`, `tool.secret.detected`) into trace events through the `TraceEmitter`.
-- **DaemonClient** (Swift, shared): Decodes `trace_event` IPC messages into `TraceEventMessage` structs and invokes the `onTraceEvent` callback.
+- **DaemonClient** (Swift, shared): Decodes `trace_event` SSE events into `TraceEventMessage` structs and invokes the `onTraceEvent` callback.
 - **TraceStore** (Swift, macOS): `@MainActor ObservableObject` that ingests `TraceEventMessage` structs. Deduplicates by `eventId`, maintains stable sort order (sequence, then timestampMs, then insertion order), groups events by session and requestId, and enforces a retention cap of 5,000 events per session. Each request group is classified with a terminal status: `completed` (via `message_complete`), `cancelled` (via `generation_cancelled`), `handedOff` (via `generation_handoff`), `error` (via `request_error` or any event with `status == "error"`), or `active` (no terminal event yet).
 - **DebugPanel** (Swift, macOS): SwiftUI view that observes `TraceStore`. Displays a metrics strip (request count, LLM calls, total tokens, average latency, tool failures) and a `TraceTimelineView` showing events grouped by requestId with color-coded status indicators. The timeline auto-scrolls to new events while the user is at the bottom; scrolling up pauses auto-scroll and shows a "Jump to bottom" button that resumes it.
 
@@ -1908,7 +1690,7 @@ Events emitted during a session lifecycle:
 
 ## Assistant Events — SSE Transport Layer
 
-The assistant-events system provides a single, shared publish path that fans out to both the Unix socket IPC layer (native clients) and an HTTP SSE endpoint (web/remote clients). There is no separate message schema for SSE — the `ServerMessage` payload is wrapped in an `AssistantEvent` envelope and serialised as JSON.
+The assistant-events system provides a single, shared publish path that fans out to all connected clients via HTTP SSE. The `ServerMessage` payload is wrapped in an `AssistantEvent` envelope and serialised as JSON.
 
 ### Data Flow
 
@@ -1916,7 +1698,7 @@ The assistant-events system provides a single, shared publish path that fans out
 graph TB
     subgraph "Event Sources"
         direction TB
-        IPC_DAEMON["Daemon IPC send paths<br/>(daemon/server.ts)"]
+        SESSION["Session process<br/>(session-process.ts)"]
         HTTP_RUN["HTTP Run path<br/>(run-orchestrator.ts)"]
     end
 
@@ -1924,9 +1706,8 @@ graph TB
         HUB["AssistantEventHub<br/>(assistant-event-hub.ts)<br/>──────────────────────<br/>maxSubscribers: 100<br/>FIFO eviction on overflow<br/>Synchronous fan-out"]
     end
 
-    subgraph "Transports"
+    subgraph "SSE Transport"
         SSE_ROUTE["SSE Route<br/>GET /v1/events?conversationKey=...<br/>(events-routes.ts)<br/>──────────────────────<br/>ReadableStream + CountQueuingStrategy(16)<br/>Heartbeat every 30 s<br/>Slow-consumer shed"]
-        SOCK["Unix Socket<br/>(daemon/session-surfaces.ts)"]
     end
 
     subgraph "Clients"
@@ -1935,13 +1716,12 @@ graph TB
         WEB["Web / Remote clients<br/>(EventSource / fetch)"]
     end
 
-    IPC_DAEMON -->|"buildAssistantEvent()"| HUB
+    SESSION -->|"buildAssistantEvent()"| HUB
     HTTP_RUN -->|"buildAssistantEvent()"| HUB
-    IPC_DAEMON --> SOCK
 
     HUB -->|"subscriber callback"| SSE_ROUTE
 
-    SOCK --> MACOS
+    SSE_ROUTE --> MACOS
     SSE_ROUTE --> IOS
     SSE_ROUTE --> WEB
 ```
@@ -1956,7 +1736,7 @@ Every event published through the hub is wrapped in an `AssistantEvent` (defined
 | `assistantId` | `string`            | Logical assistant identifier (`"self"` for HTTP runs) |
 | `sessionId`   | `string?`           | Resolved conversation ID when available               |
 | `emittedAt`   | `string` (ISO-8601) | Server-side timestamp                                 |
-| `message`     | `ServerMessage`     | Unchanged IPC outbound message — no schema fork       |
+| `message`     | `ServerMessage`     | The outbound message payload                           |
 
 ### SSE Frame Format
 
@@ -1991,7 +1771,7 @@ Keep-alive heartbeats (every 30 s by default):
 | `assistant/src/runtime/assistant-event.ts`      | `AssistantEvent` type, `buildAssistantEvent()` factory, SSE framing helpers         |
 | `assistant/src/runtime/assistant-event-hub.ts`  | `AssistantEventHub` class and process-level singleton                               |
 | `assistant/src/runtime/routes/events-routes.ts` | `handleSubscribeAssistantEvents()` — SSE route handler                              |
-| `assistant/src/daemon/server.ts`                | IPC send/broadcast paths that publish to the hub (`send` → `publishAssistantEvent`) |
+| `assistant/src/daemon/server.ts`                | Session event paths that publish to the hub (`send` → `publishAssistantEvent`)      |
 
 ---
 
@@ -2002,7 +1782,7 @@ The notification module (`assistant/src/notifications/`) uses a signal-based arc
 ```
 Producer → NotificationSignal → Candidate Generation → Decision Engine (LLM) → Deterministic Checks → Broadcaster → Conversation Pairing → Adapters → Delivery
                                                               ↑                                                            ↓
-                                                      Preference Summary                                    notification_thread_created IPC
+                                                      Preference Summary                                    notification_thread_created SSE event
                                                       Thread Candidates                                     (creation-only — not emitted on reuse)
 ```
 
@@ -2037,23 +1817,23 @@ The pairing function (`pairDeliveryWithConversation`) is resilient — errors ar
 
 The notification pipeline uses a single conversation materialization path across producers:
 
-1. **Canonical pipeline** (`emitNotificationSignal` → decision engine → broadcaster → conversation pairing → adapters): The broadcaster pairs each delivery with a conversation, then dispatches a `notification_intent` IPC event via the Vellum adapter. The IPC payload includes `deepLinkMetadata` (e.g. `{ conversationId, messageId }`) so the macOS/iOS client can deep-link to the relevant context when the user taps the notification. When `messageId` is present, the client scrolls to that specific message within the thread (message-level anchoring).
+1. **Canonical pipeline** (`emitNotificationSignal` → decision engine → broadcaster → conversation pairing → adapters): The broadcaster pairs each delivery with a conversation, then dispatches a `notification_intent` SSE event via the Vellum adapter. The payload includes `deepLinkMetadata` (e.g. `{ conversationId, messageId }`) so the macOS/iOS client can deep-link to the relevant context when the user taps the notification. When `messageId` is present, the client scrolls to that specific message within the thread (message-level anchoring).
 2. **Guardian bookkeeping** (`dispatchGuardianQuestion`): Guardian dispatch creates `guardian_action_request` / `guardian_action_delivery` audit rows derived from pipeline delivery results and the per-dispatch `onThreadCreated` callback — there is no separate thread-creation path.
 
-### Thread Surfacing via `notification_thread_created` IPC (Creation-Only)
+### Thread Surfacing via `notification_thread_created` (Creation-Only)
 
-The `notification_thread_created` IPC event is emitted **only when a brand-new conversation is created** by the broadcaster. Reusing an existing thread does not trigger this event — the macOS/iOS client already knows about the conversation from the original creation. This is enforced in `broadcaster.ts` by gating on `pairing.createdNewConversation === true`.
+The `notification_thread_created` SSE event is emitted **only when a brand-new conversation is created** by the broadcaster. Reusing an existing thread does not trigger this event — the macOS/iOS client already knows about the conversation from the original creation. This is enforced in `broadcaster.ts` by gating on `pairing.createdNewConversation === true`.
 
-When a new vellum notification thread is created (strategy `start_new_conversation`), the broadcaster emits the IPC event **immediately** (before waiting for slower channel deliveries like Telegram). This pushes the thread to the macOS/iOS client so it can display the notification thread in the sidebar and deep-link to it.
+When a new vellum notification thread is created (strategy `start_new_conversation`), the broadcaster emits the event **immediately** (before waiting for slower channel deliveries like Telegram). This pushes the thread to the macOS/iOS client so it can display the notification thread in the sidebar and deep-link to it.
 
-### IPC Thread-Created Events
+### Thread-Created Events
 
-Two IPC push events surface new threads in the macOS/iOS client sidebar:
+Two SSE push events surface new threads in the macOS/iOS client sidebar:
 
 - **`notification_thread_created`** — Emitted by `broadcaster.ts` when a notification delivery **creates** a new vellum conversation (strategy `start_new_conversation`, `createdNewConversation: true`). **Not** emitted when a thread is reused. Payload: `{ conversationId, title, sourceEventName }`.
 - **`task_run_thread_created`** — Emitted by `work-item-runner.ts` when a task run creates a conversation. Payload: `{ conversationId, workItemId, title }`.
 
-All events follow the same pattern: the daemon creates a server-side conversation, persists an initial message, and broadcasts the IPC event so the macOS `ThreadManager` can create a visible thread in the sidebar.
+All events follow the same pattern: the daemon creates a server-side conversation, persists an initial message, and broadcasts the SSE event so the macOS `ThreadManager` can create a visible thread in the sidebar.
 
 ### Thread Routing Decision Flow
 
@@ -2063,7 +1843,7 @@ The decision engine produces per-channel thread actions using a candidate-driven
 2. **LLM decision**: The candidate set is serialized into the system prompt. The LLM chooses `start_new` or `reuse_existing` (with a candidate `conversationId`) per channel.
 3. **Strict validation** (`validateThreadActions`): Reuse targets must exist in the candidate set. Invalid targets are downgraded to `start_new`.
 4. **Pairing execution**: `pairDeliveryWithConversation` executes the thread action — appending to an existing conversation on reuse, creating a new one otherwise.
-5. **IPC gating**: `notification_thread_created` fires only on actual creation, not on reuse.
+5. **Creation-only gating**: `notification_thread_created` fires only on actual creation, not on reuse.
 6. **Audit trail**: Thread actions are persisted in both `notification_decisions.validation_results` and `notification_deliveries` columns (`thread_action`, `thread_target_conversation_id`, `thread_decision_fallback_used`).
 
 ### Guardian Call Thread Affinity
@@ -2093,7 +1873,7 @@ Reminders carry optional `routingIntent` (`single_channel` | `multi_channel` | `
 
 Notifications are delivered to three channel types:
 
-- **Vellum (always connected)**: Local IPC via the daemon's broadcast mechanism. The `VellumAdapter` emits a `notification_intent` message with rendered copy and optional `deepLinkMetadata` (includes `conversationId` for thread navigation and `messageId` for message-level scroll anchoring).
+- **Vellum (always connected)**: SSE via the daemon's broadcast mechanism. The `VellumAdapter` emits a `notification_intent` message with rendered copy and optional `deepLinkMetadata` (includes `conversationId` for thread navigation and `messageId` for message-level scroll anchoring).
 - **Telegram (when guardian binding exists)**: HTTP POST to the gateway's `/deliver/telegram` endpoint. Requires an active guardian binding for the assistant.
 
 Connected channels are resolved at signal emission time: vellum is always included, and binding-based channels (Telegram) are included only when an active guardian binding exists for the assistant.
@@ -2106,12 +1886,12 @@ Connected channels are resolved at signal emission time: vellum is always includ
 | `assistant/src/notifications/emit-signal.ts`                               | Single entry point for all producers; orchestrates the full pipeline                                                                  |
 | `assistant/src/notifications/decision-engine.ts`                           | LLM-based routing decisions with deterministic fallback                                                                               |
 | `assistant/src/notifications/deterministic-checks.ts`                      | Hard invariant checks (dedupe, source-active suppression, channel availability)                                                       |
-| `assistant/src/notifications/broadcaster.ts`                               | Dispatches decisions to channel adapters; emits `notification_thread_created` IPC (creation-only)                                     |
+| `assistant/src/notifications/broadcaster.ts`                               | Dispatches decisions to channel adapters; emits `notification_thread_created` SSE event (creation-only)                               |
 | `assistant/src/notifications/conversation-pairing.ts`                      | Materializes conversation + message per delivery; executes thread reuse decisions                                                     |
 | `assistant/src/notifications/thread-candidates.ts`                         | Builds per-channel candidate set of recent conversations for the decision engine                                                      |
-| `assistant/src/notifications/adapters/macos.ts`                            | Vellum adapter — broadcasts `notification_intent` via IPC with deep-link metadata                                                     |
+| `assistant/src/notifications/adapters/macos.ts`                            | Vellum adapter — broadcasts `notification_intent` via SSE with deep-link metadata                                                     |
 | `assistant/src/notifications/adapters/telegram.ts`                         | Telegram adapter — POSTs to gateway `/deliver/telegram`                                                                               |
-| `assistant/src/notifications/destination-resolver.ts`                      | Resolves per-channel endpoints (vellum IPC, Telegram chat ID from guardian binding)                                                   |
+| `assistant/src/notifications/destination-resolver.ts`                      | Resolves per-channel endpoints (vellum SSE, Telegram chat ID from guardian binding)                                                   |
 | `assistant/src/notifications/copy-composer.ts`                             | Template-based fallback copy when LLM copy is unavailable                                                                             |
 | `assistant/src/notifications/preference-extractor.ts`                      | Detects preference statements in conversation messages                                                                                |
 | `assistant/src/notifications/preferences-store.ts`                         | CRUD for user notification preferences                                                                                                |
@@ -2148,7 +1928,6 @@ Connected channels are resolved at signal emission time: vellum is always includ
 | Trace events                                 | In-memory (TraceStore)                                            | Structured events                   | Swift ObservableObject             | Max 5,000 per session, ephemeral                           |
 | Media embed settings                         | `~/.vellum/workspace/config.json` (`ui.mediaEmbeds`)              | JSON                                | `WorkspaceConfigIO` (atomic merge) | Permanent                                                  |
 | Media embed MIME cache                       | In-memory (`ImageMIMEProbe`)                                      | `NSCache` (500 entries)             | HTTP HEAD                          | Ephemeral; cleared on app restart                          |
-| IPC blob payloads                            | `~/.vellum/workspace/data/ipc-blobs/`                             | Binary files (UUID names)           | File I/O (atomic write)            | Ephemeral; consumed on hydration, stale sweep every 5min   |
 | Tasks & task runs                            | `~/.vellum/workspace/data/db/assistant.db`                        | SQLite                              | Drizzle ORM                        | Permanent                                                  |
 | Work items (Task Queue)                      | `~/.vellum/workspace/data/db/assistant.db`                        | SQLite                              | Drizzle ORM                        | Permanent; archived items retained                         |
 | Recurrence schedules & runs                  | `~/.vellum/workspace/data/db/assistant.db`                        | SQLite                              | Drizzle ORM                        | Permanent; supports cron and RRULE syntax                  |
@@ -2167,7 +1946,6 @@ Connected channels are resolved at signal emission time: vellum is always includ
 | Notification decisions                       | `~/.vellum/workspace/data/db/assistant.db`                        | SQLite                              | Drizzle ORM                        | Permanent; FK to notification_events                       |
 | Notification deliveries                      | `~/.vellum/workspace/data/db/assistant.db`                        | SQLite                              | Drizzle ORM                        | Permanent; FK to notification_decisions                    |
 | Notification preferences                     | `~/.vellum/workspace/data/db/assistant.db`                        | SQLite                              | Drizzle ORM                        | Permanent; per-assistant conversational preferences        |
-| IPC transport                                | `~/.vellum/vellum.sock`                                           | Unix domain socket                  | NWConnection (Swift) / Bun net     | Ephemeral                                                  |
 
 ### Sensitive Tool Output Placeholder Substitution
 

--- a/assistant/README.md
+++ b/assistant/README.md
@@ -1,6 +1,6 @@
 # Vellum Assistant Runtime
 
-Bun + TypeScript assistant runtime that owns conversation history, attachment storage, and channel delivery state in a local SQLite database. Exposes a Unix domain socket (macOS) and optional TCP listener (iOS) for native clients, plus an HTTP API consumed by the gateway.
+Bun + TypeScript assistant runtime that owns conversation history, attachment storage, and channel delivery state in a local SQLite database. Exposes an HTTP+SSE API for native clients (macOS, iOS) and the gateway.
 
 ## Architecture
 
@@ -8,10 +8,7 @@ Bun + TypeScript assistant runtime that owns conversation history, attachment st
 CLI / macOS app / iOS app
         │
         ▼
-   Unix socket (~/.vellum/vellum.sock)
-        │
-        ▼
-   DaemonServer (IPC)
+   RuntimeHttpServer (HTTP + SSE)
         │
         ├── Session Manager (in-memory pool, stale eviction)
         │       ├── Anthropic Claude (primary)
@@ -47,7 +44,7 @@ cp .env.example .env
 | `OLLAMA_API_KEY`       | No       | —                           | API key for authenticated Ollama deployments      |
 | `OLLAMA_BASE_URL`      | No       | `http://127.0.0.1:11434/v1` | Ollama base URL                                   |
 | `RUNTIME_HTTP_PORT`    | No       | —                           | Enable the HTTP server (required for gateway/web) |
-| `VELLUM_DAEMON_SOCKET` | No       | `~/.vellum/vellum.sock`     | Override the assistant socket path                |
+| `RUNTIME_HTTP_HOST`    | No       | `127.0.0.1`                 | HTTP server bind address                          |
 
 ## Update Bulletin
 
@@ -101,7 +98,7 @@ assistant/
 ├── src/
 │   ├── index.ts              # CLI entrypoint (commander)
 │   ├── cli.ts                # Interactive REPL client
-│   ├── daemon/               # Daemon server, IPC protocol, session management
+│   ├── daemon/               # Daemon server, session management
 │   ├── agent/                # Agent loop and LLM interaction
 │   ├── providers/            # LLM provider integrations (Anthropic, OpenAI, Gemini, Ollama)
 │   ├── memory/               # Conversation store, memory indexer, recall (FTS5 + Qdrant)
@@ -272,7 +269,7 @@ The vellum channel (macOS, iOS, CLI) uses JWTs to bind guardian identity to HTTP
 
 - **Bootstrap**: After hatch, the macOS client calls `POST /v1/guardian/init` with `{ platform, deviceId }`. Returns `{ guardianPrincipalId, accessToken, accessTokenExpiresAt, refreshToken, refreshTokenExpiresAt, refreshAfter, isNew }`. The endpoint is idempotent -- repeated calls with the same device return the same principal but mint fresh credentials.
 - **iOS pairing**: The pairing response includes `accessToken` and `refreshToken` credentials automatically when a vellum guardian binding exists.
-- **IPC fallback**: Local IPC (Unix socket) connections resolve identity server-side via `resolveLocalIpcGuardianContext()` without requiring a JWT.
+- **Local identity**: Local connections resolve identity server-side via `resolveLocalGuardianContext()` without requiring a JWT.
 - **HTTP enforcement**: All vellum HTTP routes require a valid JWT via the `Authorization: Bearer <jwt>` header. The JWT carries identity claims (`sub` with principal type and ID) and scope permissions. Route-level enforcement in `route-policy.ts` checks scopes and principal types.
 - **Startup migration**: On assistant start, `ensureVellumGuardianBinding()` backfills a vellum guardian binding for existing installations so the identity system works without requiring a manual bootstrap step.
 
@@ -284,7 +281,7 @@ This section documents the end-to-end flow from guardian verification through in
 
 Guardian verification establishes a cryptographic trust binding between a human identity and an `(assistantId, channel)` pair. The flow is:
 
-1. **Challenge creation** — The owner initiates verification from the desktop UI, which sends a channel_verification_session IPC message (`create_session` action) to the assistant. The assistant generates a random secret (32-byte hex for unbound inbound/bootstrap sessions, 6-digit numeric for identity-bound sessions), hashes it with SHA-256, stores the hash with a 10-minute TTL, and returns the raw secret to the desktop.
+1. **Challenge creation** — The owner initiates verification from the desktop UI, which sends a channel_verification_session request (`create_session` action) to the assistant. The assistant generates a random secret (32-byte hex for unbound inbound/bootstrap sessions, 6-digit numeric for identity-bound sessions), hashes it with SHA-256, stores the hash with a 10-minute TTL, and returns the raw secret to the desktop.
 2. **Code sharing** — The desktop displays the code and instructs the owner to reply with that code in the target channel conversation (e.g., Telegram).
 3. **Verification** — When the message arrives at `/channels/inbound`, the handler intercepts valid verification-code replies before normal message processing. It hashes the provided code, looks up a matching pending challenge, validates expiry, and consumes the challenge (preventing replay).
 4. **Binding** — On success, any existing active binding for the `(assistantId, channel)` pair is revoked, and a new guardian binding is created with the verifier's `actorExternalId` and `chatId` (DB columns: `externalUserId`, `chatId`). The verifier receives a confirmation message.
@@ -395,7 +392,7 @@ Secure cross-user messaging allows external users (non-guardians) to interact wi
 
 External users join through **invite tokens**. There are two invite flows:
 
-1. **IPC-based (legacy)** — The owner creates an invite via IPC, obtains the raw token, and shares it manually. The external user redeems the token by sending it as a channel message.
+1. **Manual** — The owner creates an invite via the HTTP API, obtains the raw token, and shares it manually. The external user redeems the token by sending it as a channel message.
 2. **Guardian-initiated invite links (Telegram)** — The guardian asks the assistant to create an invite link via desktop chat. The assistant creates an invite, builds a channel-specific deep link, and presents it for sharing. The invitee clicks the link and is automatically granted access.
 
 #### Guardian-Initiated Invite Link Flow (Telegram)
@@ -432,9 +429,9 @@ On **approve**: the original message payload is recovered from the channel deliv
 
 If no guardian binding exists, escalation fails closed — the message is denied rather than left in a silent wait state.
 
-### IPC Contracts
+### HTTP API
 
-| Message Type     | Actions                      | Description                                                              |
+| Endpoint         | Actions                      | Description                                                              |
 | ---------------- | ---------------------------- | ------------------------------------------------------------------------ |
 | `ingress_invite` | create, list, revoke, redeem | Manage invite tokens (SHA-256 hashed, raw token returned once on create) |
 
@@ -444,15 +441,14 @@ If no guardian binding exists, escalation fails closed — the message is denied
 | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `src/memory/invite-store.ts`                        | CRUD for invite tokens with SHA-256 hashing and expiry                                                           |
 | `src/contacts/contact-store.ts`                     | Contact + channel CRUD with policy enforcement                                                                   |
-| `src/daemon/handlers/config-inbox.ts`               | IPC handlers for invite contract                                                                                 |
-| `src/daemon/ipc-contract/inbox.ts`                  | TypeScript type definitions for ingress IPC messages                                                             |
+| `src/daemon/handlers/config-inbox.ts`               | HTTP handlers for invite operations                                                                              |
 | `src/runtime/routes/channel-routes.ts`              | ACL enforcement point — member lookup, policy check, escalation creation                                         |
 | `src/runtime/invite-redemption-service.ts`          | Core redemption engine — token validation, member creation, discriminated-union outcomes                         |
 | `src/runtime/invite-redemption-templates.ts`        | Deterministic reply templates for each redemption outcome                                                        |
 | `src/runtime/channel-invite-transport.ts`           | Transport adapter registry — `buildShareableInvite` / `extractInboundToken` per channel                          |
 | `src/runtime/channel-invite-transports/telegram.ts` | Telegram adapter — builds `t.me/<bot>?start=iv_<token>` deep links, extracts `iv_` tokens from `/start` commands |
 | `src/daemon/guardian-invite-intent.ts`              | Intent detection — routes guardian invite management requests into the `contacts` skill                          |
-| `src/runtime/invite-service.ts`                     | Shared business logic for invite and contact operations (HTTP + IPC)                                             |
+| `src/runtime/invite-service.ts`                     | Shared business logic for invite and contact operations                                                          |
 
 ## Database
 

--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -9,7 +9,7 @@ The integration framework lets Vellum connect to third-party services via OAuth2
 - **Secrets never reach the LLM** — OAuth tokens are stored in the credential vault and accessed exclusively through the `TokenManager`, which provides tokens to tool executors via `withValidToken()`. The LLM never sees raw tokens.
 - **PKCE or client_secret flows** — Desktop apps use PKCE by default (S256). Providers that require a client secret (e.g. Slack) pass it during the OAuth2 flow and store it in credential metadata for autonomous refresh. Twitter uses PKCE with an optional client secret in `local_byo` mode.
 - **Unified messaging layer** — All messaging platforms implement the `MessagingProvider` interface. Generic tools delegate to the provider, so adding a new platform is just implementing one adapter + an OAuth setup skill.
-- **Standalone integrations** — Not all integrations fit the messaging model. Twitter has its own OAuth2 flow and IPC handlers (`twitter_auth_start`, `twitter_auth_status`) separate from the unified messaging layer.
+- **Standalone integrations** — Not all integrations fit the messaging model. Twitter has its own OAuth2 flow and HTTP handlers (`twitter_auth_start`, `twitter_auth_status`) separate from the unified messaging layer.
 - **Provider registry** — Messaging providers register at daemon startup. The registry tracks which providers have stored credentials, enabling auto-selection when only one is connected.
 
 ### Unified Messaging Architecture
@@ -223,7 +223,7 @@ The strategy is persisted in the Vellum config file as `twitter.operationStrateg
 | Default scopes        | `tweet.read`, `tweet.write`, `users.read`, `offline.access` (from provider profile)                                |
 | Identity verification | Provider profile `identityVerifier` → `GET https://api.x.com/2/users/me` with Bearer token                         |
 | Credential names      | `client_id`, `client_secret`                                                                                       |
-| IPC messages          | `oauth_connect_start` / `oauth_connect_result` (generic), plus legacy `twitter_auth_start` / `twitter_auth_status` |
+| HTTP endpoints        | `oauth_connect_start` / `oauth_connect_result` (generic), plus legacy `twitter_auth_start` / `twitter_auth_status` |
 
 #### Twitter Credential Metadata Structure
 
@@ -308,7 +308,7 @@ Note: OAuth2 scopes (`tweet.read`, `tweet.write`, `users.read`, `offline.access`
 | `assistant/src/oauth/scope-policy.ts`                  | Deterministic scope resolution and policy enforcement                                                     |
 | `assistant/src/oauth/connect-types.ts`                 | Shared types: `OAuthProviderProfile`, `OAuthScopePolicy`, `OAuthConnectResult`                            |
 | `assistant/src/oauth/token-persistence.ts`             | Token storage helper: persists tokens, metadata, and runs post-connect hooks                              |
-| `assistant/src/daemon/handlers/oauth-connect.ts`       | Generic OAuth connect IPC handler (`oauth_connect_start` / `oauth_connect_result`)                        |
+| `assistant/src/daemon/handlers/oauth-connect.ts`       | Generic OAuth connect handler (`oauth_connect_start` / `oauth_connect_result`)                            |
 | `assistant/src/daemon/handlers/twitter-auth.ts`        | Legacy Twitter OAuth2 flow handlers (`twitter_auth_start`, `twitter_auth_status`)                         |
 | `assistant/src/cli/commands/twitter/client.ts`         | Twitter CDP client: GraphQL mutations/queries via Chrome DevTools Protocol                                |
 | `assistant/src/cli/commands/twitter/oauth-client.ts`   | OAuth-backed Twitter client: X API v2 post/reply via stored tokens using `withValidToken()`               |
@@ -375,7 +375,7 @@ Result is a discriminated union: `{ success, deferred, grantedScopes, accountInf
 3. Delegates to `orchestrateOAuthConnect()`.
 4. Sends `oauth_connect_result` back to the client.
 
-This replaces provider-specific IPC handlers — any provider in the registry can be connected through the same message pair.
+This replaces provider-specific handlers — any provider in the registry can be connected through the same message pair.
 
 ### Adding a New OAuth Provider
 
@@ -385,7 +385,7 @@ This replaces provider-specific IPC handlers — any provider in the registry ca
 2. **Optional: add an identity verifier** — an async function on the profile that fetches the user's account info from the provider's API.
 3. **Optional: add setup metadata** — `setup.displayName`, `setup.dashboardUrl`, `setup.appType` enable the generic OAuth setup skill to guide users through app creation.
 4. **Optional: add injection templates** — for providers whose tokens should be auto-injected by the script proxy.
-5. **No handler code needed** — the generic `oauth_connect_start` IPC handler and the connect orchestrator handle the flow automatically.
+5. **No handler code needed** — the generic `oauth_connect_start` handler and the connect orchestrator handle the flow automatically.
 
 ### Key Source Files
 
@@ -396,7 +396,7 @@ This replaces provider-specific IPC handlers — any provider in the registry ca
 | `assistant/src/oauth/connect-orchestrator.ts`    | Shared connect orchestrator (profile → scopes → flow → tokens)                  |
 | `assistant/src/oauth/connect-types.ts`           | Shared types (`OAuthProviderProfile`, `OAuthScopePolicy`, `OAuthConnectResult`) |
 | `assistant/src/oauth/token-persistence.ts`       | Token storage: keychain writes, metadata upsert, post-connect hooks             |
-| `assistant/src/daemon/handlers/oauth-connect.ts` | Generic `oauth_connect_start` / `oauth_connect_result` IPC handler              |
+| `assistant/src/daemon/handlers/oauth-connect.ts` | Generic `oauth_connect_start` / `oauth_connect_result` handler                  |
 
 ---
 

--- a/assistant/docs/architecture/security.md
+++ b/assistant/docs/architecture/security.md
@@ -154,7 +154,7 @@ For `bash` and `host_bash` tool invocations, the permission system uses parser-d
 
 ### Prompt UX
 
-When a permission prompt is sent to the client (via `confirmation_request` IPC message), it includes:
+When a permission prompt is sent to the client (via `confirmation_request` SSE event), it includes:
 
 | Field              | Content                                             |
 | ------------------ | --------------------------------------------------- |
@@ -189,7 +189,7 @@ File tool candidates include canonical (symlink-resolved) absolute paths via `no
 
 ### Permission Simulation (Tool Permission Tester)
 
-The `tool_permission_simulate` IPC message lets clients dry-run a tool invocation through the full permission evaluation pipeline without actually executing the tool or mutating daemon state. The macOS Settings panel exposes this as a "Tool Permission Tester" UI.
+The `tool_permission_simulate` HTTP endpoint lets clients dry-run a tool invocation through the full permission evaluation pipeline without actually executing the tool or mutating daemon state. The macOS Settings panel exposes this as a "Tool Permission Tester" UI.
 
 **Simulation semantics:**
 

--- a/assistant/src/config/bundled-skills/elevenlabs-voice/SKILL.md
+++ b/assistant/src/config/bundled-skills/elevenlabs-voice/SKILL.md
@@ -7,7 +7,7 @@ metadata: {"emoji":"🗣️","vellum":{"display-name":"ElevenLabs Voice","user-i
 
 ## Overview
 
-ElevenLabs provides text-to-speech voices for both **in-app TTS** and **phone calls**. The shared config key `elevenlabs.voiceId` controls the voice across all channels. Use the `voice_config_update` tool to change the voice — it writes to the config file and pushes to the macOS app via IPC in one call.
+ElevenLabs provides text-to-speech voices for both **in-app TTS** and **phone calls**. The shared config key `elevenlabs.voiceId` controls the voice across all channels. Use the `voice_config_update` tool to change the voice — it writes to the config file and pushes to the macOS app via SSE in one call.
 
 ## Choose a Voice
 
@@ -40,7 +40,7 @@ Pick a voice that matches the your identity and the user's preferences. Offer to
 
 ### Setting the voice
 
-To set the chosen voice, use `voice_config_update`. This writes to the config file (`elevenlabs.voiceId`) for phone calls **and** pushes to the macOS app via IPC (`ttsVoiceId`) for in-app TTS in one call:
+To set the chosen voice, use `voice_config_update`. This writes to the config file (`elevenlabs.voiceId`) for phone calls **and** pushes to the macOS app via SSE (`ttsVoiceId`) for in-app TTS in one call:
 
 ```
 voice_config_update setting="tts_voice_id" value="<selected-voice-id>"

--- a/assistant/src/config/feature-flag-registry.json
+++ b/assistant/src/config/feature-flag-registry.json
@@ -74,14 +74,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "local-http-enabled",
-      "scope": "macos",
-      "key": "local_http_enabled",
-      "label": "Local HTTP Enabled",
-      "description": "Enable local HTTP transport mode in macOS app",
-      "defaultEnabled": true
-    },
-    {
       "id": "command-palette",
       "scope": "assistant",
       "key": "feature_flags.command-palette.enabled",

--- a/assistant/src/notifications/README.md
+++ b/assistant/src/notifications/README.md
@@ -88,7 +88,7 @@ Each policy defines:
 
 | Strategy                         | Behavior                                                                                                                                                                                                                                     | Used by                                  |
 | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| `start_new_conversation`         | Creates a fresh conversation per delivery. The thread is surfaced via IPC.                                                                                                                                                                   | `vellum`                                 |
+| `start_new_conversation`         | Creates a fresh conversation per delivery. The thread is surfaced via SSE.                                                                                                                                                                   | `vellum`                                 |
 | `continue_existing_conversation` | Looks up a previously bound conversation by binding key (sourceChannel + externalChatId) and appends to it. When no bound conversation exists (first delivery to a destination), creates a new one and upserts the binding for future reuse. | `telegram`, `whatsapp`, `slack`, `email` |
 | `not_deliverable`                | Channel cannot receive notifications. Pairing returns null IDs.                                                                                                                                                                              | `phone`                                  |
 
@@ -416,11 +416,11 @@ All disambiguation messages are generated through `composeGuardianActionMessageG
 | `decision-engine.ts`      | LLM-based routing with forced tool_choice; deterministic fallback                              |
 | `deterministic-checks.ts` | Pre-send gate checks (dedupe, source-active, channel availability)                             |
 | `runtime-dispatch.ts`     | Dispatch gating (no-op decisions, empty channels)                                              |
-| `broadcaster.ts`          | Fan-out to channel adapters with delivery audit trail; emits `notification_thread_created` IPC |
-| `copy-composer.ts`        | Template-based fallback notification copy when LLM copy is unavailable                         |
-| `thread-seed-composer.ts` | Surface-aware thread seed generation (richer than notification copy)                           |
-| `destination-resolver.ts` | Resolves per-channel endpoints (vellum IPC, Telegram chat ID)                                  |
-| `adapters/macos.ts`       | Vellum adapter -- broadcasts `notification_intent` via IPC with deep-link metadata             |
+| `broadcaster.ts`          | Fan-out to channel adapters with delivery audit trail; emits `notification_thread_created` SSE event |
+| `copy-composer.ts`        | Template-based fallback notification copy when LLM copy is unavailable                              |
+| `thread-seed-composer.ts` | Surface-aware thread seed generation (richer than notification copy)                                |
+| `destination-resolver.ts` | Resolves per-channel endpoints (vellum SSE, Telegram chat ID)                                       |
+| `adapters/macos.ts`       | Vellum adapter -- broadcasts `notification_intent` via SSE with deep-link metadata                  |
 | `adapters/telegram.ts`    | Telegram adapter -- POSTs to gateway `/deliver/telegram`                                       |
 | `preference-extractor.ts` | Detects notification preferences in conversation messages                                      |
 | `preference-summary.ts`   | Builds preference context string for the decision engine prompt                                |

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -10,7 +10,7 @@ The single HTTP send endpoint is `POST /v1/messages`. Key behaviors:
 - **Fire-and-forget**: Returns `202 { accepted: true }` immediately. The client observes progress via SSE (`GET /v1/events`).
 - **Hub publishing**: All agent events are published to `assistantEventHub`, making them observable via SSE.
 
-Do NOT add new send endpoints. All message ingress should go through `POST /v1/messages` (HTTP) or `session.processMessage()` (IPC).
+Do NOT add new send endpoints. All message ingress should go through `POST /v1/messages` (HTTP).
 
 ### Approvals (confirmations, secrets, trust rules)
 
@@ -33,10 +33,8 @@ Channel approval flows use `requestId` (not `runId`) as the primary identifier:
 - Guardian approval records in `channelGuardianApprovalRequests` link via `requestId`.
 - The conversational approval engine classifies user intent and resolves via `session.handleConfirmationResponse(requestId, decision)`.
 
-## HTTP-First for New Endpoints
+## HTTP-Only Transport
 
-New configuration and control endpoints MUST be exposed over HTTP on the runtime server (`assistant/src/runtime/http-server.ts`), not as IPC-only message types. The runtime HTTP server is the canonical API surface — IPC is a legacy transport being phased out.
+HTTP is the sole transport for client-daemon communication. The runtime HTTP server (`assistant/src/runtime/http-server.ts`) is the canonical API surface. Clients connect via HTTP for request/response operations and SSE (`GET /v1/events`) for streaming server-to-client events.
 
-Existing IPC-only handlers should be migrated to HTTP when touched. The pattern: extract business logic into a shared function, add an HTTP route handler in `assistant/src/runtime/routes/`, keep the IPC handler as a thin wrapper that calls the same logic.
-
-When writing skills that need to call daemon configuration endpoints, use `curl` with the runtime HTTP API (JWT-authenticated via `Authorization: Bearer <jwt>`) rather than describing IPC socket protocol details. The assistant already knows how to use `curl`.
+When writing skills that need to call daemon configuration endpoints, use `curl` with the runtime HTTP API (JWT-authenticated via `Authorization: Bearer <jwt>`). The assistant already knows how to use `curl`.

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -276,10 +276,9 @@ export class RuntimeHttpServer {
       featureFlagToken: this.readFeatureFlagToken(),
       pairingBroadcast: ipcBroadcast
         ? (msg) => {
-            // Broadcast to IPC socket clients (local Unix socket)
+            // Broadcast to all clients via the event hub so HTTP/SSE clients
+            // (e.g. macOS app) receive pairing approval requests.
             ipcBroadcast(msg);
-            // Also publish to the event hub so HTTP/SSE clients (e.g. macOS
-            // app with localHttpEnabled) receive pairing approval requests.
             void assistantEventHub.publish(
               buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg),
             );

--- a/assistant/src/tasks/SPEC.md
+++ b/assistant/src/tasks/SPEC.md
@@ -95,7 +95,7 @@ Each task run creates a new conversation thread with `threadType: 'background'`.
    template placeholders, sets up ephemeral permission rules for the approved
    tools, and processes the rendered prompt through a daemon `Session`. Status
    updates are broadcast to all connected clients via `work_item_status_changed`
-   and `tasks_changed` IPC messages.
+   and `tasks_changed` SSE events.
 3. **Completion**: When the session finishes, the work item transitions to
    `awaiting_review` (on success) or `failed` (on error). The daemon broadcasts
    the final status to all clients.
@@ -135,5 +135,5 @@ The implementation is complete. Key modules:
 | `task-store.ts`                  | `tasks` and `task_runs` tables, CRUD functions.                                                    |
 | `task-runner.ts`                 | `runTask()` — creates background conversation, renders template, processes through daemon Session. |
 | `ephemeral-permissions.ts`       | Scoped permission rules for the duration of a single task run.                                     |
-| `work-items.ts` (daemon handler) | IPC handlers for preflight, run, cancel, and status queries.                                       |
+| `work-items.ts` (daemon handler) | HTTP handlers for preflight, run, cancel, and status queries.                                      |
 | Bundled skill (`tasks/`)         | Tool definitions (`task_save`, `task_run`, `task_list`, `task_delete`, `task_list_*`) for the LLM. |

--- a/clients/AGENTS.md
+++ b/clients/AGENTS.md
@@ -207,7 +207,7 @@ All UI icons use **vendored Lucide PDF assets** rendered through the `VIcon` enu
 **How to use icons:**
 - **Direct rendering:** `VIconView(.search, size: 14)` — drop-in replacement for `Image(systemName:)`.
 - **In components that take icon strings:** Pass `VIcon.xxx.rawValue` (e.g., `VButton(label: "Save", leftIcon: VIcon.check.rawValue)`). Components use `VIcon.resolve()` internally, which handles both Lucide raw values and legacy SF Symbol names via `SFSymbolMapping`.
-- **Dynamic icons from IPC/daemon:** Use `SFSymbolMapping.icon(forSFSymbol: name, fallback: .puzzle)` at the render boundary.
+- **Dynamic icons from the assistant:** Use `SFSymbolMapping.icon(forSFSymbol: name, fallback: .puzzle)` at the render boundary.
 - **AppKit contexts:** Use `VIcon.xxx.nsImage` or `VIcon.xxx.nsImage(size: 16)`.
 - **Resolving unknown icon strings:** `VIcon.resolve("some-icon")` tries Lucide raw value first, then `SFSymbolMapping`, then falls back to `.puzzle`.
 

--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -12,7 +12,7 @@ The macOS app uses a centralized service container (`AppServices`) created once 
 
 | Service | Type | Purpose |
 |---------|------|---------|
-| `daemonClient` | `DaemonClient` | Unix socket IPC to daemon (local mode) or HTTP+SSE to platform proxy (managed mode) |
+| `daemonClient` | `DaemonClient` | HTTP+SSE to daemon (local mode) or HTTP+SSE to platform proxy (managed mode) |
 | `ambientAgent` | `AmbientAgent` | Coordinates Ride Shotgun trigger, session, and floating windows |
 | `surfaceManager` | `SurfaceManager` | Routes `ui_surface_show` messages |
 | `toolConfirmationManager` | `ToolConfirmationManager` | Handles tool permission prompts |
@@ -93,12 +93,7 @@ graph LR
         WORK_ITEMS["work_items<br/>───────────────<br/>Task Queue entries<br/>taskId (FK → tasks)<br/>title, notes, status<br/>priority_tier (0-3), sort_index<br/>last_run_id, last_run_status<br/>source_type, source_id"]
     end
 
-    subgraph "~/.vellum/workspace/data/ipc-blobs/"
-        BLOBS["*.blob<br/>───────────────<br/>Ephemeral blob files<br/>UUID filenames<br/>Atomic temp+rename writes<br/>Consumed after daemon hydration<br/>Stale sweep every 5min (30min max age)"]
-    end
-
     subgraph "~/.vellum/ (Root Files)"
-        SOCK["vellum.sock<br/>Unix domain socket"]
         TRUST["protected/trust.json<br/>Tool permission rules"]
     end
 
@@ -146,8 +141,8 @@ sequenceDiagram
         Note over CLS: Bypass Haiku API call<br/>Route directly to text_qa
         CLS-->>AD: InteractionType.textQA
         AD->>DC: send(SessionCreate + UserMessage)
-        Note over DC: Unix socket<br/>~/.vellum/vellum.sock
-        DC->>Daemon: IPC
+        Note over DC: HTTP POST
+        DC->>Daemon: HTTP
         Note over Daemon: Creates conversation in SQLite<br/>Wires escalation handler
         Daemon-->>DC: task_routed(text_qa)
         DC-->>AD: route to text_qa UI
@@ -165,7 +160,7 @@ sequenceDiagram
 
         AD->>Session: init(task, daemonClient, ...)
         Session->>DC: send(CuSessionCreateMessage)
-        Note over DC: Unix socket<br/>~/.vellum/vellum.sock<br/>newline-delimited JSON
+        Note over DC: HTTP POST
 
         loop PERCEIVE → INFER → VERIFY → EXECUTE → WAIT
             par Parallel Capture
@@ -181,7 +176,7 @@ sequenceDiagram
             Session->>DC: send(CuObservationMessage)
             Note over DC: Contains: axTree, axDiff,<br/>screenshot, secondaryWindows,<br/>executionResult/error<br/>Optional: axTreeBlob, screenshotBlob<br/>(blob refs when transport available)
 
-            DC->>Daemon: IPC message
+            DC->>Daemon: HTTP POST
             Daemon->>Claude: API call with observation
             Note over Daemon: Loads conversation from SQLite<br/>Appends observation as user msg<br/>Stores in messages table
             Claude-->>Daemon: tool_use response
@@ -233,7 +228,7 @@ idle → starting → recording → stopping → idle
                                       └→ failed → idle
 ```
 
-A recording is initiated when the daemon detects a recording-only intent in the user's message (or a mixed-intent message that includes a recording clause). The daemon generates a unique `recordingId`, stores bidirectional mappings (`recordingId ↔ conversationId`), and sends a `recording_start` IPC message to the macOS client. The client manages the actual screen capture via `RecordingManager.swift` and reports status transitions back to the daemon.
+A recording is initiated when the daemon detects a recording-only intent in the user's message (or a mixed-intent message that includes a recording clause). The daemon generates a unique `recordingId`, stores bidirectional mappings (`recordingId ↔ conversationId`), and sends a `recording_start` SSE event to the macOS client. The client manages the actual screen capture via `RecordingManager.swift` and reports status transitions back to the daemon via HTTP.
 
 ### Key Files
 
@@ -243,13 +238,13 @@ A recording is initiated when the daemon detects a recording-only intent in the 
 | `assistant/src/daemon/handlers/recording.ts` | Daemon handler for start, stop, and status lifecycle events |
 | `clients/macos/vellum-assistant/ComputerUse/RecordingManager.swift` | macOS-side screen capture using ScreenCaptureKit |
 
-### IPC Messages
+### Messages
 
-| Message | Direction | Purpose |
-|---|---|---|
-| `recording_start` | Server → Client | Instructs the client to begin recording with a `recordingId` and optional `RecordingOptions` |
-| `recording_stop` | Server → Client | Instructs the client to stop the active recording |
-| `recording_status` | Client → Server | Reports lifecycle transitions: `started`, `stopped` (with `filePath`), or `failed` (with `error`) |
+| Message | Direction | Transport | Purpose |
+|---|---|---|---|
+| `recording_start` | Server → Client | SSE | Instructs the client to begin recording with a `recordingId` and optional `RecordingOptions` |
+| `recording_stop` | Server → Client | SSE | Instructs the client to stop the active recording |
+| `recording_status` | Client → Server | HTTP POST | Reports lifecycle transitions: `started`, `stopped` (with `filePath`), or `failed` (with `error`) |
 
 ### Intent Routing
 
@@ -343,7 +338,7 @@ sequenceDiagram
             end
 
             WS-->>Session: observation data
-            Session->>DC: send observation via IPC
+            Session->>DC: send observation via HTTP
             DC->>Daemon: process observation
             Daemon-->>DC: result
             DC-->>Session: observation processed
@@ -351,7 +346,7 @@ sequenceDiagram
         end
 
         Session->>Session: summarizing
-        Session->>DC: request summary via IPC
+        Session->>DC: request summary via HTTP
         Daemon-->>DC: summary text
         DC-->>Session: summary
         Session-->>Agent: state = .complete
@@ -377,7 +372,7 @@ The workspace is a full-window mode that replaces the chat UI with an interactiv
 
 ```mermaid
 sequenceDiagram
-    participant Daemon as Daemon (IPC)
+    participant Daemon as Daemon (HTTP)
     participant DC as DaemonClient
     participant SM as SurfaceManager
     participant AD as AppDelegate
@@ -601,7 +596,7 @@ The route mode and auth mode are carried in `TransportMetadata` (defined in `Dae
 When the current assistant is managed (`isCurrentAssistantManaged == true`), the app skips:
 - **Local daemon hatching** -- the platform hosts the daemon, so `assistantCli.hatch()` is not called.
 - **Actor credential bootstrap** -- identity is derived from the platform session token, not local actor tokens. The `ensureActorCredentials()` flow is skipped entirely.
-- **Socket-missing re-hatch** -- the reconnection loop does not attempt local re-hatch when the socket file is absent.
+- **Server-unavailable re-hatch** -- the reconnection loop does not attempt local re-hatch when the daemon HTTP server is unreachable.
 
 ### Credential and State Storage
 
@@ -633,7 +628,7 @@ When a managed-mode HTTP request receives a 401, the `HTTPDaemonClient` does not
 
 ## iOS Connection Architecture
 
-The iOS app connects to the macOS assistant exclusively via HTTPS through the gateway. There is no direct TCP or Unix socket connection path.
+The iOS app connects to the macOS assistant exclusively via HTTPS through the gateway.
 
 ### Connection Flow
 
@@ -665,7 +660,7 @@ iOS pairing uses a v4 QR code protocol with Mac-side approval. There is no manua
 **Flow:**
 1. macOS generates a v4 QR code (no bearer token in QR) and pre-registers the pairing request with the daemon via `POST /v1/pairing/register`.
 2. iOS scans the QR code, extracts the `pairingRequestId` and `pairingSecret`, and sends a pairing request to the gateway (`POST /pairing/request`). Tries `localLanUrl` first (3s timeout), falls back to cloud gateway URL (`g`).
-3. The daemon validates the secret and either auto-approves (if the device is in the allowlist) or sends an IPC message to macOS to show an approval prompt.
+3. The daemon validates the secret and either auto-approves (if the device is in the allowlist) or sends an SSE event to macOS to show an approval prompt.
 4. macOS shows a floating approval window with three options: Deny, Approve Once, Always Allow.
 5. iOS polls `GET /pairing/status?id=<id>&secret=<secret>` every 2.5s until approved, denied, or expired (5-min TTL).
 6. On approval, the response includes the bearer token and gateway URL. iOS saves these and connects.
@@ -731,7 +726,7 @@ Both macOS and iOS clients use a single JWT access token for all HTTP authentica
 | `clients/macos/vellum-assistant/Features/Settings/PairingApprovalWindow.swift` | Floating approval prompt window |
 | `assistant/src/daemon/pairing-store.ts` | In-memory pairing request store with TTL |
 | `assistant/src/daemon/approved-devices-store.ts` | Persistent approved devices allowlist |
-| `assistant/src/daemon/handlers/pairing.ts` | IPC handlers for pairing approval |
+| `assistant/src/daemon/handlers/pairing.ts` | Pairing approval handlers |
 | `gateway/src/http/routes/pairing-proxy.ts` | Gateway proxy for pairing endpoints |
 
 ### Offline Message Queue (iOS)
@@ -749,7 +744,7 @@ Storage key: `offline_message_queue_v1` (UserDefaults).
 
 ### Guardian Approval Card UI (macOS/iOS)
 
-Guardian approval prompts are rendered as structured card UIs in the chat timeline using a "buttons first, text fallback" model. The daemon delivers `GuardianDecisionPrompt` objects via IPC or HTTP, and the client renders them as kind-aware cards with tappable action buttons.
+Guardian approval prompts are rendered as structured card UIs in the chat timeline using a "buttons first, text fallback" model. The daemon delivers `GuardianDecisionPrompt` objects via HTTP+SSE, and the client renders them as kind-aware cards with tappable action buttons.
 
 **Kind-aware rendering:** `GuardianDecisionBubble` renders distinct card headers for each canonical request kind:
 

--- a/clients/README.md
+++ b/clients/README.md
@@ -46,10 +46,10 @@ clients/
 **Purpose**: Platform-agnostic code shared between macOS and iOS apps
 
 **Contains**:
-- **IPC layer** (`DaemonClient`, `IPCMessages`, `Generated/IPCContractGenerated`) - Network communication with the assistant
-  - macOS: Unix domain socket (`~/.vellum/vellum.sock`)
-  - iOS: HTTP+SSE through the gateway (no direct TCP or Unix socket connection)
-  - Wire types are auto-generated from the TS IPC contract; `IPCMessages.swift` provides
+- **Network layer** (`DaemonClient`, `IPCMessages`, `Generated/IPCContractGenerated`) - HTTP+SSE communication with the assistant
+  - macOS: HTTP+SSE to the local daemon runtime server
+  - iOS: HTTP+SSE through the gateway
+  - Wire types are auto-generated from the TS contract; `IPCMessages.swift` provides
     typealiases, convenience inits, the `ServerMessage` routing enum, and a few hand-maintained
     types that need Swift-specific logic (e.g. typed enums, polymorphic `AnyCodable` data)
 - **Shared chat features** (`ChatViewModel`, `ChatMessage`, `MessageBubbleView`, `InputBarView`, `AttachmentStripView`, `MarkdownRenderer`, `CurrentStepIndicator`, inline widgets)

--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -81,7 +81,7 @@ VSplitView            (row 3 — ChatView + optional side panel)
 The core orchestration cycle runs per-task in `ComputerUseSession` (`@MainActor`):
 
 1. **PERCEIVE** — enumerate the AX tree of the focused window (`AccessibilityTree.swift`); also captures a screenshot alongside; falls back to screenshot-only if no AX tree. Computes `AXTreeDiff` between steps. Enumerates secondary windows for cross-app awareness.
-2. **INFER** — send AX tree + screenshot + previous AX tree + diff + task + action history to the daemon via IPC (`DaemonClient`); daemon calls Claude and returns exactly one tool call per turn.
+2. **INFER** — send AX tree + screenshot + previous AX tree + diff + task + action history to the daemon via HTTP (`DaemonClient`); daemon calls Claude and returns exactly one tool call per turn.
 3. **VERIFY** — safety checks: sensitive data, destructive keys, loop detection (3 identical consecutive actions), step limits, system menu bar exclusion (`ActionVerifier`).
 4. **EXECUTE** — inject mouse/keyboard events via CGEvent (`ActionExecutor`). Text input uses clipboard-paste (Cmd+V) with save/restore.
 5. **WAIT** — adaptive delay: polls AX tree for changes instead of fixed sleep, returns early when UI settles.
@@ -100,24 +100,17 @@ Tests use `Mock*` versions defined in `SessionTests.swift`. Test pattern: `@Main
 
 </details>
 
-### IPC Layer (`IPC/`)
+### Network Layer (`IPC/`)
 
-All inference (both computer-use sessions and ambient analysis) goes through daemon IPC:
-- `DaemonClient` — `@MainActor`, Unix domain socket (default `~/.vellum/vellum.sock`, resolved dynamically via `resolveSocketPath()`) or HTTP+SSE in managed mode; auto-reconnect, ping/pong keepalive, `AsyncStream<ServerMessage>`
-- `IPCMessages.swift` — Codable structs mirroring `ipc-protocol.ts`: `cu_session_create`, `cu_observation`, `cu_action`, `cu_complete`, `cu_error`, `ambient_analyze`, `trace_event`, etc.
-- `IPC/Generated/IPCContractGenerated.swift` — **auto-generated** Swift types from the TypeScript IPC contract. Use these `IPC*` types directly in Swift code instead of hand-writing structs.
-
-**When modifying `assistant/src/daemon/ipc-contract.ts`** (adding/changing message types), you MUST run these commands from the `assistant/` directory:
-```bash
-bun run generate:ipc              # regenerate IPCContractGenerated.swift
-bun run ipc:inventory:update      # regenerate ipc-contract-inventory.json
-```
-Both generated files must be committed alongside your contract changes. CI checks (`check:ipc-generated` and `ipc:inventory`) will fail if they are out of sync.
+All inference (both computer-use sessions and ambient analysis) goes through the assistant's HTTP API:
+- `DaemonClient` — `@MainActor`, HTTP+SSE transport; auto-reconnect, `AsyncStream<ServerMessage>`
+- `IPCMessages.swift` — Codable structs for HTTP request/response types: `cu_session_create`, `cu_observation`, `cu_action`, `cu_complete`, `cu_error`, `ambient_analyze`, `trace_event`, etc.
+- `IPC/Generated/IPCContractGenerated.swift` — Codable Swift types used for JSON serialization. Use these `IPC*` types directly in Swift code instead of hand-writing structs.
 
 ### Ambient Agent (`Ambient/`)
 
 A background screen-watching system that runs alongside the manual session loop:
-- `AmbientAgent` — orchestrates periodic capture → OCR → analyze cycles via daemon IPC (configurable interval, default 30s)
+- `AmbientAgent` — orchestrates periodic capture → OCR → analyze cycles via HTTP (configurable interval, default 30s)
 - `AmbientAnalyzer.swift` — type definitions only (`AmbientDecision`, `AmbientAnalysisResult`); analysis logic lives in the daemon
 - `KnowledgeStore` — persists observations as JSON in Application Support (max 500 entries)
 

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -264,7 +264,7 @@ This builds the app (if needed), generates the background image, creates a style
 
 ## Local Assistant (Daemon)
 
-The macOS app is a frontend — all inference (chat, computer-use sessions, ambient analysis) goes through the **local assistant process** (internally called the daemon), a Node/Bun process that manages Claude API calls, conversation state, and tool execution. The app connects to it via a Unix domain socket at `~/.vellum/vellum.sock` by default (the path is resolved dynamically via `resolveSocketPath()`, which honors `BASE_DATA_DIR` and the lockfile for multi-instance setups).
+The macOS app is a frontend — all inference (chat, computer-use sessions, ambient analysis) goes through the **local assistant process** (internally called the daemon), a Node/Bun process that manages Claude API calls, conversation state, and tool execution. The app connects to it via HTTP+SSE (the runtime HTTP server port is resolved dynamically from the lockfile, honoring `BASE_DATA_DIR` for multi-instance setups).
 
 **Local mode: You must start the assistant before using the app.** Without it, the app will connect but get no responses. (In managed mode, the assistant runs on the Vellum platform — no local process needed.)
 
@@ -456,7 +456,7 @@ Inference/            AI action selection
   ToolDefinitions     Tool schemas for function calling
 Services/             Singleton service containers
 Ambient/              Background screen-watching agent
-  AmbientAgent        Periodic capture → OCR → analyze via daemon IPC
+  AmbientAgent        Periodic capture → OCR → analyze via HTTP
   AmbientAnalyzer     Type definitions (AmbientDecision, AmbientAnalysisResult)
   KnowledgeStore      Persists observations as JSON
   ScreenOCR           Vision framework OCR

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -2290,9 +2290,9 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
         #if os(macOS)
         // Remote mode: httpTransport targets a non-local gateway (e.g. cloud).
-        // Delegate to it directly. When localHttpEnabled is on, httpTransport
-        // points at localhost (the runtime), which does NOT serve feature-flag
-        // routes — so we must fall through to the local gateway path below.
+        // Delegate to it directly. When httpTransport points at localhost
+        // (the runtime), it does NOT serve feature-flag routes — so we must
+        // fall through to the local gateway path below.
         if let httpTransport = self.httpTransport, !Self.isLocalBaseURL(httpTransport.baseURL) {
             let sid = OSSignpostID(log: ipcLog)
             os_signpost(.begin, log: ipcLog, name: "daemonHTTPRequest", signpostID: sid)

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-// MARK: - Manual IPC Type Allowlist
+// MARK: - Manual Type Allowlist
 //
-// Most IPC message types are auto-generated from the TS contract into
+// Most message types are auto-generated from the TS contract into
 // IPCContractGenerated.swift and referenced here via typealiases.
 // The following structs are **intentionally** hand-maintained because
 // the code generator cannot express their requirements:
@@ -740,7 +740,7 @@ extension IPCGetSigningIdentityResponse {
 
 // MARK: - Server → Client Messages (Decodable)
 //
-// These typealiases point to the auto-generated IPC types in
+// These typealiases point to the auto-generated types in
 // IPCContractGenerated.swift. Convenience inits preserve backward
 // compatibility with existing call sites (the generated structs
 // include a `type` field that the old hand-maintained types omitted).

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -19,7 +19,6 @@ All assistant API requests from clients, CLI, skills, and user-facing tooling **
 **Exception boundary:** The gateway service itself may call the runtime internally. Tests may use direct runtime URLs for isolated unit/integration scenarios. Intentional local daemon-control paths are exempt:
 
 - `clients/shared/IPC/DaemonClient.swift`
-- `clients/macos/vellum-assistant/App/AppDelegate.swift` (`localHttpEnabled`)
 - `clients/macos/vellum-assistant/Features/Settings/SettingsConnectTab.swift` (health probe)
 
 **Migration rule:** If a needed endpoint is not available at the gateway, add a gateway route/proxy first, then consume it. Do not work around a missing gateway endpoint by hitting the runtime directly.

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -364,7 +364,7 @@ The inbound message handler (`inbound-message-handler.ts`) accepts verification 
 
 #### Explicit Rebind Policy
 
-Creating a new guardian challenge when a binding already exists for the `(assistantId, channel)` pair requires explicit `rebind: true` in the IPC request. Without it, the daemon returns `already_bound` to the caller. This prevents accidental guardian replacement -- the desktop UI must explicitly acknowledge that it is replacing an existing guardian before a new challenge is issued. On the verification side, `validateAndConsumeVerification` always revokes any existing active binding before creating the new one, so the actual binding swap is atomic.
+Creating a new guardian challenge when a binding already exists for the `(assistantId, channel)` pair requires explicit `rebind: true` in the HTTP request. Without it, the daemon returns `already_bound` to the caller. This prevents accidental guardian replacement -- the desktop UI must explicitly acknowledge that it is replacing an existing guardian before a new challenge is issued. On the verification side, `validateAndConsumeVerification` always revokes any existing active binding before creating the new one, so the actual binding swap is atomic.
 
 #### Guardian Takeover Prevention
 
@@ -377,12 +377,12 @@ A challenge-response handshake binds a Telegram user as the guardian:
 ```mermaid
 sequenceDiagram
     participant User as Guardian Candidate
-    participant Desktop as Desktop / IPC
+    participant Desktop as Desktop Client
     participant TG as Telegram
     participant GW as Gateway
     participant Daemon as Daemon (Runtime)
 
-    Desktop->>Daemon: guardian_verify IPC (action: create_session)
+    Desktop->>Daemon: POST /v1/channel-verification-sessions (action: create_session)
     Daemon->>Daemon: Generate random secret, hash (SHA-256), store challenge (10min TTL)
     Daemon-->>Desktop: Return secret + instruction
     Desktop-->>User: Display verification code
@@ -506,7 +506,7 @@ The channel inbound handler (`inbound-message-handler.ts`) enforces an access co
 3. If a member exists but is not `active` (e.g., `revoked`, `blocked`), the message is denied.
 4. If the member's `policy` is `deny`, the message is rejected. If `allow`, the message proceeds to normal processing. If `escalate`, the message is held for guardian approval.
 
-**Invite-based onboarding:** Invite tokens are created via the `ingress_invite` IPC contract. Each token is SHA-256 hashed before storage -- the raw token is returned exactly once at creation time. External users redeem invites by sending the token as a channel message, which atomically creates a member record with `active` status and `allow` policy.
+**Invite-based onboarding:** Invite tokens are created via the invite HTTP API. Each token is SHA-256 hashed before storage -- the raw token is returned exactly once at creation time. External users redeem invites by sending the token as a channel message, which atomically creates a member record with `active` status and `allow` policy.
 
 **Relationship to guardian verification:** Guardian verification and ingress contact management are independent systems. Guardian verification establishes who controls the assistant on a channel (the trust anchor for approvals and escalations). Ingress contacts control who can interact with the assistant. Escalation (`policy=escalate`) depends on a guardian binding existing for the channel -- without one, escalated messages are denied (fail-closed).
 
@@ -564,7 +564,7 @@ If no guardian binding exists for the channel, escalation fails closed -- the me
 | `assistant/src/memory/invite-store.ts`           | CRUD for invite tokens with SHA-256 hashing and expiry                    |
 | `assistant/src/contacts/contact-store.ts`        | Contact and channel lookups (findContactChannel, guardian bindings)       |
 | `assistant/src/contacts/contacts-write.ts`       | Contact and channel writes (upsert, policy changes, invite redemption)    |
-| `assistant/src/daemon/handlers/config-inbox.ts`  | IPC handlers for invite and member contracts                              |
+| `assistant/src/daemon/handlers/config-inbox.ts`  | Handlers for invite and member contracts                                  |
 | `assistant/src/runtime/routes/channel-routes.ts` | ACL enforcement point -- member lookup, policy check, escalation creation |
 
 ### Telegram Credential Flow
@@ -576,11 +576,11 @@ Entry points:
 
   1. Skill-based setup (chat):
      credential_store action: "prompt" → token stored in secure storage
-       → telegram_config IPC (action: set) — daemon reads token from secure storage
+       → telegram_config HTTP (action: set) — daemon reads token from secure storage
 
   2. Desktop Settings UI (macOS):
      SettingsStore.saveTelegramToken(token)
-       → telegram_config IPC (action: set, botToken: token) — token passed directly
+       → telegram_config HTTP (action: set, botToken: token) — token passed directly
 
 Both paths converge at:
   → Daemon handler validates token via Telegram getMe API
@@ -597,13 +597,13 @@ Both paths converge at:
         → Webhook reconciliation registers webhook with Telegram
 ```
 
-The `telegram_config` IPC message supports three actions:
+The `telegram_config` HTTP endpoint supports three actions:
 
 - **`get`** — returns connection status (`hasBotToken`, `botUsername`, `connected`, `hasWebhookSecret`) without exposing secret values
 - **`set`** — validates the bot token against the Telegram API, stores it in secure storage, auto-generates a webhook secret if none exists (with rollback on failure), and self-heals webhook_secret metadata if it already exists. The gateway's credential watcher detects the storage change and triggers webhook reconciliation automatically
 - **`clear`** — deregisters the webhook by calling Telegram's `deleteWebhook` API directly (while the token is still available), then deletes the bot token and webhook secret from both secure storage and credential metadata. The gateway's credential watcher detects the storage change and updates its readiness state automatically
 
-The gateway reads Telegram credentials via its `credential-reader` module (`gateway/src/credential-reader.ts`), which uses a broker-first fallback strategy: it tries the keychain broker first (a Unix domain socket served by the assistant daemon that proxies macOS Keychain reads), then falls back to the encrypted file store (`~/.vellum/protected/keys.enc`). When the broker is unavailable (e.g., daemon not running, non-macOS platform, or socket env var unset), the encrypted store is used directly.
+The gateway reads Telegram credentials via its `credential-reader` module (`gateway/src/credential-reader.ts`), which uses a broker-first fallback strategy: it tries the keychain broker first, then falls back to the encrypted file store (`~/.vellum/protected/keys.enc`). When the broker is unavailable (e.g., daemon not running or non-macOS platform), the encrypted store is used directly.
 
 ### Webhook Reconciliation
 
@@ -742,7 +742,7 @@ sequenceDiagram
     alt ASK_GUARDIAN pattern detected
         Ctrl->>CallStore: createPendingQuestion()
         Ctrl->>GuardianDispatch: dispatchGuardianQuestion()
-        GuardianDispatch->>Mac: notification_thread_created IPC
+        GuardianDispatch->>Mac: notification_thread_created SSE
         GuardianDispatch->>TG: POST /deliver/{channel}
         Note over Mac,TG: First channel to respond wins
         Mac/TG->>Routes: guardian answer

--- a/gateway/src/feature-flag-registry.json
+++ b/gateway/src/feature-flag-registry.json
@@ -74,14 +74,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "local-http-enabled",
-      "scope": "macos",
-      "key": "local_http_enabled",
-      "label": "Local HTTP Enabled",
-      "description": "Enable local HTTP transport mode in macOS app",
-      "defaultEnabled": true
-    },
-    {
       "id": "command-palette",
       "scope": "assistant",
       "key": "feature_flags.command-palette.enabled",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -74,14 +74,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "local-http-enabled",
-      "scope": "macos",
-      "key": "local_http_enabled",
-      "label": "Local HTTP Enabled",
-      "description": "Enable local HTTP transport mode in macOS app",
-      "defaultEnabled": true
-    },
-    {
       "id": "command-palette",
       "scope": "assistant",
       "key": "feature_flags.command-palette.enabled",


### PR DESCRIPTION
## Summary

Final cleanup PR in the Phase Out IPC plan (PR 16 of 16). Removes all documentation references to Unix socket IPC transport and updates architecture diagrams to reflect HTTP+SSE as the sole client-server transport.

- Remove `local-http-enabled` feature flag from all three registry copies (meta, assistant, gateway)
- Update architecture diagrams in ARCHITECTURE.md, assistant/ARCHITECTURE.md, clients/ARCHITECTURE.md, gateway/ARCHITECTURE.md to show HTTP+SSE only
- Clean up IPC/socket references across 24 documentation files (README.md, AGENTS.md, CLAUDE.md, SPEC.md, SKILL.md, etc.)
- Update IPCMessages.swift and DaemonClient.swift comments to remove IPC-specific language
- Update http-server.ts broadcast comment

**Note:** `IPCContractGenerated.swift` is retained because its 397 Codable structs are still used by 26+ Swift files for HTTP JSON serialization. The "IPC" prefix is a naming artifact — the types are transport-agnostic and work identically over HTTP.

## Test plan

- [ ] Verify no documentation references IPC or socket transport as a current feature
- [ ] Verify architecture diagrams show HTTP+SSE as the sole transport
- [ ] Verify feature flag registries no longer contain `local-http-enabled`
- [ ] Verify Xcode builds without errors (no Swift code was removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
