### PR TITLE
fix: validate trust rule options in /v1/confirm and update stale docs

### DIFF
--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -18,9 +18,9 @@ Approvals are **orthogonal to message sending**. The assistant asks for approval
 
 - **Discovery**: Clients discover pending approvals via SSE events (`confirmation_request`, `secret_request`) which include a `requestId`.
 - **Resolution**: Clients respond via standalone endpoints keyed by `requestId`:
-  - `POST /v1/confirm` — `{ requestId, decision: "allow" | "deny" }`
+  - `POST /v1/confirm` — `{ requestId, decision, selectedPattern?, selectedScope? }`. Valid decisions: `"allow"`, `"allow_10m"`, `"allow_thread"`, `"deny"`, `"always_allow"`, `"always_deny"`, `"always_allow_high_risk"`. For persistent decisions (`always_allow`, `always_deny`, `always_allow_high_risk`), `selectedPattern` and `selectedScope` are validated against the server-provided allowlist/scope options from the original confirmation request before trust rules are persisted.
   - `POST /v1/secret` — `{ requestId, value, delivery }`
-  - `POST /v1/trust-rules` — `{ requestId, pattern, scope }`
+  - `POST /v1/trust-rules` — `{ requestId, pattern, scope, decision, allowHighRisk? }`. Validates pattern/scope against server-provided options. Does not resolve the confirmation itself.
 - **Tracking**: The `pending-interactions` tracker (`assistant/src/runtime/pending-interactions.ts`) maps `requestId → session`. Use `register()` to track, `resolve()` to consume, `getByConversation()` to query.
 
 Do NOT couple approval handling to message sending. Do NOT add run/status tracking to the send path.

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -65,14 +65,71 @@ export async function handleConfirm(
     );
   }
 
-  const interaction = pendingInteractions.resolve(requestId);
-  if (!interaction) {
+  // Peek first (non-destructive) so validation failures don't consume the
+  // pending interaction — the client can retry with corrected values.
+  const peeked = pendingInteractions.get(requestId);
+  if (!peeked) {
     return httpError(
       "NOT_FOUND",
       "No pending interaction found for this requestId",
       404,
     );
   }
+
+  // For decisions that persist trust rules, validate that selectedPattern
+  // and selectedScope are among the options the server actually offered.
+  // This prevents a crafted request from injecting overly-broad rules.
+  const persistsRule =
+    decision === "always_allow" ||
+    decision === "always_deny" ||
+    decision === "always_allow_high_risk";
+  if (persistsRule && (selectedPattern || selectedScope)) {
+    const confirmation = peeked.confirmationDetails;
+    if (!confirmation) {
+      return httpError(
+        "CONFLICT",
+        "No confirmation details available for this request",
+        409,
+      );
+    }
+
+    if (selectedPattern) {
+      const validPatterns = (confirmation.allowlistOptions ?? []).map(
+        (o) => o.pattern,
+      );
+      if (!validPatterns.includes(selectedPattern)) {
+        return httpError(
+          "FORBIDDEN",
+          "selectedPattern does not match any server-provided allowlist option",
+          403,
+        );
+      }
+    }
+
+    if (selectedScope) {
+      const validScopes = (confirmation.scopeOptions ?? []).map(
+        (o) => o.scope,
+      );
+      if (validScopes.length === 0) {
+        if (selectedScope !== "everywhere") {
+          return httpError(
+            "FORBIDDEN",
+            'non-scoped tools only accept scope "everywhere"',
+            403,
+          );
+        }
+      } else if (!validScopes.includes(selectedScope)) {
+        return httpError(
+          "FORBIDDEN",
+          "selectedScope does not match any server-provided scope option",
+          403,
+        );
+      }
+    }
+  }
+
+  // Validation passed — consume the pending interaction.
+  const interaction = pendingInteractions.resolve(requestId)!;
 
   interaction.session.handleConfirmationResponse(
     requestId,


### PR DESCRIPTION
Follow-up to #14508. Validates that selectedPattern/selectedScope in POST /v1/confirm are among the options offered in the original confirmation request before persisting trust rules. Also updates stale AGENTS.md docs for the confirm endpoint.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
