### PR TITLE
fix: resolve lint errors in cli.ts and doctor.ts

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -2,13 +2,13 @@ import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
 import * as readline from "node:readline";
 
+import { httpSend, httpHealthCheck, readHttpToken } from "./cli/http-client.js";
 import {
   type MainScreenLayout,
   renderMainScreen,
   updateDaemonText,
   updateStatusText,
 } from "./cli/main-screen.jsx";
-import { httpSend, httpHealthCheck, readHttpToken } from "./cli/http-client.js";
 import { shouldAutoStartDaemon } from "./daemon/connection-policy.js";
 import { ensureDaemonRunning } from "./daemon/lifecycle.js";
 import type {
@@ -144,7 +144,6 @@ export async function startCli(): Promise<void> {
   let reconnecting = false;
   let reconnectDelay = RECONNECT_BASE_DELAY_MS;
   let sseAbortController: AbortController | null = null;
-  let connected = false;
   const spinner = new Spinner();
 
   process.stdout.write("\x1b[2J\x1b[H");
@@ -855,7 +854,6 @@ export async function startCli(): Promise<void> {
       sseAbortController.abort();
       sseAbortController = null;
     }
-    connected = false;
   }
 
   /** Reconnect the SSE stream (e.g., after switching conversations). */
@@ -888,8 +886,6 @@ export async function startCli(): Promise<void> {
       if (!response.ok || !response.body) {
         throw new Error(`SSE connection failed: ${response.status}`);
       }
-
-      connected = true;
 
       // Read the SSE stream
       const reader = response.body.getReader();
@@ -939,7 +935,7 @@ export async function startCli(): Promise<void> {
               }
             }
           }
-        } catch (err) {
+        } catch {
           if (controller.signal.aborted) return; // intentional disconnect
           // Connection lost — trigger reconnect
         } finally {
@@ -948,7 +944,6 @@ export async function startCli(): Promise<void> {
 
         // If not intentionally disconnected, reconnect
         if (!controller.signal.aborted && !reconnecting) {
-          connected = false;
           reconnect();
         }
       };

--- a/assistant/src/cli/commands/doctor.ts
+++ b/assistant/src/cli/commands/doctor.ts
@@ -4,7 +4,6 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import type { Command } from "commander";
 
 import { loadRawConfig } from "../../config/loader.js";
-import { getRuntimeHttpPort } from "../../config/env.js";
 import { shouldAutoStartDaemon } from "../../daemon/connection-policy.js";
 import {
   getDataDir,
@@ -60,7 +59,6 @@ Examples:
 
       // 0. Connection policy info
       const httpUrl = getHttpBaseUrl();
-      const httpPort = getRuntimeHttpPort();
       const autostart = shouldAutoStartDaemon();
       log.info(`  HTTP:      ${httpUrl}`);
       log.info(`  Autostart: ${autostart ? "enabled" : "disabled"}\n`);


### PR DESCRIPTION
## Summary
- Fix import sort order in `cli.ts` (http-client before main-screen) and `doctor.ts` (env before loader)
- Remove unused `connected` variable and its assignments from `cli.ts` (leftover from socket→HTTP migration)
- Change `catch (err)` to `catch` in `cli.ts` where error is not used
- Remove unused `httpPort` variable and `getRuntimeHttpPort` import from `doctor.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
