### PR TITLE
fix: update stale help text after removing login --recording commands

### DIFF
--- a/assistant/src/cli/commands/amazon/index.ts
+++ b/assistant/src/cli/commands/amazon/index.ts
@@ -77,7 +77,7 @@ export function registerAmazonCommand(program: Command): void {
   const amz = program
     .command("amazon")
     .description(
-      "Shop on Amazon and Amazon Fresh. Requires a session imported from a Ride Shotgun recording.",
+      'Shop on Amazon and Amazon Fresh. Requires an active session (use "refresh" to authenticate).',
     )
     .option("--json", "Machine-readable JSON output");
 

--- a/assistant/src/cli/commands/twitter/index.ts
+++ b/assistant/src/cli/commands/twitter/index.ts
@@ -171,7 +171,7 @@ Examples:
       "after",
       `
 Deletes all saved browser session cookies. After logout, browser-path commands
-will fail until a new session is imported via "login" or captured via "refresh".
+will fail until a new session is captured via "refresh".
 OAuth credentials are not affected.
 
 Examples:

--- a/assistant/src/cli/reference.ts
+++ b/assistant/src/cli/reference.ts
@@ -24,7 +24,7 @@ Commands:
   email [options]                          Email operations (provider-agnostic)
   contacts [options]                       Manage and query the contact graph
   channel-verification-sessions [options]  Manage channel verification sessions
-  amazon [options]                         Shop on Amazon and Amazon Fresh. Requires a session imported from a Ride Shotgun recording.
+  amazon [options]                         Shop on Amazon and Amazon Fresh. Requires an active session (use "refresh" to authenticate).
   autonomy [options]                       View and configure autonomy tiers
   completions <shell>                      Generate shell completion script (e.g. assistant completions bash >> ~/.bashrc)
   notifications [options]                  Send and inspect notifications through the unified notification router

--- a/assistant/src/config/bundled-skills/doordash/doordash-cli.ts
+++ b/assistant/src/config/bundled-skills/doordash/doordash-cli.ts
@@ -99,7 +99,7 @@ export function registerDoordashCommand(program: Command): void {
   const dd = program
     .command("doordash")
     .description(
-      "Order food from DoorDash. Requires a session imported from a Ride Shotgun recording.",
+      'Order food from DoorDash. Requires an active session (use "refresh" to authenticate).',
     )
     .option("--json", "Machine-readable JSON output");
 

--- a/assistant/src/config/bundled-skills/doordash/lib/session.ts
+++ b/assistant/src/config/bundled-skills/doordash/lib/session.ts
@@ -1,6 +1,6 @@
 /**
  * DoorDash session persistence.
- * Stores/loads auth cookies from a recording or manual login.
+ * Stores/loads auth cookies via the credential store.
  */
 
 import { execFile } from "node:child_process";


### PR DESCRIPTION
## Summary
- Update Twitter logout help text to remove reference to deleted "login" command
- Update Amazon and DoorDash command descriptions to replace "imported from a Ride Shotgun recording" with "use refresh to authenticate"
- Update DoorDash session module doc comment to remove "from a recording" reference
- Update CLI reference.ts to match new descriptions

Fixes stale text identified during plan review for rm-import-from-recording.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/14607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
