### PR TITLE
refactor(amazon): add importFromCredentialStore for daemon-saved cookies

### DIFF
--- a/assistant/src/cli/commands/amazon/session.ts
+++ b/assistant/src/cli/commands/amazon/session.ts
@@ -105,6 +105,46 @@ export async function importFromRecording(
 }
 
 /**
+ * Import cookies that the daemon saved to the credential store under the
+ * target domain key. Validates Amazon-specific required cookies, then
+ * copies them to the canonical amazon:session:cookies key.
+ */
+export async function importFromCredentialStore(
+  targetDomain: string,
+): Promise<AmazonSession> {
+  const { stdout } = await execFileAsync("assistant", [
+    "credentials",
+    "reveal",
+    `${targetDomain}:session:cookies`,
+  ]);
+  const cookies = JSON.parse(stdout.trim()) as ExtractedCredential[];
+  if (!cookies.length) {
+    throw new Error("No cookies found in credential store");
+  }
+
+  const cookieNames = new Set(cookies.map((c) => c.name));
+  if (!cookieNames.has("session-id")) {
+    throw new Error(
+      "Credential store cookies are missing required Amazon cookie: session-id.",
+    );
+  }
+  if (!cookieNames.has("ubid-main")) {
+    throw new Error(
+      "Credential store cookies are missing required Amazon cookie: ubid-main.",
+    );
+  }
+  if (!cookieNames.has("at-main") && !cookieNames.has("x-main")) {
+    throw new Error(
+      "Credential store cookies are missing required Amazon auth cookie (at-main or x-main).",
+    );
+  }
+
+  const session: AmazonSession = { cookies };
+  await saveSession(session);
+  return session;
+}
+
+/**
  * Get the anti-CSRF token from session cookies.
  * Amazon uses anti-csrftoken-a2z or csrf-main for cart POST requests.
  */


### PR DESCRIPTION
## Summary
- Add importFromCredentialStore function to Amazon session module
- Reads cookies from the domain-based credential key and validates Amazon-specific required cookies
- Not yet called from any CLI command (Amazon refresh uses browser extension), but ready for future ride shotgun integration

Part of plan: recording-cookies-to-cred-store.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
