### PR TITLE
fix: make modelSetContext lazy to avoid stale suppressConfigReload

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -425,7 +425,7 @@ export async function runDaemon(): Promise<void> {
       },
       findSession: (sessionId) => server.findSession(sessionId),
       getSkillContext: () => server.getSkillContext(),
-      modelSetContext: server.getHandlerContext(),
+      getModelSetContext: () => server.getHandlerContext(),
       sessionManagementDeps: {
         switchSession: (sessionId) =>
           switchSession(sessionId, server.getHandlerContext()),

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -209,7 +209,7 @@ export class RuntimeHttpServer {
   private findSession?: RuntimeHttpServerOptions["findSession"];
   private getSkillContext?: RuntimeHttpServerOptions["getSkillContext"];
   private sessionManagementDeps?: RuntimeHttpServerOptions["sessionManagementDeps"];
-  private modelSetContext?: RuntimeHttpServerOptions["modelSetContext"];
+  private getModelSetContext?: RuntimeHttpServerOptions["getModelSetContext"];
   private getComputerUseDeps?: RuntimeHttpServerOptions["getComputerUseDeps"];
   private getRecordingDeps?: RuntimeHttpServerOptions["getRecordingDeps"];
   private router: HttpRouter;
@@ -229,7 +229,7 @@ export class RuntimeHttpServer {
     this.findSession = options.findSession;
     this.getSkillContext = options.getSkillContext;
     this.sessionManagementDeps = options.sessionManagementDeps;
-    this.modelSetContext = options.modelSetContext;
+    this.getModelSetContext = options.getModelSetContext;
     this.getComputerUseDeps = options.getComputerUseDeps;
     this.getRecordingDeps = options.getRecordingDeps;
     this.router = new HttpRouter(this.buildRouteTable());
@@ -735,7 +735,7 @@ export class RuntimeHttpServer {
       ),
       ...subagentRouteDefinitions(),
       ...sessionQueryRouteDefinitions({
-        modelSetContext: this.modelSetContext,
+        getModelSetContext: this.getModelSetContext,
         findSessionForQueue: this.findSession
           ? (id) => {
               const s = this.findSession!(id);

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -204,8 +204,8 @@ export interface RuntimeHttpServerOptions {
     | undefined;
   /** Dependencies for session management HTTP routes (switch, rename, clear, cancel, undo, regenerate). */
   sessionManagementDeps?: SessionManagementDeps;
-  /** Context for model config set operations (session eviction, config reload suppression). */
-  modelSetContext?: import("../daemon/handlers/config-model.js").ModelSetContext;
+  /** Lazy factory for model config set context (session eviction, config reload suppression). */
+  getModelSetContext?: () => import("../daemon/handlers/config-model.js").ModelSetContext;
   /** Provider for computer-use session dependencies (CU routes). */
   getComputerUseDeps?: () => import("./routes/computer-use-routes.js").ComputerUseDeps;
   /** Provider for recording dependencies (recording routes). */

--- a/assistant/src/runtime/routes/session-query-routes.ts
+++ b/assistant/src/runtime/routes/session-query-routes.ts
@@ -32,8 +32,8 @@ import type { RouteDefinition } from "../http-router.js";
 // ---------------------------------------------------------------------------
 
 export interface SessionQueryRouteDeps {
-  /** Context for model set operations (config reload suppression, session eviction). */
-  modelSetContext?: ModelSetContext;
+  /** Lazy factory for model set context (config reload suppression, session eviction). */
+  getModelSetContext?: () => ModelSetContext;
   /** Lookup an active session by ID for queued message deletion. */
   findSessionForQueue?: (
     id: string,
@@ -63,7 +63,7 @@ export function sessionQueryRouteDefinitions(
       method: "PUT",
       policyKey: "model",
       handler: async ({ req }) => {
-        if (!deps.modelSetContext) {
+        if (!deps.getModelSetContext) {
           return httpError(
             "INTERNAL_ERROR",
             "Model set not available",
@@ -75,7 +75,7 @@ export function sessionQueryRouteDefinitions(
           return httpError("BAD_REQUEST", "Missing required field: modelId", 400);
         }
         try {
-          const info = setModel(body.modelId, deps.modelSetContext);
+          const info = setModel(body.modelId, deps.getModelSetContext());
           return Response.json(info);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
@@ -92,7 +92,7 @@ export function sessionQueryRouteDefinitions(
       method: "PUT",
       policyKey: "model/image-gen",
       handler: async ({ req }) => {
-        if (!deps.modelSetContext) {
+        if (!deps.getModelSetContext) {
           return httpError(
             "INTERNAL_ERROR",
             "Image gen model set not available",
@@ -104,7 +104,7 @@ export function sessionQueryRouteDefinitions(
           return httpError("BAD_REQUEST", "Missing required field: modelId", 400);
         }
         try {
-          setImageGenModel(body.modelId, deps.modelSetContext);
+          setImageGenModel(body.modelId, deps.getModelSetContext());
           return Response.json({ ok: true });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Address review feedback from #14441:
- Change modelSetContext from eagerly-captured value to lazy getter so suppressConfigReload is read at call time instead of startup time
- Rename to getModelSetContext throughout the chain (http-types, http-server, session-query-routes, lifecycle)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
