### PR TITLE
fix: align managed Twitter OAuth client and proxy with platform contracts

### DIFF
--- a/assistant/src/twitter/platform-proxy-client.ts
+++ b/assistant/src/twitter/platform-proxy-client.ts
@@ -142,6 +142,15 @@ export function mapProxyError(
   const detail = obj?.detail ?? obj?.message ?? obj?.error;
   const detailStr = detail ? String(detail) : `HTTP ${status}`;
 
+  if (status === 424) {
+    return new TwitterProxyError(
+      "Connect Twitter in Settings — no active credential",
+      "credential_required",
+      false,
+      status,
+    );
+  }
+
   if (status === 403) {
     const msg = String(detailStr).toLowerCase();
     if (msg.includes("owner") && msg.includes("credential")) {
@@ -250,7 +259,7 @@ export async function proxyTwitterCall<T = unknown>(
     response = await fetch(url, {
       method: "POST",
       headers,
-      body: JSON.stringify(request),
+      body: JSON.stringify({ request }),
       signal: AbortSignal.timeout(30_000),
     });
   } catch (err) {
@@ -265,6 +274,7 @@ export async function proxyTwitterCall<T = unknown>(
     );
   }
 
+  // Platform-level errors (proxy endpoint itself returned non-200)
   if (!response.ok) {
     let errorBody: unknown;
     try {
@@ -275,9 +285,14 @@ export async function proxyTwitterCall<T = unknown>(
     throw mapProxyError(response.status, errorBody);
   }
 
-  let data: T;
+  // Parse the proxy envelope
+  let envelope: {
+    status: number;
+    headers: Record<string, string>;
+    body: unknown;
+  };
   try {
-    data = (await response.json()) as T;
+    envelope = (await response.json()) as typeof envelope;
   } catch (err) {
     throw new TwitterProxyError(
       `Failed to parse proxy response: ${err instanceof Error ? err.message : String(err)}`,
@@ -287,7 +302,12 @@ export async function proxyTwitterCall<T = unknown>(
     );
   }
 
-  return { data, status: response.status };
+  // Check upstream status from the envelope
+  if (envelope.status >= 400) {
+    throw mapProxyError(envelope.status, envelope.body);
+  }
+
+  return { data: envelope.body as T, status: envelope.status };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/twitter/platform-proxy-client.ts
+++ b/assistant/src/twitter/platform-proxy-client.ts
@@ -231,8 +231,10 @@ export function mapProxyError(
  * The proxy endpoint is:
  *   POST {platformBaseURL}/v1/assistants/{platform_assistant_id}/external-provider-proxy/twitter/
  *
- * The request body describes the Twitter API call to make:
- *   { method, path, body?, query? }
+ * The request body wraps the Twitter API call in an envelope:
+ *   { request: { method, path, body?, query?, headers? }, on_behalf_of_user_id? }
+ *
+ * The response is an envelope: { status, headers, body } where body is the Twitter payload.
  *
  * Auth uses `Authorization: Api-Key {auth_token}` (the assistant API key).
  */

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1031,13 +1031,13 @@ public final class SettingsStore: ObservableObject {
 
             let service = PlatformTwitterOAuthService(baseURL: ctx.baseURL)
             do {
-                let response = try await service.listConnections(
+                let connections = try await service.listConnections(
                     platformAssistantId: ctx.platformAssistantId,
                     organizationId: ctx.organizationId
                 )
-                if let connection = response.connections.first {
+                if let connection = connections.first, connection.connected {
                     managedTwitterConnected = true
-                    managedTwitterAccountInfo = connection.accountInfo
+                    managedTwitterAccountInfo = connection.accountLabel
                 } else {
                     managedTwitterConnected = false
                     managedTwitterAccountInfo = nil
@@ -1069,7 +1069,7 @@ public final class SettingsStore: ObservableObject {
                     platformAssistantId: ctx.platformAssistantId,
                     organizationId: ctx.organizationId
                 )
-                if let url = URL(string: response.authorizationUrl) {
+                if let url = URL(string: response.connectUrl) {
                     NSWorkspace.shared.open(url)
                 } else {
                     managedTwitterError = "Invalid authorization URL received."

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1035,7 +1035,7 @@ public final class SettingsStore: ObservableObject {
                     platformAssistantId: ctx.platformAssistantId,
                     organizationId: ctx.organizationId
                 )
-                if let connection = connections.first, connection.connected {
+                if let connection = connections.first(where: { $0.provider == "twitter" }), connection.connected {
                     managedTwitterConnected = true
                     managedTwitterAccountInfo = connection.accountLabel
                 } else {

--- a/clients/shared/App/Auth/PlatformTwitterOAuthService.swift
+++ b/clients/shared/App/Auth/PlatformTwitterOAuthService.swift
@@ -92,8 +92,7 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
         "offline.access",
     ]
 
-    /// The redirect URL the platform navigates to after OAuth completes.
-    /// Points to a desktop completion page served by the platform.
+    /// The redirect path the platform navigates to after OAuth completes.
     public static let redirectAfterConnect = "/"
 
     /// Creates a new service instance.

--- a/clients/shared/App/Auth/PlatformTwitterOAuthService.swift
+++ b/clients/shared/App/Auth/PlatformTwitterOAuthService.swift
@@ -12,45 +12,54 @@ extension URLSession: URLSessionProtocol {}
 
 /// A Twitter OAuth connection returned by the platform.
 public struct TwitterOAuthConnection: Codable, Sendable {
-    public let id: String
     public let provider: String
-    public let accountInfo: String?
-    public let createdAt: String?
+    public let status: String           // "ACTIVE", "REVOKED", "EXPIRED"
+    public let connected: Bool
+    public let accountLabel: String?
+    public let scopesGranted: [String]?
+    public let expiresAt: String?
 
     enum CodingKeys: String, CodingKey {
-        case id
         case provider
-        case accountInfo = "account_info"
-        case createdAt = "created_at"
+        case status
+        case connected
+        case accountLabel = "account_label"
+        case scopesGranted = "scopes_granted"
+        case expiresAt = "expires_at"
     }
 
-    public init(id: String, provider: String, accountInfo: String? = nil, createdAt: String? = nil) {
-        self.id = id
+    public init(provider: String, status: String, connected: Bool, accountLabel: String? = nil, scopesGranted: [String]? = nil, expiresAt: String? = nil) {
         self.provider = provider
-        self.accountInfo = accountInfo
-        self.createdAt = createdAt
-    }
-}
-
-/// Response from listing Twitter OAuth connections.
-public struct ListTwitterOAuthConnectionsResponse: Codable, Sendable {
-    public let connections: [TwitterOAuthConnection]
-
-    public init(connections: [TwitterOAuthConnection]) {
-        self.connections = connections
+        self.status = status
+        self.connected = connected
+        self.accountLabel = accountLabel
+        self.scopesGranted = scopesGranted
+        self.expiresAt = expiresAt
     }
 }
 
 /// Response from starting a Twitter OAuth connect flow.
 public struct StartTwitterConnectResponse: Codable, Sendable {
-    public let authorizationUrl: String
+    public let success: Bool
+    public let deferred: Bool
+    public let provider: String
+    public let connectUrl: String
+    public let stateId: String
 
     enum CodingKeys: String, CodingKey {
-        case authorizationUrl = "authorization_url"
+        case success
+        case deferred
+        case provider
+        case connectUrl = "connect_url"
+        case stateId = "state_id"
     }
 
-    public init(authorizationUrl: String) {
-        self.authorizationUrl = authorizationUrl
+    public init(success: Bool, deferred: Bool, provider: String, connectUrl: String, stateId: String) {
+        self.success = success
+        self.deferred = deferred
+        self.provider = provider
+        self.connectUrl = connectUrl
+        self.stateId = stateId
     }
 }
 
@@ -85,7 +94,7 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
 
     /// The redirect URL the platform navigates to after OAuth completes.
     /// Points to a desktop completion page served by the platform.
-    public static let redirectAfterConnect = "vellum://oauth/twitter/complete"
+    public static let redirectAfterConnect = "/"
 
     /// Creates a new service instance.
     ///
@@ -114,8 +123,8 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
     public func listConnections(
         platformAssistantId: String,
         organizationId: String
-    ) async throws -> ListTwitterOAuthConnectionsResponse {
-        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/twitter/connections/"
+    ) async throws -> [TwitterOAuthConnection] {
+        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/oauth/connections/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
         }
@@ -130,7 +139,7 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
         let (data, response) = try await performRequest(request)
         let statusCode = httpStatusCode(response)
 
-        log.debug("Platform request GET assistants/\(platformAssistantId, privacy: .public)/twitter/connections/ -> \(statusCode)")
+        log.debug("Platform request GET assistants/\(platformAssistantId, privacy: .public)/oauth/connections/ -> \(statusCode)")
 
         try checkAuthErrors(statusCode: statusCode)
 
@@ -140,7 +149,7 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
         }
 
         do {
-            return try JSONDecoder().decode(ListTwitterOAuthConnectionsResponse.self, from: data)
+            return try JSONDecoder().decode([TwitterOAuthConnection].self, from: data)
         } catch {
             throw PlatformAPIError.decodingError(error.localizedDescription)
         }
@@ -158,7 +167,7 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
         platformAssistantId: String,
         organizationId: String
     ) async throws -> StartTwitterConnectResponse {
-        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/twitter/connect/"
+        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/oauth/twitter/start/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
         }
@@ -180,7 +189,7 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
         let (data, response) = try await performRequest(request)
         let statusCode = httpStatusCode(response)
 
-        log.debug("Platform request POST assistants/\(platformAssistantId, privacy: .public)/twitter/connect/ -> \(statusCode)")
+        log.debug("Platform request POST assistants/\(platformAssistantId, privacy: .public)/oauth/twitter/start/ -> \(statusCode)")
 
         try checkAuthErrors(statusCode: statusCode)
 
@@ -208,7 +217,7 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
         platformAssistantId: String,
         organizationId: String
     ) async throws -> DisconnectTwitterResponse {
-        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/twitter/disconnect/"
+        let urlString = "\(baseURL)/v1/assistants/\(platformAssistantId)/oauth/twitter/disconnect/"
         guard let url = URL(string: urlString) else {
             throw PlatformAPIError.invalidURL
         }
@@ -223,7 +232,7 @@ public final class PlatformTwitterOAuthService: @unchecked Sendable {
         let (data, response) = try await performRequest(request)
         let statusCode = httpStatusCode(response)
 
-        log.debug("Platform request POST assistants/\(platformAssistantId, privacy: .public)/twitter/disconnect/ -> \(statusCode)")
+        log.debug("Platform request POST assistants/\(platformAssistantId, privacy: .public)/oauth/twitter/disconnect/ -> \(statusCode)")
 
         try checkAuthErrors(statusCode: statusCode)
 


### PR DESCRIPTION
## Summary
Fix 4 contract mismatches between the vellum-assistant managed Twitter OAuth implementation and the actual platform:

1. **Swift OAuth client**: fix endpoint paths (`/twitter/*` → `/oauth/*`), response model fields (`connect_url`, `account_label`, raw array), and redirect URL (relative path `"/"`)
2. **Proxy client**: wrap request in `{ request: {...} }` envelope, unwrap `{ status, headers, body }` response envelope, handle 424 `credential_required`
3. **SettingsStore**: use updated response shapes (`accountLabel`, `connectUrl`, raw array)
4. **Tests**: verified all 8 managed-twitter guardrail tests pass with new shapes

## Test plan
- [x] `bun test managed-twitter` — all 8 tests pass
- [ ] Verify Swift client endpoints match platform routes
- [ ] Verify proxy envelope wrapping/unwrapping works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
