### PR TITLE
fix: select active Twitter connection from provider-agnostic list

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsStore.swift
@@ -1035,7 +1035,7 @@ public final class SettingsStore: ObservableObject {
                     platformAssistantId: ctx.platformAssistantId,
                     organizationId: ctx.organizationId
                 )
-                if let connection = connections.first(where: { $0.provider == "twitter" }), connection.connected {
+                if let connection = connections.first(where: { $0.provider == "twitter" && $0.connected }) {
                     managedTwitterConnected = true
                     managedTwitterAccountInfo = connection.accountLabel
                 } else {


### PR DESCRIPTION
Filter connections for both provider == twitter AND connected == true, so revoked/expired Twitter entries don't mask an active connection.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
