### PR TITLE
Port managed Twitter prerequisite logic to HTTP routes

### DIFF
--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -976,6 +976,9 @@ async function sendTwitterConfigRequest(
       strategy: data.strategy ?? "auto",
       strategyConfigured: data.strategyConfigured ?? false,
       mode: data.mode,
+      managedAvailable: data.managedAvailable ?? false,
+      managedPrerequisites: data.managedPrerequisites,
+      localClientConfigured: data.localClientConfigured ?? false,
     };
   }
 
@@ -1127,9 +1130,7 @@ async function startLearnSession(
 
         if (status.bootstrapFailureReason) {
           reject(
-            new Error(
-              `Learn session failed: ${status.bootstrapFailureReason}`,
-            ),
+            new Error(`Learn session failed: ${status.bootstrapFailureReason}`),
           );
           return;
         }
@@ -1142,9 +1143,7 @@ async function startLearnSession(
             });
           } else {
             reject(
-              new Error(
-                "Learn session completed but no recording was saved.",
-              ),
+              new Error("Learn session completed but no recording was saved."),
             );
           }
           return;

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -15,6 +15,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { getPlatformBaseUrl } from "../../config/env.js";
 import {
   getNestedValue,
   invalidateConfigCache,
@@ -298,6 +299,29 @@ async function handleTwitterAuthStart(): Promise<Response> {
     const mode =
       (getNestedValue(raw, "twitter.integrationMode") as string | undefined) ??
       "local_byo";
+    if (mode === "managed") {
+      const apiKey = getSecureKey("credential:vellum:assistant_api_key");
+      if (!apiKey) {
+        return Response.json(
+          {
+            ok: false,
+            error:
+              "An AssistantAPIKey is required for managed Twitter. Run assistant setup.",
+            errorCode: "managed_missing_api_key",
+          },
+          { status: 400 },
+        );
+      }
+      return Response.json(
+        {
+          ok: false,
+          error:
+            "Managed Twitter authentication is handled through the Vellum platform. Open Settings to connect.",
+          errorCode: "managed_auth_via_platform",
+        },
+        { status: 400 },
+      );
+    }
     if (mode !== "local_byo") {
       return httpError(
         "BAD_REQUEST",
@@ -395,11 +419,7 @@ async function handleTwitterAuthStart(): Promise<Response> {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Twitter OAuth flow failed");
-    return httpError(
-      "INTERNAL_ERROR",
-      sanitizeTwitterAuthError(message),
-      500,
-    );
+    return httpError("INTERNAL_ERROR", sanitizeTwitterAuthError(message), 500);
   }
 }
 
@@ -418,10 +438,53 @@ function handleTwitterAuthStatus(): Response {
       | string
       | undefined;
 
+    // Managed prerequisites
+    const integrationModeManaged = mode === "managed";
+    const assistantApiKeyPresent = !!getSecureKey(
+      "credential:vellum:assistant_api_key",
+    );
+    const platformBaseUrlFromEnv = getPlatformBaseUrl();
+    const platformBaseUrlFromConfig = (
+      raw?.platform as Record<string, unknown> | undefined
+    )?.baseUrl as string | undefined;
+    const platformAssistantIdResolvable = !!(
+      platformBaseUrlFromEnv || platformBaseUrlFromConfig
+    );
+
+    const managedPrerequisites = {
+      integrationModeManaged,
+      assistantApiKeyPresent,
+      platformAssistantIdResolvable,
+    };
+    const managedAvailable =
+      integrationModeManaged &&
+      assistantApiKeyPresent &&
+      platformAssistantIdResolvable;
+
+    // Local client configured
+    const localClientConfigured = !!getSecureKey(
+      "credential:integration:twitter:client_id",
+    );
+
+    // Strategy
+    const strategyRaw = getNestedValue(raw, "twitter.strategy") as
+      | string
+      | undefined;
+    const strategy = strategyRaw ?? "auto";
+    const strategyConfigured = strategyRaw !== undefined;
+
+    // In managed mode, connected is always false (auth goes through platform)
+    const connected = mode === "managed" ? false : !!accessToken;
+
     return Response.json({
-      connected: !!accessToken,
+      connected,
       accountInfo: accountInfo ?? undefined,
       mode,
+      managedAvailable,
+      managedPrerequisites,
+      localClientConfigured,
+      strategy,
+      strategyConfigured,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -589,7 +652,8 @@ function handleToolNamesList(): Response {
         for (const entry of manifest.tools) {
           if (nameSet.has(entry.name)) continue;
           nameSet.add(entry.name);
-          schemas[entry.name] = entry.input_schema as unknown as (typeof schemas)[string];
+          schemas[entry.name] =
+            entry.input_schema as unknown as (typeof schemas)[string];
         }
       } catch {
         // Skip skills whose manifests can't be parsed
@@ -779,11 +843,7 @@ export function settingsRouteDefinitions(): RouteDefinition[] {
       handler: async ({ req }) => {
         const body = (await req.json()) as { activationKey?: string };
         if (!body.activationKey) {
-          return httpError(
-            "BAD_REQUEST",
-            "activationKey is required",
-            400,
-          );
+          return httpError("BAD_REQUEST", "activationKey is required", 400);
         }
         return handleVoiceConfigUpdate(body.activationKey);
       },
@@ -808,11 +868,7 @@ export function settingsRouteDefinitions(): RouteDefinition[] {
       handler: async ({ req }) => {
         const body = (await req.json()) as { key?: string; value?: string };
         if (!body.key || body.value === undefined) {
-          return httpError(
-            "BAD_REQUEST",
-            "key and value are required",
-            400,
-          );
+          return httpError("BAD_REQUEST", "key and value are required", 400);
         }
         return handleClientSettingsUpdate(body.key, body.value);
       },
@@ -871,7 +927,11 @@ export function settingsRouteDefinitions(): RouteDefinition[] {
       handler: ({ url }) => {
         const filePath = url.searchParams.get("path") ?? "";
         if (!filePath) {
-          return httpError("BAD_REQUEST", "path query parameter is required", 400);
+          return httpError(
+            "BAD_REQUEST",
+            "path query parameter is required",
+            400,
+          );
         }
         return handleWorkspaceFileRead(filePath);
       },

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -15,7 +15,10 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { getPlatformBaseUrl } from "../../config/env.js";
+import {
+  getPlatformAssistantId,
+  getPlatformBaseUrl,
+} from "../../config/env.js";
 import {
   getNestedValue,
   invalidateConfigCache,
@@ -448,7 +451,8 @@ function handleTwitterAuthStatus(): Response {
       raw?.platform as Record<string, unknown> | undefined
     )?.baseUrl as string | undefined;
     const platformAssistantIdResolvable = !!(
-      platformBaseUrlFromEnv || platformBaseUrlFromConfig
+      (platformBaseUrlFromEnv || platformBaseUrlFromConfig) &&
+      getPlatformAssistantId()
     );
 
     const managedPrerequisites = {


### PR DESCRIPTION
## Summary
- Port managed Twitter prerequisite computation to `handleTwitterAuthStatus()` in settings-routes.ts: returns `managedAvailable`, `managedPrerequisites`, `localClientConfigured`, `strategy`, `strategyConfigured`, and forces `connected: false` in managed mode
- Add managed-mode specific error handling to `handleTwitterAuthStart()`: returns `errorCode: "managed_missing_api_key"` or `errorCode: "managed_auth_via_platform"` with descriptive messages
- Update CLI mapper in `sendTwitterConfigRequest()` to pass through `managedAvailable`, `managedPrerequisites`, and `localClientConfigured` fields

After the IPC-to-HTTP migration deleted the old handlers, the managed Twitter logic (prerequisite computation, managed-mode guards, error codes) was lost. This PR ports that logic to the new HTTP route handlers in settings-routes.ts and updates the CLI mapper. Part of #14191.

## Test plan
- [ ] Verify `GET /v1/integrations/twitter/auth/status` returns `managedAvailable`, `managedPrerequisites`, `localClientConfigured`, `strategy`, `strategyConfigured` fields
- [ ] Verify managed mode returns `connected: false` regardless of access token presence
- [ ] Verify `POST /v1/integrations/twitter/auth/start` in managed mode returns appropriate `errorCode` values
- [ ] Verify CLI `assistant x status` passes through new fields correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
