### PR TITLE
fix(daemon): always strip cookies from recording — no plaintext fallback

### DIFF
--- a/assistant/src/daemon/ride-shotgun-handler.ts
+++ b/assistant/src/daemon/ride-shotgun-handler.ts
@@ -540,7 +540,6 @@ async function finalizeLearnRecording(
 
     // Save cookies to the encrypted credential store (keyed by target domain)
     // so they don't need to be persisted in the plaintext recording file.
-    let cookiesStoredToCredStore = false;
     if (session.targetDomain && cookies.length > 0) {
       const { setSecureKeyAsync } = await import("../security/secure-keys.js");
       const { upsertCredentialMetadata } =
@@ -554,7 +553,6 @@ async function finalizeLearnRecording(
         JSON.stringify(cookies),
       );
       if (stored) {
-        cookiesStoredToCredStore = true;
         try {
           upsertCredentialMetadata(service, field, {});
         } catch {
@@ -567,7 +565,7 @@ async function finalizeLearnRecording(
       } else {
         log.warn(
           { targetDomain: service },
-          "Failed to save cookies to credential store — preserving in recording",
+          "Failed to save cookies to credential store",
         );
       }
     }
@@ -578,7 +576,7 @@ async function finalizeLearnRecording(
       endedAt: Date.now(),
       targetDomain: session.targetDomain,
       networkEntries,
-      cookies: cookiesStoredToCredStore ? [] : cookies, // Only strip cookies if credential store write succeeded
+      cookies: [], // Cookies saved to credential store — never persisted in recording
       observations: session.observations.map((obs) => ({
         ocrText: obs.ocrText,
         appName: obs.appName,


### PR DESCRIPTION
## Summary
- Remove cookiesStoredToCredStore fallback logic from finalizeLearnRecording
- Recording files always have cookies: [] regardless of credential store write success
- Cookies should only exist in the encrypted credential store, never in plaintext recording files

Part of plan: rm-import-from-recording.md (PR 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
