### PR TITLE
fix: remove duplicate pairing event publish after IPC removal

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -53,8 +53,6 @@ import {
 } from "../security/oauth-callback-registry.js";
 import { UserError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
-import { buildAssistantEvent } from "./assistant-event.js";
-import { assistantEventHub } from "./assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 // Auth
 import { authenticateRequest } from "./auth/middleware.js";
@@ -273,9 +271,6 @@ export class RuntimeHttpServer {
             // Broadcast to all clients via the event hub so HTTP/SSE clients
             // (e.g. macOS app) receive pairing approval requests.
             ipcBroadcast(msg);
-            void assistantEventHub.publish(
-              buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg),
-            );
           }
         : undefined,
     };


### PR DESCRIPTION
Address review feedback from #14450:
- Remove redundant direct assistantEventHub.publish call in pairingContext getter since ipcBroadcast already routes through server.broadcast -> publishAssistantEvent -> assistantEventHub.publish
- Remove now-unused buildAssistantEvent and assistantEventHub imports
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
