### PR TITLE
fix: always-deny scope selection must deny current request

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -466,7 +466,7 @@ export async function startCli(): Promise<void> {
           selectedPattern,
           req.scopeOptions[idx].scope,
           trustDecision,
-          "allow",
+          trustDecision,
         );
       } else {
         // Invalid selection → deny


### PR DESCRIPTION
## Summary
- **Security fix**: When a user selects "always deny" during a permission prompt and picks a scope, the CLI now correctly denies the *current* request in addition to saving the deny trust rule for future requests.
- The HTTP refactor (402bc5f) regressed this by hard-coding the confirmation decision to `"allow"` regardless of the user's deny intent. The fix changes the confirmation decision to use `trustDecision` (which is `"deny"` for always-deny).

## Original prompt
Analyze this security finding. If it's legit then fix it: CLI "always deny" path now approves the current request

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
