### PR TITLE
fix: use adaptive color for tool row hover in dark mode

### DIFF
--- a/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
+++ b/clients/macos/vellum-assistant/Features/Chat/AssistantProgressView.swift
@@ -613,7 +613,7 @@ private struct StepDetailRow: View {
             .padding(.vertical, VSpacing.sm)
             .background(
                 RoundedRectangle(cornerRadius: VRadius.md)
-                    .fill(isHovered && hasDetails ? Moss._100 : .clear)
+                    .fill(isHovered && hasDetails ? VColor.surfaceBorder.opacity(0.5) : .clear)
             )
             .padding(.horizontal, VSpacing.sm)
             .onHover { isHovered = $0 }


### PR DESCRIPTION
## Summary
- Replace raw `Moss._100` with `VColor.surfaceBorder.opacity(0.5)` for the tool call row hover background in `StepDetailRow`
- `Moss._100` is a non-adaptive light-mode color that renders incorrectly in dark mode
- `VColor.surfaceBorder.opacity(0.5)` is the standard hover pattern used across the codebase (ToolConfirmationBubble, CurrentStepIndicator, HoverEffect modifier)

## Test plan
- [ ] Hover over a completed tool call row in dark mode — should show subtle highlight, not bright cream
- [ ] Hover in light mode — should still show subtle highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
