### PR TITLE
fix: handle unsupported client settings keys and missing schedule toggle targets

### DIFF
--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -50,7 +50,10 @@ function handleListSchedules(): Response {
 
 function handleToggleSchedule(id: string, enabled: boolean): Response {
   try {
-    updateSchedule(id, { enabled });
+    const updated = updateSchedule(id, { enabled });
+    if (!updated) {
+      return httpError("NOT_FOUND", "Schedule not found", 404);
+    }
     log.info({ id, enabled }, "Schedule toggled via HTTP");
   } catch (err) {
     log.error({ err }, "Failed to toggle schedule");

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -122,14 +122,17 @@ async function handleGenerateAvatar(description: string): Promise<Response> {
 // Client settings update (generic)
 // ---------------------------------------------------------------------------
 
+const SUPPORTED_CLIENT_SETTINGS_KEYS = new Set(["activationKey"]);
+
 function handleClientSettingsUpdate(key: string, value: string): Response {
-  // The HTTP route accepts key/value pairs for client settings.
-  // Validation is key-specific.
   if (key === "activationKey") {
     return handleVoiceConfigUpdate(value);
   }
-  // For other keys, accept as-is
-  return Response.json({ ok: true, key, value });
+  return httpError(
+    "BAD_REQUEST",
+    `Unsupported client setting key: "${key}". Supported keys: ${[...SUPPORTED_CLIENT_SETTINGS_KEYS].join(", ")}`,
+    400,
+  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Address review feedback from #14424:
- Return error for unsupported client settings keys instead of silently accepting
- Return 404 when toggling a non-existent schedule instead of silently succeeding
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
