### PR TITLE
fix: use DAEMON_INTERNAL_ASSISTANT_ID constant instead of hardcoded 'self' in lifecycle.ts

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -43,6 +43,7 @@ import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { syncUpdateBulletinOnStartup } from "../prompts/update-bulletin.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import {
   initAuthSigningKey,
   loadOrCreateSigningKey,
@@ -166,7 +167,7 @@ export async function runDaemon(): Promise<void> {
 
     // Backfill vellum guardian binding for existing installations
     try {
-      ensureVellumGuardianBinding("self");
+      ensureVellumGuardianBinding(DAEMON_INTERNAL_ASSISTANT_ID);
     } catch (err) {
       log.warn(
         { err },
@@ -448,7 +449,7 @@ export async function runDaemon(): Promise<void> {
               return;
             }
             const ae = buildAssistantEvent(
-              "self",
+              DAEMON_INTERNAL_ASSISTANT_ID,
               event,
               sessionId,
             );


### PR DESCRIPTION
Replace hardcoded "self" strings with the DAEMON_INTERNAL_ASSISTANT_ID constant in lifecycle.ts to comply with the assistant ID boundary convention.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
