### PR TITLE
fix: correct null check for getActiveRestartToken() in recording status route

### DIFF
--- a/assistant/src/runtime/routes/recording-routes.ts
+++ b/assistant/src/runtime/routes/recording-routes.ts
@@ -207,7 +207,7 @@ function handleRecordingStatus(): Response {
 
   return Response.json({
     idle,
-    restartInProgress: activeRestartToken !== undefined,
+    restartInProgress: activeRestartToken !== null,
   });
 }
 


### PR DESCRIPTION
Addresses review feedback on #14434. Changes !== undefined to !== null for getActiveRestartToken() which returns string | null, fixing inverted restartInProgress semantics.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14459" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
