### PR TITLE
fix: replace async setInterval with recursive setTimeout and add recordingId to Twitter LearnResult

### DIFF
--- a/assistant/src/cli/commands/map.ts
+++ b/assistant/src/cli/commands/map.ts
@@ -197,9 +197,8 @@ async function startLearnSession(
   const startTime = Date.now();
 
   return new Promise<LearnResult>((resolve, reject) => {
-    const poll = setInterval(async () => {
+    const tick = async () => {
       if (Date.now() - startTime > timeoutMs) {
-        clearInterval(poll);
         reject(
           new Error(`Learn session timed out after ${durationSeconds + 30}s`),
         );
@@ -211,7 +210,10 @@ async function startLearnSession(
           `/v1/computer-use/ride-shotgun/status/${watchId}`,
           { method: "GET" },
         );
-        if (!statusRes.ok) return;
+        if (!statusRes.ok) {
+          setTimeout(tick, pollIntervalMs);
+          return;
+        }
 
         const status = (await statusRes.json()) as {
           status: string;
@@ -221,7 +223,6 @@ async function startLearnSession(
         };
 
         if (status.bootstrapFailureReason) {
-          clearInterval(poll);
           reject(
             new Error(
               `Learn session failed: ${status.bootstrapFailureReason}`,
@@ -231,7 +232,6 @@ async function startLearnSession(
         }
 
         if (status.status === "completed") {
-          clearInterval(poll);
           if (status.recordingId) {
             resolve({
               recordingId: status.recordingId,
@@ -249,7 +249,11 @@ async function startLearnSession(
       } catch {
         // Status endpoint not reachable — continue polling
       }
-    }, pollIntervalMs);
+
+      setTimeout(tick, pollIntervalMs);
+    };
+
+    setTimeout(tick, pollIntervalMs);
   });
 }
 

--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -938,6 +938,7 @@ async function minimizeChrome(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 interface LearnResult {
+  recordingId?: string;
   recordingPath?: string;
 }
 
@@ -1003,9 +1004,8 @@ async function startLearnSession(
   const startTime = Date.now();
 
   return new Promise<LearnResult>((resolve, reject) => {
-    const poll = setInterval(async () => {
+    const tick = async () => {
       if (Date.now() - startTime > timeoutMs) {
-        clearInterval(poll);
         reject(
           new Error(`Learn session timed out after ${durationSeconds + 30}s`),
         );
@@ -1017,7 +1017,10 @@ async function startLearnSession(
           `/v1/computer-use/ride-shotgun/status/${watchId}`,
           { method: "GET" },
         );
-        if (!statusRes.ok) return;
+        if (!statusRes.ok) {
+          setTimeout(tick, pollIntervalMs);
+          return;
+        }
 
         const status = (await statusRes.json()) as {
           status: string;
@@ -1027,7 +1030,6 @@ async function startLearnSession(
         };
 
         if (status.bootstrapFailureReason) {
-          clearInterval(poll);
           reject(
             new Error(
               `Learn session failed: ${status.bootstrapFailureReason}`,
@@ -1037,7 +1039,6 @@ async function startLearnSession(
         }
 
         if (status.status === "completed") {
-          clearInterval(poll);
           if (status.recordingId) {
             resolve({
               recordingId: status.recordingId,
@@ -1055,6 +1056,10 @@ async function startLearnSession(
       } catch {
         // Status endpoint not reachable — continue polling
       }
-    }, pollIntervalMs);
+
+      setTimeout(tick, pollIntervalMs);
+    };
+
+    setTimeout(tick, pollIntervalMs);
   });
 }


### PR DESCRIPTION
Fixes review feedback from #14526:

1. Replace `setInterval(async () => {...})` with recursive `setTimeout` in both `map.ts` and `twitter/index.ts` to prevent overlapping poll iterations when HTTP requests take longer than the interval.

2. Add missing `recordingId` field to the Twitter `LearnResult` interface to match the `map.ts` version.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
