### PR TITLE
fix: remove ellipsis from Retire button in Settings

### DIFF
--- a/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsAccountTab.swift
@@ -415,7 +415,7 @@ struct SettingsAccountTab: View {
                             .foregroundColor(VColor.textMuted)
                     }
                 }
-                VButton(label: "Retire...", style: .danger) {
+                VButton(label: "Retire", style: .danger) {
                     showingRetireConfirmation = true
                 }
             }


### PR DESCRIPTION
## Summary
- Removes the trailing ellipsis from the "Retire..." button label in Settings > Account, changing it to "Retire"

## Test plan
- [ ] Open Settings > Account > Retire Assistant section
- [ ] Verify the button reads "Retire" (no ellipsis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
