### PR TITLE
fix: align access-request tests with vellum-anchored guardian resolution

### DIFF
--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -91,6 +91,7 @@ import {
 } from "../memory/canonical-guardian-store.js";
 import { getDb, initializeDb, resetDb } from "../memory/db.js";
 import { notifyGuardianOfAccessRequest } from "../runtime/access-request-helper.js";
+import { ensureVellumGuardianBinding } from "../runtime/guardian-vellum-migration.js";
 import { handleChannelInbound } from "../runtime/routes/channel-routes.js";
 
 initializeDb();
@@ -110,7 +111,12 @@ afterAll(() => {
 
 const TEST_BEARER_TOKEN = "test-token";
 
-function resetState(): void {
+/**
+ * Reset test state and return the vellum anchor principal ID.
+ * Guardian bindings created in tests must use this principal so the
+ * assistant-anchored resolution check in access-request-helper passes.
+ */
+function resetState(): string {
   const db = getDb();
   db.run("DELETE FROM channel_guardian_approval_requests");
   db.run("DELETE FROM channel_inbound_events");
@@ -129,6 +135,8 @@ function resetState(): void {
     reason: "mock",
     deliveryResults: [],
   };
+  // Ensure the vellum anchor binding exists and return its principal
+  return ensureVellumGuardianBinding("self");
 }
 
 async function flushAsyncAccessRequestBookkeeping(): Promise<void> {
@@ -166,8 +174,9 @@ function buildInboundRequest(overrides: Record<string, unknown> = {}): Request {
 // ---------------------------------------------------------------------------
 
 describe("non-member access request notification", () => {
+  let anchorPrincipalId: string;
   beforeEach(() => {
-    resetState();
+    anchorPrincipalId = resetState();
   });
 
   test("non-member message is denied with rejection reply", async () => {
@@ -187,12 +196,12 @@ describe("non-member access request notification", () => {
   });
 
   test("guardian is notified when a non-member messages and a guardian binding exists", async () => {
-    // Set up a guardian binding for this channel
+    // Set up a guardian binding for this channel using the anchor principal
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
       guardianDeliveryChatId: "guardian-chat-789",
-      guardianPrincipalId: "test-principal-id",
+      guardianPrincipalId: anchorPrincipalId,
       verifiedVia: "test",
     });
 
@@ -237,7 +246,7 @@ describe("non-member access request notification", () => {
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
       guardianDeliveryChatId: "guardian-chat-789",
-      guardianPrincipalId: "test-principal-id",
+      guardianPrincipalId: anchorPrincipalId,
       verifiedVia: "test",
     });
 
@@ -301,13 +310,15 @@ describe("non-member access request notification", () => {
     expect(pending[0].guardianPrincipalId).toBeDefined();
   });
 
-  test("cross-channel fallback: voice guardian binding resolves for Telegram access request", async () => {
-    // Only a voice guardian binding exists — no Telegram binding
+  test("non-source-channel binding falls back to vellum anchor for Telegram access request", async () => {
+    // Only a voice guardian binding exists — no Telegram binding.
+    // Since cross-channel fallback was removed, the access request resolves
+    // to the assistant's vellum anchor identity instead.
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "guardian-voice-user",
       guardianDeliveryChatId: "guardian-voice-chat",
-      guardianPrincipalId: "test-principal-id",
+      guardianPrincipalId: anchorPrincipalId,
       verifiedVia: "test",
     });
 
@@ -324,9 +335,10 @@ describe("non-member access request notification", () => {
       string,
       unknown
     >;
-    expect(payload.guardianBindingChannel).toBe("phone");
+    // Falls back to vellum anchor, not the phone binding
+    expect(payload.guardianBindingChannel).toBe("vellum");
 
-    // Canonical request has the voice guardian's external user ID
+    // Canonical request uses the vellum anchor identity
     const pending = listCanonicalGuardianRequests({
       status: "pending",
       requesterExternalUserId: "user-unknown-456",
@@ -334,7 +346,7 @@ describe("non-member access request notification", () => {
       kind: "access_request",
     });
     expect(pending.length).toBe(1);
-    expect(pending[0].guardianExternalUserId).toBe("guardian-voice-user");
+    expect(pending[0].guardianPrincipalId).toBe(anchorPrincipalId);
   });
 
   test("no notification when actorExternalId is absent", async () => {
@@ -342,7 +354,7 @@ describe("non-member access request notification", () => {
       channel: "telegram",
       guardianExternalUserId: "guardian-user-789",
       guardianDeliveryChatId: "guardian-chat-789",
-      guardianPrincipalId: "test-principal-id",
+      guardianPrincipalId: anchorPrincipalId,
       verifiedVia: "test",
     });
 
@@ -359,8 +371,9 @@ describe("non-member access request notification", () => {
 });
 
 describe("access-request-helper unit tests", () => {
+  let anchorPrincipalId: string;
   beforeEach(() => {
-    resetState();
+    anchorPrincipalId = resetState();
   });
 
   test("notifyGuardianOfAccessRequest returns no_sender_id when actorExternalId is absent", () => {
@@ -447,20 +460,20 @@ describe("access-request-helper unit tests", () => {
     expect(payload.guardianBindingChannel).toBe("vellum");
   });
 
-  test("notifyGuardianOfAccessRequest prefers source-channel binding over cross-channel fallback", () => {
-    // Both Telegram and voice bindings exist
+  test("notifyGuardianOfAccessRequest prefers source-channel binding over vellum anchor", () => {
+    // Both Telegram and voice bindings exist with the anchor principal
     createGuardianBinding({
       channel: "telegram",
       guardianExternalUserId: "guardian-tg",
       guardianDeliveryChatId: "tg-chat",
-      guardianPrincipalId: "test-principal-tg",
+      guardianPrincipalId: anchorPrincipalId,
       verifiedVia: "test",
     });
     createGuardianBinding({
       channel: "phone",
       guardianExternalUserId: "guardian-voice",
       guardianDeliveryChatId: "voice-chat",
-      guardianPrincipalId: "test-principal-voice",
+      guardianPrincipalId: anchorPrincipalId,
       verifiedVia: "test",
     });
 
@@ -479,7 +492,7 @@ describe("access-request-helper unit tests", () => {
       kind: "access_request",
     });
     expect(pending.length).toBe(1);
-    // Should use the Telegram binding, not voice fallback
+    // Should use the Telegram binding, not the vellum anchor
     expect(pending[0].guardianExternalUserId).toBe("guardian-tg");
 
     const payload = emitSignalCalls[0].contextPayload as Record<


### PR DESCRIPTION
## Summary
- The recent commit anchoring access-request guardian resolution to the assistant's vellum principal (#14478) missed updating several tests that created guardian bindings with hardcoded principal IDs that don't match the vellum anchor
- Updated tests to obtain the anchor principal via `ensureVellumGuardianBinding()` and use it when creating test guardian bindings
- Renamed "cross-channel fallback" test to reflect that cross-channel fallback no longer exists — non-source-channel bindings now fall back to the vellum anchor

## Original prompt
Figure out why these tests are failing and either fix them or fix the code: https://github.com/vellum-ai/vellum-assistant/actions/runs/22845204009/job/66259812806

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
