### PR TITLE
fix: recording policy scope, dead server params, CLI type, and getIpcBlobDir vestiges

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -53,7 +53,7 @@ mock.module("../util/platform.js", () => ({
   getLogPath: () => join(TEST_DIR, "logs", "vellum.log"),
   getHistoryPath: () => join(TEST_DIR, "history"),
   getHooksDir: () => join(TEST_DIR, "hooks"),
-  getIpcBlobDir: () => join(TEST_DIR, "ipc-blobs"),
+
   getSandboxRootDir: () => join(TEST_DIR, "sandbox"),
   getSandboxWorkingDir: () => TEST_DIR,
   getInterfacesDir: () => join(TEST_DIR, "interfaces"),

--- a/assistant/src/__tests__/computer-use-session-working-dir.test.ts
+++ b/assistant/src/__tests__/computer-use-session-working-dir.test.ts
@@ -28,7 +28,7 @@ mock.module("../util/platform.js", () => ({
   ...realPlatform,
   getRootDir: () => "/tmp",
   getDataDir: () => "/tmp/data",
-  getIpcBlobDir: () => "/tmp/data/ipc-blobs",
+
   getSandboxRootDir: () => "/tmp/sandbox",
   getSandboxWorkingDir: () => "/tmp/workspace",
   getInterfacesDir: () => "/tmp/interfaces",

--- a/assistant/src/__tests__/config-watcher.test.ts
+++ b/assistant/src/__tests__/config-watcher.test.ts
@@ -39,7 +39,7 @@ mock.module("../util/platform.js", () => ({
   getLogPath: () => join(WORKSPACE_DIR, "data", "logs", "vellum.log"),
   getHistoryPath: () => join(WORKSPACE_DIR, "data", "history"),
   getHooksDir: () => join(WORKSPACE_DIR, "hooks"),
-  getIpcBlobDir: () => join(WORKSPACE_DIR, "data", "ipc-blobs"),
+
   getSandboxRootDir: () => join(WORKSPACE_DIR, "data", "sandbox"),
   getSandboxWorkingDir: () => WORKSPACE_DIR,
   getInterfacesDir: () => join(WORKSPACE_DIR, "data", "interfaces"),

--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -25,7 +25,7 @@ mock.module("../util/platform.js", () => ({
   getLogPath: () => join(TEST_DIR, "logs", "vellum.log"),
   getHistoryPath: () => join(TEST_DIR, "history"),
   getHooksDir: () => join(TEST_DIR, "hooks"),
-  getIpcBlobDir: () => join(TEST_DIR, "ipc-blobs"),
+
   getSandboxRootDir: () => join(TEST_DIR, "sandbox"),
   getSandboxWorkingDir: () => TEST_DIR,
   getInterfacesDir: () => join(TEST_DIR, "interfaces"),

--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -24,7 +24,7 @@ mock.module("../util/platform.js", () => ({
   getLogPath: () => join(TEST_DIR, "logs", "vellum.log"),
   getHistoryPath: () => join(TEST_DIR, "history"),
   getHooksDir: () => join(TEST_DIR, "hooks"),
-  getIpcBlobDir: () => join(TEST_DIR, "ipc-blobs"),
+
   getSandboxRootDir: () => join(TEST_DIR, "sandbox"),
   getSandboxWorkingDir: () => TEST_DIR,
   getInterfacesDir: () => join(TEST_DIR, "interfaces"),

--- a/assistant/src/__tests__/onboarding-starter-tasks.test.ts
+++ b/assistant/src/__tests__/onboarding-starter-tasks.test.ts
@@ -28,7 +28,7 @@ mock.module("../util/platform.js", () => ({
   getLogPath: () => join(TEST_DIR, "logs", "vellum.log"),
   getHistoryPath: () => join(TEST_DIR, "history"),
   getHooksDir: () => join(TEST_DIR, "hooks"),
-  getIpcBlobDir: () => join(TEST_DIR, "ipc-blobs"),
+
   getSandboxRootDir: () => join(TEST_DIR, "sandbox"),
   getSandboxWorkingDir: () => TEST_DIR,
   getInterfacesDir: () => join(TEST_DIR, "interfaces"),

--- a/assistant/src/__tests__/session-init.benchmark.test.ts
+++ b/assistant/src/__tests__/session-init.benchmark.test.ts
@@ -98,7 +98,7 @@ mock.module("../util/platform.js", () => ({
   getLogPath: () => join(testDir, "logs", "test.log"),
   getHistoryPath: () => join(testDir, "history"),
   getHooksDir: () => join(testDir, "hooks"),
-  getIpcBlobDir: () => join(testDir, "ipc-blobs"),
+
   getSandboxRootDir: () => join(testDir, "sandbox"),
   getSandboxWorkingDir: () => testDir,
   getInterfacesDir: () => join(testDir, "interfaces"),

--- a/assistant/src/__tests__/skill-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags-integration.test.ts
@@ -47,7 +47,7 @@ mock.module("../util/platform.js", () => ({
   getLogPath: () => join(TEST_DIR, "logs", "vellum.log"),
   getHistoryPath: () => join(TEST_DIR, "history"),
   getHooksDir: () => join(TEST_DIR, "hooks"),
-  getIpcBlobDir: () => join(TEST_DIR, "ipc-blobs"),
+
   getSandboxRootDir: () => join(TEST_DIR, "sandbox"),
   getSandboxWorkingDir: () => TEST_DIR,
   getInterfacesDir: () => join(TEST_DIR, "interfaces"),

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -33,7 +33,7 @@ const platformOverrides: Record<string, (...args: unknown[]) => unknown> = {
     join(TEST_DIR, "workspace", String(f)),
   getInterfacesDir: () => join(TEST_DIR, "interfaces"),
   getHooksDir: () => join(TEST_DIR, "hooks"),
-  getIpcBlobDir: () => join(TEST_DIR, "blobs"),
+
   getSandboxRootDir: () => join(TEST_DIR, "sandbox"),
   getSandboxWorkingDir: () => join(TEST_DIR, "sandbox", "work"),
   getHistoryPath: () => join(TEST_DIR, "history"),

--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -26,7 +26,7 @@ const platformOverrides: Record<string, (...args: unknown[]) => unknown> = {
     join(TEST_DIR, "workspace", String(f)),
   getInterfacesDir: () => join(TEST_DIR, "interfaces"),
   getHooksDir: () => join(TEST_DIR, "hooks"),
-  getIpcBlobDir: () => join(TEST_DIR, "blobs"),
+
   getSandboxRootDir: () => join(TEST_DIR, "sandbox"),
   getSandboxWorkingDir: () => join(TEST_DIR, "sandbox", "work"),
   getHistoryPath: () => join(TEST_DIR, "history"),

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -18,7 +18,7 @@ mock.module("../util/platform.js", () => ({
   ...realPlatform,
   getRootDir: () => TEST_DIR,
   getDataDir: () => TEST_DIR,
-  getIpcBlobDir: () => join(TEST_DIR, "ipc-blobs"),
+
   getSandboxRootDir: () => join(TEST_DIR, "sandbox"),
   getSandboxWorkingDir: () => TEST_DIR,
   getInterfacesDir: () => join(TEST_DIR, "interfaces"),

--- a/assistant/src/__tests__/slack-channel-config.test.ts
+++ b/assistant/src/__tests__/slack-channel-config.test.ts
@@ -57,7 +57,7 @@ mock.module("../config/loader.js", () => ({
 mock.module("../util/platform.js", () => ({
   getRootDir: () => testDir,
   getDataDir: () => testDir,
-  getIpcBlobDir: () => join(testDir, "ipc-blobs"),
+
   isMacOS: () => process.platform === "darwin",
   isLinux: () => process.platform === "linux",
   isWindows: () => process.platform === "win32",

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -32,7 +32,7 @@ mock.module("../util/platform.js", () => ({
   getLogPath: () => join(TEST_DIR, "logs", "vellum.log"),
   getHistoryPath: () => join(TEST_DIR, "history"),
   getHooksDir: () => join(TEST_DIR, "hooks"),
-  getIpcBlobDir: () => join(TEST_DIR, "ipc-blobs"),
+
   getSandboxRootDir: () => join(TEST_DIR, "sandbox"),
   getSandboxWorkingDir: () => TEST_DIR,
   getInterfacesDir: () => join(TEST_DIR, "interfaces"),

--- a/assistant/src/__tests__/update-bulletin.test.ts
+++ b/assistant/src/__tests__/update-bulletin.test.ts
@@ -62,7 +62,7 @@ mock.module("../util/platform.js", () => ({
   getWorkspaceConfigPath: () => "",
   getWorkspaceSkillsDir: () => "",
   getWorkspaceHooksDir: () => "",
-  getIpcBlobDir: () => "",
+
   getSandboxRootDir: () => "",
   getSandboxWorkingDir: () => "",
   getInterfacesDir: () => "",

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -482,8 +482,6 @@ export class DaemonServer {
 
   private async getOrCreateSession(
     conversationId: string,
-    _socket?: undefined,
-    _rebindClient?: boolean,
     options?: SessionCreateOptions,
   ): Promise<Session> {
     let session = this.sessions.get(conversationId);
@@ -585,7 +583,7 @@ export class DaemonServer {
       broadcast: (msg) => this.broadcast(msg),
       clearAllSessions: () => this.clearAllSessions(),
       getOrCreateSession: (id, _rebind?, options?) =>
-        this.getOrCreateSession(id, undefined, undefined, options),
+        this.getOrCreateSession(id, options),
       touchSession: (id) => this.evictor.touch(id),
       heartbeatService: this._heartbeatService,
     };
@@ -633,8 +631,6 @@ export class DaemonServer {
 
     const session = await this.getOrCreateSession(
       conversationId,
-      undefined,
-      true,
       options,
     );
 
@@ -889,7 +885,7 @@ export class DaemonServer {
    * The handler manages busy-state checking and queueing itself.
    */
   async getSessionForMessages(conversationId: string): Promise<Session> {
-    return this.getOrCreateSession(conversationId, undefined, true);
+    return this.getOrCreateSession(conversationId);
   }
 
   /**

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -145,7 +145,7 @@ interface PendingInteractionsResponse {
   pendingSecret: (PendingSecret & { requestId?: string }) | null;
 }
 
-type TrustDecision = "always_allow" | "always_allow_high_risk" | "always_deny";
+type TrustDecision = "always_allow" | "always_deny";
 
 interface HealthResponse {
   status: string;


### PR DESCRIPTION
## Summary
- Fix POST recordings/status to require `settings.write` policy scope
- Remove dead `_socket`/`_rebindClient` params from `server.ts` getOrCreateSession()
- Remove unused `always_allow_high_risk` from CLI TrustDecision type
- Remove `getIpcBlobDir` from context interface and ~14 test stubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
