### PR TITLE
refactor: use process.env.VELLUM_DATA_DIR instead of getDataDir() import

### DIFF
--- a/assistant/src/cli/commands/amazon/request-extractor.ts
+++ b/assistant/src/cli/commands/amazon/request-extractor.ts
@@ -9,8 +9,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { getDataDir } from "../../../util/platform.js";
-
 interface NetworkRecordedRequest {
   method: string;
   url: string;
@@ -68,7 +66,7 @@ export interface CapturedRequest {
 }
 
 function getCapturedRequestsPath(): string {
-  return join(getDataDir(), "amazon", "captured-requests.json");
+  return join(process.env.VELLUM_DATA_DIR!, "amazon", "captured-requests.json");
 }
 
 /**

--- a/assistant/src/cli/commands/doctor.ts
+++ b/assistant/src/cli/commands/doctor.ts
@@ -6,7 +6,6 @@ import type { Command } from "commander";
 import { loadRawConfig } from "../../config/loader.js";
 import { shouldAutoStartDaemon } from "../../daemon/connection-policy.js";
 import {
-  getDataDir,
   getDbPath,
   getLogPath,
   getRootDir,
@@ -114,7 +113,10 @@ Examples:
           );
         }
       } catch {
-        fail("Assistant reachable", "could not connect to assistant HTTP server");
+        fail(
+          "Assistant reachable",
+          "could not connect to assistant HTTP server",
+        );
       }
 
       // 4. DB exists and readable
@@ -138,7 +140,7 @@ Examples:
 
       // 5. ~/.vellum/ directory structure (workspace layout)
       const rootDir = getRootDir();
-      const dataDir = getDataDir();
+      const dataDir = process.env.VELLUM_DATA_DIR!;
       const workspaceDir = getWorkspaceDir();
       const requiredDirs = [
         rootDir,
@@ -236,7 +238,9 @@ Examples:
           const tokenStat = statSync(tokenPath);
           const mode = tokenStat.mode & 0o777;
           if (mode === 0o600 || mode === 0o700) {
-            pass(`HTTP token permissions (${mode.toString(8).padStart(4, "0")})`);
+            pass(
+              `HTTP token permissions (${mode.toString(8).padStart(4, "0")})`,
+            );
           } else {
             fail(
               "HTTP token permissions",

--- a/assistant/src/config/bundled-skills/doordash/__tests__/doordash-session.test.ts
+++ b/assistant/src/config/bundled-skills/doordash/__tests__/doordash-session.test.ts
@@ -10,14 +10,10 @@ import {
   importFromRecording,
 } from "../lib/session.js";
 
-// Override getDataDir to use a temp directory during tests
+// Override VELLUM_DATA_DIR to use a temp directory during tests.
+// session.ts reads process.env.VELLUM_DATA_DIR directly.
 const TEST_DIR = join(tmpdir(), `vellum-dd-test-${process.pid}`);
 let originalDataDir: string | undefined;
-
-// We mock getDataDir by patching the module at the fs level:
-// session.ts calls getSessionDir() -> join(getDataDir(), 'doordash')
-// We'll test session.ts helpers that don't depend on getDataDir directly,
-// and test the persistence functions via the actual file system with a known path.
 
 function makeCookie(
   name: string,
@@ -88,25 +84,21 @@ describe("DoorDash session helpers", () => {
 
 describe("DoorDash session persistence", () => {
   // These tests exercise the real loadSession/saveSession/clearSession
-  // by writing to the actual session path. We need to mock getDataDir.
-  // Since the module uses a private function we can't easily mock,
-  // we test via importFromRecording which exercises save+load.
+  // by pointing VELLUM_DATA_DIR at a temp directory and testing via
+  // importFromRecording which exercises save+load.
 
   beforeEach(() => {
-    originalDataDir = process.env.BASE_DATA_DIR;
-    process.env.BASE_DATA_DIR = TEST_DIR;
-    // Ensure test dir exists
+    originalDataDir = process.env.VELLUM_DATA_DIR;
+    process.env.VELLUM_DATA_DIR = TEST_DIR;
     mkdirSync(TEST_DIR, { recursive: true });
   });
 
   afterEach(() => {
-    // Restore original BASE_DATA_DIR
     if (originalDataDir === undefined) {
-      delete process.env.BASE_DATA_DIR;
+      delete process.env.VELLUM_DATA_DIR;
     } else {
-      process.env.BASE_DATA_DIR = originalDataDir;
+      process.env.VELLUM_DATA_DIR = originalDataDir;
     }
-    // Clean up test dir
     if (existsSync(TEST_DIR)) {
       rmSync(TEST_DIR, { recursive: true, force: true });
     }

--- a/assistant/src/config/bundled-skills/doordash/lib/session.ts
+++ b/assistant/src/config/bundled-skills/doordash/lib/session.ts
@@ -13,7 +13,6 @@ import {
 import { join } from "node:path";
 
 import { ConfigError } from "./shared/errors.js";
-import { getDataDir } from "./shared/platform.js";
 import type {
   ExtractedCredential,
   SessionRecording,
@@ -26,7 +25,7 @@ export interface DoorDashSession {
 }
 
 function getSessionDir(): string {
-  return join(getDataDir(), "doordash");
+  return join(process.env.VELLUM_DATA_DIR!, "doordash");
 }
 
 function getSessionPath(): string {


### PR DESCRIPTION
## Summary
- Replace `getDataDir()` import/call with `process.env.VELLUM_DATA_DIR` in request-extractor, doctor, and doordash session
- Update doordash session test to set `VELLUM_DATA_DIR` instead of `BASE_DATA_DIR`

## Original prompt
Update these files and their tests to rely on process.env.VELLUM_DATA_DIR instead of importing and calling getDataDir

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
