### PR TITLE
fix: migrate legacy trust file versions to v3

### DIFF
--- a/assistant/src/__tests__/trust-store.test.ts
+++ b/assistant/src/__tests__/trust-store.test.ts
@@ -1272,7 +1272,7 @@ describe("Trust Store", () => {
       expect(withoutOptions).not.toHaveProperty("executionTarget");
     });
 
-    test("unknown version returns in-memory defaults without persisting", () => {
+    test("legacy v2 version migrates rules and persists as v3", () => {
       mkdirSync(dirname(trustPath), { recursive: true });
       writeFileSync(
         trustPath,
@@ -1293,12 +1293,50 @@ describe("Trust Store", () => {
       );
       clearCache();
       const rules = getAllRules();
-      // Should only have default rules (in-memory), user rules from unknown version are discarded
-      expect(rules).toHaveLength(NUM_DEFAULTS);
-      expect(rules.every((r) => r.id.startsWith("default:"))).toBe(true);
-      // File should NOT be overwritten — we don't understand the format
+      const migratedRule = rules.find((r) => r.id === "old-version-rule");
+      expect(migratedRule).toBeDefined();
+      expect(migratedRule!.decision).toBe("allow");
+      expect(rules).toHaveLength(1 + NUM_DEFAULTS);
+
+      // File should be persisted to the current schema version.
       const data = JSON.parse(readFileSync(trustPath, "utf-8"));
-      expect(data.version).toBe(2);
+      expect(data.version).toBe(3);
+      expect(
+        data.rules.some((r: { id: string }) => r.id === "old-version-rule"),
+      ).toBe(true);
+    });
+
+    test("legacy v1 version migrates rules and persists as v3", () => {
+      mkdirSync(dirname(trustPath), { recursive: true });
+      writeFileSync(
+        trustPath,
+        JSON.stringify({
+          version: 1,
+          rules: [
+            {
+              id: "v1-rule",
+              tool: "bash",
+              pattern: "rm *",
+              scope: "everywhere",
+              decision: "deny",
+              priority: 200,
+              createdAt: 4000,
+            },
+          ],
+        }),
+      );
+
+      clearCache();
+      const rules = getAllRules();
+      const migratedRule = rules.find((r) => r.id === "v1-rule");
+      expect(migratedRule).toBeDefined();
+      expect(migratedRule!.decision).toBe("deny");
+
+      const data = JSON.parse(readFileSync(trustPath, "utf-8"));
+      expect(data.version).toBe(3);
+      expect(data.rules.some((r: { id: string }) => r.id === "v1-rule")).toBe(
+        true,
+      );
     });
   });
 

--- a/assistant/src/permissions/trust-store.ts
+++ b/assistant/src/permissions/trust-store.ts
@@ -233,8 +233,19 @@ function loadFromDisk(): TrustRule[] {
       // Restore persisted starter bundle flag
       cachedStarterBundleAccepted = data.starterBundleAccepted === true;
 
-      if (data.version === TRUST_FILE_VERSION) {
+      if (
+        data.version === TRUST_FILE_VERSION ||
+        data.version === 1 ||
+        data.version === 2
+      ) {
         rules = rawRules;
+        if (data.version !== TRUST_FILE_VERSION) {
+          needsSave = true;
+          log.info(
+            { version: data.version, targetVersion: TRUST_FILE_VERSION },
+            "Migrating legacy trust file version",
+          );
+        }
 
         // Strip legacy principal-scoped fields from persisted v3 rules.
         // Before the principal concept was removed, rules could carry


### PR DESCRIPTION
### Motivation
- Recent change treated any non-v3 trust file as unknown and discarded user-defined v1/v2 rules, which could re-enable high-risk defaults (e.g. `host_bash`) and bypass user deny/ask policies.
- The goal is to preserve user intent for existing installations by reading legacy v1/v2 files, retaining their rules, and upgrading them to the current schema.

### Description
- Updated `loadFromDisk()` in `assistant/src/permissions/trust-store.ts` to accept legacy trust file versions `1` and `2` in addition to `3`, load their `rules` into memory, and mark the store dirty so rules are persisted back as schema `v3` (keeps legacy user deny/ask rules intact and prevents fallback to permissive defaults).
- Added a short migration log entry when a legacy version is detected and `needsSave` is set so the file is rewritten with `version: 3` after backfilling defaults and any necessary cleanup (e.g. stripping legacy principal fields).
- Added regression tests in `assistant/src/__tests__/trust-store.test.ts` to verify that v2 and v1 trust files are migrated, the user rules remain present in memory, and the on-disk file is rewritten with `version: 3`.
- Preserves prior behavior for truly unknown/future versions (still treated as unknown and not overwritten).

### Testing
- Ran the modified test file with `bun test src/__tests__/trust-store.test.ts` using the available Bun binary: `/root/.local/share/mise/installs/bun/1.2.14/bin/bun test src/__tests__/trust-store.test.ts`; the suite completed successfully with all tests passing (`114 passed, 0 failed`).
- An attempt to run `bun` via the environment `PATH` bootstrap command failed in this environment due to `bun@1.3.9` download issues, so CI-style `bun` invocation was not available; the targeted test run above provides validation of the change.
- The added tests assert that both v1 and v2 files retain user rules after load and that the trust file is persisted as `version: 3` on disk, and they passed in the run described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69adf9b402588323a6068a0dd017346f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
