### PR TITLE
fix: require settings.write for POST recordings/status and prevent type override

### DIFF
--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -367,6 +367,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "recordings/pause", scopes: ["settings.write"] },
   { endpoint: "recordings/resume", scopes: ["settings.write"] },
   { endpoint: "recordings/status", scopes: ["settings.read"] },
+  { endpoint: "recordings/status:POST", scopes: ["settings.write"] },
 
   // Surface actions
   { endpoint: "surface-actions", scopes: ["chat.write"] },

--- a/assistant/src/runtime/routes/recording-routes.ts
+++ b/assistant/src/runtime/routes/recording-routes.ts
@@ -253,8 +253,8 @@ async function handlePostRecordingStatus(
   }
 
   const msg: RecordingStatus = {
-    type: "recording_status",
     ...body,
+    type: "recording_status",
   };
 
   const ctx = deps.getHandlerContext();
@@ -325,7 +325,7 @@ export function recordingRouteDefinitions(deps: {
     {
       endpoint: "recordings/status",
       method: "POST",
-      policyKey: "recordings/status",
+      policyKey: "recordings/status:POST",
       handler: async ({ req }) => handlePostRecordingStatus(req, getDeps()),
     },
   ];


### PR DESCRIPTION
## Summary
- Add method-specific policy key `recordings/status:POST` requiring `settings.write` scope
- Move `type: "recording_status"` after spread to prevent client override

Addresses review feedback from #14483.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
