### PR TITLE
fix: remove IPC generation checks from pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,7 +8,7 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 # Cache staged file lists once (avoids repeated git diff --cached calls).
-# Two variants: ACM-filtered (most checks) and unfiltered (IPC contract check).
+# Two variants: ACM-filtered (most checks) and unfiltered (typecheck, system-prompt warning).
 STAGED_ACM_FILE=$(mktemp)
 STAGED_ALL_FILE=$(mktemp)
 trap 'rm -f "$STAGED_ACM_FILE" "$STAGED_ALL_FILE"' EXIT
@@ -790,101 +790,6 @@ if [ $ASSISTANT_TS_STAGED -eq 1 ]; then
             exit 1
         fi
         echo "✅ Type check OK in assistant/"
-    fi
-fi
-
-# --- IPC contract generation check ---
-# When contract source files are staged, verify generated output is up to date.
-
-IPC_CONTRACT_FILES=(
-    "assistant/src/daemon/ipc-protocol.ts"
-    "assistant/src/daemon/ipc-contract-inventory.ts"
-    "assistant/scripts/ipc/generate-swift.ts"
-    "assistant/scripts/ipc/check-contract-inventory.ts"
-    "assistant/scripts/ipc/check-swift-decoder-drift.ts"
-    "assistant/src/daemon/ipc-contract-inventory.json"
-    "clients/shared/IPC/Generated/IPCContractGenerated.swift"
-    "clients/shared/IPC/IPCMessages.swift"
-)
-
-IPC_CHANGED=0
-while IFS= read -r -d '' FILE; do
-    for CONTRACT_FILE in "${IPC_CONTRACT_FILES[@]}"; do
-        if [ "$FILE" = "$CONTRACT_FILE" ]; then
-            IPC_CHANGED=1
-            break 2
-        fi
-    done
-done < "$STAGED_ALL_FILE"
-
-if [ $IPC_CHANGED -eq 1 ]; then
-    echo "🔍 IPC contract files changed — checking generated code is up to date..."
-
-    if [ ! -x "$BUN" ]; then
-        echo -e "${YELLOW}⚠️  bun not found — skipping IPC generation check${NC}"
-        echo "  Install bun or run 'cd assistant && bun run generate:ipc' manually."
-    else
-        # Invoke script files directly instead of `bun run <script-name>` to
-        # skip package.json resolution and shell indirection (3 processes vs 9).
-        if ! (cd assistant && "$BUN" scripts/ipc/generate-swift.ts --check) 2>/dev/null; then
-            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-            echo -e "${RED}Generated IPC Swift models are out of date!${NC}"
-            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-            echo ""
-            echo "Run: cd assistant && bun run generate:ipc"
-            echo "Then stage the updated file and commit again."
-            exit 1
-        fi
-        echo "✅ Generated IPC Swift models are up to date"
-
-        if ! (cd assistant && "$BUN" scripts/ipc/check-contract-inventory.ts) 2>/dev/null; then
-            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-            echo -e "${RED}IPC contract inventory snapshot is out of date!${NC}"
-            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-            echo ""
-            echo "Run: cd assistant && bun run ipc:inventory:update"
-            echo "Then stage the updated file and commit again."
-            exit 1
-        fi
-        echo "✅ IPC contract inventory is up to date"
-
-        if ! (cd assistant && "$BUN" scripts/ipc/check-swift-decoder-drift.ts) 2>/dev/null; then
-            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-            echo -e "${RED}Swift decoder is out of sync with the IPC contract!${NC}"
-            echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-            echo ""
-            echo "Update IPCMessages.swift decode cases or the drift checker allowlist."
-            exit 1
-        fi
-        echo "✅ Swift decoder is in sync with the contract"
-
-        # Verify generated output files are staged (not just regenerated on disk).
-        # The checks above compare against the working tree, so if a developer
-        # regenerates but forgets to `git add`, the hook would pass while the
-        # commit still contains stale content.
-        IPC_OUTPUT_FILES=(
-            "clients/shared/IPC/Generated/IPCContractGenerated.swift"
-            "assistant/src/daemon/ipc-contract-inventory.json"
-        )
-        UNSTAGED=0
-        for OUTPUT_FILE in "${IPC_OUTPUT_FILES[@]}"; do
-            if git diff --name-only -- "$OUTPUT_FILE" | grep -q .; then
-                if [ $UNSTAGED -eq 0 ]; then
-                    echo ""
-                    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-                    echo -e "${RED}Generated IPC files have unstaged changes!${NC}"
-                    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-                fi
-                echo -e "  ${YELLOW}$OUTPUT_FILE${NC} differs between index and working tree"
-                UNSTAGED=1
-            fi
-        done
-        if [ $UNSTAGED -eq 1 ]; then
-            echo ""
-            echo "Stage the updated files with: git add ${IPC_OUTPUT_FILES[*]}"
-            echo "Then commit again."
-            exit 1
-        fi
     fi
 fi
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for phase-out-ipc.md.

**Gap:** Pre-commit hook still contains IPC generation check block referencing deleted scripts (generate-swift.ts, check-contract-inventory.ts, check-swift-decoder-drift.ts). The scripts were already deleted, so these checks silently no-op'd.

- Removed the entire IPC contract generation check block (~95 lines) from `.githooks/pre-commit`
- Updated the cached staged-files comment to reflect remaining uses (typecheck, system-prompt warning)
- No IPC-related npm scripts were found in `assistant/package.json` (already clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
