### PR TITLE
fix: recover session ownership checks in subagent IPC handlers for HTTP-only mode

### DIFF
--- a/assistant/src/daemon/handlers/subagents.ts
+++ b/assistant/src/daemon/handlers/subagents.ts
@@ -20,11 +20,11 @@ export function handleSubagentAbort(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  const callerSessionId: string | undefined = undefined;
+  const callerSessionId = msg.sessionId;
   if (!callerSessionId) {
     log.warn(
       { subagentId: msg.subagentId },
-      "Abort rejected: socket has no bound session",
+      "Abort rejected: no sessionId provided",
     );
     return;
   }
@@ -53,9 +53,9 @@ export function handleSubagentStatus(
 ): void {
   const manager = getSubagentManager();
 
-  const callerSessionId: string | undefined = undefined;
+  const callerSessionId = msg.sessionId;
   if (!callerSessionId) {
-    log.warn("Status rejected: socket has no bound session");
+    log.warn("Status rejected: no sessionId provided");
     return;
   }
 
@@ -97,11 +97,11 @@ export async function handleSubagentMessage(
   socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
-  const callerSessionId: string | undefined = undefined;
+  const callerSessionId = msg.sessionId;
   if (!callerSessionId) {
     log.warn(
       { subagentId: msg.subagentId },
-      "Message rejected: socket has no bound session",
+      "Message rejected: no sessionId provided",
     );
     ctx.send(socket, {
       type: "error",
@@ -168,12 +168,12 @@ export function handleSubagentDetailRequest(
   socket: net.Socket,
   ctx: HandlerContext,
 ): void {
-  // Ownership check: reject if the socket has no bound session.
-  const callerSessionId: string | undefined = undefined;
+  // Ownership check: reject if no sessionId was provided.
+  const callerSessionId = msg.sessionId;
   if (!callerSessionId) {
     log.warn(
       { subagentId: msg.subagentId },
-      "Detail request rejected: socket has no bound session",
+      "Detail request rejected: no sessionId provided",
     );
     return;
   }

--- a/assistant/src/daemon/ipc-contract/subagents.ts
+++ b/assistant/src/daemon/ipc-contract/subagents.ts
@@ -37,24 +37,28 @@ export interface SubagentDetailResponse {
 export interface SubagentAbortRequest {
   type: "subagent_abort";
   subagentId: string;
+  sessionId?: string;
 }
 
 export interface SubagentStatusRequest {
   type: "subagent_status";
   /** If omitted, returns all subagents for the session. */
   subagentId?: string;
+  sessionId?: string;
 }
 
 export interface SubagentMessageRequest {
   type: "subagent_message";
   subagentId: string;
   content: string;
+  sessionId?: string;
 }
 
 export interface SubagentDetailRequest {
   type: "subagent_detail_request";
   subagentId: string;
   conversationId: string;
+  sessionId?: string;
 }
 
 // --- Domain-level union aliases (consumed by the barrel file) ---


### PR DESCRIPTION
Addresses review feedback on #14456. Recovers session ownership checks that were lost when callerSessionId was hardcoded to undefined during the socket-to-HTTP migration. Adds sessionId field to subagent IPC message types and reads it in handlers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
