### PR TITLE
refactor: remove last IPC dead code from message-protocol.ts and platform.ts

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -4,8 +4,7 @@
  * All message types are defined in domain files under ./message-types/.
  * Each domain file exports `_<Domain>ClientMessages` and/or
  * `_<Domain>ServerMessages` type aliases. This file composes those
- * into the aggregate ClientMessage and ServerMessage unions, and provides
- * serialization/parsing utilities.
+ * into the aggregate ClientMessage and ServerMessage unions.
  *
  * To add a new message type:
  *   1. Define its interface in the appropriate domain file.
@@ -39,7 +38,6 @@ export * from "./message-types/work-items.js";
 export * from "./message-types/workspace.js";
 
 // Import domain-level union aliases for composition
-import { getLogger } from "../util/logger.js";
 import type {
   _AppsClientMessages,
   _AppsServerMessages,
@@ -192,75 +190,4 @@ export type ServerMessage =
 export interface ContractSchema {
   client: ClientMessage;
   server: ServerMessage;
-}
-
-const log = getLogger("message-protocol");
-
-// === Serialization ===
-
-export function serialize(msg: ClientMessage | ServerMessage): string {
-  return JSON.stringify(msg) + "\n";
-}
-
-export interface ParsedMessage<T = ClientMessage | ServerMessage> {
-  msg: T;
-  /** UTF-8 byte length of the raw line, populated only for cu_observation messages. */
-  rawByteLength?: number;
-}
-
-export function createMessageParser(options?: { maxLineSize?: number }) {
-  let buffer = "";
-  const maxLineSize = options?.maxLineSize;
-
-  function parseLines(): Array<ParsedMessage> {
-    const lines = buffer.split("\n");
-    // Keep the last partial line in the buffer
-    buffer = lines.pop() ?? "";
-    const results: Array<ParsedMessage> = [];
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (trimmed) {
-        try {
-          const msg = JSON.parse(trimmed);
-          const entry: ParsedMessage = { msg };
-          if (
-            typeof msg === "object" &&
-            msg != null &&
-            msg.type === "cu_observation"
-          ) {
-            entry.rawByteLength = Buffer.byteLength(trimmed, "utf8");
-          }
-          results.push(entry);
-        } catch (err) {
-          // Log only the error name, not the message — JSON.parse errors embed
-          // fragments of the input which could contain sensitive data.
-          log.warn(
-            {
-              lineLength: trimmed.length,
-              errorType: err instanceof Error ? err.name : "unknown",
-            },
-            "Skipping malformed IPC message",
-          );
-        }
-      }
-    }
-    if (maxLineSize != null && buffer.length > maxLineSize) {
-      buffer = "";
-      throw new Error(
-        `IPC message exceeds maximum line size of ${maxLineSize} bytes. Message discarded.`,
-      );
-    }
-    return results;
-  }
-
-  return {
-    feed(data: string): Array<ClientMessage | ServerMessage> {
-      buffer += data;
-      return parseLines().map((r) => r.msg);
-    },
-    feedRaw(data: string): Array<ParsedMessage> {
-      buffer += data;
-      return parseLines();
-    },
-  };
 }

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -243,14 +243,6 @@ export function getInterfacesDir(): string {
   return join(getDataDir(), "interfaces");
 }
 
-export function getSocketPath(): string {
-  return join(getRootDir(), "vellum.sock");
-}
-
-export function getSessionTokenPath(): string {
-  return join(getRootDir(), "session-token");
-}
-
 /**
  * Returns the TCP port the daemon should listen on for iOS clients.
  * Reads VELLUM_DAEMON_TCP_PORT env var; defaults to 8765.
@@ -326,18 +318,6 @@ export function getPlatformTokenPath(): string {
 export function readPlatformToken(): string | null {
   try {
     return readFileSync(getPlatformTokenPath(), "utf-8").trim();
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Read the daemon session token from disk. Returns null if the file
- * doesn't exist or can't be read (daemon not running).
- */
-export function readSessionToken(): string | null {
-  try {
-    return readFileSync(getSessionTokenPath(), "utf-8").trim();
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- Remove dead `serialize()` and `createMessageParser()` from `message-protocol.ts`
- Remove dead `ParsedMessage` interface (only used by `createMessageParser`)
- Remove dead `getSocketPath()`, `getSessionTokenPath()`, and `readSessionToken()` from `platform.ts`
- Remove stale `getLogger` import from `message-protocol.ts`
- All removals verified to have zero live importers (only appear in test mock factories, which are unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
