### PR TITLE
refactor(twitter): replace createSessionStore with credentials CLI subprocess

### DIFF
--- a/assistant/src/cli/commands/twitter/client.ts
+++ b/assistant/src/cli/commands/twitter/client.ts
@@ -89,8 +89,8 @@ export class SessionExpiredError extends Error {
   }
 }
 
-function requireSession(): TwitterSession {
-  const session = loadSession();
+async function requireSession(): Promise<TwitterSession> {
+  const session = await loadSession();
   if (!session) {
     throw new SessionExpiredError("No Twitter session found.");
   }
@@ -384,7 +384,7 @@ async function graphqlGet(
   queryName: string,
   variables: Record<string, unknown>,
 ): Promise<unknown> {
-  requireSession();
+  await requireSession();
   const wsUrl = await findTwitterTab();
   const url = graphqlUrl(queryId, queryName, variables);
   const json = (await cdpGet(wsUrl, url)) as {
@@ -678,7 +678,7 @@ export async function postTweet(
   text: string,
   opts?: { inReplyToTweetId?: string },
 ): Promise<PostTweetResult> {
-  requireSession();
+  await requireSession();
 
   const wsUrl = await findTwitterTab();
   const url = `https://x.com/i/api/graphql/${QUERY_IDS.CreateTweet}/CreateTweet`;
@@ -810,7 +810,7 @@ export async function searchTweets(
   query: string,
   product: "Top" | "Latest" | "People" | "Media" = "Top",
 ): Promise<TweetEntry[]> {
-  requireSession();
+  await requireSession();
   const wsUrl = await findTwitterTab();
 
   // Search requires X's client-generated transaction ID, so we navigate Chrome
@@ -923,7 +923,7 @@ export async function getFollowers(
   // Followers requires X's client-generated transaction ID.
   // Navigate to the followers page and capture via CDP.
   if (screenName) {
-    requireSession();
+    await requireSession();
     const wsUrl = await findTwitterTab();
     const json = (await cdpNavigateAndCapture(
       wsUrl,

--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -170,7 +170,7 @@ Examples:
     )
     .action(async (opts: { recording: string }, cmd: Command) => {
       await run(cmd, async () => {
-        const session = importFromRecording(opts.recording);
+        const session = await importFromRecording(opts.recording);
         return {
           message: "Session imported successfully",
           cookieCount: session.cookies.length,
@@ -193,8 +193,8 @@ OAuth credentials are not affected.
 Examples:
   $ assistant x logout`,
     )
-    .action((_opts: unknown, cmd: Command) => {
-      clearSession();
+    .action(async (_opts: unknown, cmd: Command) => {
+      await clearSession();
       output({ ok: true, message: "Session cleared" }, getJson(cmd));
     });
 
@@ -233,7 +233,7 @@ Examples:
       try {
         const result = await startLearnSession(duration);
         if (result.recordingPath) {
-          const session = importFromRecording(result.recordingPath);
+          const session = await importFromRecording(result.recordingPath);
 
           // Hide Chrome after capturing session
           try {
@@ -286,7 +286,7 @@ Examples:
   $ assistant x status --json`,
     )
     .action(async (_opts: unknown, cmd: Command) => {
-      const session = loadSession();
+      const session = await loadSession();
       const browserInfo: Record<string, unknown> = session
         ? {
             browserSessionActive: true,
@@ -1031,9 +1031,7 @@ async function startLearnSession(
 
         if (status.bootstrapFailureReason) {
           reject(
-            new Error(
-              `Learn session failed: ${status.bootstrapFailureReason}`,
-            ),
+            new Error(`Learn session failed: ${status.bootstrapFailureReason}`),
           );
           return;
         }
@@ -1046,9 +1044,7 @@ async function startLearnSession(
             });
           } else {
             reject(
-              new Error(
-                "Learn session completed but no recording was saved.",
-              ),
+              new Error("Learn session completed but no recording was saved."),
             );
           }
           return;

--- a/assistant/src/cli/commands/twitter/session.ts
+++ b/assistant/src/cli/commands/twitter/session.ts
@@ -1,14 +1,16 @@
 /**
  * Twitter session persistence.
- * Delegates to the shared cookie-session primitive for CRUD;
+ * Delegates to the `assistant credentials` CLI for CRUD;
  * keeps Twitter-specific cookie validation and CSRF extraction.
  */
 
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
 import type { CookieSession } from "../../../util/cookie-session.js";
-import {
-  createSessionStore,
-  importFromRecordingBase,
-} from "../../../util/cookie-session.js";
+import { importFromRecordingBase } from "../../../util/cookie-session.js";
 
 class ConfigError extends Error {
   constructor(message: string) {
@@ -19,16 +21,63 @@ class ConfigError extends Error {
 
 export type TwitterSession = CookieSession;
 
-const store = createSessionStore("twitter");
+interface ExtractedCredential {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  httpOnly: boolean;
+  secure: boolean;
+  expires?: number;
+}
 
-export const loadSession: () => TwitterSession | null = store.loadSession;
-export const saveSession: (session: TwitterSession) => void = store.saveSession;
-export const clearSession: () => void = store.clearSession;
+export async function loadSession(): Promise<TwitterSession | null> {
+  try {
+    const { stdout } = await execFileAsync("assistant", [
+      "credentials",
+      "reveal",
+      "twitter:session:cookies",
+    ]);
+    const cookies = JSON.parse(stdout.trim()) as ExtractedCredential[];
+    return { cookies };
+  } catch {
+    return null;
+  }
+}
+
+export async function saveSession(session: TwitterSession): Promise<void> {
+  try {
+    await execFileAsync("assistant", [
+      "credentials",
+      "set",
+      "twitter:session:cookies",
+      JSON.stringify(session.cookies),
+    ]);
+  } catch (err) {
+    throw new ConfigError(
+      `Failed to save Twitter session: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+export async function clearSession(): Promise<void> {
+  try {
+    await execFileAsync("assistant", [
+      "credentials",
+      "delete",
+      "twitter:session:cookies",
+    ]);
+  } catch {
+    // Clearing a non-existent session is fine — no-op
+  }
+}
 
 /**
  * Import cookies from a Ride Shotgun recording file.
  */
-export function importFromRecording(recordingPath: string): TwitterSession {
+export async function importFromRecording(
+  recordingPath: string,
+): Promise<TwitterSession> {
   try {
     const session = importFromRecordingBase(recordingPath, (cookieNames) => {
       // Require the two cookies that prove a logged-in Twitter session:
@@ -40,7 +89,7 @@ export function importFromRecording(recordingPath: string): TwitterSession {
         );
       }
     });
-    saveSession(session);
+    await saveSession(session);
     return session;
   } catch (error) {
     if (error instanceof ConfigError) throw error;


### PR DESCRIPTION
## Summary
- Replace createSessionStore factory in twitter/session.ts with async subprocess calls to assistant credentials CLI (reveal/set/delete)
- Make loadSession, saveSession, clearSession async; update all callers in index.ts and client.ts to await
- importFromRecordingBase and CookieSession type imports remain unchanged for now

Part of plan: cookie-session-cli-decouple.md (PR 2 of 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
