### PR TITLE
refactor: remove dead IPC serialization and socket utility functions

### DIFF
--- a/assistant/src/__tests__/platform.test.ts
+++ b/assistant/src/__tests__/platform.test.ts
@@ -18,7 +18,6 @@ import {
   getHistoryPath,
   getHooksDir,
   getInterfacesDir,
-  getIpcBlobDir,
   getLogPath,
   getPidPath,
   getRootDir,
@@ -66,7 +65,6 @@ describe("baseline path characterization (pre-migration)", () => {
     expect(getDbPath()).toBe(join(data, "db", "assistant.db"));
     expect(getLogPath()).toBe(join(data, "logs", "vellum.log"));
     expect(getHistoryPath()).toBe(join(data, "history"));
-    expect(getIpcBlobDir()).toBe(join(data, "ipc-blobs"));
     expect(getInterfacesDir()).toBe(join(data, "interfaces"));
     expect(getSandboxRootDir()).toBe(join(data, "sandbox"));
     expect(getSandboxWorkingDir()).toBe(join(root, "workspace"));

--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -1,5 +1,5 @@
 /**
- * IPC Protocol -- message types and serialization.
+ * Message Protocol -- message types and serialization.
  *
  * All message types are defined in domain files under ./message-types/.
  * Each domain file exports `_<Domain>ClientMessages` and/or
@@ -7,7 +7,7 @@
  * into the aggregate ClientMessage and ServerMessage unions, and provides
  * serialization/parsing utilities.
  *
- * To add a new IPC message type:
+ * To add a new message type:
  *   1. Define its interface in the appropriate domain file.
  *   2. Add it to that file's _<Domain>ClientMessages or _<Domain>ServerMessages.
  * No changes needed here unless you're adding an entirely new domain file.
@@ -189,7 +189,7 @@ export type ServerMessage =
 
 // === Contract schema ===
 
-export interface IPCContractSchema {
+export interface ContractSchema {
   client: ClientMessage;
   server: ServerMessage;
 }
@@ -197,15 +197,6 @@ export interface IPCContractSchema {
 const log = getLogger("message-protocol");
 
 // === Serialization ===
-
-/**
- * Maximum size of a single line in the IPC buffer (96MB).
- *
- * Attachment payloads are sent inline as base64 in `user_message`, so the
- * parser must tolerate large partial frames before the terminating newline
- * arrives.
- */
-export const MAX_LINE_SIZE = 96 * 1024 * 1024;
 
 export function serialize(msg: ClientMessage | ServerMessage): string {
   return JSON.stringify(msg) + "\n";

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -3,8 +3,6 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
-  statSync,
-  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -225,14 +223,6 @@ export function getEmbeddingModelsDir(): string {
 }
 
 /**
- * Returns the IPC blob directory (~/.vellum/workspace/data/ipc-blobs).
- * Temporary blob files for zero-copy IPC payloads live here.
- */
-export function getIpcBlobDir(): string {
-  return join(getDataDir(), "ipc-blobs");
-}
-
-/**
  * Returns the sandbox root directory (~/.vellum/data/sandbox).
  * Global sandbox state lives under this directory.
  */
@@ -351,28 +341,6 @@ export function readSessionToken(): string | null {
   } catch {
     return null;
   }
-}
-
-/**
- * Remove a socket file only if it is actually a Unix socket.
- * Refuses to delete regular files, directories, etc. to prevent
- * accidental data loss.
- */
-export function removeSocketFile(socketPath: string): void {
-  if (!existsSync(socketPath)) return;
-  const stat = statSync(socketPath);
-  if (!stat.isSocket()) {
-    throw new Error(
-      `Refusing to remove ${socketPath}: not a Unix socket (found ${
-        stat.isFile()
-          ? "regular file"
-          : stat.isDirectory()
-            ? "directory"
-            : "non-socket"
-      })`,
-    );
-  }
-  unlinkSync(socketPath);
 }
 
 export function getPidPath(): string {


### PR DESCRIPTION
## Summary
- Remove dead `IPCContractSchema` interface and `MAX_LINE_SIZE` constant from `message-protocol.ts` (zero importers)
- Rename `IPCContractSchema` to `ContractSchema` (no importers existed, fresh name for future use)
- Remove dead `getIpcBlobDir()` and `removeSocketFile()` from `platform.ts` (zero non-test importers)
- Clean up unused `statSync`/`unlinkSync` imports from `platform.ts`
- Update header comment to remove "IPC Protocol" reference
- Update `platform.test.ts` to remove `getIpcBlobDir` test assertion

### Still imported (left in place)
- `serialize()` — imported by `cli.ts`, `cli/commands/map.ts`, `cli/commands/twitter/index.ts`
- `createMessageParser()` — imported by `cli.ts`, `cli/commands/map.ts`, `cli/commands/twitter/index.ts`
- `getSocketPath()` — imported by CLI files and doordash bundled skill
- `readSessionToken()` — imported by CLI files and doordash bundled skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
