### PR TITLE
refactor: remove socket-to-session Maps and fix recording routes for HTTP-only mode

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -1308,11 +1308,8 @@ function createMockCtx(): {
   let captured: ChannelVerificationSessionResponse | null = null;
   const ctx = {
     sessions: new Map(),
-    socketToSession: new Map(),
     cuSessions: new Map(),
-    socketToCuSession: new Map(),
     cuObservationParseSequence: new Map(),
-    socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],
     debounceTimers: {
       schedule: () => {},

--- a/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
+++ b/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
@@ -130,7 +130,6 @@ describe("handleUserMessage secret redirect continuation", () => {
     };
 
     const ctx = {
-      socketToSession: new Map<net.Socket, string>(),
       sessions: new Map(),
       cuSessions: new Map(),
       getOrCreateSession: async () => session,

--- a/assistant/src/__tests__/handlers-add-trust-rule-metadata.test.ts
+++ b/assistant/src/__tests__/handlers-add-trust-rule-metadata.test.ts
@@ -80,11 +80,8 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
   const sent: ServerMessage[] = [];
   const ctx: HandlerContext = {
     sessions: new Map(),
-    socketToSession: new Map(),
     cuSessions: new Map(),
-    socketToCuSession: new Map(),
     cuObservationParseSequence: new Map(),
-    socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],
     debounceTimers: new DebouncerMap({ defaultDelayMs: 200 }),
     suppressConfigReload: false,

--- a/assistant/src/__tests__/handlers-slack-config.test.ts
+++ b/assistant/src/__tests__/handlers-slack-config.test.ts
@@ -67,11 +67,8 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
   const sent: ServerMessage[] = [];
   const ctx: HandlerContext = {
     sessions: new Map(),
-    socketToSession: new Map(),
     cuSessions: new Map(),
-    socketToCuSession: new Map(),
     cuObservationParseSequence: new Map(),
-    socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],
     debounceTimers: new DebouncerMap({ defaultDelayMs: 200 }),
     suppressConfigReload: false,

--- a/assistant/src/__tests__/handlers-telegram-config.test.ts
+++ b/assistant/src/__tests__/handlers-telegram-config.test.ts
@@ -192,11 +192,8 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
   const sent: ServerMessage[] = [];
   const ctx: HandlerContext = {
     sessions: new Map(),
-    socketToSession: new Map(),
     cuSessions: new Map(),
-    socketToCuSession: new Map(),
     cuObservationParseSequence: new Map(),
-    socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],
     debounceTimers: new DebouncerMap({ defaultDelayMs: 200 }),
     suppressConfigReload: false,

--- a/assistant/src/__tests__/handlers-twitter-config.test.ts
+++ b/assistant/src/__tests__/handlers-twitter-config.test.ts
@@ -197,11 +197,8 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
   const sent: ServerMessage[] = [];
   const ctx: HandlerContext = {
     sessions: new Map(),
-    socketToSession: new Map(),
     cuSessions: new Map(),
-    socketToCuSession: new Map(),
     cuObservationParseSequence: new Map(),
-    socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],
     debounceTimers: new DebouncerMap({ defaultDelayMs: 200 }),
     suppressConfigReload: false,

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -245,11 +245,8 @@ function createContext(session: TestSession): {
   const sent: ServerMessage[] = [];
   const ctx: HandlerContext = {
     sessions: new Map(),
-    socketToSession: new Map(),
     cuSessions: new Map(),
-    socketToCuSession: new Map(),
     cuObservationParseSequence: new Map(),
-    socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],
     debounceTimers: new DebouncerMap({ defaultDelayMs: 100 }),
     suppressConfigReload: false,

--- a/assistant/src/__tests__/oauth-connect-handler.test.ts
+++ b/assistant/src/__tests__/oauth-connect-handler.test.ts
@@ -177,11 +177,8 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
   const sent: ServerMessage[] = [];
   const ctx: HandlerContext = {
     sessions: new Map(),
-    socketToSession: new Map(),
     cuSessions: new Map(),
-    socketToCuSession: new Map(),
     cuObservationParseSequence: new Map(),
-    socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],
     debounceTimers: new DebouncerMap({ defaultDelayMs: 200 }),
     suppressConfigReload: false,

--- a/assistant/src/__tests__/recording-handler.test.ts
+++ b/assistant/src/__tests__/recording-handler.test.ts
@@ -170,15 +170,11 @@ function createCtx(): {
 } {
   const sent: Array<{ type: string; [k: string]: unknown }> = [];
   const fakeSocket = {} as net.Socket;
-  const socketToSession = new Map<net.Socket, string>();
 
   const ctx: HandlerContext = {
     sessions: new Map(),
-    socketToSession,
     cuSessions: new Map(),
-    socketToCuSession: new Map(),
     cuObservationParseSequence: new Map(),
-    socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],
     debounceTimers: new DebouncerMap({ defaultDelayMs: 200 }),
     suppressConfigReload: false,
@@ -187,7 +183,9 @@ function createCtx(): {
     send: (_socket, msg) => {
       sent.push(msg as { type: string; [k: string]: unknown });
     },
-    broadcast: noop,
+    broadcast: (msg) => {
+      sent.push(msg as { type: string; [k: string]: unknown });
+    },
     clearAllSessions: () => 0,
     getOrCreateSession: () => {
       throw new Error("not implemented");
@@ -218,7 +216,6 @@ describe("handleRecordingStart", () => {
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
 
@@ -238,7 +235,7 @@ describe("handleRecordingStart", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const options = { captureScope: "window" as const, includeAudio: true };
 
-    handleRecordingStart("conv-2", options, fakeSocket, ctx);
+    handleRecordingStart("conv-2", options, ctx);
 
     expect(sent[0].options).toEqual(options);
   });
@@ -246,10 +243,10 @@ describe("handleRecordingStart", () => {
   test("returns null when recording already active and sends no messages", () => {
     const { ctx, sent, fakeSocket } = createCtx();
 
-    const id1 = handleRecordingStart("conv-3", undefined, fakeSocket, ctx);
+    const id1 = handleRecordingStart("conv-3", undefined, ctx);
     expect(id1).toBeTruthy();
 
-    const id2 = handleRecordingStart("conv-3", undefined, fakeSocket, ctx);
+    const id2 = handleRecordingStart("conv-3", undefined, ctx);
 
     // Should return null (callers handle messaging)
     expect(id2).toBeNull();
@@ -265,7 +262,6 @@ describe("handleRecordingStart", () => {
     const id1 = handleRecordingStart(
       "conv-global-a",
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(id1).toBeTruthy();
@@ -274,7 +270,6 @@ describe("handleRecordingStart", () => {
     const id2 = handleRecordingStart(
       "conv-global-b",
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(id2).toBeNull();
@@ -301,14 +296,10 @@ describe("handleRecordingStop", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-stop-1";
 
-    // Bind socket to session so findSocketForSession can locate it
-    ctx.socketToSession.set(fakeSocket, conversationId);
-
     // Start a recording first
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(recordingId).not.toBeNull();
@@ -336,10 +327,9 @@ describe("handleRecordingStop", () => {
     const convB = "conv-stopper";
 
     // Bind socket to conv-A (the owning conversation)
-    ctx.socketToSession.set(fakeSocket, convA);
 
     // Start a recording on conv-A
-    const recordingId = handleRecordingStart(convA, undefined, fakeSocket, ctx);
+    const recordingId = handleRecordingStart(convA, undefined, ctx);
     expect(recordingId).not.toBeNull();
     sent.length = 0;
 
@@ -352,18 +342,17 @@ describe("handleRecordingStop", () => {
     expect(sent[0].recordingId).toBe(recordingId!);
   });
 
-  test("returns undefined when no socket bound to conversation", () => {
-    const { ctx, fakeSocket } = createCtx();
-    const conversationId = "conv-no-socket";
+  test("returns recordingId when stopped via broadcast", () => {
+    const { ctx } = createCtx();
+    const conversationId = "conv-broadcast-stop";
 
-    // Start a recording (socket is used for the start message)
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
-    // Do NOT bind the socket to the session in socketToSession
+    const recordingId = handleRecordingStart(conversationId, undefined, ctx);
+    expect(recordingId).not.toBeNull();
 
     const result = handleRecordingStop(conversationId, ctx);
 
-    // No socket -> returns undefined after cleanup
-    expect(result).toBeUndefined();
+    // Broadcast-based stop always returns the recordingId
+    expect(result).toBe(recordingId!);
   });
 });
 
@@ -385,7 +374,6 @@ describe("recordingHandlers.recording_status", () => {
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(recordingId).not.toBeNull();
@@ -405,12 +393,10 @@ describe("recordingHandlers.recording_status", () => {
     const conversationId = "conv-status-stopped";
 
     // Bind socket
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(recordingId).not.toBeNull();
@@ -459,12 +445,10 @@ describe("recordingHandlers.recording_status", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-status-no-msg";
 
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(recordingId).not.toBeNull();
@@ -492,13 +476,11 @@ describe("recordingHandlers.recording_status", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-status-no-file";
 
-    ctx.socketToSession.set(fakeSocket, conversationId);
     mockFileExists = false;
 
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(recordingId).not.toBeNull();
@@ -532,14 +514,12 @@ describe("recordingHandlers.recording_status", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-status-zero-file";
 
-    ctx.socketToSession.set(fakeSocket, conversationId);
     mockFileExists = true;
     mockFileSize = 0;
 
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(recordingId).not.toBeNull();
@@ -579,14 +559,12 @@ describe("recordingHandlers.recording_status", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-status-success";
 
-    ctx.socketToSession.set(fakeSocket, conversationId);
     mockFileExists = true;
     mockFileSize = 4096;
 
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(recordingId).not.toBeNull();
@@ -622,14 +600,12 @@ describe("recordingHandlers.recording_status", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-status-outside-dir";
 
-    ctx.socketToSession.set(fakeSocket, conversationId);
     mockFileExists = true;
     mockFileSize = 4096;
 
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(recordingId).not.toBeNull();
@@ -664,12 +640,10 @@ describe("recordingHandlers.recording_status", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-status-fail-final";
 
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(recordingId).not.toBeNull();
@@ -705,12 +679,10 @@ describe("recordingHandlers.recording_status", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-status-failed";
 
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(recordingId).not.toBeNull();
@@ -739,12 +711,10 @@ describe("recordingHandlers.recording_status", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-status-failed-no-err";
 
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(recordingId).not.toBeNull();
@@ -767,7 +737,6 @@ describe("recordingHandlers.recording_status", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-fallback";
 
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     // Send a recording_status directly with attachToConversationId
     // without having started a recording through handleRecordingStart

--- a/assistant/src/__tests__/recording-intent-handler.test.ts
+++ b/assistant/src/__tests__/recording-intent-handler.test.ts
@@ -423,7 +423,6 @@ function createCtx(overrides?: Partial<HandlerContext>): {
 } {
   const sent: Array<{ type: string; [k: string]: unknown }> = [];
   const fakeSocket = {} as net.Socket;
-  const socketToSession = new Map<net.Socket, string>();
 
   // Create a fake session that fulfills minimum interface for handleUserMessage
   const fakeSession = {
@@ -454,11 +453,8 @@ function createCtx(overrides?: Partial<HandlerContext>): {
 
   const ctx: HandlerContext = {
     sessions,
-    socketToSession,
     cuSessions: new Map(),
-    socketToCuSession: new Map(),
     cuObservationParseSequence: new Map(),
-    socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],
     debounceTimers: new DebouncerMap({ defaultDelayMs: 200 }),
     suppressConfigReload: false,
@@ -467,7 +463,9 @@ function createCtx(overrides?: Partial<HandlerContext>): {
     send: (_socket, msg) => {
       sent.push(msg as { type: string; [k: string]: unknown });
     },
-    broadcast: noop,
+    broadcast: (msg) => {
+      sent.push(msg as { type: string; [k: string]: unknown });
+    },
     clearAllSessions: () => 0,
     getOrCreateSession: async (conversationId: string) => {
       sessions.set(conversationId, fakeSession);

--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -151,15 +151,11 @@ function createCtx(): {
 } {
   const sent: Array<{ type: string; [k: string]: unknown }> = [];
   const fakeSocket = {} as net.Socket;
-  const socketToSession = new Map<net.Socket, string>();
 
   const ctx: HandlerContext = {
     sessions: new Map(),
-    socketToSession,
     cuSessions: new Map(),
-    socketToCuSession: new Map(),
     cuObservationParseSequence: new Map(),
-    socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],
     debounceTimers: new DebouncerMap({ defaultDelayMs: 200 }),
     suppressConfigReload: false,
@@ -168,7 +164,9 @@ function createCtx(): {
     send: (_socket, msg) => {
       sent.push(msg as { type: string; [k: string]: unknown });
     },
-    broadcast: noop,
+    broadcast: (msg) => {
+      sent.push(msg as { type: string; [k: string]: unknown });
+    },
     clearAllSessions: () => 0,
     getOrCreateSession: () => {
       throw new Error("not implemented");
@@ -191,19 +189,17 @@ describe("handleRecordingRestart", () => {
   test("sends recording_stop and defers start until stop-ack", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-restart-1";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     // Start a recording first
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(originalId).not.toBeNull();
     sent.length = 0;
 
-    const result = handleRecordingRestart(conversationId, fakeSocket, ctx);
+    const result = handleRecordingRestart(conversationId, ctx);
 
     expect(result.initiated).toBe(true);
     expect(result.operationToken).toBeTruthy();
@@ -233,7 +229,7 @@ describe("handleRecordingRestart", () => {
   test('returns "no active recording" with reason when nothing is recording', () => {
     const { ctx, fakeSocket } = createCtx();
 
-    const result = handleRecordingRestart("conv-no-rec", fakeSocket, ctx);
+    const result = handleRecordingRestart("conv-no-rec", ctx);
 
     expect(result.initiated).toBe(false);
     expect(result.reason).toBe("no_active_recording");
@@ -243,16 +239,14 @@ describe("handleRecordingRestart", () => {
   test("generates unique operation token for each restart", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-restart-unique";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     // First restart cycle
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
-    const result1 = handleRecordingRestart(conversationId, fakeSocket, ctx);
+    const result1 = handleRecordingRestart(conversationId, ctx);
 
     // Simulate the stop-ack to trigger the deferred start
     const stoppedStatus1: RecordingStatus = {
@@ -275,7 +269,7 @@ describe("handleRecordingRestart", () => {
 
     // Second restart cycle
     sent.length = 0;
-    const result2 = handleRecordingRestart(conversationId, fakeSocket, ctx);
+    const result2 = handleRecordingRestart(conversationId, ctx);
 
     expect(result1.operationToken).not.toBe(result2.operationToken);
   });
@@ -293,18 +287,15 @@ describe("restart_cancelled status", () => {
   test('emits restart_cancelled response, never "new recording started"', () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-cancel-1";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     // Start -> restart
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     const restartResult = handleRecordingRestart(
       conversationId,
-      fakeSocket,
       ctx,
     );
     expect(restartResult.initiated).toBe(true);
@@ -353,17 +344,14 @@ describe("restart_cancelled status", () => {
   test("cleans up restart state on cancel", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-cancel-cleanup";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     const restartResult = handleRecordingRestart(
       conversationId,
-      fakeSocket,
       ctx,
     );
 
@@ -410,18 +398,15 @@ describe("stale completion guard (operation token)", () => {
   test("rejects recording_status with stale operation token", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-stale-1";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     // Start recording -> restart (creates operation token)
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     const restartResult = handleRecordingRestart(
       conversationId,
-      fakeSocket,
       ctx,
     );
     expect(restartResult.initiated).toBe(true);
@@ -458,17 +443,14 @@ describe("stale completion guard (operation token)", () => {
   test("accepts recording_status with matching operation token", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-matching-1";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     const restartResult = handleRecordingRestart(
       conversationId,
-      fakeSocket,
       ctx,
     );
 
@@ -499,13 +481,11 @@ describe("stale completion guard (operation token)", () => {
   test("allows tokenless recording_status during active restart (old recording ack)", async () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-tokenless-1";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     // Start recording -> restart (creates operation token)
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    handleRecordingStart(conversationId, undefined, ctx);
     const restartResult = handleRecordingRestart(
       conversationId,
-      fakeSocket,
       ctx,
     );
     expect(restartResult.initiated).toBe(true);
@@ -541,19 +521,16 @@ describe("stale completion guard (operation token)", () => {
   test("no ghost state after restart stop/start handoff", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-ghost-1";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
 
     // Restart sends stop and defers start until stop-ack
     const restartResult = handleRecordingRestart(
       conversationId,
-      fakeSocket,
       ctx,
     );
     expect(restartResult.initiated).toBe(true);
@@ -587,12 +564,10 @@ describe("handleRecordingPause", () => {
   test("sends recording_pause for active recording", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-pause-1";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(recordingId).not.toBeNull();
@@ -616,9 +591,8 @@ describe("handleRecordingPause", () => {
   test("resolves to globally active recording from different conversation", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const convA = "conv-owner-pause";
-    ctx.socketToSession.set(fakeSocket, convA);
 
-    const recordingId = handleRecordingStart(convA, undefined, fakeSocket, ctx);
+    const recordingId = handleRecordingStart(convA, undefined, ctx);
     sent.length = 0;
 
     const result = handleRecordingPause("conv-other-pause", ctx);
@@ -634,12 +608,10 @@ describe("handleRecordingResume", () => {
   test("sends recording_resume for active recording", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-resume-1";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(recordingId).not.toBeNull();
@@ -674,17 +646,16 @@ describe("isRecordingIdle", () => {
 
   test("returns false when recording is active", () => {
     const { ctx, fakeSocket } = createCtx();
-    handleRecordingStart("conv-idle-1", undefined, fakeSocket, ctx);
+    handleRecordingStart("conv-idle-1", undefined, ctx);
     expect(isRecordingIdle()).toBe(false);
   });
 
   test("returns false when mid-restart (between stop-ack and start confirmation)", () => {
     const { ctx, fakeSocket } = createCtx();
     const conversationId = "conv-idle-restart";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
-    handleRecordingRestart(conversationId, fakeSocket, ctx);
+    handleRecordingStart(conversationId, undefined, ctx);
+    handleRecordingRestart(conversationId, ctx);
 
     // Mid-restart: the old recording maps are still present AND there's a
     // pending restart, so the system is not idle
@@ -694,17 +665,14 @@ describe("isRecordingIdle", () => {
   test("returns true after restart completes", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-idle-complete";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     const restartResult = handleRecordingRestart(
       conversationId,
-      fakeSocket,
       ctx,
     );
 
@@ -744,20 +712,18 @@ describe("executeRecordingIntent — restart/pause/resume", () => {
   test("restart_only executes actual restart (deferred start)", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-exec-restart";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     // Start a recording first
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     sent.length = 0;
 
     const result = executeRecordingIntent(
       { kind: "restart_only" },
-      { conversationId, socket: fakeSocket, ctx },
+      { conversationId, ctx },
     );
 
     expect(result.handled).toBe(true);
@@ -788,7 +754,7 @@ describe("executeRecordingIntent — restart/pause/resume", () => {
 
     const result = executeRecordingIntent(
       { kind: "restart_only" },
-      { conversationId: "conv-no-rec", socket: fakeSocket, ctx },
+      { conversationId: "conv-no-rec", ctx },
     );
 
     expect(result.handled).toBe(true);
@@ -800,7 +766,7 @@ describe("executeRecordingIntent — restart/pause/resume", () => {
 
     const result = executeRecordingIntent(
       { kind: "restart_with_remainder", remainder: "do something else" },
-      { conversationId: "conv-rem", socket: fakeSocket, ctx },
+      { conversationId: "conv-rem", ctx },
     );
 
     expect(result.handled).toBe(false);
@@ -811,14 +777,13 @@ describe("executeRecordingIntent — restart/pause/resume", () => {
   test("pause_only executes actual pause", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-exec-pause";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    handleRecordingStart(conversationId, undefined, ctx);
     sent.length = 0;
 
     const result = executeRecordingIntent(
       { kind: "pause_only" },
-      { conversationId, socket: fakeSocket, ctx },
+      { conversationId, ctx },
     );
 
     expect(result.handled).toBe(true);
@@ -833,7 +798,7 @@ describe("executeRecordingIntent — restart/pause/resume", () => {
 
     const result = executeRecordingIntent(
       { kind: "pause_only" },
-      { conversationId: "conv-no-rec", socket: fakeSocket, ctx },
+      { conversationId: "conv-no-rec", ctx },
     );
 
     expect(result.handled).toBe(true);
@@ -843,14 +808,13 @@ describe("executeRecordingIntent — restart/pause/resume", () => {
   test("resume_only executes actual resume", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-exec-resume";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    handleRecordingStart(conversationId, undefined, ctx);
     sent.length = 0;
 
     const result = executeRecordingIntent(
       { kind: "resume_only" },
-      { conversationId, socket: fakeSocket, ctx },
+      { conversationId, ctx },
     );
 
     expect(result.handled).toBe(true);
@@ -865,7 +829,7 @@ describe("executeRecordingIntent — restart/pause/resume", () => {
 
     const result = executeRecordingIntent(
       { kind: "resume_only" },
-      { conversationId: "conv-no-rec", socket: fakeSocket, ctx },
+      { conversationId: "conv-no-rec", ctx },
     );
 
     expect(result.handled).toBe(true);
@@ -887,7 +851,6 @@ describe("recording_status paused/resumed", () => {
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(recordingId).not.toBeNull();
@@ -910,7 +873,6 @@ describe("recording_status paused/resumed", () => {
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(recordingId).not.toBeNull();
@@ -939,15 +901,13 @@ describe("failure during restart", () => {
   test("failed status during restart clears pending restart state (old recording fails)", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-fail-restart";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
-    handleRecordingRestart(conversationId, fakeSocket, ctx);
+    handleRecordingRestart(conversationId, ctx);
     sent.length = 0;
 
     // Simulate the old recording failing to stop (before stop-ack)
@@ -968,17 +928,14 @@ describe("failure during restart", () => {
   test("failed status during restart clears state (new recording fails after deferred start)", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-fail-restart-new";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     const restartResult = handleRecordingRestart(
       conversationId,
-      fakeSocket,
       ctx,
     );
 
@@ -1021,13 +978,12 @@ describe("start_and_stop_only fallback to plain start when idle", () => {
   test("falls back to handleRecordingStart when no active recording", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-stop-start-idle";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     // No recording is active — start_and_stop_only should fall back to a
     // plain start rather than returning "No active recording to restart."
     const result = executeRecordingIntent(
       { kind: "start_and_stop_only" },
-      { conversationId, socket: fakeSocket, ctx },
+      { conversationId, ctx },
     );
 
     expect(result.handled).toBe(true);
@@ -1044,13 +1000,11 @@ describe("start_and_stop_only fallback to plain start when idle", () => {
   test("goes through restart when a recording is active (deferred start)", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-stop-start-active";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     // Start a recording first
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(originalId).not.toBeNull();
@@ -1059,7 +1013,7 @@ describe("start_and_stop_only fallback to plain start when idle", () => {
     // Now start_and_stop_only should go through handleRecordingRestart
     const result = executeRecordingIntent(
       { kind: "start_and_stop_only" },
-      { conversationId, socket: fakeSocket, ctx },
+      { conversationId, ctx },
     );
 
     expect(result.handled).toBe(true);
@@ -1102,7 +1056,7 @@ describe("start_and_stop_with_remainder fallback to plain start when idle", () =
 
     const result = executeRecordingIntent(
       { kind: "start_and_stop_with_remainder", remainder: "do something" },
-      { conversationId, socket: fakeSocket, ctx },
+      { conversationId, ctx },
     );
 
     expect(result.handled).toBe(false);
@@ -1114,14 +1068,13 @@ describe("start_and_stop_with_remainder fallback to plain start when idle", () =
   test("sets pendingRestart when a recording is active", () => {
     const { ctx, fakeSocket } = createCtx();
     const conversationId = "conv-rem-active";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     // Start a recording first
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    handleRecordingStart(conversationId, undefined, ctx);
 
     const result = executeRecordingIntent(
       { kind: "start_and_stop_with_remainder", remainder: "do something" },
-      { conversationId, socket: fakeSocket, ctx },
+      { conversationId, ctx },
     );
 
     expect(result.handled).toBe(false);
@@ -1143,12 +1096,11 @@ describe("deferred restart prevents race condition", () => {
   test("recording_start is NOT sent until client acks the stop", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-deferred-race";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    handleRecordingStart(conversationId, undefined, ctx);
     sent.length = 0;
 
-    handleRecordingRestart(conversationId, fakeSocket, ctx);
+    handleRecordingRestart(conversationId, ctx);
 
     // Only recording_stop should have been sent — no recording_start yet
     expect(sent.filter((m) => m.type === "recording_stop")).toHaveLength(1);
@@ -1162,10 +1114,9 @@ describe("deferred restart prevents race condition", () => {
     // This test uses a real timer via bun's jest-compatible API
     const { ctx, fakeSocket } = createCtx();
     const conversationId = "conv-deferred-timeout";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
-    handleRecordingRestart(conversationId, fakeSocket, ctx);
+    handleRecordingStart(conversationId, undefined, ctx);
+    handleRecordingRestart(conversationId, ctx);
 
     // Mid-restart: not idle
     expect(isRecordingIdle()).toBe(false);
@@ -1179,15 +1130,14 @@ describe("deferred restart prevents race condition", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const convA = "conv-owner-A";
     const convB = "conv-requester-B";
-    ctx.socketToSession.set(fakeSocket, convA);
 
     // Conversation A starts a recording
-    const originalId = handleRecordingStart(convA, undefined, fakeSocket, ctx);
+    const originalId = handleRecordingStart(convA, undefined, ctx);
     expect(originalId).not.toBeNull();
     sent.length = 0;
 
     // Conversation B requests a restart (cross-conversation via global fallback)
-    const result = handleRecordingRestart(convB, fakeSocket, ctx);
+    const result = handleRecordingRestart(convB, ctx);
     expect(result.initiated).toBe(true);
     expect(result.operationToken).toBeTruthy();
 
@@ -1247,12 +1197,10 @@ describe("deferred restart prevents race condition", () => {
   test("normal stop (non-restart) does not trigger deferred start", () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-normal-stop";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     const recordingId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(recordingId).not.toBeNull();
@@ -1289,13 +1237,11 @@ describe("restart finalization", () => {
   test("publishes previous recording attachment on restart", async () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-fin-publish";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     // Start a recording
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
     expect(originalId).not.toBeNull();
@@ -1303,7 +1249,6 @@ describe("restart finalization", () => {
     // Trigger restart
     const restartResult = handleRecordingRestart(
       conversationId,
-      fakeSocket,
       ctx,
     );
     expect(restartResult.initiated).toBe(true);
@@ -1348,20 +1293,17 @@ describe("restart finalization", () => {
   test("restart + picker cancel preserves previous publish", async () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-fin-cancel-preserve";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     // Start a recording
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
 
     // Restart
     const restartResult = handleRecordingRestart(
       conversationId,
-      fakeSocket,
       ctx,
     );
     expect(restartResult.initiated).toBe(true);
@@ -1428,20 +1370,17 @@ describe("restart finalization", () => {
   test("emits truthful failure text when previous finalize fails", async () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-fin-fail-truth";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     // Start a recording
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
 
     // Restart
     const restartResult = handleRecordingRestart(
       conversationId,
-      fakeSocket,
       ctx,
     );
     expect(restartResult.initiated).toBe(true);
@@ -1481,20 +1420,17 @@ describe("restart finalization", () => {
   test("preserves previous attachment when new start fails", async () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-fin-new-fail";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     // Start a recording
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
 
     // Restart
     const restartResult = handleRecordingRestart(
       conversationId,
-      fakeSocket,
       ctx,
     );
     expect(restartResult.initiated).toBe(true);
@@ -1553,20 +1489,17 @@ describe("restart finalization", () => {
   test("duplicate stopped callback does not double-attach", async () => {
     const { ctx, sent, fakeSocket } = createCtx();
     const conversationId = "conv-fin-dup-stop";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
     // Start a recording
     const originalId = handleRecordingStart(
       conversationId,
       undefined,
-      fakeSocket,
       ctx,
     );
 
     // Restart
     const restartResult = handleRecordingRestart(
       conversationId,
-      fakeSocket,
       ctx,
     );
     expect(restartResult.initiated).toBe(true);
@@ -1628,13 +1561,12 @@ describe("restart finalization", () => {
     // Start a recording, verify not idle
     const { ctx, fakeSocket } = createCtx();
     const conversationId = "conv-fin-sanity";
-    ctx.socketToSession.set(fakeSocket, conversationId);
 
-    handleRecordingStart(conversationId, undefined, fakeSocket, ctx);
+    handleRecordingStart(conversationId, undefined, ctx);
     expect(isRecordingIdle()).toBe(false);
 
     // Restart, verify token is set
-    handleRecordingRestart(conversationId, fakeSocket, ctx);
+    handleRecordingRestart(conversationId, ctx);
     expect(getActiveRestartToken()).not.toBeNull();
 
     // Reset everything, verify clean state

--- a/assistant/src/__tests__/tool-permission-simulate-handler.test.ts
+++ b/assistant/src/__tests__/tool-permission-simulate-handler.test.ts
@@ -79,11 +79,8 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
   const sent: ServerMessage[] = [];
   const ctx: HandlerContext = {
     sessions: new Map(),
-    socketToSession: new Map(),
     cuSessions: new Map(),
-    socketToCuSession: new Map(),
     cuObservationParseSequence: new Map(),
-    socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],
     debounceTimers: new DebouncerMap({ defaultDelayMs: 200 }),
     suppressConfigReload: false,

--- a/assistant/src/__tests__/twitter-auth-handler.test.ts
+++ b/assistant/src/__tests__/twitter-auth-handler.test.ts
@@ -203,11 +203,8 @@ function createTestContext(): { ctx: HandlerContext; sent: ServerMessage[] } {
   const sent: ServerMessage[] = [];
   const ctx: HandlerContext = {
     sessions: new Map(),
-    socketToSession: new Map(),
     cuSessions: new Map(),
-    socketToCuSession: new Map(),
     cuObservationParseSequence: new Map(),
-    socketSandboxOverride: new Map(),
     sharedRequestTimestamps: [],
     debounceTimers: new DebouncerMap({ defaultDelayMs: 200 }),
     suppressConfigReload: false,

--- a/assistant/src/daemon/handlers/computer-use.ts
+++ b/assistant/src/daemon/handlers/computer-use.ts
@@ -26,11 +26,6 @@ function removeCuSessionReferences(
   ctx.cuSessions.delete(sessionId);
   cuObservationSequenceBySession.delete(sessionId);
   ctx.cuObservationParseSequence.delete(sessionId);
-  for (const [sock, ids] of ctx.socketToCuSession) {
-    if (ids.delete(sessionId) && ids.size === 0) {
-      ctx.socketToCuSession.delete(sock);
-    }
-  }
 }
 
 export function handleCuSessionCreate(
@@ -84,14 +79,6 @@ export function handleCuSessionCreate(
   sessionRef.current = session;
 
   ctx.cuSessions.set(msg.sessionId, session);
-
-  // Track all CU sessions per socket so disconnect cleans up all of them
-  let sessionIds = ctx.socketToCuSession.get(socket);
-  if (!sessionIds) {
-    sessionIds = new Set();
-    ctx.socketToCuSession.set(socket, sessionIds);
-  }
-  sessionIds.add(msg.sessionId);
 
   log.info(
     { sessionId: msg.sessionId, taskLength: msg.task.length },

--- a/assistant/src/daemon/handlers/misc.ts
+++ b/assistant/src/daemon/handlers/misc.ts
@@ -78,7 +78,6 @@ export async function handleTaskSubmit(
       // end-to-end. The conversation is deleted after the prompt resolves
       // to avoid accumulating placeholder entries in session history.
       const conversation = createConversation("(blocked — secret detected)");
-      ctx.socketToSession.set(socket, conversation.id);
       const session = await ctx.getOrCreateSession(
         conversation.id,
         socket,
@@ -94,11 +93,7 @@ export async function handleTaskSubmit(
             s.dispose();
             ctx.sessions.delete(conversation.id);
           }
-          // Only unbind if the socket still points to this ephemeral conversation;
-          // a new task_submit may have already rebound it to a real session.
-          if (ctx.socketToSession.get(socket) === conversation.id) {
-            ctx.socketToSession.delete(socket);
-          }
+          // Socket-session unbinding removed (HTTP-only mode).
         },
       });
       return;
@@ -117,11 +112,9 @@ export async function handleTaskSubmit(
       );
       if (action === "start") {
         const conversation = createConversation(msg.task || "Screen Recording");
-        ctx.socketToSession.set(socket, conversation.id);
         const recordingId = handleRecordingStart(
           conversation.id,
           { promptForSource: true },
-          socket,
           ctx,
         );
         const responseText = recordingId
@@ -163,15 +156,10 @@ export async function handleTaskSubmit(
             content: [{ type: "text", text: responseText }],
           });
         }
-        if (!recordingId) ctx.socketToSession.delete(socket);
         return;
       } else if (action === "stop") {
-        let activeSessionId = ctx.socketToSession.get(socket);
-        if (!activeSessionId) {
-          const conversation = createConversation(msg.task || "Stop Recording");
-          activeSessionId = conversation.id;
-          ctx.socketToSession.set(socket, activeSessionId);
-        }
+        const conversation = createConversation(msg.task || "Stop Recording");
+        const activeSessionId = conversation.id;
         const stopped = handleRecordingStop(activeSessionId, ctx) !== undefined;
         const responseText = stopped
           ? "Stopping the recording."
@@ -213,17 +201,12 @@ export async function handleTaskSubmit(
         }
         return;
       } else if (action === "restart") {
-        let activeSessionId = ctx.socketToSession.get(socket);
-        if (!activeSessionId) {
-          const conversation = createConversation(
-            msg.task || "Restart Recording",
-          );
-          activeSessionId = conversation.id;
-          ctx.socketToSession.set(socket, activeSessionId);
-        }
+        const conversation = createConversation(
+          msg.task || "Restart Recording",
+        );
+        const activeSessionId = conversation.id;
         const restartResult = handleRecordingRestart(
           activeSessionId,
-          socket,
           ctx,
         );
         ctx.send(socket, {
@@ -263,14 +246,10 @@ export async function handleTaskSubmit(
         }
         return;
       } else if (action === "pause") {
-        let activeSessionId = ctx.socketToSession.get(socket);
-        if (!activeSessionId) {
-          const conversation = createConversation(
-            msg.task || "Pause Recording",
-          );
-          activeSessionId = conversation.id;
-          ctx.socketToSession.set(socket, activeSessionId);
-        }
+        const conversation = createConversation(
+          msg.task || "Pause Recording",
+        );
+        const activeSessionId = conversation.id;
         const paused = handleRecordingPause(activeSessionId, ctx) !== undefined;
         const responseText = paused
           ? "Pausing the recording."
@@ -312,14 +291,10 @@ export async function handleTaskSubmit(
         }
         return;
       } else if (action === "resume") {
-        let activeSessionId = ctx.socketToSession.get(socket);
-        if (!activeSessionId) {
-          const conversation = createConversation(
-            msg.task || "Resume Recording",
-          );
-          activeSessionId = conversation.id;
-          ctx.socketToSession.set(socket, activeSessionId);
-        }
+        const conversation = createConversation(
+          msg.task || "Resume Recording",
+        );
+        const activeSessionId = conversation.id;
         const resumed =
           handleRecordingResume(activeSessionId, ctx) !== undefined;
         const responseText = resumed
@@ -387,11 +362,9 @@ export async function handleTaskSubmit(
       if (intentResult.kind === "start_only") {
         // Create a conversation so the recording can be attached later
         const conversation = createConversation(msg.task);
-        ctx.socketToSession.set(socket, conversation.id);
 
         const execResult = executeRecordingIntent(intentResult, {
           conversationId: conversation.id,
-          socket,
           ctx,
         });
 
@@ -431,11 +404,6 @@ export async function handleTaskSubmit(
           });
         }
 
-        // If recording rejected, unbind socket
-        if (execResult.recordingStarted === false) {
-          ctx.socketToSession.delete(socket);
-        }
-
         rlog.info(
           { sessionId: conversation.id },
           "Recording-only intent intercepted — routed to standalone recording",
@@ -444,16 +412,11 @@ export async function handleTaskSubmit(
       }
 
       if (intentResult.kind === "stop_only") {
-        let activeSessionId = ctx.socketToSession.get(socket);
-        if (!activeSessionId) {
-          const conversation = createConversation(msg.task);
-          activeSessionId = conversation.id;
-          ctx.socketToSession.set(socket, activeSessionId);
-        }
+        const conversation = createConversation(msg.task);
+        const activeSessionId = conversation.id;
 
         const execResult = executeRecordingIntent(intentResult, {
           conversationId: activeSessionId,
-          socket,
           ctx,
         });
 
@@ -497,16 +460,11 @@ export async function handleTaskSubmit(
       }
 
       if (intentResult.kind === "start_and_stop_only") {
-        let activeSessionId = ctx.socketToSession.get(socket);
-        if (!activeSessionId) {
-          const conversation = createConversation(msg.task);
-          activeSessionId = conversation.id;
-          ctx.socketToSession.set(socket, activeSessionId);
-        }
+        const conversation = createConversation(msg.task);
+        const activeSessionId = conversation.id;
 
         const execResult = executeRecordingIntent(intentResult, {
           conversationId: activeSessionId,
-          socket,
           ctx,
         });
 
@@ -555,16 +513,11 @@ export async function handleTaskSubmit(
         intentResult.kind === "pause_only" ||
         intentResult.kind === "resume_only"
       ) {
-        let activeSessionId = ctx.socketToSession.get(socket);
-        if (!activeSessionId) {
-          const conversation = createConversation(msg.task);
-          activeSessionId = conversation.id;
-          ctx.socketToSession.set(socket, activeSessionId);
-        }
+        const conversation = createConversation(msg.task);
+        const activeSessionId = conversation.id;
 
         const execResult = executeRecordingIntent(intentResult, {
           conversationId: activeSessionId,
-          socket,
           ctx,
         });
 
@@ -666,16 +619,11 @@ export async function handleTaskSubmit(
           };
           const mapped = kindMap[fallback.action];
           if (mapped) {
-            let activeSessionId = ctx.socketToSession.get(socket);
-            if (!activeSessionId) {
-              const conversation = createConversation(msg.task);
-              activeSessionId = conversation.id;
-              ctx.socketToSession.set(socket, activeSessionId);
-            }
+            const conversation = createConversation(msg.task);
+            const activeSessionId = conversation.id;
 
             const execResult = executeRecordingIntent(mapped, {
               conversationId: activeSessionId,
-              socket,
               ctx,
             });
 
@@ -722,11 +670,6 @@ export async function handleTaskSubmit(
                 });
               }
 
-              // If recording was rejected (e.g. already active), unbind the
-              // socket so it doesn't stay bound to an orphaned conversation.
-              if (execResult.recordingStarted === false) {
-                ctx.socketToSession.delete(socket);
-              }
               return;
             }
           }
@@ -776,13 +719,11 @@ export async function handleTaskSubmit(
           handleRecordingStart(
             recConversation.id,
             { promptForSource: true },
-            socket,
             ctx,
           );
         if (pendingRecordingRestart) {
           const restartResult = handleRecordingRestart(
             recConversation.id,
-            socket,
             ctx,
           );
           // TOCTOU: recording may have stopped between intent resolution and
@@ -796,7 +737,6 @@ export async function handleTaskSubmit(
             handleRecordingStart(
               recConversation.id,
               { promptForSource: true },
-              socket,
               ctx,
             );
           }
@@ -816,7 +756,6 @@ export async function handleTaskSubmit(
         context: { origin: "task_submit" },
         userMessage: msg.task,
       });
-      ctx.socketToSession.set(socket, conversation.id);
       const session = await ctx.getOrCreateSession(
         conversation.id,
         socket,
@@ -838,13 +777,11 @@ export async function handleTaskSubmit(
         handleRecordingStart(
           conversation.id,
           { promptForSource: true },
-          socket,
           ctx,
         );
       if (pendingRecordingRestart) {
         const restartResult = handleRecordingRestart(
           conversation.id,
-          socket,
           ctx,
         );
         if (
@@ -855,7 +792,6 @@ export async function handleTaskSubmit(
           handleRecordingStart(
             conversation.id,
             { promptForSource: true },
-            socket,
             ctx,
           );
         }

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -12,7 +12,6 @@ import { addMessage } from "../../memory/conversation-crud.js";
 import type { RecordingOptions, RecordingStatus } from "../ipc-protocol.js";
 import {
   defineHandlers,
-  findSocketForSession,
   type HandlerContext,
   log,
 } from "./shared.js";
@@ -76,8 +75,8 @@ const deferredRestartByConversation = new Map<string, DeferredRestartParams>();
 
 /**
  * Initiate a standalone recording for a conversation.
- * Generates a unique recording ID, stores deterministic mappings, and sends
- * a `recording_start` message to the client.
+ * Generates a unique recording ID, stores deterministic mappings, and
+ * broadcasts a `recording_start` event to connected clients.
  *
  * When `operationToken` is provided (restart flow), it is threaded through
  * to the client so that status callbacks can be validated against the token.
@@ -85,7 +84,6 @@ const deferredRestartByConversation = new Map<string, DeferredRestartParams>();
 export function handleRecordingStart(
   conversationId: string,
   options: RecordingOptions | undefined,
-  socket: net.Socket,
   ctx: HandlerContext,
   operationToken?: string,
 ): string | null {
@@ -119,7 +117,7 @@ export function handleRecordingStart(
   standaloneRecordingConversationId.set(recordingId, conversationId);
   recordingOwnerByConversation.set(conversationId, recordingId);
 
-  ctx.send(socket, {
+  ctx.broadcast({
     type: "recording_start",
     recordingId,
     attachToConversationId: conversationId,
@@ -172,23 +170,7 @@ export function handleRecordingStop(
     return undefined;
   }
 
-  // Look up the socket currently bound to the owning conversation so we can
-  // send the stop command to the correct client connection.
-  const socket =
-    findSocketForSession(ownerConversationId, ctx) ??
-    findSocketForSession(conversationId, ctx);
-  if (!socket) {
-    // Keep maps intact so the recording can be stopped later when a socket
-    // reconnects. Cleaning up here would orphan the client-side recording
-    // (still running) while the daemon thinks no recording is active.
-    log.warn(
-      { conversationId, ownerConversationId, recordingId },
-      "Cannot send recording_stop: no socket bound to conversation — keeping state for retry",
-    );
-    return undefined;
-  }
-
-  ctx.send(socket, {
+  ctx.broadcast({
     type: "recording_stop",
     recordingId,
   });
@@ -261,7 +243,6 @@ export interface RecordingRestartResult {
  */
 export function handleRecordingRestart(
   conversationId: string,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): RecordingRestartResult {
   // Generate a restart operation token for race hardening
@@ -342,7 +323,7 @@ export function handleRecordingRestart(
 
 /**
  * Pause the active recording for a conversation.
- * Sends a `recording_pause` IPC message to the client.
+ * Broadcasts a `recording_pause` event to connected clients.
  *
  * Returns the recording ID if pause was sent, or `undefined` if no active
  * recording exists.
@@ -352,15 +333,13 @@ export function handleRecordingPause(
   ctx: HandlerContext,
 ): string | undefined {
   let recordingId = recordingOwnerByConversation.get(conversationId);
-  let ownerConversationId = conversationId;
 
   // Global fallback
   if (!recordingId && recordingOwnerByConversation.size > 0) {
-    const [activeConv, activeRec] = [
+    const [_activeConv, activeRec] = [
       ...recordingOwnerByConversation.entries(),
     ][0];
     recordingId = activeRec;
-    ownerConversationId = activeConv;
   }
 
   if (!recordingId) {
@@ -368,18 +347,7 @@ export function handleRecordingPause(
     return undefined;
   }
 
-  const socket =
-    findSocketForSession(ownerConversationId, ctx) ??
-    findSocketForSession(conversationId, ctx);
-  if (!socket) {
-    log.warn(
-      { conversationId, recordingId },
-      "Cannot send recording_pause: no socket bound",
-    );
-    return undefined;
-  }
-
-  ctx.send(socket, {
+  ctx.broadcast({
     type: "recording_pause",
     recordingId,
   });
@@ -392,7 +360,7 @@ export function handleRecordingPause(
 
 /**
  * Resume a paused recording for a conversation.
- * Sends a `recording_resume` IPC message to the client.
+ * Broadcasts a `recording_resume` event to connected clients.
  *
  * Returns the recording ID if resume was sent, or `undefined` if no active
  * recording exists.
@@ -402,15 +370,13 @@ export function handleRecordingResume(
   ctx: HandlerContext,
 ): string | undefined {
   let recordingId = recordingOwnerByConversation.get(conversationId);
-  let ownerConversationId = conversationId;
 
   // Global fallback
   if (!recordingId && recordingOwnerByConversation.size > 0) {
-    const [activeConv, activeRec] = [
+    const [_activeConv, activeRec] = [
       ...recordingOwnerByConversation.entries(),
     ][0];
     recordingId = activeRec;
-    ownerConversationId = activeConv;
   }
 
   if (!recordingId) {
@@ -418,18 +384,7 @@ export function handleRecordingResume(
     return undefined;
   }
 
-  const socket =
-    findSocketForSession(ownerConversationId, ctx) ??
-    findSocketForSession(conversationId, ctx);
-  if (!socket) {
-    log.warn(
-      { conversationId, recordingId },
-      "Cannot send recording_resume: no socket bound",
-    );
-    return undefined;
-  }
-
-  ctx.send(socket, {
+  ctx.broadcast({
     type: "recording_resume",
     recordingId,
   });
@@ -498,10 +453,9 @@ export async function finalizeAndPublishRecording(params: {
   conversationId: string;
   filePath?: string;
   durationMs?: number;
-  notifySocket: net.Socket;
   ctx: HandlerContext;
 }): Promise<{ success: boolean; messageId?: string }> {
-  const { recordingId, conversationId, filePath, notifySocket, ctx } = params;
+  const { recordingId, conversationId, filePath, ctx } = params;
 
   // Idempotency guard: prevent double-finalization.
   // Mark as finalized eagerly (before any async work) so concurrent calls
@@ -535,12 +489,12 @@ export async function finalizeAndPublishRecording(params: {
         "Failed to persist recording error message",
       );
     }
-    ctx.send(notifySocket, {
+    ctx.broadcast({
       type: "assistant_text_delta",
       text: errorText,
       sessionId: conversationId,
     });
-    ctx.send(notifySocket, {
+    ctx.broadcast({
       type: "message_complete",
       sessionId: conversationId,
     });
@@ -588,12 +542,12 @@ export async function finalizeAndPublishRecording(params: {
         "Failed to persist recording error message",
       );
     }
-    ctx.send(notifySocket, {
+    ctx.broadcast({
       type: "assistant_text_delta",
       text: errorText,
       sessionId: conversationId,
     });
-    ctx.send(notifySocket, {
+    ctx.broadcast({
       type: "message_complete",
       sessionId: conversationId,
     });
@@ -616,12 +570,12 @@ export async function finalizeAndPublishRecording(params: {
           "Failed to persist recording error message",
         );
       }
-      ctx.send(notifySocket, {
+      ctx.broadcast({
         type: "assistant_text_delta",
         text: errorText,
         sessionId: conversationId,
       });
-      ctx.send(notifySocket, {
+      ctx.broadcast({
         type: "message_complete",
         sessionId: conversationId,
       });
@@ -649,12 +603,12 @@ export async function finalizeAndPublishRecording(params: {
           "Failed to persist recording error message",
         );
       }
-      ctx.send(notifySocket, {
+      ctx.broadcast({
         type: "assistant_text_delta",
         text: errorText,
         sessionId: conversationId,
       });
-      ctx.send(notifySocket, {
+      ctx.broadcast({
         type: "message_complete",
         sessionId: conversationId,
       });
@@ -711,12 +665,12 @@ export async function finalizeAndPublishRecording(params: {
     const thumbnailData: string | undefined = undefined;
 
     // Notify the client via the reporting socket
-    ctx.send(notifySocket, {
+    ctx.broadcast({
       type: "assistant_text_delta",
       text: msgText,
       sessionId: conversationId,
     });
-    ctx.send(notifySocket, {
+    ctx.broadcast({
       type: "message_complete",
       sessionId: conversationId,
       attachments: [
@@ -751,12 +705,12 @@ export async function finalizeAndPublishRecording(params: {
         "Failed to persist recording error message",
       );
     }
-    ctx.send(notifySocket, {
+    ctx.broadcast({
       type: "assistant_text_delta",
       text: errorText,
       sessionId: conversationId,
     });
-    ctx.send(notifySocket, {
+    ctx.broadcast({
       type: "message_complete",
       sessionId: conversationId,
     });
@@ -832,11 +786,6 @@ async function handleRecordingStatus(
     cancelStopTimeout(recordingId);
   }
 
-  // Use the reporting socket (which delivered this message) as the primary
-  // recipient. Fall back to session-based lookup if the user switched sessions.
-  const notifySocket =
-    reportingSocket ?? findSocketForSession(conversationId, ctx);
-
   switch (msg.status) {
     case "started": {
       log.info(
@@ -874,17 +823,15 @@ async function handleRecordingStatus(
         activeRestartToken = null;
       }
 
-      if (notifySocket) {
-        ctx.send(notifySocket, {
-          type: "assistant_text_delta",
-          text: "Recording restart cancelled.",
-          sessionId: conversationId,
-        });
-        ctx.send(notifySocket, {
-          type: "message_complete",
-          sessionId: conversationId,
-        });
-      }
+      ctx.broadcast({
+        type: "assistant_text_delta",
+        text: "Recording restart cancelled.",
+        sessionId: conversationId,
+      });
+      ctx.broadcast({
+        type: "message_complete",
+        sessionId: conversationId,
+      });
       break;
     }
 
@@ -918,22 +865,6 @@ async function handleRecordingStatus(
       if (deferred) {
         deferredRestartByConversation.delete(conversationId);
 
-        // Resolve a fresh socket at stop-ack time instead of using the one
-        // captured at restart-request time, which may be stale (disconnected
-        // or replaced) by the time the async stop completes.
-        const freshSocket =
-          findSocketForSession(deferred.conversationId, ctx) ?? reportingSocket;
-
-        if (!freshSocket) {
-          log.warn(
-            { conversationId, requesterId: deferred.conversationId },
-            "Deferred restart aborted — no socket available at stop-ack time",
-          );
-          activeRestartToken = null;
-          pendingRestartByConversation.delete(conversationId);
-          break;
-        }
-
         log.info(
           {
             recordingId,
@@ -946,7 +877,6 @@ async function handleRecordingStatus(
         const newRecordingId = handleRecordingStart(
           deferred.conversationId,
           { promptForSource: true },
-          freshSocket,
           ctx,
           deferred.operationToken,
         );
@@ -1013,35 +943,27 @@ async function handleRecordingStatus(
         // and notify the client. The deferred start fires first so the user
         // sees immediate activity (new recording starting) before the old
         // recording's completion message appears.
-        if (notifySocket) {
-          const finResult = await finalizeAndPublishRecording({
-            recordingId,
-            conversationId,
-            filePath: msg.filePath,
-            durationMs: msg.durationMs,
-            notifySocket,
-            ctx,
-          });
+        const finResult = await finalizeAndPublishRecording({
+          recordingId,
+          conversationId,
+          filePath: msg.filePath,
+          durationMs: msg.durationMs,
+          ctx,
+        });
 
-          // Handle old-success + new-start-failure: the old recording saved
-          // but the new one couldn't start. Send explicit follow-up text so
-          // the user knows the state.
-          if (!newRecordingId && finResult.success) {
-            ctx.send(freshSocket, {
-              type: "assistant_text_delta",
-              text: "Previous recording saved. New recording failed to start.",
-              sessionId: deferred.conversationId,
-            });
-            ctx.send(freshSocket, {
-              type: "message_complete",
-              sessionId: deferred.conversationId,
-            });
-          }
-          // Other failure combos:
-          // - new-start-failure + old-finalize-failure: finalizeAndPublishRecording
-          //   already sent error messages, restart state already cleaned up above.
-          // - new-start-success + old-finalize-failure: finalization already sent
-          //   error messages, new recording is running — no extra message needed.
+        // Handle old-success + new-start-failure: the old recording saved
+        // but the new one couldn't start. Send explicit follow-up text so
+        // the user knows the state.
+        if (!newRecordingId && finResult.success) {
+          ctx.broadcast({
+            type: "assistant_text_delta",
+            text: "Previous recording saved. New recording failed to start.",
+            sessionId: deferred.conversationId,
+          });
+          ctx.broadcast({
+            type: "message_complete",
+            sessionId: deferred.conversationId,
+          });
         }
 
         // Prevent fall-through to the normal finalization path below since
@@ -1050,16 +972,13 @@ async function handleRecordingStatus(
       }
 
       // Finalize: attach the recording file to the conversation
-      if (notifySocket) {
-        await finalizeAndPublishRecording({
-          recordingId,
-          conversationId,
-          filePath: msg.filePath,
-          durationMs: msg.durationMs,
-          notifySocket,
-          ctx,
-        });
-      }
+      await finalizeAndPublishRecording({
+        recordingId,
+        conversationId,
+        filePath: msg.filePath,
+        durationMs: msg.durationMs,
+        ctx,
+      });
 
       break;
     }
@@ -1070,17 +989,15 @@ async function handleRecordingStatus(
         "Standalone recording failed",
       );
 
-      if (notifySocket) {
-        ctx.send(notifySocket, {
-          type: "assistant_text_delta",
-          text: `Recording failed: ${msg.error ?? "unknown error"}`,
-          sessionId: conversationId,
-        });
-        ctx.send(notifySocket, {
-          type: "message_complete",
-          sessionId: conversationId,
-        });
-      }
+      ctx.broadcast({
+        type: "assistant_text_delta",
+        text: `Recording failed: ${msg.error ?? "unknown error"}`,
+        sessionId: conversationId,
+      });
+      ctx.broadcast({
+        type: "message_complete",
+        sessionId: conversationId,
+      });
 
       cleanupMaps(recordingId, conversationId);
 
@@ -1096,41 +1013,6 @@ async function handleRecordingStatus(
 
       break;
     }
-  }
-}
-
-// ─── Socket disconnect cleanup ───────────────────────────────────────────────
-
-/**
- * Clean up recording state for recordings whose owning conversation is bound
- * to the disconnecting socket. Accepts a lookup function that resolves a
- * conversation ID to its current socket, so we only clean up recordings
- * affected by this specific socket disconnect — not unrelated sessions.
- */
-export function cleanupRecordingsOnDisconnect(
-  disconnectedSocket: net.Socket,
-  findSocketForConversation: (conversationId: string) => net.Socket | undefined,
-): void {
-  if (recordingOwnerByConversation.size === 0) return;
-  for (const [convId, recId] of [...recordingOwnerByConversation.entries()]) {
-    const ownerSocket = findSocketForConversation(convId);
-    // Clean up if the owner conversation's socket is the one disconnecting,
-    // or if the owner conversation has no socket bound at all.
-    if (!ownerSocket || ownerSocket === disconnectedSocket) {
-      log.warn(
-        { conversationId: convId, recordingId: recId },
-        "Cleaning up recording state for disconnected socket",
-      );
-      cancelStopTimeout(recId);
-      standaloneRecordingConversationId.delete(recId);
-      recordingOwnerByConversation.delete(convId);
-      pendingRestartByConversation.delete(convId);
-      deferredRestartByConversation.delete(convId);
-    }
-  }
-  // Clear restart token if all pending restarts were cleaned up
-  if (pendingRestartByConversation.size === 0) {
-    activeRestartToken = null;
   }
 }
 

--- a/assistant/src/daemon/handlers/session-user-message.ts
+++ b/assistant/src/daemon/handlers/session-user-message.ts
@@ -210,7 +210,6 @@ async function handleStructuredRecordingIntent(
     const recordingId = handleRecordingStart(
       msg.sessionId,
       { promptForSource: true },
-      socket,
       ctx,
     );
     const responseText = recordingId
@@ -240,7 +239,7 @@ async function handleStructuredRecordingIntent(
     );
     return true;
   } else if (action === "restart") {
-    const restartResult = handleRecordingRestart(msg.sessionId, socket, ctx);
+    const restartResult = handleRecordingRestart(msg.sessionId, ctx);
     await persistRecordingExchange(
       msg.sessionId,
       messageText,
@@ -324,7 +323,6 @@ async function handleStandaloneRecordingIntent(
   ) {
     const execResult = executeRecordingIntent(intentResult, {
       conversationId: msg.sessionId,
-      socket,
       ctx,
     });
 
@@ -354,7 +352,6 @@ async function handleStandaloneRecordingIntent(
   ) {
     const execResult = executeRecordingIntent(intentResult, {
       conversationId: msg.sessionId,
-      socket,
       ctx,
     });
 
@@ -369,7 +366,6 @@ async function handleStandaloneRecordingIntent(
       handleRecordingStart(
         msg.sessionId,
         { promptForSource: true },
-        socket,
         ctx,
       );
     }
@@ -377,7 +373,7 @@ async function handleStandaloneRecordingIntent(
       intentResult.kind === "restart_with_remainder" ||
       intentResult.kind === "start_and_stop_with_remainder"
     ) {
-      const restartResult = handleRecordingRestart(msg.sessionId, socket, ctx);
+      const restartResult = handleRecordingRestart(msg.sessionId, ctx);
       if (
         !restartResult.initiated &&
         restartResult.reason === "no_active_recording" &&
@@ -386,7 +382,6 @@ async function handleStandaloneRecordingIntent(
         handleRecordingStart(
           msg.sessionId,
           { promptForSource: true },
-          socket,
           ctx,
         );
       }
@@ -431,7 +426,6 @@ async function handleStandaloneRecordingIntent(
       if (mapped) {
         const execResult = executeRecordingIntent(mapped, {
           conversationId: msg.sessionId,
-          socket,
           ctx,
         });
 
@@ -854,7 +848,6 @@ export async function handleUserMessage(
   const requestId = uuid();
   const rlog = log.child({ sessionId: msg.sessionId, requestId });
   try {
-    ctx.socketToSession.set(socket, msg.sessionId);
     const session = await ctx.getOrCreateSession(msg.sessionId, socket, true);
     // Only wire the escalation handler if one isn't already set — handleTaskSubmit
     // sets a handler with the client's actual screen dimensions, and overwriting it

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -409,7 +409,6 @@ export async function handleSessionCreate(
       });
     }
 
-    ctx.socketToSession.set(socket, conversation.id);
     const requestId = uuid();
     const transportChannel =
       parseChannelId(msg.transport?.channelId) ?? "vellum";
@@ -488,8 +487,6 @@ export async function switchSession(
   const isHeadlessLocked = existingSession?.headlessLock;
 
   if (socket) {
-    ctx.socketToSession.set(socket, sessionId);
-
     if (isHeadlessLocked) {
       // Load the session without rebinding the client — the session stays headless
       await ctx.getOrCreateSession(sessionId, socket, false);
@@ -600,7 +597,7 @@ export function handleCancel(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  const sessionId = msg.sessionId || ctx.socketToSession.get(socket);
+  const sessionId = msg.sessionId;
   if (sessionId) {
     cancelGeneration(sessionId, ctx);
   }

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -151,11 +151,8 @@ export interface SessionCreateOptions {
  */
 export interface HandlerContext {
   sessions: Map<string, Session>;
-  socketToSession: Map<net.Socket, string>;
   cuSessions: Map<string, ComputerUseSession>;
-  socketToCuSession: Map<net.Socket, Set<string>>;
   cuObservationParseSequence: Map<string, number>;
-  socketSandboxOverride: Map<net.Socket, boolean>;
   sharedRequestTimestamps: number[];
   debounceTimers: DebouncerMap;
   suppressConfigReload: boolean;
@@ -226,31 +223,15 @@ export function getScreenDimensions(): { width: number; height: number } {
 }
 
 /**
- * Find the current socket bound to a given session by reversing the
- * `socketToSession` map. Returns `undefined` if no socket is bound.
- */
-export function findSocketForSession(
-  sessionId: string,
-  ctx: HandlerContext,
-): net.Socket | undefined {
-  for (const [sock, id] of ctx.socketToSession) {
-    if (id === sessionId) return sock;
-  }
-  return undefined;
-}
-
-/**
  * Wire the escalation handler on a text_qa session so that invoking
  * `computer_use_request_control` creates a CU session and notifies the client.
  *
- * Instead of closing over the original `socket`, the handler looks up the
- * current socket for the session at call time via `ctx.socketToSession`.
- * This ensures the handler targets the correct socket even after a
- * disconnect-and-rebind cycle.
+ * In the HTTP-only world, the escalation handler broadcasts events via
+ * `ctx.broadcast` instead of targeting a specific socket.
  */
 export function wireEscalationHandler(
   session: Session,
-  _socket: net.Socket,
+  socket: net.Socket,
   ctx: HandlerContext,
   explicitWidth?: number,
   explicitHeight?: number,
@@ -266,15 +247,6 @@ export function wireEscalationHandler(
   const screenHeight = dims.height;
   session.setEscalationHandler(
     (task: string, sourceSessionId: string): boolean => {
-      const currentSocket = findSocketForSession(sourceSessionId, ctx);
-      if (!currentSocket) {
-        log.warn(
-          { sourceSessionId },
-          "Escalation handler: no active socket found for session",
-        );
-        return false;
-      }
-
       const cuSessionId = uuid();
       const cuMsg: CuSessionCreate = {
         type: "cu_session_create",
@@ -284,9 +256,9 @@ export function wireEscalationHandler(
         screenHeight,
         interactionType: "computer_use",
       };
-      handleCuSessionCreate(cuMsg, currentSocket, ctx);
+      handleCuSessionCreate(cuMsg, socket, ctx);
 
-      ctx.send(currentSocket, {
+      ctx.broadcast({
         type: "task_routed",
         sessionId: cuSessionId,
         interactionType: "computer_use",

--- a/assistant/src/daemon/handlers/subagents.ts
+++ b/assistant/src/daemon/handlers/subagents.ts
@@ -20,7 +20,7 @@ export function handleSubagentAbort(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  const callerSessionId = ctx.socketToSession.get(socket);
+  const callerSessionId: string | undefined = undefined;
   if (!callerSessionId) {
     log.warn(
       { subagentId: msg.subagentId },
@@ -53,7 +53,7 @@ export function handleSubagentStatus(
 ): void {
   const manager = getSubagentManager();
 
-  const callerSessionId = ctx.socketToSession.get(socket);
+  const callerSessionId: string | undefined = undefined;
   if (!callerSessionId) {
     log.warn("Status rejected: socket has no bound session");
     return;
@@ -97,7 +97,7 @@ export async function handleSubagentMessage(
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
-  const callerSessionId = ctx.socketToSession.get(socket);
+  const callerSessionId: string | undefined = undefined;
   if (!callerSessionId) {
     log.warn(
       { subagentId: msg.subagentId },
@@ -169,7 +169,7 @@ export function handleSubagentDetailRequest(
   ctx: HandlerContext,
 ): void {
   // Ownership check: reject if the socket has no bound session.
-  const callerSessionId = ctx.socketToSession.get(socket);
+  const callerSessionId: string | undefined = undefined;
   if (!callerSessionId) {
     log.warn(
       { subagentId: msg.subagentId },

--- a/assistant/src/daemon/recording-executor.ts
+++ b/assistant/src/daemon/recording-executor.ts
@@ -3,8 +3,6 @@
 // handlers/recording.ts (side effects), so both sessions.ts and misc.ts
 // can share the same execution logic without duplicating switch/case blocks.
 
-import type * as net from "node:net";
-
 import {
   handleRecordingPause,
   handleRecordingRestart,
@@ -18,7 +16,6 @@ import type { RecordingIntentResult } from "./recording-intent.js";
 
 export interface RecordingExecutionContext {
   conversationId: string;
-  socket: net.Socket;
   ctx: HandlerContext;
 }
 
@@ -51,7 +48,6 @@ export function executeRecordingIntent(
       const recordingId = handleRecordingStart(
         context.conversationId,
         { promptForSource: true },
-        context.socket,
         context.ctx,
       );
       return {
@@ -94,7 +90,6 @@ export function executeRecordingIntent(
       // blocking the new recording.
       const restartResult = handleRecordingRestart(
         context.conversationId,
-        context.socket,
         context.ctx,
       );
 
@@ -110,7 +105,6 @@ export function executeRecordingIntent(
         const recordingId = handleRecordingStart(
           context.conversationId,
           { promptForSource: true },
-          context.socket,
           context.ctx,
         );
         return {
@@ -145,7 +139,6 @@ export function executeRecordingIntent(
     case "restart_only": {
       const restartResult = handleRecordingRestart(
         context.conversationId,
-        context.socket,
         context.ctx,
       );
       return {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -570,11 +570,8 @@ export class DaemonServer {
   private handlerContext(): HandlerContext {
     return {
       sessions: this.sessions,
-      socketToSession: new Map(),
       cuSessions: this.cuSessions,
-      socketToCuSession: new Map(),
       cuObservationParseSequence: this.cuObservationParseSequence,
-      socketSandboxOverride: new Map(),
       sharedRequestTimestamps: this.sharedRequestTimestamps,
       debounceTimers: this.configWatcher.timers,
       suppressConfigReload: this.configWatcher.suppressConfigReload,

--- a/assistant/src/runtime/routes/recording-routes.ts
+++ b/assistant/src/runtime/routes/recording-routes.ts
@@ -2,9 +2,8 @@
  * HTTP route handlers for screen recording lifecycle.
  *
  * These endpoints expose recording start/stop/pause/resume/status
- * functionality over HTTP. The existing IPC handlers remain as the
- * primary transport; these routes provide the HTTP-first API surface
- * for the phase-out-ipc migration.
+ * functionality over HTTP. Recording commands are broadcast to connected
+ * clients via the assistant event hub (SSE).
  *
  * Recording write operations require `settings.write`; status queries
  * require `settings.read`.
@@ -19,7 +18,6 @@ import {
   isRecordingIdle,
 } from "../../daemon/handlers/recording.js";
 import type { HandlerContext } from "../../daemon/handlers/shared.js";
-import { findSocketForSession } from "../../daemon/handlers/shared.js";
 import type { RecordingOptions } from "../../daemon/ipc-protocol.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
@@ -36,7 +34,7 @@ const log = getLogger("recording-routes");
  * The daemon wires a concrete HandlerContext at startup.
  */
 export interface RecordingDeps {
-  /** The daemon's handler context for IPC message dispatch. */
+  /** The daemon's handler context for recording operations. */
   getHandlerContext: () => HandlerContext;
 }
 
@@ -65,19 +63,10 @@ async function handleStartRecording(
   }
 
   const ctx = deps.getHandlerContext();
-  const socket = findSocketForSession(body.conversationId, ctx);
-  if (!socket) {
-    return httpError(
-      "UNPROCESSABLE_ENTITY",
-      "No active client connection for this conversation — recording requires a connected client",
-      422,
-    );
-  }
 
   const recordingId = handleRecordingStart(
     body.conversationId,
     body.options,
-    socket,
     ctx,
   );
 


### PR DESCRIPTION
## Summary
- Remove `socketToSession`, `socketToCuSession`, and `socketSandboxOverride` Map fields from `HandlerContext` interface and all references across production and test code
- Remove `findSocketForSession()` utility and `cleanupRecordingsOnDisconnect()` dead code
- Refactor all recording handlers (`handleRecordingStart`, `handleRecordingStop`, `handleRecordingRestart`, `handleRecordingPause`, `handleRecordingResume`, `finalizeAndPublishRecording`) to use `ctx.broadcast()` instead of socket-direct messaging, fixing the 422 error in recording-routes where `findSocketForSession` always returned null for HTTP requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
