### PR TITLE
fix(assistant): gate Telegram streaming approval metadata to bound guardians

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import { isBoundGuardianActor } from "./background-dispatch.js";
+
+describe("isBoundGuardianActor", () => {
+  test("returns true only when requester matches bound guardian", () => {
+    expect(
+      isBoundGuardianActor({
+        trustClass: "guardian",
+        guardianExternalUserId: "guardian-1",
+        requesterExternalUserId: "guardian-1",
+      }),
+    ).toBe(true);
+  });
+
+  test("returns false for non-guardian trust classes", () => {
+    expect(
+      isBoundGuardianActor({
+        trustClass: "trusted_contact",
+        guardianExternalUserId: "guardian-1",
+        requesterExternalUserId: "guardian-1",
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false when guardian id is missing", () => {
+    expect(
+      isBoundGuardianActor({
+        trustClass: "guardian",
+        requesterExternalUserId: "guardian-1",
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false when requester does not match guardian", () => {
+    expect(
+      isBoundGuardianActor({
+        trustClass: "guardian",
+        guardianExternalUserId: "guardian-1",
+        requesterExternalUserId: "requester-1",
+      }),
+    ).toBe(false);
+  });
+});

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -41,6 +41,21 @@ import { deliverGeneratedApprovalPrompt } from "../guardian-approval-prompt.js";
 
 const log = getLogger("runtime-http");
 
+export function isBoundGuardianActor(params: {
+  trustClass: TrustContext["trustClass"];
+  guardianExternalUserId?: string;
+  requesterExternalUserId?: string;
+}): boolean {
+  const { trustClass, guardianExternalUserId, requesterExternalUserId } =
+    params;
+
+  return (
+    trustClass === "guardian" &&
+    !!guardianExternalUserId &&
+    requesterExternalUserId === guardianExternalUserId
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -97,6 +112,12 @@ export function processChannelMessageInBackground(
   } = params;
 
   (async () => {
+    const boundGuardianActor = isBoundGuardianActor({
+      trustClass: trustCtx.trustClass,
+      guardianExternalUserId: trustCtx.guardianExternalUserId,
+      requesterExternalUserId: trustCtx.requesterExternalUserId,
+    });
+
     const typingCallbackUrl = shouldEmitTelegramTyping(
       sourceChannel,
       replyCallbackUrl,
@@ -210,8 +231,14 @@ export function processChannelMessageInBackground(
       if (telegramStreaming) {
         // Retrieve approval metadata from pending interactions (if any)
         // so approval buttons can be attached to the final streamed message.
-        const prompt = getChannelApprovalPrompt(conversationId);
-        const pending = getApprovalInfoByConversation(conversationId);
+        // Approval prompts are guardian-only and must never be attached for
+        // non-guardian or unverified actors.
+        const prompt = boundGuardianActor
+          ? getChannelApprovalPrompt(conversationId)
+          : undefined;
+        const pending = boundGuardianActor
+          ? getApprovalInfoByConversation(conversationId)
+          : [];
         const approvalMeta =
           prompt && pending.length > 0
             ? buildApprovalUIMetadata(prompt, pending[0])
@@ -474,11 +501,13 @@ export function startPendingApprovalPromptWatcher(params: {
   // actors must never receive approval prompt broadcasts for the conversation.
   // We also require an explicit identity match against the bound guardian to
   // avoid broadcasting prompts when trustClass is stale/mis-scoped.
-  const isBoundGuardianActor =
-    trustClass === "guardian" &&
-    !!guardianExternalUserId &&
-    requesterExternalUserId === guardianExternalUserId;
-  if (!isBoundGuardianActor) {
+  if (
+    !isBoundGuardianActor({
+      trustClass,
+      guardianExternalUserId,
+      requesterExternalUserId,
+    })
+  ) {
     return () => {};
   }
 


### PR DESCRIPTION
### Motivation
- Close an authorization bypass where Telegram streaming finalization could attach guardian approval UI to messages without verifying the recipient is the bound guardian. 
- Ensure the streaming path enforces the same guardian-only delivery invariant already present in the pending-approval watcher. 

### Description
- Add an exported helper `isBoundGuardianActor(...)` in `assistant/src/runtime/routes/inbound-stages/background-dispatch.ts` that centralizes the bound-guardian predicate. 
- Gate building/finalization of Telegram streaming approval metadata behind `isBoundGuardianActor(...)` so approval buttons are only attached when the requester identity matches the bound guardian. 
- Replace the previous inline predicate in the pending approval watcher with a call to `isBoundGuardianActor(...)` to avoid logic drift. 
- Add focused unit tests in `assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts` that cover guardian-match, non-guardian trust class, missing guardian id, and mismatched requester cases for the new predicate. 

### Testing
- Added `assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts` (unit tests); attempted to run `cd assistant && bun test src/runtime/routes/inbound-stages/background-dispatch.test.ts` but `bun` is not available in the execution environment so tests were not executed. 
- Commit-time hooks executed and reported Bun-dependent lint/type-check steps were skipped due to missing `bun`. 
- No automated tests in CI were executed in this environment; tests were added and are expected to pass when run with the project-standard command `cd assistant && bun test src/runtime/routes/inbound-stages/background-dispatch.test.ts` and a normal `bun` toolchain present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69adee189ae88323a10c3ba42b797099)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
