### PR TITLE
fix: accept optional sessionId in surface-action routes

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -424,6 +424,8 @@ export async function runDaemon(): Promise<void> {
           })),
       },
       findSession: (sessionId) => server.findSession(sessionId),
+      findSessionBySurfaceId: (surfaceId) =>
+        server.findSessionBySurfaceId(surfaceId),
       getSkillContext: () => server.getSkillContext(),
       getModelSetContext: () => server.getHandlerContext(),
       sessionManagementDeps: {

--- a/assistant/src/daemon/server.ts
+++ b/assistant/src/daemon/server.ts
@@ -898,6 +898,22 @@ export class DaemonServer {
   }
 
   /**
+   * Look up an active session that owns a given surfaceId.
+   * Falls back across both normal and computer-use sessions.
+   */
+  findSessionBySurfaceId(
+    surfaceId: string,
+  ): Session | ComputerUseSession | undefined {
+    for (const s of this.cuSessions.values()) {
+      if (s.surfaceState.has(surfaceId)) return s;
+    }
+    for (const s of this.sessions.values()) {
+      if (s.surfaceState.has(surfaceId)) return s;
+    }
+    return undefined;
+  }
+
+  /**
    * Expose the handler context for use by session management HTTP routes.
    * The context is built on-the-fly so it always reflects the current server state.
    */

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -207,6 +207,7 @@ export class RuntimeHttpServer {
   private pairingBroadcast?: (msg: ServerMessage) => void;
   private sendMessageDeps?: SendMessageDeps;
   private findSession?: RuntimeHttpServerOptions["findSession"];
+  private findSessionBySurfaceId?: RuntimeHttpServerOptions["findSessionBySurfaceId"];
   private getSkillContext?: RuntimeHttpServerOptions["getSkillContext"];
   private sessionManagementDeps?: RuntimeHttpServerOptions["sessionManagementDeps"];
   private getModelSetContext?: RuntimeHttpServerOptions["getModelSetContext"];
@@ -227,6 +228,7 @@ export class RuntimeHttpServer {
     this.interfacesDir = options.interfacesDir ?? null;
     this.sendMessageDeps = options.sendMessageDeps;
     this.findSession = options.findSession;
+    this.findSessionBySurfaceId = options.findSessionBySurfaceId;
     this.getSkillContext = options.getSkillContext;
     this.sessionManagementDeps = options.sessionManagementDeps;
     this.getModelSetContext = options.getModelSetContext;
@@ -933,7 +935,10 @@ export class RuntimeHttpServer {
           })
         : []),
       ...trustRulesRouteDefinitions(),
-      ...surfaceActionRouteDefinitions({ findSession: this.findSession }),
+      ...surfaceActionRouteDefinitions({
+        findSession: this.findSession,
+        findSessionBySurfaceId: this.findSessionBySurfaceId,
+      }),
       ...surfaceContentRouteDefinitions({ findSession: this.findSession }),
       ...guardianActionRouteDefinitions(),
 

--- a/assistant/src/runtime/http-types.ts
+++ b/assistant/src/runtime/http-types.ts
@@ -202,6 +202,20 @@ export interface RuntimeHttpServerOptions {
         removeQueuedMessage?: (requestId: string) => boolean;
       }
     | undefined;
+  /** Lookup an active session by surfaceId (fallback when sessionId is absent). */
+  findSessionBySurfaceId?: (surfaceId: string) =>
+    | {
+        handleSurfaceAction(
+          surfaceId: string,
+          actionId: string,
+          data?: Record<string, unknown>,
+        ): void;
+        surfaceState: Map<
+          string,
+          { surfaceType: SurfaceType; data: SurfaceData; title?: string }
+        >;
+      }
+    | undefined;
   /** Dependencies for session management HTTP routes (switch, rename, clear, cancel, undo, regenerate). */
   sessionManagementDeps?: SessionManagementDeps;
   /** Lazy factory for model config set context (session eviction, config reload suppression). */

--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -24,17 +24,22 @@ export type SessionLookup = (
   sessionId: string,
 ) => SurfaceActionTarget | undefined;
 
+export type SessionLookupBySurfaceId = (
+  surfaceId: string,
+) => SurfaceActionTarget | undefined;
+
 /**
  * POST /v1/surface-actions — handle a UI surface action.
  *
- * Body: { sessionId, surfaceId, actionId, data? }
+ * Body: { sessionId?, surfaceId, actionId, data? }
  */
 export async function handleSurfaceAction(
   req: Request,
   findSession: SessionLookup,
+  findSessionBySurfaceId?: SessionLookupBySurfaceId,
 ): Promise<Response> {
   const body = (await req.json()) as {
-    sessionId?: string;
+    sessionId?: string | null;
     surfaceId?: string;
     actionId?: string;
     data?: Record<string, unknown>;
@@ -42,9 +47,6 @@ export async function handleSurfaceAction(
 
   const { sessionId, surfaceId, actionId, data } = body;
 
-  if (!sessionId || typeof sessionId !== "string") {
-    return httpError("BAD_REQUEST", "sessionId is required", 400);
-  }
   if (!surfaceId || typeof surfaceId !== "string") {
     return httpError("BAD_REQUEST", "surfaceId is required", 400);
   }
@@ -52,11 +54,15 @@ export async function handleSurfaceAction(
     return httpError("BAD_REQUEST", "actionId is required", 400);
   }
 
-  const session = findSession(sessionId);
+  const session =
+    sessionId && typeof sessionId === "string"
+      ? findSession(sessionId)
+      : findSessionBySurfaceId?.(surfaceId);
+
   if (!session) {
     return httpError(
       "NOT_FOUND",
-      "No active session found for this sessionId",
+      "No active session found",
       404,
     );
   }
@@ -64,13 +70,13 @@ export async function handleSurfaceAction(
   try {
     session.handleSurfaceAction(surfaceId, actionId, data);
     log.info(
-      { sessionId, surfaceId, actionId },
+      { sessionId: sessionId ?? undefined, surfaceId, actionId },
       "Surface action handled via HTTP",
     );
     return Response.json({ ok: true });
   } catch (err) {
     log.error(
-      { err, sessionId, surfaceId, actionId },
+      { err, sessionId: sessionId ?? undefined, surfaceId, actionId },
       "Failed to handle surface action via HTTP",
     );
     return httpError("INTERNAL_ERROR", "Failed to handle surface action", 500);
@@ -90,22 +96,23 @@ export async function handleSurfaceUndo(
   req: Request,
   surfaceId: string,
   findSession: SessionLookup,
+  findSessionBySurfaceId?: SessionLookupBySurfaceId,
 ): Promise<Response> {
   const body = (await req.json()) as {
-    sessionId?: string;
+    sessionId?: string | null;
   };
 
   const { sessionId } = body;
 
-  if (!sessionId || typeof sessionId !== "string") {
-    return httpError("BAD_REQUEST", "sessionId is required", 400);
-  }
+  const session =
+    sessionId && typeof sessionId === "string"
+      ? findSession(sessionId)
+      : findSessionBySurfaceId?.(surfaceId);
 
-  const session = findSession(sessionId);
   if (!session) {
     return httpError(
       "NOT_FOUND",
-      "No active session found for this sessionId",
+      "No active session found",
       404,
     );
   }
@@ -136,6 +143,7 @@ export async function handleSurfaceUndo(
 
 export function surfaceActionRouteDefinitions(deps: {
   findSession?: SessionLookup;
+  findSessionBySurfaceId?: SessionLookupBySurfaceId;
 }): RouteDefinition[] {
   return [
     {
@@ -149,7 +157,11 @@ export function surfaceActionRouteDefinitions(deps: {
             501,
           );
         }
-        return handleSurfaceAction(req, deps.findSession);
+        return handleSurfaceAction(
+          req,
+          deps.findSession,
+          deps.findSessionBySurfaceId,
+        );
       },
     },
     {
@@ -163,7 +175,12 @@ export function surfaceActionRouteDefinitions(deps: {
             501,
           );
         }
-        return handleSurfaceUndo(req, params.id, deps.findSession);
+        return handleSurfaceUndo(
+          req,
+          params.id,
+          deps.findSession,
+          deps.findSessionBySurfaceId,
+        );
       },
     },
   ];


### PR DESCRIPTION
Follow-up to #14505. Makes sessionId optional in POST /v1/surface-actions and /v1/surfaces/:id/undo so surfaces without a session ID can send action/dismiss responses. When sessionId is absent, falls back to finding the session by surfaceId.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14528" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
