### PR TITLE
fix: stamp denied on ToolCallData after OS permission denial

### DIFF
--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1319,6 +1319,9 @@ extension ChatViewModel {
                     toolResult: truncatedResult,
                     isError: toolErrored
                 )
+                if toolErrored, Self.isOSPermissionDeniedError(truncatedResult) {
+                    messages[msgIndex].toolCalls[tcIndex].confirmationDecision = .denied
+                }
                 for stepIdx in messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.indices {
                     if !messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps[stepIdx].isComplete {
                         messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps[stepIdx].isComplete = true


### PR DESCRIPTION
## Summary
- When a tool is user-approved but the OS denies the operation, `downgradeAdjacentApprovedConfirmationForPermissionDeniedError` updates the confirmation bubble state but not `ToolCallData.confirmationDecision`
- This fix ensures the `ToolCallData` also reflects the `.denied` state, which is needed for inline permission badges (M2)

## Test plan
- [ ] Trigger an OS permission denial on an approved tool call
- [ ] Verify `ToolCallData.confirmationDecision` is set to `.denied`
- [ ] Verify inline badge (when implemented) shows correct denied state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
