### PR TITLE
fix: use configured host for daemon HTTP health check

### DIFF
--- a/assistant/src/daemon/daemon-control.ts
+++ b/assistant/src/daemon/daemon-control.ts
@@ -10,7 +10,7 @@ import {
 } from "node:fs";
 import { join, resolve } from "node:path";
 
-import { getRuntimeHttpPort } from "../config/env.js";
+import { getRuntimeHttpHost, getRuntimeHttpPort } from "../config/env.js";
 import { DaemonError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
@@ -133,9 +133,10 @@ function isVellumDaemonProcess(pid: number): boolean {
  *  with HTTP 200 within the timeout — false on connection refused, timeout,
  *  or any other error. */
 async function isHttpHealthy(): Promise<boolean> {
+  const host = getRuntimeHttpHost();
   const port = getRuntimeHttpPort();
   try {
-    const response = await fetch(`http://127.0.0.1:${port}/healthz`, {
+    const response = await fetch(`http://${host}:${port}/healthz`, {
       signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
     });
     return response.ok;


### PR DESCRIPTION
Address review feedback from #14480:
- Replace hardcoded 127.0.0.1 with getRuntimeHttpHost() in isHttpHealthy() so health checks target the correct host when RUNTIME_HTTP_HOST is overridden
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
