### PR TITLE
feat: hatch confirmation modal, post-hatch auto-switch, retire auto-wake

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+AuthLifecycle.swift
@@ -329,12 +329,35 @@ extension AppDelegate {
             assistantCli.stop()
         }
 
-        // Check if other assistants remain in the lockfile
+        // Check if other assistants remain in the lockfile.
+        // Prefer remote assistants (always reachable), then try waking local ones.
         let remaining = LockfileAssistant.loadAll().filter { $0.assistantId != assistantName }
-        if let next = remaining.first {
-            // Auto-switch to the next available assistant
-            performSwitchAssistant(to: next)
-            return true
+        if !remaining.isEmpty {
+            // Try remote assistants first — they're always reachable
+            if let remote = remaining.first(where: { $0.isRemote }) {
+                performSwitchAssistant(to: remote)
+                return true
+            }
+
+            // Try local assistants — check if awake, otherwise wake them
+            for candidate in remaining {
+                let env: [String: String]? = candidate.instanceDir.map { ["BASE_DATA_DIR": $0] }
+                if DaemonClient.isDaemonProcessAlive(environment: env) {
+                    performSwitchAssistant(to: candidate)
+                    return true
+                }
+
+                // Sleeping — try to wake it
+                do {
+                    try await assistantCli.wake(name: candidate.assistantId)
+                    performSwitchAssistant(to: candidate)
+                    return true
+                } catch {
+                    log.warning("Failed to wake \(candidate.assistantId): \(error.localizedDescription)")
+                    continue
+                }
+            }
+            // All local wake attempts failed — fall through to onboarding
         }
 
         // No assistants left — tear down fully and show onboarding

--- a/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate+WindowsAndSurfaces.swift
@@ -286,6 +286,65 @@ extension AppDelegate {
         onboardingWindow = onboarding
     }
 
+    /// Hatches a new assistant via onboarding and auto-switches to it on success.
+    /// Unlike `replayOnboarding()`, this method detects the newly created assistant
+    /// and makes it the active one.
+    func hatchNewAssistant() {
+        guard onboardingWindow == nil else { return }
+
+        if !daemonClient.isConnected {
+            setupDaemonClient()
+        }
+
+        // Snapshot existing assistant IDs so we can detect the new one after hatch
+        let existingIds = Set(LockfileAssistant.loadAll().map(\.assistantId))
+
+        // Hide the main window during hatch to avoid showing stale old-assistant UI
+        let mainWindowWasVisible = mainWindow?.isVisible ?? false
+        if mainWindowWasVisible {
+            mainWindow?.hide()
+        }
+
+        OnboardingState.clearPersistedState()
+
+        let onboarding = OnboardingWindow(daemonClient: daemonClient, authManager: authManager)
+        onboarding.onComplete = { [weak self] state in
+            OnboardingState.clearPersistedState()
+            UserDefaults.standard.set(state.chosenKey.rawValue, forKey: "activationKey")
+
+            onboarding.close()
+            self?.onboardingWindow = nil
+            UserDefaults.standard.removeObject(forKey: "lastActivePanel")
+
+            // Detect the newly hatched assistant by diffing lockfile against snapshot.
+            // loadAll() returns newest-first, so the first new ID is the most recently hatched.
+            let allAssistants = LockfileAssistant.loadAll()
+            let newAssistant = allAssistants.first { !existingIds.contains($0.assistantId) }
+
+            if let assistant = newAssistant {
+                self?.performSwitchAssistant(to: assistant)
+            } else {
+                // No new assistant detected (e.g. managed bootstrap set connectedAssistantId
+                // but reused an existing entry). Check if connectedAssistantId changed.
+                if let connectedId = UserDefaults.standard.string(forKey: "connectedAssistantId"),
+                   !existingIds.isEmpty,
+                   let connected = allAssistants.first(where: { $0.assistantId == connectedId }) {
+                    self?.performSwitchAssistant(to: connected)
+                } else {
+                    self?.showMainWindow()
+                }
+            }
+        }
+        onboarding.onDismiss = { [weak self] in
+            self?.onboardingWindow = nil
+            if mainWindowWasVisible {
+                self?.showMainWindow()
+            }
+        }
+        onboarding.show()
+        onboardingWindow = onboarding
+    }
+
     /// Returns `true` when `~/.vellum.lock.json` contains at least one
     /// assistant entry.
     func lockfileHasAssistants() -> Bool {

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -25,6 +25,7 @@ struct SettingsAccountTab: View {
     @State private var devModeMessage: String?
     @State private var isHatchFlagEnabled: Bool = true
     @State private var isLoadingHatchFlag: Bool = false
+    @State private var showingHatchConfirmation: Bool = false
 
     // -- Wake/sleep toggle state --
     @State private var awakeStates: [String: Bool] = [:]
@@ -477,8 +478,16 @@ struct SettingsAccountTab: View {
                             .foregroundColor(VColor.textMuted)
                     }
                     VButton(label: "Hatch...", style: .primary) {
-                        AppDelegate.shared?.replayOnboarding()
-                        onClose()
+                        showingHatchConfirmation = true
+                    }
+                    .alert("Hatch New Assistant", isPresented: $showingHatchConfirmation) {
+                        Button("Cancel", role: .cancel) {}
+                        Button("Continue") {
+                            AppDelegate.shared?.hatchNewAssistant()
+                            onClose()
+                        }
+                    } message: {
+                        Text("This will create a brand new assistant. Your existing assistant(s) will continue to exist and you can switch back to using them.")
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Add confirmation dialog before hatching a new assistant from Settings
- Auto-detect and switch to the newly hatched assistant after onboarding completes (via lockfile diff)
- Hide main window during hatch flow to avoid stale UI
- On retire, prefer remote assistants, then try waking sleeping local ones before falling through to onboarding

## Test plan
- [ ] Settings → Hatch → Cancel modal → nothing happens
- [ ] Settings → Hatch → Continue → onboarding opens → complete hatch → main window opens on new assistant
- [ ] Start hatch, close onboarding window before completing → returns to current assistant
- [ ] Retire with sleeping sibling → auto-wakes and switches
- [ ] Retire with no siblings → onboarding appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
