### PR TITLE
feat: update Sentry DSN to new project

### DIFF
--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -151,7 +151,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
             options.dsn = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
             options.debug = false
             options.tracesSampleRate = 1.0
-            options.sendDefaultPii = true
+            options.sendDefaultPii = false
         }
 
         // Surface any crash log from the previous session so the user can send

--- a/clients/macos/vellum-assistant/App/AppDelegate.swift
+++ b/clients/macos/vellum-assistant/App/AppDelegate.swift
@@ -148,10 +148,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
         // applied via SentrySDK.close() — matching the daemon-side pattern in
         // lifecycle.ts (init at top, close after config load if flag disabled).
         SentrySDK.start { options in
-            options.dsn = "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992"
+            options.dsn = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
             options.debug = false
-            options.tracesSampleRate = 0.1
-            options.sendDefaultPii = false
+            options.tracesSampleRate = 1.0
+            options.sendDefaultPii = true
         }
 
         // Surface any crash log from the previous session so the user can send

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -102,7 +102,7 @@ import os
                 options.dsn = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
                 options.debug = false
                 options.tracesSampleRate = 1.0
-                options.sendDefaultPii = true
+                options.sendDefaultPii = false
             }
         }
     }

--- a/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
+++ b/clients/macos/vellum-assistant/Telemetry/MetricKitManager.swift
@@ -62,7 +62,7 @@ import os
             let wasDisabled = !SentrySDK.isEnabled
             if wasDisabled {
                 SentrySDK.start { options in
-                    options.dsn = "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992"
+                    options.dsn = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
                     options.sendDefaultPii = false
                     // Disable crash capture and session tracking so the temporary
                     // restart only sends the explicit event, not incidental crashes.
@@ -99,10 +99,10 @@ import os
         sentrySerialQueue.async {
             guard !SentrySDK.isEnabled else { return }
             SentrySDK.start { options in
-                options.dsn = "https://db2d38a082e4ee35eeaea08c44b376ec@o4504590528675840.ingest.us.sentry.io/4510874712276992"
+                options.dsn = "https://c8d6b12505ab6b1785f0e82b5fb50662@o4504590528675840.ingest.us.sentry.io/4511015779696640"
                 options.debug = false
-                options.tracesSampleRate = 0.1
-                options.sendDefaultPii = false
+                options.tracesSampleRate = 1.0
+                options.sendDefaultPii = true
             }
         }
     }


### PR DESCRIPTION
Updates all 3 SentrySDK.start() call sites to use the new Sentry project DSN. Adjusts sendDefaultPii and tracesSampleRate per new project setup. Manual report path keeps sendDefaultPii=false since it sends data even when user opted out.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
