### PR TITLE
refactor(twitter): update session module for simplified CookieSession type

### DIFF
--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -176,7 +176,6 @@ Examples:
         return {
           message: "Session imported successfully",
           cookieCount: session.cookies.length,
-          recordingId: session.recordingId,
         };
       });
     });
@@ -250,7 +249,6 @@ Examples:
               ok: true,
               message: "Session refreshed successfully",
               cookieCount: session.cookies.length,
-              recordingId: result.recordingId,
             },
             json,
           );
@@ -259,7 +257,6 @@ Examples:
             {
               ok: false,
               error: "Recording completed but no recording path returned",
-              recordingId: result.recordingId,
             },
             json,
           );
@@ -280,8 +277,7 @@ Examples:
       `
 Shows the current state of both authentication paths:
 
-  Browser session — whether cookies are loaded, cookie count, import timestamp,
-    and the recording ID they came from.
+  Browser session — whether cookies are loaded and the cookie count.
   OAuth — whether an OAuth credential is connected, the linked account, the
     current strategy setting, and whether a strategy has been explicitly configured.
 
@@ -297,8 +293,6 @@ Examples:
         ? {
             browserSessionActive: true,
             cookieCount: session.cookies.length,
-            importedAt: session.importedAt,
-            recordingId: session.recordingId,
           }
         : { browserSessionActive: false };
 
@@ -393,7 +387,9 @@ Examples:
     .action(async (value: string, _opts: unknown, cmd: Command) => {
       const json = getJson(cmd);
       try {
-        const r = await sendTwitterConfigRequest("set_strategy", { strategy: value });
+        const r = await sendTwitterConfigRequest("set_strategy", {
+          strategy: value,
+        });
         if (r.success) {
           output({ ok: true, strategy: r.strategy }, json);
         } else {
@@ -944,7 +940,6 @@ async function minimizeChrome(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 interface LearnResult {
-  recordingId?: string;
   recordingPath?: string;
 }
 
@@ -1029,9 +1024,7 @@ async function startLearnSession(
           const stat = statSync(filePath);
           if (stat.mtimeMs >= startTime - 1000) {
             clearInterval(poll);
-            const filename = filePath.split("/").pop() ?? "";
-            const recordingId = filename.replace(/\.json$/, "");
-            resolve({ recordingId, recordingPath: filePath });
+            resolve({ recordingPath: filePath });
             return;
           }
         } catch {

--- a/assistant/src/cli/commands/twitter/session.ts
+++ b/assistant/src/cli/commands/twitter/session.ts
@@ -1,7 +1,7 @@
 /**
  * Twitter session persistence.
- * Delegates to the shared cookie-session primitive for CRUD and cookie header
- * logic; keeps Twitter-specific cookie validation and CSRF extraction.
+ * Delegates to the shared cookie-session primitive for CRUD;
+ * keeps Twitter-specific cookie validation and CSRF extraction.
  */
 
 import type { CookieSession } from "../../../util/cookie-session.js";
@@ -24,8 +24,6 @@ const store = createSessionStore("twitter");
 export const loadSession: () => TwitterSession | null = store.loadSession;
 export const saveSession: (session: TwitterSession) => void = store.saveSession;
 export const clearSession: () => void = store.clearSession;
-export const getCookieHeader: (session: TwitterSession) => string =
-  store.getCookieHeader;
 
 /**
  * Import cookies from a Ride Shotgun recording file.


### PR DESCRIPTION
## Summary
- Remove getCookieHeader export from Twitter session module
- Remove references to session.importedAt and session.recordingId from Twitter CLI outputs
- Remove recordingId from refresh command ride_shotgun output for consistency
- Clean up dead code: remove recordingId from LearnResult interface and startLearnSession
- Update help text for status command to reflect simplified output

Part of plan: cookie-session-credential-store.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)