### PR TITLE
fix: remove dead net.Socket params from daemon handler infrastructure

### DIFF
--- a/assistant/src/__tests__/channel-guardian.test.ts
+++ b/assistant/src/__tests__/channel-guardian.test.ts
@@ -30,8 +30,6 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import type * as net from "node:net";
-
 mock.module("../config/env.js", () => ({
   isHttpAuthDisabled: () => true,
   getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
@@ -1318,7 +1316,7 @@ function createMockCtx(): {
     suppressConfigReload: false,
     setSuppressConfigReload: () => {},
     updateConfigFingerprint: () => {},
-    send: (_socket: net.Socket, msg: unknown) => {
+    send: (msg: unknown) => {
       captured = msg as ChannelVerificationSessionResponse;
     },
     broadcast: () => {},
@@ -1329,7 +1327,6 @@ function createMockCtx(): {
   return { ctx, lastResponse: () => captured };
 }
 
-const mockSocket = {} as net.Socket;
 
 describe("IPC handler channel-aware guardian status", () => {
   beforeEach(() => {
@@ -1344,7 +1341,7 @@ describe("IPC handler channel-aware guardian status", () => {
       channel: "telegram",
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -1363,7 +1360,7 @@ describe("IPC handler channel-aware guardian status", () => {
       channel: "phone",
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -1388,7 +1385,7 @@ describe("IPC handler channel-aware guardian status", () => {
       channel: "telegram",
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -1440,7 +1437,7 @@ describe("IPC handler channel-aware guardian status", () => {
       channel: "telegram",
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -1456,7 +1453,7 @@ describe("IPC handler channel-aware guardian status", () => {
       // channel omitted — should default to 'telegram'
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -1473,7 +1470,7 @@ describe("IPC handler channel-aware guardian status", () => {
       // assistantId omitted — should default to 'self'
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -1489,7 +1486,7 @@ describe("IPC handler channel-aware guardian status", () => {
       channel: "phone",
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -1508,7 +1505,7 @@ describe("IPC handler channel-aware guardian status", () => {
       channel: "phone",
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -1524,7 +1521,7 @@ describe("IPC handler channel-aware guardian status", () => {
       channel: "phone",
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -1973,7 +1970,7 @@ describe("IPC handler voice guardian verification", () => {
       channel: "phone",
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -1993,7 +1990,7 @@ describe("IPC handler voice guardian verification", () => {
       channel: "phone",
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -2018,7 +2015,7 @@ describe("IPC handler voice guardian verification", () => {
       channel: "phone",
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -2044,7 +2041,7 @@ describe("IPC handler voice guardian verification", () => {
       channel: "phone",
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -2076,7 +2073,7 @@ describe("IPC handler voice guardian verification", () => {
       channel: "phone",
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     expect(getGuardianBinding("self", "phone")).toBeNull();
     expect(getGuardianBinding("self", "telegram")).not.toBeNull();
@@ -2560,7 +2557,7 @@ describe("outbound voice verification", () => {
       destination: "+15551234567",
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -2597,7 +2594,7 @@ describe("outbound voice verification", () => {
       rebind: false,
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -2623,7 +2620,7 @@ describe("outbound voice verification", () => {
       rebind: true,
     };
 
-    await handleChannelVerificationSession(msg, mockSocket, ctx);
+    await handleChannelVerificationSession(msg, ctx);
 
     const resp = lastResponse();
     expect(resp).not.toBeNull();
@@ -2641,7 +2638,6 @@ describe("outbound voice verification", () => {
         channel: "phone",
         destination: "+15551234567",
       },
-      mockSocket,
       startCtx,
     );
 
@@ -2653,7 +2649,6 @@ describe("outbound voice verification", () => {
         action: "resend_session",
         channel: "phone",
       },
-      mockSocket,
       ctx,
     );
 
@@ -2673,7 +2668,6 @@ describe("outbound voice verification", () => {
         channel: "phone",
         destination: "+15551234567",
       },
-      mockSocket,
       startCtx,
     );
 
@@ -2698,7 +2692,6 @@ describe("outbound voice verification", () => {
         action: "resend_session",
         channel: "phone",
       },
-      mockSocket,
       ctx,
     );
 
@@ -2719,7 +2712,6 @@ describe("outbound voice verification", () => {
         channel: "phone",
         destination: "+15551234567",
       },
-      mockSocket,
       startCtx,
     );
 
@@ -2741,7 +2733,6 @@ describe("outbound voice verification", () => {
         action: "resend_session",
         channel: "phone",
       },
-      mockSocket,
       ctx,
     );
 
@@ -2761,7 +2752,6 @@ describe("outbound voice verification", () => {
         channel: "phone",
         destination: "+15551234567",
       },
-      mockSocket,
       startCtx,
     );
 
@@ -2777,7 +2767,6 @@ describe("outbound voice verification", () => {
         action: "cancel_session",
         channel: "phone",
       },
-      mockSocket,
       ctx,
     );
 
@@ -2849,7 +2838,6 @@ describe("outbound voice verification", () => {
         channel: "email",
         destination: "user@example.com",
       },
-      mockSocket,
       ctx,
     );
 
@@ -2868,7 +2856,6 @@ describe("outbound voice verification", () => {
         channel: "phone",
         // no destination — unified create_session creates an inbound challenge
       },
-      mockSocket,
       ctx,
     );
 
@@ -2887,7 +2874,6 @@ describe("outbound voice verification", () => {
         channel: "phone",
         destination: "not-a-phone",
       },
-      mockSocket,
       ctx,
     );
 
@@ -2906,7 +2892,6 @@ describe("outbound voice verification", () => {
         channel: "phone",
         destination: "(555) 123-4567",
       },
-      mockSocket,
       ctx,
     );
 
@@ -2939,7 +2924,6 @@ describe("outbound voice verification", () => {
         action: "cancel_session",
         channel: "phone",
       },
-      mockSocket,
       ctx,
     );
 
@@ -2967,7 +2951,6 @@ describe("outbound Telegram verification", () => {
         channel: "telegram",
         destination: "@someuser",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3002,7 +2985,6 @@ describe("outbound Telegram verification", () => {
         channel: "telegram",
         destination: "someuser",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3024,7 +3006,6 @@ describe("outbound Telegram verification", () => {
         channel: "telegram",
         destination: "123456789",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3065,7 +3046,6 @@ describe("outbound Telegram verification", () => {
         channel: "telegram",
         destination: "@someuser",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3092,7 +3072,6 @@ describe("outbound Telegram verification", () => {
         destination: "@newuser",
         rebind: false,
       },
-      mockSocket,
       ctx,
     );
 
@@ -3255,7 +3234,6 @@ describe("outbound Telegram verification", () => {
         channel: "telegram",
         destination: "123456789",
       },
-      mockSocket,
       startCtx,
     );
 
@@ -3276,7 +3254,6 @@ describe("outbound Telegram verification", () => {
         action: "resend_session",
         channel: "telegram",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3301,7 +3278,6 @@ describe("outbound Telegram verification", () => {
         channel: "telegram",
         destination: "@someuser",
       },
-      mockSocket,
       startCtx,
     );
 
@@ -3312,7 +3288,6 @@ describe("outbound Telegram verification", () => {
         action: "resend_session",
         channel: "telegram",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3332,7 +3307,6 @@ describe("outbound Telegram verification", () => {
         channel: "telegram",
         destination: "123456789",
       },
-      mockSocket,
       startCtx,
     );
 
@@ -3346,7 +3320,6 @@ describe("outbound Telegram verification", () => {
         action: "cancel_session",
         channel: "telegram",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3395,7 +3368,6 @@ describe("outbound Telegram verification", () => {
         action: "create_session",
         channel: "telegram",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3415,7 +3387,6 @@ describe("outbound Telegram verification", () => {
         channel: "telegram",
         destination: "123456789",
       },
-      mockSocket,
       startCtx,
     );
 
@@ -3437,7 +3408,6 @@ describe("outbound Telegram verification", () => {
         action: "resend_session",
         channel: "telegram",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3457,7 +3427,6 @@ describe("outbound Telegram verification", () => {
         channel: "telegram",
         destination: "123456789",
       },
-      mockSocket,
       startCtx,
     );
 
@@ -3469,7 +3438,6 @@ describe("outbound Telegram verification", () => {
         action: "resend_session",
         channel: "telegram",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3498,7 +3466,6 @@ describe("outbound voice verification", () => {
         channel: "phone",
         destination: "+15551234567",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3540,7 +3507,6 @@ describe("outbound voice verification", () => {
         channel: "phone",
         destination: "not-a-phone",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3559,7 +3525,6 @@ describe("outbound voice verification", () => {
         channel: "phone",
         destination: "555-123-4567",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3603,7 +3568,6 @@ describe("outbound voice verification", () => {
         destination: "+15559876543",
         rebind: false,
       },
-      mockSocket,
       ctx,
     );
 
@@ -3623,7 +3587,6 @@ describe("outbound voice verification", () => {
         channel: "phone",
         destination: "+15551234567",
       },
-      mockSocket,
       startCtx,
     );
 
@@ -3635,7 +3598,6 @@ describe("outbound voice verification", () => {
         action: "resend_session",
         channel: "phone",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3655,7 +3617,6 @@ describe("outbound voice verification", () => {
         channel: "phone",
         destination: "+15551234567",
       },
-      mockSocket,
       startCtx,
     );
 
@@ -3667,7 +3628,6 @@ describe("outbound voice verification", () => {
         action: "cancel_session",
         channel: "phone",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3710,7 +3670,6 @@ describe("outbound voice verification", () => {
         channel: "phone",
         destination: "+15551234567",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3728,7 +3687,6 @@ describe("outbound voice verification", () => {
         action: "create_session",
         channel: "phone",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3765,7 +3723,6 @@ describe("M1–M4 hardening coverage", () => {
         channel: "phone",
         destination: "+15551234567",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3789,7 +3746,6 @@ describe("M1–M4 hardening coverage", () => {
         channel: "phone",
         destination: "+15551234567",
       },
-      mockSocket,
       startCtx,
     );
 
@@ -3811,7 +3767,6 @@ describe("M1–M4 hardening coverage", () => {
         action: "resend_session",
         channel: "phone",
       },
-      mockSocket,
       ctx,
     );
 
@@ -3834,7 +3789,6 @@ describe("M1–M4 hardening coverage", () => {
         channel: "telegram",
         destination: "@someuser",
       },
-      mockSocket,
       ctx,
     );
 

--- a/assistant/src/__tests__/daemon-assistant-events.test.ts
+++ b/assistant/src/__tests__/daemon-assistant-events.test.ts
@@ -6,7 +6,6 @@
  *   - send()      → one mirrored assistant event per message
  *   - broadcast() → one mirrored assistant event per message (not per socket)
  */
-import * as net from "node:net";
 import { describe, expect, mock, test } from "bun:test";
 
 // ── Platform mock (must happen before imports that read it) ─────────────────
@@ -45,16 +44,6 @@ import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-function makeFakeSocket(destroyed = false): net.Socket {
-  const s = Object.create(net.Socket.prototype) as net.Socket;
-  Object.assign(s, {
-    destroyed,
-    write: () => true,
-    on: () => s,
-  });
-  return s;
-}
 
 // ── buildAssistantEvent factory ───────────────────────────────────────────────
 
@@ -115,7 +104,7 @@ describe("daemon send → one mirrored assistant event", () => {
     expect(received[0].message.type).toBe("assistant_text_delta");
   });
 
-  test("sessionId falls back to socket binding when message lacks it", async () => {
+  test("sessionId falls back to explicit parameter when message lacks it", async () => {
     const hub = new AssistantEventHub();
     const received: AssistantEvent[] = [];
 
@@ -123,19 +112,13 @@ describe("daemon send → one mirrored assistant event", () => {
       received.push(e);
     });
 
-    // Simulate server.ts resolving sessionId from socket→session map
-    const socketSessionMap = new Map<object, string>();
-    const fakeSocket = makeFakeSocket();
-    socketSessionMap.set(fakeSocket, "sess_from_socket");
-
     const msg: ServerMessage = { type: "pong" }; // no sessionId field
-    const sessionId = socketSessionMap.get(fakeSocket);
-    const event = buildAssistantEvent("ast_ipc", msg, sessionId);
+    const event = buildAssistantEvent("ast_ipc", msg, "sess_explicit");
 
     await hub.publish(event);
 
     expect(received).toHaveLength(1);
-    expect(received[0].sessionId).toBe("sess_from_socket");
+    expect(received[0].sessionId).toBe("sess_explicit");
   });
 });
 

--- a/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
+++ b/assistant/src/__tests__/handle-user-message-secret-resume.test.ts
@@ -1,4 +1,3 @@
-import * as net from "node:net";
 import { describe, expect, mock, test } from "bun:test";
 
 const actualEnv = await import("../config/env.js");
@@ -133,7 +132,7 @@ describe("handleUserMessage secret redirect continuation", () => {
       sessions: new Map(),
       cuSessions: new Map(),
       getOrCreateSession: async () => session,
-      send: (_socket: net.Socket, message: Record<string, unknown>) => {
+      send: (message: Record<string, unknown>) => {
         sentMessages.push(message);
       },
     };
@@ -146,7 +145,6 @@ describe("handleUserMessage secret redirect continuation", () => {
           "Set up Telegram with my bot token 123456789:ABCDefGHIJklmnopQRSTuvwxyz012345678",
         interface: "cli",
       },
-      new net.Socket(),
       ctx as never,
     );
 

--- a/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
+++ b/assistant/src/__tests__/handlers-user-message-approval-consumption.test.ts
@@ -1,4 +1,3 @@
-import * as net from "node:net";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
@@ -252,7 +251,7 @@ function createContext(session: TestSession): {
     suppressConfigReload: false,
     setSuppressConfigReload: () => {},
     updateConfigFingerprint: () => {},
-    send: (_socket, msg) => {
+    send: (msg) => {
       sent.push(msg);
     },
     broadcast: () => {},
@@ -338,7 +337,7 @@ describe("handleUserMessage pending-confirmation reply interception", () => {
     const session = makeSession();
     const { ctx, sent } = createContext(session);
 
-    await handleUserMessage(makeMessage("go for it"), {} as net.Socket, ctx);
+    await handleUserMessage(makeMessage("go for it"), ctx);
 
     expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
     const routeCall = (routeGuardianReplyMock as any).mock
@@ -414,7 +413,7 @@ describe("handleUserMessage pending-confirmation reply interception", () => {
     });
     const { ctx } = createContext(session);
 
-    await handleUserMessage(makeMessage("approve"), {} as net.Socket, ctx);
+    await handleUserMessage(makeMessage("approve"), ctx);
 
     expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
     expect((session.denyAllPendingConfirmations as any).mock.calls.length).toBe(
@@ -438,7 +437,7 @@ describe("handleUserMessage pending-confirmation reply interception", () => {
     const session = makeSession({ isProcessing: () => true });
     const { ctx, sent } = createContext(session);
 
-    await handleUserMessage(makeMessage("approve"), {} as net.Socket, ctx);
+    await handleUserMessage(makeMessage("approve"), ctx);
 
     expect(addMessageMock).toHaveBeenCalledTimes(2);
     expect(session.messages).toHaveLength(0);
@@ -475,11 +474,7 @@ describe("handleUserMessage pending-confirmation reply interception", () => {
     const session = makeSession();
     const { ctx, sent } = createContext(session);
 
-    await handleUserMessage(
-      makeMessage("what does that do?"),
-      {} as net.Socket,
-      ctx,
-    );
+    await handleUserMessage(makeMessage("what does that do?"), ctx);
 
     expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
     expect((session.denyAllPendingConfirmations as any).mock.calls.length).toBe(
@@ -520,7 +515,7 @@ describe("handleUserMessage pending-confirmation reply interception", () => {
     });
 
     const { ctx } = createContext(session);
-    await handleUserMessage(makeMessage("allow"), {} as net.Socket, ctx);
+    await handleUserMessage(makeMessage("allow"), ctx);
 
     expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
     const routeCall = (routeGuardianReplyMock as any).mock
@@ -560,11 +555,7 @@ describe("handleUserMessage pending-confirmation reply interception", () => {
     });
     const { ctx, sent } = createContext(session);
 
-    await handleUserMessage(
-      makeMessage("please call now"),
-      {} as net.Socket,
-      ctx,
-    );
+    await handleUserMessage(makeMessage("please call now"), ctx);
 
     expect(registerMock).toHaveBeenCalledTimes(1);
     expect(registerMock).toHaveBeenCalledWith(
@@ -623,11 +614,7 @@ describe("handleUserMessage pending-confirmation reply interception", () => {
     });
     const { ctx, sent } = createContext(session);
 
-    await handleUserMessage(
-      makeMessage("please call now"),
-      {} as net.Socket,
-      ctx,
-    );
+    await handleUserMessage(makeMessage("please call now"), ctx);
 
     expect(registerMock).toHaveBeenCalledWith(
       "req-prompter-1",
@@ -666,7 +653,7 @@ describe("handleUserMessage pending-confirmation reply interception", () => {
       decision: "always_allow",
     };
 
-    handleConfirmationResponse(msg, {} as net.Socket, ctx);
+    handleConfirmationResponse(msg, ctx);
 
     expect((session.handleConfirmationResponse as any).mock.calls.length).toBe(
       1,
@@ -708,7 +695,7 @@ describe("handleUserMessage pending-confirmation reply interception", () => {
       decision: "always_deny",
     };
 
-    handleConfirmationResponse(msg, {} as net.Socket, ctx);
+    handleConfirmationResponse(msg, ctx);
 
     expect(
       (cuSession.handleConfirmationResponse as any).mock.calls.length,

--- a/assistant/src/__tests__/recording-handler.test.ts
+++ b/assistant/src/__tests__/recording-handler.test.ts
@@ -1,4 +1,3 @@
-import * as net from "node:net";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ─── Mocks (must be before any imports that depend on them) ─────────────────
@@ -166,10 +165,8 @@ import { DebouncerMap } from "../util/debounce.js";
 function createCtx(): {
   ctx: HandlerContext;
   sent: Array<{ type: string; [k: string]: unknown }>;
-  fakeSocket: net.Socket;
 } {
   const sent: Array<{ type: string; [k: string]: unknown }> = [];
-  const fakeSocket = {} as net.Socket;
 
   const ctx: HandlerContext = {
     sessions: new Map(),
@@ -180,7 +177,7 @@ function createCtx(): {
     suppressConfigReload: false,
     setSuppressConfigReload: noop,
     updateConfigFingerprint: noop,
-    send: (_socket, msg) => {
+    send: (msg) => {
       sent.push(msg as { type: string; [k: string]: unknown });
     },
     broadcast: (msg) => {
@@ -193,7 +190,7 @@ function createCtx(): {
     touchSession: noop,
   };
 
-  return { ctx, sent, fakeSocket };
+  return { ctx, sent };
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -368,7 +365,7 @@ describe("recordingHandlers.recording_status", () => {
   });
 
   test("handles started status without errors", async () => {
-    const { ctx, fakeSocket } = createCtx();
+    const { ctx } = createCtx();
     const conversationId = "conv-status-1";
 
     const recordingId = handleRecordingStart(
@@ -385,11 +382,11 @@ describe("recordingHandlers.recording_status", () => {
     };
 
     // Should not throw
-    await recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+    await recordingHandlers.recording_status(statusMsg, ctx);
   });
 
   test("handles stopped status with file — creates attachment and notifies client", async () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-status-stopped";
 
     // Bind socket
@@ -417,7 +414,7 @@ describe("recordingHandlers.recording_status", () => {
       durationMs: 5000,
     };
 
-    await recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+    await recordingHandlers.recording_status(statusMsg, ctx);
 
     // Should have sent assistant_text_delta and message_complete
     const textDeltas = sent.filter((m) => m.type === "assistant_text_delta");
@@ -442,7 +439,7 @@ describe("recordingHandlers.recording_status", () => {
   });
 
   test("handles stopped status and creates assistant message when none exists", async () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-status-no-msg";
 
 
@@ -464,7 +461,7 @@ describe("recordingHandlers.recording_status", () => {
       durationMs: 3000,
     };
 
-    await recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+    await recordingHandlers.recording_status(statusMsg, ctx);
 
     // An assistant message should have been created via addMessage mock
     expect(mockMessages.length).toBeGreaterThanOrEqual(1);
@@ -473,7 +470,7 @@ describe("recordingHandlers.recording_status", () => {
   });
 
   test("handles stopped status when file does not exist — notifies client", async () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-status-no-file";
 
     mockFileExists = false;
@@ -495,7 +492,7 @@ describe("recordingHandlers.recording_status", () => {
     };
 
     // Should not throw — the handler logs the error and notifies the client
-    await recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+    await recordingHandlers.recording_status(statusMsg, ctx);
 
     // No attachment should have been created
     expect(mockAttachments.length).toBe(0);
@@ -511,7 +508,7 @@ describe("recordingHandlers.recording_status", () => {
   });
 
   test("handles stopped status with zero-length file — treated as failure", async () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-status-zero-file";
 
     mockFileExists = true;
@@ -533,7 +530,7 @@ describe("recordingHandlers.recording_status", () => {
       durationMs: 2000,
     };
 
-    await recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+    await recordingHandlers.recording_status(statusMsg, ctx);
 
     // No attachment should have been created for a zero-length file
     expect(mockAttachments.length).toBe(0);
@@ -556,7 +553,7 @@ describe("recordingHandlers.recording_status", () => {
   });
 
   test("successful finalization — attachment created and success message sent", async () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-status-success";
 
     mockFileExists = true;
@@ -578,7 +575,7 @@ describe("recordingHandlers.recording_status", () => {
       durationMs: 5000,
     };
 
-    await recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+    await recordingHandlers.recording_status(statusMsg, ctx);
 
     // Attachment should have been created
     expect(mockAttachments.length).toBe(1);
@@ -597,7 +594,7 @@ describe("recordingHandlers.recording_status", () => {
   });
 
   test("rejects file path outside allowed directory", async () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-status-outside-dir";
 
     mockFileExists = true;
@@ -619,7 +616,7 @@ describe("recordingHandlers.recording_status", () => {
       durationMs: 5000,
     };
 
-    await recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+    await recordingHandlers.recording_status(statusMsg, ctx);
 
     // No attachment should have been created — path is outside allowlist
     expect(mockAttachments.length).toBe(0);
@@ -637,7 +634,7 @@ describe("recordingHandlers.recording_status", () => {
   });
 
   test("failed finalization — failure status sent and no success message", async () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-status-fail-final";
 
 
@@ -657,7 +654,7 @@ describe("recordingHandlers.recording_status", () => {
       error: "Video writer finished with non-completed status 3",
     };
 
-    await recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+    await recordingHandlers.recording_status(statusMsg, ctx);
 
     // No attachment should have been created
     expect(mockAttachments.length).toBe(0);
@@ -676,7 +673,7 @@ describe("recordingHandlers.recording_status", () => {
   });
 
   test("handles failed status and notifies client", async () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-status-failed";
 
 
@@ -695,7 +692,7 @@ describe("recordingHandlers.recording_status", () => {
       error: "Permission denied",
     };
 
-    await recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+    await recordingHandlers.recording_status(statusMsg, ctx);
 
     // Should send error notification
     const textDeltas = sent.filter((m) => m.type === "assistant_text_delta");
@@ -708,7 +705,7 @@ describe("recordingHandlers.recording_status", () => {
   });
 
   test("handles failed status with no error message", async () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-status-failed-no-err";
 
 
@@ -726,7 +723,7 @@ describe("recordingHandlers.recording_status", () => {
       status: "failed",
     };
 
-    await recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+    await recordingHandlers.recording_status(statusMsg, ctx);
 
     const textDeltas = sent.filter((m) => m.type === "assistant_text_delta");
     expect(textDeltas.length).toBeGreaterThanOrEqual(1);
@@ -734,7 +731,7 @@ describe("recordingHandlers.recording_status", () => {
   });
 
   test("handles status with attachToConversationId fallback", async () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-fallback";
 
 
@@ -749,7 +746,7 @@ describe("recordingHandlers.recording_status", () => {
     };
 
     // Should not throw — uses attachToConversationId as fallback
-    await recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+    await recordingHandlers.recording_status(statusMsg, ctx);
 
     const textDeltas = sent.filter((m) => m.type === "assistant_text_delta");
     expect(textDeltas.length).toBeGreaterThanOrEqual(1);

--- a/assistant/src/__tests__/recording-state-machine.test.ts
+++ b/assistant/src/__tests__/recording-state-machine.test.ts
@@ -1,4 +1,3 @@
-import * as net from "node:net";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ─── Mocks (must be before any imports that depend on them) ─────────────────
@@ -147,10 +146,8 @@ const ALLOWED_RECORDINGS_DIR = `${process.env.HOME}/Library/Application Support/
 function createCtx(): {
   ctx: HandlerContext;
   sent: Array<{ type: string; [k: string]: unknown }>;
-  fakeSocket: net.Socket;
 } {
   const sent: Array<{ type: string; [k: string]: unknown }> = [];
-  const fakeSocket = {} as net.Socket;
 
   const ctx: HandlerContext = {
     sessions: new Map(),
@@ -161,7 +158,7 @@ function createCtx(): {
     suppressConfigReload: false,
     setSuppressConfigReload: noop,
     updateConfigFingerprint: noop,
-    send: (_socket, msg) => {
+    send: (msg) => {
       sent.push(msg as { type: string; [k: string]: unknown });
     },
     broadcast: (msg) => {
@@ -174,7 +171,7 @@ function createCtx(): {
     touchSession: noop,
   };
 
-  return { ctx, sent, fakeSocket };
+  return { ctx, sent };
 }
 
 // ─── Restart state machine tests ────────────────────────────────────────────
@@ -187,7 +184,7 @@ describe("handleRecordingRestart", () => {
   });
 
   test("sends recording_stop and defers start until stop-ack", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-restart-1";
 
     // Start a recording first
@@ -218,7 +215,7 @@ describe("handleRecordingRestart", () => {
       status: "stopped",
       attachToConversationId: conversationId,
     };
-    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(stoppedStatus, ctx);
 
     // NOW the deferred recording_start should have been sent
     const startMsgsAfterAck = sent.filter((m) => m.type === "recording_start");
@@ -237,7 +234,7 @@ describe("handleRecordingRestart", () => {
   });
 
   test("generates unique operation token for each restart", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-restart-unique";
 
     // First restart cycle
@@ -255,7 +252,7 @@ describe("handleRecordingRestart", () => {
       status: "stopped",
       attachToConversationId: conversationId,
     };
-    recordingHandlers.recording_status(stoppedStatus1, fakeSocket, ctx);
+    recordingHandlers.recording_status(stoppedStatus1, ctx);
 
     // Simulate the first restart completing (started status)
     const startMsg1 = sent.filter((m) => m.type === "recording_start").pop();
@@ -265,7 +262,7 @@ describe("handleRecordingRestart", () => {
       status: "started",
       operationToken: result1.operationToken,
     };
-    recordingHandlers.recording_status(status1, fakeSocket, ctx);
+    recordingHandlers.recording_status(status1, ctx);
 
     // Second restart cycle
     sent.length = 0;
@@ -285,7 +282,7 @@ describe("restart_cancelled status", () => {
   });
 
   test('emits restart_cancelled response, never "new recording started"', () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-cancel-1";
 
     // Start -> restart
@@ -307,7 +304,7 @@ describe("restart_cancelled status", () => {
       status: "stopped",
       attachToConversationId: conversationId,
     };
-    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(stoppedStatus, ctx);
 
     // Get the new recording ID from the deferred recording_start message
     const startMsg = sent.filter((m) => m.type === "recording_start").pop();
@@ -321,7 +318,7 @@ describe("restart_cancelled status", () => {
       attachToConversationId: conversationId,
       operationToken: restartResult.operationToken,
     };
-    recordingHandlers.recording_status(cancelStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(cancelStatus, ctx);
 
     // Should have emitted the cancellation message
     const textDeltas = sent.filter((m) => m.type === "assistant_text_delta");
@@ -342,7 +339,7 @@ describe("restart_cancelled status", () => {
   });
 
   test("cleans up restart state on cancel", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-cancel-cleanup";
 
     const originalId = handleRecordingStart(
@@ -365,7 +362,7 @@ describe("restart_cancelled status", () => {
       status: "stopped",
       attachToConversationId: conversationId,
     };
-    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(stoppedStatus, ctx);
 
     // Still not idle — the new recording has started
     expect(isRecordingIdle()).toBe(false);
@@ -378,7 +375,7 @@ describe("restart_cancelled status", () => {
       attachToConversationId: conversationId,
       operationToken: restartResult.operationToken,
     };
-    recordingHandlers.recording_status(cancelStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(cancelStatus, ctx);
 
     // After cancel: truly idle
     expect(isRecordingIdle()).toBe(true);
@@ -396,7 +393,7 @@ describe("stale completion guard (operation token)", () => {
   });
 
   test("rejects recording_status with stale operation token", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-stale-1";
 
     // Start recording -> restart (creates operation token)
@@ -418,7 +415,7 @@ describe("stale completion guard (operation token)", () => {
       status: "stopped",
       attachToConversationId: conversationId,
     };
-    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(stoppedStatus, ctx);
 
     const startMsg = sent.filter((m) => m.type === "recording_start").pop();
     sent.length = 0;
@@ -430,7 +427,7 @@ describe("stale completion guard (operation token)", () => {
       status: "started",
       operationToken: "old-stale-token-from-previous-cycle",
     };
-    recordingHandlers.recording_status(staleStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(staleStatus, ctx);
 
     // Should have been rejected — no "started" confirmation messages
     const textDeltas = sent.filter((m) => m.type === "assistant_text_delta");
@@ -441,7 +438,7 @@ describe("stale completion guard (operation token)", () => {
   });
 
   test("accepts recording_status with matching operation token", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-matching-1";
 
     const originalId = handleRecordingStart(
@@ -461,7 +458,7 @@ describe("stale completion guard (operation token)", () => {
       status: "stopped",
       attachToConversationId: conversationId,
     };
-    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(stoppedStatus, ctx);
 
     const startMsg = sent.filter((m) => m.type === "recording_start").pop();
 
@@ -472,14 +469,14 @@ describe("stale completion guard (operation token)", () => {
       status: "started",
       operationToken: restartResult.operationToken,
     };
-    recordingHandlers.recording_status(validStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(validStatus, ctx);
 
     // Should have been accepted — restart token cleared
     expect(getActiveRestartToken()).toBeNull();
   });
 
   test("allows tokenless recording_status during active restart (old recording ack)", async () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-tokenless-1";
 
     // Start recording -> restart (creates operation token)
@@ -505,7 +502,7 @@ describe("stale completion guard (operation token)", () => {
       attachToConversationId: conversationId,
       // No operationToken — from old recording, should be allowed
     };
-    await recordingHandlers.recording_status(tokenlessStatus, fakeSocket, ctx);
+    await recordingHandlers.recording_status(tokenlessStatus, ctx);
 
     // Should have triggered the deferred restart start
     const newStartMsgs = sent.filter((m) => m.type === "recording_start");
@@ -519,7 +516,7 @@ describe("stale completion guard (operation token)", () => {
   });
 
   test("no ghost state after restart stop/start handoff", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-ghost-1";
 
     const originalId = handleRecordingStart(
@@ -542,7 +539,7 @@ describe("stale completion guard (operation token)", () => {
       status: "stopped",
       attachToConversationId: conversationId,
     };
-    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(stoppedStatus, ctx);
 
     // The new recording should be active (not the old one)
     const startMsgs = sent.filter((m) => m.type === "recording_start");
@@ -663,7 +660,7 @@ describe("isRecordingIdle", () => {
   });
 
   test("returns true after restart completes", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-idle-complete";
 
     const originalId = handleRecordingStart(
@@ -683,7 +680,7 @@ describe("isRecordingIdle", () => {
       status: "stopped",
       attachToConversationId: conversationId,
     };
-    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(stoppedStatus, ctx);
 
     // Simulate the new recording starting
     const startMsg = sent.filter((m) => m.type === "recording_start").pop();
@@ -693,7 +690,7 @@ describe("isRecordingIdle", () => {
       status: "started",
       operationToken: restartResult.operationToken,
     };
-    recordingHandlers.recording_status(startedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(startedStatus, ctx);
 
     // Restart is complete, but recording is still active
     expect(getActiveRestartToken()).toBeNull();
@@ -710,7 +707,7 @@ describe("executeRecordingIntent — restart/pause/resume", () => {
   });
 
   test("restart_only executes actual restart (deferred start)", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-exec-restart";
 
     // Start a recording first
@@ -742,7 +739,7 @@ describe("executeRecordingIntent — restart/pause/resume", () => {
       status: "stopped",
       attachToConversationId: conversationId,
     };
-    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(stoppedStatus, ctx);
 
     // NOW the deferred start should have been sent
     const startMsgsAfterAck = sent.filter((m) => m.type === "recording_start");
@@ -845,7 +842,7 @@ describe("recording_status paused/resumed", () => {
   });
 
   test("handles paused status without error", () => {
-    const { ctx, fakeSocket } = createCtx();
+    const { ctx } = createCtx();
     const conversationId = "conv-status-paused";
 
     const recordingId = handleRecordingStart(
@@ -862,12 +859,12 @@ describe("recording_status paused/resumed", () => {
     };
 
     expect(() => {
-      recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+      recordingHandlers.recording_status(statusMsg, ctx);
     }).not.toThrow();
   });
 
   test("handles resumed status without error", () => {
-    const { ctx, fakeSocket } = createCtx();
+    const { ctx } = createCtx();
     const conversationId = "conv-status-resumed";
 
     const recordingId = handleRecordingStart(
@@ -884,7 +881,7 @@ describe("recording_status paused/resumed", () => {
     };
 
     expect(() => {
-      recordingHandlers.recording_status(statusMsg, fakeSocket, ctx);
+      recordingHandlers.recording_status(statusMsg, ctx);
     }).not.toThrow();
   });
 });
@@ -899,7 +896,7 @@ describe("failure during restart", () => {
   });
 
   test("failed status during restart clears pending restart state (old recording fails)", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-fail-restart";
 
     const originalId = handleRecordingStart(
@@ -918,7 +915,7 @@ describe("failure during restart", () => {
       error: "Permission denied",
       attachToConversationId: conversationId,
     };
-    recordingHandlers.recording_status(failedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(failedStatus, ctx);
 
     // Restart state and deferred restart should be cleaned up
     expect(getActiveRestartToken()).toBeNull();
@@ -926,7 +923,7 @@ describe("failure during restart", () => {
   });
 
   test("failed status during restart clears state (new recording fails after deferred start)", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-fail-restart-new";
 
     const originalId = handleRecordingStart(
@@ -946,7 +943,7 @@ describe("failure during restart", () => {
       status: "stopped",
       attachToConversationId: conversationId,
     };
-    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(stoppedStatus, ctx);
 
     const startMsg = sent.filter((m) => m.type === "recording_start").pop();
     sent.length = 0;
@@ -960,7 +957,7 @@ describe("failure during restart", () => {
       attachToConversationId: conversationId,
       operationToken: restartResult.operationToken,
     };
-    recordingHandlers.recording_status(failedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(failedStatus, ctx);
 
     // Restart state should be cleaned up
     expect(getActiveRestartToken()).toBeNull();
@@ -998,7 +995,7 @@ describe("start_and_stop_only fallback to plain start when idle", () => {
   });
 
   test("goes through restart when a recording is active (deferred start)", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-stop-start-active";
 
     // Start a recording first
@@ -1035,7 +1032,7 @@ describe("start_and_stop_only fallback to plain start when idle", () => {
       status: "stopped",
       attachToConversationId: conversationId,
     };
-    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(stoppedStatus, ctx);
 
     // NOW the deferred start should have been sent
     const startMsgsAfterAck = sent.filter((m) => m.type === "recording_start");
@@ -1127,7 +1124,7 @@ describe("deferred restart prevents race condition", () => {
   });
 
   test("cross-conversation restart: conversation B restarts recording owned by A", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const convA = "conv-owner-A";
     const convB = "conv-requester-B";
 
@@ -1153,7 +1150,7 @@ describe("deferred restart prevents race condition", () => {
       status: "stopped",
       attachToConversationId: convA,
     };
-    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(stoppedStatus, ctx);
 
     // The deferred recording_start MUST have been triggered even though the
     // stopped callback resolved to conversation A (owner), not B (requester).
@@ -1173,7 +1170,7 @@ describe("deferred restart prevents race condition", () => {
       operationToken: result.operationToken,
       attachToConversationId: convB,
     };
-    recordingHandlers.recording_status(startedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(startedStatus, ctx);
 
     // Restart cycle must be fully complete: activeRestartToken cleared
     expect(getActiveRestartToken()).toBeNull();
@@ -1189,13 +1186,13 @@ describe("deferred restart prevents race condition", () => {
       status: "stopped",
       attachToConversationId: convB,
     };
-    recordingHandlers.recording_status(newStoppedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(newStoppedStatus, ctx);
 
     expect(isRecordingIdle()).toBe(true);
   });
 
   test("normal stop (non-restart) does not trigger deferred start", () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-normal-stop";
 
     const recordingId = handleRecordingStart(
@@ -1216,7 +1213,7 @@ describe("deferred restart prevents race condition", () => {
       status: "stopped",
       attachToConversationId: conversationId,
     };
-    recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    recordingHandlers.recording_status(stoppedStatus, ctx);
 
     // Should NOT have sent a recording_start (no deferred restart pending)
     const startMsgs = sent.filter((m) => m.type === "recording_start");
@@ -1235,7 +1232,7 @@ describe("restart finalization", () => {
   });
 
   test("publishes previous recording attachment on restart", async () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-fin-publish";
 
     // Start a recording
@@ -1263,7 +1260,7 @@ describe("restart finalization", () => {
       durationMs: 5000,
       attachToConversationId: conversationId,
     };
-    await recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    await recordingHandlers.recording_status(stoppedStatus, ctx);
 
     // Verify: a new recording_start IPC was sent (deferred start triggered)
     const startMsgs = sent.filter((m) => m.type === "recording_start");
@@ -1291,7 +1288,7 @@ describe("restart finalization", () => {
   });
 
   test("restart + picker cancel preserves previous publish", async () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-fin-cancel-preserve";
 
     // Start a recording
@@ -1317,7 +1314,7 @@ describe("restart finalization", () => {
       durationMs: 3000,
       attachToConversationId: conversationId,
     };
-    await recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    await recordingHandlers.recording_status(stoppedStatus, ctx);
 
     // Capture sent messages so far (should include old recording's attachment)
     const preCancelTextDeltas = sent.filter(
@@ -1342,7 +1339,7 @@ describe("restart finalization", () => {
       attachToConversationId: conversationId,
       operationToken: restartResult.operationToken,
     };
-    await recordingHandlers.recording_status(cancelStatus, fakeSocket, ctx);
+    await recordingHandlers.recording_status(cancelStatus, ctx);
 
     // Verify: the old recording's attachment messages are still in sent
     const postCancelTextDeltas = sent.filter(
@@ -1368,7 +1365,7 @@ describe("restart finalization", () => {
   });
 
   test("emits truthful failure text when previous finalize fails", async () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-fin-fail-truth";
 
     // Start a recording
@@ -1394,7 +1391,7 @@ describe("restart finalization", () => {
       // No filePath — recording stopped without producing a file
       attachToConversationId: conversationId,
     };
-    await recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    await recordingHandlers.recording_status(stoppedStatus, ctx);
 
     // Verify: error message text is sent (not "Screen recording complete")
     const textDeltas = sent.filter((m) => m.type === "assistant_text_delta");
@@ -1418,7 +1415,7 @@ describe("restart finalization", () => {
   });
 
   test("preserves previous attachment when new start fails", async () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-fin-new-fail";
 
     // Start a recording
@@ -1452,7 +1449,7 @@ describe("restart finalization", () => {
       durationMs: 4000,
       attachToConversationId: conversationId,
     };
-    await recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    await recordingHandlers.recording_status(stoppedStatus, ctx);
 
     // Verify: old recording attachment is published (finalization succeeded)
     const textDeltas = sent.filter((m) => m.type === "assistant_text_delta");
@@ -1487,7 +1484,7 @@ describe("restart finalization", () => {
   });
 
   test("duplicate stopped callback does not double-attach", async () => {
-    const { ctx, sent, fakeSocket } = createCtx();
+    const { ctx, sent } = createCtx();
     const conversationId = "conv-fin-dup-stop";
 
     // Start a recording
@@ -1514,7 +1511,7 @@ describe("restart finalization", () => {
       durationMs: 2000,
       attachToConversationId: conversationId,
     };
-    await recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    await recordingHandlers.recording_status(stoppedStatus, ctx);
 
     // Count attachment-related messages after first callback
     const firstCallAttachmentMsgs = sent.filter(
@@ -1531,7 +1528,7 @@ describe("restart finalization", () => {
     expect(firstCallMsgCount).toBe(1);
 
     // Send stopped again with same recordingId (duplicate)
-    await recordingHandlers.recording_status(stoppedStatus, fakeSocket, ctx);
+    await recordingHandlers.recording_status(stoppedStatus, ctx);
 
     // Verify: only one attachment message exists in sent — the duplicate was
     // rejected by the idempotency guard in finalizeAndPublishRecording

--- a/assistant/src/__tests__/ride-shotgun-handler.test.ts
+++ b/assistant/src/__tests__/ride-shotgun-handler.test.ts
@@ -1,4 +1,3 @@
-import type * as net from "node:net";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { HandlerContext } from "../daemon/handlers/shared.js";
@@ -101,14 +100,10 @@ const { watchSessions } = await import("../tools/watch/watch-state.js");
 
 // ── Helpers ────────────────────────────────────────────────────────
 
-function makeMockSocket(): net.Socket {
-  return { destroyed: false } as unknown as net.Socket;
-}
-
 function makeMockCtx() {
   const sent: unknown[] = [];
   return {
-    send: (_socket: net.Socket, msg: unknown) => sent.push(msg),
+    send: (msg: unknown) => sent.push(msg),
     sent,
   } as unknown as HandlerContext & { sent: unknown[] };
 }
@@ -157,7 +152,6 @@ describe("ride-shotgun-handler", () => {
   });
 
   test("learn mode calls ensureChromeWithCdp before starting recorder", async () => {
-    const socket = makeMockSocket();
     const ctx = makeMockCtx();
 
     await handleRideShotgunStart(
@@ -169,7 +163,6 @@ describe("ride-shotgun-handler", () => {
         targetDomain: "example.com",
         autoNavigate: false,
       },
-      socket,
       ctx,
     );
 
@@ -188,7 +181,6 @@ describe("ride-shotgun-handler", () => {
       userDataDir: "/tmp/cdp-custom",
     };
 
-    const socket = makeMockSocket();
     const ctx = makeMockCtx();
 
     await handleRideShotgunStart(
@@ -200,7 +192,6 @@ describe("ride-shotgun-handler", () => {
         targetDomain: "example.com",
         autoNavigate: false,
       },
-      socket,
       ctx,
     );
 
@@ -212,7 +203,6 @@ describe("ride-shotgun-handler", () => {
   test("learn mode does not start recorder when ensureChromeWithCdp fails", async () => {
     mockEnsureChromeShouldThrow = true;
 
-    const socket = makeMockSocket();
     const ctx = makeMockCtx();
 
     await handleRideShotgunStart(
@@ -224,7 +214,6 @@ describe("ride-shotgun-handler", () => {
         targetDomain: "example.com",
         autoNavigate: false,
       },
-      socket,
       ctx,
     );
 
@@ -241,7 +230,6 @@ describe("ride-shotgun-handler", () => {
       userDataDir: "/tmp/cdp-test",
     };
 
-    const socket = makeMockSocket();
     const ctx = makeMockCtx();
 
     await handleRideShotgunStart(
@@ -253,7 +241,6 @@ describe("ride-shotgun-handler", () => {
         targetDomain: "example.com",
         autoNavigate: false,
       },
-      socket,
       ctx,
     );
 
@@ -263,7 +250,6 @@ describe("ride-shotgun-handler", () => {
     const watchId = [...watchSessions.keys()][0]!;
     await handleRideShotgunStop(
       { type: "ride_shotgun_stop", watchId },
-      socket,
       ctx,
     );
 
@@ -278,7 +264,6 @@ describe("ride-shotgun-handler", () => {
       userDataDir: "/tmp/cdp-test",
     };
 
-    const socket = makeMockSocket();
     const ctx = makeMockCtx();
 
     await handleRideShotgunStart(
@@ -290,7 +275,6 @@ describe("ride-shotgun-handler", () => {
         targetDomain: "example.com",
         autoNavigate: false,
       },
-      socket,
       ctx,
     );
 
@@ -300,7 +284,6 @@ describe("ride-shotgun-handler", () => {
     const watchId = [...watchSessions.keys()][0]!;
     await handleRideShotgunStop(
       { type: "ride_shotgun_stop", watchId },
-      socket,
       ctx,
     );
 
@@ -308,7 +291,6 @@ describe("ride-shotgun-handler", () => {
   });
 
   test("observe mode does not call ensureChromeWithCdp", async () => {
-    const socket = makeMockSocket();
     const ctx = makeMockCtx();
 
     await handleRideShotgunStart(
@@ -318,7 +300,6 @@ describe("ride-shotgun-handler", () => {
         intervalSeconds: 5,
         mode: "observe",
       },
-      socket,
       ctx,
     );
 
@@ -332,13 +313,11 @@ describe("ride-shotgun-handler", () => {
     const watchId = [...watchSessions.keys()][0]!;
     await handleRideShotgunStop(
       { type: "ride_shotgun_stop", watchId },
-      socket,
       ctx,
     );
   });
 
   test("sends watch_started message with session IDs", async () => {
-    const socket = makeMockSocket();
     const ctx = makeMockCtx();
 
     await handleRideShotgunStart(
@@ -350,7 +329,6 @@ describe("ride-shotgun-handler", () => {
         targetDomain: "example.com",
         autoNavigate: false,
       },
-      socket,
       ctx,
     );
 
@@ -366,7 +344,6 @@ describe("ride-shotgun-handler", () => {
     const watchId = startMsg.watchId;
     await handleRideShotgunStop(
       { type: "ride_shotgun_stop", watchId },
-      socket,
       ctx,
     );
   });
@@ -374,7 +351,6 @@ describe("ride-shotgun-handler", () => {
   test("sends ride_shotgun_error when ensureChromeWithCdp fails", async () => {
     mockEnsureChromeShouldThrow = true;
 
-    const socket = makeMockSocket();
     const ctx = makeMockCtx();
 
     await handleRideShotgunStart(
@@ -386,7 +362,6 @@ describe("ride-shotgun-handler", () => {
         targetDomain: "example.com",
         autoNavigate: false,
       },
-      socket,
       ctx,
     );
 
@@ -405,7 +380,6 @@ describe("ride-shotgun-handler", () => {
   test("cleans up session when ensureChromeWithCdp fails", async () => {
     mockEnsureChromeShouldThrow = true;
 
-    const socket = makeMockSocket();
     const ctx = makeMockCtx();
 
     await handleRideShotgunStart(
@@ -417,7 +391,6 @@ describe("ride-shotgun-handler", () => {
         targetDomain: "example.com",
         autoNavigate: false,
       },
-      socket,
       ctx,
     );
 
@@ -432,7 +405,6 @@ describe("ride-shotgun-handler", () => {
   test("reports failure summary when no recorder ever started", async () => {
     mockEnsureChromeShouldThrow = true;
 
-    const socket = makeMockSocket();
     const ctx = makeMockCtx();
 
     await handleRideShotgunStart(
@@ -444,7 +416,6 @@ describe("ride-shotgun-handler", () => {
         targetDomain: "example.com",
         autoNavigate: false,
       },
-      socket,
       ctx,
     );
 
@@ -465,7 +436,6 @@ describe("ride-shotgun-handler", () => {
     mockRecorderStartShouldThrow = true;
     mockRecorderStartThrowCount = 10;
 
-    const socket = makeMockSocket();
     const ctx = makeMockCtx();
 
     await handleRideShotgunStart(
@@ -477,7 +447,6 @@ describe("ride-shotgun-handler", () => {
         targetDomain: "example.com",
         autoNavigate: false,
       },
-      socket,
       ctx,
     );
 

--- a/assistant/src/daemon/handlers/config-channels.ts
+++ b/assistant/src/daemon/handlers/config-channels.ts
@@ -1,5 +1,4 @@
 import { createHash, randomBytes } from "node:crypto";
-import * as net from "node:net";
 
 import { startVerificationCall } from "../../calls/call-domain.js";
 import type { ChannelId } from "../../channels/types.js";
@@ -520,7 +519,6 @@ export async function verifyTrustedContact(
 
 export async function handleChannelVerificationSession(
   msg: ChannelVerificationSessionRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   const channel = msg.channel ?? "telegram";
@@ -528,7 +526,7 @@ export async function handleChannelVerificationSession(
   try {
     if (msg.action === "create_session") {
       if (msg.purpose === "trusted_contact" && !msg.contactChannelId) {
-        ctx.send(socket, {
+        ctx.send({
           type: "channel_verification_session_response",
           success: false,
           error: "contactChannelId is required for trusted_contact purpose",
@@ -539,7 +537,7 @@ export async function handleChannelVerificationSession(
           msg.contactChannelId!,
           DAEMON_INTERNAL_ASSISTANT_ID,
         );
-        ctx.send(socket, {
+        ctx.send({
           type: "channel_verification_session_response",
           ...result,
         });
@@ -550,7 +548,7 @@ export async function handleChannelVerificationSession(
           rebind: msg.rebind,
           originConversationId: msg.originConversationId,
         });
-        ctx.send(socket, {
+        ctx.send({
           type: "channel_verification_session_response",
           ...result,
         });
@@ -560,28 +558,28 @@ export async function handleChannelVerificationSession(
           msg.rebind,
           msg.sessionId,
         );
-        ctx.send(socket, {
+        ctx.send({
           type: "channel_verification_session_response",
           ...result,
         });
       }
     } else if (msg.action === "status") {
       const result = getVerificationStatus(channel);
-      ctx.send(socket, {
+      ctx.send({
         type: "channel_verification_session_response",
         ...result,
       });
     } else if (msg.action === "cancel_session") {
       cancelOutbound({ channel });
       revokePendingSessions(channel);
-      ctx.send(socket, {
+      ctx.send({
         type: "channel_verification_session_response",
         success: true,
         channel,
       });
     } else if (msg.action === "revoke") {
       const result = revokeVerificationForChannel(channel);
-      ctx.send(socket, {
+      ctx.send({
         type: "channel_verification_session_response",
         ...result,
       });
@@ -590,12 +588,12 @@ export async function handleChannelVerificationSession(
         channel,
         originConversationId: msg.originConversationId,
       });
-      ctx.send(socket, {
+      ctx.send({
         type: "channel_verification_session_response",
         ...result,
       });
     } else {
-      ctx.send(socket, {
+      ctx.send({
         type: "channel_verification_session_response",
         success: false,
         error: `Unknown action: ${String(msg.action)}`,
@@ -605,7 +603,7 @@ export async function handleChannelVerificationSession(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Failed to handle channel verification session");
-    ctx.send(socket, {
+    ctx.send({
       type: "channel_verification_session_response",
       success: false,
       error: message,

--- a/assistant/src/daemon/handlers/config-ingress.ts
+++ b/assistant/src/daemon/handlers/config-ingress.ts
@@ -1,5 +1,3 @@
-import * as net from "node:net";
-
 import {
   getTwilioCredentials,
   hasTwilioCredentials,
@@ -93,7 +91,6 @@ export async function syncTwilioWebhooks(
 
 export async function handleIngressConfig(
   msg: IngressConfigRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   const localGatewayTarget = computeGatewayTarget();
@@ -103,7 +100,7 @@ export async function handleIngressConfig(
       const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
       const publicBaseUrl = (ingress.publicBaseUrl as string) ?? "";
       const enabled = (ingress.enabled as boolean | undefined) ?? false;
-      ctx.send(socket, {
+      ctx.send({
         type: "ingress_config_response",
         enabled,
         publicBaseUrl,
@@ -164,7 +161,7 @@ export async function handleIngressConfig(
         setIngressPublicBaseUrl(undefined);
       }
 
-      ctx.send(socket, {
+      ctx.send({
         type: "ingress_config_response",
         enabled: isEnabled,
         publicBaseUrl: value,
@@ -233,7 +230,7 @@ export async function handleIngressConfig(
         }
       }
     } else {
-      ctx.send(socket, {
+      ctx.send({
         type: "ingress_config_response",
         enabled: false,
         publicBaseUrl: "",
@@ -244,7 +241,7 @@ export async function handleIngressConfig(
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    ctx.send(socket, {
+    ctx.send({
       type: "ingress_config_response",
       enabled: false,
       publicBaseUrl: "",

--- a/assistant/src/daemon/handlers/config-model.ts
+++ b/assistant/src/daemon/handlers/config-model.ts
@@ -1,5 +1,3 @@
-import * as net from "node:net";
-
 import {
   getConfig,
   loadRawConfig,
@@ -161,9 +159,9 @@ export function setImageGenModel(
 // IPC handlers (delegate to shared logic)
 // ---------------------------------------------------------------------------
 
-export function handleModelGet(socket: net.Socket, ctx: HandlerContext): void {
+export function handleModelGet(ctx: HandlerContext): void {
   const info = getModelInfo();
-  ctx.send(socket, {
+  ctx.send({
     type: "model_info",
     ...info,
   });
@@ -171,15 +169,14 @@ export function handleModelGet(socket: net.Socket, ctx: HandlerContext): void {
 
 export function handleModelSet(
   msg: ModelSetRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   try {
     const info = setModel(msg.model, ctx);
-    ctx.send(socket, { type: "model_info", ...info });
+    ctx.send({ type: "model_info", ...info });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    ctx.send(socket, {
+    ctx.send({
       type: "error",
       message: `Failed to set model: ${message}`,
     });
@@ -188,7 +185,6 @@ export function handleModelSet(
 
 export function handleImageGenModelSet(
   msg: ImageGenModelSetRequest,
-  _socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   try {
@@ -200,7 +196,7 @@ export function handleImageGenModelSet(
 }
 
 export const modelHandlers = defineHandlers({
-  model_get: (_msg, socket, ctx) => handleModelGet(socket, ctx),
+  model_get: (_msg, ctx) => handleModelGet(ctx),
   model_set: handleModelSet,
   image_gen_model_set: handleImageGenModelSet,
 });

--- a/assistant/src/daemon/handlers/config-telegram.ts
+++ b/assistant/src/daemon/handlers/config-telegram.ts
@@ -1,5 +1,3 @@
-import * as net from "node:net";
-
 import {
   invalidateConfigCache,
   loadRawConfig,
@@ -365,7 +363,6 @@ export async function setupTelegram(
 
 export async function handleTelegramConfig(
   msg: TelegramConfigRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   try {
@@ -391,11 +388,11 @@ export async function handleTelegramConfig(
       };
     }
 
-    ctx.send(socket, { type: "telegram_config_response", ...result });
+    ctx.send({ type: "telegram_config_response", ...result });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Failed to handle Telegram config");
-    ctx.send(socket, {
+    ctx.send({
       type: "telegram_config_response",
       success: false,
       hasBotToken: false,

--- a/assistant/src/daemon/handlers/config-voice.ts
+++ b/assistant/src/daemon/handlers/config-voice.ts
@@ -1,5 +1,3 @@
-import * as net from "node:net";
-
 import type { VoiceConfigUpdateRequest } from "../message-types/settings.js";
 import { defineHandlers, type HandlerContext, log } from "./shared.js";
 
@@ -201,7 +199,6 @@ export function normalizeActivationKey(
  */
 export function handleVoiceConfigUpdate(
   msg: VoiceConfigUpdateRequest,
-  _socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   const result = normalizeActivationKey(msg.activationKey);

--- a/assistant/src/daemon/handlers/dictation.ts
+++ b/assistant/src/daemon/handlers/dictation.ts
@@ -1,5 +1,3 @@
-import * as net from "node:net";
-
 import {
   createTimeout,
   extractToolUse,
@@ -218,7 +216,6 @@ function computeMaxTokens(inputLength: number): number {
 
 export async function handleDictationRequest(
   msg: DictationRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   log.info(
@@ -250,7 +247,6 @@ export async function handleDictationRequest(
     log.info({ mode: "command" }, "Command mode (selected text present)");
     await handleCommandMode(
       msg,
-      socket,
       ctx,
       profile,
       profileMeta,
@@ -271,7 +267,7 @@ export async function handleDictationRequest(
       const mode = detectDictationModeHeuristic(msg);
       const normalizedText = applyDictionary(transcription, profile.dictionary);
       if (mode === "action") {
-        ctx.send(socket, {
+        ctx.send({
           type: "dictation_response",
           text: msg.transcription,
           mode: "action",
@@ -279,7 +275,7 @@ export async function handleDictationRequest(
           ...profileMeta,
         });
       } else {
-        ctx.send(socket, {
+        ctx.send({
           type: "dictation_response",
           text: normalizedText,
           mode,
@@ -352,7 +348,7 @@ export async function handleDictationRequest(
         );
 
         if (mode === "action") {
-          ctx.send(socket, {
+          ctx.send({
             type: "dictation_response",
             text: msg.transcription,
             mode: "action",
@@ -365,7 +361,7 @@ export async function handleDictationRequest(
             cleanedText,
             profile.dictionary,
           );
-          ctx.send(socket, {
+          ctx.send({
             type: "dictation_response",
             text: normalizedText,
             mode: "dictation",
@@ -392,7 +388,7 @@ export async function handleDictationRequest(
   const fallbackMode = detectDictationModeHeuristic(msg);
   log.info({ mode: fallbackMode }, "Using heuristic fallback");
   if (fallbackMode === "action") {
-    ctx.send(socket, {
+    ctx.send({
       type: "dictation_response",
       text: msg.transcription,
       mode: "action",
@@ -401,7 +397,7 @@ export async function handleDictationRequest(
     });
   } else {
     const normalizedText = applyDictionary(transcription, profile.dictionary);
-    ctx.send(socket, {
+    ctx.send({
       type: "dictation_response",
       text: normalizedText,
       mode: fallbackMode,
@@ -413,7 +409,6 @@ export async function handleDictationRequest(
 /** Handle command mode (selected text) — separate code path, latency-optimized. */
 async function handleCommandMode(
   msg: DictationRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
   profile: ReturnType<typeof resolveProfile>["profile"],
   profileMeta: {
@@ -435,7 +430,7 @@ async function handleCommandMode(
         msg.context.selectedText ?? msg.transcription,
         profile.dictionary,
       );
-      ctx.send(socket, {
+      ctx.send({
         type: "dictation_response",
         text: normalizedText,
         mode: "command",
@@ -457,7 +452,7 @@ async function handleCommandMode(
         ? textBlock.text.trim()
         : (msg.context.selectedText ?? msg.transcription);
     const normalizedText = applyDictionary(cleanedText, profile.dictionary);
-    ctx.send(socket, {
+    ctx.send({
       type: "dictation_response",
       text: normalizedText,
       mode: "command",
@@ -470,13 +465,13 @@ async function handleCommandMode(
       msg.context.selectedText ?? msg.transcription,
       profile.dictionary,
     );
-    ctx.send(socket, {
+    ctx.send({
       type: "dictation_response",
       text: normalizedText,
       mode: "command",
       ...profileMeta,
     });
-    ctx.send(socket, {
+    ctx.send({
       type: "error",
       message: `Dictation cleanup failed: ${message}`,
     });

--- a/assistant/src/daemon/handlers/identity.ts
+++ b/assistant/src/daemon/handlers/identity.ts
@@ -1,5 +1,4 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
-import * as net from "node:net";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -60,11 +59,11 @@ export function parseIdentityFields(content: string): IdentityFields {
   };
 }
 
-function handleIdentityGet(socket: net.Socket, ctx: HandlerContext): void {
+function handleIdentityGet(ctx: HandlerContext): void {
   const identityPath = getWorkspacePromptPath("IDENTITY.md");
 
   if (!existsSync(identityPath)) {
-    ctx.send(socket, {
+    ctx.send({
       type: "identity_get_response",
       found: false,
       name: "",
@@ -127,7 +126,7 @@ function handleIdentityGet(socket: net.Socket, ctx: HandlerContext): void {
       // ignore — lockfile may not exist
     }
 
-    ctx.send(socket, {
+    ctx.send({
       type: "identity_get_response",
       found: true,
       name: fields.name,
@@ -142,7 +141,7 @@ function handleIdentityGet(socket: net.Socket, ctx: HandlerContext): void {
     });
   } catch (err) {
     log.error({ err }, "Failed to read identity");
-    ctx.send(socket, {
+    ctx.send({
       type: "identity_get_response",
       found: false,
       name: "",
@@ -155,5 +154,5 @@ function handleIdentityGet(socket: net.Socket, ctx: HandlerContext): void {
 }
 
 export const identityHandlers = defineHandlers({
-  identity_get: (_msg, socket, ctx) => handleIdentityGet(socket, ctx),
+  identity_get: (_msg, ctx) => handleIdentityGet(ctx),
 });

--- a/assistant/src/daemon/handlers/pairing.ts
+++ b/assistant/src/daemon/handlers/pairing.ts
@@ -1,5 +1,3 @@
-import * as net from "node:net";
-
 import { cleanupPairingState } from "../../runtime/routes/pairing-routes.js";
 import {
   approveDevice,
@@ -28,7 +26,6 @@ export function initPairingHandlers(
 
 function handlePairingApprovalResponse(
   msg: PairingApprovalResponse,
-  _socket: net.Socket,
   _ctx: HandlerContext,
 ): void {
   if (!pairingStoreRef) {
@@ -83,11 +80,10 @@ function handlePairingApprovalResponse(
 }
 
 function handleApprovedDevicesList(
-  socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   const devices = listDevices();
-  ctx.send(socket, {
+  ctx.send({
     type: "approved_devices_list_response",
     devices,
   });
@@ -95,11 +91,10 @@ function handleApprovedDevicesList(
 
 function handleApprovedDeviceRemove(
   msg: ApprovedDeviceRemove,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   const success = removeDevice(msg.hashedDeviceId);
-  ctx.send(socket, {
+  ctx.send({
     type: "approved_device_remove_response",
     success,
   });
@@ -110,7 +105,6 @@ function handleApprovedDeviceRemove(
 }
 
 function handleApprovedDevicesClear(
-  _socket: net.Socket,
   _ctx: HandlerContext,
 ): void {
   clearAllDevices();
@@ -119,9 +113,7 @@ function handleApprovedDevicesClear(
 
 export const pairingHandlers = defineHandlers({
   pairing_approval_response: handlePairingApprovalResponse,
-  approved_devices_list: (_msg, socket, ctx) =>
-    handleApprovedDevicesList(socket, ctx),
+  approved_devices_list: (_msg, ctx) => handleApprovedDevicesList(ctx),
   approved_device_remove: handleApprovedDeviceRemove,
-  approved_devices_clear: (_msg, socket, ctx) =>
-    handleApprovedDevicesClear(socket, ctx),
+  approved_devices_clear: (_msg, ctx) => handleApprovedDevicesClear(ctx),
 });

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -1,5 +1,4 @@
 import { existsSync, realpathSync, statSync } from "node:fs";
-import * as net from "node:net";
 import * as path from "node:path";
 
 import { v4 as uuid } from "uuid";
@@ -664,7 +663,7 @@ export async function finalizeAndPublishRecording(params: {
     // AVAssetImageGenerator, which is faster and doesn't depend on ffmpeg.
     const thumbnailData: string | undefined = undefined;
 
-    // Notify the client via the reporting socket
+    // Notify the client via broadcast
     ctx.broadcast({
       type: "assistant_text_delta",
       text: msgText,
@@ -1056,7 +1055,6 @@ export function __resetRecordingState(): void {
 /** IPC-compatible wrapper: ignores the socket (unused) and delegates to core. */
 async function handleRecordingStatusIpc(
   msg: RecordingStatus,
-  _reportingSocket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   return handleRecordingStatusCore(msg, ctx);

--- a/assistant/src/daemon/handlers/session-history.ts
+++ b/assistant/src/daemon/handlers/session-history.ts
@@ -1,5 +1,3 @@
-import * as net from "node:net";
-
 import {
   getAttachmentsForMessage,
   getFilePathForAttachment,
@@ -30,7 +28,6 @@ import {
 
 export function handleHistoryRequest(
   msg: HistoryRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   // No limit means return all messages.
@@ -277,7 +274,7 @@ export function handleHistoryRequest(
   const oldestMessageId =
     historyMessages.length > 0 ? historyMessages[0].id : undefined;
 
-  ctx.send(socket, {
+  ctx.send({
     type: "history_response",
     sessionId: msg.sessionId,
     messages: historyMessages,
@@ -367,7 +364,6 @@ export function getMessageContent(
 
 export function handleConversationSearch(
   msg: ConversationSearchRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   const results = performConversationSearch({
@@ -375,7 +371,7 @@ export function handleConversationSearch(
     limit: msg.limit,
     maxMessagesPerConversation: msg.maxMessagesPerConversation,
   });
-  ctx.send(socket, {
+  ctx.send({
     type: "conversation_search_response",
     query: msg.query,
     results,
@@ -384,19 +380,18 @@ export function handleConversationSearch(
 
 export function handleMessageContentRequest(
   msg: MessageContentRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   const result = getMessageContent(msg.messageId, msg.sessionId);
   if (!result) {
-    ctx.send(socket, {
+    ctx.send({
       type: "error",
       message: `Message ${msg.messageId} not found in session ${msg.sessionId}`,
     });
     return;
   }
 
-  ctx.send(socket, {
+  ctx.send({
     type: "message_content_response",
     sessionId: msg.sessionId,
     messageId: msg.messageId,

--- a/assistant/src/daemon/handlers/session-user-message.ts
+++ b/assistant/src/daemon/handlers/session-user-message.ts
@@ -1,5 +1,3 @@
-import * as net from "node:net";
-
 import { v4 as uuid } from "uuid";
 
 import {
@@ -74,15 +72,14 @@ async function persistRecordingExchange(
   messageText: string,
   responseText: string,
   session: Session,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
-  ctx.send(socket, {
+  ctx.send({
     type: "assistant_text_delta",
     text: responseText,
     sessionId,
   });
-  ctx.send(socket, {
+  ctx.send({
     type: "message_complete",
     sessionId,
   });
@@ -113,7 +110,6 @@ async function persistRecordingExchange(
 function handleSecretIngress(
   msg: UserMessage,
   messageText: string,
-  socket: net.Socket,
   ctx: HandlerContext,
   session: Session,
   rlog: typeof log,
@@ -128,7 +124,7 @@ function handleSecretIngress(
     { detectedTypes: ingressCheck.detectedTypes },
     "Blocked user message containing secrets",
   );
-  ctx.send(socket, {
+  ctx.send({
     type: "error",
     message: ingressCheck.userNotice!,
     category: "secret_blocked",
@@ -149,12 +145,12 @@ function handleSecretIngress(
 
   session.redirectToSecurePrompt(ingressCheck.detectedTypes, {
     onStored: (record) => {
-      ctx.send(socket, {
+      ctx.send({
         type: "assistant_text_delta",
         sessionId: msg.sessionId,
         text: "Saved your secret securely. Continuing with your request.",
       });
-      ctx.send(socket, {
+      ctx.send({
         type: "message_complete",
         sessionId: msg.sessionId,
       });
@@ -188,7 +184,6 @@ async function handleStructuredRecordingIntent(
   msg: UserMessage,
   messageText: string,
   session: Session,
-  socket: net.Socket,
   ctx: HandlerContext,
   rlog: typeof log,
 ): Promise<boolean> {
@@ -220,7 +215,6 @@ async function handleStructuredRecordingIntent(
       messageText,
       responseText,
       session,
-      socket,
       ctx,
     );
     return true;
@@ -234,7 +228,6 @@ async function handleStructuredRecordingIntent(
       messageText,
       responseText,
       session,
-      socket,
       ctx,
     );
     return true;
@@ -245,7 +238,6 @@ async function handleStructuredRecordingIntent(
       messageText,
       restartResult.responseText,
       session,
-      socket,
       ctx,
     );
     return true;
@@ -259,7 +251,6 @@ async function handleStructuredRecordingIntent(
       messageText,
       responseText,
       session,
-      socket,
       ctx,
     );
     return true;
@@ -273,7 +264,6 @@ async function handleStructuredRecordingIntent(
       messageText,
       responseText,
       session,
-      socket,
       ctx,
     );
     return true;
@@ -295,7 +285,6 @@ async function handleStandaloneRecordingIntent(
   msg: UserMessage,
   messageText: string,
   session: Session,
-  socket: net.Socket,
   ctx: HandlerContext,
   rlog: typeof log,
 ): Promise<{
@@ -336,7 +325,6 @@ async function handleStandaloneRecordingIntent(
         messageText,
         execResult.responseText!,
         session,
-        socket,
         ctx,
       );
       return { handled: true, updatedMessageText: messageText };
@@ -439,7 +427,6 @@ async function handleStandaloneRecordingIntent(
             messageText,
             execResult.responseText!,
             session,
-            socket,
             ctx,
           );
           return { handled: true, updatedMessageText: messageText };
@@ -460,7 +447,6 @@ async function handlePendingConfirmationReply(
   session: Session,
   ipcChannel: ChannelId,
   ipcInterface: InterfaceId,
-  socket: net.Socket,
   ctx: HandlerContext,
   rlog: typeof log,
 ): Promise<boolean> {
@@ -578,26 +564,26 @@ async function handlePendingConfirmationReply(
         session.messages.push(consumedUserMessage, consumedAssistantMessage);
       }
 
-      ctx.send(socket, {
+      ctx.send({
         type: "message_queued",
         sessionId: msg.sessionId,
         requestId,
         position: 0,
       });
-      ctx.send(socket, {
+      ctx.send({
         type: "message_dequeued",
         sessionId: msg.sessionId,
         requestId,
       });
 
       if (!session.isProcessing()) {
-        ctx.send(socket, {
+        ctx.send({
           type: "assistant_text_delta",
           text: replyText,
           sessionId: msg.sessionId,
         });
       }
-      ctx.send(socket, {
+      ctx.send({
         type: "message_request_complete",
         sessionId: msg.sessionId,
         requestId,
@@ -689,7 +675,6 @@ function buildDispatchUserMessage(params: {
   sendEvent: (event: ServerMessage) => void;
   ipcChannel: ChannelId;
   ipcInterface: InterfaceId;
-  socket: net.Socket;
   ctx: HandlerContext;
   rlog: typeof log;
 }): DispatchUserMessageFn {
@@ -699,7 +684,6 @@ function buildDispatchUserMessage(params: {
     sendEvent,
     ipcChannel,
     ipcInterface,
-    socket,
     ctx,
     rlog,
   } = params;
@@ -762,7 +746,6 @@ function buildDispatchUserMessage(params: {
         },
       );
       ctx.send(
-        socket,
         buildSessionErrorMessage(msg.sessionId, {
           code: "QUEUE_FULL",
           userMessage:
@@ -785,7 +768,7 @@ function buildDispatchUserMessage(params: {
           attributes: { position, source },
         },
       );
-      ctx.send(socket, {
+      ctx.send({
         type: "message_queued",
         sessionId: msg.sessionId,
         requestId: dispatchRequestId,
@@ -830,36 +813,34 @@ function buildDispatchUserMessage(params: {
           { err, source },
           "Error processing user message (session or provider failure)",
         );
-        ctx.send(socket, {
+        ctx.send({
           type: "error",
           message: `Failed to process message: ${message}`,
         });
         const classified = classifySessionError(err, { phase: "agent_loop" });
-        ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
+        ctx.send( buildSessionErrorMessage(msg.sessionId, classified));
       });
   };
 }
 
 export async function handleUserMessage(
   msg: UserMessage,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   const requestId = uuid();
   const rlog = log.child({ sessionId: msg.sessionId, requestId });
   try {
-    const session = await ctx.getOrCreateSession(msg.sessionId, socket, true);
+    const session = await ctx.getOrCreateSession(msg.sessionId, true);
     // Only wire the escalation handler if one isn't already set — handleTaskSubmit
     // sets a handler with the client's actual screen dimensions, and overwriting it
     // here would replace those dimensions with the daemon's defaults.
     if (!session.hasEscalationHandler()) {
-      wireEscalationHandler(session, socket, ctx);
+      wireEscalationHandler(session, ctx);
     }
 
     const ipcChannel = parseChannelId(msg.channel) ?? "vellum";
     const sendEvent = makeIpcEventSender({
       ctx,
-      socket,
       session,
       conversationId: msg.sessionId,
       sourceChannel: ipcChannel,
@@ -870,7 +851,7 @@ export async function handleUserMessage(
     session.updateClient(sendEvent, false);
     const ipcInterface = parseInterfaceId(msg.interface);
     if (!ipcInterface) {
-      ctx.send(socket, {
+      ctx.send({
         type: "error",
         message:
           "Invalid user_message: interface is required and must be valid",
@@ -893,7 +874,6 @@ export async function handleUserMessage(
       sendEvent,
       ipcChannel,
       ipcInterface,
-      socket,
       ctx,
       rlog,
     });
@@ -905,7 +885,6 @@ export async function handleUserMessage(
       handleSecretIngress(
         msg,
         messageText,
-        socket,
         ctx,
         session,
         rlog,
@@ -921,7 +900,6 @@ export async function handleUserMessage(
         msg,
         messageText,
         session,
-        socket,
         ctx,
         rlog,
       )
@@ -934,7 +912,6 @@ export async function handleUserMessage(
       msg,
       messageText,
       session,
-      socket,
       ctx,
       rlog,
     );
@@ -952,7 +929,6 @@ export async function handleUserMessage(
         session,
         ipcChannel,
         ipcInterface,
-        socket,
         ctx,
         rlog,
       )
@@ -975,11 +951,11 @@ export async function handleUserMessage(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     rlog.error({ err }, "Error setting up user message processing");
-    ctx.send(socket, {
+    ctx.send( {
       type: "error",
       message: `Failed to process message: ${message}`,
     });
     const classified = classifySessionError(err, { phase: "handler" });
-    ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
+    ctx.send( buildSessionErrorMessage(msg.sessionId, classified));
   }
 }

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -1,5 +1,3 @@
-import * as net from "node:net";
-
 import { v4 as uuid } from "uuid";
 
 import {
@@ -110,12 +108,11 @@ export function syncCanonicalStatusFromIpcConfirmationDecision(
 
 export function makeIpcEventSender(params: {
   ctx: HandlerContext;
-  socket: net.Socket;
   session: Session;
   conversationId: string;
   sourceChannel: string;
 }): (event: ServerMessage) => void {
-  const { ctx, socket, session, conversationId, sourceChannel } = params;
+  const { ctx, session, conversationId, sourceChannel } = params;
 
   return (event: ServerMessage) => {
     if (event.type === "confirmation_request") {
@@ -163,17 +160,16 @@ export function makeIpcEventSender(params: {
       });
     }
 
-    ctx.send(socket, event);
+    ctx.send(event);
   };
 }
 
 export function handleConfirmationResponse(
   msg: ConfirmationResponse,
-  _socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   // Route by requestId to the session that originated the prompt, not by
-  // the current socket-session binding which may have changed since the
+  // the current session binding which may have changed since the
   // request was issued (e.g. after a session switch).
   for (const [sessionId, session] of ctx.sessions) {
     if (session.hasPendingConfirmation(msg.requestId)) {
@@ -221,7 +217,6 @@ export function handleConfirmationResponse(
 
 export function handleSecretResponse(
   msg: SecretResponse,
-  _socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   // Check standalone (non-session) prompts first, since they use a dedicated
@@ -239,7 +234,7 @@ export function handleSecretResponse(
   }
 
   // Route by requestId to the session that originated the prompt, not by
-  // the current socket-session binding which may have changed since the
+  // the current session binding which may have changed since the
   // request was issued (e.g. after a session switch).
   for (const [sessionId, session] of ctx.sessions) {
     if (session.hasPendingSecret(msg.requestId)) {
@@ -256,7 +251,6 @@ export function handleSecretResponse(
 }
 
 export function handleSessionList(
-  socket: net.Socket,
   ctx: HandlerContext,
   offset = 0,
   limit = 50,
@@ -268,7 +262,7 @@ export function handleSessionList(
     externalConversationStore.getBindingsForConversations(conversationIds);
   const attentionStates = getAttentionStateByConversationIds(conversationIds);
   const displayMetas = getDisplayMetaForConversations(conversationIds);
-  ctx.send(socket, {
+  ctx.send({
     type: "session_list_response",
     sessions: conversations.map((c) => {
       const binding = bindings.get(c.id);
@@ -347,16 +341,14 @@ export function clearAllSessions(ctx: HandlerContext): number {
 }
 
 export function handleSessionsClear(
-  socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   const cleared = clearAllSessions(ctx);
-  ctx.send(socket, { type: "sessions_clear_response", cleared });
+  ctx.send({ type: "sessions_clear_response", cleared });
 }
 
 export async function handleSessionCreate(
   msg: SessionCreateRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   const threadType = normalizeThreadType(msg.threadType);
@@ -366,12 +358,12 @@ export async function handleSessionCreate(
     title,
     threadType,
   });
-  const session = await ctx.getOrCreateSession(conversation.id, socket, true, {
+  const session = await ctx.getOrCreateSession(conversation.id, true, {
     systemPromptOverride: msg.systemPromptOverride,
     maxResponseTokens: msg.maxResponseTokens,
     transport: msg.transport,
   });
-  wireEscalationHandler(session, socket, ctx);
+  wireEscalationHandler(session, ctx);
 
   // Pre-activate skills before sending session_info so they're available
   // for the initial message processing.
@@ -379,7 +371,7 @@ export async function handleSessionCreate(
     session.setPreactivatedSkillIds(msg.preactivatedSkillIds);
   }
 
-  ctx.send(socket, {
+  ctx.send({
     type: "session_info",
     sessionId: conversation.id,
     title: conversation.title ?? "New Conversation",
@@ -400,7 +392,7 @@ export async function handleSessionCreate(
         context: { origin: "ipc" },
         userMessage: msg.initialMessage,
         onTitleUpdated: (newTitle) => {
-          ctx.send(socket, {
+          ctx.send({
             type: "session_title_updated",
             sessionId: conversation.id,
             title: newTitle,
@@ -414,7 +406,6 @@ export async function handleSessionCreate(
       parseChannelId(msg.transport?.channelId) ?? "vellum";
     const sendEvent = makeIpcEventSender({
       ctx,
-      socket,
       session,
       conversationId: conversation.id,
       sourceChannel: transportChannel,
@@ -438,7 +429,7 @@ export async function handleSessionCreate(
           { err, sessionId: conversation.id },
           "Error processing initial message",
         );
-        ctx.send(socket, {
+        ctx.send({
           type: "error",
           message: `Failed to process initial message: ${message}`,
         });
@@ -450,7 +441,7 @@ export async function handleSessionCreate(
           if (current && current.title === GENERATING_TITLE) {
             const fallback = UNTITLED_FALLBACK;
             updateConversationTitle(conversation.id, fallback);
-            ctx.send(socket, {
+            ctx.send({
               type: "session_title_updated",
               sessionId: conversation.id,
               title: fallback,
@@ -470,7 +461,6 @@ export async function handleSessionCreate(
 export async function switchSession(
   sessionId: string,
   ctx: HandlerContext,
-  socket?: net.Socket,
 ): Promise<{
   sessionId: string;
   title: string;
@@ -482,28 +472,20 @@ export async function switchSession(
   }
 
   // If the target session is headless-locked (actively executing a task run),
-  // skip rebinding the socket so tool confirmations stay suppressed.
+  // skip rebinding so tool confirmations stay suppressed.
   const existingSession = ctx.sessions.get(sessionId);
   const isHeadlessLocked = existingSession?.headlessLock;
 
-  if (socket) {
-    if (isHeadlessLocked) {
-      // Load the session without rebinding the client — the session stays headless
-      await ctx.getOrCreateSession(sessionId, socket, false);
-    } else {
-      const session = await ctx.getOrCreateSession(sessionId, socket, true);
-      // Only wire the escalation handler if one isn't already set — handleTaskSubmit
-      // sets a handler with the client's actual screen dimensions, and overwriting it
-      // here would replace those dimensions with the daemon's defaults.
-      if (!session.hasEscalationHandler()) {
-        wireEscalationHandler(session, socket, ctx);
-      }
-    }
+  if (isHeadlessLocked) {
+    // Load the session without rebinding the client — the session stays headless
+    await ctx.getOrCreateSession(sessionId, false);
   } else {
-    // Socketless callers (HTTP) still need the session hydrated in memory so
-    // follow-up operations (undo, regenerate, cancel) find an active session.
-    if (!existingSession) {
-      await ctx.getOrCreateSession(sessionId);
+    const session = await ctx.getOrCreateSession(sessionId, true);
+    // Only wire the escalation handler if one isn't already set — handleTaskSubmit
+    // sets a handler with the client's actual screen dimensions, and overwriting it
+    // here would replace those dimensions with the daemon's defaults.
+    if (!session.hasEscalationHandler()) {
+      wireEscalationHandler(session, ctx);
     }
   }
 
@@ -516,19 +498,18 @@ export async function switchSession(
 
 export async function handleSessionSwitch(
   msg: SessionSwitchRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
-  const result = await switchSession(msg.sessionId, ctx, socket);
+  const result = await switchSession(msg.sessionId, ctx);
   if (!result) {
-    ctx.send(socket, {
+    ctx.send({
       type: "error",
       message: `Session ${msg.sessionId} not found`,
     });
     return;
   }
 
-  ctx.send(socket, {
+  ctx.send({
     type: "session_info",
     sessionId: result.sessionId,
     title: result.title,
@@ -553,18 +534,17 @@ export function renameSession(
 
 export function handleSessionRename(
   msg: SessionRenameRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   const success = renameSession(msg.sessionId, msg.title);
   if (!success) {
-    ctx.send(socket, {
+    ctx.send({
       type: "error",
       message: `Session ${msg.sessionId} not found`,
     });
     return;
   }
-  ctx.send(socket, {
+  ctx.send({
     type: "session_title_updated",
     sessionId: msg.sessionId,
     title: msg.title,
@@ -594,7 +574,6 @@ export function cancelGeneration(
 
 export function handleCancel(
   msg: CancelRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   const sessionId = msg.sessionId;
@@ -621,15 +600,14 @@ export function undoLastMessage(
 
 export function handleUndo(
   msg: UndoRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   const result = undoLastMessage(msg.sessionId, ctx);
   if (!result) {
-    ctx.send(socket, { type: "error", message: "No active session" });
+    ctx.send({ type: "error", message: "No active session" });
     return;
   }
-  ctx.send(socket, {
+  ctx.send({
     type: "undo_complete",
     removedCount: result.removedCount,
     sessionId: msg.sessionId,
@@ -678,12 +656,11 @@ export async function regenerateResponse(
 
 export async function handleRegenerate(
   msg: RegenerateRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   const session = ctx.sessions.get(msg.sessionId);
   if (!session) {
-    ctx.send(socket, { type: "error", message: "No active session" });
+    ctx.send({ type: "error", message: "No active session" });
     return;
   }
 
@@ -692,7 +669,6 @@ export async function handleRegenerate(
     "vellum";
   const sendEvent = makeIpcEventSender({
     ctx,
-    socket,
     session,
     conversationId: msg.sessionId,
     sourceChannel: regenerateChannel,
@@ -702,27 +678,26 @@ export async function handleRegenerate(
     await regenerateResponse(msg.sessionId, ctx, sendEvent);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    ctx.send(socket, {
+    ctx.send({
       type: "error",
       message: `Failed to regenerate: ${message}`,
     });
     const classified = classifySessionError(err, { phase: "regenerate" });
-    ctx.send(socket, buildSessionErrorMessage(msg.sessionId, classified));
+    ctx.send(buildSessionErrorMessage(msg.sessionId, classified));
   }
 }
 
 export function handleUsageRequest(
   msg: UsageRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   const conversation = getConversation(msg.sessionId);
   if (!conversation) {
-    ctx.send(socket, { type: "error", message: "No active session" });
+    ctx.send({ type: "error", message: "No active session" });
     return;
   }
   const config = getConfig();
-  ctx.send(socket, {
+  ctx.send({
     type: "usage_response",
     totalInputTokens: conversation.totalInputTokens,
     totalOutputTokens: conversation.totalOutputTokens,
@@ -769,7 +744,6 @@ export function deleteQueuedMessage(
 
 export function handleDeleteQueuedMessage(
   msg: DeleteQueuedMessage,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   const result = deleteQueuedMessage(
@@ -778,7 +752,7 @@ export function handleDeleteQueuedMessage(
     (id) => ctx.sessions.get(id),
   );
   if (result.removed) {
-    ctx.send(socket, {
+    ctx.send({
       type: "message_queued_deleted",
       sessionId: msg.sessionId,
       requestId: msg.requestId,
@@ -788,7 +762,6 @@ export function handleDeleteQueuedMessage(
 
 export function handleReorderThreads(
   msg: ReorderThreadsRequest,
-  _socket: net.Socket,
   _ctx: HandlerContext,
 ): void {
   if (!Array.isArray(msg.updates)) {
@@ -807,10 +780,10 @@ export const sessionHandlers = defineHandlers({
   user_message: handleUserMessage,
   confirmation_response: handleConfirmationResponse,
   secret_response: handleSecretResponse,
-  session_list: (msg, socket, ctx) =>
-    handleSessionList(socket, ctx, msg.offset ?? 0, msg.limit ?? 50),
+  session_list: (msg, ctx) =>
+    handleSessionList(ctx, msg.offset ?? 0, msg.limit ?? 50),
   session_create: handleSessionCreate,
-  sessions_clear: (_msg, socket, ctx) => handleSessionsClear(socket, ctx),
+  sessions_clear: (_msg, ctx) => handleSessionsClear(ctx),
   session_switch: handleSessionSwitch,
   session_rename: handleSessionRename,
   cancel: handleCancel,

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -1,5 +1,4 @@
 import { execSync } from "node:child_process";
-import * as net from "node:net";
 
 import { v4 as uuid } from "uuid";
 
@@ -159,12 +158,11 @@ export interface HandlerContext {
   suppressConfigReload: boolean;
   setSuppressConfigReload(value: boolean): void;
   updateConfigFingerprint(): void;
-  send(socket: net.Socket, msg: ServerMessage): void;
+  send(msg: ServerMessage): void;
   broadcast(msg: ServerMessage): void;
   clearAllSessions(): number;
   getOrCreateSession(
     conversationId: string,
-    socket?: net.Socket,
     rebindClient?: boolean,
     options?: SessionCreateOptions,
   ): Promise<Session>;
@@ -182,7 +180,6 @@ export type DispatchableType = Exclude<MessageType, "auth">;
 type MessageOfType<T extends MessageType> = Extract<ClientMessage, { type: T }>;
 type MessageHandler<T extends MessageType> = (
   msg: MessageOfType<T>,
-  socket: net.Socket,
   ctx: HandlerContext,
 ) => void | Promise<void>;
 export type DispatchMap = { [T in DispatchableType]: MessageHandler<T> };
@@ -232,7 +229,6 @@ export function getScreenDimensions(): { width: number; height: number } {
  */
 export function wireEscalationHandler(
   session: Session,
-  socket: net.Socket,
   ctx: HandlerContext,
   explicitWidth?: number,
   explicitHeight?: number,
@@ -270,7 +266,7 @@ export function wireEscalationHandler(
       }
 
       const sendToClient = (serverMsg: ServerMessage) => {
-        ctx.send(socket, serverMsg);
+        ctx.send(serverMsg);
       };
 
       const sessionRef: { current?: ComputerUseSession } = {};
@@ -588,7 +584,6 @@ export function renderHistoryContent(content: unknown): RenderedHistoryContent {
  * outside of a session context (e.g. from handler-level code like publish_page).
  */
 export function requestSecretStandalone(
-  socket: net.Socket,
   ctx: HandlerContext,
   params: {
     service: string;
@@ -609,7 +604,7 @@ export function requestSecretStandalone(
       resolve({ value: null, delivery: "store" });
     }, config.timeouts.permissionTimeoutSec * 1000);
     pendingStandaloneSecrets.set(requestId, { resolve, timer });
-    ctx.send(socket, {
+    ctx.send({
       type: "secret_request",
       requestId,
       service: params.service,
@@ -632,7 +627,6 @@ const SIGNING_TIMEOUT_MS = 30_000;
  * over IPC and waits for the `sign_bundle_payload_response`.
  */
 export function createSigningCallback(
-  socket: net.Socket,
   ctx: HandlerContext,
 ): (
   payload: string,
@@ -645,7 +639,7 @@ export function createSigningCallback(
         reject(new Error("Signing request timed out"));
       }, SIGNING_TIMEOUT_MS);
       pendingSignBundlePayload.set(requestId, { resolve, reject, timer });
-      ctx.send(socket, { type: "sign_bundle_payload", requestId, payload });
+      ctx.send({ type: "sign_bundle_payload", requestId, payload });
     });
 }
 

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -1,5 +1,4 @@
 import { existsSync, rmSync } from "node:fs";
-import * as net from "node:net";
 import { join } from "node:path";
 
 import {
@@ -746,20 +745,18 @@ export async function createSkill(
 // ─── IPC handlers (thin wrappers) ───────────────────────────────────────────
 
 export function handleSkillsList(
-  socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   const skills = listSkills(ctx);
-  ctx.send(socket, { type: "skills_list_response", skills });
+  ctx.send({ type: "skills_list_response", skills });
 }
 
 export function handleSkillsEnable(
   msg: SkillsEnableRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   const result = enableSkill(msg.name, ctx);
-  ctx.send(socket, {
+  ctx.send({
     type: "skills_operation_response",
     operation: "enable",
     ...result,
@@ -768,11 +765,10 @@ export function handleSkillsEnable(
 
 export function handleSkillsDisable(
   msg: SkillsDisableRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   const result = disableSkill(msg.name, ctx);
-  ctx.send(socket, {
+  ctx.send({
     type: "skills_operation_response",
     operation: "disable",
     ...result,
@@ -781,7 +777,6 @@ export function handleSkillsDisable(
 
 export function handleSkillsConfigure(
   msg: SkillsConfigureRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): void {
   const result = configureSkill(
@@ -789,7 +784,7 @@ export function handleSkillsConfigure(
     { env: msg.env, apiKey: msg.apiKey, config: msg.config },
     ctx,
   );
-  ctx.send(socket, {
+  ctx.send({
     type: "skills_operation_response",
     operation: "configure",
     ...result,
@@ -798,14 +793,13 @@ export function handleSkillsConfigure(
 
 export async function handleSkillsInstall(
   msg: SkillsInstallRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   const result = await installSkill(
     { slug: msg.slug, version: msg.version },
     ctx,
   );
-  ctx.send(socket, {
+  ctx.send({
     type: "skills_operation_response",
     operation: "install",
     ...result,
@@ -814,11 +808,10 @@ export async function handleSkillsInstall(
 
 export async function handleSkillsUninstall(
   msg: SkillsUninstallRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   const result = await uninstallSkill(msg.name, ctx);
-  ctx.send(socket, {
+  ctx.send({
     type: "skills_operation_response",
     operation: "uninstall",
     ...result,
@@ -827,11 +820,10 @@ export async function handleSkillsUninstall(
 
 export async function handleSkillsUpdate(
   msg: SkillsUpdateRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   const result = await updateSkill(msg.name, ctx);
-  ctx.send(socket, {
+  ctx.send({
     type: "skills_operation_response",
     operation: "update",
     ...result,
@@ -840,11 +832,10 @@ export async function handleSkillsUpdate(
 
 export async function handleSkillsCheckUpdates(
   _msg: SkillsCheckUpdatesRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   const result = await checkSkillUpdates(ctx);
-  ctx.send(socket, {
+  ctx.send({
     type: "skills_operation_response",
     operation: "check_updates",
     ...result,
@@ -853,11 +844,10 @@ export async function handleSkillsCheckUpdates(
 
 export async function handleSkillsSearch(
   msg: SkillsSearchRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   const result = await searchSkills(msg.query, ctx);
-  ctx.send(socket, {
+  ctx.send({
     type: "skills_operation_response",
     operation: "search",
     ...result,
@@ -866,11 +856,10 @@ export async function handleSkillsSearch(
 
 export async function handleSkillsInspect(
   msg: SkillsInspectRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   const result = await inspectSkill(msg.slug, ctx);
-  ctx.send(socket, {
+  ctx.send({
     type: "skills_inspect_response",
     ...result,
   });
@@ -878,7 +867,6 @@ export async function handleSkillsInspect(
 
 export async function handleSkillDetail(
   msg: SkillDetailRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   const result = loadSkillBySelector(msg.skillId);
@@ -888,14 +876,14 @@ export async function handleSkillDetail(
       result.skill.displayName,
       result.skill.description,
     );
-    ctx.send(socket, {
+    ctx.send({
       type: "skill_detail_response",
       skillId: result.skill.id,
       body: result.skill.body,
       ...(icon ? { icon } : {}),
     });
   } else {
-    ctx.send(socket, {
+    ctx.send({
       type: "skill_detail_response",
       skillId: msg.skillId,
       body: "",
@@ -906,16 +894,14 @@ export async function handleSkillDetail(
 
 export async function handleSkillsDraft(
   msg: SkillsDraftRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   const result = await draftSkill({ sourceText: msg.sourceText }, ctx);
-  ctx.send(socket, { type: "skills_draft_response", ...result });
+  ctx.send({ type: "skills_draft_response", ...result });
 }
 
 export async function handleSkillsCreate(
   msg: SkillsCreateRequest,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   const result = await createSkill(
@@ -931,7 +917,7 @@ export async function handleSkillsCreate(
     },
     ctx,
   );
-  ctx.send(socket, {
+  ctx.send({
     type: "skills_operation_response",
     operation: "create",
     ...result,
@@ -939,7 +925,7 @@ export async function handleSkillsCreate(
 }
 
 export const skillHandlers = defineHandlers({
-  skills_list: (_msg, socket, ctx) => handleSkillsList(socket, ctx),
+  skills_list: (_msg, ctx) => handleSkillsList(ctx),
   skill_detail: handleSkillDetail,
   skills_enable: handleSkillsEnable,
   skills_disable: handleSkillsDisable,

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -1,5 +1,4 @@
 import { chmodSync, writeFileSync } from "node:fs";
-import type * as net from "node:net";
 import { join } from "node:path";
 
 import { config as dotenvConfig } from "dotenv";
@@ -480,22 +479,19 @@ export async function runDaemon(): Promise<void> {
       },
       getComputerUseDeps: () => {
         const ctx = server.getHandlerContext();
-        // Stub socket for IPC handlers called from HTTP — ctx.send ignores
-        // the socket parameter and broadcasts to all clients instead.
-        const stubSocket = {} as net.Socket;
         return {
           cuSessions: ctx.cuSessions,
           sharedRequestTimestamps: ctx.sharedRequestTimestamps,
           cuObservationParseSequence: ctx.cuObservationParseSequence,
           handleRideShotgunStart: async (params) => {
-            // The IPC handler generates its own watchId/sessionId and
+            // The handler generates its own watchId/sessionId and
             // sends them via ctx.send as a watch_started message.
             // We intercept send to capture the IDs before they broadcast.
             let capturedWatchId = "";
             let capturedSessionId = "";
             const interceptCtx = {
               ...ctx,
-              send: (_socket: net.Socket, msg: ServerMessage) => {
+              send: (msg: ServerMessage) => {
                 if (
                   "type" in msg &&
                   msg.type === "watch_started" &&
@@ -505,7 +501,7 @@ export async function runDaemon(): Promise<void> {
                   capturedWatchId = (msg as { watchId: string }).watchId;
                   capturedSessionId = (msg as { sessionId: string }).sessionId;
                 }
-                ctx.send(_socket, msg);
+                ctx.send(msg);
               },
             };
             await handleRideShotgunStart(
@@ -518,7 +514,6 @@ export async function runDaemon(): Promise<void> {
                 navigateDomain: params.navigateDomain,
                 autoNavigate: params.autoNavigate,
               },
-              stubSocket,
               interceptCtx,
             );
             return { watchId: capturedWatchId, sessionId: capturedSessionId };
@@ -526,7 +521,6 @@ export async function runDaemon(): Promise<void> {
           handleRideShotgunStop: async (watchId) => {
             await handleRideShotgunStop(
               { type: "ride_shotgun_stop", watchId },
-              stubSocket,
               ctx,
             );
           },
@@ -544,7 +538,6 @@ export async function runDaemon(): Promise<void> {
                 captureIndex: params.captureIndex,
                 totalExpected: params.totalExpected,
               },
-              stubSocket,
               ctx,
             );
           },

--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import type * as net from "node:net";
 
 import { autoNavigate } from "../tools/browser/auto-navigate.js";
 import {
@@ -134,7 +133,6 @@ async function completeSession(session: WatchSession): Promise<void> {
 
 export async function handleRideShotgunStart(
   msg: RideShotgunStart,
-  socket: net.Socket,
   ctx: HandlerContext,
 ): Promise<void> {
   const watchId = randomUUID();
@@ -224,7 +222,7 @@ export async function handleRideShotgunStart(
           { err, watchId },
           "Failed to ensure Chrome with CDP — cannot start recording",
         );
-        ctx.send(socket, {
+        ctx.send({
           type: "ride_shotgun_error",
           watchId,
           sessionId,
@@ -291,7 +289,7 @@ export async function handleRideShotgunStart(
                   { watchId, currentCount },
                   "Activity resumed — clearing idleHint",
                 );
-                ctx.send(socket, {
+                ctx.send({
                   type: "ride_shotgun_progress",
                   watchId,
                   message: `Recording network traffic...`,
@@ -315,7 +313,7 @@ export async function handleRideShotgunStart(
               );
             }
 
-            ctx.send(socket, {
+            ctx.send({
               type: "ride_shotgun_progress",
               watchId,
               message: `Recording network traffic...`,
@@ -374,7 +372,7 @@ export async function handleRideShotgunStart(
                 // Send progress to connected client
                 if (progress.type === "visiting" && progress.url) {
                   const shortUrl = progress.url.replace(/^https?:\/\//, "");
-                  ctx.send(socket, {
+                  ctx.send({
                     type: "ride_shotgun_progress",
                     watchId,
                     message: `[${progress.pageNumber || "?"}] ${shortUrl}`,
@@ -423,7 +421,7 @@ export async function handleRideShotgunStart(
               { err, watchId },
               "Failed to start network recording after 10 attempts",
             );
-            ctx.send(socket, {
+            ctx.send({
               type: "ride_shotgun_error",
               watchId,
               sessionId,
@@ -466,12 +464,11 @@ export async function handleRideShotgunStart(
           sessionId,
           observationCount,
           summaryLength: summary.length,
-          socketDestroyed: socket.destroyed,
         },
         "Completion notifier firing — sending ride_shotgun_result to client",
       );
 
-      ctx.send(socket, {
+      ctx.send({
         type: "ride_shotgun_result",
         sessionId,
         watchId,
@@ -494,7 +491,7 @@ export async function handleRideShotgunStart(
   fireWatchStartNotifier(sessionId, session);
 
   // Send watch_started so the Swift client knows the watchId/sessionId
-  ctx.send(socket, {
+  ctx.send({
     type: "watch_started",
     sessionId,
     watchId,
@@ -510,7 +507,6 @@ export async function handleRideShotgunStart(
 
 export async function handleRideShotgunStop(
   msg: RideShotgunStop,
-  _socket: net.Socket,
   _ctx: HandlerContext,
 ): Promise<void> {
   const { watchId } = msg;

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -581,10 +581,10 @@ export class DaemonServer {
       updateConfigFingerprint: () => {
         this.configWatcher.updateFingerprint();
       },
-      send: (_socket, msg) => this.broadcast(msg),
+      send: (msg) => this.broadcast(msg),
       broadcast: (msg) => this.broadcast(msg),
       clearAllSessions: () => this.clearAllSessions(),
-      getOrCreateSession: (id, _socket?, _rebind?, options?) =>
+      getOrCreateSession: (id, _rebind?, options?) =>
         this.getOrCreateSession(id, undefined, undefined, options),
       touchSession: (id) => this.evictor.touch(id),
       heartbeatService: this._heartbeatService,

--- a/assistant/src/daemon/watch-handler.ts
+++ b/assistant/src/daemon/watch-handler.ts
@@ -1,5 +1,3 @@
-import type * as net from "node:net";
-
 import {
   extractText,
   getConfiguredProvider,
@@ -30,7 +28,6 @@ export const lastSummaryBySession = new Map<string, string>();
 
 export async function handleWatchObservation(
   msg: WatchObservation,
-  _socket: net.Socket,
   _ctx: HandlerContext,
 ): Promise<void> {
   try {


### PR DESCRIPTION
## Summary
- Remove vestigial `net.Socket` parameters from `HandlerContext.send()`, `HandlerContext.getOrCreateSession()`, `MessageHandler<T>`, and all 25 handler/test files
- The Unix socket server was previously removed but handler functions still passed around `{} as net.Socket` stubs — this cleans up the dead parameter threading
- Net reduction of 236 lines across daemon handlers, lifecycle, server, and 7 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
