### PR TITLE
fix(gateway): respect trust proxy for browser relay token loopback checks

### DIFF
--- a/gateway/src/__tests__/browser-relay-websocket.test.ts
+++ b/gateway/src/__tests__/browser-relay-websocket.test.ts
@@ -5,6 +5,7 @@ import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
 import {
   createBrowserRelayWebsocketHandler,
   getBrowserRelayWebsocketHandlers,
+  isLoopbackPeer,
 } from "../http/routes/browser-relay-websocket.js";
 
 const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
@@ -268,5 +269,39 @@ describe("getBrowserRelayWebsocketHandlers", () => {
 
     fakeUpstream.emit("message", { data: "runtime-message" });
     expect(ws.sent).toEqual(["runtime-message"]);
+  });
+});
+
+describe("isLoopbackPeer", () => {
+  test("uses x-forwarded-for first hop when trustProxy is enabled", () => {
+    const req = new Request("http://localhost:7830/v1/browser-relay/token", {
+      headers: { "x-forwarded-for": "203.0.113.5, 127.0.0.1" },
+    });
+
+    const fakeServer = {
+      requestIP: mock(() => ({
+        address: "127.0.0.1",
+        family: "IPv4",
+        port: 54000,
+      })),
+    } as unknown as import("bun").Server<any>;
+
+    expect(isLoopbackPeer(fakeServer, req, { trustProxy: true })).toBe(false);
+  });
+
+  test("falls back to peer IP when trustProxy is disabled", () => {
+    const req = new Request("http://localhost:7830/v1/browser-relay/token", {
+      headers: { "x-forwarded-for": "203.0.113.5, 127.0.0.1" },
+    });
+
+    const fakeServer = {
+      requestIP: mock(() => ({
+        address: "127.0.0.1",
+        family: "IPv4",
+        port: 54000,
+      })),
+    } as unknown as import("bun").Server<any>;
+
+    expect(isLoopbackPeer(fakeServer, req, { trustProxy: false })).toBe(true);
   });
 });

--- a/gateway/src/http/routes/browser-relay-websocket.ts
+++ b/gateway/src/http/routes/browser-relay-websocket.ts
@@ -73,10 +73,20 @@ export function isLoopbackAddress(addr: string): boolean {
 export function isLoopbackPeer(
   server: import("bun").Server<unknown>,
   req: Request,
+  opts?: { trustProxy?: boolean },
 ): boolean {
-  const ip = server.requestIP(req);
-  if (!ip) return false;
-  return isLoopbackAddress(ip.address);
+  if (opts?.trustProxy) {
+    const forwarded = req.headers.get("x-forwarded-for");
+    if (forwarded) {
+      const first = forwarded.split(",")[0]?.trim();
+      if (!first) return false;
+      return isLoopbackAddress(first);
+    }
+  }
+
+  const peer = server.requestIP(req);
+  if (!peer) return false;
+  return isLoopbackAddress(peer.address);
 }
 
 export type BrowserRelaySocketData = {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -787,7 +787,7 @@ async function main() {
         url.pathname === "/v1/browser-relay/token" &&
         req.method === "GET"
       ) {
-        if (!isLoopbackPeer(svr, req)) {
+        if (!isLoopbackPeer(svr, req, { trustProxy: config.trustProxy })) {
           return Response.json(
             { error: "Browser relay token only available from localhost" },
             { status: 403 },


### PR DESCRIPTION
### Motivation
- The unauthenticated `GET /v1/browser-relay/token` endpoint used a loopback gate that relied solely on `server.requestIP()`, which can be bypassed when the gateway is fronted by a local proxy that forwards remote traffic from `127.0.0.1`.
- Prevent remote clients from minting privileged `gateway_service_v1` tokens by ensuring the loopback check is proxy-aware when `trustProxy` is enabled.

### Description
- Updated `isLoopbackPeer` in `gateway/src/http/routes/browser-relay-websocket.ts` to accept an `opts` parameter and, when `trustProxy` is true, validate the first `x-forwarded-for` hop as the peer IP before falling back to `server.requestIP()`.
- Wired the `/v1/browser-relay/token` pre-router gate in `gateway/src/index.ts` to pass `config.trustProxy` into `isLoopbackPeer` so proxy-fronted deployments honor the configured trust model.
- Added focused unit tests in `gateway/src/__tests__/browser-relay-websocket.test.ts` that assert proxy-enabled behavior (uses `x-forwarded-for`) and proxy-disabled behavior (falls back to direct peer IP).

### Testing
- Added unit tests for `isLoopbackPeer` in `gateway/src/__tests__/browser-relay-websocket.test.ts`; tests verify `x-forwarded-for` handling when `trustProxy` is enabled and fallback to `server.requestIP()` when disabled.
- Attempted to run `cd gateway && bun test src/__tests__/browser-relay-websocket.test.ts` in this environment but `bun` is not installed and automated install failed, so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae082e4ef083238767c3e94320167c)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
