### PR TITLE
refactor(amazon): replace createSessionStore with credentials CLI subprocess

### DIFF
--- a/assistant/src/cli/commands/amazon/client.ts
+++ b/assistant/src/cli/commands/amazon/client.ts
@@ -167,8 +167,8 @@ export class RateLimitError extends Error {
   }
 }
 
-function requireSession(): AmazonSession {
-  const session = loadSession();
+async function requireSession(): Promise<AmazonSession> {
+  const session = await loadSession();
   if (!session) {
     throw new SessionExpiredError("No Amazon session found.");
   }
@@ -183,7 +183,7 @@ export async function prepareRequest(): Promise<{
   tabId: number;
   session: AmazonSession;
 }> {
-  const session = requireSession();
+  const session = await requireSession();
   const tabId = await findAmazonTab();
   // Skip cookie sync — use Chrome's own live cookies instead of overwriting with stale CLI ones
   // await syncCookiesToBrowser(session.cookies);
@@ -493,7 +493,7 @@ export async function refreshSessionFromExtension(): Promise<AmazonSession> {
     cookies,
   };
 
-  saveSession(session);
+  await saveSession(session);
   return session;
 }
 

--- a/assistant/src/cli/commands/amazon/index.ts
+++ b/assistant/src/cli/commands/amazon/index.ts
@@ -139,7 +139,7 @@ Examples:
     )
     .action(async (opts: { recording: string }, cmd: Command) => {
       await run(cmd, async () => {
-        const session = importFromRecording(opts.recording);
+        const session = await importFromRecording(opts.recording);
         return {
           message: "Session imported successfully",
           cookieCount: session.cookies.length,
@@ -163,8 +163,8 @@ all shopping commands will fail until a new session is established via
 Examples:
   $ assistant amazon logout`,
     )
-    .action((_opts: unknown, cmd: Command) => {
-      clearSession();
+    .action(async (_opts: unknown, cmd: Command) => {
+      await clearSession();
       output({ ok: true, message: "Session cleared" }, getJson(cmd));
     });
 
@@ -242,7 +242,7 @@ Examples:
       const json = getJson(cmd);
       try {
         const session = await extractSessionFromChromeCookies();
-        saveSession(session);
+        await saveSession(session);
         output(
           {
             ok: true,
@@ -274,8 +274,8 @@ Examples:
   $ assistant amazon status
   $ assistant amazon status --json`,
     )
-    .action((_opts: unknown, cmd: Command) => {
-      const session = loadSession();
+    .action(async (_opts: unknown, cmd: Command) => {
+      const session = await loadSession();
       if (session) {
         output(
           {

--- a/assistant/src/cli/commands/amazon/session.ts
+++ b/assistant/src/cli/commands/amazon/session.ts
@@ -1,26 +1,70 @@
 /**
  * Amazon session persistence.
- * Delegates cookie CRUD to the shared cookie-session primitive;
+ * Delegates cookie CRUD to the `assistant credentials` CLI subprocess;
  * keeps Amazon-specific cookie validation and CSRF extraction.
  */
 
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
 import {
   type CookieSession,
-  createSessionStore,
   importFromRecordingBase,
 } from "../../../util/cookie-session.js";
+import type { ExtractedCredential } from "./client.js";
+
+const execFileAsync = promisify(execFile);
 
 export type AmazonSession = CookieSession;
 
-const store = createSessionStore("amazon");
+export async function loadSession(): Promise<AmazonSession | null> {
+  try {
+    const { stdout } = await execFileAsync("assistant", [
+      "credentials",
+      "reveal",
+      "amazon:session:cookies",
+    ]);
+    const cookies = JSON.parse(stdout.trim()) as ExtractedCredential[];
+    return { cookies };
+  } catch {
+    return null;
+  }
+}
 
-export const { loadSession, saveSession, clearSession } = store;
+export async function saveSession(session: AmazonSession): Promise<void> {
+  try {
+    await execFileAsync("assistant", [
+      "credentials",
+      "set",
+      "amazon:session:cookies",
+      JSON.stringify(session.cookies),
+    ]);
+  } catch (err) {
+    throw new Error(
+      `Failed to save Amazon session: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+export async function clearSession(): Promise<void> {
+  try {
+    await execFileAsync("assistant", [
+      "credentials",
+      "delete",
+      "amazon:session:cookies",
+    ]);
+  } catch {
+    // Clearing a non-existent session is fine — no-op
+  }
+}
 
 /**
  * Import cookies from a Ride Shotgun recording file.
  * Validates that the recording contains Amazon's required auth cookies.
  */
-export function importFromRecording(recordingPath: string): AmazonSession {
+export async function importFromRecording(
+  recordingPath: string,
+): Promise<AmazonSession> {
   const session = importFromRecordingBase(recordingPath, (cookieNames) => {
     if (!cookieNames.has("session-id")) {
       throw new Error(
@@ -41,7 +85,7 @@ export function importFromRecording(recordingPath: string): AmazonSession {
       );
     }
   });
-  saveSession(session);
+  await saveSession(session);
   return session;
 }
 


### PR DESCRIPTION
## Summary
- Replace createSessionStore factory in amazon/session.ts with async subprocess calls to assistant credentials CLI (reveal/set/delete)
- Make loadSession, saveSession, clearSession async; update all callers in index.ts and client.ts to await
- importFromRecordingBase and CookieSession type imports remain unchanged for now

Part of plan: cookie-session-cli-decouple.md (PR 1 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
