### PR TITLE
refactor(doordash): remove importFromRecording and login --recording command

### DIFF
--- a/assistant/src/config/bundled-skills/doordash/SKILL.md
+++ b/assistant/src/config/bundled-skills/doordash/SKILL.md
@@ -125,7 +125,6 @@ doordash cart add --store-id <id> --menu-id <id> --item-id <id> --item-name "Lat
 ```
 doordash status --json              # Check if logged in
 doordash refresh --json             # Capture fresh session via Ride Shotgun (auto-stops after login)
-doordash login --recording <path>   # Import session from a recording file manually
 doordash logout --json              # Clear session
 doordash search "<query>" --json    # Search restaurants
 doordash menu <storeId> --json      # Get store menu (auto-detects retail stores)

--- a/assistant/src/config/bundled-skills/doordash/__tests__/doordash-session.test.ts
+++ b/assistant/src/config/bundled-skills/doordash/__tests__/doordash-session.test.ts
@@ -1,19 +1,10 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 import {
   type DoorDashSession,
   getCookieHeader,
   getCsrfToken,
-  importFromRecording,
 } from "../lib/session.js";
-
-// Override VELLUM_DATA_DIR to use a temp directory during tests.
-// session.ts reads process.env.VELLUM_DATA_DIR directly.
-const TEST_DIR = join(tmpdir(), `vellum-dd-test-${process.pid}`);
-let originalDataDir: string | undefined;
 
 function makeCookie(
   name: string,
@@ -78,77 +69,6 @@ describe("DoorDash session helpers", () => {
         cookies: [makeCookie("dd_session", "abc123")],
       });
       expect(getCsrfToken(session)).toBeUndefined();
-    });
-  });
-});
-
-describe("DoorDash session persistence", () => {
-  // These tests exercise the real loadSession/saveSession/clearSession
-  // by pointing VELLUM_DATA_DIR at a temp directory and testing via
-  // importFromRecording which exercises save+load.
-
-  beforeEach(() => {
-    originalDataDir = process.env.VELLUM_DATA_DIR;
-    process.env.VELLUM_DATA_DIR = TEST_DIR;
-    mkdirSync(TEST_DIR, { recursive: true });
-  });
-
-  afterEach(() => {
-    if (originalDataDir === undefined) {
-      delete process.env.VELLUM_DATA_DIR;
-    } else {
-      process.env.VELLUM_DATA_DIR = originalDataDir;
-    }
-    if (existsSync(TEST_DIR)) {
-      rmSync(TEST_DIR, { recursive: true, force: true });
-    }
-  });
-
-  describe("importFromRecording", () => {
-    it("throws when the recording file does not exist", async () => {
-      await expect(
-        importFromRecording("/nonexistent/recording.json"),
-      ).rejects.toThrow("Recording not found");
-    });
-
-    it("throws when the recording contains no cookies and no targetDomain", async () => {
-      const recordingPath = join(TEST_DIR, "empty-recording.json");
-      writeFileSync(
-        recordingPath,
-        JSON.stringify({
-          id: "rec-empty",
-          startedAt: 0,
-          endedAt: 1,
-          networkEntries: [],
-          cookies: [],
-          observations: [],
-        }),
-      );
-      await expect(importFromRecording(recordingPath)).rejects.toThrow(
-        "Recording contains no cookies",
-      );
-    });
-
-    it("successfully imports a recording with cookies", async () => {
-      const recordingPath = join(TEST_DIR, "valid-recording.json");
-      writeFileSync(
-        recordingPath,
-        JSON.stringify({
-          id: "rec-valid",
-          startedAt: 0,
-          endedAt: 1,
-          targetDomain: "doordash.com",
-          networkEntries: [],
-          cookies: [makeCookie("session_id", "xyz")],
-          observations: [],
-        }),
-      );
-      const session = await importFromRecording(recordingPath);
-      expect(session.cookies).toHaveLength(1);
-      expect(session.cookies[0].name).toBe("session_id");
-      expect(session.cookies[0].value).toBe("xyz");
-      expect(session.recordingId).toBe("rec-valid");
-      expect(session.importedAt).toBeTruthy();
     });
   });
 });

--- a/assistant/src/config/bundled-skills/doordash/doordash-cli.ts
+++ b/assistant/src/config/bundled-skills/doordash/doordash-cli.ts
@@ -34,7 +34,6 @@ import { extractQueries, saveQueries } from "./lib/query-extractor.js";
 import {
   clearSession,
   importFromCredentialStore,
-  importFromRecording,
   loadSession,
 } from "./lib/session.js";
 import { NetworkRecorder } from "./lib/shared/network-recorder.js";
@@ -103,23 +102,6 @@ export function registerDoordashCommand(program: Command): void {
       "Order food from DoorDash. Requires a session imported from a Ride Shotgun recording.",
     )
     .option("--json", "Machine-readable JSON output");
-
-  // =========================================================================
-  // login — import session from a recording
-  // =========================================================================
-  dd.command("login")
-    .description("Import a DoorDash session from a Ride Shotgun recording")
-    .requiredOption("--recording <path>", "Path to the recording JSON file")
-    .action(async (opts: { recording: string }, cmd: Command) => {
-      await run(cmd, async () => {
-        const session = await importFromRecording(opts.recording);
-        return {
-          message: "Session imported successfully",
-          cookieCount: session.cookies.length,
-          recordingId: session.recordingId,
-        };
-      });
-    });
 
   // =========================================================================
   // logout — clear saved session

--- a/assistant/src/config/bundled-skills/doordash/lib/session.ts
+++ b/assistant/src/config/bundled-skills/doordash/lib/session.ts
@@ -15,10 +15,7 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 
 import { ConfigError } from "./shared/errors.js";
-import type {
-  ExtractedCredential,
-  SessionRecording,
-} from "./shared/recording-types.js";
+import type { ExtractedCredential } from "./shared/recording-types.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -57,33 +54,6 @@ export function clearSession(): void {
   if (existsSync(path)) {
     unlinkSync(path);
   }
-}
-
-/**
- * Import cookies from a Ride Shotgun recording file.
- */
-export async function importFromRecording(
-  recordingPath: string,
-): Promise<DoorDashSession> {
-  if (!existsSync(recordingPath)) {
-    throw new ConfigError(`Recording not found: ${recordingPath}`);
-  }
-  const recording = JSON.parse(
-    readFileSync(recordingPath, "utf-8"),
-  ) as SessionRecording;
-  if (!recording.cookies?.length) {
-    if (recording.targetDomain) {
-      return importFromCredentialStore(recording.targetDomain);
-    }
-    throw new ConfigError("Recording contains no cookies");
-  }
-  const session: DoorDashSession = {
-    cookies: recording.cookies,
-    importedAt: new Date().toISOString(),
-    recordingId: recording.id,
-  };
-  saveSession(session);
-  return session;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Delete importFromRecording function from doordash/lib/session.ts
- Remove login --recording command from doordash-cli.ts
- Remove importFromRecording tests, keep getCookieHeader/getCsrfToken tests
- Clean up SessionRecording import and SKILL.md reference

Part of plan: rm-import-from-recording.md (PR 4 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
