### PR TITLE
fix: return 400 for malformed JSON payload in sign-bundle route

### DIFF
--- a/assistant/src/runtime/routes/app-management-routes.ts
+++ b/assistant/src/runtime/routes/app-management-routes.ts
@@ -557,7 +557,7 @@ export function appManagementRouteDefinitions(): RouteDefinition[] {
               };
               contentHashes = parsed.content_hashes ?? {};
             } catch {
-              // If payload isn't valid JSON, proceed with empty hashes.
+              return httpError("BAD_REQUEST", "payload is not valid JSON", 400);
             }
 
             const signatureJson: import("../../bundler/bundle-signer.js").SignatureJson = {


### PR DESCRIPTION
Addresses review feedback on #14438. Returns a 400 error when the payload is not valid JSON instead of silently proceeding with empty content_hashes, which would produce an unverifiable signature.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
