### PR TITLE
fix: reject non-string sessionId in surface-action routes

### DIFF
--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -53,6 +53,9 @@ export async function handleSurfaceAction(
   if (!actionId || typeof actionId !== "string") {
     return httpError("BAD_REQUEST", "actionId is required", 400);
   }
+  if (sessionId != null && typeof sessionId !== "string") {
+    return httpError("BAD_REQUEST", "sessionId must be a string", 400);
+  }
 
   const session =
     sessionId && typeof sessionId === "string"
@@ -103,6 +106,10 @@ export async function handleSurfaceUndo(
   };
 
   const { sessionId } = body;
+
+  if (sessionId != null && typeof sessionId !== "string") {
+    return httpError("BAD_REQUEST", "sessionId must be a string", 400);
+  }
 
   const session =
     sessionId && typeof sessionId === "string"


### PR DESCRIPTION
Addresses Codex review feedback on #14528:

Adds explicit validation to reject non-string sessionId values with 400 instead of silently falling through to surfaceId lookup. Applied to both handleSurfaceAction and handleSurfaceUndo.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
