### PR TITLE
fix: update tests for managed Twitter proxy envelope format

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -230,6 +230,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)
       "daemon/session-messaging.ts", // credential storage during session messaging
       "runtime/routes/settings-routes.ts", // settings routes OAuth credential lookup (client_id/client_secret/access tokens)
+      "twitter/platform-proxy-client.ts", // managed Twitter proxy — reads assistant_api_key for Api-Key auth
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));

--- a/assistant/src/__tests__/twitter-platform-proxy-client.test.ts
+++ b/assistant/src/__tests__/twitter-platform-proxy-client.test.ts
@@ -78,7 +78,11 @@ beforeEach(() => {
   fetchResponse = {
     ok: true,
     status: 200,
-    json: async () => ({ data: { id: "12345", text: "Hello world" } }),
+    json: async () => ({
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      body: { data: { id: "12345", text: "Hello world" } },
+    }),
   };
 });
 
@@ -205,9 +209,9 @@ describe("proxyTwitterCall", () => {
     });
 
     const parsed = JSON.parse(lastFetchArgs![1].body as string);
-    expect(parsed.method).toBe("POST");
-    expect(parsed.path).toBe("/2/tweets");
-    expect(parsed.body).toEqual({ text: "Hello world" });
+    expect(parsed.request.method).toBe("POST");
+    expect(parsed.request.path).toBe("/2/tweets");
+    expect(parsed.request.body).toEqual({ text: "Hello world" });
   });
 
   test("GET-style request includes query parameters", async () => {
@@ -218,16 +222,20 @@ describe("proxyTwitterCall", () => {
     });
 
     const parsed = JSON.parse(lastFetchArgs![1].body as string);
-    expect(parsed.method).toBe("GET");
-    expect(parsed.path).toBe("/2/users/me");
-    expect(parsed.query).toEqual({ "user.fields": "name,username" });
+    expect(parsed.request.method).toBe("GET");
+    expect(parsed.request.path).toBe("/2/users/me");
+    expect(parsed.request.query).toEqual({ "user.fields": "name,username" });
   });
 
   test("returns parsed response data on success", async () => {
     fetchResponse = {
       ok: true,
       status: 200,
-      json: async () => ({ data: { id: "99", text: "ok" } }),
+      json: async () => ({
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        body: { data: { id: "99", text: "ok" } },
+      }),
     };
 
     const result = await proxyTwitterCall({
@@ -412,16 +420,16 @@ describe("postTweet", () => {
     await postTweet("Hello from proxy");
 
     const parsed = JSON.parse(lastFetchArgs![1].body as string);
-    expect(parsed.method).toBe("POST");
-    expect(parsed.path).toBe("/2/tweets");
-    expect(parsed.body.text).toBe("Hello from proxy");
+    expect(parsed.request.method).toBe("POST");
+    expect(parsed.request.path).toBe("/2/tweets");
+    expect(parsed.request.body.text).toBe("Hello from proxy");
   });
 
   test("includes reply metadata when replyToId is provided", async () => {
     await postTweet("This is a reply", { replyToId: "tweet_789" });
 
     const parsed = JSON.parse(lastFetchArgs![1].body as string);
-    expect(parsed.body.reply).toEqual({
+    expect(parsed.request.body.reply).toEqual({
       in_reply_to_tweet_id: "tweet_789",
     });
   });
@@ -432,9 +440,9 @@ describe("getMe", () => {
     await getMe({ "user.fields": "name,username,profile_image_url" });
 
     const parsed = JSON.parse(lastFetchArgs![1].body as string);
-    expect(parsed.method).toBe("GET");
-    expect(parsed.path).toBe("/2/users/me");
-    expect(parsed.query).toEqual({
+    expect(parsed.request.method).toBe("GET");
+    expect(parsed.request.path).toBe("/2/users/me");
+    expect(parsed.request.query).toEqual({
       "user.fields": "name,username,profile_image_url",
     });
   });
@@ -443,8 +451,8 @@ describe("getMe", () => {
     await getMe();
 
     const parsed = JSON.parse(lastFetchArgs![1].body as string);
-    expect(parsed.method).toBe("GET");
-    expect(parsed.path).toBe("/2/users/me");
-    expect(parsed.query).toBeUndefined();
+    expect(parsed.request.method).toBe("GET");
+    expect(parsed.request.path).toBe("/2/users/me");
+    expect(parsed.request.query).toBeUndefined();
   });
 });

--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -32,7 +32,7 @@ Commands:
   oauth [options]                          Manage OAuth tokens for connected integrations
   skills                                   Browse and install skills from the Vellum catalog
   browser                                  Browser automation, extension relay, and Chrome CDP management
-  x|twitter [options]                      Post on X and manage connections. Supports OAuth (official API) and browser session paths.
+  x|twitter [options]                      Post on X and manage connections. Supports managed (platform proxy), OAuth (official API), and browser session paths.
   map [options] <domain>                   Auto-navigate a domain and produce a deduplicated API map. Launches Chrome with CDP, starts a Ride Shotgun learn session, then analyzes captured network traffic.
   sequence [options]                       Manage email sequences
 `;


### PR DESCRIPTION
## Summary
- Update CLI_HELP_REFERENCE to include "managed (platform proxy)" in twitter command description
- Add `twitter/platform-proxy-client.ts` to credential-security allowlist (reads assistant_api_key for Api-Key auth)
- Update twitter-platform-proxy-client tests for `{ request: {...} }` request envelope and `{ status, headers, body }` response envelope

## Original prompt
Fix 3 failing test files: cli-help-reference-sync, credential-security-invariants, twitter-platform-proxy-client

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
