### PR TITLE
refactor(amazon): update session module for simplified CookieSession type

### DIFF
--- a/assistant/src/cli/commands/amazon/client.ts
+++ b/assistant/src/cli/commands/amazon/client.ts
@@ -490,7 +490,6 @@ export async function refreshSessionFromExtension(): Promise<AmazonSession> {
 
   const session: AmazonSession = {
     cookies,
-    importedAt: new Date().toISOString(),
   };
 
   saveSession(session);

--- a/assistant/src/cli/commands/amazon/index.ts
+++ b/assistant/src/cli/commands/amazon/index.ts
@@ -143,7 +143,6 @@ Examples:
         return {
           message: "Session imported successfully",
           cookieCount: session.cookies.length,
-          recordingId: session.recordingId,
         };
       });
     });
@@ -267,8 +266,7 @@ Examples:
       "after",
       `
 Reports whether an Amazon session is currently stored locally. If a session
-exists, returns the cookie count, import timestamp, and recording ID. If no
-session exists, returns loggedIn: false.
+exists, returns the cookie count. If no session exists, returns loggedIn: false.
 
 Use this to verify session health before running shopping commands.
 
@@ -284,8 +282,6 @@ Examples:
             ok: true,
             loggedIn: true,
             cookieCount: session.cookies.length,
-            importedAt: session.importedAt,
-            recordingId: session.recordingId,
           },
           getJson(cmd),
         );
@@ -920,6 +916,5 @@ async function extractSessionFromChromeCookies(): Promise<
 
   return {
     cookies,
-    importedAt: new Date().toISOString(),
   };
 }

--- a/assistant/src/cli/commands/amazon/session.ts
+++ b/assistant/src/cli/commands/amazon/session.ts
@@ -14,8 +14,7 @@ export type AmazonSession = CookieSession;
 
 const store = createSessionStore("amazon");
 
-export const { loadSession, saveSession, clearSession, getCookieHeader } =
-  store;
+export const { loadSession, saveSession, clearSession } = store;
 
 /**
  * Import cookies from a Ride Shotgun recording file.

--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -176,7 +176,6 @@ Examples:
         return {
           message: "Session imported successfully",
           cookieCount: session.cookies.length,
-          recordingId: session.recordingId,
         };
       });
     });
@@ -297,8 +296,6 @@ Examples:
         ? {
             browserSessionActive: true,
             cookieCount: session.cookies.length,
-            importedAt: session.importedAt,
-            recordingId: session.recordingId,
           }
         : { browserSessionActive: false };
 
@@ -393,7 +390,9 @@ Examples:
     .action(async (value: string, _opts: unknown, cmd: Command) => {
       const json = getJson(cmd);
       try {
-        const r = await sendTwitterConfigRequest("set_strategy", { strategy: value });
+        const r = await sendTwitterConfigRequest("set_strategy", {
+          strategy: value,
+        });
         if (r.success) {
           output({ ok: true, strategy: r.strategy }, json);
         } else {

--- a/assistant/src/cli/commands/twitter/session.ts
+++ b/assistant/src/cli/commands/twitter/session.ts
@@ -24,8 +24,6 @@ const store = createSessionStore("twitter");
 export const loadSession: () => TwitterSession | null = store.loadSession;
 export const saveSession: (session: TwitterSession) => void = store.saveSession;
 export const clearSession: () => void = store.clearSession;
-export const getCookieHeader: (session: TwitterSession) => string =
-  store.getCookieHeader;
 
 /**
  * Import cookies from a Ride Shotgun recording file.


### PR DESCRIPTION
## Summary
- Remove getCookieHeader export from Amazon session module
- Remove references to importedAt and recordingId from Amazon CLI outputs
- Simplify session objects to only contain cookies array
- Fix same issues in Twitter session module (required for type-checking to pass)

Part of plan: cookie-session-credential-store.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
