### PR TITLE
fix: remove stale entries from ALLOWED_IMPORTERS in credential security guard test

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -199,16 +199,11 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
     // Hard boundary: only these production files may import from secure-keys.
     // Any new import must be reviewed for secret-leak risk and added here.
     const ALLOWED_IMPORTERS = new Set([
-      "security/secure-keys.ts", // self (re-export infrastructure)
-      "index.ts", // daemon startup / API key config
       "config/loader.ts", // config management (API keys)
       "tools/credentials/vault.ts", // credential store tool
       "tools/credentials/broker.ts", // brokered credential access
       "tools/network/web-search.ts", // web search API key lookup
-      "daemon/handlers.ts", // Vercel API token + integration OAuth
-      "daemon/handlers/config-integrations.ts", // Vercel API token + Twitter integration OAuth
       "daemon/handlers/config-telegram.ts", // Telegram bot token management
-      "daemon/handlers/config-ingress.ts", // Ingress config (reads Twilio credentials for webhook sync)
       "runtime/routes/integrations/twilio.ts", // Twilio credential management (HTTP control-plane)
       "security/token-manager.ts", // OAuth token refresh flow
       "email/providers/index.ts", // email provider API key lookup
@@ -221,14 +216,10 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/channel-invite-transports/telegram.ts", // Telegram invite transport bot token lookup
       "cli/commands/keys.ts", // CLI credential management commands
       "cli/commands/credentials.ts", // CLI credential management commands
-      "runtime/http-server.ts", // HTTP server credential lookup
-      "daemon/handlers/twitter-auth.ts", // Twitter OAuth token storage
-      "cli/commands/twitter/oauth-client.ts", // Twitter OAuth API client (reads access token for API calls)
       "messaging/providers/telegram-bot/adapter.ts", // Telegram bot token lookup for connectivity check
       "runtime/channel-readiness-service.ts", // channel readiness probes for Telegram connectivity
       "messaging/providers/whatsapp/adapter.ts", // WhatsApp credential lookup for connectivity check
       "schedule/integration-status.ts", // integration status checks for scheduled reports
-      "daemon/handlers/oauth-connect.ts", // OAuth connect handler for integration setup
       "daemon/handlers/config-slack-channel.ts", // Slack channel config credential management
       "media/managed-avatar-client.ts", // managed avatar API key lookup for platform authentication
       "providers/managed-proxy/context.ts", // managed proxy API key lookup for provider initialization


### PR DESCRIPTION
Addresses Devin review feedback on #14530:

Removes entries from the ALLOWED_IMPORTERS set that no longer actually import from secure-keys. These stale allowlist entries were harmless but confusing for future readers.

Removed 9 stale entries:
- `security/secure-keys.ts` (self-reference, doesn't import itself)
- `index.ts` (no longer imports secure-keys)
- `daemon/handlers.ts` (file doesn't exist)
- `daemon/handlers/config-integrations.ts` (file doesn't exist)
- `daemon/handlers/config-ingress.ts` (exists but doesn't import secure-keys)
- `runtime/http-server.ts` (exists but doesn't import secure-keys)
- `daemon/handlers/twitter-auth.ts` (file doesn't exist)
- `cli/commands/twitter/oauth-client.ts` (exists but doesn't import secure-keys)
- `daemon/handlers/oauth-connect.ts` (file doesn't exist)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
