### PR TITLE
fix(auth): use best-effort try? for platform assistant ID injection on provision path

### DIFF
--- a/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
+++ b/clients/shared/App/Auth/LocalAssistantBootstrapService.swift
@@ -182,7 +182,9 @@ public final class LocalAssistantBootstrapService {
 
         // Step 5: Inject into daemon
         try await injectKeyIntoDaemon(key: rawKey, daemonBaseURL: daemonBaseURL, daemonToken: daemonToken)
-        try await injectPlatformAssistantIdIntoDaemon(id: platformAssistantId, daemonBaseURL: daemonBaseURL, daemonToken: daemonToken)
+        if (try? await injectPlatformAssistantIdIntoDaemon(id: platformAssistantId, daemonBaseURL: daemonBaseURL, daemonToken: daemonToken)) == nil {
+            log.warning("Failed to inject platform assistant ID into daemon on provision path; the TS env-var fallback will be used")
+        }
 
         return .registeredAndProvisioned(assistantId: platformAssistantId)
     }


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for platform-id-resolution.md.

**Gap:** try vs try? asymmetry on new-provisioning path
**What was expected:** Platform assistant ID injection should be best-effort since the API key is already provisioned
**What was found:** Used try (hard failure) instead of try? (best-effort) on the fresh-provision path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
