### PR TITLE
fix: update stale IPCContractGenerated.swift reference in clients/macos/CLAUDE.md

### DIFF
--- a/clients/macos/CLAUDE.md
+++ b/clients/macos/CLAUDE.md
@@ -105,7 +105,7 @@ Tests use `Mock*` versions defined in `SessionTests.swift`. Test pattern: `@Main
 All inference (both computer-use sessions and ambient analysis) goes through the assistant's HTTP API:
 - `DaemonClient` — `@MainActor`, HTTP+SSE transport; auto-reconnect, `AsyncStream<ServerMessage>`
 - `IPCMessages.swift` — Codable structs for HTTP request/response types: `cu_session_create`, `cu_observation`, `cu_action`, `cu_complete`, `cu_error`, `ambient_analyze`, `trace_event`, etc.
-- `IPC/Generated/IPCContractGenerated.swift` — Codable Swift types used for JSON serialization. Use these `IPC*` types directly in Swift code instead of hand-writing structs.
+- `IPC/Generated/GeneratedAPITypes.swift` — Codable Swift types used for JSON serialization. Use these `IPC*` types directly in Swift code instead of hand-writing structs.
 
 ### Ambient Agent (`Ambient/`)
 


### PR DESCRIPTION
Update clients/macos/CLAUDE.md to reference the renamed GeneratedAPITypes.swift file (renamed in #14464).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
