### PR TITLE
fix: update guard test allowlists for cookie-session and VELLUM_DATA_DIR

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -239,6 +239,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)
       "daemon/session-messaging.ts", // credential storage during session messaging
       "runtime/routes/settings-routes.ts", // settings routes OAuth credential lookup (client_id/client_secret/access tokens)
+      "util/cookie-session.ts", // shared cookie-session persistence (session CRUD via credential store)
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/__tests__/tool-executor.test.ts
+++ b/assistant/src/__tests__/tool-executor.test.ts
@@ -2248,6 +2248,7 @@ describe("buildSanitizedEnv — baseline: credential exclusion", () => {
       "GPG_TTY",
       "GNUPGHOME",
       "INTERNAL_GATEWAY_BASE_URL",
+      "VELLUM_DATA_DIR",
     ];
 
     const env = buildSanitizedEnv();


### PR DESCRIPTION
## Summary
- Add `util/cookie-session.ts` to the secure-keys authorized importers list in `credential-security-invariants.test.ts` — the shared cookie-session module legitimately needs credential store access for session CRUD
- Add `VELLUM_DATA_DIR` to the `buildSanitizedEnv` test allowlist in `tool-executor.test.ts` — this env var was recently added to the sanitized env but the test wasn't updated

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/22855269513/job/66293802183

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
