### PR TITLE
fix: handle optional sessionId in Surface.from and SurfaceRef

### DIFF
--- a/clients/shared/Features/Chat/ChatMessage.swift
+++ b/clients/shared/Features/Chat/ChatMessage.swift
@@ -1295,7 +1295,7 @@ public struct ToolCallData: Identifiable, Equatable {
 /// retains the entire HTML payload) in memory.
 public struct SurfaceRef: Equatable {
     public let surfaceId: String
-    public let sessionId: String
+    public let sessionId: String?
     public let surfaceType: String
     public let title: String?
     /// The real app ID from DynamicPageSurfaceData. Used for app_open_request
@@ -1303,7 +1303,7 @@ public struct SurfaceRef: Equatable {
     /// that doesn't match any real app.
     public let appId: String?
 
-    public init(surfaceId: String, sessionId: String, surfaceType: String, title: String?, appId: String? = nil) {
+    public init(surfaceId: String, sessionId: String?, surfaceType: String, title: String?, appId: String? = nil) {
         self.surfaceId = surfaceId
         self.sessionId = sessionId
         self.surfaceType = surfaceType

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -470,6 +470,9 @@ public extension Surface {
         guard let surfaceType = SurfaceType(rawValue: message.surfaceType) else {
             return nil
         }
+        guard let sessionId = message.sessionId else {
+            return nil
+        }
 
         let dict = message.data.value as? [String: Any?] ?? [:]
 
@@ -488,7 +491,7 @@ public extension Surface {
 
         return Surface(
             id: message.surfaceId,
-            sessionId: message.sessionId,
+            sessionId: sessionId,
             type: surfaceType,
             title: message.title,
             data: surfaceData,


### PR DESCRIPTION
## Summary
- `UiSurfaceShowMessage.sessionId` was changed to `String?` in #14489 to support nil for app-open surfaces, but two usage sites were missed
- `Surface.from(_ message:)` now guards on nil sessionId and returns nil instead of passing `String?` to a `String` parameter
- `SurfaceRef.sessionId` changed to `String?` so app-open surfaces without a session can still build a `SurfaceRef`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
