### PR TITLE
fix: restore pairing event publish with correct assistantId for SSE clients

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -53,6 +53,8 @@ import {
 } from "../security/oauth-callback-registry.js";
 import { UserError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import { buildAssistantEvent } from "./assistant-event.js";
+import { assistantEventHub } from "./assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
 // Auth
 import { authenticateRequest } from "./auth/middleware.js";
@@ -271,6 +273,9 @@ export class RuntimeHttpServer {
             // Broadcast to all clients via the event hub so HTTP/SSE clients
             // (e.g. macOS app) receive pairing approval requests.
             ipcBroadcast(msg);
+            assistantEventHub.publish(
+              buildAssistantEvent(DAEMON_INTERNAL_ASSISTANT_ID, msg),
+            );
           }
         : undefined,
     };


### PR DESCRIPTION
## Summary
- Re-add assistantEventHub.publish with DAEMON_INTERNAL_ASSISTANT_ID for pairing events
- SSE subscribers filter on 'self' assistantId which the broadcast path doesn't provide

Addresses review feedback from #14491.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
