### PR TITLE
fix: pass nil sessionId in synthesized UiSurfaceShowMessage for app-open

### DIFF
--- a/clients/shared/IPC/HTTPDaemonClient+Apps.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Apps.swift
@@ -199,7 +199,7 @@ extension HTTPTransport {
             let rest = try decoder.decode(RESTAppOpenResponse.self, from: data)
             let surfaceId = "app-\(rest.appId)"
             let surfaceMessage = UiSurfaceShowMessage(
-                sessionId: "",
+                sessionId: nil,
                 surfaceId: surfaceId,
                 surfaceType: "dynamic_page",
                 title: rest.name,

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -913,7 +913,7 @@ public typealias DaemonStatusMessage = IPCDaemonStatusMessage
 /// Surface show command from daemon.
 /// Wire type: `"ui_surface_show"`
 public struct UiSurfaceShowMessage: Decodable, Sendable {
-    public let sessionId: String
+    public let sessionId: String?
     public let surfaceId: String
     public let surfaceType: String
     public let title: String?
@@ -924,7 +924,7 @@ public struct UiSurfaceShowMessage: Decodable, Sendable {
     /// The message ID that this surface belongs to (for history loading).
     public let messageId: String?
 
-    public init(sessionId: String, surfaceId: String, surfaceType: String, title: String?, data: AnyCodable, actions: [SurfaceActionData]?, display: String?, messageId: String?) {
+    public init(sessionId: String?, surfaceId: String, surfaceType: String, title: String?, data: AnyCodable, actions: [SurfaceActionData]?, display: String?, messageId: String?) {
         self.sessionId = sessionId
         self.surfaceId = surfaceId
         self.surfaceType = surfaceType


### PR DESCRIPTION
Address review feedback from #14448:
- Change sessionId from empty string to nil in handleAppOpen's UiSurfaceShowMessage so the belongsToSession nil-bypass triggers correctly
- Change UiSurfaceShowMessage.sessionId type from String to String? to allow nil
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
