### PR TITLE
fix: separate exact env var names from prefix matching to prevent credential leaks

### DIFF
--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -706,15 +706,15 @@ async function handleToolPermissionSimulate(body: {
 // ---------------------------------------------------------------------------
 
 /**
- * Allowlist of env-var prefixes/names safe to expose via diagnostics.
+ * Allowlist of env-var names safe to expose via diagnostics.
  * Everything else is redacted to prevent secret leakage.
+ *
+ * IMPORTANT: Exact names use strict `===` matching so that e.g. "HOME" does
+ * not also expose "HOME_SECRET". Only entries in the *prefixes* list (which
+ * all end with `_`) use `startsWith`.
  */
-const SAFE_ENV_VAR_PREFIXES = [
-  "NODE_",
-  "BUN_",
-  "npm_",
+const SAFE_ENV_VAR_EXACT_NAMES = new Set([
   "LANG",
-  "LC_",
   "TERM",
   "SHELL",
   "HOME",
@@ -725,22 +725,30 @@ const SAFE_ENV_VAR_PREFIXES = [
   "OLDPWD",
   "HOSTNAME",
   "DISPLAY",
-  "XDG_",
   "COLORTERM",
   "EDITOR",
   "VISUAL",
   "TZ",
   "TMPDIR",
-  "VELLUM_",
   "BASE_DATA_DIR",
   "QDRANT_HTTP_PORT",
   "PORT",
   "DEBUG",
+]);
+
+const SAFE_ENV_VAR_PREFIXES = [
+  "NODE_",
+  "BUN_",
+  "npm_",
+  "LC_",
+  "XDG_",
+  "VELLUM_",
 ];
 
 function isEnvVarSafe(key: string): boolean {
-  return SAFE_ENV_VAR_PREFIXES.some(
-    (prefix) => key === prefix || key.startsWith(prefix),
+  return (
+    SAFE_ENV_VAR_EXACT_NAMES.has(key) ||
+    SAFE_ENV_VAR_PREFIXES.some((prefix) => key.startsWith(prefix))
   );
 }
 


### PR DESCRIPTION
Addresses review feedback on #14439. Splits the env var allowlist into exact-match names and prefix patterns so that entries like HOME, USER, PATH don't accidentally expose HOME_SECRET, USER_API_TOKEN, etc.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
