### PR TITLE
refactor(twitter): remove importFromRecording and login --recording command

### DIFF
--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -35,7 +35,6 @@ import {
 import {
   clearSession,
   importFromCredentialStore,
-  importFromRecording,
   loadSession,
 } from "./session.js";
 
@@ -149,7 +148,6 @@ The strategy system controls which path is used for operations that support mult
   auto     — try OAuth first, fall back to browser session (default)
 
 Session management:
-  - "login" imports cookies from a Ride Shotgun recording file
   - "refresh" launches Chrome with CDP, navigates to x.com/login, and runs a
     Ride Shotgun learn session to capture fresh cookies automatically
   - "status" shows whether browser session and OAuth are active
@@ -163,36 +161,6 @@ Examples:
   $ assistant x search "from:vaborsh AI agents" --product Latest
   $ assistant x strategy set oauth`,
   );
-
-  // =========================================================================
-  // login — import session from a recording
-  // =========================================================================
-  tw.command("login")
-    .description("Import a Twitter session from a Ride Shotgun recording")
-    .requiredOption("--recording <path>", "Path to the recording JSON file")
-    .addHelpText(
-      "after",
-      `
-Imports cookies from a Ride Shotgun recording file to establish a browser
-session. The recording file is a JSON file produced by a Ride Shotgun learn
-session that contains captured cookies for x.com.
-
-After import, all browser-path commands (timeline, search, bookmarks, etc.)
-will use these cookies for authentication.
-
-Examples:
-  $ assistant x login --recording /tmp/ride-shotgun/recording-abc123.json
-  $ assistant x login --recording ~/recordings/twitter-session.json`,
-    )
-    .action(async (opts: { recording: string }, cmd: Command) => {
-      await run(cmd, async () => {
-        const session = await importFromRecording(opts.recording);
-        return {
-          message: "Session imported successfully",
-          cookieCount: session.cookies.length,
-        };
-      });
-    });
 
   // =========================================================================
   // logout — clear saved session

--- a/assistant/src/cli/commands/twitter/session.ts
+++ b/assistant/src/cli/commands/twitter/session.ts
@@ -5,7 +5,6 @@
  */
 
 import { execFile } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -19,11 +18,6 @@ class ConfigError extends Error {
 
 export interface TwitterSession {
   cookies: ExtractedCredential[];
-}
-
-interface SessionRecording {
-  cookies?: ExtractedCredential[];
-  targetDomain?: string;
 }
 
 interface ExtractedCredential {
@@ -74,46 +68,6 @@ export async function clearSession(): Promise<void> {
     ]);
   } catch {
     // Clearing a non-existent session is fine — no-op
-  }
-}
-
-/**
- * Import cookies from a Ride Shotgun recording file.
- */
-export async function importFromRecording(
-  recordingPath: string,
-): Promise<TwitterSession> {
-  try {
-    if (!existsSync(recordingPath)) {
-      throw new ConfigError(`Recording not found: ${recordingPath}`);
-    }
-    const recording = JSON.parse(
-      readFileSync(recordingPath, "utf-8"),
-    ) as SessionRecording;
-    if (!recording.cookies?.length) {
-      if (recording.targetDomain) {
-        return importFromCredentialStore(recording.targetDomain);
-      }
-      throw new ConfigError("Recording contains no cookies");
-    }
-
-    const cookieNames = new Set(recording.cookies.map((c) => c.name));
-
-    if (!cookieNames.has("ct0") || !cookieNames.has(`auth_${"token"}`)) {
-      throw new ConfigError(
-        "Recording is missing required Twitter session cookies. " +
-          "Make sure you are logged in to x.com before recording.",
-      );
-    }
-
-    const session: TwitterSession = { cookies: recording.cookies };
-    await saveSession(session);
-    return session;
-  } catch (error) {
-    if (error instanceof ConfigError) throw error;
-    throw new ConfigError(
-      error instanceof Error ? error.message : String(error),
-    );
   }
 }
 


### PR DESCRIPTION
## Summary
- Delete importFromRecording function and SessionRecording interface from twitter/session.ts
- Remove login --recording command from twitter/index.ts
- Clean up unused node:fs imports (existsSync, readFileSync)

Part of plan: rm-import-from-recording.md (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
