### PR TITLE
docs(skills): update Amazon and Twitter SKILL.md for credential-store sessions

### DIFF
--- a/assistant/src/config/bundled-skills/amazon/SKILL.md
+++ b/assistant/src/config/bundled-skills/amazon/SKILL.md
@@ -58,6 +58,16 @@ Many Amazon products (clothing, electronics) have variations (size, color, style
 
 Alternatively, run `assistant amazon variations <asin> --json` to list just the variations.
 
+## Session Storage
+
+Session cookies are stored in the encrypted credential store under the key `amazon:session:cookies`. You can inspect the stored session with:
+
+```bash
+assistant credentials inspect amazon:session:cookies
+```
+
+Session capture (`assistant amazon refresh`) and session checks (`assistant amazon status`) use the credential store automatically — no manual file management is needed.
+
 ## Important Behavior
 
 - **Chrome extension relay required.** The Amazon CLI uses `assistant browser chrome relay` internally for browser automation. The Chrome extension must be connected before Amazon commands will work. If a command fails with a connection error, tell the user: "Please open Chrome, click the Vellum extension icon, and click Connect — then I'll retry."

--- a/assistant/src/config/bundled-skills/twitter/SKILL.md
+++ b/assistant/src/config/bundled-skills/twitter/SKILL.md
@@ -27,6 +27,7 @@ The browser path is quick to start and useful when the user does not have X deve
 - Supports: **all operations** (post, reply, timeline, search, home, bookmarks, notifications, likes, followers, following, media)
 - Setup: Run `assistant x refresh` to open Chrome and capture session cookies automatically.
 - Set the strategy: `assistant config set twitter.operationStrategy browser`
+- **Session storage**: Session cookies are stored in the encrypted credential store under the key `twitter:session:cookies`. You can inspect the stored session with `assistant credentials inspect twitter:session:cookies`.
 
 ### Auto mode (default)
 


### PR DESCRIPTION
## Summary
- Add credential store documentation to Amazon SKILL.md (amazon:session:cookies)
- Add credential store documentation to Twitter SKILL.md (twitter:session:cookies)
- Remove any references to plaintext session.json files

Part of plan: cookie-session-credential-store.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
