### PR TITLE
fix: revert ride-shotgun status scope to chat.write and add fetch timeout to polling

### DIFF
--- a/assistant/src/config/bundled-skills/doordash/doordash-cli.ts
+++ b/assistant/src/config/bundled-skills/doordash/doordash-cli.ts
@@ -1019,7 +1019,8 @@ async function startLearnSession(
 
       // Poll session status to detect failures early
       try {
-        const statusRes = await fetch(statusUrl, { headers });
+        const fetchAbort = AbortSignal.timeout(10_000);
+        const statusRes = await fetch(statusUrl, { headers, signal: fetchAbort });
         if (statusRes.ok) {
           const status = (await statusRes.json()) as {
             status: string;

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -359,7 +359,7 @@ const ACTOR_ENDPOINTS: Array<{ endpoint: string; scopes: Scope[] }> = [
   { endpoint: "computer-use/tasks", scopes: ["chat.write"] },
   { endpoint: "computer-use/ride-shotgun/start", scopes: ["chat.write"] },
   { endpoint: "computer-use/ride-shotgun/stop", scopes: ["chat.write"] },
-  { endpoint: "computer-use/ride-shotgun/status", scopes: ["chat.read"] },
+  { endpoint: "computer-use/ride-shotgun/status", scopes: ["chat.write"] },
   { endpoint: "computer-use/watch", scopes: ["chat.write"] },
 
   // Recordings


### PR DESCRIPTION
Addresses Codex review feedback on #14519:

1. Reverts the ride-shotgun/status endpoint scope from chat.read back to chat.write so CLI edge tokens can poll session status without 403s.
2. Adds an AbortController with a 10s timeout to the fetch call in startLearnSession's pollOnce to prevent stalled HTTP requests from blocking the polling loop and the overall timeout.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
