### PR TITLE
fix: simplify redundant typeof sessionId checks in surface-action routes

### DIFF
--- a/assistant/src/runtime/routes/surface-action-routes.ts
+++ b/assistant/src/runtime/routes/surface-action-routes.ts
@@ -57,10 +57,9 @@ export async function handleSurfaceAction(
     return httpError("BAD_REQUEST", "sessionId must be a string", 400);
   }
 
-  const session =
-    sessionId && typeof sessionId === "string"
-      ? findSession(sessionId)
-      : findSessionBySurfaceId?.(surfaceId);
+  const session = sessionId
+    ? findSession(sessionId)
+    : findSessionBySurfaceId?.(surfaceId);
 
   if (!session) {
     return httpError(
@@ -111,10 +110,9 @@ export async function handleSurfaceUndo(
     return httpError("BAD_REQUEST", "sessionId must be a string", 400);
   }
 
-  const session =
-    sessionId && typeof sessionId === "string"
-      ? findSession(sessionId)
-      : findSessionBySurfaceId?.(surfaceId);
+  const session = sessionId
+    ? findSession(sessionId)
+    : findSessionBySurfaceId?.(surfaceId);
 
   if (!session) {
     return httpError(


### PR DESCRIPTION
After the new sessionId validation rejects non-string values early, the subsequent `typeof sessionId === "string"` checks are always true when sessionId is truthy. Simplifies both `handleSurfaceAction` and `handleSurfaceUndo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
