### PR TITLE
refactor(daemon): save cookies to credential store during learn finalization

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -228,6 +228,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "mcp/client.ts", // MCP client cached-token lookup
       "oauth/token-persistence.ts", // OAuth token persistence (set/delete tokens)
       "runtime/routes/secret-routes.ts", // HTTP secret management routes (set/delete secrets)
+      "daemon/ride-shotgun-handler.ts", // learn session cookie persistence
       "daemon/session-messaging.ts", // credential storage during session messaging
       "runtime/routes/settings-routes.ts", // settings routes OAuth credential lookup (client_id/client_secret/access tokens)
       "twitter/platform-proxy-client.ts", // managed Twitter proxy auth token lookup

--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -538,13 +538,45 @@ async function finalizeLearnRecording(
     const networkEntries = recorder ? await recorder.stop() : [];
     activeRecorders.delete(watchId);
 
+    // Save cookies to the encrypted credential store (keyed by target domain)
+    // so they don't need to be persisted in the plaintext recording file.
+    if (session.targetDomain && cookies.length > 0) {
+      const { setSecureKeyAsync } = await import("../security/secure-keys.js");
+      const { upsertCredentialMetadata } =
+        await import("../tools/credentials/metadata-store.js");
+
+      const service = session.targetDomain;
+      const field = "session:cookies";
+      const storageKey = `credential:${service}:${field}`;
+      const stored = await setSecureKeyAsync(
+        storageKey,
+        JSON.stringify(cookies),
+      );
+      if (stored) {
+        try {
+          upsertCredentialMetadata(service, field, {});
+        } catch {
+          // Non-critical: metadata upsert is best-effort
+        }
+        log.info(
+          { targetDomain: service, cookieCount: cookies.length },
+          "Cookies saved to credential store",
+        );
+      } else {
+        log.warn(
+          { targetDomain: service },
+          "Failed to save cookies to credential store",
+        );
+      }
+    }
+
     const recording: SessionRecording = {
       id: recordingId,
       startedAt: session.startedAt,
       endedAt: Date.now(),
       targetDomain: session.targetDomain,
       networkEntries,
-      cookies,
+      cookies: [], // Cookies saved to credential store above — not persisted in recording
       observations: session.observations.map((obs) => ({
         ocrText: obs.ocrText,
         appName: obs.appName,


### PR DESCRIPTION
## Summary
- Save extracted cookies directly to the encrypted credential store during learn session finalization, keyed by target domain
- Strip cookies from the recording JSON file before writing to disk (write empty array instead)
- Add ride-shotgun-handler.ts to the ALLOWED_IMPORTERS security allowlist

Part of plan: recording-cookies-to-cred-store.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
