### PR TITLE
fix: only deduplicate state signals when onStateSignal listener is wired

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -437,11 +437,17 @@ export async function runDaemon(): Promise<void> {
           undoLastMessage(sessionId, server.getHandlerContext()),
         regenerateResponse: (sessionId) => {
           let hubChain: Promise<void> = Promise.resolve();
+          const session = server
+            .getHandlerContext()
+            .sessions.get(sessionId);
           const sendEvent = (event: ServerMessage) => {
-            // Skip state-signal events — these are already published to the
-            // hub by session.onStateSignal (set in conversation-routes.ts).
-            // Publishing them here too would duplicate SSE state transitions.
+            // Skip state-signal events only when the session has an
+            // onStateSignal listener wired (set in conversation-routes.ts),
+            // since that listener already publishes them to the hub.
+            // Without the listener (e.g. IPC-originated sessions regenerated
+            // via HTTP), we must let these events through to avoid silent loss.
             if (
+              session?.hasStateSignalListener &&
               "type" in event &&
               (event.type === "assistant_activity_state" ||
                 event.type === "confirmation_state_changed")

--- a/assistant/src/daemon/session.ts
+++ b/assistant/src/daemon/session.ts
@@ -403,6 +403,10 @@ export class Session {
     this.onStateSignal = listener;
   }
 
+  get hasStateSignalListener(): boolean {
+    return this.onStateSignal !== undefined;
+  }
+
   setSandboxOverride(enabled: boolean | undefined): void {
     this.sandboxOverride = enabled;
   }


### PR DESCRIPTION
Address review feedback from #14465:
- Make the state-signal dedup filter conditional on session.hasStateSignalListener
- Prevents silent loss of activity/confirmation state events during HTTP regenerate for sessions without onStateSignal wired (e.g. IPC-originated sessions)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
