### PR TITLE
fix(twitter): resolve platform assistant ID from secure key store with env fallback

### DIFF
--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -441,7 +441,8 @@ function handleTwitterAuthStatus(): Response {
     )?.baseUrl as string | undefined;
     const platformAssistantIdResolvable = !!(
       (platformBaseUrlFromEnv || platformBaseUrlFromConfig) &&
-      getPlatformAssistantId()
+      (getSecureKey("credential:vellum:platform_assistant_id") ||
+        getPlatformAssistantId())
     );
 
     const managedPrerequisites = {

--- a/assistant/src/twitter/platform-proxy-client.ts
+++ b/assistant/src/twitter/platform-proxy-client.ts
@@ -9,7 +9,7 @@
  * Prerequisites:
  * - Platform base URL (env `PLATFORM_BASE_URL` or config `platform.baseUrl`)
  * - Auth token (secure key `credential:vellum:assistant_api_key`)
- * - Platform assistant ID (env `PLATFORM_ASSISTANT_ID`)
+ * - Platform assistant ID (secure key store or env `PLATFORM_ASSISTANT_ID`)
  */
 
 import { getPlatformAssistantId, getPlatformBaseUrl } from "../config/env.js";
@@ -64,10 +64,13 @@ export function resolveAuthToken(): string | undefined {
 }
 
 /**
- * Resolve the platform assistant ID from environment.
+ * Resolve the platform assistant ID from secure storage (local) or environment (containerized).
  */
 export function resolvePlatformAssistantId(): string {
-  return getPlatformAssistantId();
+  return (
+    getSecureKey("credential:vellum:platform_assistant_id") ||
+    getPlatformAssistantId()
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Change resolvePlatformAssistantId() to read from secure key store first, falling back to env var for containerized deployments
- Update platformAssistantIdResolvable check in settings-routes.ts to also check secure key store
- Fixes managed Twitter OAuth for local assistants where the platform assistant ID is injected during bootstrap

Part of plan: platform-id-resolution.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
