### PR TITLE
feat: swap tool row title to reasonDescription and add inline permission badge

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -607,7 +607,7 @@ private struct StepDetailRow: View {
                         if let decision = toolCall.confirmationDecision {
                             compactPermissionChip(
                                 state: decision,
-                                label: toolCall.confirmationLabel ?? toolCall.toolName
+                                label: toolCall.confirmationLabel ?? toolCall.friendlyName
                             )
                         }
 

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -554,50 +554,63 @@ private struct StepDetailRow: View {
                             .frame(width: 16)
                     }
 
-                    // Title + reason
+                    // Title (reason-first, falling back to action/running label)
                     VStack(alignment: .leading, spacing: VSpacing.xxs) {
                         if toolCall.isComplete {
-                            Text(toolCall.actionDescription)
+                            Text({
+                                if let reason = toolCall.reasonDescription, !reason.isEmpty {
+                                    return reason
+                                }
+                                return toolCall.actionDescription
+                            }())
                                 .font(VFont.bodyMedium)
                                 .foregroundColor(toolCall.isError ? VColor.error : VColor.textPrimary)
                                 .lineLimit(1)
                                 .truncationMode(.tail)
                         } else if phase == .denied {
-                            Text("Blocked — " + ChatBubble.friendlyRunningLabel(
-                                toolCall.toolName,
-                                inputSummary: toolCall.inputSummary,
-                                buildingStatus: toolCall.buildingStatus
-                            ))
+                            Text({
+                                if let reason = toolCall.reasonDescription, !reason.isEmpty {
+                                    return "Blocked — " + reason
+                                }
+                                return "Blocked — " + ChatBubble.friendlyRunningLabel(
+                                    toolCall.toolName,
+                                    inputSummary: toolCall.inputSummary,
+                                    buildingStatus: toolCall.buildingStatus
+                                )
+                            }())
                             .font(VFont.bodyMedium)
                             .foregroundColor(VColor.textMuted)
                             .lineLimit(1)
                             .truncationMode(.tail)
                         } else {
-                            Text(ChatBubble.friendlyRunningLabel(
-                                toolCall.toolName,
-                                inputSummary: toolCall.inputSummary,
-                                buildingStatus: toolCall.buildingStatus
-                            ))
+                            Text({
+                                if let reason = toolCall.reasonDescription, !reason.isEmpty {
+                                    return reason
+                                }
+                                return ChatBubble.friendlyRunningLabel(
+                                    toolCall.toolName,
+                                    inputSummary: toolCall.inputSummary,
+                                    buildingStatus: toolCall.buildingStatus
+                                )
+                            }())
                             .font(VFont.bodyMedium)
                             .foregroundColor(VColor.textPrimary)
                             .lineLimit(1)
                             .truncationMode(.tail)
                         }
-
-                        // Reason subtitle — only for completed tools
-                        if let reason = toolCall.reasonDescription, !reason.isEmpty, toolCall.isComplete {
-                            Text(reason)
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
-                        }
                     }
 
                     Spacer()
 
-                    // Duration + chevron (completed only)
+                    // Permission badge + duration + chevron (completed only)
                     HStack(spacing: VSpacing.xs) {
+                        if let decision = toolCall.confirmationDecision {
+                            compactPermissionChip(
+                                state: decision,
+                                label: toolCall.confirmationLabel ?? toolCall.toolName
+                            )
+                        }
+
                         if let start = toolCall.startedAt, let end = toolCall.completedAt, toolCall.isComplete {
                             Text(formatDuration(end.timeIntervalSince(start)))
                                 .font(VFont.small)
@@ -683,6 +696,9 @@ private struct StepDetailRow: View {
                 }
 
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    Text(toolCall.actionDescription)
+                        .font(VFont.captionMedium)
+                        .foregroundColor(VColor.textSecondary)
                     Text(toolCall.friendlyName)
                         .font(VFont.captionMedium)
                         .foregroundColor(VColor.textSecondary)
@@ -851,6 +867,44 @@ private struct StepDetailRow: View {
         seconds < 60
             ? String(format: "%.1fs", seconds)
             : "\(Int(seconds) / 60)m \(Int(seconds) % 60)s"
+    }
+
+    /// Renders a compact permission chip from a confirmation state + label.
+    private func compactPermissionChip(state: ToolConfirmationState, label: String) -> some View {
+        let isApproved = state == .approved
+        let isDenied = state == .denied
+        let chipColor: Color = isApproved ? VColor.iconAccent : isDenied ? VColor.error : VColor.textMuted
+
+        return HStack(spacing: VSpacing.xxs) {
+            Group {
+                switch state {
+                case .approved:
+                    VIconView(.circleCheck, size: 10)
+                        .foregroundColor(chipColor)
+                case .denied:
+                    VIconView(.circleAlert, size: 10)
+                        .foregroundColor(chipColor)
+                case .timedOut:
+                    VIconView(.clock, size: 10)
+                        .foregroundColor(chipColor)
+                default:
+                    EmptyView()
+                }
+            }
+
+            Text(isApproved ? "\(label) Allowed" :
+                 isDenied ? "\(label) Denied" : "Timed Out")
+                .font(VFont.small)
+                .foregroundColor(chipColor)
+        }
+        .padding(.horizontal, VSpacing.xs)
+        .padding(.vertical, VSpacing.xxs)
+        .background(
+            Capsule().fill(Color.clear)
+        )
+        .overlay(
+            Capsule().stroke(chipColor.opacity(0.3), lineWidth: 1)
+        )
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -696,9 +696,11 @@ private struct StepDetailRow: View {
                 }
 
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
-                    Text(toolCall.actionDescription)
-                        .font(VFont.captionMedium)
-                        .foregroundColor(VColor.textSecondary)
+                    if let reason = toolCall.reasonDescription, !reason.isEmpty {
+                        Text(toolCall.actionDescription)
+                            .font(VFont.captionMedium)
+                            .foregroundColor(VColor.textSecondary)
+                    }
                     Text(toolCall.friendlyName)
                         .font(VFont.captionMedium)
                         .foregroundColor(VColor.textSecondary)


### PR DESCRIPTION
## Summary
- Swaps the `StepDetailRow` primary title from `actionDescription` to `reasonDescription` (with fallback to `actionDescription`) for completed, running, and denied tool states
- Adds a compact permission chip inline before the duration text when `confirmationDecision` is present
- Moves the old `actionDescription` into the expanded "Technical details" section above `friendlyName`

## Test plan
- [ ] Verify completed tool rows show `reasonDescription` as title when available, falling back to `actionDescription`
- [ ] Verify denied tool rows show "Blocked — {reasonDescription}" when available
- [ ] Verify running tool rows show `reasonDescription` when available
- [ ] Verify the compact permission badge (Allowed/Denied/Timed Out) appears inline before the duration
- [ ] Verify the `actionDescription` appears in expanded technical details
- [ ] Verify no badge shows when `confirmationDecision` is nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
