### PR TITLE
fix: simplify search button and use SidebarPrimaryRow for skill categories

### DIFF
--- a/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/MainWindowView.swift
@@ -361,18 +361,9 @@ struct MainWindowView: View {
                     }
                 }
 
-                Button {
+                VIconButton(label: "Search", icon: VIcon.search.rawValue, iconOnly: true, tooltip: "Search (\u{2318}K)") {
                     AppDelegate.shared?.toggleCommandPalette()
-                } label: {
-                    HStack(spacing: VSpacing.xs) {
-                        VIconView(.search, size: 13)
-                            .foregroundColor(adaptiveColor(light: Color(hex: 0x537D53), dark: Forest._400))
-                        VShortcutTag("\u{2318}K")
-                    }
-                    .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
-                .help("Search (\u{2318}K)")
             }
             Spacer()
             if windowState.isConversationVisible {

--- a/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/Panels/AgentPanel.swift
@@ -721,24 +721,19 @@ struct AgentPanelContent: View {
     @ViewBuilder
     private var categorySidebar: some View {
         VStack(alignment: .leading, spacing: VSpacing.xxs) {
-            // "All" row
-            categoryRow(
-                icon: .layoutGrid,
-                iconColor: VColor.textMuted,
+            SidebarPrimaryRow(
+                icon: VIcon.layoutGrid.rawValue,
                 label: "All",
-                count: filteredUserSkills.count,
-                isSelected: selectedCategory == nil
+                isActive: selectedCategory == nil
             ) {
                 withAnimation(VAnimation.fast) { selectedCategory = nil }
             }
 
             ForEach(SkillCategory.allCases, id: \.rawValue) { category in
-                categoryRow(
-                    icon: category.icon,
-                    iconColor: category.color,
+                SidebarPrimaryRow(
+                    icon: category.icon.rawValue,
                     label: category.displayName,
-                    count: skillCount(for: category),
-                    isSelected: selectedCategory == category
+                    isActive: selectedCategory == category
                 ) {
                     withAnimation(VAnimation.fast) { selectedCategory = category }
                 }
@@ -747,40 +742,6 @@ struct AgentPanelContent: View {
             Spacer()
         }
         .frame(width: 180)
-    }
-
-    @ViewBuilder
-    private func categoryRow(icon: VIcon, iconColor: Color, label: String, count: Int, isSelected: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            HStack(spacing: VSpacing.xs) {
-                VIconView(icon, size: 12)
-                    .foregroundColor(iconColor)
-                    .frame(width: 20)
-
-                Text(label)
-                    .font(.system(size: 13))
-                    .foregroundColor(isSelected ? VColor.textPrimary : VColor.textMuted)
-                    .lineLimit(1)
-
-                Spacer()
-
-                Text("\(count)")
-                    .font(VFont.small)
-                    .foregroundColor(VColor.textMuted)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, VSpacing.xs)
-            .padding(.trailing, VSpacing.sm)
-            .padding(.vertical, VSpacing.sm)
-            .background(
-                isSelected
-                    ? adaptiveColor(light: Moss._100, dark: Moss._700)
-                    : Color.clear
-            )
-            .clipShape(RoundedRectangle(cornerRadius: VRadius.md))
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
     }
 
     // MARK: - Installed Skills Content


### PR DESCRIPTION
## Summary
- Remove the ⌘K shortcut tag from the top bar search button, replacing the custom Button+HStack with a standard `VIconButton`
- Migrate the skill category sidebar in AgentPanel to use `SidebarPrimaryRow` for consistent hover states and design system styling

## Test plan
- [ ] Verify search button in top bar shows only the icon (no ⌘K tag), still opens command palette on click
- [ ] Verify Intelligence > Installed Skills category sidebar renders with proper hover/active states
- [ ] Verify selecting categories still filters the skill list correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
