### PR TITLE
fix: prevent duplicate SSE state events during HTTP regenerate

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -437,6 +437,16 @@ export async function runDaemon(): Promise<void> {
         regenerateResponse: (sessionId) => {
           let hubChain: Promise<void> = Promise.resolve();
           const sendEvent = (event: ServerMessage) => {
+            // Skip state-signal events — these are already published to the
+            // hub by session.onStateSignal (set in conversation-routes.ts).
+            // Publishing them here too would duplicate SSE state transitions.
+            if (
+              "type" in event &&
+              (event.type === "assistant_activity_state" ||
+                event.type === "confirmation_state_changed")
+            ) {
+              return;
+            }
             const ae = buildAssistantEvent(
               "self",
               event,


### PR DESCRIPTION
Addresses review feedback on #14445. Prevents state-signal events from being published twice to SSE during HTTP regenerate — once via the session's state signal listener and once via the regenerate callback.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
