### PR TITLE
fix: propagate optional sessionId to Surface, SurfaceRef, and SurfaceManager

### DIFF
--- a/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
+++ b/clients/macos/vellum-assistant/Features/Surfaces/SurfaceManager.swift
@@ -81,8 +81,8 @@ final class SurfaceManager: ObservableObject {
     // MARK: - Action Callback
 
     /// Called when a user interacts with a surface action button.
-    /// Parameters: sessionId, surfaceId, actionId, optional data dictionary.
-    var onAction: ((String, String, String, [String: Any]?) -> Void)?
+    /// Parameters: sessionId (optional), surfaceId, actionId, optional data dictionary.
+    var onAction: ((String?, String, String, [String: Any]?) -> Void)?
 
     /// Called when a persistent app's JS makes a data request via the RPC bridge.
     /// Parameters: surfaceId, callId, method, appId, recordId, data.

--- a/clients/shared/Features/Surfaces/SurfaceTypes.swift
+++ b/clients/shared/Features/Surfaces/SurfaceTypes.swift
@@ -445,13 +445,13 @@ public struct SurfaceActionButton: Identifiable, Equatable, Sendable {
 
 public struct Surface: Identifiable, Sendable {
     public let id: String
-    public let sessionId: String
+    public let sessionId: String?
     public let type: SurfaceType
     public let title: String?
     public let data: SurfaceData
     public let actions: [SurfaceActionButton]
 
-    public init(id: String, sessionId: String, type: SurfaceType, title: String? = nil, data: SurfaceData, actions: [SurfaceActionButton]) {
+    public init(id: String, sessionId: String?, type: SurfaceType, title: String? = nil, data: SurfaceData, actions: [SurfaceActionButton]) {
         self.id = id
         self.sessionId = sessionId
         self.type = type
@@ -468,9 +468,6 @@ public extension Surface {
     /// The message carries an `AnyCodable` data payload whose shape depends on `surfaceType`.
     static func from(_ message: UiSurfaceShowMessage) -> Surface? {
         guard let surfaceType = SurfaceType(rawValue: message.surfaceType) else {
-            return nil
-        }
-        guard let sessionId = message.sessionId else {
             return nil
         }
 
@@ -491,7 +488,7 @@ public extension Surface {
 
         return Surface(
             id: message.surfaceId,
-            sessionId: sessionId,
+            sessionId: message.sessionId,
             type: surfaceType,
             title: message.title,
             data: surfaceData,
@@ -499,9 +496,9 @@ public extension Surface {
         )
     }
 
-    /// Create a Surface from a history response surface (without sessionId).
+    /// Create a Surface from a history response surface.
     /// Used when populating messages from history.
-    static func from(_ historySurface: IPCHistoryResponseSurface, sessionId: String) -> Surface? {
+    static func from(_ historySurface: IPCHistoryResponseSurface, sessionId: String?) -> Surface? {
         guard let surfaceType = SurfaceType(rawValue: historySurface.surfaceType) else {
             return nil
         }

--- a/clients/shared/IPC/DaemonClient.swift
+++ b/clients/shared/IPC/DaemonClient.swift
@@ -775,7 +775,7 @@ public final class DaemonClient: ObservableObject, DaemonClientProtocol {
 
     /// Convenience method for sending a surface action response to the daemon.
     /// Keeps the IPC message construction co-located with the client.
-    public func sendSurfaceAction(sessionId: String, surfaceId: String, actionId: String, data: [String: AnyCodable]?) throws {
+    public func sendSurfaceAction(sessionId: String?, surfaceId: String, actionId: String, data: [String: AnyCodable]?) throws {
         let message = UiSurfaceActionMessage(
             sessionId: sessionId,
             surfaceId: surfaceId,

--- a/clients/shared/IPC/HTTPDaemonClient.swift
+++ b/clients/shared/IPC/HTTPDaemonClient.swift
@@ -2267,10 +2267,12 @@ public final class HTTPTransport {
         applyAuth(&request)
 
         var body: [String: Any] = [
-            "sessionId": action.sessionId,
             "surfaceId": action.surfaceId,
             "actionId": action.actionId,
         ]
+        if let sessionId = action.sessionId {
+            body["sessionId"] = sessionId
+        }
         if let data = action.data {
             body["data"] = jsonCompatibleDictionary(data)
         }

--- a/clients/shared/IPC/IPCMessages.swift
+++ b/clients/shared/IPC/IPCMessages.swift
@@ -380,12 +380,20 @@ extension IPCPingMessage {
 }
 
 /// Sent when user interacts with a surface.
-/// Backed by generated `IPCUiSurfaceAction`.
-public typealias UiSurfaceActionMessage = IPCUiSurfaceAction
+/// Hand-written to allow optional `sessionId` (the generated `IPCUiSurfaceAction` requires non-nil).
+public struct UiSurfaceActionMessage: Codable, Sendable {
+    public let type: String
+    public let sessionId: String?
+    public let surfaceId: String
+    public let actionId: String
+    public let data: [String: AnyCodable]?
 
-extension IPCUiSurfaceAction {
-    public init(sessionId: String, surfaceId: String, actionId: String, data: [String: AnyCodable]?) {
-        self.init(type: "ui_surface_action", sessionId: sessionId, surfaceId: surfaceId, actionId: actionId, data: data)
+    public init(sessionId: String?, surfaceId: String, actionId: String, data: [String: AnyCodable]?) {
+        self.type = "ui_surface_action"
+        self.sessionId = sessionId
+        self.surfaceId = surfaceId
+        self.actionId = actionId
+        self.data = data
     }
 }
 
@@ -943,7 +951,7 @@ public typealias SurfaceActionData = IPCSurfaceAction
 /// Surface update command from daemon.
 /// Wire type: `"ui_surface_update"`
 public struct UiSurfaceUpdateMessage: Decodable, Sendable {
-    public let sessionId: String
+    public let sessionId: String?
     public let surfaceId: String
     public let data: AnyCodable
 }
@@ -954,7 +962,7 @@ public typealias UiSurfaceDismissMessage = IPCUiSurfaceDismiss
 
 /// Surface completion message from daemon, sent when user interaction completes a surface.
 public struct UiSurfaceCompleteMessage: Decodable, Sendable {
-    public let sessionId: String
+    public let sessionId: String?
     public let surfaceId: String
     public let summary: String
     public let submittedData: [String: AnyCodable]?


### PR DESCRIPTION
## Summary
- Update `Surface.sessionId` from `String` to `String?` and remove guard unwrap in `Surface.from(_:)` so surfaces without a sessionId are no longer silently dropped
- Update `UiSurfaceUpdateMessage.sessionId` and `UiSurfaceCompleteMessage.sessionId` to `String?` for consistency with `UiSurfaceShowMessage`
- Replace `UiSurfaceActionMessage` typealias with hand-written struct to allow optional `sessionId` in action responses
- Update `SurfaceManager.onAction` callback signature to accept `String?`
- Update `DaemonClient.sendSurfaceAction` and HTTP transport to handle optional sessionId
- `SurfaceRef.sessionId` was already `String?` — no change needed
- PanelCoordinator call sites already pass `surface.sessionId` to `onAction`, which now correctly flows through as `String?`

Addresses review feedback from #14489.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
