### PR TITLE
fix: avoid loading Playwright from writable workspace

### DIFF
--- a/assistant/src/tools/browser/runtime-check.ts
+++ b/assistant/src/tools/browser/runtime-check.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { getWorkspaceDir } from "../../util/platform.js";
+import { getRootDir } from "../../util/platform.js";
 
 export interface BrowserRuntimeStatus {
   playwrightAvailable: boolean;
@@ -73,7 +73,9 @@ export async function importPlaywright(): Promise<typeof import("playwright")> {
   // Compiled binary fallback: install playwright to disk and import
   // from an absolute path so the JS runtime resolves it from the
   // filesystem instead of the compiled module cache.
-  const externalDir = join(getWorkspaceDir(), "external");
+  // Use the internal assistant root (outside tool sandbox working dir)
+  // so untrusted workspace writes cannot plant a forged playwright package.
+  const externalDir = join(getRootDir(), "external");
   const pwPkg = join(externalDir, "node_modules", "playwright");
 
   if (!existsSync(join(pwPkg, "package.json"))) {


### PR DESCRIPTION
### Motivation
- Prevent untrusted workspace writes from being used as a module load source by ensuring the runtime Playwright fallback installs/loads from the assistant internal root rather than the sandboxed workspace directory.

### Description
- Change runtime fallback install/import path in `importPlaywright()` to use `join(getRootDir(), "external")` instead of `join(getWorkspaceDir(), "external")`, and add a brief comment explaining the security rationale; the existing fallback install/import behavior is otherwise unchanged.

### Testing
- Attempted to run type-check with `cd assistant && bunx tsc --noEmit`, which could not run in this environment because `bun`/`bunx` were unavailable (network/installer error), and no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae1e1d7dac8323b4aa420405a2fa32)