### PR TITLE
refactor(doordash): read cookies from credential store after learn session refresh

### DIFF
--- a/assistant/src/config/bundled-skills/doordash/doordash-cli.ts
+++ b/assistant/src/config/bundled-skills/doordash/doordash-cli.ts
@@ -33,11 +33,17 @@ import {
 import { extractQueries, saveQueries } from "./lib/query-extractor.js";
 import {
   clearSession,
+  importFromCredentialStore,
   importFromRecording,
   loadSession,
 } from "./lib/session.js";
 import { NetworkRecorder } from "./lib/shared/network-recorder.js";
-import { buildDaemonUrl, getDataDir, getHttpPort, readHttpToken } from "./lib/shared/platform.js";
+import {
+  buildDaemonUrl,
+  getDataDir,
+  getHttpPort,
+  readHttpToken,
+} from "./lib/shared/platform.js";
 import { loadRecording, saveRecording } from "./lib/shared/recording-store.js";
 import type { SessionRecording } from "./lib/shared/recording-types.js";
 
@@ -148,13 +154,13 @@ export function registerDoordashCommand(program: Command): void {
         }
 
         const result = await startLearnSession(duration);
-        if (result.recordingPath) {
-          const session = importFromRecording(result.recordingPath);
+        if (result.recordingId) {
+          const session = await importFromCredentialStore("doordash.com");
 
           // Also extract and save captured queries for self-healing
           let queriesCaptured = 0;
           try {
-            const recording = loadRecording(result.recordingId ?? "");
+            const recording = loadRecording(result.recordingId);
             if (recording) {
               const queries = extractQueries(recording);
               if (queries.length > 0) {
@@ -188,7 +194,7 @@ export function registerDoordashCommand(program: Command): void {
           output(
             {
               ok: false,
-              error: "Recording completed but no recording path returned",
+              error: "Recording completed but no recording ID returned",
               recordingId: result.recordingId,
             },
             json,
@@ -1020,7 +1026,10 @@ async function startLearnSession(
       // Poll session status to detect failures early
       try {
         const fetchAbort = AbortSignal.timeout(10_000);
-        const statusRes = await fetch(statusUrl, { headers, signal: fetchAbort });
+        const statusRes = await fetch(statusUrl, {
+          headers,
+          signal: fetchAbort,
+        });
         if (statusRes.ok) {
           const status = (await statusRes.json()) as {
             status: string;
@@ -1073,9 +1082,7 @@ async function startLearnSession(
 
             // Completed but no recordingId — cannot correlate
             reject(
-              new Error(
-                "Learn session completed but no recording was saved.",
-              ),
+              new Error("Learn session completed but no recording was saved."),
             );
             return;
           }

--- a/assistant/src/config/bundled-skills/doordash/lib/session.ts
+++ b/assistant/src/config/bundled-skills/doordash/lib/session.ts
@@ -3,6 +3,7 @@
  * Stores/loads auth cookies from a recording or manual login.
  */
 
+import { execFile } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -11,12 +12,15 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { promisify } from "node:util";
 
 import { ConfigError } from "./shared/errors.js";
 import type {
   ExtractedCredential,
   SessionRecording,
 } from "./shared/recording-types.js";
+
+const execFileAsync = promisify(execFile);
 
 export interface DoorDashSession {
   cookies: ExtractedCredential[];
@@ -72,6 +76,31 @@ export function importFromRecording(recordingPath: string): DoorDashSession {
     cookies: recording.cookies,
     importedAt: new Date().toISOString(),
     recordingId: recording.id,
+  };
+  saveSession(session);
+  return session;
+}
+
+/**
+ * Import cookies that the daemon saved to the credential store under the
+ * target domain key. Copies them into the local DoorDash session file.
+ */
+export async function importFromCredentialStore(
+  targetDomain: string,
+): Promise<DoorDashSession> {
+  const { stdout } = await execFileAsync("assistant", [
+    "credentials",
+    "reveal",
+    `${targetDomain}:session:cookies`,
+  ]);
+  const cookies = JSON.parse(stdout.trim()) as ExtractedCredential[];
+  if (!cookies.length) {
+    throw new ConfigError("No cookies found in credential store");
+  }
+
+  const session: DoorDashSession = {
+    cookies,
+    importedAt: new Date().toISOString(),
   };
   saveSession(session);
   return session;


### PR DESCRIPTION
## Summary
- Add importFromCredentialStore function to DoorDash session module that reads cookies from the domain-based credential key
- Update refresh action to use importFromCredentialStore instead of importFromRecording
- Query extraction from recording files continues to work (network entries still saved)
- Preserve login --recording path for backward compatibility

Part of plan: recording-cookies-to-cred-store.md (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
