### PR TITLE
fix: importFromRecording falls back to credential store for new recordings

### DIFF
--- a/assistant/src/cli/commands/amazon/session.ts
+++ b/assistant/src/cli/commands/amazon/session.ts
@@ -18,6 +18,7 @@ export interface AmazonSession {
 
 interface SessionRecording {
   cookies?: ExtractedCredential[];
+  targetDomain?: string;
 }
 
 export async function loadSession(): Promise<AmazonSession | null> {
@@ -75,6 +76,9 @@ export async function importFromRecording(
     readFileSync(recordingPath, "utf-8"),
   ) as SessionRecording;
   if (!recording.cookies?.length) {
+    if (recording.targetDomain) {
+      return importFromCredentialStore(recording.targetDomain);
+    }
     throw new Error("Recording contains no cookies");
   }
 

--- a/assistant/src/cli/commands/twitter/session.ts
+++ b/assistant/src/cli/commands/twitter/session.ts
@@ -23,6 +23,7 @@ export interface TwitterSession {
 
 interface SessionRecording {
   cookies?: ExtractedCredential[];
+  targetDomain?: string;
 }
 
 interface ExtractedCredential {
@@ -90,6 +91,9 @@ export async function importFromRecording(
       readFileSync(recordingPath, "utf-8"),
     ) as SessionRecording;
     if (!recording.cookies?.length) {
+      if (recording.targetDomain) {
+        return importFromCredentialStore(recording.targetDomain);
+      }
       throw new ConfigError("Recording contains no cookies");
     }
 

--- a/assistant/src/config/bundled-skills/doordash/__tests__/doordash-session.test.ts
+++ b/assistant/src/config/bundled-skills/doordash/__tests__/doordash-session.test.ts
@@ -105,13 +105,13 @@ describe("DoorDash session persistence", () => {
   });
 
   describe("importFromRecording", () => {
-    it("throws when the recording file does not exist", () => {
-      expect(() => importFromRecording("/nonexistent/recording.json")).toThrow(
-        "Recording not found",
-      );
+    it("throws when the recording file does not exist", async () => {
+      await expect(
+        importFromRecording("/nonexistent/recording.json"),
+      ).rejects.toThrow("Recording not found");
     });
 
-    it("throws when the recording contains no cookies", () => {
+    it("throws when the recording contains no cookies and no targetDomain", async () => {
       const recordingPath = join(TEST_DIR, "empty-recording.json");
       writeFileSync(
         recordingPath,
@@ -119,18 +119,17 @@ describe("DoorDash session persistence", () => {
           id: "rec-empty",
           startedAt: 0,
           endedAt: 1,
-          targetDomain: "doordash.com",
           networkEntries: [],
           cookies: [],
           observations: [],
         }),
       );
-      expect(() => importFromRecording(recordingPath)).toThrow(
+      await expect(importFromRecording(recordingPath)).rejects.toThrow(
         "Recording contains no cookies",
       );
     });
 
-    it("successfully imports a recording with cookies", () => {
+    it("successfully imports a recording with cookies", async () => {
       const recordingPath = join(TEST_DIR, "valid-recording.json");
       writeFileSync(
         recordingPath,
@@ -144,7 +143,7 @@ describe("DoorDash session persistence", () => {
           observations: [],
         }),
       );
-      const session = importFromRecording(recordingPath);
+      const session = await importFromRecording(recordingPath);
       expect(session.cookies).toHaveLength(1);
       expect(session.cookies[0].name).toBe("session_id");
       expect(session.cookies[0].value).toBe("xyz");

--- a/assistant/src/config/bundled-skills/doordash/doordash-cli.ts
+++ b/assistant/src/config/bundled-skills/doordash/doordash-cli.ts
@@ -112,7 +112,7 @@ export function registerDoordashCommand(program: Command): void {
     .requiredOption("--recording <path>", "Path to the recording JSON file")
     .action(async (opts: { recording: string }, cmd: Command) => {
       await run(cmd, async () => {
-        const session = importFromRecording(opts.recording);
+        const session = await importFromRecording(opts.recording);
         return {
           message: "Session imported successfully",
           cookieCount: session.cookies.length,

--- a/assistant/src/config/bundled-skills/doordash/lib/session.ts
+++ b/assistant/src/config/bundled-skills/doordash/lib/session.ts
@@ -62,7 +62,9 @@ export function clearSession(): void {
 /**
  * Import cookies from a Ride Shotgun recording file.
  */
-export function importFromRecording(recordingPath: string): DoorDashSession {
+export async function importFromRecording(
+  recordingPath: string,
+): Promise<DoorDashSession> {
   if (!existsSync(recordingPath)) {
     throw new ConfigError(`Recording not found: ${recordingPath}`);
   }
@@ -70,6 +72,9 @@ export function importFromRecording(recordingPath: string): DoorDashSession {
     readFileSync(recordingPath, "utf-8"),
   ) as SessionRecording;
   if (!recording.cookies?.length) {
+    if (recording.targetDomain) {
+      return importFromCredentialStore(recording.targetDomain);
+    }
     throw new ConfigError("Recording contains no cookies");
   }
   const session: DoorDashSession = {


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for recording-cookies-to-cred-store.md.

**Gap:** login --recording broken for new recordings
**What was expected:** importFromRecording should work with both old recordings (cookies in file) and new recordings (cookies in credential store)
**What was found:** New recordings have cookies: [] which causes importFromRecording to throw

Updates all three `importFromRecording` functions (Twitter, Amazon, DoorDash) to fall back to `importFromCredentialStore(recording.targetDomain)` when the recording has no cookies but does have a `targetDomain` field. This makes `login --recording` work for both legacy recordings (cookies embedded in the file) and new recordings (cookies stored in the credential store by the daemon).

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
