### PR TITLE
fix: correct CU endpoint paths from singular to plural in Swift client

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -719,9 +719,9 @@ public final class HTTPTransport {
             let encoded = sessionId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? sessionId
             return ("/v1/computer-use/sessions/\(encoded)/abort", nil)
         case .cuObservation:
-            return ("/v1/computer-use/observation", nil)
+            return ("/v1/computer-use/observations", nil)
         case .cuTaskSubmit:
-            return ("/v1/computer-use/task", nil)
+            return ("/v1/computer-use/tasks", nil)
         case .rideShotgunStart:
             return ("/v1/computer-use/ride-shotgun/start", nil)
         case .rideShotgunStop:
@@ -1102,9 +1102,9 @@ public final class HTTPTransport {
             let encoded = sessionId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? sessionId
             return ("\(prefix)/computer-use/sessions/\(encoded)/abort/", nil)
         case .cuObservation:
-            return ("\(prefix)/computer-use/observation/", nil)
+            return ("\(prefix)/computer-use/observations/", nil)
         case .cuTaskSubmit:
-            return ("\(prefix)/computer-use/task/", nil)
+            return ("\(prefix)/computer-use/tasks/", nil)
         case .rideShotgunStart:
             return ("\(prefix)/computer-use/ride-shotgun/start/", nil)
         case .rideShotgunStop:


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for phase-out-ipc.md.

**Gap:** Swift client sends to /v1/computer-use/observation and /v1/computer-use/task (singular) but server routes are /v1/computer-use/observations and /v1/computer-use/tasks (plural), causing 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
