### PR TITLE
fix: remove dead removeSocketFile mock stubs from test files

### DIFF
--- a/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/assistant-feature-flags-integration.test.ts
@@ -63,7 +63,6 @@ mock.module("../util/platform.js", () => ({
   getPlatformName: () => "linux",
   getClipboardCommand: () => null,
   readSessionToken: () => null,
-  removeSocketFile: () => {},
 }));
 
 const noopLogger = new Proxy({} as Record<string, unknown>, {

--- a/assistant/src/__tests__/computer-use-session-working-dir.test.ts
+++ b/assistant/src/__tests__/computer-use-session-working-dir.test.ts
@@ -46,7 +46,6 @@ mock.module("../util/platform.js", () => ({
   getHistoryPath: () => "/tmp/data/history",
   getHooksDir: () => "/tmp/hooks",
   readSessionToken: () => null,
-  removeSocketFile: () => {},
   ensureDataDir: () => {},
   isMacOS: () => false,
   isLinux: () => true,

--- a/assistant/src/__tests__/config-watcher.test.ts
+++ b/assistant/src/__tests__/config-watcher.test.ts
@@ -48,7 +48,6 @@ mock.module("../util/platform.js", () => ({
   isWindows: () => process.platform === "win32",
   getPlatformName: () => process.platform,
   getClipboardCommand: () => null,
-  removeSocketFile: () => {},
 }));
 
 mock.module("../util/logger.js", () => ({

--- a/assistant/src/__tests__/daemon-assistant-events.test.ts
+++ b/assistant/src/__tests__/daemon-assistant-events.test.ts
@@ -27,7 +27,6 @@ mock.module("../util/platform.js", () => ({
   getLogPath: () => "/tmp/test.log",
   getDbPath: () => "/tmp/test.db",
   ensureDataDir: () => {},
-  removeSocketFile: () => {},
 }));
 
 mock.module("../util/logger.js", () => ({

--- a/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
+++ b/assistant/src/__tests__/dynamic-skill-workflow-prompt.test.ts
@@ -35,7 +35,6 @@ mock.module("../util/platform.js", () => ({
   getPlatformName: () => process.platform,
   getClipboardCommand: () => null,
   readSessionToken: () => null,
-  removeSocketFile: () => {},
 }));
 
 const noopLogger = new Proxy({} as Record<string, unknown>, {

--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -34,7 +34,6 @@ mock.module("../util/platform.js", () => ({
   getPlatformName: () => process.platform,
   getClipboardCommand: () => null,
   readSessionToken: () => null,
-  removeSocketFile: () => {},
 }));
 
 const noopLogger = new Proxy({} as Record<string, unknown>, {

--- a/assistant/src/__tests__/managed-skill-lifecycle.test.ts
+++ b/assistant/src/__tests__/managed-skill-lifecycle.test.ts
@@ -42,7 +42,6 @@ mock.module("../util/platform.js", () => ({
   isWindows: () => process.platform === "win32",
   getPlatformName: () => process.platform,
   getClipboardCommand: () => null,
-  removeSocketFile: () => {},
 }));
 
 mock.module("../util/logger.js", () => ({

--- a/assistant/src/__tests__/onboarding-starter-tasks.test.ts
+++ b/assistant/src/__tests__/onboarding-starter-tasks.test.ts
@@ -38,7 +38,6 @@ mock.module("../util/platform.js", () => ({
   getPlatformName: () => process.platform,
   getClipboardCommand: () => null,
   readSessionToken: () => null,
-  removeSocketFile: () => {},
   readLockfile: () => null,
   writeLockfile: () => {},
 }));

--- a/assistant/src/__tests__/session-init.benchmark.test.ts
+++ b/assistant/src/__tests__/session-init.benchmark.test.ts
@@ -115,7 +115,6 @@ mock.module("../util/platform.js", () => ({
   readLockfile: () => null,
   readPlatformToken: () => null,
   readSessionToken: () => null,
-  removeSocketFile: () => {},
   writeLockfile: () => {},
   ensureDataDir: () => {},
 }));

--- a/assistant/src/__tests__/skill-feature-flags-integration.test.ts
+++ b/assistant/src/__tests__/skill-feature-flags-integration.test.ts
@@ -57,7 +57,6 @@ mock.module("../util/platform.js", () => ({
   getPlatformName: () => "linux",
   getClipboardCommand: () => null,
   readSessionToken: () => null,
-  removeSocketFile: () => {},
 }));
 
 const noopLogger = new Proxy({} as Record<string, unknown>, {

--- a/assistant/src/__tests__/skill-load-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-load-feature-flag.test.ts
@@ -44,7 +44,6 @@ const platformOverrides: Record<string, (...args: unknown[]) => unknown> = {
   isLinux: () => process.platform === "linux",
   isWindows: () => process.platform === "win32",
   getPlatformName: () => process.platform,
-  removeSocketFile: () => {},
 };
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const realPlatform = require("../util/platform.js");

--- a/assistant/src/__tests__/skill-load-tool.test.ts
+++ b/assistant/src/__tests__/skill-load-tool.test.ts
@@ -47,7 +47,6 @@ const platformOverrides: Record<string, (...args: unknown[]) => unknown> = {
   isLinux: () => process.platform === "linux",
   isWindows: () => process.platform === "win32",
   getPlatformName: () => process.platform,
-  removeSocketFile: () => {},
 };
 mock.module("../util/platform.js", () => platformOverrides);
 

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -40,7 +40,6 @@ mock.module("../util/platform.js", () => ({
   getWorkspaceDir: () => TEST_DIR,
   getWorkspacePromptPath: (file: string) => join(TEST_DIR, file),
   readSessionToken: () => null,
-  removeSocketFile: () => {},
   normalizeAssistantId: (id: string) => id,
   readLockfile: () => null,
   writeLockfile: () => {},

--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -42,7 +42,6 @@ mock.module("../util/platform.js", () => ({
   getPlatformName: () => process.platform,
   getClipboardCommand: () => null,
   readSessionToken: () => null,
-  removeSocketFile: () => {},
 }));
 
 const noopLogger = new Proxy({} as Record<string, unknown>, {

--- a/assistant/src/__tests__/update-bulletin.test.ts
+++ b/assistant/src/__tests__/update-bulletin.test.ts
@@ -71,7 +71,6 @@ mock.module("../util/platform.js", () => ({
   writeLockfile: () => {},
   readPlatformToken: () => null,
   readSessionToken: () => null,
-  removeSocketFile: () => {},
   getTCPPort: () => 8765,
   isTCPEnabled: () => false,
   getTCPHost: () => "127.0.0.1",


### PR DESCRIPTION
Follow-up to #14486. Removes leftover `removeSocketFile` mock stubs from 15 test files. The function was removed from `platform.ts` in #14486 but the mock stubs were left behind. The other feedback item (`maxLineSize`/`createMessageParser`) was already addressed in #14486.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
