### PR TITLE
fix: update stale session.json reference in amazon client docblock

### DIFF
--- a/assistant/src/cli/commands/amazon/client.ts
+++ b/assistant/src/cli/commands/amazon/client.ts
@@ -13,8 +13,9 @@
  *      page), NOT from `document`. The browser's live page rarely has the data we need.
  *
  *   2. Session cookies live in the Chrome-CDP browser profile
- *      (~Library/Application Support/Google/Chrome-CDP). The session.json on disk is only
- *      used to validate that a session exists. Actual auth goes through the browser's cookies.
+ *      (~Library/Application Support/Google/Chrome-CDP). Session metadata is stored in the
+ *      encrypted credential store and used to validate that a session exists. Actual auth
+ *      goes through the browser's cookies.
  *
  * AMAZON FRESH vs REGULAR CART
  * ============================


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for cookie-session-credential-store.md.

**Gap:** Stale session.json comment in amazon/client.ts
**What was expected:** No references to session.json after credential store migration
**What was found:** Architecture docblock still references session.json

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
