### PR TITLE
fix: complete rebindClient dead code removal from HandlerContext and callers

### DIFF
--- a/assistant/src/daemon/handlers/session-user-message.ts
+++ b/assistant/src/daemon/handlers/session-user-message.ts
@@ -830,7 +830,7 @@ export async function handleUserMessage(
   const requestId = uuid();
   const rlog = log.child({ sessionId: msg.sessionId, requestId });
   try {
-    const session = await ctx.getOrCreateSession(msg.sessionId, true);
+    const session = await ctx.getOrCreateSession(msg.sessionId);
     // Only wire the escalation handler if one isn't already set — handleTaskSubmit
     // sets a handler with the client's actual screen dimensions, and overwriting it
     // here would replace those dimensions with the daemon's defaults.

--- a/assistant/src/daemon/handlers/sessions.ts
+++ b/assistant/src/daemon/handlers/sessions.ts
@@ -358,7 +358,7 @@ export async function handleSessionCreate(
     title,
     threadType,
   });
-  const session = await ctx.getOrCreateSession(conversation.id, true, {
+  const session = await ctx.getOrCreateSession(conversation.id, {
     systemPromptOverride: msg.systemPromptOverride,
     maxResponseTokens: msg.maxResponseTokens,
     transport: msg.transport,
@@ -478,9 +478,9 @@ export async function switchSession(
 
   if (isHeadlessLocked) {
     // Load the session without rebinding the client — the session stays headless
-    await ctx.getOrCreateSession(sessionId, false);
+    await ctx.getOrCreateSession(sessionId);
   } else {
-    const session = await ctx.getOrCreateSession(sessionId, true);
+    const session = await ctx.getOrCreateSession(sessionId);
     // Only wire the escalation handler if one isn't already set — handleTaskSubmit
     // sets a handler with the client's actual screen dimensions, and overwriting it
     // here would replace those dimensions with the daemon's defaults.

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -163,7 +163,6 @@ export interface HandlerContext {
   clearAllSessions(): number;
   getOrCreateSession(
     conversationId: string,
-    rebindClient?: boolean,
     options?: SessionCreateOptions,
   ): Promise<Session>;
   /** Refresh the eviction timestamp for a session that was accessed directly. */

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -582,7 +582,7 @@ export class DaemonServer {
       send: (msg) => this.broadcast(msg),
       broadcast: (msg) => this.broadcast(msg),
       clearAllSessions: () => this.clearAllSessions(),
-      getOrCreateSession: (id, _rebind?, options?) =>
+      getOrCreateSession: (id, options?) =>
         this.getOrCreateSession(id, options),
       touchSession: (id) => this.evictor.touch(id),
       heartbeatService: this._heartbeatService,


### PR DESCRIPTION
Follow-up to #14509. Removes the dead rebindClient parameter from HandlerContext.getOrCreateSession interface, the server adapter, and all callers.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
