### PR TITLE
fix: bracket IPv6 hosts and normalize wildcards in health check URL

### DIFF
--- a/assistant/src/daemon/daemon-control.ts
+++ b/assistant/src/daemon/daemon-control.ts
@@ -129,11 +129,22 @@ function isVellumDaemonProcess(pid: number): boolean {
   }
 }
 
+/** Normalize a bind address to a connectable host for health checks.
+ *  Wildcard addresses (0.0.0.0, ::) bind all interfaces but aren't
+ *  connectable on all platforms — substitute loopback. IPv6 literals
+ *  need brackets in URLs. */
+function healthCheckHost(host: string): string {
+  if (host === "0.0.0.0") return "127.0.0.1";
+  if (host === "::") return "[::1]";
+  if (host.includes(":")) return `[${host}]`;
+  return host;
+}
+
 /** Hit the daemon's HTTP /healthz endpoint. Returns true if it responds
  *  with HTTP 200 within the timeout — false on connection refused, timeout,
  *  or any other error. */
 async function isHttpHealthy(): Promise<boolean> {
-  const host = getRuntimeHttpHost();
+  const host = healthCheckHost(getRuntimeHttpHost());
   const port = getRuntimeHttpPort();
   try {
     const response = await fetch(`http://${host}:${port}/healthz`, {


### PR DESCRIPTION
## Summary
- Bracket-wrap IPv6 literal hosts in health check URL construction
- Normalize wildcard bind addresses (0.0.0.0 → 127.0.0.1, :: → ::1) for health checks

Addresses review feedback from #14490.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
