### PR TITLE
feat: inject VELLUM_DATA_DIR into sanitized child-process env

### DIFF
--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -6,6 +6,7 @@
  * Shared by the sandbox bash tool and skill sandbox runner.
  */
 import { getGatewayInternalBaseUrl } from "../../config/env.js";
+import { getDataDir } from "../../util/platform.js";
 
 const SAFE_ENV_VARS = [
   "PATH",
@@ -38,5 +39,8 @@ export function buildSanitizedEnv(): Record<string, string> {
   // Always inject an internal gateway base for local control-plane/API calls.
   const internalGatewayBase = getGatewayInternalBaseUrl();
   env.INTERNAL_GATEWAY_BASE_URL = internalGatewayBase;
+  // Expose the runtime data directory so child processes can locate databases,
+  // logs, and other instance-scoped state without re-deriving the path.
+  env.VELLUM_DATA_DIR = getDataDir();
   return env;
 }


### PR DESCRIPTION
## Summary
- Adds `VELLUM_DATA_DIR` to the sanitized environment built by `buildSanitizedEnv()`, using `getDataDir()` from `util/platform`
- Allows child processes (sandbox shells, skill runners) to locate the runtime data directory without re-deriving it

## Original prompt
Lets update buildSanitizedEnv to also inject a new VELLUM_DATA_DIR env var using utils/platform/getDataDir

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
