### PR TITLE
fix: show friendly error when no API key is configured

### DIFF
--- a/assistant/src/__tests__/error-handler-friendly-messages.test.ts
+++ b/assistant/src/__tests__/error-handler-friendly-messages.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+
+import { withErrorHandling } from "../runtime/middleware/error-handler.js";
+import { ConfigError, ProviderNotConfiguredError } from "../util/errors.js";
+
+describe("withErrorHandling – friendly error messages", () => {
+  test("ProviderNotConfiguredError returns actionable message", async () => {
+    const response = await withErrorHandling("test", async () => {
+      throw new ProviderNotConfiguredError("anthropic", []);
+    });
+
+    expect(response.status).toBe(422);
+    const body = (await response.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(body.error.code).toBe("UNPROCESSABLE_ENTITY");
+    expect(body.error.message).toContain("No API key configured");
+    expect(body.error.message).toContain("ANTHROPIC_API_KEY");
+    expect(body.error.message).toContain("vellum hatch");
+  });
+
+  test("generic ConfigError still returns its own message", async () => {
+    const response = await withErrorHandling("test", async () => {
+      throw new ConfigError("Twilio phone number not configured.");
+    });
+
+    expect(response.status).toBe(422);
+    const body = (await response.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(body.error.message).toBe("Twilio phone number not configured.");
+  });
+});

--- a/assistant/src/__tests__/error-handler-friendly-messages.test.ts
+++ b/assistant/src/__tests__/error-handler-friendly-messages.test.ts
@@ -4,7 +4,7 @@ import { withErrorHandling } from "../runtime/middleware/error-handler.js";
 import { ConfigError, ProviderNotConfiguredError } from "../util/errors.js";
 
 describe("withErrorHandling – friendly error messages", () => {
-  test("ProviderNotConfiguredError returns actionable message", async () => {
+  test("ProviderNotConfiguredError returns actionable message for anthropic", async () => {
     const response = await withErrorHandling("test", async () => {
       throw new ProviderNotConfiguredError("anthropic", []);
     });
@@ -17,6 +17,19 @@ describe("withErrorHandling – friendly error messages", () => {
     expect(body.error.message).toContain("No API key configured");
     expect(body.error.message).toContain("ANTHROPIC_API_KEY");
     expect(body.error.message).toContain("vellum hatch");
+  });
+
+  test("ProviderNotConfiguredError tailors env var to requested provider", async () => {
+    const response = await withErrorHandling("test", async () => {
+      throw new ProviderNotConfiguredError("openai", []);
+    });
+
+    expect(response.status).toBe(422);
+    const body = (await response.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(body.error.message).toContain("OPENAI_API_KEY");
+    expect(body.error.message).not.toContain("ANTHROPIC_API_KEY");
   });
 
   test("generic ConfigError still returns its own message", async () => {

--- a/assistant/src/__tests__/provider-fail-open-selection.test.ts
+++ b/assistant/src/__tests__/provider-fail-open-selection.test.ts
@@ -32,6 +32,7 @@ import {
   listProviders,
   resolveProviderSelection,
 } from "../providers/registry.js";
+import { ProviderNotConfiguredError } from "../util/errors.js";
 
 /**
  * Tests for fail-open provider selection: when the configured primary provider
@@ -138,11 +139,20 @@ describe("getFailoverProvider (fail-open)", () => {
     expect(provider).toBeDefined();
   });
 
-  test("throws ConfigError when no providers are available", () => {
+  test("throws ProviderNotConfiguredError when no providers are available", () => {
     setupNoProviders();
     expect(() => getFailoverProvider("gemini", ["fireworks"])).toThrow(
-      /No providers available/,
+      ProviderNotConfiguredError,
     );
+    try {
+      getFailoverProvider("gemini", ["fireworks"]);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProviderNotConfiguredError);
+      const typed = err as ProviderNotConfiguredError;
+      expect(typed.requestedProvider).toBe("gemini");
+      expect(typed.registeredProviders).toEqual([]);
+      expect(typed.message).toMatch(/No providers available/);
+    }
   });
 
   test("single available provider returns it directly (no failover wrapper)", () => {

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -1,5 +1,5 @@
 import { wrapWithLogfire } from "../logfire.js";
-import { ConfigError } from "../util/errors.js";
+import { ConfigError, ProviderNotConfiguredError } from "../util/errors.js";
 import { AnthropicProvider } from "./anthropic/client.js";
 import { FailoverProvider, type ProviderHealthStatus } from "./failover.js";
 import { FireworksProvider } from "./fireworks/client.js";
@@ -94,9 +94,7 @@ export function getFailoverProvider(
   const selection = resolveProviderSelection(primaryName, providerOrder);
 
   if (!selection.selectedPrimary) {
-    throw new ConfigError(
-      `No providers available. Requested: "${primaryName}". Registered: ${listProviders().join(", ") || "none"}`,
-    );
+    throw new ProviderNotConfiguredError(primaryName, listProviders());
   }
 
   const orderedProviders: Provider[] = selection.availableProviders.map(

--- a/assistant/src/runtime/middleware/error-handler.ts
+++ b/assistant/src/runtime/middleware/error-handler.ts
@@ -32,9 +32,10 @@ export async function withErrorHandling(
     }
     if (err instanceof ProviderNotConfiguredError) {
       log.warn({ err, endpoint }, "No LLM provider configured");
+      const envVar = `${err.requestedProvider.toUpperCase()}_API_KEY`;
       return httpError(
         "UNPROCESSABLE_ENTITY",
-        "No API key configured. Add ANTHROPIC_API_KEY to ~/.vellum/.env or run `vellum hatch` to set up your assistant.",
+        `No API key configured. Set ${envVar} in your environment or run \`vellum hatch\` to set up your assistant.`,
         422,
       );
     }

--- a/assistant/src/runtime/middleware/error-handler.ts
+++ b/assistant/src/runtime/middleware/error-handler.ts
@@ -2,7 +2,11 @@
  * Centralized error handling for runtime HTTP request dispatch.
  */
 
-import { ConfigError, IngressBlockedError } from "../../util/errors.js";
+import {
+  ConfigError,
+  IngressBlockedError,
+  ProviderNotConfiguredError,
+} from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
 
@@ -25,6 +29,14 @@ export async function withErrorHandling(
         "Blocked HTTP request containing secrets",
       );
       return httpError("UNPROCESSABLE_ENTITY", err.message, 422);
+    }
+    if (err instanceof ProviderNotConfiguredError) {
+      log.warn({ err, endpoint }, "No LLM provider configured");
+      return httpError(
+        "UNPROCESSABLE_ENTITY",
+        "No API key configured. Add ANTHROPIC_API_KEY to ~/.vellum/.env or run `vellum hatch` to set up your assistant.",
+        422,
+      );
     }
     if (err instanceof ConfigError) {
       log.warn({ err, endpoint }, "Runtime HTTP config error");

--- a/assistant/src/util/errors.ts
+++ b/assistant/src/util/errors.ts
@@ -151,6 +151,18 @@ export class ConfigError extends AssistantError {
   }
 }
 
+export class ProviderNotConfiguredError extends ConfigError {
+  constructor(
+    public readonly requestedProvider: string,
+    public readonly registeredProviders: string[],
+  ) {
+    super(
+      `No providers available. Requested: "${requestedProvider}". Registered: ${registeredProviders.join(", ") || "none"}`,
+    );
+    this.name = "ProviderNotConfiguredError";
+  }
+}
+
 export class DaemonError extends AssistantError {
   constructor(message: string, options?: { cause?: unknown }) {
     super(message, ErrorCode.DAEMON_ERROR, options);

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -152,6 +152,19 @@ interface HealthResponse {
   message?: string;
 }
 
+/** Extract human-readable message from a daemon JSON error response. */
+function friendlyErrorMessage(status: number, body: string): string {
+  try {
+    const parsed = JSON.parse(body) as { error?: { message?: string } };
+    if (parsed?.error?.message) {
+      return parsed.error.message;
+    }
+  } catch {
+    // Not JSON — fall through
+  }
+  return `HTTP ${status}: ${body || "Unknown error"}`;
+}
+
 async function runtimeRequest<T>(
   baseUrl: string,
   assistantId: string,
@@ -171,7 +184,7 @@ async function runtimeRequest<T>(
 
   if (!response.ok) {
     const body = await response.text().catch(() => "");
-    throw new Error(`HTTP ${response.status}: ${body || response.statusText}`);
+    throw new Error(friendlyErrorMessage(response.status, body));
   }
 
   if (response.status === 204) {
@@ -1758,7 +1771,8 @@ function ChatApp({
           clearTimeout(timeoutId);
           h.setBusy(false);
           h.hideSpinner();
-          const errorMsg = `Failed to send: ${sendErr instanceof Error ? sendErr.message : sendErr}`;
+          const errorMsg =
+            sendErr instanceof Error ? sendErr.message : String(sendErr);
           h.showError(errorMsg);
           chatLogRef.current.push({ role: "error", content: errorMsg });
           return;


### PR DESCRIPTION
## Summary
- Introduces `ProviderNotConfiguredError` subclass of `ConfigError` for when no LLM providers are registered
- Catches it in the HTTP error handler to return an actionable message instead of raw internal error details
- CLI client now extracts human-readable `error.message` from daemon JSON error responses instead of dumping raw JSON

**Before:** `Failed to send: HTTP 422: {"error":{"code":"UNPROCESSABLE_ENTITY","message":"No providers available. Requested: \"anthropic\". Registered: none"}}`

**After:** `No API key configured. Add ANTHROPIC_API_KEY to ~/.vellum/.env or run `vellum hatch` to set up your assistant.`

## Test plan
- [x] `bunx tsc --noEmit` passes in both `assistant/` and `cli/`
- [x] Existing provider selection tests pass (`provider-fail-open-selection.test.ts`)
- [ ] Manual: start daemon without API key, run `vellum client`, send message, verify friendly error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
