### PR TITLE
fix: remove residual blob transport dead code from Swift clients

### DIFF
--- a/clients/ARCHITECTURE.md
+++ b/clients/ARCHITECTURE.md
@@ -174,7 +174,7 @@ sequenceDiagram
             end
 
             Session->>DC: send(CuObservationMessage)
-            Note over DC: Contains: axTree, axDiff,<br/>screenshot, secondaryWindows,<br/>executionResult/error<br/>Optional: axTreeBlob, screenshotBlob<br/>(blob refs when transport available)
+            Note over DC: Contains: axTree, axDiff,<br/>screenshot, secondaryWindows,<br/>executionResult/error
 
             DC->>Daemon: HTTP POST
             Daemon->>Claude: API call with observation

--- a/clients/shared/IPC/HTTPDaemonClient+Settings.swift
+++ b/clients/shared/IPC/HTTPDaemonClient+Settings.swift
@@ -217,13 +217,6 @@ extension HTTPTransport {
                 Task { await self.sendEncodablePost(.workspaceFilesRead, body: msg, label: "workspace_file_read") }
                 return true
             }
-
-            // --- IPC Blob Probe ---
-            if let msg = message as? IpcBlobProbeMessage {
-                Task { await self.sendEncodablePost(.diagnosticsExport, body: msg, label: "ipc_blob_probe") }
-                return true
-            }
-
             // --- Register Device Token ---
             if let msg = message as? RegisterDeviceTokenMessage {
                 Task { await self.sendEncodablePost(.registerDeviceToken, body: msg, label: "register_device_token") }

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -1412,20 +1412,6 @@ public typealias BundleAppResponseMessage = IPCBundleAppResponse
 /// Backed by generated `IPCSignBundlePayloadRequest`.
 public typealias SignBundlePayloadMessage = IPCSignBundlePayloadRequest
 
-/// Blob probe request sent after connecting to verify filesystem reachability.
-/// Backed by generated `IPCIpcBlobProbe`.
-public typealias IpcBlobProbeMessage = IPCIpcBlobProbe
-
-extension IPCIpcBlobProbe {
-    public init(probeId: String, nonceSha256: String) {
-        self.init(type: "ipc_blob_probe", probeId: probeId, nonceSha256: nonceSha256)
-    }
-}
-
-/// Result from a blob probe verification.
-/// Backed by generated `IPCIpcBlobProbeResult`.
-public typealias IpcBlobProbeResultMessage = IPCIpcBlobProbeResult
-
 /// Real-time execution trace event from the daemon.
 /// Wire type: `"trace_event"`
 public struct TraceEventMessage: Decodable, Sendable {
@@ -2219,7 +2205,6 @@ public enum ServerMessage: Decodable, Sendable {
     case documentSaveResponse(DocumentSaveResponseMessage)
     case documentLoadResponse(DocumentLoadResponseMessage)
     case documentListResponse(DocumentListResponseMessage)
-    case ipcBlobProbeResult(IpcBlobProbeResultMessage)
     case daemonStatus(DaemonStatusMessage)
     case openUrl(OpenUrlMessage)
     case navigateSettings(IPCNavigateSettings)
@@ -2557,9 +2542,6 @@ public enum ServerMessage: Decodable, Sendable {
         case "ui_surface_undo_result":
             let message = try UiSurfaceUndoResultMessage(from: decoder)
             self = .uiSurfaceUndoResult(message)
-        case "ipc_blob_probe_result":
-            let message = try IpcBlobProbeResultMessage(from: decoder)
-            self = .ipcBlobProbeResult(message)
         case "open_url":
             let message = try OpenUrlMessage(from: decoder)
             self = .openUrl(message)


### PR DESCRIPTION
## Summary
- Remove unreachable IpcBlobProbe send handler from HTTPDaemonClient+Settings
- Remove IpcBlobProbeMessage typealias and convenience init from IPCMessages
- Remove ipcBlobProbeResult case from ServerMessage enum
- Update ARCHITECTURE.md diagram to remove blob refs note

Addresses review feedback from #14485.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
