### PR TITLE
fix: remove deleted transport cases from DebugStateWriter and fix Package.swift comment

### DIFF
--- a/clients/Package.swift
+++ b/clients/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
                 .enableUpcomingFeature("BareSlashRegexLiterals")
             ],
             linkerSettings: [
-                .linkedFramework("Network"),  // Required for DaemonClient (NWConnection)
+                .linkedFramework("Network"),  // Required for KeychainBrokerServer (NWListener/NWConnection)
                 .linkedFramework("AuthenticationServices"),  // Required for shared AuthManager (ASWebAuthenticationSession)
             ]
         ),

--- a/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
+++ b/clients/macos/vellum-assistant/Logging/DebugStateWriter.swift
@@ -62,10 +62,6 @@ final class DebugStateWriter {
 
         let transport: String
         switch daemonClient.config.transport {
-        case .socket:
-            transport = "socket"
-        case .tcp:
-            transport = "tcp"
         case .http:
             transport = "http"
         }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for phase-out-ipc.md.

**Gap A:** DebugStateWriter.swift still switches over .socket and .tcp transport cases that were deleted in PR 14
**Gap B:** Package.swift comment incorrectly attributes Network framework to DaemonClient instead of KeychainBrokerServer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
