### PR TITLE
fix: resolve lint errors in recording tests and routes

### DIFF
--- a/assistant/src/__tests__/recording-handler.test.ts
+++ b/assistant/src/__tests__/recording-handler.test.ts
@@ -210,7 +210,7 @@ describe("handleRecordingStart", () => {
   });
 
   test("sends recording_start IPC and returns a UUID", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent, _fakeSocket } = createCtx();
     const conversationId = "conv-1";
 
     const recordingId = handleRecordingStart(
@@ -232,7 +232,7 @@ describe("handleRecordingStart", () => {
   });
 
   test("passes recording options through", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent, _fakeSocket } = createCtx();
     const options = { captureScope: "window" as const, includeAudio: true };
 
     handleRecordingStart("conv-2", options, ctx);
@@ -241,7 +241,7 @@ describe("handleRecordingStart", () => {
   });
 
   test("returns null when recording already active and sends no messages", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent, _fakeSocket } = createCtx();
 
     const id1 = handleRecordingStart("conv-3", undefined, ctx);
     expect(id1).toBeTruthy();
@@ -257,7 +257,7 @@ describe("handleRecordingStart", () => {
   });
 
   test("returns null when a different conversation already has an active recording (global guard)", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent, _fakeSocket } = createCtx();
 
     const id1 = handleRecordingStart(
       "conv-global-a",
@@ -293,7 +293,7 @@ describe("handleRecordingStop", () => {
   });
 
   test("sends recording_stop for an active recording", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent, _fakeSocket } = createCtx();
     const conversationId = "conv-stop-1";
 
     // Start a recording first
@@ -322,7 +322,7 @@ describe("handleRecordingStop", () => {
   });
 
   test("resolves to globally active recording from a different conversation", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent, _fakeSocket } = createCtx();
     const convA = "conv-owner";
     const convB = "conv-stopper";
 

--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -227,7 +227,7 @@ describe("handleRecordingRestart", () => {
   });
 
   test('returns "no active recording" with reason when nothing is recording', () => {
-    const { ctx, fakeSocket } = createCtx();
+    const { ctx, _fakeSocket } = createCtx();
 
     const result = handleRecordingRestart("conv-no-rec", ctx);
 
@@ -562,7 +562,7 @@ describe("handleRecordingPause", () => {
   });
 
   test("sends recording_pause for active recording", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent, _fakeSocket } = createCtx();
     const conversationId = "conv-pause-1";
 
     const recordingId = handleRecordingStart(
@@ -589,7 +589,7 @@ describe("handleRecordingPause", () => {
   });
 
   test("resolves to globally active recording from different conversation", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent, _fakeSocket } = createCtx();
     const convA = "conv-owner-pause";
 
     const recordingId = handleRecordingStart(convA, undefined, ctx);
@@ -606,7 +606,7 @@ describe("handleRecordingResume", () => {
   });
 
   test("sends recording_resume for active recording", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent, _fakeSocket } = createCtx();
     const conversationId = "conv-resume-1";
 
     const recordingId = handleRecordingStart(
@@ -645,13 +645,13 @@ describe("isRecordingIdle", () => {
   });
 
   test("returns false when recording is active", () => {
-    const { ctx, fakeSocket } = createCtx();
+    const { ctx, _fakeSocket } = createCtx();
     handleRecordingStart("conv-idle-1", undefined, ctx);
     expect(isRecordingIdle()).toBe(false);
   });
 
   test("returns false when mid-restart (between stop-ack and start confirmation)", () => {
-    const { ctx, fakeSocket } = createCtx();
+    const { ctx, _fakeSocket } = createCtx();
     const conversationId = "conv-idle-restart";
 
     handleRecordingStart(conversationId, undefined, ctx);
@@ -750,7 +750,7 @@ describe("executeRecordingIntent — restart/pause/resume", () => {
   });
 
   test('restart_only returns "no active recording" when idle', () => {
-    const { ctx, fakeSocket } = createCtx();
+    const { ctx, _fakeSocket } = createCtx();
 
     const result = executeRecordingIntent(
       { kind: "restart_only" },
@@ -762,7 +762,7 @@ describe("executeRecordingIntent — restart/pause/resume", () => {
   });
 
   test("restart_with_remainder returns deferred restart", () => {
-    const { ctx, fakeSocket } = createCtx();
+    const { ctx, _fakeSocket } = createCtx();
 
     const result = executeRecordingIntent(
       { kind: "restart_with_remainder", remainder: "do something else" },
@@ -775,7 +775,7 @@ describe("executeRecordingIntent — restart/pause/resume", () => {
   });
 
   test("pause_only executes actual pause", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent, _fakeSocket } = createCtx();
     const conversationId = "conv-exec-pause";
 
     handleRecordingStart(conversationId, undefined, ctx);
@@ -794,7 +794,7 @@ describe("executeRecordingIntent — restart/pause/resume", () => {
   });
 
   test('pause_only returns "no active recording" when idle', () => {
-    const { ctx, fakeSocket } = createCtx();
+    const { ctx, _fakeSocket } = createCtx();
 
     const result = executeRecordingIntent(
       { kind: "pause_only" },
@@ -806,7 +806,7 @@ describe("executeRecordingIntent — restart/pause/resume", () => {
   });
 
   test("resume_only executes actual resume", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent, _fakeSocket } = createCtx();
     const conversationId = "conv-exec-resume";
 
     handleRecordingStart(conversationId, undefined, ctx);
@@ -825,7 +825,7 @@ describe("executeRecordingIntent — restart/pause/resume", () => {
   });
 
   test('resume_only returns "no active recording" when idle', () => {
-    const { ctx, fakeSocket } = createCtx();
+    const { ctx, _fakeSocket } = createCtx();
 
     const result = executeRecordingIntent(
       { kind: "resume_only" },
@@ -976,7 +976,7 @@ describe("start_and_stop_only fallback to plain start when idle", () => {
   });
 
   test("falls back to handleRecordingStart when no active recording", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent, _fakeSocket } = createCtx();
     const conversationId = "conv-stop-start-idle";
 
     // No recording is active — start_and_stop_only should fall back to a
@@ -1051,7 +1051,7 @@ describe("start_and_stop_with_remainder fallback to plain start when idle", () =
   });
 
   test("sets pendingStart (not pendingRestart) when no active recording", () => {
-    const { ctx, fakeSocket } = createCtx();
+    const { ctx, _fakeSocket } = createCtx();
     const conversationId = "conv-rem-idle";
 
     const result = executeRecordingIntent(
@@ -1066,7 +1066,7 @@ describe("start_and_stop_with_remainder fallback to plain start when idle", () =
   });
 
   test("sets pendingRestart when a recording is active", () => {
-    const { ctx, fakeSocket } = createCtx();
+    const { ctx, _fakeSocket } = createCtx();
     const conversationId = "conv-rem-active";
 
     // Start a recording first
@@ -1094,7 +1094,7 @@ describe("deferred restart prevents race condition", () => {
   });
 
   test("recording_start is NOT sent until client acks the stop", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent, _fakeSocket } = createCtx();
     const conversationId = "conv-deferred-race";
 
     handleRecordingStart(conversationId, undefined, ctx);
@@ -1112,7 +1112,7 @@ describe("deferred restart prevents race condition", () => {
 
   test("stop-ack timeout cleans up deferred restart state", () => {
     // This test uses a real timer via bun's jest-compatible API
-    const { ctx, fakeSocket } = createCtx();
+    const { ctx, _fakeSocket } = createCtx();
     const conversationId = "conv-deferred-timeout";
 
     handleRecordingStart(conversationId, undefined, ctx);
@@ -1559,7 +1559,7 @@ describe("restart finalization", () => {
     expect(getActiveRestartToken()).toBeNull();
 
     // Start a recording, verify not idle
-    const { ctx, fakeSocket } = createCtx();
+    const { ctx, _fakeSocket } = createCtx();
     const conversationId = "conv-fin-sanity";
 
     handleRecordingStart(conversationId, undefined, ctx);

--- a/assistant/src/__tests__/session-surfaces-deselection.test.ts
+++ b/assistant/src/__tests__/session-surfaces-deselection.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
+import type { SurfaceData, SurfaceType } from "../daemon/message-protocol.js";
 import type {
   ListSurfaceData,
   TableColumn,
   TableRow,
   TableSurfaceData,
 } from "../daemon/message-types/surfaces.js";
-import type { SurfaceData, SurfaceType } from "../daemon/message-protocol.js";
 import {
   buildDeselectionDescription,
   describeTableRow,

--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -11,6 +11,7 @@ import {
 } from "./cli/main-screen.jsx";
 import { hasNoAuthOverride } from "./daemon/connection-policy.js";
 import { shouldAutoStartDaemon } from "./daemon/connection-policy.js";
+import { ensureDaemonRunning } from "./daemon/lifecycle.js";
 import {
   type ClientMessage,
   type ConfirmationRequest,
@@ -18,7 +19,6 @@ import {
   serialize,
   type ServerMessage,
 } from "./daemon/message-protocol.js";
-import { ensureDaemonRunning } from "./daemon/lifecycle.js";
 import {
   copyToClipboard,
   extractLastCodeBlock,

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -92,9 +92,9 @@ import {
   registerMessagingProviders,
   registerWatcherProviders,
 } from "./providers-setup.js";
+import { handleRideShotgunStart, handleRideShotgunStop } from "./ride-shotgun-handler.js";
 import { seedInterfaceFiles } from "./seed-files.js";
 import { DaemonServer } from "./server.js";
-import { handleRideShotgunStart, handleRideShotgunStop } from "./ride-shotgun-handler.js";
 import { initSlashPairingContext } from "./session-slash.js";
 import { installShutdownHandlers } from "./shutdown-handlers.js";
 import { handleWatchObservation } from "./watch-handler.js";

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -47,16 +47,16 @@ import * as approvalOverrides from "../runtime/session-approval-overrides.js";
 import { ToolExecutor } from "../tools/executor.js";
 import type { AssistantAttachmentDraft } from "./assistant-attachments.js";
 import type {
-  AssistantActivityState,
-  ConfirmationStateChanged,
-} from "./message-types/messages.js";
-import type {
   ServerMessage,
   SurfaceData,
   SurfaceType,
   UsageStats,
   UserMessageAttachment,
 } from "./message-protocol.js";
+import type {
+  AssistantActivityState,
+  ConfirmationStateChanged,
+} from "./message-types/messages.js";
 import { runAgentLoopImpl } from "./session-agent-loop.js";
 import { ConflictGate } from "./session-conflict-gate.js";
 import type { HistorySessionContext } from "./session-history.js";

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -3,11 +3,11 @@
  */
 import type { ChannelId, InterfaceId } from "../channels/types.js";
 import type { SkillOperationContext } from "../daemon/handlers/skills.js";
+import type { ServerMessage } from "../daemon/message-protocol.js";
 import type {
   SurfaceData,
   SurfaceType,
 } from "../daemon/message-types/surfaces.js";
-import type { ServerMessage } from "../daemon/message-protocol.js";
 import type { Session } from "../daemon/session.js";
 import type { TrustContext } from "../daemon/session-runtime-assembly.js";
 import type {

--- a/assistant/src/runtime/routes/recording-routes.ts
+++ b/assistant/src/runtime/routes/recording-routes.ts
@@ -207,7 +207,7 @@ function handleRecordingStatus(): Response {
 
   return Response.json({
     idle,
-    restartInProgress: activeRestartToken !== null,
+    restartInProgress: Boolean(activeRestartToken),
   });
 }
 


### PR DESCRIPTION
## Summary
- Prefix unused `fakeSocket` destructurings with `_` in recording test files to satisfy `@typescript-eslint/no-unused-vars`
- Fix import sort order in `session-surfaces-deselection.test.ts`, `cli.ts`, `daemon/lifecycle.ts`, `daemon/session.ts`, and `runtime/http-types.ts`
- Replace `!== null` with `Boolean()` in `recording-routes.ts` to satisfy `no-restricted-syntax` rule

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22843580499/job/66254677668

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
