### PR TITLE
fix: preserve cookies in recording when credential store write fails

### DIFF
--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -540,6 +540,7 @@ async function finalizeLearnRecording(
 
     // Save cookies to the encrypted credential store (keyed by target domain)
     // so they don't need to be persisted in the plaintext recording file.
+    let cookiesStoredToCredStore = false;
     if (session.targetDomain && cookies.length > 0) {
       const { setSecureKeyAsync } = await import("../security/secure-keys.js");
       const { upsertCredentialMetadata } =
@@ -553,6 +554,7 @@ async function finalizeLearnRecording(
         JSON.stringify(cookies),
       );
       if (stored) {
+        cookiesStoredToCredStore = true;
         try {
           upsertCredentialMetadata(service, field, {});
         } catch {
@@ -565,7 +567,7 @@ async function finalizeLearnRecording(
       } else {
         log.warn(
           { targetDomain: service },
-          "Failed to save cookies to credential store",
+          "Failed to save cookies to credential store — preserving in recording",
         );
       }
     }
@@ -576,7 +578,7 @@ async function finalizeLearnRecording(
       endedAt: Date.now(),
       targetDomain: session.targetDomain,
       networkEntries,
-      cookies: [], // Cookies saved to credential store above — not persisted in recording
+      cookies: cookiesStoredToCredStore ? [] : cookies, // Only strip cookies if credential store write succeeded
       observations: session.observations.map((obs) => ({
         ocrText: obs.ocrText,
         appName: obs.appName,


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for recording-cookies-to-cred-store.md.

**Gap:** Cookie data loss when credential store write fails
**What was expected:** Cookies should not be permanently lost if the credential store write fails
**What was found:** Recording always written with cookies: [] regardless of credential store write success

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
