### PR TITLE
fix: handle always_allow/always_deny in POST /v1/confirm by creating trust rules

### DIFF
--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -35,15 +35,25 @@ export async function handleConfirm(
   const body = (await req.json()) as {
     requestId?: string;
     decision?: string;
+    selectedPattern?: string;
+    selectedScope?: string;
   };
 
-  const { requestId, decision } = body;
+  const { requestId, decision, selectedPattern, selectedScope } = body;
 
   if (!requestId || typeof requestId !== "string") {
     return httpError("BAD_REQUEST", "requestId is required", 400);
   }
 
-  const validConfirmDecisions = ["allow", "allow_10m", "allow_thread", "deny"];
+  const validConfirmDecisions = [
+    "allow",
+    "allow_10m",
+    "allow_thread",
+    "deny",
+    "always_allow",
+    "always_deny",
+    "always_allow_high_risk",
+  ];
   if (
     typeof decision !== "string" ||
     !validConfirmDecisions.includes(decision)
@@ -67,8 +77,8 @@ export async function handleConfirm(
   interaction.session.handleConfirmationResponse(
     requestId,
     decision as UserDecision,
-    undefined,
-    undefined,
+    selectedPattern,
+    selectedScope,
     undefined,
     {
       source: "button",


### PR DESCRIPTION
## Summary
Fixes critical regression where Swift client 'Always Allow' and 'Denylist' confirmation actions silently fail. The server's POST /v1/confirm endpoint now accepts `always_allow`, `always_deny`, and `always_allow_high_risk` decisions — creating the corresponding trust rule before resolving the pending confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14508" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
