### PR TITLE
fix: wire CU/recording deps in lifecycle.ts and deduplicate sequence counters

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1,4 +1,5 @@
 import { chmodSync, writeFileSync } from "node:fs";
+import type * as net from "node:net";
 import { join } from "node:path";
 
 import { config as dotenvConfig } from "dotenv";
@@ -93,8 +94,10 @@ import {
 } from "./providers-setup.js";
 import { seedInterfaceFiles } from "./seed-files.js";
 import { DaemonServer } from "./server.js";
+import { handleRideShotgunStart, handleRideShotgunStop } from "./ride-shotgun-handler.js";
 import { initSlashPairingContext } from "./session-slash.js";
 import { installShutdownHandlers } from "./shutdown-handlers.js";
+import { handleWatchObservation } from "./watch-handler.js";
 
 // Re-export public API so existing consumers don't need to change imports
 export type { StopResult } from "./daemon-control.js";
@@ -458,6 +461,81 @@ export async function runDaemon(): Promise<void> {
           );
         },
       },
+      getComputerUseDeps: () => {
+        const ctx = server.getHandlerContext();
+        // Stub socket for IPC handlers called from HTTP — ctx.send ignores
+        // the socket parameter and broadcasts to all clients instead.
+        const stubSocket = {} as net.Socket;
+        return {
+          cuSessions: ctx.cuSessions,
+          sharedRequestTimestamps: ctx.sharedRequestTimestamps,
+          cuObservationParseSequence: ctx.cuObservationParseSequence,
+          handleRideShotgunStart: async (params) => {
+            // The IPC handler generates its own watchId/sessionId and
+            // sends them via ctx.send as a watch_started message.
+            // We intercept send to capture the IDs before they broadcast.
+            let capturedWatchId = "";
+            let capturedSessionId = "";
+            const interceptCtx = {
+              ...ctx,
+              send: (_socket: net.Socket, msg: ServerMessage) => {
+                if (
+                  "type" in msg &&
+                  msg.type === "watch_started" &&
+                  "watchId" in msg &&
+                  "sessionId" in msg
+                ) {
+                  capturedWatchId = (msg as { watchId: string }).watchId;
+                  capturedSessionId = (msg as { sessionId: string }).sessionId;
+                }
+                ctx.send(_socket, msg);
+              },
+            };
+            await handleRideShotgunStart(
+              {
+                type: "ride_shotgun_start",
+                durationSeconds: params.durationSeconds,
+                intervalSeconds: params.intervalSeconds,
+                mode: params.mode,
+                targetDomain: params.targetDomain,
+                navigateDomain: params.navigateDomain,
+                autoNavigate: params.autoNavigate,
+              },
+              stubSocket,
+              interceptCtx,
+            );
+            return { watchId: capturedWatchId, sessionId: capturedSessionId };
+          },
+          handleRideShotgunStop: async (watchId) => {
+            await handleRideShotgunStop(
+              { type: "ride_shotgun_stop", watchId },
+              stubSocket,
+              ctx,
+            );
+          },
+          handleWatchObservation: async (params) => {
+            await handleWatchObservation(
+              {
+                type: "watch_observation",
+                watchId: params.watchId,
+                sessionId: params.sessionId,
+                ocrText: params.ocrText,
+                appName: params.appName,
+                windowTitle: params.windowTitle,
+                bundleIdentifier: params.bundleIdentifier,
+                timestamp: params.timestamp,
+                captureIndex: params.captureIndex,
+                totalExpected: params.totalExpected,
+              },
+              stubSocket,
+              ctx,
+            );
+          },
+        };
+      },
+      getRecordingDeps: () => ({
+        getHandlerContext: () => server.getHandlerContext(),
+      }),
     });
 
     // Inject voice bridge deps BEFORE attempting to start the HTTP server.

--- a/assistant/src/runtime/routes/computer-use-routes.ts
+++ b/assistant/src/runtime/routes/computer-use-routes.ts
@@ -65,12 +65,6 @@ export interface ComputerUseDeps {
 }
 
 // ---------------------------------------------------------------------------
-// Module-level state (mirrors IPC handler)
-// ---------------------------------------------------------------------------
-
-const cuObservationSequenceBySession = new Map<string, number>();
-
-// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -91,7 +85,6 @@ function removeCuSessionReferences(
     return;
   }
   deps.cuSessions.delete(sessionId);
-  cuObservationSequenceBySession.delete(sessionId);
   deps.cuObservationParseSequence.delete(sessionId);
 }
 
@@ -229,10 +222,11 @@ async function handleObservation(
   }
 
   // HTTP observations arrive with inline data (no blob refs to hydrate).
+  // Use the shared deps-injected sequence map as the single source of truth.
   const previousSequence =
-    cuObservationSequenceBySession.get(msg.sessionId) ?? 0;
+    deps.cuObservationParseSequence.get(msg.sessionId) ?? 0;
   const sequence = previousSequence + 1;
-  cuObservationSequenceBySession.set(msg.sessionId, sequence);
+  deps.cuObservationParseSequence.set(msg.sessionId, sequence);
 
   const axTreeBytes = msg.axTree ? Buffer.byteLength(msg.axTree, "utf8") : 0;
   const axDiffBytes = msg.axDiff ? Buffer.byteLength(msg.axDiff, "utf8") : 0;


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for phase-out-ipc.md.

**Gap A:** CU and recording HTTP routes never registered — lifecycle.ts missing getComputerUseDeps and getRecordingDeps wiring
**Gap B:** Dual observation sequence counters — removed module-level Map, using deps-injected Map as single source of truth

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
