### PR TITLE
fix: sort imports in twitter index and recording-store to fix lint

### DIFF
--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -13,8 +13,8 @@ import { Command } from "commander";
 
 const execFileAsync = promisify(execFile);
 
-import { httpSend } from "../../http-client.js";
 import { listRecordingFiles } from "../../../tools/browser/recording-store.js";
+import { httpSend } from "../../http-client.js";
 import {
   getBookmarks,
   getFollowers,

--- a/assistant/src/tools/browser/recording-store.ts
+++ b/assistant/src/tools/browser/recording-store.ts
@@ -6,8 +6,8 @@
 import {
   existsSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   writeFileSync,
 } from "node:fs";
 import { join, resolve } from "node:path";


### PR DESCRIPTION
## Summary
- Fix `simple-import-sort/imports` lint errors in two files
- Swap `readdirSync`/`readFileSync` order in `recording-store.ts` named imports (alphabetical)
- Move `../../../tools/browser/recording-store.js` import before `../../http-client.js` in `twitter/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
