### PR TITLE
test(twitter): update proxy and guardrail tests for secure key store platform ID resolution

### DIFF
--- a/assistant/src/__tests__/managed-twitter-guardrails.test.ts
+++ b/assistant/src/__tests__/managed-twitter-guardrails.test.ts
@@ -106,7 +106,11 @@ mock.module("../util/logger.js", () => ({
 }));
 
 mock.module("../security/secure-keys.js", () => ({
-  getSecureKey: (account: string) => secureKeyStore[account] ?? undefined,
+  getSecureKey: (account: string) => {
+    if (account === "credential:vellum:platform_assistant_id")
+      return "ast_test123";
+    return secureKeyStore[account] ?? undefined;
+  },
   setSecureKey: (account: string, value: string) => {
     secureKeyStore[account] = value;
     return true;

--- a/assistant/src/__tests__/twitter-platform-proxy-client.test.ts
+++ b/assistant/src/__tests__/twitter-platform-proxy-client.test.ts
@@ -7,11 +7,14 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 let mockApiKey: string | undefined = "test-api-key-123";
 let mockPlatformEnvUrl = "https://platform.vellum.ai";
 let mockPlatformAssistantId = "ast_abc123";
+let mockPlatformAssistantIdFromStore: string | undefined = undefined;
 let mockConfigBaseUrl = "";
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKey: (account: string) => {
     if (account === "credential:vellum:assistant_api_key") return mockApiKey;
+    if (account === "credential:vellum:platform_assistant_id")
+      return mockPlatformAssistantIdFromStore;
     return undefined;
   },
 }));
@@ -73,6 +76,7 @@ beforeEach(() => {
   mockApiKey = "test-api-key-123";
   mockPlatformEnvUrl = "https://platform.vellum.ai";
   mockPlatformAssistantId = "ast_abc123";
+  mockPlatformAssistantIdFromStore = undefined;
   mockConfigBaseUrl = "";
   lastFetchArgs = null;
   fetchResponse = {
@@ -118,7 +122,20 @@ describe("prerequisite resolution", () => {
   });
 
   test("resolvePlatformAssistantId returns the env value", () => {
+    mockPlatformAssistantIdFromStore = undefined;
     expect(resolvePlatformAssistantId()).toBe("ast_abc123");
+  });
+
+  test("resolvePlatformAssistantId prefers secure key store over env", () => {
+    mockPlatformAssistantIdFromStore = "ast_from_store";
+    mockPlatformAssistantId = "ast_from_env";
+    expect(resolvePlatformAssistantId()).toBe("ast_from_store");
+  });
+
+  test("resolvePlatformAssistantId falls back to env when store is empty", () => {
+    mockPlatformAssistantIdFromStore = undefined;
+    mockPlatformAssistantId = "ast_from_env";
+    expect(resolvePlatformAssistantId()).toBe("ast_from_env");
   });
 
   test("resolvePrerequisites returns all values when present", () => {


### PR DESCRIPTION
## Summary
- Update twitter-platform-proxy-client tests to mock secure key store for platform assistant ID
- Add tests verifying secure key store takes precedence over env var, and env var fallback works
- Update managed-twitter-guardrails test mock to provide platform assistant ID via secure key store

Part of plan: platform-id-resolution.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
