### PR TITLE
fix: update CODEOWNERS paths from ipc-contract/ to message-types/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@ assistant/src/config/skills.ts @awlevin
 assistant/src/config/skill-state.ts @awlevin
 assistant/src/config/bundled-skills/ @awlevin
 assistant/src/daemon/handlers/skills.ts @awlevin
-assistant/src/daemon/ipc-contract/skills.ts @awlevin
+assistant/src/daemon/message-types/skills.ts @awlevin
 assistant/src/daemon/session-skill-tools.ts @awlevin
 
 # Agent-to-agent / agent-to-person interactions (Harrison)
@@ -96,8 +96,8 @@ assistant/src/daemon/approval-generators.ts @noanflaherty
 assistant/src/daemon/guardian-*.ts @noanflaherty
 assistant/src/daemon/handlers/config-trust.ts @noanflaherty
 assistant/src/daemon/handlers/guardian-actions.ts @noanflaherty
-assistant/src/daemon/ipc-contract/guardian-actions.ts @noanflaherty
-assistant/src/daemon/ipc-contract/trust.ts @noanflaherty
+assistant/src/daemon/message-types/guardian-actions.ts @noanflaherty
+assistant/src/daemon/message-types/trust.ts @noanflaherty
 assistant/src/tools/verification-control-plane-policy.ts @noanflaherty
 assistant/src/tools/tool-approval-handler.ts @noanflaherty
 assistant/src/security/tool-approval-digest.ts @noanflaherty


### PR DESCRIPTION
Update stale CODEOWNERS entries that still reference the old ipc-contract/ directory after it was renamed to message-types/ in #14463.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
