### PR TITLE
fix: polling race condition, early clearInterval, and wrong scope in ride-shotgun

### DIFF
--- a/assistant/src/config/bundled-skills/doordash/doordash-cli.ts
+++ b/assistant/src/config/bundled-skills/doordash/doordash-cli.ts
@@ -1009,9 +1009,8 @@ async function startLearnSession(
   const startTime = Date.now();
 
   return new Promise<LearnResult>((resolve, reject) => {
-    const poll = setInterval(async () => {
+    const pollOnce = async () => {
       if (Date.now() - startTime > timeoutMs) {
-        clearInterval(poll);
         reject(
           new Error(`Learn session timed out after ${durationSeconds + 30}s`),
         );
@@ -1031,7 +1030,6 @@ async function startLearnSession(
 
           // Session failed without producing a recording
           if (status.bootstrapFailureReason) {
-            clearInterval(poll);
             reject(
               new Error(
                 `Learn session failed: ${status.bootstrapFailureReason}`,
@@ -1042,8 +1040,6 @@ async function startLearnSession(
 
           // Session completed — check for the correlated recording file
           if (status.status === "completed") {
-            clearInterval(poll);
-
             if (status.savedRecordingPath && status.recordingId) {
               resolve({
                 recordingId: status.recordingId,
@@ -1068,11 +1064,13 @@ async function startLearnSession(
                 });
                 return;
               } catch {
-                // Recording file not yet written — will retry
+                // Recording file not yet written — continue polling
+                setTimeout(pollOnce, pollIntervalMs);
+                return;
               }
             }
 
-            // Completed but no recording saved
+            // Completed but no recordingId — cannot correlate
             reject(
               new Error(
                 "Learn session completed but no recording was saved.",
@@ -1084,6 +1082,10 @@ async function startLearnSession(
       } catch {
         // Status endpoint not reachable — continue polling
       }
-    }, pollIntervalMs);
+
+      setTimeout(pollOnce, pollIntervalMs);
+    };
+
+    setTimeout(pollOnce, pollIntervalMs);
   });
 }

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -359,7 +359,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "computer-use/tasks", scopes: ["chat.write"] },
   { endpoint: "computer-use/ride-shotgun/start", scopes: ["chat.write"] },
   { endpoint: "computer-use/ride-shotgun/stop", scopes: ["chat.write"] },
-  { endpoint: "computer-use/ride-shotgun/status", scopes: ["chat.write"] },
+  { endpoint: "computer-use/ride-shotgun/status", scopes: ["chat.read"] },
   { endpoint: "computer-use/watch", scopes: ["chat.write"] },
 
   // Recordings


### PR DESCRIPTION
Follow-up to #14504. Fixes three issues: replaces setInterval with sequential setTimeout polling to prevent races, moves clearInterval to success/final-reject paths only, and changes ride-shotgun status endpoint scope from chat.write to chat.read.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
