### PR TITLE
fix: sort imports in cli.ts

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -2,7 +2,7 @@ import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
 import * as readline from "node:readline";
 
-import { httpSend, httpHealthCheck, readHttpToken } from "./cli/http-client.js";
+import { httpHealthCheck, httpSend, readHttpToken } from "./cli/http-client.js";
 import {
   type MainScreenLayout,
   renderMainScreen,


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint error in `assistant/src/cli.ts` by sorting named imports in the `http-client.js` import alphabetically (`httpHealthCheck, httpSend, readHttpToken`).

## Test plan
- [ ] Lint CI passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
