### PR TITLE
fix: add POST recording/status route for client lifecycle callbacks

### DIFF
--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -720,9 +720,16 @@ export async function finalizeAndPublishRecording(params: {
 
 // ─── Status (client → server lifecycle updates) ─────────────────────────────
 
-async function handleRecordingStatus(
+/**
+ * Core recording-status business logic. Handles conversation ID resolution,
+ * operation token validation for restart race hardening, file attachment
+ * after recording stops, broadcasting recording lifecycle events, and
+ * triggering deferred recording restarts.
+ *
+ * Shared by both the IPC handler and the HTTP POST route.
+ */
+export async function handleRecordingStatusCore(
   msg: RecordingStatus,
-  reportingSocket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   const recordingId = msg.sessionId;
@@ -1044,8 +1051,19 @@ export function __resetRecordingState(): void {
   activeRestartToken = null;
 }
 
+// ─── IPC handler wrapper ─────────────────────────────────────────────────────
+
+/** IPC-compatible wrapper: ignores the socket (unused) and delegates to core. */
+async function handleRecordingStatusIpc(
+  msg: RecordingStatus,
+  _reportingSocket: net.Socket,
+  ctx: HandlerContext,
+): Promise<void> {
+  return handleRecordingStatusCore(msg, ctx);
+}
+
 // ─── Export handler group ────────────────────────────────────────────────────
 
 export const recordingHandlers = defineHandlers({
-  recording_status: handleRecordingStatus,
+  recording_status: handleRecordingStatusIpc,
 });

--- a/assistant/src/runtime/routes/recording-routes.ts
+++ b/assistant/src/runtime/routes/recording-routes.ts
@@ -14,11 +14,15 @@ import {
   handleRecordingPause,
   handleRecordingResume,
   handleRecordingStart,
+  handleRecordingStatusCore,
   handleRecordingStop,
   isRecordingIdle,
 } from "../../daemon/handlers/recording.js";
 import type { HandlerContext } from "../../daemon/handlers/shared.js";
-import type { RecordingOptions } from "../../daemon/message-protocol.js";
+import type {
+  RecordingOptions,
+  RecordingStatus,
+} from "../../daemon/message-protocol.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
@@ -201,7 +205,7 @@ async function handleResumeRecording(
 /**
  * GET /v1/recordings/status — get current recording status.
  */
-function handleRecordingStatus(): Response {
+function handleGetRecordingStatus(): Response {
   const idle = isRecordingIdle();
   const activeRestartToken = getActiveRestartToken();
 
@@ -209,6 +213,68 @@ function handleRecordingStatus(): Response {
     idle,
     restartInProgress: Boolean(activeRestartToken),
   });
+}
+
+/**
+ * POST /v1/recordings/status — recording lifecycle callback from the client.
+ *
+ * Body: RecordingStatus fields (sessionId, status, filePath?, durationMs?,
+ *       error?, attachToConversationId?, operationToken?)
+ *
+ * The client sends this when a recording transitions state (started, stopped,
+ * paused, resumed, failed, restart_cancelled). The handler performs conversation
+ * ID resolution, operation token validation, file attachment after stop,
+ * broadcasting lifecycle events, and triggering deferred recording restarts.
+ */
+async function handlePostRecordingStatus(
+  req: Request,
+  deps: RecordingDeps,
+): Promise<Response> {
+  const body = (await req.json()) as Omit<RecordingStatus, "type">;
+
+  if (!body.sessionId || typeof body.sessionId !== "string") {
+    return httpError("BAD_REQUEST", "sessionId is required", 400);
+  }
+
+  if (!body.status || typeof body.status !== "string") {
+    return httpError("BAD_REQUEST", "status is required", 400);
+  }
+
+  const validStatuses = [
+    "started",
+    "stopped",
+    "failed",
+    "restart_cancelled",
+    "paused",
+    "resumed",
+  ];
+  if (!validStatuses.includes(body.status)) {
+    return httpError("BAD_REQUEST", `Invalid status: ${body.status}`, 400);
+  }
+
+  const msg: RecordingStatus = {
+    type: "recording_status",
+    ...body,
+  };
+
+  const ctx = deps.getHandlerContext();
+
+  try {
+    await handleRecordingStatusCore(msg, ctx);
+  } catch (err) {
+    log.error(
+      { err, sessionId: body.sessionId, status: body.status },
+      "Recording status handler failed",
+    );
+    return httpError("INTERNAL_ERROR", "Recording status processing failed", 500);
+  }
+
+  log.info(
+    { sessionId: body.sessionId, status: body.status },
+    "Recording status processed via HTTP",
+  );
+
+  return Response.json({ ok: true });
 }
 
 // ---------------------------------------------------------------------------
@@ -254,7 +320,13 @@ export function recordingRouteDefinitions(deps: {
       endpoint: "recordings/status",
       method: "GET",
       policyKey: "recordings/status",
-      handler: () => handleRecordingStatus(),
+      handler: () => handleGetRecordingStatus(),
+    },
+    {
+      endpoint: "recordings/status",
+      method: "POST",
+      policyKey: "recordings/status",
+      handler: async ({ req }) => handlePostRecordingStatus(req, getDeps()),
     },
   ];
 }


### PR DESCRIPTION
## Summary
Adds missing POST handler at `/v1/recordings/status` that the Swift client calls for recording lifecycle callbacks (start, stop, pause, fail). The existing GET handler only returns status; the POST handler performs conversation resolution, file attachment, event broadcasting, and restart flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
