### PR TITLE
feat: inline permission badges on tool call rows

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -590,6 +590,7 @@ private struct StepDetailRow: View {
                                 state: decision,
                                 label: toolCall.confirmationLabel ?? toolCall.friendlyName
                             )
+                            .padding(.trailing, VSpacing.xs)
                         }
 
                         if let start = toolCall.startedAt, let end = toolCall.completedAt, toolCall.isComplete {

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -171,11 +171,6 @@ struct AssistantProgressView: View {
             if isExpanded {
                 expandedContent
                     .padding(.bottom, VSpacing.xs)
-
-                // Permission chips at bottom of expanded list
-                permissionChips
-                    .padding(.horizontal, VSpacing.sm)
-                    .padding(.bottom, VSpacing.sm)
             }
 
             // Code preview (streaming code phase)
@@ -382,20 +377,6 @@ struct AssistantProgressView: View {
                         .padding(.horizontal, VSpacing.lg)
                 } else {
                     StepDetailRow(toolCall: toolCall, phase: phase, onRehydrate: onRehydrate)
-                }
-            }
-        }
-    }
-
-    // MARK: - Permission Chips
-
-    @ViewBuilder
-    private var permissionChips: some View {
-        let resolved = decidedConfirmations.filter { $0.state != .pending }
-        if !resolved.isEmpty {
-            FlowLayout(spacing: VSpacing.xs) {
-                ForEach(Array(resolved.enumerated()), id: \.offset) { _, confirmation in
-                    compactPermissionChip(confirmation)
                 }
             }
         }
@@ -923,64 +904,6 @@ private struct AssistantProgressPulsingModifier: ViewModifier {
                 value: isPulsing
             )
             .onAppear { isPulsing = true }
-    }
-}
-
-// MARK: - Flow Layout
-
-/// A simple wrapping layout that arranges children left-to-right and wraps
-/// to the next row when the available width is exceeded.
-private struct FlowLayout: Layout {
-    var spacing: CGFloat = VSpacing.xs
-
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
-        let rows = computeRows(proposal: proposal, subviews: subviews)
-        let height = rows.enumerated().reduce(CGFloat.zero) { total, pair in
-            let rowHeight = pair.element.map(\.size.height).max() ?? 0
-            return total + rowHeight + (pair.offset > 0 ? spacing : 0)
-        }
-        let width: CGFloat = proposal.width ?? rows.map { row in
-            row.enumerated().reduce(CGFloat.zero) { total, pair in
-                total + pair.element.size.width + (pair.offset > 0 ? spacing : 0)
-            }
-        }.max() ?? 0
-        return CGSize(width: width, height: height)
-    }
-
-    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        let rows = computeRows(proposal: proposal, subviews: subviews)
-        var y = bounds.minY
-        for row in rows {
-            let rowHeight = row.map(\.size.height).max() ?? 0
-            var x = bounds.minX
-            for item in row {
-                item.subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(item.size))
-                x += item.size.width + spacing
-            }
-            y += rowHeight + spacing
-        }
-    }
-
-    private struct LayoutItem {
-        let subview: LayoutSubview
-        let size: CGSize
-    }
-
-    private func computeRows(proposal: ProposedViewSize, subviews: Subviews) -> [[LayoutItem]] {
-        let maxWidth = proposal.width ?? .infinity
-        var rows: [[LayoutItem]] = [[]]
-        var rowWidth: CGFloat = 0
-        for subview in subviews {
-            let size = subview.sizeThatFits(.unspecified)
-            let needed = rowWidth > 0 ? size.width + spacing : size.width
-            if rowWidth + needed > maxWidth && !rows[rows.count - 1].isEmpty {
-                rows.append([])
-                rowWidth = 0
-            }
-            rows[rows.count - 1].append(LayoutItem(subview: subview, size: size))
-            rowWidth += rowWidth > 0 ? size.width + spacing : size.width
-        }
-        return rows
     }
 }
 

--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -554,50 +554,63 @@ private struct StepDetailRow: View {
                             .frame(width: 16)
                     }
 
-                    // Title + reason
+                    // Title (reason-first, falling back to action/running label)
                     VStack(alignment: .leading, spacing: VSpacing.xxs) {
                         if toolCall.isComplete {
-                            Text(toolCall.actionDescription)
+                            Text({
+                                if let reason = toolCall.reasonDescription, !reason.isEmpty {
+                                    return reason
+                                }
+                                return toolCall.actionDescription
+                            }())
                                 .font(VFont.bodyMedium)
                                 .foregroundColor(toolCall.isError ? VColor.error : VColor.textPrimary)
                                 .lineLimit(1)
                                 .truncationMode(.tail)
                         } else if phase == .denied {
-                            Text("Blocked — " + ChatBubble.friendlyRunningLabel(
-                                toolCall.toolName,
-                                inputSummary: toolCall.inputSummary,
-                                buildingStatus: toolCall.buildingStatus
-                            ))
+                            Text({
+                                if let reason = toolCall.reasonDescription, !reason.isEmpty {
+                                    return "Blocked — " + reason
+                                }
+                                return "Blocked — " + ChatBubble.friendlyRunningLabel(
+                                    toolCall.toolName,
+                                    inputSummary: toolCall.inputSummary,
+                                    buildingStatus: toolCall.buildingStatus
+                                )
+                            }())
                             .font(VFont.bodyMedium)
                             .foregroundColor(VColor.textMuted)
                             .lineLimit(1)
                             .truncationMode(.tail)
                         } else {
-                            Text(ChatBubble.friendlyRunningLabel(
-                                toolCall.toolName,
-                                inputSummary: toolCall.inputSummary,
-                                buildingStatus: toolCall.buildingStatus
-                            ))
+                            Text({
+                                if let reason = toolCall.reasonDescription, !reason.isEmpty {
+                                    return reason
+                                }
+                                return ChatBubble.friendlyRunningLabel(
+                                    toolCall.toolName,
+                                    inputSummary: toolCall.inputSummary,
+                                    buildingStatus: toolCall.buildingStatus
+                                )
+                            }())
                             .font(VFont.bodyMedium)
                             .foregroundColor(VColor.textPrimary)
                             .lineLimit(1)
                             .truncationMode(.tail)
                         }
-
-                        // Reason subtitle — only for completed tools
-                        if let reason = toolCall.reasonDescription, !reason.isEmpty, toolCall.isComplete {
-                            Text(reason)
-                                .font(VFont.caption)
-                                .foregroundColor(VColor.textMuted)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
-                        }
                     }
 
                     Spacer()
 
-                    // Duration + chevron (completed only)
+                    // Permission badge + duration + chevron (completed only)
                     HStack(spacing: VSpacing.xs) {
+                        if let decision = toolCall.confirmationDecision {
+                            compactPermissionChip(
+                                state: decision,
+                                label: toolCall.confirmationLabel ?? toolCall.friendlyName
+                            )
+                        }
+
                         if let start = toolCall.startedAt, let end = toolCall.completedAt, toolCall.isComplete {
                             Text(formatDuration(end.timeIntervalSince(start)))
                                 .font(VFont.small)
@@ -683,6 +696,11 @@ private struct StepDetailRow: View {
                 }
 
                 VStack(alignment: .leading, spacing: VSpacing.xs) {
+                    if let reason = toolCall.reasonDescription, !reason.isEmpty {
+                        Text(toolCall.actionDescription)
+                            .font(VFont.captionMedium)
+                            .foregroundColor(VColor.textSecondary)
+                    }
                     Text(toolCall.friendlyName)
                         .font(VFont.captionMedium)
                         .foregroundColor(VColor.textSecondary)
@@ -851,6 +869,44 @@ private struct StepDetailRow: View {
         seconds < 60
             ? String(format: "%.1fs", seconds)
             : "\(Int(seconds) / 60)m \(Int(seconds) % 60)s"
+    }
+
+    /// Renders a compact permission chip from a confirmation state + label.
+    private func compactPermissionChip(state: ToolConfirmationState, label: String) -> some View {
+        let isApproved = state == .approved
+        let isDenied = state == .denied
+        let chipColor: Color = isApproved ? VColor.iconAccent : isDenied ? VColor.error : VColor.textMuted
+
+        return HStack(spacing: VSpacing.xxs) {
+            Group {
+                switch state {
+                case .approved:
+                    VIconView(.circleCheck, size: 10)
+                        .foregroundColor(chipColor)
+                case .denied:
+                    VIconView(.circleAlert, size: 10)
+                        .foregroundColor(chipColor)
+                case .timedOut:
+                    VIconView(.clock, size: 10)
+                        .foregroundColor(chipColor)
+                default:
+                    EmptyView()
+                }
+            }
+
+            Text(isApproved ? "\(label) Allowed" :
+                 isDenied ? "\(label) Denied" : "Timed Out")
+                .font(VFont.small)
+                .foregroundColor(chipColor)
+        }
+        .padding(.horizontal, VSpacing.xs)
+        .padding(.vertical, VSpacing.xxs)
+        .background(
+            Capsule().fill(Color.clear)
+        )
+        .overlay(
+            Capsule().stroke(chipColor.opacity(0.3), lineWidth: 1)
+        )
     }
 }
 

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1319,7 +1319,8 @@ extension ChatViewModel {
                     toolResult: truncatedResult,
                     isError: toolErrored
                 )
-                if toolErrored, Self.isOSPermissionDeniedError(truncatedResult) {
+                if toolErrored, Self.isOSPermissionDeniedError(truncatedResult),
+                   messages[msgIndex].toolCalls[tcIndex].confirmationDecision == .approved {
                     messages[msgIndex].toolCalls[tcIndex].confirmationDecision = .denied
                 }
                 for stepIdx in messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.indices {

--- a/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
+++ b/clients/shared/Features/Chat/ChatViewModel+MessageHandling.swift
@@ -1319,6 +1319,9 @@ extension ChatViewModel {
                     toolResult: truncatedResult,
                     isError: toolErrored
                 )
+                if toolErrored, Self.isOSPermissionDeniedError(truncatedResult) {
+                    messages[msgIndex].toolCalls[tcIndex].confirmationDecision = .denied
+                }
                 for stepIdx in messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps.indices {
                     if !messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps[stepIdx].isComplete {
                         messages[msgIndex].toolCalls[tcIndex].claudeCodeSteps[stepIdx].isComplete = true


### PR DESCRIPTION
## Summary
Moves permission badges (Allowed/Denied) from the bottom FlowLayout of the expanded AssistantProgressView to be inline with individual tool call rows. Swaps the row title from the technical `actionDescription` to the human-readable `reasonDescription`. Fixes a correctness gap where OS permission denials weren't stamped on ToolCallData.

## Changes
- Fixed OS permission-denied not being stamped on `ToolCallData.confirmationDecision` after `downgradeAdjacentApprovedConfirmationForPermissionDeniedError`
- Swapped `StepDetailRow` title from `actionDescription` to `reasonDescription` (with fallback), moved old title into expanded technical details
- Added inline `compactPermissionChip` to the left of duration in each tool call row
- Removed the redundant bottom `FlowLayout` permission section and its `FlowLayout` helper struct
- Kept collapsed header permission chips for quick-glance scanning

## Milestone PRs (merged into feature branch)
- #14575: fix: stamp denied on ToolCallData after OS permission denial
- #14581: feat: swap tool row title to reasonDescription and add inline permission badge
- #14582: refactor: remove redundant bottom FlowLayout permission section

## Project issue
Closes #14570

## Test plan
- [ ] Build the macOS app and verify tool call rows show `reasonDescription` as title
- [ ] Verify permission badges (Allowed/Denied) appear inline next to duration
- [ ] Verify expanding a tool call still shows `actionDescription` in technical details
- [ ] Verify collapsed header still shows summary permission chips
- [ ] Test with OS permission denial to confirm badge shows Denied

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
