### PR TITLE
fix: add top padding to settings caption text

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Sidebar/DrawerMenuView.swift
@@ -21,6 +21,7 @@ struct DrawerMenuView: View {
                 .font(VFont.caption)
                 .foregroundColor(VColor.textSecondary)
                 .padding(.horizontal, VSpacing.lg)
+                .padding(.top, VSpacing.xs)
                 .padding(.bottom, VSpacing.xs)
 
             VColor.surfaceBorder.frame(height: 1)


### PR DESCRIPTION
## Summary
- Add top padding to the settings helper caption in the drawer menu for better spacing

## Test plan
- [ ] Settings caption text has consistent spacing above and below

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
