### PR TITLE
fix: address Home Base removal review feedback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1018,6 +1018,9 @@ jobs:
           cp -R "$ASSISTANT_SRC_DIR/src/prompts/templates" daemon-bin/templates
           rm -rf daemon-bin/hook-templates
           cp -R "$ASSISTANT_SRC_DIR/hook-templates" daemon-bin/hook-templates
+          rm -rf daemon-bin/brain-graph
+          mkdir -p daemon-bin/brain-graph
+          cp "$ASSISTANT_SRC_DIR/src/runtime/routes/brain-graph/brain-graph.html" daemon-bin/brain-graph/
 
           # CLI
           (cd "$CLI_SRC_DIR" && bun install --frozen-lockfile 2>/dev/null || bun install)

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -205,6 +205,9 @@ build_binaries() {
     cp -R "$ASSISTANT_SRC_DIR/src/prompts/templates" "$SCRIPT_DIR/daemon-bin/templates"
     rm -rf "$SCRIPT_DIR/daemon-bin/hook-templates"
     cp -R "$ASSISTANT_SRC_DIR/hook-templates" "$SCRIPT_DIR/daemon-bin/hook-templates"
+    rm -rf "$SCRIPT_DIR/daemon-bin/brain-graph"
+    mkdir -p "$SCRIPT_DIR/daemon-bin/brain-graph"
+    cp "$ASSISTANT_SRC_DIR/src/runtime/routes/brain-graph/brain-graph.html" "$SCRIPT_DIR/daemon-bin/brain-graph/"
     # CLI
     build_bun_binary "$CLI_SRC_DIR" "$CLI_SRC_DIR/src/index.ts" \
         "$SCRIPT_DIR/cli-bin" "vellum-cli"
@@ -381,6 +384,11 @@ if [ -d "$ASSISTANT_SRC_DIR/hook-templates" ]; then
     rm -rf "$SCRIPT_DIR/daemon-bin/hook-templates"
     cp -R "$ASSISTANT_SRC_DIR/hook-templates" "$SCRIPT_DIR/daemon-bin/hook-templates"
 fi
+if [ -f "$ASSISTANT_SRC_DIR/src/runtime/routes/brain-graph/brain-graph.html" ]; then
+    rm -rf "$SCRIPT_DIR/daemon-bin/brain-graph"
+    mkdir -p "$SCRIPT_DIR/daemon-bin/brain-graph"
+    cp "$ASSISTANT_SRC_DIR/src/runtime/routes/brain-graph/brain-graph.html" "$SCRIPT_DIR/daemon-bin/brain-graph/"
+fi
 # Also rebuild if daemon binary changed or newly added
 if [ -f "$SCRIPT_DIR/daemon-bin/vellum-daemon" ]; then
     if [ ! -f "$MACOS_DIR/vellum-daemon" ] || [ "$SCRIPT_DIR/daemon-bin/vellum-daemon" -nt "$MACOS_DIR/vellum-daemon" ]; then
@@ -518,6 +526,10 @@ fi
 if [ -d "$SCRIPT_DIR/daemon-bin/hook-templates" ]; then
     rm -rf "$RESOURCES_DIR/hook-templates"
     cp -R "$SCRIPT_DIR/daemon-bin/hook-templates" "$RESOURCES_DIR/hook-templates"
+fi
+if [ -d "$SCRIPT_DIR/daemon-bin/brain-graph" ]; then
+    rm -rf "$RESOURCES_DIR/brain-graph"
+    cp -R "$SCRIPT_DIR/daemon-bin/brain-graph" "$RESOURCES_DIR/brain-graph"
 fi
 # Always refresh feature flag registry for the bundled gateway.
 # The compiled gateway resolves this from Contents/Resources in app layouts.

--- a/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
+++ b/clients/macos/vellum-assistant/Features/MainWindow/SidePanelType.swift
@@ -20,8 +20,8 @@ enum SidePanelType: Hashable, CaseIterable {
         case "usageDashboard": self = .usageDashboard
         // Legacy values from older builds — map to the unified Intelligence panel
         case "identity", "agent": self = .intelligence
-        // Legacy Home Base panel — removed
-        case "directory": return nil
+        // Legacy Home Base panel — map to apps as a reasonable fallback
+        case "directory": self = .apps
         default: return nil
         }
     }


### PR DESCRIPTION
## Summary

- Add brain-graph.html copy steps to `build.sh` (3 places) and `release.yml` to ensure `/v1/brain-graph-ui` works in release builds after moving brain-graph.html from home-base directory
- Fix `SidePanelType` to map legacy "directory" value to `.apps` (matching `NativePanelId` behavior) instead of returning `nil`

Addresses review feedback from Devin and Vargas on #14579 and #14592.

## Test plan

- [ ] Verify release build includes brain-graph.html in the bundle
- [ ] Verify `/v1/brain-graph-ui` endpoint works after release build

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
