### PR TITLE
fix: remove stale IPC handler entry from guardian routing invariants test

### DIFF
--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -187,12 +187,6 @@ describe("routing invariant: all decision paths reference applyCanonicalGuardian
       path: "runtime/routes/guardian-action-routes.ts",
       symbols: ["processGuardianDecision"],
     },
-    // IPC handler (desktop socket clients) — uses processGuardianDecision
-    // which is a shared wrapper around applyCanonicalGuardianDecision
-    {
-      path: "daemon/handlers/guardian-actions.ts",
-      symbols: ["processGuardianDecision"],
-    },
     // Shared service where processGuardianDecision is defined — must route
     // through the canonical primitive to complete the chain:
     // entrypoint → processGuardianDecision → applyCanonicalGuardianDecision


### PR DESCRIPTION
## Summary
- The `daemon/handlers/guardian-actions.ts` IPC handler was deleted as dead code in #14457, but the guard test still listed it as a required decision entrypoint
- Removes the stale entry from `DECISION_ENTRYPOINTS` in `guardian-routing-invariants.test.ts` to fix the failing CI test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
