### PR TITLE
fix: resolve CLI HTTP migration issues — trust rules, session search, conversation switch, ride-shotgun

### DIFF
--- a/assistant/src/cli.ts
+++ b/assistant/src/cli.ts
@@ -240,11 +240,18 @@ export async function startCli(): Promise<void> {
     scope: string,
     decision: "allow" | "deny",
     confirmDecision: string,
+    options?: { allowHighRisk?: boolean },
   ): Promise<void> {
     try {
       await httpSend("/v1/trust-rules", {
         method: "POST",
-        body: JSON.stringify({ requestId, pattern, scope, decision }),
+        body: JSON.stringify({
+          requestId,
+          pattern,
+          scope,
+          decision,
+          ...(options?.allowHighRisk ? { allowHighRisk: true } : {}),
+        }),
       });
       await httpSend("/v1/confirm", {
         method: "POST",
@@ -467,6 +474,9 @@ export async function startCli(): Promise<void> {
           req.scopeOptions[idx].scope,
           trustDecision,
           trustDecision,
+          decision === "always_allow_high_risk"
+            ? { allowHighRisk: true }
+            : undefined,
         );
       } else {
         // Invalid selection → deny
@@ -522,15 +532,18 @@ export async function startCli(): Promise<void> {
           prompt();
         } else {
           try {
+            const newKey = `builtin-cli:${selected.id}`;
             const resp = await httpSend("/v1/conversations/switch", {
               method: "POST",
-              body: JSON.stringify({ conversationId: selected.id }),
+              body: JSON.stringify({
+                conversationId: selected.id,
+                conversationKey: newKey,
+              }),
             });
             if (resp.ok) {
               const data = (await resp.json()) as { sessionId: string; title: string };
               sessionId = data.sessionId;
-              // Use the session ID as conversation key for the SSE stream
-              conversationKey = `builtin-cli:${sessionId}`;
+              conversationKey = newKey;
               pendingSessionPick = false;
               await reconnectSse();
               process.stdout.write(

--- a/assistant/src/cli/commands/map.ts
+++ b/assistant/src/cli/commands/map.ts
@@ -5,6 +5,8 @@
  * the given domain, then analyzes captured network traffic into a deduplicated API map.
  */
 
+import { statSync } from "node:fs";
+
 import { Command } from "commander";
 import { parse as parseTld } from "tldts";
 
@@ -14,7 +16,10 @@ import {
   saveApiMap,
 } from "../../tools/browser/api-map.js";
 import { ensureChromeWithCdp } from "../../tools/browser/chrome-cdp.js";
-import { loadRecording } from "../../tools/browser/recording-store.js";
+import {
+  listRecordingFiles,
+  loadRecording,
+} from "../../tools/browser/recording-store.js";
 import { httpSend } from "../http-client.js";
 import { getCliLogger } from "../logger.js";
 
@@ -161,6 +166,9 @@ async function startLearnSession(
     process.stderr.write(`Chrome is ready — using tab at ${tabUrl}\n`);
   }
 
+  // Snapshot existing recordings so we can detect new ones after the session
+  const existingRecordings = new Set(listRecordingFiles());
+
   // Start ride shotgun via HTTP
   const response = await httpSend("/v1/computer-use/ride-shotgun/start", {
     method: "POST",
@@ -181,17 +189,49 @@ async function startLearnSession(
     );
   }
 
-  const result = (await response.json()) as {
+  const startResult = (await response.json()) as {
     watchId?: string;
     sessionId?: string;
-    recordingId?: string;
-    recordingPath?: string;
   };
 
-  return {
-    recordingId: result.recordingId,
-    recordingPath: result.recordingPath,
-  };
+  if (!startResult.watchId) {
+    throw new Error("Ride-shotgun start response missing watchId");
+  }
+
+  // Poll for a new recording file to appear after the session completes
+  const timeoutMs = (durationSeconds + 30) * 1000;
+  const pollIntervalMs = 2000;
+  const startTime = Date.now();
+
+  return new Promise<LearnResult>((resolve, reject) => {
+    const poll = setInterval(() => {
+      if (Date.now() - startTime > timeoutMs) {
+        clearInterval(poll);
+        reject(
+          new Error(`Learn session timed out after ${durationSeconds + 30}s`),
+        );
+        return;
+      }
+
+      const currentRecordings = listRecordingFiles();
+      for (const filePath of currentRecordings) {
+        if (existingRecordings.has(filePath)) continue;
+
+        try {
+          const stat = statSync(filePath);
+          if (stat.mtimeMs >= startTime - 1000) {
+            clearInterval(poll);
+            const filename = filePath.split("/").pop() ?? "";
+            const recordingId = filename.replace(/\.json$/, "");
+            resolve({ recordingId, recordingPath: filePath });
+            return;
+          }
+        } catch {
+          // File may have been deleted between readdir and stat
+        }
+      }
+    }, pollIntervalMs);
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { execFile } from "node:child_process";
+import { statSync } from "node:fs";
 import { promisify } from "node:util";
 
 import { Command } from "commander";
@@ -13,6 +14,7 @@ import { Command } from "commander";
 const execFileAsync = promisify(execFile);
 
 import { httpSend } from "../../http-client.js";
+import { listRecordingFiles } from "../../../tools/browser/recording-store.js";
 import {
   getBookmarks,
   getFollowers,
@@ -974,6 +976,9 @@ async function startLearnSession(
   const cdpSession = await launchChromeCdp("https://x.com/login");
   await navigateToX(cdpSession.baseUrl);
 
+  // Snapshot existing recordings so we can detect new ones after the session
+  const existingRecordings = new Set(listRecordingFiles());
+
   // Start ride shotgun via HTTP
   const response = await httpSend("/v1/computer-use/ride-shotgun/start", {
     method: "POST",
@@ -992,15 +997,47 @@ async function startLearnSession(
     );
   }
 
-  const result = (await response.json()) as {
+  const startResult = (await response.json()) as {
     watchId?: string;
     sessionId?: string;
-    recordingId?: string;
-    recordingPath?: string;
   };
 
-  return {
-    recordingId: result.recordingId,
-    recordingPath: result.recordingPath,
-  };
+  if (!startResult.watchId) {
+    throw new Error("Ride-shotgun start response missing watchId");
+  }
+
+  // Poll for a new recording file to appear after the session completes
+  const timeoutMs = (durationSeconds + 30) * 1000;
+  const pollIntervalMs = 2000;
+  const startTime = Date.now();
+
+  return new Promise<LearnResult>((resolve, reject) => {
+    const poll = setInterval(() => {
+      if (Date.now() - startTime > timeoutMs) {
+        clearInterval(poll);
+        reject(
+          new Error(`Learn session timed out after ${durationSeconds + 30}s`),
+        );
+        return;
+      }
+
+      const currentRecordings = listRecordingFiles();
+      for (const filePath of currentRecordings) {
+        if (existingRecordings.has(filePath)) continue;
+
+        try {
+          const stat = statSync(filePath);
+          if (stat.mtimeMs >= startTime - 1000) {
+            clearInterval(poll);
+            const filename = filePath.split("/").pop() ?? "";
+            const recordingId = filename.replace(/\.json$/, "");
+            resolve({ recordingId, recordingPath: filePath });
+            return;
+          }
+        } catch {
+          // File may have been deleted between readdir and stat
+        }
+      }
+    }, pollIntervalMs);
+  });
 }

--- a/assistant/src/daemon/handlers/session-history.ts
+++ b/assistant/src/daemon/handlers/session-history.ts
@@ -6,6 +6,7 @@ import {
 import { getMessageById } from "../../memory/conversation-crud.js";
 import {
   getMessagesPaginated,
+  listConversations,
   searchConversations,
 } from "../../memory/conversation-queries.js";
 import { silentlyWithLog } from "../../util/silently.js";
@@ -299,6 +300,16 @@ export interface ConversationSearchParams {
 
 /** Search conversations and return results (no transport dependency). */
 export function performConversationSearch(params: ConversationSearchParams) {
+  // Treat "*" as a list-all wildcard — FTS treats it as a literal character.
+  if (params.query.trim() === "*") {
+    const rows = listConversations(params.limit);
+    return rows.map((r) => ({
+      conversationId: r.id,
+      conversationTitle: r.title,
+      conversationUpdatedAt: r.updatedAt,
+      matchingMessages: [],
+    }));
+  }
   return searchConversations(params.query, {
     limit: params.limit,
     maxMessagesPerConversation: params.maxMessagesPerConversation,

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -150,9 +150,10 @@ export async function handleTrustRule(
     pattern?: string;
     scope?: string;
     decision?: string;
+    allowHighRisk?: boolean;
   };
 
-  const { requestId, pattern, scope, decision } = body;
+  const { requestId, pattern, scope, decision, allowHighRisk } = body;
 
   if (!requestId || typeof requestId !== "string") {
     return httpError("BAD_REQUEST", "requestId is required", 400);
@@ -234,6 +235,7 @@ export async function handleTrustRule(
     const executionTarget =
       tool?.origin === "skill" ? confirmation.executionTarget : undefined;
     addRule(confirmation.toolName, pattern, scope, decision, undefined, {
+      allowHighRisk: allowHighRisk || undefined,
       executionTarget,
     });
     log.info(

--- a/assistant/src/runtime/routes/session-management-routes.ts
+++ b/assistant/src/runtime/routes/session-management-routes.ts
@@ -9,6 +9,7 @@
  * POST   /v1/conversations/:id/regenerate — regenerate last assistant response
  */
 
+import { setConversationKeyIfAbsent } from "../../memory/conversation-key-store.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
 import type { RouteDefinition } from "../http-router.js";
@@ -53,6 +54,7 @@ export function sessionManagementRouteDefinitions(
       handler: async ({ req }) => {
         const body = (await req.json()) as {
           conversationId?: string;
+          conversationKey?: string;
         };
         const conversationId = body.conversationId;
         if (!conversationId || typeof conversationId !== "string") {
@@ -65,6 +67,11 @@ export function sessionManagementRouteDefinitions(
             `Conversation ${conversationId} not found`,
             404,
           );
+        }
+        // Register the conversation key mapping so the client can use it
+        // for SSE subscriptions and message endpoints after switching.
+        if (body.conversationKey && typeof body.conversationKey === "string") {
+          setConversationKeyIfAbsent(body.conversationKey, conversationId);
         }
         return Response.json(result);
       },

--- a/assistant/src/tools/browser/recording-store.ts
+++ b/assistant/src/tools/browser/recording-store.ts
@@ -3,7 +3,13 @@
  * Stores recordings at ~/.vellum/workspace/data/recordings/<id>.json
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
 import { join, resolve } from "node:path";
 
 import { getLogger } from "../../util/logger.js";
@@ -34,6 +40,18 @@ export function saveRecording(recording: SessionRecording): string {
     "Recording saved",
   );
   return filePath;
+}
+
+/** List all recording file paths in the recordings directory. */
+export function listRecordingFiles(): string[] {
+  const dir = getRecordingsDir();
+  try {
+    return readdirSync(dir)
+      .filter((f) => f.endsWith(".json"))
+      .map((f) => join(dir, f));
+  } catch {
+    return [];
+  }
 }
 
 export function loadRecording(recordingId: string): SessionRecording | null {


### PR DESCRIPTION
## Summary
- Preserve always_allow_high_risk distinction in trust rule creation by passing allowHighRisk flag
- Fix session search to treat '*' as list-all wildcard instead of literal FTS character
- Preserve conversation key mapping after session switch by registering key server-side
- Fix ride-shotgun in map/twitter to poll for recording completion instead of expecting immediate response

Addresses review feedback from #14492.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
