### PR TITLE
fix: sort imports in daemon lifecycle.ts

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -52,6 +52,7 @@ import {
 import { ensureVellumGuardianBinding } from "../runtime/guardian-vellum-migration.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import { startScheduler } from "../schedule/scheduler.js";
+import { watchSessions } from "../tools/watch/watch-state.js";
 import { getLogger, initLogger } from "../util/logger.js";
 import {
   ensureDataDir,
@@ -93,7 +94,6 @@ import {
   registerWatcherProviders,
 } from "./providers-setup.js";
 import { handleRideShotgunStart, handleRideShotgunStop } from "./ride-shotgun-handler.js";
-import { watchSessions } from "../tools/watch/watch-state.js";
 import { seedInterfaceFiles } from "./seed-files.js";
 import { DaemonServer } from "./server.js";
 import { initSlashPairingContext } from "./session-slash.js";


### PR DESCRIPTION
## Summary
- Moved the `watchSessions` import from `../tools/watch/watch-state.js` to be grouped with the other `../` imports, before the `./` (same-directory) imports
- This fixes the `simple-import-sort/imports` ESLint error that was failing CI

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/22847911548/job/66268850120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
