### PR TITLE
fix: re-fetch expanded directory contents after rename cache invalidation

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/WorkspacePanel.swift
@@ -479,6 +479,11 @@ private struct WorkspaceTreeRow: View {
                     for key in cacheKeys {
                         state.directoryCache.removeValue(forKey: key)
                     }
+                    // Re-fetch contents for directories that remain expanded under the new path
+                    let newExpandedDirs = state.expandedDirs.filter { $0 == newPath || $0.hasPrefix(newPath + "/") }
+                    for dir in newExpandedDirs {
+                        await state.refreshDirectory(dir, using: daemonClient)
+                    }
                 }
             }
             state.renamingPath = nil


### PR DESCRIPTION
Addresses review feedback on #14435. After invalidating the directory cache during rename, re-fetches contents for directories that remain expanded so they don't appear empty.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
